### PR TITLE
virtlogd: bump memory overhead

### DIFF
--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -468,7 +468,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 
 var _ = Describe("GetMemoryOverhead calculation", func() {
 	// VirtLauncherMonitorOverhead + VirtLauncherOverhead + VirtlogdOverhead + VirtqemudOverhead + QemuOverhead + IothreadsOverhead
-	const staticOverheadString = "218Mi"
+	const staticOverheadString = "223Mi"
 	var (
 		vmi                     *v1.VirtualMachineInstance
 		staticOverhead          *resource.Quantity

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -112,7 +112,7 @@ const ephemeralStorageOverheadSize = "50M"
 const (
 	VirtLauncherMonitorOverhead = "25Mi"  // The `ps` RSS for virt-launcher-monitor
 	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
-	VirtlogdOverhead            = "20Mi"  // The `ps` RSS for virtlogd
+	VirtlogdOverhead            = "25Mi"  // The `ps` RSS for virtlogd
 	VirtqemudOverhead           = "40Mi"  // The `ps` RSS for virtqemud
 	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 	// Default: limits.memory = 2*requests.memory

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1869,8 +1869,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1260951397", "2260951397"),
-				Entry("on arm64", "arm64", "1395169125", "2395169125"),
+				Entry("on amd64", "amd64", "1266194277", "2266194277"),
+				Entry("on arm64", "arm64", "1400412005", "2400412005"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvStore, svc = configFactory(arch)
@@ -1906,8 +1906,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2260951397"),
-				Entry("on arm64", "arm64", "2395169125"),
+				Entry("on amd64", "amd64", "2266194277"),
+				Entry("on arm64", "arm64", "2400412005"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvStore, svc = configFactory(arch)
@@ -1945,8 +1945,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 340),
-				Entry("on arm64", "arm64", 475),
+				Entry("on amd64", "amd64", 346),
+				Entry("on arm64", "arm64", 480),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1982,12 +1982,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 340),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.P(true), 340),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.P(false), 324),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 475),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.P(true), 475),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.P(false), 458),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 346),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.P(true), 346),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.P(false), 329),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 480),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.P(true), 480),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.P(false), 463),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvStore, svc = configFactory(defaultArch)
@@ -2196,10 +2196,10 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 260),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 260),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 394),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 394),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 265),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 265),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 399),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 399),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2275,8 +2275,8 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("on amd64", "amd64", 260),
-				Entry("on arm64", "arm64", 394),
+				Entry("on amd64", "amd64", 265),
+				Entry("on arm64", "arm64", 399),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -312,7 +312,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(411)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(416)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
### What this PR does
Before this PR:
We allocate 20Mi of overhead memory for virtlogd. However, virtlogd was seen using 20968Ki, which is more.

After this PR:
We allocate 25Mi of overhead memory for virtlogd.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-54566

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

