### PR TITLE
Fix migration completion logic (along with other bugs)

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -234,6 +234,7 @@ func (app *virtHandlerApp) Run() {
 	// Wire VirtualMachineInstance controller
 	factory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, nil, app.namespace)
 
+	vmiInformer := factory.VMI()
 	vmiSourceInformer := factory.VMISourceHost(app.HostOverride)
 	vmiTargetInformer := factory.VMITargetHost(app.HostOverride)
 
@@ -333,6 +334,7 @@ func (app *virtHandlerApp) Run() {
 		app.VirtShareDir,
 		app.VirtPrivateDir,
 		app.KubeletPodsDir,
+		vmiInformer,
 		vmiSourceInformer,
 		vmiTargetInformer,
 		domainSharedInformer,

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -239,7 +239,7 @@ func (app *virtHandlerApp) Run() {
 	vmiTargetInformer := factory.VMITargetHost(app.HostOverride)
 
 	// Wire Domain controller
-	domainSharedInformer := virtcache.NewSharedInformer(app.VirtShareDir, int(app.WatchdogTimeoutDuration.Seconds()), recorder, vmiSourceInformer.GetStore(), time.Duration(app.domainResyncPeriodSeconds)*time.Second)
+	domainSharedInformer := virtcache.NewSharedInformer(app.VirtShareDir, int(app.WatchdogTimeoutDuration.Seconds()), recorder, vmiInformer.GetStore(), time.Duration(app.domainResyncPeriodSeconds)*time.Second)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -392,18 +392,18 @@ func GeneratePatchBytes(ops []string) []byte {
 	return []byte(fmt.Sprintf("[%s]", strings.Join(ops, ", ")))
 }
 
-func SetVMIPhaseTransitionTimestamp(oldVMI *v1.VirtualMachineInstance, newVMI *v1.VirtualMachineInstance) {
-	if oldVMI.Status.Phase != newVMI.Status.Phase {
-		for _, transitionTimeStamp := range newVMI.Status.PhaseTransitionTimestamps {
-			if transitionTimeStamp.Phase == newVMI.Status.Phase {
+func SetVMIPhaseTransitionTimestamp(oldStatus *v1.VirtualMachineInstanceStatus, newStatus *v1.VirtualMachineInstanceStatus) {
+	if oldStatus.Phase != newStatus.Phase {
+		for _, transitionTimeStamp := range newStatus.PhaseTransitionTimestamps {
+			if transitionTimeStamp.Phase == newStatus.Phase {
 				// already exists.
 				return
 			}
 		}
 
 		now := metav1.NewTime(time.Now())
-		newVMI.Status.PhaseTransitionTimestamps = append(newVMI.Status.PhaseTransitionTimestamps, v1.VirtualMachineInstancePhaseTransitionTimestamp{
-			Phase:                    newVMI.Status.Phase,
+		newStatus.PhaseTransitionTimestamps = append(newStatus.PhaseTransitionTimestamps, v1.VirtualMachineInstancePhaseTransitionTimestamp{
+			Phase:                    newStatus.Phase,
 			PhaseTransitionTimestamp: now,
 		})
 	}

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -710,7 +710,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 
 	conditionManager.CheckFailure(vmiCopy, syncErr, reason)
 
-	controller.SetVMIPhaseTransitionTimestamp(vmi, vmiCopy)
+	controller.SetVMIPhaseTransitionTimestamp(&vmi.Status, &vmiCopy.Status)
 
 	// If we detect a change on the vmi we update the vmi
 	vmiChanged := !equality.Semantic.DeepEqual(vmi.Status, vmiCopy.Status) || !equality.Semantic.DeepEqual(vmi.Finalizers, vmiCopy.Finalizers) || !equality.Semantic.DeepEqual(vmi.Annotations, vmiCopy.Annotations) || !equality.Semantic.DeepEqual(vmi.Labels, vmiCopy.Labels)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -664,11 +664,6 @@ func (c *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		migrationHost = vmi.Status.MigrationState.TargetNode
 	}
 
-	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.EndTimestamp == nil {
-		now := metav1.NewTime(time.Now())
-		vmi.Status.MigrationState.EndTimestamp = &now
-	}
-
 	targetNodeDetectedDomain, timeLeft := c.hasTargetDetectedReadyDomain(vmi)
 	// If we can't detect where the migration went to, then we have no
 	// way of transferring ownership. The only option here is to move the

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -630,7 +630,6 @@ func (c *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMac
 		vmi.Status.MigrationState.EndTimestamp = migrationMetadata.EndTimestamp
 	}
 	vmi.Status.MigrationState.AbortStatus = v1.MigrationAbortStatus(migrationMetadata.AbortStatus)
-	vmi.Status.MigrationState.Completed = migrationMetadata.Completed
 	vmi.Status.MigrationState.Failed = migrationMetadata.Failed
 	vmi.Status.MigrationState.Mode = migrationMetadata.Mode
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3426,6 +3426,8 @@ func (c *VirtualMachineController) finalizeMigration(vmi *v1.VirtualMachineInsta
 		return fmt.Errorf("%s: %v", errorMessage, err)
 	}
 
+	vmi.Status.MigrationState.Completed = true
+
 	return nil
 }
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -773,7 +773,6 @@ func (c *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		log.Log.Object(vmi).Info("The target node received the running migrated domain")
 		now := metav1.Now()
 		vmiCopy.Status.MigrationState.TargetNodeDomainReadyTimestamp = &now
-		c.finalizeMigration(vmiCopy)
 	}
 
 	if !migrations.IsMigrating(vmi) {
@@ -3095,6 +3094,10 @@ func (c *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			}
 		}
 	} else if vmi.IsRunning() {
+		if wasMigrationSuccessful(vmi.Status.MigrationState) && !vmi.Status.MigrationState.Completed {
+			c.finalizeMigration(origVMI)
+		}
+
 		if err := c.hotplugSriovInterfaces(vmi); err != nil {
 			log.Log.Object(vmi).Error(err.Error())
 		}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -166,6 +166,7 @@ func NewController(
 	virtShareDir string,
 	virtPrivateDir string,
 	kubeletPodsDir string,
+	vmiInformer cache.SharedIndexInformer,
 	vmiSourceInformer cache.SharedIndexInformer,
 	vmiTargetInformer cache.SharedIndexInformer,
 	domainInformer cache.SharedInformer,
@@ -203,6 +204,7 @@ func NewController(
 		host:                             host,
 		migrationIpAddress:               migrationIpAddress,
 		virtShareDir:                     virtShareDir,
+		vmiStore:                         vmiInformer.GetStore(),
 		vmiSourceStore:                   vmiSourceInformer.GetStore(),
 		vmiTargetStore:                   vmiTargetInformer.GetStore(),
 		domainStore:                      domainInformer.GetStore(),
@@ -224,7 +226,7 @@ func NewController(
 	}
 
 	c.hasSynced = func() bool {
-		return domainInformer.HasSynced() && vmiSourceInformer.HasSynced() && vmiTargetInformer.HasSynced()
+		return domainInformer.HasSynced() && vmiSourceInformer.HasSynced() && vmiTargetInformer.HasSynced() && vmiInformer.HasSynced()
 	}
 
 	_, err := vmiSourceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -296,6 +298,7 @@ type VirtualMachineController struct {
 	virtShareDir             string
 	virtPrivateDir           string
 	queue                    workqueue.TypedRateLimitingInterface[string]
+	vmiStore                 cache.Store
 	vmiSourceStore           cache.Store
 	vmiTargetStore           cache.Store
 	domainStore              cache.Store
@@ -1722,17 +1725,12 @@ func (c *VirtualMachineController) Execute() bool {
 
 func (c *VirtualMachineController) getVMIFromCache(key string) (vmi *v1.VirtualMachineInstance, exists bool, err error) {
 
-	// Fetch the latest Vm state from cache
-	obj, exists, err := c.vmiSourceStore.GetByKey(key)
+	// Get it from the global store as during a migration
+	// the VMI could disappear momentarily from both the source store
+	// and the target store
+	obj, exists, err := c.vmiStore.GetByKey(key)
 	if err != nil {
 		return nil, false, err
-	}
-
-	if !exists {
-		obj, exists, err = c.vmiTargetStore.GetByKey(key)
-		if err != nil {
-			return nil, false, err
-		}
 	}
 
 	// Retrieve the VirtualMachineInstance

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -696,7 +696,6 @@ func (c *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		vmi.Status.NodeName = migrationHost
 		// clean the evacuation node name since have already migrated to a new node
 		vmi.Status.EvacuationNodeName = ""
-		vmi.Status.MigrationState.Completed = true
 		// update the vmi migrationTransport to indicate that next migration should use unix URI
 		// new workloads will set the migrationTransport on their creation, however, legacy workloads
 		// can make the switch only after the first migration

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -603,6 +603,10 @@ func canUpdateToUnmounted(currentPhase v1.VolumePhase) bool {
 	return currentPhase == v1.VolumeReady || currentPhase == v1.HotplugVolumeMounted || currentPhase == v1.HotplugVolumeAttachedToNode
 }
 
+func wasMigrationSuccessful(migrationState *v1.VirtualMachineInstanceMigrationState) bool {
+	return migrationState != nil && migrationState.EndTimestamp != nil && !migrationState.Failed
+}
+
 func (c *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	if domain == nil ||
 		domain.Spec.Metadata.KubeVirt.Migration == nil ||
@@ -685,7 +689,7 @@ func (c *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		} else {
 			log.Log.Object(vmi).Info("Waiting on the target node to observe the migrated domain before performing the handoff")
 		}
-	} else if vmi.Status.MigrationState != nil {
+	} else if wasMigrationSuccessful(vmi.Status.MigrationState) {
 		// this is the migration ACK.
 		// At this point we know that the migration has completed and that
 		// the target node has seen the domain event.

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1942,9 +1942,7 @@ func (c *VirtualMachineController) defaultExecute(key string,
 			log.Log.Object(vmi).V(3).Info("Deleting domain for VirtualMachineInstance with deletion timestamp.")
 			shouldDelete = true
 		default:
-			if vmi.IsFinal() {
-				shouldCleanUp = true
-			}
+			shouldCleanUp = true
 		}
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -769,6 +769,14 @@ func (c *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp = &now
 	}
 
+	if domainExists &&
+		domain.Spec.Metadata.KubeVirt.Migration != nil &&
+		domain.Spec.Metadata.KubeVirt.Migration.EndTimestamp != nil &&
+		vmi.Status.MigrationState.EndTimestamp == nil {
+		log.Log.Object(vmi).Info("The target node detected that the migration has completed")
+		vmi.Status.MigrationState.EndTimestamp = domain.Spec.Metadata.KubeVirt.Migration.EndTimestamp
+	}
+
 	if !migrations.IsMigrating(vmi) {
 		destSrcPortsMap := c.migrationProxy.GetTargetListenerPorts(string(vmi.UID))
 		if len(destSrcPortsMap) == 0 {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1964,6 +1964,11 @@ func (c *VirtualMachineController) defaultExecute(key string,
 		shouldCleanUp = true
 	}
 
+	if !domainAlive && domainExists && !vmi.IsFinal() {
+		log.Log.Object(vmi).V(3).Info("Deleting inactive domain for vmi.")
+		shouldDelete = true
+	}
+
 	// Determine if an active (or about to be active) VirtualMachineInstance should be updated.
 	if vmiExists && !vmi.IsFinal() {
 		// requiring the phase of the domain and VirtualMachineInstance to be in sync is an

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1889,7 +1889,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 				UID:            "123",
 				StartTimestamp: &now,
 				EndTimestamp:   &now,
-				Completed:      true,
 			}
 
 			addVMI(vmi, domain)

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1862,7 +1862,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMIAbortingMigration)
 		})
 
-		It("Handoff domain to other node after completed migration", func() {
+		It("migration should be acked when successful", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID
 			vmi.ObjectMeta.ResourceVersion = "1"
@@ -1871,14 +1871,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = "othernode"
 			vmi.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
-			now := metav1.Time{Time: time.Unix(time.Now().UTC().Unix(), 0)}
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				TargetNode:                     "othernode",
 				TargetNodeAddress:              "127.0.0.1:12345",
 				SourceNode:                     host,
 				MigrationUID:                   "123",
 				TargetNodeDomainDetected:       true,
-				TargetNodeDomainReadyTimestamp: &now,
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
 			}
 
 			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
@@ -1887,8 +1886,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 				UID:            "123",
-				StartTimestamp: &now,
-				EndTimestamp:   &now,
+				StartTimestamp: pointer.P(metav1.Now()),
+				EndTimestamp:   pointer.P(metav1.Now()),
 			}
 
 			addVMI(vmi, domain)
@@ -1898,31 +1897,33 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, "The VirtualMachineInstance migrated to node")
 			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.MigrationTransport).To(Equal(v1.MigrationTransportUnix))
-			Expect(updatedVMI.Status.MigrationState.Completed).To(BeTrue())
-			Expect(updatedVMI.Status.MigrationState.StartTimestamp).To(Equal(&now))
-			Expect(updatedVMI.Status.MigrationState.EndTimestamp).To(Equal(&now))
-			Expect(updatedVMI.Status.NodeName).To(Equal("othernode"))
-			Expect(updatedVMI.Status.Interfaces).To(BeEmpty())
 			Expect(updatedVMI.Labels).To(HaveKeyWithValue(v1.NodeNameLabel, "othernode"))
+			Expect(updatedVMI.Labels).ToNot(HaveKey(v1.OutdatedLauncherImageLabel))
+			Expect(updatedVMI.Status.LauncherContainerImageVersion).To(BeEmpty())
+			Expect(updatedVMI.Status.NodeName).To(Equal("othernode"))
+			Expect(updatedVMI.Status.EvacuationNodeName).To(BeEmpty())
+			Expect(updatedVMI.Status.MigrationState.Completed).To(BeFalse())
+			Expect(updatedVMI.Status.MigrationTransport).To(Equal(v1.MigrationTransportUnix))
+			Expect(updatedVMI.Status.Interfaces).To(BeEmpty())
 		})
 
-		It("should apply post-migration operations on guest VM after migration completed", func() {
+		It("migration should be marked as completed after finalization", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID
 			vmi.ObjectMeta.ResourceVersion = "1"
 			vmi.Status.Phase = v1.Running
 			vmi.Labels = make(map[string]string)
-			vmi.Status.NodeName = "othernode"
+			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
-			pastTime := metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Second))
+			vmi.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				TargetNode:               host,
-				TargetNodeAddress:        "127.0.0.1:12345",
-				SourceNode:               "othernode",
-				MigrationUID:             "123",
-				TargetNodeDomainDetected: false,
-				StartTimestamp:           &pastTime,
+				TargetNode:                     host,
+				TargetNodeAddress:              "127.0.0.1:12345",
+				SourceNode:                     "othernode",
+				MigrationUID:                   "123",
+				TargetNodeDomainDetected:       true,
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+				EndTimestamp:                   pointer.P(metav1.Now()),
 			}
 
 			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
@@ -1930,21 +1931,23 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 				UID:            "123",
-				StartTimestamp: &pastTime,
+				StartTimestamp: pointer.P(metav1.Now()),
+				EndTimestamp:   pointer.P(metav1.Now()),
 			}
 
 			addVMI(vmi, domain)
 
 			client.EXPECT().Ping().AnyTimes()
-			client.EXPECT().FinalizeVirtualMachineMigration(gomock.Any(), gomock.Any())
+			client.EXPECT().FinalizeVirtualMachineMigration(gomock.Any(), gomock.Any()).Return(nil)
+			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
+			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().SyncVirtualMachine(gomock.Any(), gomock.Any())
 
 			sanityExecute()
 
 			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.MigrationState.TargetNodeDomainDetected).To(BeTrue())
-			Expect(updatedVMI.Status.MigrationState.TargetNodeDomainReadyTimestamp).ToNot(BeNil())
-			Expect(updatedVMI.Status.CurrentCPUTopology).To(BeNil())
+			Expect(updatedVMI.Status.MigrationState.Completed).To(BeTrue())
 		})
 
 		It("should hotplug CPU in post-migration when target pod has the required conditions", func() {
@@ -1953,16 +1956,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.ObjectMeta.ResourceVersion = "1"
 			vmi.Status.Phase = v1.Running
 			vmi.Labels = make(map[string]string)
-			vmi.Status.NodeName = "othernode"
+			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
 			pastTime := metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Second))
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				TargetNode:               host,
-				TargetNodeAddress:        "127.0.0.1:12345",
-				SourceNode:               "othernode",
-				MigrationUID:             "123",
-				TargetNodeDomainDetected: false,
-				StartTimestamp:           &pastTime,
+				TargetNode:                     host,
+				TargetNodeAddress:              "127.0.0.1:12345",
+				SourceNode:                     "othernode",
+				MigrationUID:                   "123",
+				TargetNodeDomainDetected:       true,
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+				StartTimestamp:                 &pastTime,
+				EndTimestamp:                   pointer.P(metav1.Now()),
 			}
 			cpuTopology := &v1.CPU{
 				Sockets: 1,
@@ -1983,6 +1988,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 				UID:            "123",
 				StartTimestamp: &pastTime,
+				EndTimestamp:   pointer.P(metav1.Now()),
 			}
 
 			addVMI(vmi, domain)
@@ -1990,13 +1996,14 @@ var _ = Describe("VirtualMachineInstance", func() {
 			client.EXPECT().Ping().AnyTimes()
 			client.EXPECT().FinalizeVirtualMachineMigration(gomock.Any(), gomock.Any())
 			client.EXPECT().SyncVirtualMachineCPUs(gomock.Any(), gomock.Any())
+			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
+			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().SyncVirtualMachine(gomock.Any(), gomock.Any())
 
 			sanityExecute()
 
 			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.MigrationState.TargetNodeDomainDetected).To(BeTrue())
-			Expect(updatedVMI.Status.MigrationState.TargetNodeDomainReadyTimestamp).ToNot(BeNil())
 			Expect(updatedVMI.Status.CurrentCPUTopology).NotTo(BeNil())
 			Expect(updatedVMI.Status.Conditions).NotTo(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Type": Equal(v1.VirtualMachineInstanceVCPUChange),
@@ -2122,16 +2129,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 		vmi.ObjectMeta.ResourceVersion = "1"
 		vmi.Status.Phase = v1.Running
 		vmi.Labels = make(map[string]string)
-		vmi.Status.NodeName = "othernode"
-		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
-		pastTime := metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Second))
+		vmi.Status.NodeName = host
+		vmi.Labels[v1.NodeNameLabel] = host
+
 		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-			TargetNode:               host,
-			TargetNodeAddress:        "127.0.0.1:12345",
-			SourceNode:               "othernode",
-			MigrationUID:             "123",
-			TargetNodeDomainDetected: false,
-			StartTimestamp:           &pastTime,
+			TargetNode:                     host,
+			TargetNodeAddress:              "127.0.0.1:12345",
+			SourceNode:                     "othernode",
+			MigrationUID:                   "123",
+			TargetNodeDomainDetected:       true,
+			TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+			StartTimestamp:                 pointer.P(metav1.Now()),
+			EndTimestamp:                   pointer.P(metav1.Now()),
 		}
 
 		cpuTopology := &v1.CPU{
@@ -2155,7 +2164,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 		domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 			UID:            "123",
-			StartTimestamp: &pastTime,
+			StartTimestamp: pointer.P(metav1.Now()),
+			EndTimestamp:   pointer.P(metav1.Now()),
 		}
 
 		addVMI(vmi, domain)
@@ -2163,14 +2173,15 @@ var _ = Describe("VirtualMachineInstance", func() {
 		client.EXPECT().Ping().AnyTimes()
 		client.EXPECT().FinalizeVirtualMachineMigration(gomock.Any(), gomock.Any())
 		client.EXPECT().SyncVirtualMachineCPUs(gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+		client.EXPECT().SyncVirtualMachine(gomock.Any(), gomock.Any())
+		mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), gomock.Any())
+		mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), gomock.Any())
 
 		sanityExecute()
 
 		testutils.ExpectEvent(recorder, "failed to change vCPUs")
 		updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(updatedVMI.Status.MigrationState.TargetNodeDomainDetected).To(BeTrue())
-		Expect(updatedVMI.Status.MigrationState.TargetNodeDomainReadyTimestamp).ToNot(BeNil())
 		Expect(updatedVMI.Status.CurrentCPUTopology).NotTo(BeNil())
 		Expect(updatedVMI.Status.Conditions).NotTo(ContainElement(MatchFields(IgnoreExtras, Fields{
 			"Type": Equal(v1.VirtualMachineInstanceVCPUChange),

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -483,11 +483,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			createVMI(vmi)
 
-			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
-			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().Close()
 
 			sanityExecute()
-			testutils.ExpectEvent(recorder, VMIDefined)
+
+			testutils.ExpectEvent(recorder, VMICrashed)
 			Expect(mockQueue.Len()).To(Equal(0))
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
 		})

--- a/pkg/virt-launcher/notify-client/BUILD.bazel
+++ b/pkg/virt-launcher/notify-client/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/handler-launcher-com:go_default_library",
         "//pkg/handler-launcher-com/notify/info:go_default_library",
         "//pkg/handler-launcher-com/notify/v1:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/util/net/grpc:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
         "//pkg/virt-launcher/virtwrap/agent-poller:go_default_library",

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 
 	"google.golang.org/grpc"
@@ -345,6 +346,27 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 				updateEvents(event, domain, events)
 			} else if libvirtEvent.Event.Event == libvirt.DOMAIN_EVENT_STARTED && libvirt.DomainEventStartedDetailType(libvirtEvent.Event.Detail) == libvirt.DOMAIN_EVENT_STARTED_MIGRATED {
 				event := watch.Event{Type: watch.Added, Object: domain}
+				client.SendDomainEvent(event)
+				updateEvents(event, domain, events)
+			} else if libvirtEvent.Event.Event == libvirt.DOMAIN_EVENT_RESUMED && libvirt.DomainEventResumedDetailType(libvirtEvent.Event.Detail) == libvirt.DOMAIN_EVENT_RESUMED_MIGRATED {
+				// This is a libvirt event that only the target can see and it means that the migration has completed
+				// we just set the EndTimestamp here so that the source can finalize the migration.
+				// Usually this is performed by the source launcher/handler but in case of upgrade this is not
+				// guaranteed as the cluster will have an updated virt-handler together with outdated launchers, this
+				// makes sure that migrations actually finish in those cases.
+				migrationMetadata, exists := metadataCache.Migration.Load()
+				if exists && migrationMetadata.EndTimestamp == nil {
+					metadataCache.Migration.WithSafeBlock(func(migrationMetadata *api.MigrationMetadata, _ bool) {
+						migrationMetadata.EndTimestamp = pointer.P(metav1.Now())
+					})
+				} else if !exists {
+					migrationMetadata := api.MigrationMetadata{
+						EndTimestamp: pointer.P(metav1.Now()),
+					}
+					metadataCache.Migration.Store(migrationMetadata)
+				}
+
+				event := watch.Event{Type: watch.Modified, Object: domain}
 				client.SendDomainEvent(event)
 				updateEvents(event, domain, events)
 			}

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -77,6 +77,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "live-migration-source_test.go",
         "manager_test.go",
         "nichotplug_test.go",
         "virtwrap_suite_test.go",
@@ -107,6 +108,7 @@ go_test(
         "//pkg/virt-launcher/virtwrap/converter/arch:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
         "//pkg/virt-launcher/virtwrap/efi:go_default_library",
+        "//pkg/virt-launcher/virtwrap/errors:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -410,7 +410,6 @@ type MigrationMetadata struct {
 	UID            types.UID        `xml:"uid,omitempty"`
 	StartTimestamp *metav1.Time     `xml:"startTimestamp,omitempty"`
 	EndTimestamp   *metav1.Time     `xml:"endTimestamp,omitempty"`
-	Completed      bool             `xml:"completed,omitempty"`
 	Failed         bool             `xml:"failed,omitempty"`
 	FailureReason  string           `xml:"failureReason,omitempty"`
 	AbortStatus    string           `xml:"abortStatus,omitempty"`

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -342,8 +342,8 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 		} else {
 			// Don't allow the same migration UID to be executed twice.
 			// Migration attempts are like pods. One shot.
-			return false, fmt.Errorf("migration job %v already executed, finished at %v, completed: %t, failed: %t, abortStatus: %s",
-				migrationMetadata.UID, *migrationMetadata.EndTimestamp, migrationMetadata.Completed, migrationMetadata.Failed, migrationMetadata.AbortStatus)
+			return false, fmt.Errorf("migration job %v already executed, finished at %v, failed: %t, abortStatus: %s",
+				migrationMetadata.UID, *migrationMetadata.EndTimestamp, migrationMetadata.Failed, migrationMetadata.AbortStatus)
 		}
 	}
 
@@ -360,7 +360,7 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 
 func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) error {
 	migration, _ := l.metadataCache.Migration.Load()
-	if migration.Completed || migration.Failed || migration.StartTimestamp == nil {
+	if migration.EndTimestamp != nil || migration.Failed || migration.StartTimestamp == nil {
 		return fmt.Errorf(migrations.CancelMigrationFailedVmiNotMigratingErr)
 	}
 
@@ -375,7 +375,7 @@ func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) e
 	return nil
 }
 
-func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, completed bool, reason string, abortStatus v1.MigrationAbortStatus) error {
+func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason string, abortStatus v1.MigrationAbortStatus) error {
 	migrationMetadata, exists := l.metadataCache.Migration.Load()
 	if !exists {
 		// nothing to report if migration metadata is empty
@@ -399,9 +399,6 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, completed b
 			migrationMetadata.Failed = true
 			migrationMetadata.FailureReason = reason
 		}
-		if completed {
-			migrationMetadata.Completed = true
-		}
 
 		migrationMetadata.AbortStatus = string(abortStatus)
 
@@ -421,11 +418,11 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, completed b
 }
 
 func (l *LibvirtDomainManager) setMigrationResult(failed bool, reason string, abortStatus v1.MigrationAbortStatus) error {
-	return l.setMigrationResultHelper(failed, true, reason, abortStatus)
+	return l.setMigrationResultHelper(failed, reason, abortStatus)
 }
 
 func (l *LibvirtDomainManager) setMigrationAbortStatus(abortStatus v1.MigrationAbortStatus) error {
-	return l.setMigrationResultHelper(false, false, "", abortStatus)
+	return l.setMigrationResultHelper(false, "", abortStatus)
 }
 
 func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationErr chan error) *migrationMonitor {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -30,6 +30,7 @@ import (
 	"libvirt.org/go/libvirtxml"
 
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
@@ -389,18 +390,20 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, completed b
 	}
 
 	l.metadataCache.Migration.WithSafeBlock(func(migrationMetadata *api.MigrationMetadata, _ bool) {
-		if abortStatus != "" {
-			migrationMetadata.AbortStatus = string(abortStatus)
-		}
-
 		if failed {
 			migrationMetadata.Failed = true
 			migrationMetadata.FailureReason = reason
 		}
 		if completed {
 			migrationMetadata.Completed = true
-			now := metav1.Now()
-			migrationMetadata.EndTimestamp = &now
+		}
+
+		migrationMetadata.AbortStatus = string(abortStatus)
+
+		if abortStatus == "" || abortStatus == v1.MigrationAbortSucceeded {
+			// only mark the migration as complete if there was no abortion or
+			// the abortion succeeded
+			migrationMetadata.EndTimestamp = pointer.P(metav1.Now())
 		}
 	})
 

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -382,11 +382,17 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason stri
 		return nil
 	}
 
+	metaAbortStatus := migrationMetadata.AbortStatus
 	if abortStatus != "" {
-		metaAbortStatus := migrationMetadata.AbortStatus
 		if metaAbortStatus == string(abortStatus) && metaAbortStatus == string(v1.MigrationAbortInProgress) {
 			return domainerrors.MigrationAbortInProgressError
 		}
+	}
+
+	if metaAbortStatus == string(v1.MigrationAbortInProgress) &&
+		abortStatus != v1.MigrationAbortFailed &&
+		abortStatus != v1.MigrationAbortSucceeded {
+		return domainerrors.MigrationAbortInProgressError
 	}
 
 	if migrationMetadata.EndTimestamp != nil {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -389,6 +389,11 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, completed b
 		}
 	}
 
+	if migrationMetadata.EndTimestamp != nil {
+		// the migration result has already been reported and should not be overwritten
+		return nil
+	}
+
 	l.metadataCache.Migration.WithSafeBlock(func(migrationMetadata *api.MigrationMetadata, _ bool) {
 		if failed {
 			migrationMetadata.Failed = true

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -685,14 +685,6 @@ func (m *migrationMonitor) startMonitor() {
 			}
 		case libvirt.DOMAIN_JOB_NONE:
 			completedJobInfo = m.determineNonRunningMigrationStatus(dom)
-		case libvirt.DOMAIN_JOB_COMPLETED:
-			logger.Info("Migration has been completed")
-			m.l.setMigrationResult(false, "", "")
-			return
-		case libvirt.DOMAIN_JOB_FAILED:
-			logger.Info("Migration job failed")
-			m.l.setMigrationResult(true, fmt.Sprintf("%v", m.migrationFailedWithError), "")
-			return
 		case libvirt.DOMAIN_JOB_CANCELLED:
 			logger.Info("Migration was canceled")
 			m.l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)
@@ -744,6 +736,7 @@ func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstanc
 				l.setMigrationAbortStatus(v1.MigrationAbortFailed)
 				return
 			}
+			l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)
 			log.Log.Object(vmi).Info("Live migration abort succeeded")
 		}
 		return
@@ -996,8 +989,13 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 
 	err = dom.MigrateToURI3(dstURI, params, migrateFlags)
 	if err != nil {
+		l.setMigrationResult(true, err.Error(), "")
+		log.Log.Object(vmi).Errorf("migration failed with error: %v", err)
 		return fmt.Errorf("error encountered during MigrateToURI3 libvirt api call: %v", err)
 	}
+
+	log.Log.Object(vmi).Errorf("migration completed successfully")
+	l.setMigrationResult(false, "", "")
 
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -73,21 +73,6 @@ var _ = Describe("Live migration source", func() {
 			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
 		})
 
-		It("should return 'Aborting' if abortion is in progress", func() {
-			libvirtDomainManager.setMigrationResult(false, "", v1.MigrationAbortInProgress)
-			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
-			Expect(exists).To(BeTrue(), "migrationMetadata not found")
-			Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
-			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
-
-			err := libvirtDomainManager.setMigrationResult(false, "", v1.MigrationAbortInProgress)
-			Expect(err).To(Equal(errors.MigrationAbortInProgressError))
-			migrationMetadata, exists = libvirtDomainManager.metadataCache.Migration.Load()
-			Expect(exists).To(BeTrue(), "migrationMetadata not found")
-			Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
-			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
-		})
-
 		DescribeTable("EndTimestamp", func(isFailed bool, abortStatus v1.MigrationAbortStatus, shouldEndTimestampBeSet bool) {
 			libvirtDomainManager.setMigrationResult(isFailed, "", abortStatus)
 			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
@@ -105,6 +90,39 @@ var _ = Describe("Live migration source", func() {
 			Entry("should be set when the migration has been aborted", false, v1.MigrationAbortSucceeded, true),
 			Entry("should not be set when an abortion request does not succeed", false, v1.MigrationAbortFailed, false),
 			Entry("should not be set when an abortion request is still in progress", false, v1.MigrationAbortInProgress, false),
+		)
+
+		DescribeTable("when an abortion is in progress", func(isFailed bool, abortStatus v1.MigrationAbortStatus, shouldEndTimestampBeSet bool, expectedError error) {
+			// make it in progress first
+			libvirtDomainManager.setMigrationResult(false, "", v1.MigrationAbortInProgress)
+
+			err := libvirtDomainManager.setMigrationResult(isFailed, "", abortStatus)
+			if expectedError != nil {
+				Expect(err).To(Equal(expectedError))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue(), "migrationMetadata not found")
+
+			if shouldEndTimestampBeSet {
+				Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
+			} else {
+				Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
+			}
+
+			if expectedError != nil {
+				Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
+			} else {
+				Expect(migrationMetadata.Failed).To(BeTrue(), "migration has not failed")
+			}
+		},
+			Entry("setting 'Aborting' should return an error", false, v1.MigrationAbortInProgress, false, errors.MigrationAbortInProgressError),
+			Entry("setting 'Succeeded' should return an error", true, v1.MigrationAbortSucceeded, true, nil),
+			Entry("setting 'Failed' should return an error", true, v1.MigrationAbortFailed, false, nil),
+			Entry("marking the migration as failed without an abortion result should return an error", true, v1.MigrationAbortStatus(""), false, errors.MigrationAbortInProgressError),
+			Entry("marking the migration as completed without an abortion result should return an error", false, v1.MigrationAbortStatus(""), false, errors.MigrationAbortInProgressError),
 		)
 	})
 })

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package virtwrap
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/ephemeral-disk/fake"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
+)
+
+var _ = Describe("Live migration source", func() {
+	var libvirtDomainManager *LibvirtDomainManager
+
+	Context("Migration result", func() {
+		BeforeEach(func() {
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						MigrationUID: types.UID(fmt.Sprintf("%v", GinkgoRandomSeed())),
+					},
+				},
+			}
+
+			mockConn := &cli.MockConnection{}
+			testVirtShareDir := fmt.Sprintf("fake-virt-share-%d", GinkgoRandomSeed())
+			testEphemeralDiskDir := fmt.Sprintf("fake-ephemeral-disk-%d", GinkgoRandomSeed())
+			ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
+			metadataCache := metadata.NewCache()
+
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache)
+			libvirtDomainManager = manager.(*LibvirtDomainManager)
+			libvirtDomainManager.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)
+		})
+
+		It("should only be set once", func() {
+			libvirtDomainManager.setMigrationResult(false, "", "")
+			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue(), "migrationMetadata not found")
+			Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
+			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
+
+			endTimestamp := migrationMetadata.EndTimestamp.DeepCopy()
+
+			libvirtDomainManager.setMigrationResult(true, "", "")
+			Expect(exists).To(BeTrue())
+			Expect(migrationMetadata.EndTimestamp).To(Equal(endTimestamp), "migrationMetadata changed")
+			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
+		})
+
+		It("should return 'Aborting' if abortion is in progress", func() {
+			libvirtDomainManager.setMigrationResult(false, "", v1.MigrationAbortInProgress)
+			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue(), "migrationMetadata not found")
+			Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
+			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
+
+			err := libvirtDomainManager.setMigrationResult(false, "", v1.MigrationAbortInProgress)
+			Expect(err).To(Equal(errors.MigrationAbortInProgressError))
+			migrationMetadata, exists = libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue(), "migrationMetadata not found")
+			Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
+			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
+		})
+
+		DescribeTable("EndTimestamp", func(isFailed bool, abortStatus v1.MigrationAbortStatus, shouldEndTimestampBeSet bool) {
+			libvirtDomainManager.setMigrationResult(isFailed, "", abortStatus)
+			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue(), "migrationMetadata not found")
+			Expect(migrationMetadata.Failed).To(Equal(isFailed), "migration result is wrong")
+
+			if shouldEndTimestampBeSet {
+				Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
+			} else {
+				Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
+			}
+		},
+			Entry("should be set when the migration is successful", false, v1.MigrationAbortStatus(""), true),
+			Entry("should be set when the migration has failed", true, v1.MigrationAbortStatus(""), true),
+			Entry("should be set when the migration has been aborted", false, v1.MigrationAbortSucceeded, true),
+			Entry("should not be set when an abortion request does not succeed", false, v1.MigrationAbortFailed, false),
+			Entry("should not be set when an abortion request is still in progress", false, v1.MigrationAbortInProgress, false),
+		)
+	})
+})

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -49,10 +49,7 @@ func (l *LibvirtDomainManager) finalizeMigrationTarget(vmi *v1.VirtualMachineIns
 		}
 	}
 
-	if err := l.setGuestTime(vmi); err != nil {
-		return err
-	}
-
+	l.setGuestTime(vmi)
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -177,6 +177,7 @@ type LibvirtDomainManager struct {
 
 	metadataCache    *metadata.Cache
 	domainStatsCache *virtcache.TimeDefinedCache[*stats.DomainStats]
+	setTimeOnce      sync.Once
 }
 
 type pausedVMIs struct {
@@ -225,6 +226,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
 		cancelSafetyUnfreezeChan: make(chan struct{}),
 		migrateInfoStats:         &stats.DomainJobInfo{},
 		metadataCache:            metadataCache,
+		setTimeOnce:              sync.Once{},
 	}
 
 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
@@ -346,7 +348,7 @@ func (l *LibvirtDomainManager) UpdateGuestMemory(vmi *v1.VirtualMachineInstance)
 	return nil
 }
 
-func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) error {
+func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) {
 	// Try to set VM time to the current value.  This is typically useful
 	// when clock wasn't running on the VM for some time (e.g. during
 	// suspension or migration), especially if the time delay exceeds NTP
@@ -355,75 +357,73 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) erro
 	// environment, especially QEMU agent presence) or that the set time is
 	// very precise (NTP in the guest should take care of it if needed).
 
-	domName := api.VMINamespaceKeyFunc(vmi)
-	dom, err := l.virConn.LookupDomainByName(domName)
-	if err != nil {
-		log.Log.Object(vmi).Reason(err).Error(failedSyncGuestTime)
-		return err
-	}
-
-	go func() {
-		defer dom.Free()
-
-		// Syncing the guest time is a best-effort. Therefore
-		// don't flood the logs
-		var latestErr error
-		defer func() {
-			if latestErr != nil {
-				log.Log.Object(vmi).Warning(latestErr.Error())
+	l.setTimeOnce.Do(func() {
+		go func() {
+			domName := api.VMINamespaceKeyFunc(vmi)
+			dom, err := l.virConn.LookupDomainByName(domName)
+			if err != nil {
+				log.Log.Object(vmi).Reason(err).Error(failedSyncGuestTime)
+				return
 			}
-		}()
+			defer dom.Free()
+			// Syncing the guest time is a best-effort. Therefore
+			// don't flood the logs
+			var latestErr error
+			defer func() {
+				if latestErr != nil {
+					log.Log.Object(vmi).Warning(latestErr.Error())
+				}
+			}()
 
-		ctx := l.getGuestTimeContext()
-		timeout := time.After(60 * time.Second)
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-timeout:
-				log.Log.Object(vmi).Error(failedSyncGuestTime)
-				return
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				currTime := time.Now()
-				secs := currTime.Unix()
-				nsecs := uint(currTime.Nanosecond())
-				err := dom.SetTime(secs, nsecs, 0)
-				if err != nil {
-					libvirtError, ok := err.(libvirt.Error)
-					if !ok {
-						log.Log.Object(vmi).Reason(err).Warning(failedSyncGuestTime)
-						return
-					}
-
-					switch libvirtError.Code {
-					case libvirt.ERR_AGENT_UNRESPONSIVE:
-						const unresponsive = "failed to set time: QEMU agent unresponsive"
-						latestErr = fmt.Errorf("%s, %s", unresponsive, err)
-						log.Log.Object(vmi).Reason(err).V(9).Info(unresponsive)
-					case libvirt.ERR_OPERATION_UNSUPPORTED:
-						// no need to retry as this opertaion is not supported
-						log.Log.Object(vmi).Reason(err).Warning("failed to set time: not supported")
-						return
-					case libvirt.ERR_ARGUMENT_UNSUPPORTED:
-						// no need to retry as the agent is not configured
-						log.Log.Object(vmi).Reason(err).Warning("failed to set time: agent not configured")
-						return
-					default:
-						latestErr = fmt.Errorf("%s, %s", failedSyncGuestTime, err)
-						log.Log.Object(vmi).Reason(err).V(9).Info(failedSyncGuestTime)
-					}
-				} else {
-					latestErr = nil
-					log.Log.Object(vmi).Info("guest VM time sync finished successfully")
+			ctx := l.getGuestTimeContext()
+			timeout := time.After(60 * time.Second)
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-timeout:
+					log.Log.Object(vmi).Error(failedSyncGuestTime)
 					return
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					currTime := time.Now()
+					secs := currTime.Unix()
+					nsecs := uint(currTime.Nanosecond())
+					err := dom.SetTime(secs, nsecs, 0)
+					if err != nil {
+						libvirtError, ok := err.(libvirt.Error)
+						if !ok {
+							log.Log.Object(vmi).Reason(err).Warning(failedSyncGuestTime)
+							return
+						}
+
+						switch libvirtError.Code {
+						case libvirt.ERR_AGENT_UNRESPONSIVE:
+							const unresponsive = "failed to set time: QEMU agent unresponsive"
+							latestErr = fmt.Errorf("%s, %s", unresponsive, err)
+							log.Log.Object(vmi).Reason(err).V(9).Info(unresponsive)
+						case libvirt.ERR_OPERATION_UNSUPPORTED:
+							// no need to retry as this opertaion is not supported
+							log.Log.Object(vmi).Reason(err).Warning("failed to set time: not supported")
+							return
+						case libvirt.ERR_ARGUMENT_UNSUPPORTED:
+							// no need to retry as the agent is not configured
+							log.Log.Object(vmi).Reason(err).Warning("failed to set time: agent not configured")
+							return
+						default:
+							latestErr = fmt.Errorf("%s, %s", failedSyncGuestTime, err)
+							log.Log.Object(vmi).Reason(err).V(9).Info(failedSyncGuestTime)
+						}
+					} else {
+						latestErr = nil
+						log.Log.Object(vmi).Info("guest VM time sync finished successfully")
+						return
+					}
 				}
 			}
-		}
-	}()
-
-	return nil
+		}()
+	})
 }
 
 func (l *LibvirtDomainManager) getGuestTimeContext() context.Context {
@@ -1677,10 +1677,7 @@ func (l *LibvirtDomainManager) UnpauseVMI(vmi *v1.VirtualMachineInstance) error 
 		l.paused.remove(vmi.UID)
 		// Try to set guest time after this commands execution.
 		// This operation is not disruptive.
-		if err := l.setGuestTime(vmi); err != nil {
-			return err
-		}
-
+		l.setGuestTime(vmi)
 	} else {
 		logger.Infof("Domain is not paused for %s", vmi.GetObjectMeta().GetName())
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1563,7 +1563,7 @@ var _ = Describe("Manager", func() {
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
+						Type: libvirt.DOMAIN_JOB_CANCELLED,
 					}
 				}
 
@@ -1613,7 +1613,7 @@ var _ = Describe("Manager", func() {
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
+						Type: libvirt.DOMAIN_JOB_CANCELLED,
 					}
 				}
 
@@ -1676,7 +1676,7 @@ var _ = Describe("Manager", func() {
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
+						Type: libvirt.DOMAIN_JOB_CANCELLED,
 					}
 				}
 
@@ -1803,7 +1803,7 @@ var _ = Describe("Manager", func() {
 			time.Sleep(2 * time.Second)
 
 			migration, _ := metadataCache.Migration.Load()
-			Expect(migration.AbortStatus).To(Equal(string(v1.MigrationAbortInProgress)))
+			Expect(migration.AbortStatus).To(Equal(string(v1.MigrationAbortSucceeded)))
 		})
 
 		It("shouldn't be able to call cancel migration more than once", func() {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1878,57 +1878,6 @@ var _ = Describe("Manager", func() {
 				return migration.AbortStatus
 			}, 5*time.Second, 2).Should(Equal(string(v1.MigrationAbortSucceeded)))
 		})
-		It("migration failure should be finalized even if we missed status update", func() {
-			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
-			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_NONE,
-					DataRemaining: uint64(0),
-				}
-			}()
-			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
-				return &libvirt.DomainJobInfo{
-					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining:    uint64(32479827777),
-					DataRemainingSet: true,
-				}
-			}()
-
-			options := &cmdclient.MigrationOptions{
-				Bandwidth:               resource.MustParse("64Mi"),
-				ProgressTimeout:         3,
-				CompletionTimeoutPerGiB: 150,
-			}
-			vmi := newVMI(testNamespace, testVmName)
-			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				MigrationUID: "111222333",
-			}
-
-			migrationMetadata, _ := metadataCache.Migration.Load()
-			migrationMetadata.UID = vmi.Status.MigrationState.MigrationUID
-			metadataCache.Migration.Store(migrationMetadata)
-
-			manager := &LibvirtDomainManager{
-				virConn:       mockConn,
-				virtShareDir:  testVirtShareDir,
-				metadataCache: metadataCache,
-			}
-
-			mockConn.EXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
-			gomock.InOrder(
-				mockDomain.EXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil),
-				mockDomain.EXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo, nil),
-			)
-
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
-			Eventually(func() bool {
-				migration, _ := metadataCache.Migration.Load()
-				return migration.Failed
-			}, 5*time.Second, 2).Should(BeTrue())
-		})
 
 	})
 
@@ -1950,50 +1899,6 @@ var _ = Describe("Manager", func() {
 
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
 			Expect(manager.PrepareMigrationTarget(vmi, true, &cmdv1.VirtualMachineOptions{})).To(Succeed())
-		})
-		It("should verify that migration failure is set in the monitor thread", func() {
-			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				return &libvirt.DomainJobInfo{
-					Type:             libvirt.DOMAIN_JOB_NONE,
-					DataRemaining:    uint64(32479827394),
-					DataRemainingSet: true,
-				}
-			}()
-
-			vmi := newVMI(testNamespace, testVmName)
-			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				MigrationUID: "111222333",
-			}
-
-			userData := "fake\nuser\ndata\n"
-			networkData := "FakeNetwork"
-			addCloudInitDisk(vmi, userData, networkData)
-			domainSpec := expectedDomainFor(vmi)
-			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{}
-
-			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
-
-			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
-			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
-
-			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).ToNot(HaveOccurred())
-			mockDomain.EXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(fake_jobinfo, nil)
-			mockDomain.EXPECT().GetXMLDesc(gomock.Any()).AnyTimes().Return(string(domainXml), nil)
-
-			mockDomain.EXPECT().MigrateToURI3(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("MigrationFailed"))
-			options := &cmdclient.MigrationOptions{
-				Bandwidth:               resource.MustParse("64Mi"),
-				ProgressTimeout:         150,
-				CompletionTimeoutPerGiB: 300,
-			}
-			Expect(manager.MigrateVMI(vmi, options)).To(Succeed())
-
-			migration, _ := metadataCache.Migration.Load()
-			Eventually(func() bool {
-				migration, _ = metadataCache.Migration.Load()
-				return migration.Failed
-			}, 5*time.Second, 2).Should(BeTrue(), fmt.Sprintf("failed migration result wasn't set [%+v]", migration))
 		})
 
 		It("should detect inprogress migration job", func() {

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -363,7 +363,7 @@ func ConfirmVMIPostMigrationFailed(vmi *v1.VirtualMachineInstance, migrationUID 
 	Expect(vmi.Status.MigrationState.EndTimestamp).ToNot(BeNil())
 	Expect(vmi.Status.MigrationState.SourceNode).To(Equal(vmi.Status.NodeName))
 	Expect(vmi.Status.MigrationState.TargetNode).ToNot(Equal(vmi.Status.MigrationState.SourceNode))
-	Expect(vmi.Status.MigrationState.Completed).To(BeTrue())
+	Expect(vmi.Status.MigrationState.Completed).To(BeFalse())
 	Expect(vmi.Status.MigrationState.Failed).To(BeTrue())
 	Expect(vmi.Status.MigrationState.TargetNodeAddress).ToNot(Equal(""))
 	Expect(string(vmi.Status.MigrationState.MigrationUID)).To(Equal(migrationUID))
@@ -388,7 +388,7 @@ func ConfirmVMIPostMigrationAborted(vmi *v1.VirtualMachineInstance, migrationUID
 
 	}, timeout, 1*time.Second).Should(
 		gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Completed":   BeTrue(),
+			"Completed":   BeFalse(),
 			"AbortStatus": Equal(v1.MigrationAbortSucceeded),
 		}),
 	)

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1559,9 +1559,6 @@ var _ = SIGMigrationDescribe("VM Live Migration", decorators.RequiresTwoSchedula
 
 				// check VMI, confirm migration state
 				vmi = libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
-				// Not sure how consistent the entire error is, so just making sure the failure happened in libvirt. Example string:
-				// Live migration failed error encountered during MigrateToURI3 libvirt api call: virError(Code=1, Domain=7, Message='internal error: client socket is closed'
-				Expect(vmi.Status.MigrationState.FailureReason).To(ContainSubstring("libvirt api call"))
 
 				By("Removing our migration killer pods")
 				for _, podName := range createdPods {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

KubeVirt would mark a migration as completed as soon as the domain would start running on the target, this is wrong as it doesn't really mean that the migration ended and it is particularly harmful when the migration runs in PostCopy mode as it would lead to hotplug operations to fail.

After this PR:

The migration code marks the migration as completed when it is actually completed, in addition this PR fixes a series of bugs in the migration logic.

A nice side-effect is that now hotplug works in postcopy-mode.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix virt-handler migration completion logic 
```

