### PR TITLE
[release-1.4] Set VM status indication if storage exceeds quota

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -193,6 +193,16 @@ func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeSt
 	return nil
 }
 
+// FIXME: Bound mistakenly reports ErrExceededQuota with ConditionUnknown status
+func HasDataVolumeExceededQuotaError(dv *cdiv1.DataVolume) error {
+	dvBoundCond := NewDataVolumeConditionManager().GetCondition(dv, cdiv1.DataVolumeBound)
+	if dvBoundCond != nil && dvBoundCond.Status != v1.ConditionTrue && dvBoundCond.Reason == "ErrExceededQuota" {
+		return fmt.Errorf("DataVolume %s importer is not running due to an error: %v", dv.Name, dvBoundCond.Message)
+	}
+
+	return nil
+}
+
 func HasDataVolumeProvisioning(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store) bool {
 	for _, volume := range volumes {
 		if volume.DataVolume == nil {

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -3924,6 +3924,41 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(err).To(Succeed())
 					Expect(vm.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusProvisioning))
 				})
+
+				It("should set a Provisioning status and add a Failure condition if DV PVC creation fails due to exceeded quota", func() {
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					dv, _ := watchutil.CreateDataVolumeManifest(virtClient, vm.Spec.DataVolumeTemplates[0], vm)
+					dv.Status.Phase = cdiv1.Pending
+					dv.Status.Conditions = append(dv.Status.Conditions, cdiv1.DataVolumeCondition{
+						Type:   cdiv1.DataVolumeBound,
+						Status: k8sv1.ConditionUnknown,
+						Reason: "ErrExceededQuota",
+						Message: "persistentvolumeclaims \"dv1\" is forbidden: exceeded quota: storage, " +
+							"requested: requests.storage=2Gi, used: requests.storage=0, limited: requests.storage=1Gi",
+					})
+					controller.dataVolumeStore.Add(dv)
+
+					sanityExecute(vm)
+
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+					Expect(vm.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusProvisioning))
+
+					cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(vm, v1.VirtualMachineFailure)
+					Expect(cond).To(Not(BeNil()))
+					Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Type":   Equal(v1.VirtualMachineFailure),
+						"Reason": Equal("FailedCreate"),
+						"Message": And(
+							ContainSubstring("Error encountered while creating DataVolumes"),
+							ContainSubstring("importer is not running due to an error"),
+							ContainSubstring("forbidden: exceeded quota: storage"),
+						),
+					}))
+				})
 			})
 
 			Context("VM with PersistentVolumeClaims", func() {


### PR DESCRIPTION
### What this PR does
Manual backport of #13667

When a VM requests storage beyond the limits defined by a` ResourceQuota`, it gets stuck in the `Provisioning` status with only a `VMINotExists` reason. This leaves the user unaware of how to resolve the issue:

```
  status:
    conditions:
    - message: VMI does not exist
      reason: VMINotExists
      status: "False"
      type: Ready
```
The fix adds an informative `FailedCreate` condition:

```
  status:
    conditions:
    - message: VMI does not exist
      reason: VMINotExists
      status: "False"
      type: Ready
    - message: 'Error encountered while creating DataVolumes: DataVolume my-vol importer is not running due to an error: persistentvolumeclaims "my-vol" is forbidden: exceeded quota: storage, requested: requests.storage=10737418240, used: requests.storage=0, limited: requests.storage=2Gi'
      reason: FailedCreate
      status: "True"
      type: Failure
```

jira-ticket: https://issues.redhat.com/browse/CNV-42175

### Release note
```release-note
Set VM status indication if storage exceeds quota
```