### PR TITLE
Create sidecar hooks to mount EKS service accounts

### DIFF
--- a/cmd/sidecars/eks-env-vars/BUILD.bazel
+++ b/cmd/sidecars/eks-env-vars/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["eks.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/eks",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "preCloudInitIso",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+
+container_image(
+    name = "example-hook-sidecar-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = "//cmd/sidecars:sidecar-shim-image",
+    directory = "/usr/bin/",
+    entrypoint = ["/sidecar-shim"],
+    files = [":preCloudInitIso"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sidecars/eks-env-vars/eks.go
+++ b/cmd/sidecars/eks-env-vars/eks.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/pflag"
+	v1 "kubevirt.io/api/core/v1"
+	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
+)
+
+const (
+	awsRoleArn                        = "AWS_ROLE_ARN"
+	awsRegion                         = "AWS_REGION"
+	serviceAccountTargetDirAnnotation = "serviceaccounts.vm.kubevirt.io/targetDir"
+)
+
+const cloudInitTemplate = `
+#cloud-config
+write_files:
+  - path: /etc/profile.d/aws_env.sh
+    permissions: '0644'
+    owner: root:root
+    content: |
+      export AWS_ROLE_ARN="{{ .arn }}"
+      export AWS_WEB_IDENTITY_TOKEN_FILE="{{ .tokenFile }}"
+      export AWS_REGION="{{ .region }}"
+
+runcmd:
+  - chmod +x /etc/profile.d/aws_env.sh
+  - source /etc/profile.d/aws_env.sh
+`
+
+func preCloudInitIso(log *log.Logger, vmiJSON, cloudInitDataJSON []byte) (string, error) {
+	log.Print("Hook's PreCloudInitIso callback method has been called")
+
+	vmi := v1.VirtualMachineInstance{}
+	err := json.Unmarshal(vmiJSON, &vmi)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal given VMI spec: %s %s", err, string(vmiJSON))
+	}
+
+	// The hook will read the source (the path to the socket on the virt launcher) to set it as the AWS_WEB_IDENTITY_TOKEN_FILE
+	if _, ok := vmi.Annotations[serviceAccountTargetDirAnnotation]; ok {
+		return "", fmt.Errorf("target directory annotation not set, exiting")
+	}
+
+	cloudInitData := cloudinit.CloudInitData{}
+	err = json.Unmarshal(cloudInitDataJSON, &cloudInitData)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal given CloudInitData: %s %s", err, string(cloudInitDataJSON))
+	}
+
+	// Use a go template to parse the variables into a script to be used in cloud init user data
+	var out *bytes.Buffer
+	tmpl, err := template.New("aws").Parse(cloudInitTemplate)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse go template: %s", err)
+	}
+
+	// Read the variables from the container env, they should be added by the AWS pod identity webhook
+	arn, region := getAwsEnvVars()
+	awsMap := map[string]string{
+		"arn":       arn,
+		"tokenFile": vmi.Annotations[serviceAccountTargetDirAnnotation],
+		"region":    region,
+	}
+
+	if err := tmpl.Execute(out, awsMap); err != nil {
+		return "", fmt.Errorf("Failed to replace template variables")
+	}
+
+	// Handle the case where there already is a cloud init user data, by appending what the user had to the end of the script specified
+	// TODO: this might not work if the keys can't be duplicated
+	if cloudInitData.UserData != "" {
+		withoutCloudConfig := strings.Replace(cloudInitData.UserData, "#cloud-config", "", 1)
+		endConfig := out.String() + withoutCloudConfig
+		cloudInitData.UserData = endConfig
+	} else {
+		cloudInitData.UserData = out.String()
+	}
+
+	response, err := json.Marshal(cloudInitData)
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal CloudInitData: %s %+v", err, cloudInitData)
+	}
+
+	return string(response), nil
+}
+
+func getAwsEnvVars() (string, string) {
+	return mustGetEnv(awsRoleArn), mustGetEnv(awsRegion)
+}
+
+func mustGetEnv(key string) string {
+	if key := os.Getenv(key); key != "" {
+		return key
+	}
+	panic("Key " + key + " not set, exiting!")
+}
+
+func main() {
+	var vmiJSON, cloudInitDataJSON string
+	pflag.StringVar(&vmiJSON, "vmi", "", "Current VMI, in JSON format")
+	pflag.StringVar(&cloudInitDataJSON, "cloud-init", "", "The CloudInitData, in JSON format")
+	pflag.Parse()
+
+	logger := log.New(os.Stderr, "cloudinit", log.Ldate)
+	if vmiJSON == "" || cloudInitDataJSON == "" {
+		logger.Printf("Bad input vmi=%d, cloud-init=%d", len(vmiJSON), len(cloudInitDataJSON))
+		os.Exit(1)
+	}
+
+	cloudInitData, err := preCloudInitIso(logger, []byte(vmiJSON), []byte(cloudInitDataJSON))
+	if err != nil {
+		logger.Printf("preCloudInitIso failed: %s", err)
+		panic(err)
+	}
+	fmt.Println(cloudInitData)
+}

--- a/cmd/sidecars/vmi-service-account/BUILD.bazel
+++ b/cmd/sidecars/vmi-service-account/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["sa.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/eks",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "onDefineDomain",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+
+container_image(
+    name = "example-hook-sidecar-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = "//cmd/sidecars:sidecar-shim-image",
+    directory = "/usr/bin/",
+    entrypoint = ["/sidecar-shim"],
+    files = [":onDefineDomain"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sidecars/vmi-service-account/sa.go
+++ b/cmd/sidecars/vmi-service-account/sa.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/pflag"
+	vmSchema "kubevirt.io/api/core/v1"
+	"libvirt.org/go/libvirtxml"
+)
+
+const (
+	virtioFsSocketDirAnnotation       = "serviceaccounts.vm.kubevirt.io/socketSourceDir"
+	serviceAccountTargetDirAnnotation = "serviceaccounts.vm.kubevirt.io/targetDir"
+)
+
+func onDefineDomain(vmiJSON, domainXML []byte) (string, error) {
+	vmiSpec := vmSchema.VirtualMachineInstance{}
+	if err := json.Unmarshal(vmiJSON, &vmiSpec); err != nil {
+		return "", fmt.Errorf("failed to unmarshal given VMI spec: %s %s", err, string(vmiJSON))
+	}
+
+	// Read the source socket file and its mount target from the VMI spec
+	if _, ok := vmiSpec.Annotations[serviceAccountTargetDirAnnotation]; ok {
+		return "", fmt.Errorf("target directory annotation not set, exiting")
+	}
+
+	if _, ok := vmiSpec.Annotations[virtioFsSocketDirAnnotation]; !ok {
+		return "", fmt.Errorf("source directory annotation not set, exiting")
+	}
+
+	domainSpec := libvirtxml.Domain{}
+	if err := xml.Unmarshal(domainXML, &domainSpec); err != nil {
+		return "", fmt.Errorf("failed to unmarshal given domain spec: %s %s", err, string(domainXML))
+	}
+
+	// TODO: Verify if this configuration applies to everything
+	var (
+		d uint = 0x0000
+		b uint = 0x01
+		f uint = 0x00
+		s uint = 0x00
+	)
+
+	// Create a libvirt domain entry for a virtio filesystem that maps to the socket file of the service account mounted from the pod
+	domainSpec.Devices.Filesystems = append(domainSpec.Devices.Filesystems, libvirtxml.DomainFilesystem{
+		Address: &libvirtxml.DomainAddress{
+			PCI: &libvirtxml.DomainAddressPCI{
+				Domain:   &d,
+				Bus:      &b,
+				Function: &f,
+				Slot:     &s,
+			},
+		},
+		Source: &libvirtxml.DomainFilesystemSource{File: &libvirtxml.DomainFilesystemSourceFile{File: vmiSpec.Annotations[virtioFsSocketDirAnnotation]}},
+		Target: &libvirtxml.DomainFilesystemTarget{Dir: vmiSpec.Annotations[serviceAccountTargetDirAnnotation]},
+		Driver: &libvirtxml.DomainFilesystemDriver{Type: "virtiofs"}})
+
+	newDomainXML, err := xml.Marshal(domainSpec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal new Domain spec: %s %+v", err, domainSpec)
+	}
+
+	return string(newDomainXML), nil
+}
+
+func main() {
+	var vmiJSON, domainXML string
+	pflag.StringVar(&vmiJSON, "vmi", "", "VMI to change in JSON format")
+	pflag.StringVar(&domainXML, "domain", "", "Domain spec in XML format")
+	pflag.Parse()
+
+	logger := log.New(os.Stderr, "smbios", log.Ldate)
+	if vmiJSON == "" || domainXML == "" {
+		logger.Printf("Bad input vmi=%d, domain=%d", len(vmiJSON), len(domainXML))
+		os.Exit(1)
+	}
+
+	domainXML, err := onDefineDomain([]byte(vmiJSON), []byte(domainXML))
+	if err != nil {
+		logger.Printf("onDefineDomain failed: %s", err)
+		panic(err)
+	}
+	fmt.Println(domainXML)
+}


### PR DESCRIPTION
### What this PR does
Before this PR:

Only the default service account gets mounted into the VM

After this PR:

Other service accounts (EKS) can be added to the VM as well, allowing the VM to assume an IAM role

Fixes https://github.com/kubevirt/kubevirt/issues/13311

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
MOUNT EKS SERVICE ACCOUNTS TO THE VM
```
