### PR TITLE
tests/clone_test: Refactor createVM function

### DIFF
--- a/pkg/libvmi/vm.go
+++ b/pkg/libvmi/vm.go
@@ -59,6 +59,28 @@ func NewVirtualMachine(vmi *v1.VirtualMachineInstance, opts ...VMOption) *v1.Vir
 	return vm
 }
 
+func WithAnnotations(annotations map[string]string) VMOption {
+	return func(vm *v1.VirtualMachine) {
+		if vm.Annotations == nil {
+			vm.Annotations = annotations
+		}
+		for key, val := range annotations {
+			vm.Annotations[key] = val
+		}
+	}
+}
+
+func WithLabels(labels map[string]string) VMOption {
+	return func(vm *v1.VirtualMachine) {
+		if vm.Labels == nil {
+			vm.Labels = labels
+		}
+		for key, val := range labels {
+			vm.Labels[key] = val
+		}
+	}
+}
+
 func WithRunStrategy(strategy v1.VirtualMachineRunStrategy) VMOption {
 	return func(vm *v1.VirtualMachine) {
 		vm.Spec.RunStrategy = &strategy

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -267,19 +267,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			Expect(vm1Spec).To(Equal(vm2Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec not including mac adresses"))
 		}
 
-		createVM := func(options ...libvmi.Option) *virtv1.VirtualMachine {
-			vmi := libvmifact.NewCirros(options...)
-			vmi.Namespace = testsuite.GetTestNamespace(nil)
-			vm := libvmi.NewVirtualMachine(vmi,
-				libvmi.WithAnnotations(vmi.Annotations),
-				libvmi.WithLabels(vmi.Labels))
-
-			By(fmt.Sprintf("Creating VM %s", vm.Name))
-			vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-			return vm
-		}
-
 		generateCloneFromVM := func() *clone.VirtualMachineClone {
 			return generateCloneFromVMWithParams(sourceVM, targetVMName)
 		}
@@ -291,7 +278,8 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			}
 
 			It("simple default clone", func() {
-				sourceVM = createVM(defaultVMIOptions...)
+				sourceVM, err = createSourceVM(defaultVMIOptions...)
+				Expect(err).ShouldNot(HaveOccurred())
 				vmClone = generateCloneFromVM()
 
 				createCloneAndWaitForFinish(vmClone)
@@ -324,7 +312,8 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 
 			It("simple clone with snapshot source", func() {
 				By("Creating a VM")
-				sourceVM = createVM(defaultVMIOptions...)
+				sourceVM, err = createSourceVM(defaultVMIOptions...)
+				Expect(err).ShouldNot(HaveOccurred())
 				Eventually(func() virtv1.VirtualMachinePrintableStatus {
 					sourceVM, err = virtClient.VirtualMachine(sourceVM.Namespace).Get(context.Background(), sourceVM.Name, v1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -362,7 +351,8 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			})
 
 			It("clone with only some of labels/annotations", func() {
-				sourceVM = createVM(defaultVMIOptions...)
+				sourceVM, err = createSourceVM(defaultVMIOptions...)
+				Expect(err).ShouldNot(HaveOccurred())
 				vmClone = generateCloneFromVM()
 
 				vmClone.Spec.LabelFilters = []string{
@@ -387,7 +377,8 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			})
 
 			It("clone with only some of template.labels/template.annotations", func() {
-				sourceVM = createVM(defaultVMIOptions...)
+				sourceVM, err = createSourceVM(defaultVMIOptions...)
+				Expect(err).ShouldNot(HaveOccurred())
 				vmClone = generateCloneFromVM()
 
 				vmClone.Spec.Template.LabelFilters = []string{
@@ -417,7 +408,8 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 				)
-				sourceVM = createVM(options...)
+				sourceVM, err = createSourceVM(options...)
+				Expect(err).ShouldNot(HaveOccurred())
 
 				srcInterfaces := sourceVM.Spec.Template.Spec.Domain.Devices.Interfaces
 				Expect(srcInterfaces).ToNot(BeEmpty())
@@ -467,7 +459,8 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 						defaultVMIOptions,
 						withFirmware(&virtv1.Firmware{Serial: sourceSerial}),
 					)
-					sourceVM = createVM(options...)
+					sourceVM, err = createSourceVM(options...)
+					Expect(err).ShouldNot(HaveOccurred())
 
 					vmClone = generateCloneFromVM()
 					vmClone.Spec.NewSMBiosSerial = pointer.P(targetSerial)
@@ -499,7 +492,8 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 						defaultVMIOptions,
 						withFirmware(&virtv1.Firmware{UUID: fakeFirmwareUUID}),
 					)
-					sourceVM = createVM(options...)
+					sourceVM, err = createSourceVM(options...)
+					Expect(err).ShouldNot(HaveOccurred())
 					vmClone = generateCloneFromVM()
 
 					createCloneAndWaitForFinish(vmClone)
@@ -867,4 +861,16 @@ func withFirmware(firmware *virtv1.Firmware) libvmi.Option {
 	return func(vmi *virtv1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Firmware = firmware
 	}
+}
+
+func createSourceVM(options ...libvmi.Option) (*virtv1.VirtualMachine, error) {
+	vmi := libvmifact.NewCirros(options...)
+	vmi.Namespace = testsuite.GetTestNamespace(nil)
+	vm := libvmi.NewVirtualMachine(vmi,
+		libvmi.WithAnnotations(vmi.Annotations),
+		libvmi.WithLabels(vmi.Labels))
+
+	By(fmt.Sprintf("Creating VM %s", vm.Name))
+	virtClient := kubevirt.Client()
+	return virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})
 }

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -61,20 +61,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		format.MaxLength = 0
 	})
 
-	createVM := func(options ...libvmi.Option) (vm *virtv1.VirtualMachine) {
-		vmi := libvmifact.NewCirros(options...)
-		vmi.Namespace = testsuite.GetTestNamespace(nil)
-		vm = libvmi.NewVirtualMachine(vmi,
-			libvmi.WithAnnotations(vmi.Annotations),
-			libvmi.WithLabels(vmi.Labels))
-
-		By(fmt.Sprintf("Creating VM %s", vm.Name))
-		vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		return
-	}
-
 	createSnapshot := func(vm *virtv1.VirtualMachine) *snapshotv1.VirtualMachineSnapshot {
 		var err error
 
@@ -284,7 +270,16 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			}
 
 			options = append(options, defaultOptions...)
-			return createVM(options...)
+			vmi := libvmifact.NewCirros(options...)
+			vmi.Namespace = testsuite.GetTestNamespace(nil)
+			vm := libvmi.NewVirtualMachine(vmi,
+				libvmi.WithAnnotations(vmi.Annotations),
+				libvmi.WithLabels(vmi.Labels))
+
+			By(fmt.Sprintf("Creating VM %s", vm.Name))
+			vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			return
 		}
 
 		generateCloneFromVM := func() *clone.VirtualMachineClone {

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -64,9 +64,9 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 	createVM := func(options ...libvmi.Option) (vm *virtv1.VirtualMachine) {
 		vmi := libvmifact.NewCirros(options...)
 		vmi.Namespace = testsuite.GetTestNamespace(nil)
-		vm = libvmi.NewVirtualMachine(vmi)
-		vm.Annotations = vmi.Annotations
-		vm.Labels = vmi.Labels
+		vm = libvmi.NewVirtualMachine(vmi,
+			libvmi.WithAnnotations(vmi.Annotations),
+			libvmi.WithLabels(vmi.Labels))
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
 		vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -67,8 +67,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		vm = libvmi.NewVirtualMachine(vmi)
 		vm.Annotations = vmi.Annotations
 		vm.Labels = vmi.Labels
-		vm.Spec.Template.ObjectMeta.Annotations = vmi.Annotations
-		vm.Spec.Template.ObjectMeta.Labels = vmi.Labels
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
 		vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -464,9 +464,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 					const targetSerial = "target-serial"
 
 					sourceVM = createVM(
-						func(vmi *virtv1.VirtualMachineInstance) {
-							vmi.Spec.Domain.Firmware = &virtv1.Firmware{Serial: sourceSerial}
-						},
+						withFirmware(&virtv1.Firmware{Serial: sourceSerial}),
 					)
 
 					vmClone = generateCloneFromVM()
@@ -496,9 +494,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 					const fakeFirmwareUUID = "fake-uuid"
 
 					sourceVM = createVM(
-						func(vmi *virtv1.VirtualMachineInstance) {
-							vmi.Spec.Domain.Firmware = &virtv1.Firmware{UUID: fakeFirmwareUUID}
-						},
+						withFirmware(&virtv1.Firmware{UUID: fakeFirmwareUUID}),
 					)
 					vmClone = generateCloneFromVM()
 
@@ -861,4 +857,10 @@ func stopCloneVM(virtClient kubecli.KubevirtClient, vm *virtv1.VirtualMachine) (
 	}
 
 	return virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, v1.PatchOptions{})
+}
+
+func withFirmware(firmware *virtv1.Firmware) libvmi.Option {
+	return func(vmi *virtv1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Firmware = firmware
+	}
 }

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -261,7 +261,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			Expect(vm1Spec).To(Equal(vm2Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec not including mac adresses"))
 		}
 
-		createVM := func(options ...libvmi.Option) (vm *virtv1.VirtualMachine) {
+		createVM := func(options ...libvmi.Option) *virtv1.VirtualMachine {
 			defaultOptions := []libvmi.Option{
 				libvmi.WithLabel(key1, value1),
 				libvmi.WithLabel(key2, value2),
@@ -279,7 +279,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			By(fmt.Sprintf("Creating VM %s", vm.Name))
 			vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
-			return
+			return vm
 		}
 
 		generateCloneFromVM := func() *clone.VirtualMachineClone {


### PR DESCRIPTION
### What this PR does
This PR refactors a function createVM on tests/clone_test.go.
Reducing function complexity by:
- removing function shadowing
- refactoring to use as regular function.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

