### PR TITLE
[OWNERS] Remove stu-gott and kbidarkar from being reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,7 +26,6 @@ aliases:
     - dhiller # 2024-03-15
     - AlonaKaplan
   code-reviewers:
-    - stu-gott
     - vladikr
     - enp0s3
     - jean-edouard

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -45,6 +45,10 @@ aliases:
   #
   sig-test-reviewers:
     - kbidarkar
+    - enp0s3
+    - xpivarc
+    - acardace
+    - 0xFelix
   sig-test-approvers:
     - kbidarkar
     - phoracek

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -44,7 +44,6 @@ aliases:
   # SIG Test
   #
   sig-test-reviewers:
-    - kbidarkar
     - enp0s3
     - xpivarc
     - acardace


### PR DESCRIPTION
### What this PR does
We use Prow to auto-assign folks for a PR review. These assigned reviewers are expected to act within a reasonable time, hence be pretty active community members.

This PR removes @stu-gott and @kbidarkar from being reviewers, since they've expressed their lack of time to constantly review PRs. They are still approvers (@stu-gott is a root approver and @kbidarkar is a test approver), but won't be assigned to code-reviews anymore.

I've pinged them both offline to make sure this is OK with them, but please raise your concerns / objections if you have any.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

