### PR TITLE
fix(virt-controller): prevent exec probes to be wrapped twice

### DIFF
--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -261,7 +261,7 @@ func wrapExecProbeWithVirtProbe(vmi *v1.VirtualMachineInstance, probe *k8sv1.Pro
 	}
 
 	originalCommand := probe.ProbeHandler.Exec.Command
-	if len(originalCommand) < 1 {
+	if len(originalCommand) < 1 || originalCommand[0] == "virt-probe" {
 		return
 	}
 


### PR DESCRIPTION
### What this PR does
Before this PR:
* There's an unidentified "double reconcile" and/or kind of race condition that is wrapping the exec conmmand twice when processing a VMI.
* Wrapping a `virt-probe` inside another `virt-probe` command definitely breaks the VMI and then requires a manual operation to fix it.

After this PR:
* wrapping function now verfiies that VMI probe exec command is not already wrapped before wrapping it.

**Fixes #11755**

### Why we need it and why it was done in this way
The following tradeoffs were made:
* _none_

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

