### PR TITLE
Memory Dump: move memory dump code to pkg/storage

### DIFF
--- a/pkg/storage/memorydump/BUILD.bazel
+++ b/pkg/storage/memorydump/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["memorydump.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/storage/memorydump",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/storage/types:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "memorydump_suite_test.go",
+        "memorydump_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/pointer:go_default_library",
+        "//pkg/testutils:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)

--- a/pkg/storage/memorydump/BUILD.bazel
+++ b/pkg/storage/memorydump/BUILD.bazel
@@ -38,9 +38,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
-        "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/storage/memorydump/memorydump.go
+++ b/pkg/storage/memorydump/memorydump.go
@@ -1,0 +1,299 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package memorydump
+
+import (
+	"context"
+	"fmt"
+
+	k8score "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+)
+
+const (
+	ErrorReason = "MemoryDumpError"
+	failed      = "Memory dump failed"
+)
+
+func HasCompleted(vm *v1.VirtualMachine) bool {
+	return vm.Status.MemoryDumpRequest != nil && vm.Status.MemoryDumpRequest.Phase != v1.MemoryDumpAssociating && vm.Status.MemoryDumpRequest.Phase != v1.MemoryDumpInProgress
+}
+
+func RemoveMemoryDumpVolumeFromVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, claimName string) *v1.VirtualMachineInstanceSpec {
+	newVolumesList := []v1.Volume{}
+	for _, volume := range vmiSpec.Volumes {
+		if volume.Name != claimName {
+			newVolumesList = append(newVolumesList, volume)
+		}
+	}
+	vmiSpec.Volumes = newVolumesList
+	return vmiSpec
+}
+
+func HandleRequest(client kubecli.KubevirtClient, vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, pvcStore cache.Store) error {
+	if vm.Status.MemoryDumpRequest == nil {
+		return nil
+	}
+
+	vmiVolumeMap := make(map[string]v1.Volume)
+	if vmi != nil {
+		for _, volume := range vmi.Spec.Volumes {
+			vmiVolumeMap[volume.Name] = volume
+		}
+	}
+	switch vm.Status.MemoryDumpRequest.Phase {
+	case v1.MemoryDumpAssociating:
+		if vmi == nil || vmi.DeletionTimestamp != nil || !vmi.IsRunning() {
+			return nil
+		}
+		// When in state associating we want to add the memory dump pvc
+		// as a volume in the vm and in the vmi to trigger the mount
+		// to virt launcher and the memory dump
+		vm.Spec.Template.Spec = *applyMemoryDumpVolumeRequestOnVMISpec(&vm.Spec.Template.Spec, vm.Status.MemoryDumpRequest.ClaimName)
+		if _, exists := vmiVolumeMap[vm.Status.MemoryDumpRequest.ClaimName]; exists {
+			return nil
+		}
+		if err := generateVMIMemoryDumpVolumePatch(client, vmi, vm.Status.MemoryDumpRequest, true); err != nil {
+			log.Log.Object(vmi).Errorf("unable to patch vmi to add memory dump volume: %v", err)
+			return err
+		}
+	case v1.MemoryDumpUnmounting, v1.MemoryDumpFailed:
+		if err := updatePVCMemoryDumpAnnotation(client, vm, pvcStore); err != nil {
+			return err
+		}
+		// Check if the memory dump is in the vmi list of volumes,
+		// if it still there remove it to make it unmount from virt launcher
+		if _, exists := vmiVolumeMap[vm.Status.MemoryDumpRequest.ClaimName]; !exists {
+			return nil
+		}
+
+		if err := generateVMIMemoryDumpVolumePatch(client, vmi, vm.Status.MemoryDumpRequest, false); err != nil {
+			log.Log.Object(vmi).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
+			return err
+		}
+	case v1.MemoryDumpDissociating:
+		// Check if the memory dump is in the vmi list of volumes,
+		// if it still there remove it to make it unmount from virt launcher
+		if _, exists := vmiVolumeMap[vm.Status.MemoryDumpRequest.ClaimName]; exists {
+			if err := generateVMIMemoryDumpVolumePatch(client, vmi, vm.Status.MemoryDumpRequest, false); err != nil {
+				log.Log.Object(vmi).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
+				return err
+			}
+		}
+
+		vm.Spec.Template.Spec = *RemoveMemoryDumpVolumeFromVMISpec(&vm.Spec.Template.Spec, vm.Status.MemoryDumpRequest.ClaimName)
+	}
+
+	return nil
+}
+
+func UpdateRequest(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) {
+	if vm.Status.MemoryDumpRequest == nil {
+		return
+	}
+
+	updatedMemoryDumpReq := vm.Status.MemoryDumpRequest.DeepCopy()
+
+	if vm.Status.MemoryDumpRequest.Remove {
+		updatedMemoryDumpReq.Phase = v1.MemoryDumpDissociating
+	}
+
+	switch vm.Status.MemoryDumpRequest.Phase {
+	case v1.MemoryDumpCompleted:
+		// Once memory dump completed, there is no update neeeded,
+		// A new update will come from the subresource API once
+		// a new request will be issued
+		return
+	case v1.MemoryDumpAssociating:
+		// Update Phase to InProgrees once the memory dump
+		// is in the list of vm volumes
+		for _, volume := range vm.Spec.Template.Spec.Volumes {
+			if vm.Status.MemoryDumpRequest.ClaimName == volume.Name {
+				updatedMemoryDumpReq.Phase = v1.MemoryDumpInProgress
+				break
+			}
+		}
+	case v1.MemoryDumpInProgress:
+		// Update to unmounting once getting update in the vmi volume status
+		// that the dump timestamp is updated
+		if vmi != nil && len(vmi.Status.VolumeStatus) > 0 {
+			for _, volumeStatus := range vmi.Status.VolumeStatus {
+				if volumeStatus.Name == vm.Status.MemoryDumpRequest.ClaimName &&
+					volumeStatus.MemoryDumpVolume != nil {
+					if volumeStatus.MemoryDumpVolume.StartTimestamp != nil {
+						updatedMemoryDumpReq.StartTimestamp = volumeStatus.MemoryDumpVolume.StartTimestamp
+					}
+					if volumeStatus.Phase == v1.MemoryDumpVolumeCompleted {
+						updatedMemoryDumpReq.Phase = v1.MemoryDumpUnmounting
+						updatedMemoryDumpReq.EndTimestamp = volumeStatus.MemoryDumpVolume.EndTimestamp
+						updatedMemoryDumpReq.FileName = &volumeStatus.MemoryDumpVolume.TargetFileName
+					} else if volumeStatus.Phase == v1.MemoryDumpVolumeFailed {
+						updatedMemoryDumpReq.Phase = v1.MemoryDumpFailed
+						updatedMemoryDumpReq.Message = volumeStatus.Message
+						updatedMemoryDumpReq.EndTimestamp = volumeStatus.MemoryDumpVolume.EndTimestamp
+					}
+				}
+			}
+		}
+	case v1.MemoryDumpUnmounting:
+		// Update memory dump as completed once the memory dump has been
+		// unmounted - not a part of the vmi volume status
+		if vmi != nil {
+			for _, volumeStatus := range vmi.Status.VolumeStatus {
+				// If we found the claim name in the vmi volume status
+				// then the pvc is still mounted
+				if volumeStatus.Name == vm.Status.MemoryDumpRequest.ClaimName {
+					return
+				}
+			}
+		}
+		updatedMemoryDumpReq.Phase = v1.MemoryDumpCompleted
+	case v1.MemoryDumpDissociating:
+		// Make sure the memory dump is not in the vmi list of volumes
+		if vmi != nil {
+			for _, volumeStatus := range vmi.Status.VolumeStatus {
+				if volumeStatus.Name == vm.Status.MemoryDumpRequest.ClaimName {
+					return
+				}
+			}
+		}
+		// Make sure the memory dump is not in the list of vm volumes
+		for _, volume := range vm.Spec.Template.Spec.Volumes {
+			if vm.Status.MemoryDumpRequest.ClaimName == volume.Name {
+				return
+			}
+		}
+		// Remove the memory dump request
+		updatedMemoryDumpReq = nil
+	}
+
+	vm.Status.MemoryDumpRequest = updatedMemoryDumpReq
+}
+
+func generateVMIMemoryDumpVolumePatch(client kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, request *v1.VirtualMachineMemoryDumpRequest, addVolume bool) error {
+	foundRemoveVol := false
+	for _, volume := range vmi.Spec.Volumes {
+		if request.ClaimName == volume.Name {
+			if addVolume {
+				return fmt.Errorf("Unable to add volume [%s] because it already exists", volume.Name)
+			} else {
+				foundRemoveVol = true
+			}
+		}
+	}
+
+	if !foundRemoveVol && !addVolume {
+		return fmt.Errorf("Unable to remove volume [%s] because it does not exist", request.ClaimName)
+	}
+
+	vmiCopy := vmi.DeepCopy()
+	if addVolume {
+		vmiCopy.Spec = *applyMemoryDumpVolumeRequestOnVMISpec(&vmiCopy.Spec, request.ClaimName)
+	} else {
+		vmiCopy.Spec = *RemoveMemoryDumpVolumeFromVMISpec(&vmiCopy.Spec, request.ClaimName)
+	}
+	patchset := patch.New(
+		patch.WithTest("/spec/volumes", vmi.Spec.Volumes),
+	)
+	if len(vmi.Spec.Volumes) > 0 {
+		patchset.AddOption(patch.WithReplace("/spec/volumes", vmiCopy.Spec.Volumes))
+	} else {
+		patchset.AddOption(patch.WithAdd("/spec/volumes", vmiCopy.Spec.Volumes))
+	}
+
+	patchBytes, err := patchset.GeneratePayload()
+	if err != nil {
+		return err
+	}
+	_, err = client.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	return err
+}
+
+func applyMemoryDumpVolumeRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, claimName string) *v1.VirtualMachineInstanceSpec {
+	for _, volume := range vmiSpec.Volumes {
+		if volume.Name == claimName {
+			return vmiSpec
+		}
+	}
+
+	memoryDumpVol := &v1.MemoryDumpVolumeSource{
+		PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+			PersistentVolumeClaimVolumeSource: k8score.PersistentVolumeClaimVolumeSource{
+				ClaimName: claimName,
+			},
+			Hotpluggable: true,
+		},
+	}
+
+	newVolume := v1.Volume{
+		Name: claimName,
+	}
+	newVolume.VolumeSource.MemoryDump = memoryDumpVol
+
+	vmiSpec.Volumes = append(vmiSpec.Volumes, newVolume)
+
+	return vmiSpec
+}
+
+func needUpdatePVCMemoryDumpAnnotation(pvc *k8score.PersistentVolumeClaim, request *v1.VirtualMachineMemoryDumpRequest) bool {
+	if pvc.GetAnnotations() == nil {
+		return true
+	}
+	annotation, hasAnnotation := pvc.Annotations[v1.PVCMemoryDumpAnnotation]
+	return !hasAnnotation || (request.Phase == v1.MemoryDumpUnmounting && annotation != *request.FileName) || (request.Phase == v1.MemoryDumpFailed && annotation != failed)
+}
+
+func updatePVCMemoryDumpAnnotation(client kubecli.KubevirtClient, vm *v1.VirtualMachine, pvcStore cache.Store) error {
+	request := vm.Status.MemoryDumpRequest
+	pvc, err := storagetypes.GetPersistentVolumeClaimFromCache(vm.Namespace, request.ClaimName, pvcStore)
+	if err != nil {
+		log.Log.Object(vm).Errorf("Error getting PersistentVolumeClaim to update memory dump annotation: %v", err)
+		return err
+	}
+	if pvc == nil {
+		log.Log.Object(vm).Errorf("Error getting PersistentVolumeClaim to update memory dump annotation: %v", err)
+		return fmt.Errorf("Error when trying to update memory dump annotation, pvc %s not found", request.ClaimName)
+	}
+
+	if needUpdatePVCMemoryDumpAnnotation(pvc, request) {
+		if pvc.GetAnnotations() == nil {
+			pvc.SetAnnotations(make(map[string]string))
+		}
+		if request.Phase == v1.MemoryDumpUnmounting {
+			pvc.Annotations[v1.PVCMemoryDumpAnnotation] = *request.FileName
+		} else if request.Phase == v1.MemoryDumpFailed {
+			pvc.Annotations[v1.PVCMemoryDumpAnnotation] = failed
+		}
+		if _, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/storage/memorydump/memorydump_suite_test.go
+++ b/pkg/storage/memorydump/memorydump_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 The KubeVirt Contributors
+ *
+ */
+
+package memorydump_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestMemoryDump(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/storage/memorydump/memorydump_test.go
+++ b/pkg/storage/memorydump/memorydump_test.go
@@ -1,0 +1,286 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 The KubeVirt Contributors
+ *
+ */
+package memorydump
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8score "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/api"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/kubevirt/fake"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/testutils"
+)
+
+const (
+	testPVCName    = "testPVC"
+	targetFileName = "memory.dump"
+	vmName         = "testVM"
+)
+
+var now = metav1.Now()
+
+var _ = Describe("MemoryDump", func() {
+	var k8sClient *k8sfake.Clientset
+	var virtClient *kubecli.MockKubevirtClient
+	var virtFakeClient *fake.Clientset
+	var pvcStore cache.Store
+
+	BeforeEach(func() {
+		virtClient = kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
+		virtFakeClient = fake.NewSimpleClientset()
+
+		pvcInformer, _ := testutils.NewFakeInformerFor(&k8score.PersistentVolumeClaim{})
+		pvcStore = pvcInformer.GetStore()
+
+		// Set up mock client
+		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(
+			virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault),
+		).AnyTimes()
+
+		k8sClient = k8sfake.NewSimpleClientset()
+		virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
+	})
+
+	expectPVCAnnotationUpdate := func(expectedAnnotation string, pvcAnnotationUpdated chan bool) {
+		virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
+		k8sClient.Fake.PrependReactor("update", "persistentvolumeclaims", func(action testing.Action) (bool, runtime.Object, error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+
+			pvc, ok := update.GetObject().(*k8score.PersistentVolumeClaim)
+			Expect(ok).To(BeTrue())
+			Expect(pvc.Name).To(Equal(testPVCName))
+			Expect(pvc.Annotations[v1.PVCMemoryDumpAnnotation]).To(Equal(expectedAnnotation))
+			pvcAnnotationUpdated <- true
+
+			return true, nil, nil
+		})
+	}
+
+	Context("UpdateRequest", func() {
+		It("should update memory dump phase to InProgress when memory dump in vm volumes", func() {
+			vm, vmi := createVirtualMachineWithMemoryDump(v1.MemoryDumpAssociating)
+
+			// when the memory dump volume is in the vm volume list
+			// we should change status to in progress
+			updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
+				ClaimName: testPVCName,
+				Phase:     v1.MemoryDumpInProgress,
+			}
+
+			UpdateRequest(vm, vmi)
+			Expect(vm.Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+		})
+
+		It("should update status to unmounting when memory dump timestamp updated", func() {
+			vm, vmi := createVirtualMachineWithMemoryDump(v1.MemoryDumpInProgress)
+			vmi.Status.VolumeStatus = []v1.VolumeStatus{
+				{
+					Name:  testPVCName,
+					Phase: v1.MemoryDumpVolumeCompleted,
+					MemoryDumpVolume: &v1.DomainMemoryDumpInfo{
+						StartTimestamp: pointer.P(now),
+						EndTimestamp:   pointer.P(now),
+						ClaimName:      testPVCName,
+						TargetFileName: targetFileName,
+					},
+				},
+			}
+
+			updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
+				ClaimName:      testPVCName,
+				Phase:          v1.MemoryDumpUnmounting,
+				EndTimestamp:   pointer.P(now),
+				StartTimestamp: pointer.P(now),
+				FileName:       &vmi.Status.VolumeStatus[0].MemoryDumpVolume.TargetFileName,
+			}
+
+			UpdateRequest(vm, vmi)
+
+			Expect(vm.Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+		})
+
+		It("should update status to failed when memory dump failed", func() {
+			vm, vmi := createVirtualMachineWithMemoryDump(v1.MemoryDumpInProgress)
+			vmi.Status.VolumeStatus = []v1.VolumeStatus{
+				{
+					Name:    testPVCName,
+					Phase:   v1.MemoryDumpVolumeFailed,
+					Message: "Memory dump failed",
+					MemoryDumpVolume: &v1.DomainMemoryDumpInfo{
+						ClaimName:    testPVCName,
+						EndTimestamp: pointer.P(now),
+					},
+				},
+			}
+
+			updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
+				ClaimName:    testPVCName,
+				Phase:        v1.MemoryDumpFailed,
+				Message:      vmi.Status.VolumeStatus[0].Message,
+				EndTimestamp: pointer.P(now),
+			}
+
+			UpdateRequest(vm, vmi)
+
+			Expect(vm.Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+		})
+
+		It("should update memory dump to completed once memory dump volume unmounted", func() {
+			vm, vmi := createVirtualMachineWithMemoryDump(v1.MemoryDumpUnmounting)
+
+			// In case the volume is not in vmi volume status
+			// we should update status to completed
+			updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
+				ClaimName:    testPVCName,
+				Phase:        v1.MemoryDumpCompleted,
+				EndTimestamp: pointer.P(now),
+				FileName:     pointer.P(targetFileName),
+			}
+
+			UpdateRequest(vm, vmi)
+
+			Expect(vm.Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+		})
+
+		It("should dissociate memory dump request when status is Dissociating and not in vm volumes", func() {
+			// No need to add vmi - can do this action even if vm not running
+			vm, _ := createVirtualMachineWithMemoryDump(v1.MemoryDumpDissociating)
+
+			UpdateRequest(vm, nil)
+
+			Expect(vm.Status.MemoryDumpRequest).To(BeNil())
+		})
+	})
+
+	DescribeTable("should remove memory dump volume from vmi volumes and update pvc annotation", func(phase v1.MemoryDumpPhase, expectedAnnotation string) {
+		vm, vmi := createVirtualMachineWithMemoryDump(phase)
+
+		vmi.Status.VolumeStatus = []v1.VolumeStatus{
+			{
+				Name: testPVCName,
+				MemoryDumpVolume: &v1.DomainMemoryDumpInfo{
+					ClaimName: testPVCName,
+				},
+			},
+		}
+
+		vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		pvc := k8score.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testPVCName,
+				Namespace: vm.Namespace,
+			},
+		}
+		Expect(pvcStore.Add(&pvc)).To(Succeed())
+
+		pvcAnnotationUpdated := make(chan bool, 1)
+		defer close(pvcAnnotationUpdated)
+		// TODO: convert this to action check
+		expectPVCAnnotationUpdate(expectedAnnotation, pvcAnnotationUpdated)
+
+		HandleRequest(virtClient, vm, vmi, pvcStore)
+
+		vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vmi.Spec.Volumes).To(BeEmpty())
+
+		Eventually(func() bool {
+			select {
+			case updated := <-pvcAnnotationUpdated:
+				return updated
+			default:
+			}
+			return false
+		}, 10*time.Second, 2).Should(BeTrue(), "failed, pvc annotation wasn't updated")
+	},
+		Entry("when phase is Unmounting", v1.MemoryDumpUnmounting, targetFileName),
+		Entry("when phase is Failed", v1.MemoryDumpFailed, "Memory dump failed"),
+	)
+})
+
+func ApplyVMIMemoryDumpVol(spec *v1.VirtualMachineInstanceSpec) {
+	newVolume := v1.Volume{
+		Name: testPVCName,
+		VolumeSource: v1.VolumeSource{
+			MemoryDump: &v1.MemoryDumpVolumeSource{
+				PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: k8score.PersistentVolumeClaimVolumeSource{
+						ClaimName: testPVCName,
+					},
+					Hotpluggable: true,
+				},
+			},
+		},
+	}
+
+	spec.Volumes = append(spec.Volumes, newVolume)
+}
+
+func createVirtualMachineWithMemoryDump(memoryDumpPhase v1.MemoryDumpPhase) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
+	vmi := api.NewMinimalVMI(vmName)
+	vmi.Status.Phase = v1.Running
+	vm := &v1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: vmi.ObjectMeta.Namespace, ResourceVersion: "1", UID: "vm-uid"},
+		Spec: v1.VirtualMachineSpec{
+			RunStrategy: pointer.P(v1.RunStrategyAlways),
+			Template: &v1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   vmi.ObjectMeta.Name,
+					Labels: vmi.ObjectMeta.Labels,
+				},
+				Spec: vmi.Spec,
+			},
+		},
+	}
+	vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
+		ClaimName: testPVCName,
+		Phase:     memoryDumpPhase,
+	}
+	switch memoryDumpPhase {
+	case v1.MemoryDumpAssociating:
+		ApplyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
+	case v1.MemoryDumpInProgress, v1.MemoryDumpFailed:
+		ApplyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
+		vmi.Spec = vm.Spec.Template.Spec
+	case v1.MemoryDumpUnmounting:
+		ApplyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
+		vmi.Spec = vm.Spec.Template.Spec
+		vm.Status.MemoryDumpRequest.EndTimestamp = pointer.P(now)
+		vm.Status.MemoryDumpRequest.FileName = pointer.P(targetFileName)
+	}
+	return vm, vmi
+}

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/liveupdate/memory:go_default_library",
         "//pkg/network/admitter:go_default_library",
         "//pkg/network/vmispec:go_default_library",
+        "//pkg/storage/memorydump:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -64,6 +64,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/storage/memorydump"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
@@ -89,7 +90,6 @@ const (
 	failedCreateCRforVmErrMsg                 = "Failed to create controller revision for VirtualMachine."
 	failedProcessDeleteNotificationErrMsg     = "Failed to process delete notification"
 	failureDeletingVmiErrFormat               = "Failure attempting to delete VMI: %v"
-	failedMemoryDump                          = "Memory dump failed"
 	failedCleanupRestartRequired              = "Failed to delete RestartRequired condition or last-seen controller revisions"
 	failedManualRecoveryRequiredCondSetErrMsg = "cannot start the VM since it has the manual recovery required condtion set"
 
@@ -110,7 +110,6 @@ const (
 const (
 	hotplugVolumeErrorReason     = "HotPlugVolumeError"
 	hotplugCPUErrorReason        = "HotPlugCPUError"
-	memoryDumpErrorReason        = "MemoryDumpError"
 	failedUpdateErrorReason      = "FailedUpdateError"
 	failedCreateReason           = "FailedCreate"
 	vmiFailedDeleteReason        = "FailedDelete"
@@ -534,119 +533,6 @@ func (c *Controller) handleDataVolumes(vm *virtv1.VirtualMachine) (bool, error) 
 	return ready, nil
 }
 
-func removeMemoryDumpVolumeFromVMISpec(vmiSpec *virtv1.VirtualMachineInstanceSpec, claimName string) *virtv1.VirtualMachineInstanceSpec {
-	newVolumesList := []virtv1.Volume{}
-	for _, volume := range vmiSpec.Volumes {
-		if volume.Name != claimName {
-			newVolumesList = append(newVolumesList, volume)
-		}
-	}
-	vmiSpec.Volumes = newVolumesList
-	return vmiSpec
-}
-
-func applyMemoryDumpVolumeRequestOnVMISpec(vmiSpec *virtv1.VirtualMachineInstanceSpec, claimName string) *virtv1.VirtualMachineInstanceSpec {
-	for _, volume := range vmiSpec.Volumes {
-		if volume.Name == claimName {
-			return vmiSpec
-		}
-	}
-
-	memoryDumpVol := &virtv1.MemoryDumpVolumeSource{
-		PersistentVolumeClaimVolumeSource: virtv1.PersistentVolumeClaimVolumeSource{
-			PersistentVolumeClaimVolumeSource: k8score.PersistentVolumeClaimVolumeSource{
-				ClaimName: claimName,
-			},
-			Hotpluggable: true,
-		},
-	}
-
-	newVolume := virtv1.Volume{
-		Name: claimName,
-	}
-	newVolume.VolumeSource.MemoryDump = memoryDumpVol
-
-	vmiSpec.Volumes = append(vmiSpec.Volumes, newVolume)
-
-	return vmiSpec
-}
-
-func (c *Controller) generateVMIMemoryDumpVolumePatch(vmi *virtv1.VirtualMachineInstance, request *virtv1.VirtualMachineMemoryDumpRequest, addVolume bool) error {
-	foundRemoveVol := false
-	for _, volume := range vmi.Spec.Volumes {
-		if request.ClaimName == volume.Name {
-			if addVolume {
-				return fmt.Errorf("Unable to add volume [%s] because it already exists", volume.Name)
-			} else {
-				foundRemoveVol = true
-			}
-		}
-	}
-
-	if !foundRemoveVol && !addVolume {
-		return fmt.Errorf("Unable to remove volume [%s] because it does not exist", request.ClaimName)
-	}
-
-	vmiCopy := vmi.DeepCopy()
-	if addVolume {
-		vmiCopy.Spec = *applyMemoryDumpVolumeRequestOnVMISpec(&vmiCopy.Spec, request.ClaimName)
-	} else {
-		vmiCopy.Spec = *removeMemoryDumpVolumeFromVMISpec(&vmiCopy.Spec, request.ClaimName)
-	}
-	patchset := patch.New(
-		patch.WithTest("/spec/volumes", vmi.Spec.Volumes),
-	)
-	if len(vmi.Spec.Volumes) > 0 {
-		patchset.AddOption(patch.WithReplace("/spec/volumes", vmiCopy.Spec.Volumes))
-	} else {
-		patchset.AddOption(patch.WithAdd("/spec/volumes", vmiCopy.Spec.Volumes))
-	}
-
-	patchBytes, err := patchset.GeneratePayload()
-	if err != nil {
-		return err
-	}
-	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
-	return err
-}
-
-func needUpdatePVCMemoryDumpAnnotation(pvc *k8score.PersistentVolumeClaim, request *virtv1.VirtualMachineMemoryDumpRequest) bool {
-	if pvc.GetAnnotations() == nil {
-		return true
-	}
-	annotation, hasAnnotation := pvc.Annotations[virtv1.PVCMemoryDumpAnnotation]
-	return !hasAnnotation || (request.Phase == virtv1.MemoryDumpUnmounting && annotation != *request.FileName) || (request.Phase == virtv1.MemoryDumpFailed && annotation != failedMemoryDump)
-}
-
-func (c *Controller) updatePVCMemoryDumpAnnotation(vm *virtv1.VirtualMachine) error {
-	request := vm.Status.MemoryDumpRequest
-	pvc, err := storagetypes.GetPersistentVolumeClaimFromCache(vm.Namespace, request.ClaimName, c.pvcStore)
-	if err != nil {
-		log.Log.Object(vm).Errorf("Error getting PersistentVolumeClaim to update memory dump annotation: %v", err)
-		return err
-	}
-	if pvc == nil {
-		log.Log.Object(vm).Errorf("Error getting PersistentVolumeClaim to update memory dump annotation: %v", err)
-		return fmt.Errorf("Error when trying to update memory dump annotation, pvc %s not found", request.ClaimName)
-	}
-
-	if needUpdatePVCMemoryDumpAnnotation(pvc, request) {
-		if pvc.GetAnnotations() == nil {
-			pvc.SetAnnotations(make(map[string]string))
-		}
-		if request.Phase == virtv1.MemoryDumpUnmounting {
-			pvc.Annotations[virtv1.PVCMemoryDumpAnnotation] = *request.FileName
-		} else if request.Phase == virtv1.MemoryDumpFailed {
-			pvc.Annotations[virtv1.PVCMemoryDumpAnnotation] = failedMemoryDump
-		}
-		if _, err = c.clientset.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (c *Controller) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
 	patchSet := patch.New(
 		patch.WithTest("/spec/domain/cpu/sockets", vmi.Spec.Domain.CPU.Sockets),
@@ -878,63 +764,6 @@ func (c *Controller) handleAffinityChangeRequest(vm *virtv1.VirtualMachine, vmi 
 			return err
 		}
 	}
-	return nil
-}
-
-func (c *Controller) handleMemoryDumpRequest(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
-	if vm.Status.MemoryDumpRequest == nil {
-		return nil
-	}
-
-	vmiVolumeMap := make(map[string]virtv1.Volume)
-	if vmi != nil {
-		for _, volume := range vmi.Spec.Volumes {
-			vmiVolumeMap[volume.Name] = volume
-		}
-	}
-	switch vm.Status.MemoryDumpRequest.Phase {
-	case virtv1.MemoryDumpAssociating:
-		if vmi == nil || vmi.DeletionTimestamp != nil || !vmi.IsRunning() {
-			return nil
-		}
-		// When in state associating we want to add the memory dump pvc
-		// as a volume in the vm and in the vmi to trigger the mount
-		// to virt launcher and the memory dump
-		vm.Spec.Template.Spec = *applyMemoryDumpVolumeRequestOnVMISpec(&vm.Spec.Template.Spec, vm.Status.MemoryDumpRequest.ClaimName)
-		if _, exists := vmiVolumeMap[vm.Status.MemoryDumpRequest.ClaimName]; exists {
-			return nil
-		}
-		if err := c.generateVMIMemoryDumpVolumePatch(vmi, vm.Status.MemoryDumpRequest, true); err != nil {
-			log.Log.Object(vmi).Errorf("unable to patch vmi to add memory dump volume: %v", err)
-			return err
-		}
-	case virtv1.MemoryDumpUnmounting, virtv1.MemoryDumpFailed:
-		if err := c.updatePVCMemoryDumpAnnotation(vm); err != nil {
-			return err
-		}
-		// Check if the memory dump is in the vmi list of volumes,
-		// if it still there remove it to make it unmount from virt launcher
-		if _, exists := vmiVolumeMap[vm.Status.MemoryDumpRequest.ClaimName]; !exists {
-			return nil
-		}
-
-		if err := c.generateVMIMemoryDumpVolumePatch(vmi, vm.Status.MemoryDumpRequest, false); err != nil {
-			log.Log.Object(vmi).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
-			return err
-		}
-	case virtv1.MemoryDumpDissociating:
-		// Check if the memory dump is in the vmi list of volumes,
-		// if it still there remove it to make it unmount from virt launcher
-		if _, exists := vmiVolumeMap[vm.Status.MemoryDumpRequest.ClaimName]; exists {
-			if err := c.generateVMIMemoryDumpVolumePatch(vmi, vm.Status.MemoryDumpRequest, false); err != nil {
-				log.Log.Object(vmi).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
-				return err
-			}
-		}
-
-		vm.Spec.Template.Spec = *removeMemoryDumpVolumeFromVMISpec(&vm.Spec.Template.Spec, vm.Status.MemoryDumpRequest.ClaimName)
-	}
-
 	return nil
 }
 
@@ -1970,10 +1799,6 @@ func (c *Controller) createVMRevision(vm *virtv1.VirtualMachine) (string, error)
 	return cr.Name, nil
 }
 
-func hasCompletedMemoryDump(vm *virtv1.VirtualMachine) bool {
-	return vm.Status.MemoryDumpRequest != nil && vm.Status.MemoryDumpRequest.Phase != virtv1.MemoryDumpAssociating && vm.Status.MemoryDumpRequest.Phase != virtv1.MemoryDumpInProgress
-}
-
 // setupVMIfromVM creates a VirtualMachineInstance object from one VirtualMachine object.
 func (c *Controller) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.VirtualMachineInstance {
 	vmi := virtv1.NewVMIReferenceFromNameWithNS(vm.ObjectMeta.Namespace, "")
@@ -1989,8 +1814,8 @@ func (c *Controller) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.VirtualMa
 	}
 
 	// prevent from retriggering memory dump after shutdown if memory dump is complete
-	if hasCompletedMemoryDump(vm) {
-		vmi.Spec = *removeMemoryDumpVolumeFromVMISpec(&vmi.Spec, vm.Status.MemoryDumpRequest.ClaimName)
+	if memorydump.HasCompleted(vm) {
+		vmi.Spec = *memorydump.RemoveMemoryDumpVolumeFromVMISpec(&vmi.Spec, vm.Status.MemoryDumpRequest.ClaimName)
 	}
 
 	setupStableFirmwareUUID(vm, vmi)
@@ -2563,7 +2388,7 @@ func (c *Controller) updateStatus(vm, vmOrig *virtv1.VirtualMachine, vmi *virtv1
 	}
 
 	c.trimDoneVolumeRequests(vm)
-	c.updateMemoryDumpRequest(vm, vmi)
+	memorydump.UpdateRequest(vm, vmi)
 
 	if c.isTrimFirstChangeRequestNeeded(vm, vmi) {
 		popStateChangeRequest(vm)
@@ -2923,89 +2748,6 @@ func (c *Controller) isTrimFirstChangeRequestNeeded(vm *virtv1.VirtualMachine, v
 	return false
 }
 
-func (c *Controller) updateMemoryDumpRequest(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {
-	if vm.Status.MemoryDumpRequest == nil {
-		return
-	}
-
-	updatedMemoryDumpReq := vm.Status.MemoryDumpRequest.DeepCopy()
-
-	if vm.Status.MemoryDumpRequest.Remove {
-		updatedMemoryDumpReq.Phase = virtv1.MemoryDumpDissociating
-	}
-
-	switch vm.Status.MemoryDumpRequest.Phase {
-	case virtv1.MemoryDumpCompleted:
-		// Once memory dump completed, there is no update neeeded,
-		// A new update will come from the subresource API once
-		// a new request will be issued
-		return
-	case virtv1.MemoryDumpAssociating:
-		// Update Phase to InProgrees once the memory dump
-		// is in the list of vm volumes
-		for _, volume := range vm.Spec.Template.Spec.Volumes {
-			if vm.Status.MemoryDumpRequest.ClaimName == volume.Name {
-				updatedMemoryDumpReq.Phase = virtv1.MemoryDumpInProgress
-				break
-			}
-		}
-	case virtv1.MemoryDumpInProgress:
-		// Update to unmounting once getting update in the vmi volume status
-		// that the dump timestamp is updated
-		if vmi != nil && len(vmi.Status.VolumeStatus) > 0 {
-			for _, volumeStatus := range vmi.Status.VolumeStatus {
-				if volumeStatus.Name == vm.Status.MemoryDumpRequest.ClaimName &&
-					volumeStatus.MemoryDumpVolume != nil {
-					if volumeStatus.MemoryDumpVolume.StartTimestamp != nil {
-						updatedMemoryDumpReq.StartTimestamp = volumeStatus.MemoryDumpVolume.StartTimestamp
-					}
-					if volumeStatus.Phase == virtv1.MemoryDumpVolumeCompleted {
-						updatedMemoryDumpReq.Phase = virtv1.MemoryDumpUnmounting
-						updatedMemoryDumpReq.EndTimestamp = volumeStatus.MemoryDumpVolume.EndTimestamp
-						updatedMemoryDumpReq.FileName = &volumeStatus.MemoryDumpVolume.TargetFileName
-					} else if volumeStatus.Phase == virtv1.MemoryDumpVolumeFailed {
-						updatedMemoryDumpReq.Phase = virtv1.MemoryDumpFailed
-						updatedMemoryDumpReq.Message = volumeStatus.Message
-						updatedMemoryDumpReq.EndTimestamp = volumeStatus.MemoryDumpVolume.EndTimestamp
-					}
-				}
-			}
-		}
-	case virtv1.MemoryDumpUnmounting:
-		// Update memory dump as completed once the memory dump has been
-		// unmounted - not a part of the vmi volume status
-		if vmi != nil {
-			for _, volumeStatus := range vmi.Status.VolumeStatus {
-				// If we found the claim name in the vmi volume status
-				// then the pvc is still mounted
-				if volumeStatus.Name == vm.Status.MemoryDumpRequest.ClaimName {
-					return
-				}
-			}
-		}
-		updatedMemoryDumpReq.Phase = virtv1.MemoryDumpCompleted
-	case virtv1.MemoryDumpDissociating:
-		// Make sure the memory dump is not in the vmi list of volumes
-		if vmi != nil {
-			for _, volumeStatus := range vmi.Status.VolumeStatus {
-				if volumeStatus.Name == vm.Status.MemoryDumpRequest.ClaimName {
-					return
-				}
-			}
-		}
-		// Make sure the memory dump is not in the list of vm volumes
-		for _, volume := range vm.Spec.Template.Spec.Volumes {
-			if vm.Status.MemoryDumpRequest.ClaimName == volume.Name {
-				return
-			}
-		}
-		// Remove the memory dump request
-		updatedMemoryDumpReq = nil
-	}
-
-	vm.Status.MemoryDumpRequest = updatedMemoryDumpReq
-}
-
 func (c *Controller) trimDoneVolumeRequests(vm *virtv1.VirtualMachine) {
 	if len(vm.Status.VolumeRequests) == 0 {
 		return
@@ -3306,8 +3048,8 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 		return vm, vmi, common.NewSyncError(fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), hotplugVolumeErrorReason), nil
 	}
 
-	if err := c.handleMemoryDumpRequest(vmCopy, vmi); err != nil {
-		return vm, vmi, common.NewSyncError(fmt.Errorf("Error encountered while handling memory dump request: %v", err), memoryDumpErrorReason), nil
+	if err := memorydump.HandleRequest(c.clientset, vmCopy, vmi, c.pvcStore); err != nil {
+		return vm, vmi, common.NewSyncError(fmt.Errorf("Error encountered while handling memory dump request: %v", err), memorydump.ErrorReason), nil
 	}
 
 	conditionManager := controller.NewVirtualMachineConditionManager()


### PR DESCRIPTION
### What this PR does
We want to remove storage logic from other places as much as possible to not overload general vm code and to be able to own storage code better.
Also moved and improved memory dump UT.
And change Update to Patch, since we can so why not.

Before this PR: memory dump code in watch/vm

After this PR: memory dump code in pkg/storage/memorydump

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
/kind cleanup

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

