### PR TITLE
Enable VMI live migration using virtiofs volumes

### DIFF
--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -98,6 +98,16 @@ func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv
 
 	args := []string{socketPathArg, sourceArg, "--sandbox=none", "--cache=auto"}
 
+	// If some files cannot be migrated, let's allow the migration to finish.
+	// Mark these files as invalid, the guest will not be able to access any such files,
+	// receiving only errors
+	args = append(args, "--migration-on-error=guest-error")
+
+	// This mode look up its file references paths by reading the symlinks in /proc/self/fd,
+	// falling back to iterating through the shared directory (exhaustive search) to find those paths.
+	// This migration mode doesn't require any privileges.
+	args = append(args, "--migration-mode=find-paths")
+
 	volumeMounts := []k8sv1.VolumeMount{
 		// This is required to pass socket to compute
 		{

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//pkg/controller/testing:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/errors:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2584,7 +2584,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Entry("don't exist migration should fail", ""),
 		)
 
-		It("should not be allowed to live-migrate if the VMI uses virtiofs ", func() {
+		It("should be allowed to live-migrate if the VMI uses virtiofs ", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Devices.Filesystems = []v1.Filesystem{
 				{
@@ -2596,8 +2596,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
 			Expect(isBlockMigration).To(BeFalse())
 			Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
-			Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(v1.VirtualMachineInstanceReasonVirtIOFSNotMigratable))
+			Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
 		})
 
 		It("should not be allowed to live-migrate if the VMI has non-migratable interface", func() {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -55,6 +55,7 @@ import (
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -2584,19 +2585,100 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Entry("don't exist migration should fail", ""),
 		)
 
-		It("should be allowed to live-migrate if the VMI uses virtiofs ", func() {
-			vmi := api2.NewMinimalVMI("testvmi")
-			vmi.Spec.Domain.Devices.Filesystems = []v1.Filesystem{
-				{
-					Name:     "VIRTIOFS",
-					Virtiofs: &v1.FilesystemVirtiofs{},
+		Context("check that migration is supported when using Filesystem Devices", func() {
+			fsPvcVolume := v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "testpvc",
+					},
 				},
 			}
 
-			condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
-			Expect(isBlockMigration).To(BeFalse())
-			Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
-			Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+			fsDvVolume := v1.VolumeSource{
+				DataVolume: &v1.DataVolumeSource{
+					Name: "testDV",
+				},
+			}
+
+			const errorMsg = "cannot migrate VMI: PVC %s is not shared, live migration requires that all PVCs must be shared (using ReadWriteMany access mode"
+
+			It("should be allowed to live-migrate if the VMI uses virtiofs ", func() {
+				vmi := api2.NewMinimalVMI("testvmi")
+				vmi.Spec.Domain.Devices.Filesystems = []v1.Filesystem{
+					{
+						Name:     "VIRTIOFS",
+						Virtiofs: &v1.FilesystemVirtiofs{},
+					},
+				}
+
+				condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
+				Expect(isBlockMigration).To(BeFalse())
+				Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+				Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+			})
+
+			DescribeTable("using virtiofs and a", func(volumeSource v1.VolumeSource, accessMode k8sv1.PersistentVolumeAccessMode, shouldFail bool, errorMsg string) {
+				vmi := api2.NewMinimalVMI("testvmi")
+				vmi.Spec.Domain.Devices.Filesystems = []v1.Filesystem{
+					{
+						Name:     "VIRTIOFS",
+						Virtiofs: &v1.FilesystemVirtiofs{},
+					},
+				}
+
+				vmi.Spec.Volumes = []v1.Volume{
+					{
+						Name:         "VIRTIOFS",
+						VolumeSource: volumeSource,
+					},
+				}
+
+				vmi.Status.VolumeStatus = []v1.VolumeStatus{
+					{
+						Name: "VIRTIOFS",
+						PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+							AccessModes: []k8sv1.PersistentVolumeAccessMode{accessMode},
+							VolumeMode:  pointer.P(k8sv1.PersistentVolumeFilesystem),
+						},
+					},
+				}
+
+				condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
+
+				if shouldFail {
+					Expect(isBlockMigration).To(BeTrue())
+					Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+					Expect(condition.Message).To(ContainSubstring(errorMsg))
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+				} else {
+					Expect(isBlockMigration).To(BeFalse())
+					Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+					Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+				}
+			},
+				Entry("PVC with access mode ReadWriteOne", fsPvcVolume, k8sv1.ReadWriteOnce, true, fmt.Sprintf(errorMsg, fsPvcVolume.PersistentVolumeClaim.PersistentVolumeClaimVolumeSource.ClaimName)),
+				Entry("PVC with access mode ReadOnlyMany", fsPvcVolume, k8sv1.ReadOnlyMany, true, fmt.Sprintf(errorMsg, fsPvcVolume.PersistentVolumeClaim.PersistentVolumeClaimVolumeSource.ClaimName)),
+				Entry("PVC with access mode ReadWriteMany", fsPvcVolume, k8sv1.ReadWriteMany, false, ""),
+				Entry("DV with access mode ReadWriteMany", fsDvVolume, k8sv1.ReadWriteMany, false, ""),
+				Entry("DV with access mode ReadOnlyMany", fsDvVolume, k8sv1.ReadOnlyMany, true, fmt.Sprintf(errorMsg, fsDvVolume.DataVolume.Name)),
+				Entry("DV with access mode ReadWriteOnce", fsDvVolume, k8sv1.ReadWriteOnce, true, fmt.Sprintf(errorMsg, fsDvVolume.DataVolume.Name)),
+			)
+
+			DescribeTable("sharing with virtiofs a", func(configVolume libvmi.Option) {
+				vmi := api2.NewMinimalVMI("testvmi")
+				configVolume(vmi)
+
+				condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
+
+				Expect(isBlockMigration).To(BeFalse())
+				Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+				Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+			},
+				Entry("ConfigMap", libvmi.WithConfigMapFs("configmapTest", "configMapVolume")),
+				Entry("Secret", libvmi.WithSecretFs("secretTest", "secretVolume")),
+				Entry("ServiceAccount", libvmi.WithServiceAccountFs("serviceAccountTest", "serviceAccountVolume")),
+				Entry("DownwardAPI", libvmi.WithDownwardAPIFs("serviceAccountTest")),
+			)
 		})
 
 		It("should not be allowed to live-migrate if the VMI has non-migratable interface", func() {

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -176,6 +176,15 @@ func CreateFSPVC(name, namespace, size string, labels map[string]string) *k8sv1.
 	return createPVC(pvc, namespace)
 }
 
+func CreateRWXFSPVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
+	sc, _ := GetRWXFileSystemStorageClass()
+	pvc := NewPVC(name, size, sc)
+	pvc.Spec.VolumeMode = pointer.P(k8sv1.PersistentVolumeFilesystem)
+	pvc.Spec.AccessModes = []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteMany}
+
+	return createPVC(pvc, namespace)
+}
+
 func CreateBlockPVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
 	sc, _ := GetRWOBlockStorageClass()
 	pvc := NewPVC(name, size, sc)

--- a/tests/migration/BUILD.bazel
+++ b/tests/migration/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//tests/watcher:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",


### PR DESCRIPTION
Recently, the infrastructure container were updated to Centos 9.6. That version includes virtiofsd 1.13.0, which support live migration (also the required qemu and libvirt versions).

This PR enables the live migration of a VMI using a volume shared using virtiofs, for instance:

```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachineInstance
...
spec:
  domain:
    devices:
      filesystems:
        - name: foo
          virtiofs: {}
  volumes:
    ...
    - name: foo
      serviceAccount:
        serviceAccountName: default
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Live migration support for VMIs with (virtiofs) filesystem devices
```

