### PR TITLE
vm: add unit test for virt-handler/vm functions and fix some small bugs - part 1

### DIFF
--- a/pkg/libvmi/BUILD.bazel
+++ b/pkg/libvmi/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -23,6 +23,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -286,6 +287,12 @@ func WithTPM(persistent bool) Option {
 		vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{
 			Persistent: pointer.P(persistent),
 		}
+	}
+}
+
+func WithUID(uid types.UID) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.ObjectMeta.UID = uid
 	}
 }
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3558,7 +3558,7 @@ func (c *VirtualMachineController) reportTargetTopologyForMigratingVMI(vmi *v1.V
 }
 
 func (c *VirtualMachineController) handleMigrationAbort(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
-	if vmi.Status.MigrationState.AbortStatus == v1.MigrationAbortInProgress {
+	if vmi.Status.MigrationState.AbortStatus == v1.MigrationAbortInProgress || vmi.Status.MigrationState.AbortStatus == v1.MigrationAbortSucceeded {
 		return nil
 	}
 
@@ -3568,7 +3568,6 @@ func (c *VirtualMachineController) handleMigrationAbort(vmi *v1.VirtualMachineIn
 		log.Log.Object(vmi).Infof("skipping migration cancellation since vmi is not migrating")
 		return err
 	}
-
 	c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrating.String(), VMIAbortingMigration)
 	return nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3562,10 +3562,11 @@ func (c *VirtualMachineController) handleMigrationAbort(vmi *v1.VirtualMachineIn
 		return nil
 	}
 
-	err := client.CancelVirtualMachineMigration(vmi)
-	if err != nil && err.Error() == migrations.CancelMigrationFailedVmiNotMigratingErr {
-		// If migration did not even start there is no need to cancel it
-		log.Log.Object(vmi).Infof("skipping migration cancellation since vmi is not migrating")
+	if err := client.CancelVirtualMachineMigration(vmi); err != nil {
+		if err.Error() == migrations.CancelMigrationFailedVmiNotMigratingErr {
+			// If migration did not even start there is no need to cancel it
+			log.Log.Object(vmi).Infof("skipping migration cancellation since vmi is not migrating")
+		}
 		return err
 	}
 	c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrating.String(), VMIAbortingMigration)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3517,7 +3517,7 @@ func (c *VirtualMachineController) claimDeviceOwnership(virtLauncherRootMount *s
 	softwareEmulation := c.clusterConfig.AllowEmulation()
 	devicePath, err := safepath.JoinNoFollow(virtLauncherRootMount, filepath.Join("dev", deviceName))
 	if err != nil {
-		if softwareEmulation {
+		if softwareEmulation && deviceName == "kvm" {
 			return nil
 		}
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Several function in the virt-handler/vm.go are untested

After this PR:
Added unit tests for some handler functions and fixed some minor bugs

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->


### Special notes for your reviewer
Recently we have reviewed the virt-handler code for migration, and we discovered a lot of small bugs  (e.g https://github.com/kubevirt/kubevirt/pull/13729). This PR starts adding some unit tests for each functions. We have unit tests but they cover the general flow when the vm controller runs, but we don't test all the possible code paths. Hence, this PR start to introduce some more granular unit tests and a couple of small fixes

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

