### PR TITLE
Refactor unit tests to use libvmi for resource creation in vmi-preset-admitter_test.go

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
@@ -29,10 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
 
@@ -63,7 +62,9 @@ var _ = Describe("Validating VMIPreset Admitter", func() {
 		),
 	)
 	It("reject invalid VirtualMachineInstance spec", func() {
-		vmi := api.NewMinimalVMI("testvmi")
+		vmi := libvmi.New(
+			libvmi.WithName("testvmi"),
+		)
 		vmiPDomain := &v1.DomainSpec{}
 		vmiDomainByte, _ := json.Marshal(vmi.Spec.Domain)
 		Expect(json.Unmarshal(vmiDomainByte, &vmiPDomain)).To(Succeed())
@@ -97,11 +98,6 @@ var _ = Describe("Validating VMIPreset Admitter", func() {
 		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[0]"))
 	})
 	It("should accept valid vmi spec", func() {
-		vmi := api.NewMinimalVMI("testvmi")
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: "testdisk",
-		})
-
 		vmiPreset := &v1.VirtualMachineInstancePreset{
 			Spec: v1.VirtualMachineInstancePresetSpec{
 				Domain: &v1.DomainSpec{},


### PR DESCRIPTION
### What this PR does
Before this PR: Unit tests in `pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go` use the `NewMinimalVMI` function to create a VMI object, and then modify the data members of the VMI object to customize it.

After this PR: We will use the `libvmi.New` function to create a VMI object, and while doing so use its Builder design pattern to customize the VMI object.

Partially address: #12059 

### Why we need it and why it was done in this way

- Using the libvmi package simplifies the unit tests and makes them more readable.

- This approach ensures a standard way of creating VM and VMI resources across tests.

- The following tradeoffs were made:

  - Direct manipulation of resources was replaced with libvmi functions, which enhances readability and maintainability.

Links to places where the discussion took place: Issue #12059 

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

