### PR TITLE
[virt-operator]: clean up unused returned values 

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1218,16 +1218,16 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
 	all = append(all, components.NewApiServerService(NAMESPACE))
 	all = append(all, components.NewExportProxyService(NAMESPACE))
 
-	apiDeployment, _ := getDefaultVirtApiDeployment(NAMESPACE, config)
+	apiDeployment := getDefaultVirtApiDeployment(NAMESPACE, config)
 	apiDeploymentPdb := components.NewPodDisruptionBudgetForDeployment(apiDeployment)
-	controller, _ := getDefaultVirtControllerDeployment(NAMESPACE, config)
+	controller := getDefaultVirtControllerDeployment(NAMESPACE, config)
 	controllerPdb := components.NewPodDisruptionBudgetForDeployment(controller)
 
-	handler, _ := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
+	handler := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
 	all = append(all, apiDeployment, apiDeploymentPdb, controller, controllerPdb, handler)
 
 	if exportProxyEnabled(kv) {
-		exportProxy, _ := getDefaultExportProxyDeployment(NAMESPACE, config)
+		exportProxy := getDefaultExportProxyDeployment(NAMESPACE, config)
 		exportProxyPdb := components.NewPodDisruptionBudgetForDeployment(exportProxy)
 		route := components.NewExportProxyRoute(NAMESPACE)
 		all = append(all, exportProxy, exportProxyPdb, route)
@@ -1335,8 +1335,7 @@ func (k *KubeVirtTestData) addAllButHandler(config *util.KubeVirtDeploymentConfi
 }
 
 func (k *KubeVirtTestData) addVirtHandler(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
-	handler, err := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
-	Expect(err).ToNot(HaveOccurred())
+	handler := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
 
 	c, _ := apply.NewCustomizer(kv.Spec.CustomizeComponents)
 
@@ -1556,7 +1555,7 @@ func (k *KubeVirtTestData) addPodsWithIndividualConfigs(config *util.KubeVirtDep
 	// virt-controller
 	// virt-handler
 	var deployments []*appsv1.Deployment
-	apiDeployment, _ := getDefaultVirtApiDeployment(NAMESPACE, config)
+	apiDeployment := getDefaultVirtApiDeployment(NAMESPACE, config)
 
 	pod := &k8sv1.Pod{
 		ObjectMeta: apiDeployment.Spec.Template.ObjectMeta,
@@ -1573,7 +1572,7 @@ func (k *KubeVirtTestData) addPodsWithIndividualConfigs(config *util.KubeVirtDep
 	k.addPod(pod)
 	deployments = append(deployments, apiDeployment)
 
-	controller, _ := getDefaultVirtControllerDeployment(NAMESPACE, config)
+	controller := getDefaultVirtControllerDeployment(NAMESPACE, config)
 	pod = &k8sv1.Pod{
 		ObjectMeta: controller.Spec.Template.ObjectMeta,
 		Spec:       controller.Spec.Template.Spec,
@@ -1589,7 +1588,7 @@ func (k *KubeVirtTestData) addPodsWithIndividualConfigs(config *util.KubeVirtDep
 	k.addPod(pod)
 	deployments = append(deployments, controller)
 
-	handler, _ := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
+	handler := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
 	pod = &k8sv1.Pod{
 		ObjectMeta: handler.Spec.Template.ObjectMeta,
 		Spec:       handler.Spec.Template.Spec,
@@ -1607,7 +1606,7 @@ func (k *KubeVirtTestData) addPodsWithIndividualConfigs(config *util.KubeVirtDep
 	k.addPod(pod)
 
 	if exportProxyEnabled(kv) {
-		exportProxy, _ := getDefaultExportProxyDeployment(NAMESPACE, config)
+		exportProxy := getDefaultExportProxyDeployment(NAMESPACE, config)
 		pod = &k8sv1.Pod{
 			ObjectMeta: exportProxy.Spec.Template.ObjectMeta,
 			Spec:       exportProxy.Spec.Template.Spec,
@@ -2170,8 +2169,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
 
-			apiDeployment, err := getDefaultVirtApiDeployment(NAMESPACE, config)
-			Expect(err).ToNot(HaveOccurred())
+			apiDeployment := getDefaultVirtApiDeployment(NAMESPACE, config)
 			Expect(apiDeployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
 		})
 
@@ -2185,8 +2183,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
 
-			controllerDeployment, err := getDefaultVirtControllerDeployment(NAMESPACE, config)
-			Expect(err).ToNot(HaveOccurred())
+			controllerDeployment := getDefaultVirtControllerDeployment(NAMESPACE, config)
 			Expect(controllerDeployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
 		})
 
@@ -2200,8 +2197,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
 
-			handlerDaemonset, err := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
-			Expect(err).ToNot(HaveOccurred())
+			handlerDaemonset := getDefaultVirtHandlerDaemonSet(NAMESPACE, config)
 			Expect(handlerDaemonset.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
 		})
 
@@ -3090,7 +3086,7 @@ func shouldExpectHCOConditions(kv *v1.KubeVirt, available k8sv1.ConditionStatus,
 	))
 }
 
-func getDefaultVirtApiDeployment(namespace string, config *util.KubeVirtDeploymentConfig) (*appsv1.Deployment, error) {
+func getDefaultVirtApiDeployment(namespace string, config *util.KubeVirtDeploymentConfig) *appsv1.Deployment {
 	return components.NewApiServerDeployment(
 		namespace,
 		config.GetImageRegistry(),
@@ -3106,7 +3102,7 @@ func getDefaultVirtApiDeployment(namespace string, config *util.KubeVirtDeployme
 		config.GetExtraEnv())
 }
 
-func getDefaultVirtControllerDeployment(namespace string, config *util.KubeVirtDeploymentConfig) (*appsv1.Deployment, error) {
+func getDefaultVirtControllerDeployment(namespace string, config *util.KubeVirtDeploymentConfig) *appsv1.Deployment {
 	return components.NewControllerDeployment(
 		namespace,
 		config.GetImageRegistry(),
@@ -3128,7 +3124,7 @@ func getDefaultVirtControllerDeployment(namespace string, config *util.KubeVirtD
 		config.GetExtraEnv())
 }
 
-func getDefaultVirtHandlerDaemonSet(namespace string, config *util.KubeVirtDeploymentConfig) (*appsv1.DaemonSet, error) {
+func getDefaultVirtHandlerDaemonSet(namespace string, config *util.KubeVirtDeploymentConfig) *appsv1.DaemonSet {
 	return components.NewHandlerDaemonSet(
 		namespace,
 		config.GetImageRegistry(),
@@ -3152,7 +3148,7 @@ func getDefaultVirtHandlerDaemonSet(namespace string, config *util.KubeVirtDeplo
 		false)
 }
 
-func getDefaultExportProxyDeployment(namespace string, config *util.KubeVirtDeploymentConfig) (*appsv1.Deployment, error) {
+func getDefaultExportProxyDeployment(namespace string, config *util.KubeVirtDeploymentConfig) *appsv1.Deployment {
 	return components.NewExportProxyDeployment(
 		namespace,
 		config.GetImageRegistry(),

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Apply Apps", func() {
 				Registry:        Registry,
 				KubeVirtVersion: Version,
 			}
-			deployment, err = components.NewApiServerDeployment(
+			deployment = components.NewApiServerDeployment(
 				Namespace,
 				virtApiConfig.GetImageRegistry(),
 				virtApiConfig.GetImagePrefix(),
@@ -135,7 +135,6 @@ var _ = Describe("Apply Apps", func() {
 				virtApiConfig.GetImagePullSecrets(),
 				virtApiConfig.GetVerbosity(),
 				virtApiConfig.GetExtraEnv())
-			Expect(err).ToNot(HaveOccurred())
 
 			cachedPodDisruptionBudget = components.NewPodDisruptionBudgetForDeployment(deployment)
 		})
@@ -328,7 +327,7 @@ var _ = Describe("Apply Apps", func() {
 				Registry:        Registry,
 				KubeVirtVersion: Version,
 			}
-			daemonSet, err = components.NewHandlerDaemonSet(
+			daemonSet = components.NewHandlerDaemonSet(
 				Namespace,
 				virtHandlerConfig.GetImageRegistry(),
 				virtHandlerConfig.GetImagePrefix(),
@@ -349,7 +348,6 @@ var _ = Describe("Apply Apps", func() {
 				virtHandlerConfig.GetVerbosity(),
 				virtHandlerConfig.GetExtraEnv(),
 				false)
-			Expect(err).ToNot(HaveOccurred())
 			markHandlerReady(daemonSet)
 			daemonSet.UID = "random-id"
 		})
@@ -1192,7 +1190,7 @@ var _ = Describe("Apply Apps", func() {
 				KubeVirtVersion: Version,
 			}
 			var err error
-			strategyDeployment, err = components.NewControllerDeployment(
+			strategyDeployment = components.NewControllerDeployment(
 				Namespace,
 				virtControllerConfig.GetImageRegistry(),
 				virtControllerConfig.GetImagePrefix(),
@@ -1211,7 +1209,6 @@ var _ = Describe("Apply Apps", func() {
 				virtControllerConfig.GetImagePullSecrets(),
 				virtControllerConfig.GetVerbosity(),
 				virtControllerConfig.GetExtraEnv())
-			Expect(err).ToNot(HaveOccurred())
 
 			cachedDeployment = strategyDeployment.DeepCopy()
 			cachedDeployment.Generation = 2

--- a/pkg/virt-operator/resource/apply/pdb_test.go
+++ b/pkg/virt-operator/resource/apply/pdb_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Apply PDBs", func() {
 			Registry:        Registry,
 			KubeVirtVersion: Version,
 		}
-		deployment, err = components.NewApiServerDeployment(
+		deployment = components.NewApiServerDeployment(
 			Namespace,
 			virtApiConfig.GetImageRegistry(),
 			virtApiConfig.GetImagePrefix(),
@@ -89,7 +89,6 @@ var _ = Describe("Apply PDBs", func() {
 			virtApiConfig.GetImagePullSecrets(),
 			virtApiConfig.GetVerbosity(),
 			virtApiConfig.GetExtraEnv())
-		Expect(err).ToNot(HaveOccurred())
 
 		kv.Status.TargetKubeVirtRegistry = Registry
 		kv.Status.TargetKubeVirtVersion = Version

--- a/pkg/virt-operator/resource/apply/pdb_test.go
+++ b/pkg/virt-operator/resource/apply/pdb_test.go
@@ -31,11 +31,9 @@ var _ = Describe("Apply PDBs", func() {
 	var expectations *util.Expectations
 	var kv *v1.KubeVirt
 	var deployment *v12.Deployment
-	var mockPodDisruptionBudgetCacheStore *MockStore
 	var requiredPDB *policyv1.PodDisruptionBudget
 	var r *Reconciler
 	var mockGeneration int64
-	var err error
 
 	getCachedPDB := func() *policyv1.PodDisruptionBudget {
 		Expect(requiredPDB).ToNot(BeNil())
@@ -93,9 +91,6 @@ var _ = Describe("Apply PDBs", func() {
 		kv.Status.TargetKubeVirtRegistry = Registry
 		kv.Status.TargetKubeVirtVersion = Version
 		kv.Status.TargetDeploymentID = Id
-
-		mockPodDisruptionBudgetCacheStore = &MockStore{}
-		err = stores.PodDisruptionBudgetCache.Add(mockPodDisruptionBudgetCacheStore)
 
 		mockGeneration = 123
 

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -52,15 +52,12 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 	}
 }
 
-func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVersion, prHelperVersion, sidecarShimVersion, productName, productVersion, productComponent, image, launcherImage, prHelperImage, sidecarShimImage string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, migrationNetwork *string, verbosity string, extraEnv map[string]string, enablePrHelper bool) (*appsv1.DaemonSet, error) {
+func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVersion, prHelperVersion, sidecarShimVersion, productName, productVersion, productComponent, image, launcherImage, prHelperImage, sidecarShimImage string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, migrationNetwork *string, verbosity string, extraEnv map[string]string, enablePrHelper bool) *appsv1.DaemonSet {
 
 	deploymentName := VirtHandlerName
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, nil, env)
-	if err != nil {
-		return nil, err
-	}
+	podTemplateSpec := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, nil, env)
 
 	if launcherImage == "" {
 		launcherImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", AddVersionSeparatorPrefix(launcherVersion))
@@ -348,6 +345,6 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 		})
 		pod.Containers = append(pod.Containers, RenderPrHelperContainer(prHelperImage, pullPolicy))
 	}
-	return daemonset, nil
+	return daemonset
 
 }

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -150,7 +150,7 @@ func NewExportProxyService(namespace string) *corev1.Service {
 	}
 }
 
-func newPodTemplateSpec(podName, imageName, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*corev1.PodTemplateSpec, error) {
+func newPodTemplateSpec(podName, imageName, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) *corev1.PodTemplateSpec {
 
 	if image == "" {
 		image = fmt.Sprintf("%s/%s%s", repository, imageName, AddVersionSeparatorPrefix(version))
@@ -198,7 +198,7 @@ func newPodTemplateSpec(podName, imageName, repository, version, productName, pr
 		podTemplateSpec.Spec.Containers[0].Env = *envVars
 	}
 
-	return podTemplateSpec, nil
+	return podTemplateSpec
 }
 
 func attachProfileVolume(spec *corev1.PodSpec) {
@@ -239,12 +239,9 @@ func attachCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath 
 	spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, secretVolumeMount)
 }
 
-func newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*appsv1.Deployment, error) {
+func newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) *appsv1.Deployment {
 
-	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAffinity, envVars)
-	if err != nil {
-		return nil, err
-	}
+	podTemplateSpec := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAffinity, envVars)
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -282,7 +279,7 @@ func newBaseDeployment(deploymentName, imageName, namespace, repository, version
 		deployment.ObjectMeta.Labels[virtv1.AppComponentLabel] = productComponent
 	}
 
-	return deployment, nil
+	return deployment
 }
 
 func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOperator, values []string) *corev1.Affinity {
@@ -309,15 +306,12 @@ func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOp
 	}
 }
 
-func NewApiServerDeployment(namespace, repository, imagePrefix, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewApiServerDeployment(namespace, repository, imagePrefix, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, verbosity string, extraEnv map[string]string) *appsv1.Deployment {
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, corev1.LabelHostname, metav1.LabelSelectorOpIn, []string{VirtAPIName})
 	deploymentName := VirtAPIName
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAntiAffinity, env)
-	if err != nil {
-		return nil, err
-	}
+	deployment := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAntiAffinity, env)
 
 	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtApiCertSecretName, "/etc/virt-api/certificates")
 	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtHandlerCertSecretName, "/etc/virt-handler/clientcertificates")
@@ -384,18 +378,15 @@ func NewApiServerDeployment(namespace, repository, imagePrefix, version, product
 		},
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
-	return deployment, nil
+	return deployment
 }
 
-func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersion, launcherVersion, exportServerVersion, sidecarVersion, productName, productVersion, productComponent, image, launcherImage, exporterImage, sidecarImage string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersion, launcherVersion, exportServerVersion, sidecarVersion, productName, productVersion, productComponent, image, launcherImage, exporterImage, sidecarImage string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, verbosity string, extraEnv map[string]string) *appsv1.Deployment {
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, corev1.LabelHostname, metav1.LabelSelectorOpIn, []string{VirtControllerName})
 	deploymentName := VirtControllerName
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, controllerVersion, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAntiAffinity, env)
-	if err != nil {
-		return nil, err
-	}
+	deployment := newBaseDeployment(deploymentName, imageName, namespace, repository, controllerVersion, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAntiAffinity, env)
 
 	if launcherImage == "" {
 		launcherImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", AddVersionSeparatorPrefix(launcherVersion))
@@ -487,13 +478,13 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 	}
 	container.Env = append(container.Env, corev1.EnvVar{Name: operatorutil.SidecarShimImageEnvName, Value: sidecarImage})
 
-	return deployment, nil
+	return deployment
 }
 
 // Used for manifest generation only
 func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosity, kubeVirtVersionEnv, virtApiShaEnv, virtControllerShaEnv, virtHandlerShaEnv, virtLauncherShaEnv, virtExportProxyShaEnv,
 	virtExportServerShaEnv, gsShaEnv, prHelperShaEnv, sidecarShimShaEnv, runbookURLTemplate, virtApiImageEnv, virtControllerImageEnv, virtHandlerImageEnv, virtLauncherImageEnv, virtExportProxyImageEnv, virtExportServerImageEnv, gsImage, prHelperImage, sidecarShimImage,
-	image string, pullPolicy corev1.PullPolicy) (*appsv1.Deployment, error) {
+	image string, pullPolicy corev1.PullPolicy) *appsv1.Deployment {
 
 	const kubernetesOSLinux = "linux"
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, corev1.LabelHostname, metav1.LabelSelectorOpIn, []string{VirtOperatorName})
@@ -632,18 +623,15 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtOperatorCertSecretName, "/etc/virt-operator/certificates")
 	attachProfileVolume(&deployment.Spec.Template.Spec)
 
-	return deployment, nil
+	return deployment
 }
 
-func NewExportProxyDeployment(namespace, repository, imagePrefix, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewExportProxyDeployment(namespace, repository, imagePrefix, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, verbosity string, extraEnv map[string]string) *appsv1.Deployment {
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, corev1.LabelHostname, metav1.LabelSelectorOpIn, []string{VirtAPIName})
 	deploymentName := VirtExportProxyName
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAntiAffinity, env)
-	if err != nil {
-		return nil, err
-	}
+	deployment := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image, pullPolicy, imagePullSecrets, podAntiAffinity, env)
 
 	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtExportProxyCertSecretName, "/etc/virt-exportproxy/certificates")
 	attachProfileVolume(&deployment.Spec.Template.Spec)
@@ -700,7 +688,7 @@ func NewExportProxyDeployment(namespace, repository, imagePrefix, version, produ
 		},
 	}
 
-	return deployment, nil
+	return deployment
 }
 
 func criticalAddonsToleration() []corev1.Toleration {

--- a/pkg/virt-operator/resource/generate/csv/csv.go
+++ b/pkg/virt-operator/resource/generate/csv/csv.go
@@ -159,7 +159,7 @@ KubeVirt is distributed under the
 
 func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.ClusterServiceVersion, error) {
 
-	deployment, err := components.NewOperatorDeployment(
+	deployment := components.NewOperatorDeployment(
 		data.Namespace,
 		data.DockerPrefix,
 		data.ImagePrefix,
@@ -187,9 +187,6 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 		data.SidecarShimImage,
 		data.VirtOperatorImage,
 		v1.PullPolicy(data.ImagePullPolicy))
-	if err != nil {
-		return nil, err
-	}
 
 	imageVersion := components.AddVersionSeparatorPrefix(data.OperatorImageVersion)
 

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -562,30 +562,18 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	strategy.services = append(strategy.services, components.NewApiServerService(config.GetNamespace()))
 	strategy.services = append(strategy.services, components.NewOperatorWebhookService(operatorNamespace))
 	strategy.services = append(strategy.services, components.NewExportProxyService(config.GetNamespace()))
-	apiDeployment, err := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), productName, productVersion, productComponent, config.VirtApiImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetVerbosity(), config.GetExtraEnv())
-	if err != nil {
-		return nil, fmt.Errorf("error generating virt-apiserver deployment %v", err)
-	}
+	apiDeployment := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), productName, productVersion, productComponent, config.VirtApiImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetVerbosity(), config.GetExtraEnv())
 	strategy.deployments = append(strategy.deployments, apiDeployment)
 
-	controller, err := components.NewControllerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetExportServerVersion(), config.GetSidecarShimVersion(), productName, productVersion, productComponent, config.VirtControllerImage, config.VirtLauncherImage, config.VirtExportServerImage, config.SidecarShimImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetVerbosity(), config.GetExtraEnv())
-	if err != nil {
-		return nil, fmt.Errorf("error generating virt-controller deployment %v", err)
-	}
+	controller := components.NewControllerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetExportServerVersion(), config.GetSidecarShimVersion(), productName, productVersion, productComponent, config.VirtControllerImage, config.VirtLauncherImage, config.VirtExportServerImage, config.SidecarShimImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetVerbosity(), config.GetExtraEnv())
 	strategy.deployments = append(strategy.deployments, controller)
 
 	strategy.configMaps = append(strategy.configMaps, components.NewCAConfigMaps(operatorNamespace)...)
 
-	exportProxyDeployment, err := components.NewExportProxyDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetExportProxyVersion(), productName, productVersion, productComponent, config.VirtExportProxyImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetVerbosity(), config.GetExtraEnv())
-	if err != nil {
-		return nil, fmt.Errorf("error generating export proxy deployment %v", err)
-	}
+	exportProxyDeployment := components.NewExportProxyDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetExportProxyVersion(), productName, productVersion, productComponent, config.VirtExportProxyImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetVerbosity(), config.GetExtraEnv())
 	strategy.deployments = append(strategy.deployments, exportProxyDeployment)
 
-	handler, err := components.NewHandlerDaemonSet(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetLauncherVersion(), config.GetPrHelperVersion(), config.GetSidecarShimVersion(), productName, productVersion, productComponent, config.VirtHandlerImage, config.VirtLauncherImage, config.PrHelperImage, config.SidecarShimImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetMigrationNetwork(), config.GetVerbosity(), config.GetExtraEnv(), config.PersistentReservationEnabled())
-	if err != nil {
-		return nil, fmt.Errorf("error generating virt-handler deployment %v", err)
-	}
+	handler := components.NewHandlerDaemonSet(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetLauncherVersion(), config.GetPrHelperVersion(), config.GetSidecarShimVersion(), productName, productVersion, productComponent, config.VirtHandlerImage, config.VirtLauncherImage, config.PrHelperImage, config.SidecarShimImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetMigrationNetwork(), config.GetVerbosity(), config.GetExtraEnv(), config.PersistentReservationEnabled())
 
 	strategy.daemonSets = append(strategy.daemonSets, handler)
 	strategy.sccs = append(strategy.sccs, components.GetAllSCC(config.GetNamespace())...)

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -106,7 +106,7 @@ func main() {
 
 	operatorCsv, err := csv.NewClusterServiceVersion(&csvData)
 	if err != nil {
-		panic(nil)
+		panic(err)
 	}
 
 	util.MarshallObject(operatorCsv, os.Stdout)

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -288,7 +288,7 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		version = data.VirtOperatorSha
 	}
 
-	deployment, err := components.NewOperatorDeployment(
+	deployment := components.NewOperatorDeployment(
 		data.Namespace,
 		data.DockerPrefix,
 		data.ImagePrefix,
@@ -316,12 +316,9 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		data.SidecarShimImage,
 		data.VirtOperatorImage,
 		v1.PullPolicy(data.ImagePullPolicy))
-	if err != nil {
-		panic(err)
-	}
 
 	writer := strings.Builder{}
-	err = util.MarshallObject(deployment.Spec, &writer)
+	err := util.MarshallObject(deployment.Spec, &writer)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

### What this PR does
Before this PR:
function signature was misleading, the returned error wasn't actually used inside the function.
It created boilerplate when reading the code, and redundant assertions in unit tests.

After this PR:
The error was removed from the functions and its wrappers, unit tests adjusted.


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

