### PR TITLE
Fix test "the VMs running in that node should be respawned"

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1402,9 +1402,9 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			// This is only possible if the VMI has been in Phase Failed
 			By("Check if the VMI has been recreated")
-			Eventually(func() types.UID {
+			Eventually(func(g Gomega) types.UID {
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				return vmi.UID
 			}, 30*time.Second, 1*time.Second).ShouldNot(BeEquivalentTo(oldUID), "The UID should not match to old VMI, new VMI should appear")
 		})


### PR DESCRIPTION
### What this PR does
Re-starting VM on failure causes the VMI to be gone.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #



### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

