### PR TITLE
Update backup and restore docs with info about backend PVC

### DIFF
--- a/docs/backup-restore-integration.md
+++ b/docs/backup-restore-integration.md
@@ -223,6 +223,34 @@ spec:
 
 - ("", "Secret", "ns1", "my-user-password")
 
+#### Backend Storage PVC
+
+The backend storage PVC (also known as **persistent state PVC**) is used to persist changes made by a VirtualMachineInstance that are outside the guest. This includes:
+- **EFI firmware settings**: Firmware data is stored here such as EFI vars or custom secure boot certificates.
+- **TPM state**: Information stored inside the TPM.
+
+For a VM or VMI to use this PVC, it must be explicitly enabled through one or both of the following fields in the VMI spec:
+1. `spec.domain.firmware.bootloader.efi.persistent`
+2. `spec.domain.devices.tpm.persistent`
+
+When either of these options is set to `true`, the system ensures that the backend PVC is created and attached to the VMI.
+
+**How to Identify the Backend Storage PVC**
+Currently, this PVC is not reflected in the VMI or VM spec, but is created and handled by a controller once the VMI is started. The backend PVC can be identified by the `persistent-state-for` label, which would be set to the name of the VMI it is associated with.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: persistent-state-vmi1-XXXXX
+  namespace: ns1
+  labels:
+    persistent-state-for: vmi1
+...
+```
+
+- ("", "PersistentVolumeClaim", "ns1", "persistent-state-vmi1-XXXXX")
+
 ### VirtualMachineInstanceReplicaSet Object Graph
 
 ```yaml


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Kubevirt's Velero plugin now includes the backend storage PVC in its VM object graph, so it makes sense to include documentation about this PVC and how to identify it in the backup and restore docs.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

