### PR TITLE
net, Multus: Unexport implementation details

### DIFF
--- a/pkg/network/multus/annotation.go
+++ b/pkg/network/multus/annotation.go
@@ -60,7 +60,7 @@ func GenerateCNIAnnotationFromNameScheme(
 	networkNameScheme map[string]string,
 	config *virtconfig.ClusterConfig,
 ) (string, error) {
-	multusNetworkAnnotationPool := NetworkAnnotationPool{}
+	multusNetworkAnnotationPool := networkAnnotationPool{}
 
 	for _, network := range networks {
 		if vmispec.IsSecondaryMultusNetwork(network) {
@@ -89,19 +89,19 @@ func GenerateCNIAnnotationFromNameScheme(
 	return "", nil
 }
 
-type NetworkAnnotationPool struct {
+type networkAnnotationPool struct {
 	pool []networkv1.NetworkSelectionElement
 }
 
-func (nap *NetworkAnnotationPool) Add(multusNetworkAnnotation networkv1.NetworkSelectionElement) {
+func (nap *networkAnnotationPool) Add(multusNetworkAnnotation networkv1.NetworkSelectionElement) {
 	nap.pool = append(nap.pool, multusNetworkAnnotation)
 }
 
-func (nap *NetworkAnnotationPool) IsEmpty() bool {
+func (nap *networkAnnotationPool) IsEmpty() bool {
 	return len(nap.pool) == 0
 }
 
-func (nap *NetworkAnnotationPool) ToString() (string, error) {
+func (nap *networkAnnotationPool) ToString() (string, error) {
 	multusNetworksAnnotation, err := json.Marshal(nap.pool)
 	if err != nil {
 		return "", fmt.Errorf("failed to create JSON list from multus interface pool %v", nap.pool)

--- a/pkg/network/multus/annotation.go
+++ b/pkg/network/multus/annotation.go
@@ -66,7 +66,7 @@ func GenerateCNIAnnotationFromNameScheme(
 		if vmispec.IsSecondaryMultusNetwork(network) {
 			podInterfaceName := networkNameScheme[network.Name]
 			multusNetworkAnnotationPool.Add(
-				NewAnnotationData(namespace, interfaces, network, podInterfaceName))
+				newAnnotationData(namespace, interfaces, network, podInterfaceName))
 		}
 
 		if config != nil {
@@ -109,7 +109,7 @@ func (nap *networkAnnotationPool) ToString() (string, error) {
 	return string(multusNetworksAnnotation), nil
 }
 
-func NewAnnotationData(
+func newAnnotationData(
 	namespace string,
 	interfaces []v1.Interface,
 	network v1.Network,

--- a/pkg/network/multus/annotation_test.go
+++ b/pkg/network/multus/annotation_test.go
@@ -104,61 +104,6 @@ var _ = Describe("Multus annotations", func() {
 	})
 })
 
-var _ = Describe("Multus annotations", func() {
-	var multusAnnotationPool multus.NetworkAnnotationPool
-	var vmi v1.VirtualMachineInstance
-	var network v1.Network
-
-	BeforeEach(func() {
-		vmi = v1.VirtualMachineInstance{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "testvmi", Namespace: "namespace1", UID: "1234",
-			},
-		}
-		network = v1.Network{
-			NetworkSource: v1.NetworkSource{
-				Multus: &v1.MultusNetwork{NetworkName: "test1"},
-			},
-		}
-	})
-
-	Context("a multus annotation pool with no elements", func() {
-		BeforeEach(func() {
-			multusAnnotationPool = multus.NetworkAnnotationPool{}
-		})
-
-		It("is empty", func() {
-			Expect(multusAnnotationPool.IsEmpty()).To(BeTrue())
-		})
-
-		It("when added an element, is no longer empty", func() {
-			podIfaceName := "net1"
-			multusAnnotationPool.Add(multus.NewAnnotationData(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, network, podIfaceName))
-			Expect(multusAnnotationPool.IsEmpty()).To(BeFalse())
-		})
-
-		It("generate a null string", func() {
-			Expect(multusAnnotationPool.ToString()).To(BeIdenticalTo("null"))
-		})
-	})
-
-	Context("a multus annotation pool with elements", func() {
-		BeforeEach(func() {
-			multusAnnotationPool = multus.NetworkAnnotationPool{}
-			multusAnnotationPool.Add(multus.NewAnnotationData(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, network, "net1"))
-		})
-
-		It("is not empty", func() {
-			Expect(multusAnnotationPool.IsEmpty()).To(BeFalse())
-		})
-
-		It("generates a json serialized string representing the annotation", func() {
-			expectedString := `[{"name":"test1","namespace":"namespace1","interface":"net1"}]`
-			Expect(multusAnnotationPool.ToString()).To(BeIdenticalTo(expectedString))
-		})
-	})
-})
-
 func testsClusterConfig(plugins map[string]v1.InterfaceBindingPlugin) *virtconfig.ClusterConfig {
 	kvConfig := &v1.KubeVirtConfiguration{
 		DeveloperConfiguration: &v1.DeveloperConfiguration{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
`NetworkAnnotationPool` and `NewAnnotationData` are implementation details - no need to export them.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

