### PR TITLE
instancetype: VM controller implementation cleanups

### DIFF
--- a/pkg/instancetype/controller/vm/controller.go
+++ b/pkg/instancetype/controller/vm/controller.go
@@ -16,7 +16,7 @@
  * Copyright 2024 Red Hat, Inc.
  *
  */
-package controller
+package vm
 
 import (
 	"context"

--- a/pkg/instancetype/controller/vm/mock.go
+++ b/pkg/instancetype/controller/vm/mock.go
@@ -2,15 +2,12 @@ package controller
 
 import (
 	virtv1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/api/instancetype/v1beta1"
 )
 
 type mockController struct {
 	syncFunc                   func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, error)
 	applyToVMFunc              func(*virtv1.VirtualMachine) error
 	applyToVMIFunc             func(*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) error
-	findFunc                   func(*virtv1.VirtualMachine) (*v1beta1.VirtualMachineInstancetypeSpec, error)
-	findPreferenceFunc         func(*virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error)
 	applyDevicePreferencesFunc func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error
 }
 
@@ -25,12 +22,6 @@ func NewMockController() *mockController {
 		applyToVMIFunc: func(*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) error {
 			return nil
 		},
-		findFunc: func(*virtv1.VirtualMachine) (*v1beta1.VirtualMachineInstancetypeSpec, error) {
-			return nil, nil
-		},
-		findPreferenceFunc: func(*virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error) {
-			return nil, nil
-		},
 		applyDevicePreferencesFunc: func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
 			return nil
 		},
@@ -43,14 +34,6 @@ func (m *mockController) ApplyToVM(vm *virtv1.VirtualMachine) error {
 
 func (m *mockController) ApplyToVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
 	return m.applyToVMIFunc(vm, vmi)
-}
-
-func (m *mockController) Find(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachineInstancetypeSpec, error) {
-	return m.findFunc(vm)
-}
-
-func (m *mockController) FindPreference(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error) {
-	return m.findPreferenceFunc(vm)
 }
 
 func (m *mockController) Sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, error) {

--- a/pkg/instancetype/controller/vm/mock.go
+++ b/pkg/instancetype/controller/vm/mock.go
@@ -1,4 +1,4 @@
-package controller
+package vm
 
 import (
 	virtv1 "kubevirt.io/api/core/v1"

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/virt-controller/watch/util:go_default_library",
         "//pkg/virt-controller/watch/volume-migration:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -57,7 +57,6 @@ import (
 	"k8s.io/utils/trace"
 
 	virtv1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -241,8 +240,6 @@ type instancetypeHandler interface {
 	synchronizer
 	ApplyToVM(*virtv1.VirtualMachine) error
 	ApplyToVMI(*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) error
-	Find(*virtv1.VirtualMachine) (*v1beta1.VirtualMachineInstancetypeSpec, error)
-	FindPreference(*virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error)
 	ApplyDevicePreferences(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error
 }
 


### PR DESCRIPTION
### What this PR does

Some simple cleanups after https://github.com/kubevirt/kubevirt/pull/13037 landed.

* Incorrect package name used by VM controller implementation
* Unused functions listed by the consuming `instancetypeHandler` interface

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

