### PR TITLE
matcher: Introduce and use HaveRevisionNames

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -19,6 +19,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	virtsnapshot "kubevirt.io/api/snapshot"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
@@ -695,13 +696,13 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 							libstorage.EventuallyDVWith(sourceVM.Namespace, dvt.Name, 180, HaveSucceeded())
 						}
 						By("Waiting until the source VM has instancetype and preference RevisionNames")
-						libinstancetype.WaitForVMInstanceTypeRevisionNames(sourceVM.Name, virtClient)
+						Eventually(matcher.ThisVM(sourceVM)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveRevisionNames())
 
 						vmClone = generateCloneFromVM()
 						createCloneAndWaitForFinish(vmClone)
 
 						By("Waiting until the targetVM has instancetype and preference RevisionNames")
-						libinstancetype.WaitForVMInstanceTypeRevisionNames(targetVMName, virtClient)
+						Eventually(matcher.ThisVMWith(testsuite.GetTestNamespace(sourceVM), targetVMName)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveRevisionNames())
 
 						By("Asserting that the targetVM has new instancetype and preference controllerRevisions")
 						sourceVM, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(sourceVM)).Get(context.Background(), sourceVM.Name, v1.GetOptions{})

--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "conditions.go",
         "existence.go",
         "getter.go",
+        "instancetype.go",
         "owner.go",
         "phase.go",
         "readiness.go",

--- a/tests/framework/matcher/instancetype.go
+++ b/tests/framework/matcher/instancetype.go
@@ -1,0 +1,27 @@
+package matcher
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+func HaveRevisionNames() types.GomegaMatcher {
+	return And(
+		HaveInstancetypeRevisionName(),
+		HavePreferenceRevisionName(),
+	)
+}
+
+func HaveInstancetypeRevisionName() types.GomegaMatcher {
+	return And(
+		HaveField("Spec.Instancetype", Not(BeNil())),
+		HaveField("Spec.Instancetype.RevisionName", Not(BeEmpty())),
+	)
+}
+
+func HavePreferenceRevisionName() types.GomegaMatcher {
+	return And(
+		HaveField("Spec.Preference", Not(BeNil())),
+		HaveField("Spec.Preference.RevisionName", Not(BeEmpty())),
+	)
+}

--- a/tests/instancetype/BUILD.bazel
+++ b/tests/instancetype/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//tests/decorators:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
-        "//tests/libinstancetype:go_default_library",
         "//tests/libinstancetype/builder:go_default_library",
         "//tests/libinstancetype/builder/v1alpha1:go_default_library",
         "//tests/libinstancetype/builder/v1alpha2:go_default_library",

--- a/tests/instancetype/upgrade.go
+++ b/tests/instancetype/upgrade.go
@@ -30,7 +30,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/libinstancetype"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libinstancetype/builder"
 	builderv1alpha1 "kubevirt.io/kubevirt/tests/libinstancetype/builder/v1alpha1"
 	builderv1alpha2 "kubevirt.io/kubevirt/tests/libinstancetype/builder/v1alpha2"
@@ -138,7 +138,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Expect(err).ToNot(HaveOccurred())
 
 		// Wait for the initial revisionNames to be populated before we start out tests
-		libinstancetype.WaitForVMInstanceTypeRevisionNames(vm.Name, virtClient)
+		Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.HaveRevisionNames())
 	})
 
 	DescribeTable("should upgrade", func(generateControllerRevision func() (*appsv1.ControllerRevision, error), updateMatcher func(string), getVMRevisionName func() string) {

--- a/tests/libinstancetype/instancetype.go
+++ b/tests/libinstancetype/instancetype.go
@@ -21,8 +21,6 @@ package libinstancetype
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -33,27 +31,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
-
-func CheckForVMInstancetypeRevisionNames(vmName string, virtClient kubecli.KubevirtClient) func() error {
-	return func() error {
-		vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Get(context.Background(), vmName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if vm.Spec.Instancetype.RevisionName == "" {
-			return fmt.Errorf("instancetype revision name is expected to not be empty")
-		}
-
-		if vm.Spec.Preference.RevisionName == "" {
-			return fmt.Errorf("preference revision name is expected to not be empty")
-		}
-		return nil
-	}
-}
-
-func WaitForVMInstanceTypeRevisionNames(vmName string, virtClient kubecli.KubevirtClient) {
-	Eventually(CheckForVMInstancetypeRevisionNames(vmName, virtClient), 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-}
 
 func EnsureControllerRevisionObjectsEqual(crNameA, crNameB string, virtClient kubecli.KubevirtClient) bool {
 	crA, err := virtClient.AppsV1().ControllerRevisions(testsuite.GetTestNamespace(nil)).Get(context.Background(), crNameA, metav1.GetOptions{})

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -647,7 +647,8 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting until the VM has instancetype and preference RevisionNames")
-				libinstancetype.WaitForVMInstanceTypeRevisionNames(vm.Name, virtClient)
+				Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveRevisionNames())
+
 				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				originalVMInstancetypeRevisionName := vm.Spec.Instancetype.RevisionName
@@ -690,7 +691,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting until the VM has instancetype and preference RevisionNames")
-				libinstancetype.WaitForVMInstanceTypeRevisionNames(vm.Name, virtClient)
+				Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveRevisionNames())
 
 				for _, dvt := range vm.Spec.DataVolumeTemplates {
 					libstorage.EventuallyDVWith(vm.Namespace, dvt.Name, 180, HaveSucceeded())
@@ -710,7 +711,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				_ = expectNewVMCreation(restoreVMName)
 
 				By("Waiting until the restoreVM has instancetype and preference RevisionNames")
-				libinstancetype.WaitForVMInstanceTypeRevisionNames(restoreVMName, virtClient)
+				Eventually(matcher.ThisVMWith(testsuite.GetTestNamespace(vm), restoreVMName)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveRevisionNames())
 
 				By("Asserting that the restoreVM has new instancetype and preference controllerRevisions")
 				sourceVM, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Name, metav1.GetOptions{})


### PR DESCRIPTION
/kind cleanup

### What this PR does

This change introduces a simple composite matcher to assert that
instance type and preference revisionNames are populated. This replaces
the cumbersome libinstancetype WaitForVMInstanceTypeRevisionNames helper
that is now removed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

