### PR TITLE
fix(virtctl): Support VMs/VMIs with dots in their name

### DIFF
--- a/pkg/virtctl/portforward/portforward.go
+++ b/pkg/virtctl/portforward/portforward.go
@@ -255,15 +255,12 @@ func ParseTarget(target string) (string, string, string, error) {
 	if target[len(target)-1] == '.' {
 		return "", "", "", errors.New("expected namespace after '.'")
 	}
-	subparts := strings.Split(target, ".")
-	if len(subparts) > 2 {
-		return "", "", "", errors.New("target is not valid with more than one '.'")
-	}
 
-	name := subparts[0]
+	name := target
 	namespace := ""
-	if len(subparts) == 2 {
-		namespace = subparts[1]
+	if lastDot := strings.LastIndex(target, "."); lastDot != -1 {
+		name = target[:lastDot]
+		namespace = target[lastDot+1:]
 	}
 
 	return kind, namespace, name, nil

--- a/pkg/virtctl/portforward/portforward_test.go
+++ b/pkg/virtctl/portforward/portforward_test.go
@@ -21,6 +21,8 @@ var _ = Describe("Port forward", func() {
 	},
 		Entry("only name", "testvmi", "", "testvmi", "vmi", ""),
 		Entry("name and namespace", "testvmi.default", "default", "testvmi", "vmi", ""),
+		Entry("name with dot and namespace", "testvmi.dot.default", "default", "testvmi.dot", "vmi", ""),
+		Entry("name with dots and namespace", "testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", ""),
 		Entry("kind vmi with name", "vmi/testvmi", "", "testvmi", "vmi", ""),
 		Entry("kind vmi with name and namespace", "vmi/testvmi.default", "default", "testvmi", "vmi", ""),
 		Entry("kind vm with name", "vm/testvm", "", "testvm", "vm", ""),

--- a/pkg/virtctl/scp/scp_test.go
+++ b/pkg/virtctl/scp/scp_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("SCP", func() {
-	DescribeTable("ParseArguments", func(arg0, arg1 string, expLocal *scp.LocalArgument, expRemote *scp.RemoteArgument, expToRemote bool) {
+	DescribeTable("ParseTarget", func(arg0, arg1 string, expLocal *scp.LocalArgument, expRemote *scp.RemoteArgument, expToRemote bool) {
 		local, remote, toRemote, err := scp.ParseTarget(arg0, arg1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(local).To(Equal(expLocal))

--- a/pkg/virtctl/ssh/ssh_test.go
+++ b/pkg/virtctl/ssh/ssh_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("SSH", func() {
-	DescribeTable("ParseSSHTarget", func(arg, targetNamespace, targetName, targetKind, targetUsername, expectedError string) {
+	DescribeTable("ParseTarget", func(arg, targetNamespace, targetName, targetKind, targetUsername, expectedError string) {
 		kind, namespace, name, username, err := ssh.ParseTarget(arg)
 		Expect(namespace).To(Equal(targetNamespace))
 		Expect(name).To(Equal(targetName))
@@ -20,13 +20,33 @@ var _ = Describe("SSH", func() {
 			Expect(err).To(MatchError(expectedError))
 		}
 	},
+		Entry("name", "testvmi", "", "testvmi", "vmi", "", ""),
+		Entry("name and namespace", "testvmi.default", "default", "testvmi", "vmi", "", ""),
+		Entry("name with dot and namespace", "testvmi.dot.default", "default", "testvmi.dot", "vmi", "", ""),
+		Entry("name with dots and namespace", "testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", "", ""),
 		Entry("username and name", "user@testvmi", "", "testvmi", "vmi", "user", ""),
 		Entry("username and name and namespace", "user@testvmi.default", "default", "testvmi", "vmi", "user", ""),
+		Entry("username and name with dot and namespace", "user@testvmi.dot.default", "default", "testvmi.dot", "vmi", "user", ""),
+		Entry("username and name with dots and namespace", "user@testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", "user", ""),
+		Entry("kind vmi with name", "vmi/testvmi", "", "testvmi", "vmi", "", ""),
+		Entry("kind vmi with name and namespace", "vmi/testvmi.default", "default", "testvmi", "vmi", "", ""),
 		Entry("kind vmi with name and username", "user@vmi/testvmi", "", "testvmi", "vmi", "user", ""),
 		Entry("kind vmi with name and namespace and username", "user@vmi/testvmi.default", "default", "testvmi", "vmi", "user", ""),
+		Entry("kind vmi with name with dot and namespace and username", "user@vmi/testvmi.dot.default", "default", "testvmi.dot", "vmi", "user", ""),
+		Entry("kind vmi with name with dots and namespace and username", "user@vmi/testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", "user", ""),
+		Entry("kind vm with name", "vm/testvm", "", "testvm", "vm", "", ""),
+		Entry("kind vm with name and namespace", "vm/testvm.default", "default", "testvm", "vm", "", ""),
+		Entry("kind vm with name and username", "user@vm/testvm", "", "testvm", "vm", "user", ""),
+		Entry("kind vm with name and namespace and username", "user@vm/testvm.default", "default", "testvm", "vm", "user", ""),
+		Entry("kind vm with name with dot and namespace and username", "user@vm/testvm.dot.default", "default", "testvm.dot", "vm", "user", ""),
+		Entry("kind vm with name with dots and namespace and username", "user@vm/testvm.with.dots.default", "default", "testvm.with.dots", "vm", "user", ""),
+		Entry("only valid kind", "vmi/", "", "", "", "", "expected name after '/'"),
+		Entry("only dot", ".", "", "", "", "", "expected name before '.'"),
+		Entry("only slash", "/", "", "", "", "", "unsupported resource kind "),
+		Entry("only separators", "/.", "", "", "", "", "unsupported resource kind "),
+		Entry("only separators and at", "@/.", "", "", "", "", "expected username before '@'"),
 		Entry("only username", "user@", "", "", "", "", "expected target after '@'"),
-		Entry("only at and target", "@testvmi", "", "", "", "", "expected username before '@'"),
-		Entry("only separators", "@/.", "", "", "", "", "expected username before '@'"),
 		Entry("only at", "@", "", "", "", "", "expected username before '@'"),
+		Entry("only at and target", "@testvmi", "", "", "", "", "expected username before '@'"),
 	)
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

With this change VMs/VMIs with dots in their name are supported if they are used as a target in virtctl portforward, ssh or scp. These are only supported if the namespace is explicitly specified, otherwise a distinction between name and namespace is not possible.

Before this PR:

VMs/VMIs with dots in their name are not supported in virtctl portforward, ssh and scp.

After this PR:

VMs/VMIs with dots in their name are supported in virtctl portforward, ssh and scp.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/13679

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

There will be a follow-up to overhaul this feature and to deprecate dots as a way to separate namespace and name. For 1.4 this should be backported as a fix.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl: VMs/VMIs with dots in their name are now supported in virtctl portforward, ssh and scp.
```

