### PR TITLE
controller: Remove unused shouldExpandInstancetypeAndPreference

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3357,25 +3357,6 @@ func handleSynchronizerErr(err error) common.SyncError {
 	return common.NewSyncError(fmt.Errorf("unsupported error: %v", err), "UnsupportedSyncError")
 }
 
-func shouldExpandInstancetypeAndPreference(vm *virtv1.VirtualMachine, referencePolicy virtv1.InstancetypeReferencePolicy) bool {
-	// With Expand we only want to expand if we are using instance types and preferences with no revisionNames set
-	if referencePolicy == virtv1.Expand {
-		if vm.Spec.Instancetype == nil && vm.Spec.Preference == nil {
-			return false
-		}
-		if vm.Spec.Instancetype != nil && vm.Spec.Instancetype.RevisionName != "" {
-			log.Log.Object(vm).Infof("not expanding as instance type already has revisionName")
-			return false
-		}
-		if vm.Spec.Preference != nil && vm.Spec.Preference.RevisionName != "" {
-			log.Log.Object(vm).Infof("not expanding as preference already has revisionName")
-			return false
-		}
-	}
-	// Otherwise for ExpandAll we always expand
-	return true
-}
-
 // resolveControllerRef returns the controller referenced by a ControllerRef,
 // or nil if the ControllerRef could not be resolved to a matching controller
 // of the correct Kind.


### PR DESCRIPTION
/cc @0xFelix 
/cc @fossedihelm

### What this PR does

Missed during #13037 and #13771, this func is now unused and can be removed.

Using a standalone PR for this to allow #13771 to merge in the meantime as it's already approved.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

