### PR TITLE
virt-handler, vm ctrl: Extract networks filtering logic

### DIFF
--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/deviceinfo:go_default_library",
         "//pkg/network/dhcp:go_default_library",

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "configstatecache.go",
+        "filters.go",
         "netconf.go",
         "netstat.go",
         "network.go",
@@ -38,6 +39,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "configstatecache_test.go",
+        "filters_test.go",
         "netconf_test.go",
         "netstat_test.go",
         "network_suite_test.go",
@@ -47,6 +49,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/deviceinfo:go_default_library",
         "//pkg/network/dhcp:go_default_library",

--- a/pkg/network/setup/filters.go
+++ b/pkg/network/setup/filters.go
@@ -47,3 +47,7 @@ func FilterNetsForLiveUpdate(vmi *v1.VirtualMachineInstance) []v1.Network {
 
 	return append(netsToHotplug, netsToHotunplug...)
 }
+
+func FilterNetsForMigrationTarget(vmi *v1.VirtualMachineInstance) []v1.Network {
+	return vmi.Spec.Networks
+}

--- a/pkg/network/setup/filters.go
+++ b/pkg/network/setup/filters.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package network
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+)
+
+func FilterNetsForVMStartup(vmi *v1.VirtualMachineInstance) []v1.Network {
+	nonAbsentIfaces := vmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
+		return iface.State != v1.InterfaceStateAbsent
+	})
+
+	return vmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, nonAbsentIfaces)
+}

--- a/pkg/network/setup/filters_test.go
+++ b/pkg/network/setup/filters_test.go
@@ -186,4 +186,26 @@ var _ = Describe("Network setup filters", func() {
 			))
 		})
 	})
+
+	Context("FilterNetsForMigrationTarget", func() {
+		It("Should return a list of all networks - no matter their interface state", func() {
+			const absentNetName = "absent-net"
+			absentIface := libvmi.InterfaceDeviceWithBridgeBinding(absentNetName)
+			absentIface.State = v1.InterfaceStateAbsent
+
+			vmi := libvmi.New(
+				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+				libvmi.WithInterface(absentIface),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithNetwork(libvmi.MultusNetwork(absentNetName, "somenad")),
+			)
+
+			Expect(network.FilterNetsForMigrationTarget(vmi)).To(Equal(
+				[]v1.Network{
+					*v1.DefaultPodNetwork(),
+					*libvmi.MultusNetwork(absentNetName, "somenad"),
+				},
+			))
+		})
+	})
 })

--- a/pkg/network/setup/filters_test.go
+++ b/pkg/network/setup/filters_test.go
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package network_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	network "kubevirt.io/kubevirt/pkg/network/setup"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+)
+
+var _ = Describe("Network setup filters", func() {
+	Context("FilterNetsForVMStartup", func() {
+		It("Should return a list non-absent networks", func() {
+			const absentNetName = "absent-net"
+			absentIface := libvmi.InterfaceDeviceWithBridgeBinding(absentNetName)
+			absentIface.State = v1.InterfaceStateAbsent
+
+			vmi := libvmi.New(
+				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+				libvmi.WithInterface(absentIface),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithNetwork(libvmi.MultusNetwork(absentNetName, "somenad")),
+			)
+
+			Expect(network.FilterNetsForVMStartup(vmi)).To(Equal([]v1.Network{*v1.DefaultPodNetwork()}))
+		})
+	})
+})

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/network/cache:go_default_library",
         "//pkg/network/domainspec:go_default_library",
         "//pkg/network/errors:go_default_library",
+        "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/safepath:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2812,7 +2812,7 @@ func (c *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 	}
 
 	// configure network inside virt-launcher compute container
-	if err := c.setupNetwork(vmi, vmi.Spec.Networks); err != nil {
+	if err := c.setupNetwork(vmi, netsetup.FilterNetsForMigrationTarget(vmi)); err != nil {
 		return fmt.Errorf("failed to configure vmi network for migration target: %w", err)
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -67,6 +67,7 @@ import (
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/domainspec"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
+	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/safepath"
@@ -3027,12 +3028,7 @@ func (c *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			return err
 		}
 
-		nonAbsentIfaces := netvmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
-			return iface.State != v1.InterfaceStateAbsent
-		})
-		nonAbsentNets := netvmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, nonAbsentIfaces)
-
-		if err := c.setupNetwork(vmi, nonAbsentNets); err != nil {
+		if err := c.setupNetwork(vmi, netsetup.FilterNetsForVMStartup(vmi)); err != nil {
 			return fmt.Errorf("failed to configure vmi network: %w", err)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the virt-handler's VM controller performs network setup based on some filtering logic:
1. On VM's initial setup.
2. When the VM is running - in order to perform NIC hotplug/unplug.
3. When a migration target pod is set up.

Extracting the logic above has several advantages:
1. The VM controller's code is shorter and more readable.
2. There is less SIG-specific code in a core component. 
3. This logic is specific to SIG-network and should be owned by it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

