### PR TITLE
e2e, tests-suite: Controlled cleanup for Ordered tests

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -114,4 +114,9 @@ var (
 	// LargeStoragePoolRequired indicates that the test may fail in a cluster with a low storage pool capacity.
 	// This decorator can be used to skip the test as the failure might not indicate a functional problem.
 	LargeStoragePoolRequired = Label("large-storage-pool-required")
+
+	// OncePerOrderedCleanup decorates Ordered tests to only cleanup after the last
+	// test in an Ordered container.
+	// Currently, in pilot mode, restricted to SIG-Network and virtctl only.
+	OncePerOrderedCleanup = Label("OncePerOrderedCleanup")
 )

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
 
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnode"
@@ -104,8 +105,27 @@ var _ = SynchronizedBeforeSuite(testsuite.SynchronizedBeforeTestSetup, testsuite
 var _ = SynchronizedAfterSuite(testsuite.AfterTestSuiteCleanup, testsuite.SynchronizedAfterTestSuiteCleanup)
 
 var _ = AfterEach(func() {
-	testCleanup()
+	if !hasOncePerOrderedCleanupLabel() {
+		testCleanup()
+	}
 })
+
+var _ = AfterEach(OncePerOrdered, func() {
+	if hasOncePerOrderedCleanupLabel() {
+		testCleanup()
+	}
+})
+
+func hasOncePerOrderedCleanupLabel() bool {
+	oncePerOrderedCleanupText := decorators.OncePerOrderedCleanup[0]
+	oncePerOrderedCleanup, err := CurrentSpecReport().MatchesLabelFilter(oncePerOrderedCleanupText)
+	if err != nil {
+		fmt.Printf("Failed to parse labels %q\n", err)
+		return false
+	}
+
+	return oncePerOrderedCleanup
+}
 
 func getMaxFailsFromEnv() int {
 	maxFailsEnv := os.Getenv("REPORTER_MAX_FAILS")


### PR DESCRIPTION
Currently most test resources are cleaned up (vm/vmis, nodes, config)
following each spec, since `AfterEach() ` is global and uncustomizable.
This does not enable running multiple test cases on a single set of
VMs without complete cleanup and restart in between.
Some tests may benefit from delayed cleanup triggers, thus reduce test duration.
This change introduces a new decorator label 'skipGlobalCleanup',
Test that are labeled 'skipGlobalCleanup' and also `Ordered` are cleaned 
up only once per ordered container.
See [OncePerOrdered documentation](https://onsi.github.io/ginkgo/#setup-around-ordered-containers-the-onceperordered-decorator) for details.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
https://github.com/kubevirt/kubevirt/pull/13963 demonstrates usage of this feature.

For those concerned about the use of Ordered containers see [this response](https://github.com/kubevirt/kubevirt/pull/13963#issuecomment-2663043666) from the author.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
