### PR TITLE
pkg/util: move a few functions next to their users

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -104,12 +104,6 @@ func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-// NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
-// This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
-func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
-	return WantVirtioNetDevice(vmi) && !allowEmulation
-}
-
 func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {
 	return (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,10 +2,8 @@ package util
 
 import (
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math/big"
-	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -112,23 +110,6 @@ func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {
 
 func IsAutoAttachVSOCK(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.Devices.AutoattachVSOCK != nil && *vmi.Spec.Domain.Devices.AutoattachVSOCK
-}
-
-// UseSoftwareEmulationForDevice determines whether to fallback to software emulation for the given device.
-// This happens when the given device doesn't exist, and software emulation is enabled.
-func UseSoftwareEmulationForDevice(devicePath string, allowEmulation bool) (bool, error) {
-	if !allowEmulation {
-		return false, nil
-	}
-
-	_, err := os.Stat(devicePath)
-	if err == nil {
-		return false, nil
-	}
-	if errors.Is(err, os.ErrNotExist) {
-		return true, nil
-	}
-	return false, err
 }
 
 func ResourceNameToEnvVar(prefix string, resourceName string) string {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -101,12 +101,6 @@ func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
 	return IsSEVVMI(vmi) && vmi.Spec.Domain.LaunchSecurity.SEV.Attestation != nil
 }
 
-func IsEFIVMI(vmi *v1.VirtualMachineInstance) bool {
-	return vmi.Spec.Domain.Firmware != nil &&
-		vmi.Spec.Domain.Firmware.Bootloader != nil &&
-		vmi.Spec.Domain.Firmware.Bootloader.EFI != nil
-}
-
 func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
 	if vmi == nil {
 		return false

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -93,17 +93,6 @@ func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
 	return IsSEVVMI(vmi) && vmi.Spec.Domain.LaunchSecurity.SEV.Attestation != nil
 }
 
-func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
-	if vmi == nil {
-		return false
-	}
-
-	domainFeatures := vmi.Spec.Domain.Features
-
-	return domainFeatures != nil && domainFeatures.Hyperv != nil && domainFeatures.Hyperv.Reenlightenment != nil &&
-		domainFeatures.Hyperv.Reenlightenment.Enabled != nil && *domainFeatures.Hyperv.Reenlightenment.Enabled
-}
-
 // WantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
 func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -88,14 +88,6 @@ func IsSEVVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Domain.LaunchSecurity.SEV != nil
 }
 
-// Check if a VMI spec requests AMD SEV-ES
-func IsSEVESVMI(vmi *v1.VirtualMachineInstance) bool {
-	return IsSEVVMI(vmi) &&
-		vmi.Spec.Domain.LaunchSecurity.SEV.Policy != nil &&
-		vmi.Spec.Domain.LaunchSecurity.SEV.Policy.EncryptedState != nil &&
-		*vmi.Spec.Domain.LaunchSecurity.SEV.Policy.EncryptedState
-}
-
 // Check if a VMI spec requests SEV with attestation
 func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
 	return IsSEVVMI(vmi) && vmi.Spec.Domain.LaunchSecurity.SEV.Attestation != nil

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -486,7 +486,7 @@ func getRequiredResources(vmi *v1.VirtualMachineInstance, allowEmulation bool) k
 	if util.NeedTunDevice(vmi) {
 		res[TunDevice] = resource.MustParse("1")
 	}
-	if util.NeedVirtioNetDevice(vmi, allowEmulation) {
+	if needVirtioNetDevice(vmi, allowEmulation) {
 		// Note that about network interface, allowEmulation does not make
 		// any difference on eventual Domain xml, but uniformly making
 		// /dev/vhost-net unavailable and libvirt implicitly fallback
@@ -748,4 +748,10 @@ func getMemoryLimitsRatio(namespace string, namespaceStore cache.Store) float64 
 	}
 
 	return limitRatioValue
+}
+
+// needVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
+// This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
+func needVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
+	return util.WantVirtioNetDevice(vmi) && !allowEmulation
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -700,7 +700,7 @@ func (t *templateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		log.Log.V(4).Info("Add SEV node label selector")
 		opts = append(opts, WithSEVSelector())
 	}
-	if util.IsSEVESVMI(vmi) {
+	if isSEVESVMI(vmi) {
 		log.Log.V(4).Info("Add SEV-ES node label selector")
 		opts = append(opts, WithSEVESSelector())
 	}
@@ -1572,4 +1572,12 @@ func WithNetTargetAnnotationsGenerator(generator targetAnnotationsGenerator) tem
 
 func hasHugePages(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.Memory != nil && vmi.Spec.Domain.Memory.Hugepages != nil
+}
+
+// Check if a VMI spec requests AMD SEV-ES
+func isSEVESVMI(vmi *v1.VirtualMachineInstance) bool {
+	return util.IsSEVVMI(vmi) &&
+		vmi.Spec.Domain.LaunchSecurity.SEV.Policy != nil &&
+		vmi.Spec.Domain.LaunchSecurity.SEV.Policy.EncryptedState != nil &&
+		*vmi.Spec.Domain.LaunchSecurity.SEV.Policy.EncryptedState
 }

--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/pointer:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/util/nodes:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/topology/tsc.go
+++ b/pkg/virt-controller/watch/topology/tsc.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"kubevirt.io/kubevirt/pkg/util"
-
 	v1 "k8s.io/api/core/v1"
 
 	k6tv1 "kubevirt.io/api/core/v1"
@@ -142,7 +140,7 @@ func GetTscFrequencyRequirement(vmi *k6tv1.VirtualMachineInstance) TscFrequencyR
 	if vmiHasInvTSCFeature(vmi) {
 		return newRequirement(RequiredForBoot, "VMI with invtsc CPU feature must have tsc frequency defined in order to boot")
 	}
-	if util.IsVmiUsingHyperVReenlightenment(vmi) {
+	if isVmiUsingHyperVReenlightenment(vmi) {
 		return newRequirement(RequiredForMigration, "HyperV Reenlightenment VMIs cannot migrate when TSC Frequency is not exposed on the cluster: guest timers might be inconsistent")
 	}
 
@@ -162,4 +160,15 @@ func vmiHasInvTSCFeature(vmi *k6tv1.VirtualMachineInstance) bool {
 		}
 	}
 	return false
+}
+
+func isVmiUsingHyperVReenlightenment(vmi *k6tv1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return false
+	}
+
+	domainFeatures := vmi.Spec.Domain.Features
+
+	return domainFeatures != nil && domainFeatures.Hyperv != nil && domainFeatures.Hyperv.Reenlightenment != nil &&
+		domainFeatures.Hyperv.Reenlightenment.Enabled != nil && *domainFeatures.Hyperv.Reenlightenment.Enabled
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1177,7 +1177,7 @@ func Convert_v1_Firmware_To_related_apis(vmi *v1.VirtualMachineInstance, domain 
 		},
 	}
 
-	if util.IsEFIVMI(vmi) {
+	if isEFIVMI(vmi) {
 		domain.Spec.OS.BootLoader = &api.Loader{
 			Path:     c.EFIConfiguration.EFICode,
 			ReadOnly: "yes",
@@ -1809,7 +1809,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == nil || *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice {
-		c.Architecture.AddGraphicsDevice(vmi, domain, c.BochsForEFIGuests && util.IsEFIVMI(vmi))
+		c.Architecture.AddGraphicsDevice(vmi, domain, c.BochsForEFIGuests && isEFIVMI(vmi))
 		domain.Spec.Devices.Graphics = []api.Graphics{
 			{
 				Listen: &api.GraphicsListen{
@@ -2056,4 +2056,10 @@ func domainVCPUTopologyForHotplug(vmi *v1.VirtualMachineInstance, domain *api.Do
 		Placement: "static",
 		CPUs:      cpuCount,
 	}
+}
+
+func isEFIVMI(vmi *v1.VirtualMachineInstance) bool {
+	return vmi.Spec.Domain.Firmware != nil &&
+		vmi.Spec.Domain.Firmware.Bootloader != nil &&
+		vmi.Spec.Domain.Firmware.Bootloader.EFI != nil
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1406,14 +1406,14 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	kvmPath := "/dev/kvm"
-	if softwareEmulation, err := useSoftwareEmulationForDevice(kvmPath, c.AllowEmulation); err != nil {
-		return err
-	} else if softwareEmulation {
-		logger := log.DefaultLogger()
-		logger.Infof("Hardware emulation device '%s' not present. Using software emulation.", kvmPath)
-		domain.Spec.Type = "qemu"
-	} else if _, err := os.Stat(kvmPath); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("hardware emulation device '%s' not present", kvmPath)
+	if _, err := os.Stat(kvmPath); errors.Is(err, os.ErrNotExist) {
+		if c.AllowEmulation {
+			logger := log.DefaultLogger()
+			logger.Infof("Hardware emulation device '%s' not present. Using software emulation.", kvmPath)
+			domain.Spec.Type = "qemu"
+		} else {
+			return fmt.Errorf("hardware emulation device '%s' not present", kvmPath)
+		}
 	} else if err != nil {
 		return err
 	}
@@ -2062,21 +2062,4 @@ func isEFIVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.Firmware != nil &&
 		vmi.Spec.Domain.Firmware.Bootloader != nil &&
 		vmi.Spec.Domain.Firmware.Bootloader.EFI != nil
-}
-
-// useSoftwareEmulationForDevice determines whether to fallback to software emulation for the given device.
-// This happens when the given device doesn't exist, and software emulation is enabled.
-func useSoftwareEmulationForDevice(devicePath string, allowEmulation bool) (bool, error) {
-	if !allowEmulation {
-		return false, nil
-	}
-
-	_, err := os.Stat(devicePath)
-	if err == nil {
-		return false, nil
-	}
-	if errors.Is(err, os.ErrNotExist) {
-		return true, nil
-	}
-	return false, err
 }


### PR DESCRIPTION
Move a few functions out of pkg/util in order to reduce coupling between unrelated parts of the code.

/kind cleanup

```release-note
NONE
```

