### PR TITLE
e2e/clone_test:  Refactor closures to regular functions

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -61,29 +61,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		format.MaxLength = 0
 	})
 
-	createSnapshot := func(vm *virtv1.VirtualMachine) *snapshotv1.VirtualMachineSnapshot {
-		var err error
-
-		snapshot := &snapshotv1.VirtualMachineSnapshot{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      "snapshot-" + vm.Name,
-				Namespace: vm.Namespace,
-			},
-			Spec: snapshotv1.VirtualMachineSnapshotSpec{
-				Source: k8sv1.TypedLocalObjectReference{
-					APIGroup: pointer.P(vmAPIGroup),
-					Kind:     "VirtualMachine",
-					Name:     vm.Name,
-				},
-			},
-		}
-
-		snapshot, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, v1.CreateOptions{})
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-		return snapshot
-	}
-
 	waitSnapshotReady := func(snapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.VirtualMachineSnapshot {
 		var err error
 
@@ -873,4 +850,27 @@ func createSourceVM(options ...libvmi.Option) (*virtv1.VirtualMachine, error) {
 	By(fmt.Sprintf("Creating VM %s", vm.Name))
 	virtClient := kubevirt.Client()
 	return virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v1.CreateOptions{})
+}
+
+func createSnapshot(vm *virtv1.VirtualMachine) *snapshotv1.VirtualMachineSnapshot {
+	var err error
+
+	snapshot := &snapshotv1.VirtualMachineSnapshot{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "snapshot-" + vm.Name,
+			Namespace: vm.Namespace,
+		},
+		Spec: snapshotv1.VirtualMachineSnapshotSpec{
+			Source: k8sv1.TypedLocalObjectReference{
+				APIGroup: pointer.P(vmAPIGroup),
+				Kind:     "VirtualMachine",
+				Name:     vm.Name,
+			},
+		},
+	}
+
+	snapshot, err = kubevirt.Client().VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, v1.CreateOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	return snapshot
 }

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -61,18 +61,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		format.MaxLength = 0
 	})
 
-	filterOutIrrelevantKeys := func(in map[string]string) map[string]string {
-		out := make(map[string]string)
-
-		for key, val := range in {
-			if !strings.Contains(key, "kubevirt.io") && !strings.Contains(key, "kubemacpool.io") {
-				out[key] = val
-			}
-		}
-
-		return out
-	}
-
 	Context("VM clone", func() {
 
 		const (
@@ -874,4 +862,16 @@ func expectVMRunnable(vm *virtv1.VirtualMachine, login console.LoginToFunction) 
 	Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(Not(BeReady()))
 
 	return vm
+}
+
+func filterOutIrrelevantKeys(in map[string]string) map[string]string {
+	out := make(map[string]string)
+
+	for key, val := range in {
+		if !strings.Contains(key, "kubevirt.io") && !strings.Contains(key, "kubemacpool.io") {
+			out[key] = val
+		}
+	}
+
+	return out
 }

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -61,24 +61,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		format.MaxLength = 0
 	})
 
-	generateCloneFromVMWithParams := func(sourceVM *virtv1.VirtualMachine, targetVMName string) *clone.VirtualMachineClone {
-		vmClone := kubecli.NewMinimalCloneWithNS("testclone", sourceVM.Namespace)
-
-		cloneSourceRef := &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.P(vmAPIGroup),
-			Kind:     "VirtualMachine",
-			Name:     sourceVM.Name,
-		}
-
-		cloneTargetRef := cloneSourceRef.DeepCopy()
-		cloneTargetRef.Name = targetVMName
-
-		vmClone.Spec.Source = cloneSourceRef
-		vmClone.Spec.Target = cloneTargetRef
-
-		return vmClone
-	}
-
 	generateCloneFromSnapshot := func(snapshot *snapshotv1.VirtualMachineSnapshot, targetVMName string) *clone.VirtualMachineClone {
 		vmClone := kubecli.NewMinimalCloneWithNS("testclone", snapshot.Namespace)
 
@@ -874,4 +856,22 @@ func waitSnapshotContentsExist(snapshotName, snapshotNamespace string) *snapshot
 	}).ShouldNot(HaveOccurred())
 
 	return snapshot
+}
+
+func generateCloneFromVMWithParams(sourceVM *virtv1.VirtualMachine, targetVMName string) *clone.VirtualMachineClone {
+	vmClone := kubecli.NewMinimalCloneWithNS("testclone", sourceVM.Namespace)
+
+	cloneSourceRef := &k8sv1.TypedLocalObjectReference{
+		APIGroup: pointer.P(vmAPIGroup),
+		Kind:     "VirtualMachine",
+		Name:     sourceVM.Name,
+	}
+
+	cloneTargetRef := cloneSourceRef.DeepCopy()
+	cloneTargetRef.Name = targetVMName
+
+	vmClone.Spec.Source = cloneSourceRef
+	vmClone.Spec.Target = cloneTargetRef
+
+	return vmClone
 }

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -540,7 +540,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 					It("with snapshot source", func() {
 						By("Snapshotting VM")
 						snapshot := createSnapshot(sourceVM.Name, sourceVM.Namespace)
-						snapshot = waitSnapshotReady(snapshot)
+						snapshot = waitSnapshotReady(snapshot.Name, snapshot.Namespace)
 
 						By("Deleting VM")
 						err = virtClient.VirtualMachine(sourceVM.Namespace).Delete(context.Background(), sourceVM.Name, v1.DeleteOptions{})
@@ -861,11 +861,12 @@ func createSnapshot(vmName, vmNamespace string) *snapshotv1.VirtualMachineSnapsh
 	return snapshot
 }
 
-func waitSnapshotReady(snapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.VirtualMachineSnapshot {
-	var err error
+func waitSnapshotReady(snapshotName, snapshotNamespace string) *snapshotv1.VirtualMachineSnapshot {
+	var snapshot *snapshotv1.VirtualMachineSnapshot
 
 	EventuallyWithOffset(1, func() bool {
-		snapshot, err = kubevirt.Client().VirtualMachineSnapshot(snapshot.Namespace).Get(context.Background(), snapshot.Name, v1.GetOptions{})
+		var err error
+		snapshot, err = kubevirt.Client().VirtualMachineSnapshot(snapshotNamespace).Get(context.Background(), snapshotName, v1.GetOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse
 	}, 180*time.Second, time.Second).Should(BeTrue(), "snapshot should be ready")

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -235,7 +235,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Creating a clone with a snapshot source")
-				vmClone = generateCloneFromSnapshot(snapshot, targetVMName)
+				vmClone = generateCloneFromSnapshot(snapshot.Name, snapshot.Namespace, targetVMName)
 				createCloneAndWaitForFinish(vmClone)
 
 				By(fmt.Sprintf("Getting the target VM %s", targetVMName))
@@ -482,7 +482,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						By("Creating a clone and expecting error")
-						vmClone = generateCloneFromSnapshot(snapshot, targetVMName)
+						vmClone = generateCloneFromSnapshot(snapshot.Name, snapshot.Namespace, targetVMName)
 						vmClone, err = virtClient.VirtualMachineClone(vmClone.Namespace).Create(context.Background(), vmClone, v1.CreateOptions{})
 						Expect(err).Should(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("not backed up in snapshot"))
@@ -855,13 +855,13 @@ func generateCloneFromVMWithParams(sourceVMName, sourceVMNamespace, targetVMName
 	return vmClone
 }
 
-func generateCloneFromSnapshot(snapshot *snapshotv1.VirtualMachineSnapshot, targetVMName string) *clone.VirtualMachineClone {
-	vmClone := kubecli.NewMinimalCloneWithNS("testclone", snapshot.Namespace)
+func generateCloneFromSnapshot(snapshotName, snapshotNamespace, targetVMName string) *clone.VirtualMachineClone {
+	vmClone := kubecli.NewMinimalCloneWithNS("testclone", snapshotNamespace)
 
 	cloneSourceRef := &k8sv1.TypedLocalObjectReference{
 		APIGroup: pointer.P(virtsnapshot.GroupName),
 		Kind:     "VirtualMachineSnapshot",
-		Name:     snapshot.Name,
+		Name:     snapshotName,
 	}
 
 	cloneTargetRef := &k8sv1.TypedLocalObjectReference{

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -189,7 +189,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		}
 
 		generateCloneFromVM := func() *clone.VirtualMachineClone {
-			return generateCloneFromVMWithParams(sourceVM, targetVMName)
+			return generateCloneFromVMWithParams(sourceVM.Name, sourceVM.Namespace, targetVMName)
 		}
 
 		Context("[sig-compute]simple VM and cloning operations", decorators.SigCompute, func() {
@@ -651,7 +651,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 						vmClone.Spec.Template.AnnotationFilters = filters
 					}
 					generateCloneWithFilters := func(sourceVM *virtv1.VirtualMachine, targetVMName string) *clone.VirtualMachineClone {
-						vmclone := generateCloneFromVMWithParams(sourceVM, targetVMName)
+						vmclone := generateCloneFromVMWithParams(sourceVM.Name, sourceVM.Namespace, targetVMName)
 						addCloneAnnotationAndLabelFilters(vmclone)
 						return vmclone
 					}
@@ -709,7 +709,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 							vmClone.Spec.Template.AnnotationFilters = filters
 						}
 						generateCloneWithFilters := func(sourceVM *virtv1.VirtualMachine, targetVMName string) *clone.VirtualMachineClone {
-							vmclone := generateCloneFromVMWithParams(sourceVM, targetVMName)
+							vmclone := generateCloneFromVMWithParams(sourceVM.Name, sourceVM.Namespace, targetVMName)
 							addCloneAnnotationAndLabelFilters(vmclone)
 							return vmclone
 						}
@@ -858,13 +858,13 @@ func waitSnapshotContentsExist(snapshotName, snapshotNamespace string) *snapshot
 	return snapshot
 }
 
-func generateCloneFromVMWithParams(sourceVM *virtv1.VirtualMachine, targetVMName string) *clone.VirtualMachineClone {
-	vmClone := kubecli.NewMinimalCloneWithNS("testclone", sourceVM.Namespace)
+func generateCloneFromVMWithParams(sourceVMName, sourceVMNamespace, targetVMName string) *clone.VirtualMachineClone {
+	vmClone := kubecli.NewMinimalCloneWithNS("testclone", sourceVMNamespace)
 
 	cloneSourceRef := &k8sv1.TypedLocalObjectReference{
 		APIGroup: pointer.P(vmAPIGroup),
 		Kind:     "VirtualMachine",
-		Name:     sourceVM.Name,
+		Name:     sourceVMName,
 	}
 
 	cloneTargetRef := cloneSourceRef.DeepCopy()

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -61,27 +61,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		format.MaxLength = 0
 	})
 
-	generateCloneFromSnapshot := func(snapshot *snapshotv1.VirtualMachineSnapshot, targetVMName string) *clone.VirtualMachineClone {
-		vmClone := kubecli.NewMinimalCloneWithNS("testclone", snapshot.Namespace)
-
-		cloneSourceRef := &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.P(virtsnapshot.GroupName),
-			Kind:     "VirtualMachineSnapshot",
-			Name:     snapshot.Name,
-		}
-
-		cloneTargetRef := &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.P(vmAPIGroup),
-			Kind:     "VirtualMachine",
-			Name:     targetVMName,
-		}
-
-		vmClone.Spec.Source = cloneSourceRef
-		vmClone.Spec.Target = cloneTargetRef
-
-		return vmClone
-	}
-
 	createCloneAndWaitForFinish := func(vmClone *clone.VirtualMachineClone) {
 		By(fmt.Sprintf("Creating clone object %s", vmClone.Name))
 		vmClone, err = virtClient.VirtualMachineClone(vmClone.Namespace).Create(context.Background(), vmClone, v1.CreateOptions{})
@@ -869,6 +848,27 @@ func generateCloneFromVMWithParams(sourceVMName, sourceVMNamespace, targetVMName
 
 	cloneTargetRef := cloneSourceRef.DeepCopy()
 	cloneTargetRef.Name = targetVMName
+
+	vmClone.Spec.Source = cloneSourceRef
+	vmClone.Spec.Target = cloneTargetRef
+
+	return vmClone
+}
+
+func generateCloneFromSnapshot(snapshot *snapshotv1.VirtualMachineSnapshot, targetVMName string) *clone.VirtualMachineClone {
+	vmClone := kubecli.NewMinimalCloneWithNS("testclone", snapshot.Namespace)
+
+	cloneSourceRef := &k8sv1.TypedLocalObjectReference{
+		APIGroup: pointer.P(virtsnapshot.GroupName),
+		Kind:     "VirtualMachineSnapshot",
+		Name:     snapshot.Name,
+	}
+
+	cloneTargetRef := &k8sv1.TypedLocalObjectReference{
+		APIGroup: pointer.P(vmAPIGroup),
+		Kind:     "VirtualMachine",
+		Name:     targetVMName,
+	}
 
 	vmClone.Spec.Source = cloneSourceRef
 	vmClone.Spec.Target = cloneTargetRef

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -61,18 +61,6 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 		format.MaxLength = 0
 	})
 
-	waitSnapshotReady := func(snapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.VirtualMachineSnapshot {
-		var err error
-
-		EventuallyWithOffset(1, func() bool {
-			snapshot, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Get(context.Background(), snapshot.Name, v1.GetOptions{})
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
-			return snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse
-		}, 180*time.Second, time.Second).Should(BeTrue(), "snapshot should be ready")
-
-		return snapshot
-	}
-
 	waitSnapshotContentsExist := func(snapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.VirtualMachineSnapshot {
 		var contentsName string
 		EventuallyWithOffset(1, func() error {
@@ -869,6 +857,18 @@ func createSnapshot(vmName, vmNamespace string) *snapshotv1.VirtualMachineSnapsh
 
 	snapshot, err := kubevirt.Client().VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, v1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	return snapshot
+}
+
+func waitSnapshotReady(snapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.VirtualMachineSnapshot {
+	var err error
+
+	EventuallyWithOffset(1, func() bool {
+		snapshot, err = kubevirt.Client().VirtualMachineSnapshot(snapshot.Namespace).Get(context.Background(), snapshot.Name, v1.GetOptions{})
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		return snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse
+	}, 180*time.Second, time.Second).Should(BeTrue(), "snapshot should be ready")
 
 	return snapshot
 }


### PR DESCRIPTION
### What this PR does
This PR is refactoring clusre (lambda) functions to regular functions.
Most of the functions only require the virtctl input param, that can be accessed via kubevirt library anyways.
Moving it to regular function simplifies the code.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

