### PR TITLE
tests/infra/prometheus: use option slice for cleaner VMI initialization

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -222,11 +222,16 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 		// but if the default disk is not vda, the test will break
 		// TODO: introspect the VMI and get the device name of this
 		// block device?
-		vmi := libvmifact.NewAlpine(libvmi.WithEmptyDisk("testdisk", v1.VirtIO, resource.MustParse("1G")))
-		if preferredNodeName != "" {
-			vmi = libvmifact.NewAlpine(libvmi.WithEmptyDisk("testdisk", v1.VirtIO, resource.MustParse("1G")),
-				libvmi.WithNodeSelectorFor(preferredNodeName))
+		options := []libvmi.Option{
+			libvmi.WithEmptyDisk("testdisk", v1.VirtIO, resource.MustParse("1G")),
 		}
+
+		if preferredNodeName != "" {
+			options = append(options, libvmi.WithNodeSelectorFor(preferredNodeName))
+		}
+
+		vmi := libvmifact.NewAlpine(options...)
+
 		const vmiStartTimeout = 30
 
 		vmi = libvmops.RunVMIAndExpectLaunch(vmi, vmiStartTimeout)


### PR DESCRIPTION
This commit refactors the VMI initialization logic in the `prepareVMIForTests` function. Instead of duplicating the initialization code for different cases, an option slice is used to collect functional options.

All VMIs now start with the `WithEmptyDisk` option by default. If the `preferredNodeName` argument is provided, the `WithNodeSelectorFor` option is appended to the slice. This results in a cleaner and more maintainable initialization process.

/kind cleanup

### Release note
```release-note
None
```

