### PR TITLE
[release-1.4] Collect resource requests and limits from VM instance type/preference

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/instancetype:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/common/workqueue:go_default_library",
         "//pkg/util/migrations:go_default_library",
@@ -49,6 +50,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/instancetype:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/workqueue"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -41,34 +42,25 @@ var (
 		vmSnapshotMetrics,
 	}
 
-	vmInformer                  cache.SharedIndexInformer
-	vmiInformer                 cache.SharedIndexInformer
-	clusterInstanceTypeInformer cache.SharedIndexInformer
-	instanceTypeInformer        cache.SharedIndexInformer
-	clusterPreferenceInformer   cache.SharedIndexInformer
-	preferenceInformer          cache.SharedIndexInformer
-	vmiMigrationInformer        cache.SharedIndexInformer
-	clusterConfig               *virtconfig.ClusterConfig
+	vmInformer           cache.SharedIndexInformer
+	vmiInformer          cache.SharedIndexInformer
+	vmiMigrationInformer cache.SharedIndexInformer
+	clusterConfig        *virtconfig.ClusterConfig
+	instancetypeMethods  *instancetype.InstancetypeMethods
 )
 
 func SetupMetrics(
 	vm cache.SharedIndexInformer,
 	vmi cache.SharedIndexInformer,
-	clusterInstanceType cache.SharedIndexInformer,
-	instanceType cache.SharedIndexInformer,
-	clusterPreference cache.SharedIndexInformer,
-	preference cache.SharedIndexInformer,
 	vmiMigration cache.SharedIndexInformer,
 	virtClusterConfig *virtconfig.ClusterConfig,
+	methods *instancetype.InstancetypeMethods,
 ) error {
 	vmInformer = vm
 	vmiInformer = vmi
-	clusterInstanceTypeInformer = clusterInstanceType
-	instanceTypeInformer = instanceType
-	clusterPreferenceInformer = clusterPreference
-	preferenceInformer = preference
 	vmiMigrationInformer = vmiMigration
 	clusterConfig = virtClusterConfig
+	instancetypeMethods = methods
 
 	if err := client.SetupMetrics(); err != nil {
 		return err

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -204,11 +204,11 @@ func getVMIMachine(vmi *k6tv1.VirtualMachineInstance) (guestOSMachineType string
 
 func getVMIInstancetype(vmi *k6tv1.VirtualMachineInstance) string {
 	if instancetypeName, ok := vmi.Annotations[k6tv1.InstancetypeAnnotation]; ok {
-		return fetchResourceName(instancetypeName, instanceTypeInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.InstancetypeStore)
 	}
 
 	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterInstancetypeAnnotation]; ok {
-		return fetchResourceName(instancetypeName, clusterInstanceTypeInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.ClusterInstancetypeStore)
 	}
 
 	return none
@@ -216,18 +216,18 @@ func getVMIInstancetype(vmi *k6tv1.VirtualMachineInstance) string {
 
 func getVMIPreference(vmi *k6tv1.VirtualMachineInstance) string {
 	if instancetypeName, ok := vmi.Annotations[k6tv1.PreferenceAnnotation]; ok {
-		return fetchResourceName(instancetypeName, preferenceInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.PreferenceStore)
 	}
 
 	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterPreferenceAnnotation]; ok {
-		return fetchResourceName(instancetypeName, clusterPreferenceInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.ClusterPreferenceStore)
 	}
 
 	return none
 }
 
-func fetchResourceName(name string, indexer cache.Indexer) string {
-	obj, ok, err := indexer.GetByKey(name)
+func fetchResourceName(name string, store cache.Store) string {
+	obj, ok, err := store.GetByKey(name)
 	if err != nil || !ok {
 		return other
 	}

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -213,11 +213,11 @@ func getVMInstancetype(vm *k6tv1.VirtualMachine) string {
 	}
 
 	if instancetype.Kind == "VirtualMachineInstancetype" {
-		return fetchResourceName(instancetype.Name, instanceTypeInformer.GetIndexer())
+		return fetchResourceName(instancetype.Name, instancetypeMethods.InstancetypeStore)
 	}
 
 	if instancetype.Kind == "VirtualMachineClusterInstancetype" {
-		return fetchResourceName(instancetype.Name, clusterInstanceTypeInformer.GetIndexer())
+		return fetchResourceName(instancetype.Name, instancetypeMethods.ClusterInstancetypeStore)
 	}
 
 	return none
@@ -231,11 +231,11 @@ func getVMPreference(vm *k6tv1.VirtualMachine) string {
 	}
 
 	if preference.Kind == "VirtualMachinePreference" {
-		return fetchResourceName(preference.Name, preferenceInformer.GetIndexer())
+		return fetchResourceName(preference.Name, instancetypeMethods.PreferenceStore)
 	}
 
 	if preference.Kind == "VirtualMachineClusterPreference" {
-		return fetchResourceName(preference.Name, clusterPreferenceInformer.GetIndexer())
+		return fetchResourceName(preference.Name, instancetypeMethods.ClusterPreferenceStore)
 	}
 
 	return none
@@ -262,16 +262,20 @@ func CollectResourceRequestsAndLimits(vms []*k6tv1.VirtualMachine) []operatormet
 	var results []operatormetrics.CollectorResult
 
 	for _, vm := range vms {
+		// Apply any instance type and preference to a copy of the VM before proceeding
+		vmCopy := vm.DeepCopy()
+		_ = instancetypeMethods.ApplyToVM(vmCopy)
+
 		// Memory requests and limits from domain resources
-		results = append(results, collectMemoryResourceRequestsFromDomainResources(vm)...)
-		results = append(results, collectMemoryResourceLimitsFromDomainResources(vm)...)
+		results = append(results, collectMemoryResourceRequestsFromDomainResources(vmCopy)...)
+		results = append(results, collectMemoryResourceLimitsFromDomainResources(vmCopy)...)
 
 		// CPU requests from domain CPU
-		results = append(results, collectCpuResourceRequestsFromDomainCpu(vm)...)
+		results = append(results, collectCpuResourceRequestsFromDomainCpu(vmCopy)...)
 
 		// CPU requests and limits from domain resources
-		results = append(results, collectCpuResourceRequestsFromDomainResources(vm)...)
-		results = append(results, collectCpuResourceLimitsFromDomainResources(vm)...)
+		results = append(results, collectCpuResourceRequestsFromDomainResources(vmCopy)...)
+		results = append(results, collectCpuResourceLimitsFromDomainResources(vmCopy)...)
 	}
 
 	return results
@@ -378,6 +382,27 @@ func collectCpuResourceRequestsFromDomainResources(vm *k6tv1.VirtualMachine) []o
 	cpuRequests := vm.Spec.Template.Spec.Domain.Resources.Requests.Cpu()
 
 	if cpuRequests == nil || cpuRequests.IsZero() {
+		// If no CPU requests and no Domain CPU are set, the VMI will default to 1 thread with 1 core and 1 socket
+		if vm.Spec.Template.Spec.Domain.CPU == nil {
+			return append(cr,
+				operatormetrics.CollectorResult{
+					Metric: vmResourceRequests,
+					Value:  1.0,
+					Labels: []string{vm.Name, vm.Namespace, "cpu", "cores", "default"},
+				},
+				operatormetrics.CollectorResult{
+					Metric: vmResourceRequests,
+					Value:  1.0,
+					Labels: []string{vm.Name, vm.Namespace, "cpu", "threads", "default"},
+				},
+				operatormetrics.CollectorResult{
+					Metric: vmResourceRequests,
+					Value:  1.0,
+					Labels: []string{vm.Name, vm.Namespace, "cpu", "sockets", "default"},
+				},
+			)
+		}
+
 		return cr
 	}
 

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -251,8 +251,8 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			cr := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
-			Expect(cr).To(BeZero())
+			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
+			expectDefaultCPUResourceRequests(crs)
 		})
 
 		It("should collect VM memory resource requests and limits", func() {
@@ -280,7 +280,6 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
-			Expect(crs).To(HaveLen(2), "Expected 2 metrics")
 
 			By("checking the resource requests")
 			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
@@ -291,6 +290,8 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_limits"))
 			Expect(crs[1].Value).To(BeEquivalentTo(2048))
 			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes"}))
+
+			expectDefaultCPUResourceRequests(crs[2:])
 		})
 
 		It("should collect VM memory guest and hugepages requests", func() {
@@ -316,7 +317,6 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
-			Expect(crs).To(HaveLen(2), "Expected 2 metrics")
 
 			By("checking the memory guest requests")
 			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
@@ -327,6 +327,8 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
 			Expect(crs[1].Value).To(BeEquivalentTo(2097152))
 			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes", "hugepages"}))
+
+			expectDefaultCPUResourceRequests(crs[2:])
 		})
 
 		It("should collect VM CPU resource requests and limits", func() {
@@ -389,7 +391,7 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
-			Expect(crs).To(HaveLen(3), "Expected 1 metric")
+			Expect(crs).To(HaveLen(3), "Expected 3 metrics")
 
 			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
 			Expect(crs[0].Value).To(BeEquivalentTo(2))
@@ -403,5 +405,55 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(crs[2].Value).To(BeEquivalentTo(1))
 			Expect(crs[2].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "sockets", "domain"}))
 		})
+
+		It("should collect VM CPU and Memory resource requests from Instance Type", func() {
+			vm := &k6tv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "testvm",
+				},
+				Spec: k6tv1.VirtualMachineSpec{
+					Instancetype: &k6tv1.InstancetypeMatcher{
+						Kind: "VirtualMachineClusterInstancetype",
+						Name: "ci-managed",
+					},
+					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{},
+				},
+			}
+
+			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
+
+			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(crs[0].Value).To(BeEquivalentTo(2048))
+			Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes", "guest"}))
+
+			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(crs[1].Value).To(BeEquivalentTo(1))
+			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores", "domain"}))
+
+			Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(crs[2].Value).To(BeEquivalentTo(1))
+			Expect(crs[2].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "threads", "domain"}))
+
+			Expect(crs[3].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(crs[3].Value).To(BeEquivalentTo(2))
+			Expect(crs[3].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "sockets", "domain"}))
+		})
 	})
 })
+
+func expectDefaultCPUResourceRequests(crs []operatormetrics.CollectorResult) {
+	Expect(crs).To(HaveLen(3), "Expected 3 metrics")
+
+	Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+	Expect(crs[0].Value).To(BeEquivalentTo(1))
+	Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores", "default"}))
+
+	Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+	Expect(crs[1].Value).To(BeEquivalentTo(1))
+	Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "threads", "default"}))
+
+	Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+	Expect(crs[2].Value).To(BeEquivalentTo(1))
+	Expect(crs[2].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "sockets", "default"}))
+}

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -435,12 +435,16 @@ func Execute() {
 	if err := metrics.SetupMetrics(
 		app.vmInformer,
 		app.vmiInformer,
-		app.clusterInstancetypeInformer,
-		app.instancetypeInformer,
-		app.clusterPreferenceInformer,
-		app.preferenceInformer,
 		app.migrationInformer,
 		app.clusterConfig,
+		&instancetype.InstancetypeMethods{
+			InstancetypeStore:        app.instancetypeInformer.GetStore(),
+			ClusterInstancetypeStore: app.clusterInstancetypeInformer.GetStore(),
+			PreferenceStore:          app.preferenceInformer.GetStore(),
+			ClusterPreferenceStore:   app.clusterInstancetypeInformer.GetStore(),
+			ControllerRevisionStore:  app.controllerRevisionInformer.GetStore(),
+			Clientset:                app.clientSet,
+		},
 	); err != nil {
 		golog.Fatal(err)
 	}

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -95,7 +95,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			err = virtapi.SetupMetrics()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil)
+			err = virtcontroller.SetupMetrics(nil, nil, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = virtcontroller.RegisterLeaderMetrics()

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -41,7 +41,7 @@ this document.
 `
 
 func main() {
-	if err := virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+	if err := virtcontroller.SetupMetrics(nil, nil, nil, nil, nil); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/13535

Before this PR:

Sometimes the VMs do not have any explicit resource requests/limits, but those are usually defined by Instance Types/Preferences. In this situation, the resource metrics were not collecting the data.

After this PR:

kubevirt_vm_resource_requests and kubevirt_vm_resource_limits also collect data from the instance types and preferences.

Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-53260

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect resource requests and limits from VM instance type/preference
```

/cc @sradco @lyarwood @avlitman @enp0s3 