### PR TITLE
Backend storage: Allow specifying different PVC size

### DIFF
--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/tests/migration/recovery.go
+++ b/tests/migration/recovery.go
@@ -172,7 +172,7 @@ func createPVCFor(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine) *k8s
 		Spec: k8score.PersistentVolumeClaimSpec{
 			AccessModes: []k8score.PersistentVolumeAccessMode{accessMode},
 			Resources: k8score.VolumeResourceRequirements{
-				Requests: k8score.ResourceList{k8score.ResourceStorage: resource.MustParse(backendstorage.PVCSize)},
+				Requests: k8score.ResourceList{k8score.ResourceStorage: resource.MustParse(backendstorage.DefaultPVCSize)},
 			},
 			StorageClassName: &storageClass,
 			VolumeMode:       &mode,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

The storage size for the backend storage PVC is hardcoded to 10Mi. This behavior can be problematic for provisioners that require a minimum storage size above this quantity, for example, https://aws.amazon.com/ebs/volume-types/#product-faqs#ebs-volume-types#ssd-based-volumes-.

This Pull Request allows specifying a different backend storage size via VM state storage class annotation.

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: vm-state-storageclass
  annotations:
    storage.kubevirt.io/minimum-supported-pvc-size: "4Gi"
```
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-51171

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow specifying different backend PVC size
```

