### PR TITLE
VMSnapshot: wait for volumes to be bound instead of skip

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -1467,7 +1467,7 @@ func CreateRestorePVCDefFromVMRestore(vmRestoreName, restorePVCName string, volu
 }
 
 func updateRestoreCondition(r *snapshotv1.VirtualMachineRestore, c snapshotv1.Condition) {
-	r.Status.Conditions = updateCondition(r.Status.Conditions, c, true)
+	r.Status.Conditions = updateCondition(r.Status.Conditions, c)
 }
 
 // Returns a set of volumes not for restore

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -777,14 +777,12 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 	// terminal phase 1 - failed
 	if vmSnapshotDeadlineExceeded(vmSnapshotCpy) {
 		vmSnapshotCpy.Status.Phase = snapshotv1.Failed
-		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, vmSnapshotDeadlineExceededError))
 		updateSnapshotCondition(vmSnapshotCpy, newFailureCondition(corev1.ConditionTrue, vmSnapshotDeadlineExceededError))
-		updateSnapshotCondition(vmSnapshotCpy, newReadyCondition(corev1.ConditionFalse, "Operation failed"))
+		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "Operation failed"))
 		// terminal phase 2 - succeeded
 	} else if vmSnapshotSucceeded(vmSnapshotCpy) || vmSnapshotCpy.Status.CreationTime != nil {
 		vmSnapshotCpy.Status.Phase = snapshotv1.Succeeded
 		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "Operation complete"))
-		updateSnapshotCondition(vmSnapshotCpy, newReadyCondition(corev1.ConditionTrue, "Operation complete"))
 		if err := ctrl.updateSnapshotSnapshotableVolumes(vmSnapshotCpy, content); err != nil {
 			return nil, err
 		}
@@ -1105,5 +1103,5 @@ func (ctrl *VMSnapshotController) getVMI(vm *kubevirtv1.VirtualMachine) (*kubevi
 }
 
 func updateSnapshotCondition(ss *snapshotv1.VirtualMachineSnapshot, c snapshotv1.Condition) {
-	ss.Status.Conditions = updateCondition(ss.Status.Conditions, c, false)
+	ss.Status.Conditions = updateCondition(ss.Status.Conditions, c)
 }

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -608,11 +608,6 @@ func (ctrl *VMSnapshotController) createContent(vmSnapshot *snapshotv1.VirtualMa
 	var volumeBackups []snapshotv1.VolumeBackup
 	pvcs, err := source.PersistentVolumeClaims()
 	if err != nil {
-		if storageutils.IsErrNoBackendPVC(err) {
-			// No backend pvc when we should have one, lets wait
-			// TODO: Improve this error handling
-			return nil
-		}
 		return err
 	}
 	for volumeName, pvcName := range pvcs {
@@ -684,7 +679,7 @@ func (ctrl *VMSnapshotController) getSnapshotPVC(namespace, volumeName string) (
 
 	pvc := obj.(*corev1.PersistentVolumeClaim).DeepCopy()
 
-	if pvc.Spec.VolumeName == "" {
+	if pvc.Status.Phase != corev1.ClaimBound {
 		log.Log.Warningf("Unbound PVC %s/%s", pvc.Namespace, pvc.Name)
 		return nil, nil
 	}

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -439,13 +439,6 @@ var _ = Describe("Snapshot controlleer", func() {
 			mockVMSnapshotContentQueue.Wait()
 		}
 
-		addVM := func(vm *v1.VirtualMachine) {
-			syncCaches(stop)
-			mockVMSnapshotQueue.ExpectAdds(1)
-			vmSource.Add(vm)
-			mockVMSnapshotQueue.Wait()
-		}
-
 		addVolumeSnapshot := func(s *vsv1.VolumeSnapshot) {
 			syncCaches(stop)
 			mockVMSnapshotContentQueue.ExpectAdds(1)
@@ -486,6 +479,11 @@ var _ = Describe("Snapshot controlleer", func() {
 					volumeSnapshotInformer.HasSynced,
 					volumeSnapshotClassInformer.HasSynced,
 				)).To(BeTrue())
+
+				pvcs := createPersistentVolumeClaims()
+				for i := range pvcs {
+					pvcSource.Add(&pvcs[i])
+				}
 			})
 
 			It("should initialize VirtualMachineSnapshot status", func() {
@@ -691,22 +689,57 @@ var _ = Describe("Snapshot controlleer", func() {
 				Expect(*contentDeletes).To(Equal(1))
 			})
 
-			It("should (partial) lock source", func() {
+			DescribeTable("should partial lock source if VM patch fails", func(runstrategy v1.VirtualMachineRunStrategy) {
 				vmSnapshot := createVMSnapshotInProgress()
 				vm := createVM()
+				vm.Spec.RunStrategy = pointer.P(runstrategy)
 				vmUpdate := vm.DeepCopy()
 				vmUpdate.ResourceVersion = "1"
 				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
 
-				vmSource.Add(vm)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdate, metav1.UpdateOptions{}).Return(vmUpdate, nil).Times(1)
 				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(nil, fmt.Errorf("error")).Times(1)
 
+				vmSource.Add(vm)
 				addVirtualMachineSnapshot(vmSnapshot)
 				controller.processVMSnapshotWorkItem()
+			},
+				Entry("With runstrategy halted", v1.RunStrategyHalted),
+				Entry("With runstrategy always", v1.RunStrategyAlways),
+				Entry("With runstrategy manual", v1.RunStrategyManual),
+				Entry("With runstrategy rerunOnFailure", v1.RunStrategyRerunOnFailure),
+			)
+
+			It("should complete lock source after partial lock", func() {
+				vmSnapshot := createVMSnapshotInProgress()
+				vm := createVM()
+				// Update of snapshotinprogress succeeded already
+				vm.Status.SnapshotInProgress = &vmSnapshotName
+				vmUpdate := vm.DeepCopy()
+				vmUpdate.ResourceVersion = "1"
+				vmUpdate.Finalizers = []string{"snapshot.kubevirt.io/snapshot-source-protection"}
+
+				vmSource.Add(vm)
+
+				patchBytes, err := patch.GenerateTestReplacePatch("/metadata/finalizers", nil, []string{"snapshot.kubevirt.io/snapshot-source-protection"})
+				Expect(err).ToNot(HaveOccurred())
+				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}).Return(vmUpdate, nil).Times(1)
+
+				updatedSnapshot := vmSnapshot.DeepCopy()
+				updatedSnapshot.ResourceVersion = "1"
+				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
+					newReadyCondition(corev1.ConditionFalse, "Not ready"),
+				}
+				updatedSnapshot.Status.Indications = nil
+				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
+
+				addVirtualMachineSnapshot(vmSnapshot)
+				controller.processVMSnapshotWorkItem()
+				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
-			It("should (complete) lock source", func() {
+			DescribeTable("should complete lock source", func(vmiExists bool) {
 				vmSnapshot := createVMSnapshotInProgress()
 				vm := createVM()
 				vmUpdate := vm.DeepCopy()
@@ -714,6 +747,10 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
 
 				vmSource.Add(vm)
+				if vmiExists {
+					vmi := createVMI(vm)
+					vmiSource.Add(vmi)
+				}
 				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdate, metav1.UpdateOptions{}).Return(vmUpdate, nil).Times(1)
 
 				vmUpdate2 := vmUpdate.DeepCopy()
@@ -725,173 +762,27 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot := vmSnapshot.DeepCopy()
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
+					newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
 					newReadyCondition(corev1.ConditionFalse, "Not ready"),
 				}
 				updatedSnapshot.Status.Indications = nil
-				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
-
-				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
-				Expect(*updateStatusCalls).To(Equal(1))
-			})
-
-			It("should (partial) lock source manual runstrategy", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vm := createVM()
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyManual)
-				vmUpdate := vm.DeepCopy()
-				vmUpdate.ResourceVersion = "1"
-				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
-
-				vmSource.Add(vm)
-				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdate, metav1.UpdateOptions{}).Return(vmUpdate, nil).Times(1)
-				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(nil, fmt.Errorf("error")).Times(1)
-
-				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
-			})
-
-			It("should (finish) lock source", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vm := createVM()
-				vm.Status.SnapshotInProgress = &vmSnapshotName
-				vmUpdate := vm.DeepCopy()
-				vmUpdate.ResourceVersion = "1"
-				vmUpdate.Finalizers = []string{"snapshot.kubevirt.io/snapshot-source-protection"}
-
-				vmSource.Add(vm)
-				patchBytes, err := patch.GenerateTestReplacePatch("/metadata/finalizers", nil, []string{"snapshot.kubevirt.io/snapshot-source-protection"})
-				Expect(err).ToNot(HaveOccurred())
-				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}).Return(vmUpdate, nil).Times(1)
-
-				updatedSnapshot := vmSnapshot.DeepCopy()
-				updatedSnapshot.ResourceVersion = "1"
-				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
-					newReadyCondition(corev1.ConditionFalse, "Not ready"),
-				}
-				updatedSnapshot.Status.Indications = nil
-				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
-
-				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
-				Expect(*updateStatusCalls).To(Equal(1))
-
-			})
-
-			It("should (partial) lock source when VM updated", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vm := createVM()
-				vmUpdate := vm.DeepCopy()
-				vmUpdate.ResourceVersion = "1"
-				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
-
-				vmSnapshotSource.Add(vmSnapshot)
-				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdate, metav1.UpdateOptions{}).Return(vmUpdate, nil).Times(1)
-				addVM(vm)
-				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(nil, fmt.Errorf("error")).Times(1)
-				controller.processVMSnapshotWorkItem()
-			})
-
-			It("should (partial) lock source if running but no VMI", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vm := createVM()
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
-				vmUpdate := vm.DeepCopy()
-				vmUpdate.ResourceVersion = "1"
-				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
-
-				vmSource.Add(vm)
-				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdate, metav1.UpdateOptions{}).Return(vmUpdate, nil).Times(1)
-				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(nil, fmt.Errorf("error")).Times(1)
-
-				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
-			})
-
-			It("should (finish) lock source if running but no VMI", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vm := createVM()
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
-				vm.Status.SnapshotInProgress = &vmSnapshotName
-				vmUpdate := vm.DeepCopy()
-				vmUpdate.ResourceVersion = "1"
-				vmUpdate.Finalizers = []string{"snapshot.kubevirt.io/snapshot-source-protection"}
-
-				vmSource.Add(vm)
-				patchBytes, err := patch.GenerateTestReplacePatch("/metadata/finalizers", nil, []string{"snapshot.kubevirt.io/snapshot-source-protection"})
-				Expect(err).ToNot(HaveOccurred())
-				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}).Return(vmUpdate, nil).Times(1)
-
-				updatedSnapshot := vmSnapshot.DeepCopy()
-				updatedSnapshot.ResourceVersion = "1"
-				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
-					newReadyCondition(corev1.ConditionFalse, "Not ready"),
+				if vmiExists {
+					updatedSnapshot.Status.Indications = []snapshotv1.Indication{
+						snapshotv1.VMSnapshotOnlineSnapshotIndication,
+						snapshotv1.VMSnapshotNoGuestAgentIndication,
+					}
 				}
 				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
 
 				addVirtualMachineSnapshot(vmSnapshot)
 				controller.processVMSnapshotWorkItem()
 				Expect(*updateStatusCalls).To(Equal(1))
-			})
+			},
+				Entry("when vm running", true),
+				Entry("when vm not running", false),
+			)
 
-			It("should (partial) lock source if VMI exists", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vm := createVM()
-				vmUpdate := vm.DeepCopy()
-				vmUpdate.ResourceVersion = "1"
-				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
-				vmRevision := createVMRevision(vm)
-				crSource.Add(vmRevision)
-				vmi := createVMI(vm)
-				vmi.Status.VirtualMachineRevisionName = vmRevisionName
-				vmiSource.Add(vmi)
-				vmSource.Add(vm)
-				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdate, metav1.UpdateOptions{}).Return(vmUpdate, nil).Times(1)
-				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(nil, fmt.Errorf("error")).Times(1)
-
-				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
-			})
-
-			It("should (finish) lock source if VMI exists", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vm := createVM()
-				vm.Status.SnapshotInProgress = &vmSnapshotName
-				vmUpdate := vm.DeepCopy()
-				vmUpdate.ResourceVersion = "1"
-				vmUpdate.Finalizers = []string{"snapshot.kubevirt.io/snapshot-source-protection"}
-				vmRevision := createVMRevision(vm)
-				crSource.Add(vmRevision)
-
-				vmi := createVMI(vm)
-				vmi.Status.VirtualMachineRevisionName = vmRevisionName
-				vmiSource.Add(vmi)
-				vmSource.Add(vm)
-				patchBytes, err := patch.GenerateTestReplacePatch("/metadata/finalizers", nil, []string{"snapshot.kubevirt.io/snapshot-source-protection"})
-				Expect(err).ToNot(HaveOccurred())
-				vmInterface.EXPECT().Patch(context.Background(), vmUpdate.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}).Return(vmUpdate, nil).Times(1)
-
-				updatedSnapshot := vmSnapshot.DeepCopy()
-				updatedSnapshot.ResourceVersion = "1"
-				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
-					newReadyCondition(corev1.ConditionFalse, "Not ready"),
-				}
-				updatedSnapshot.Status.Indications = []snapshotv1.Indication{
-					snapshotv1.VMSnapshotOnlineSnapshotIndication,
-					snapshotv1.VMSnapshotNoGuestAgentIndication,
-				}
-				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
-
-				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
-				Expect(*updateStatusCalls).To(Equal(1))
-			})
-
-			It("should not lock source if pods using PVCs", func() {
+			It("should not lock source if pods using PVCs when vm not running", func() {
 				vmSnapshot := createVMSnapshotInProgress()
 				vm := createVM()
 
@@ -902,7 +793,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot := vmSnapshot.DeepCopy()
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
+					newProgressingCondition(corev1.ConditionFalse, "Source not locked source is offline but 1 pods using PVCs [alpine-dv]"),
 					newReadyCondition(corev1.ConditionFalse, "Not ready"),
 				}
 				updatedSnapshot.Status.Indications = nil
@@ -943,7 +834,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.Phase = snapshotv1.InProgress
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
+					newProgressingCondition(corev1.ConditionFalse, fmt.Sprintf("Source not locked snapshot %q in progress", n)),
 					newReadyCondition(corev1.ConditionFalse, "Not ready"),
 				}
 				updatedSnapshot.Status.Indications = nil
@@ -959,14 +850,10 @@ var _ = Describe("Snapshot controlleer", func() {
 				vm := createLockedVM()
 				storageClass := createStorageClass()
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
-				pvcs := createPersistentVolumeClaims()
 				vmSnapshotContent := createVMSnapshotContent()
 
 				vmSource.Add(vm)
 				storageClassSource.Add(storageClass)
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 				createCalls := expectVMSnapshotContentCreate(vmSnapshotClient, vmSnapshotContent)
 				vmSnapshotSource.Add(vmSnapshot)
 				addVolumeSnapshotClass(volumeSnapshotClass)
@@ -1016,6 +903,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				// the content source will have the a combination of the vm revision, the vmi and the vm volumes
 				vm.ObjectMeta.Generation = 2
 				pvcs := createPersistentVolumeClaims()
+
 				expectedContent := createVirtualMachineSnapshotContent(vmSnapshot, vm, pvcs)
 				vm.Spec.Template.Spec.Domain.Resources.Requests = corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
@@ -1024,9 +912,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				storageClass := createStorageClass()
 				storageClassSource.Add(storageClass)
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 				createCalls := expectVMSnapshotContentCreate(vmSnapshotClient, expectedContent)
 				vmSnapshotSource.Add(vmSnapshot)
 				addVolumeSnapshotClass(volumeSnapshotClass)
@@ -1062,14 +947,13 @@ var _ = Describe("Snapshot controlleer", func() {
 				vm := createLockedVM()
 				vm = updateVMWithMemoryDump(vm)
 				pvcs := createPersistentVolumeClaims()
-				pvcs = addMemoryDumpPVC(pvcs)
+				md := memoryDumpPVC()
+				pvcSource.Add(&md)
+				pvcs = append(pvcs, md)
 				vmSnapshotContent := createVirtualMachineSnapshotContent(vmSnapshot, vm, pvcs)
 
 				vmSource.Add(vm)
 				storageClassSource.Add(storageClass)
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 				createCalls := expectVMSnapshotContentCreate(vmSnapshotClient, vmSnapshotContent)
 				vmSnapshotSource.Add(vmSnapshot)
 				addVolumeSnapshotClass(volumeSnapshotClass)
@@ -1282,7 +1166,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				storageClass := createStorageClass()
 				vmSnapshot := createVMSnapshotInProgress()
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
-				pvcs := createPersistentVolumeClaims()
 				vmSnapshotContent := createVMSnapshotContent()
 				vmSnapshotContent.UID = contentUID
 
@@ -1302,9 +1185,6 @@ var _ = Describe("Snapshot controlleer", func() {
 
 				vmSource.Add(vm)
 				storageClassSource.Add(storageClass)
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 
 				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClass.Name, vmSnapshotContent)
 				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
@@ -1321,7 +1201,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				vm := createLockedVM()
 				storageClass := createStorageClass()
 				volumeSnapshotClasses := createVolumeSnapshotClasses()
-				pvcs := createPersistentVolumeClaims()
 				vmSnapshot := createVMSnapshotInProgress()
 				vmSnapshotContent := createVMSnapshotContent()
 				vmSnapshotContent.UID = contentUID
@@ -1342,9 +1221,6 @@ var _ = Describe("Snapshot controlleer", func() {
 
 				vmSource.Add(vm)
 				storageClassSource.Add(storageClass)
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 
 				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClasses[0].Name, vmSnapshotContent)
 				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
@@ -1361,7 +1237,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				vm := createLockedVM()
 				storageClass := createStorageClass()
 				volumeSnapshotClasses := createVolumeSnapshotClasses()
-				pvcs := createPersistentVolumeClaims()
 				storageProfile := createStorageProfile()
 				vmSnapshot := createVMSnapshotInProgress()
 				vmSnapshotContent := createVMSnapshotContent()
@@ -1384,9 +1259,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmSource.Add(vm)
 				storageClassSource.Add(storageClass)
 				storageProfileSource.Add(storageProfile)
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 
 				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClassName2, vmSnapshotContent)
 				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
@@ -1404,7 +1276,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				storageClass := createStorageClass()
 				vmSnapshot := createVMSnapshotInProgress()
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
-				pvcs := createPersistentVolumeClaims()
 				vmSnapshotContent := createVMSnapshotContent()
 				vmSnapshotContent.UID = contentUID
 				vmSource.Add(vm)
@@ -1427,9 +1298,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 
 				storageClassSource.Add(storageClass)
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 
 				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClass.Name, vmSnapshotContent)
 				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
@@ -1445,7 +1313,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				storageClass := createStorageClass()
 				vmSnapshot := createVMSnapshotInProgress()
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
-				pvcs := createPersistentVolumeClaims()
 				vmSnapshotContent := createVMSnapshotContent()
 				vmSnapshotContent.UID = contentUID
 				vm := createLockedVM()
@@ -1478,9 +1345,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 
 				storageClassSource.Add(storageClass)
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 
 				vmiInterface.EXPECT().Freeze(context.Background(), vm.Name, 0*time.Second).Return(nil).Times(1)
 				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClass.Name, vmSnapshotContent)
@@ -1634,10 +1498,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				storageClass := createStorageClass()
 				storageClassSource.Add(storageClass)
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
-				pvcs := createPersistentVolumeClaims()
-				for i := range pvcs {
-					pvcSource.Add(&pvcs[i])
-				}
 
 				vm := createLockedVM()
 				vmSource.Add(vm)
@@ -2722,7 +2582,7 @@ func createPodsUsingPVCs(vm *v1.VirtualMachine) []corev1.Pod {
 	return pods
 }
 
-func addMemoryDumpPVC(pvcs []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
+func memoryDumpPVC() corev1.PersistentVolumeClaim {
 	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       testNamespace,
@@ -2740,8 +2600,7 @@ func addMemoryDumpPVC(pvcs []corev1.PersistentVolumeClaim) []corev1.PersistentVo
 			StorageClassName: &storageClassName,
 		},
 	}
-	pvcs = append(pvcs, pvc)
-	return pvcs
+	return pvc
 }
 
 func updateVMWithMemoryDump(vm *v1.VirtualMachine) *v1.VirtualMachine {

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -2447,7 +2447,8 @@ func expectVMSnapshotUpdateStatus(client *kubevirtfake.Clientset, vmSnapshot *sn
 
 		calls++
 
-		return reflect.DeepEqual(updateObj.Status, vmSnapshot.Status), update.GetObject(), nil
+		Expect(updateObj.Status).To(Equal(vmSnapshot.Status))
+		return true, update.GetObject(), nil
 	})
 	return &calls
 }

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			CreationTime: timeFunc(),
 			Conditions: []snapshotv1.Condition{
 				newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
-				newReadyCondition(corev1.ConditionTrue, "Operation complete"),
+				newReadyCondition(corev1.ConditionTrue, "Ready"),
 			},
 			Phase: snapshotv1.Succeeded,
 		}
@@ -193,7 +193,7 @@ var _ = Describe("Snapshot controlleer", func() {
 		vms.Status.Indications = nil
 		vms.Status.Conditions = []snapshotv1.Condition{
 			newProgressingCondition(corev1.ConditionFalse, "In error state"),
-			newReadyCondition(corev1.ConditionFalse, "Error"),
+			newReadyCondition(corev1.ConditionFalse, "Not ready"),
 		}
 		vms.Status.Error = content.Status.Error
 		return vms
@@ -1023,7 +1023,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
-					newReadyCondition(corev1.ConditionTrue, "Operation complete"),
+					newReadyCondition(corev1.ConditionTrue, "Ready"),
 				}
 				updatedSnapshot.Status.SnapshotVolumes = &snapshotv1.SnapshotVolumesLists{
 					IncludedVolumes: []string{diskName},
@@ -1065,7 +1065,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
-					newReadyCondition(corev1.ConditionTrue, "Operation complete"),
+					newReadyCondition(corev1.ConditionTrue, "Ready"),
 				}
 				updatedSnapshot.Status.SnapshotVolumes = &snapshotv1.SnapshotVolumesLists{
 					IncludedVolumes: []string{diskName},
@@ -1145,7 +1145,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.Error = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
-					newReadyCondition(corev1.ConditionFalse, "Error"),
+					newReadyCondition(corev1.ConditionFalse, "Not ready"),
 				}
 
 				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
@@ -1180,9 +1180,9 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot := vmSnapshot.DeepCopy()
 				updatedSnapshot.Status.Phase = snapshotv1.Failed
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionFalse, vmSnapshotDeadlineExceededError),
 					newFailureCondition(corev1.ConditionTrue, vmSnapshotDeadlineExceededError),
-					newReadyCondition(corev1.ConditionFalse, "Operation failed"),
+					newProgressingCondition(corev1.ConditionFalse, "Operation failed"),
+					newReadyCondition(corev1.ConditionFalse, "Not ready"),
 				}
 
 				contentDeletes := expectVMSnapshotContentDelete(vmSnapshotClient, vmSnapshotContent.Name)

--- a/pkg/storage/snapshot/util.go
+++ b/pkg/storage/snapshot/util.go
@@ -84,11 +84,11 @@ func hasConditionType(conditions []snapshotv1.Condition, condType snapshotv1.Con
 	return false
 }
 
-func updateCondition(conditions []snapshotv1.Condition, c snapshotv1.Condition, includeReason bool) []snapshotv1.Condition {
+func updateCondition(conditions []snapshotv1.Condition, c snapshotv1.Condition) []snapshotv1.Condition {
 	found := false
 	for i := range conditions {
 		if conditions[i].Type == c.Type {
-			if conditions[i].Status != c.Status || (includeReason && conditions[i].Reason != c.Reason) {
+			if conditions[i].Status != c.Status || conditions[i].Reason != c.Reason {
 				conditions[i] = c
 			}
 			found = true

--- a/tests/libstorage/virtualmachinesnapshot.go
+++ b/tests/libstorage/virtualmachinesnapshot.go
@@ -45,6 +45,7 @@ func WaitSnapshotSucceeded(virtClient kubecli.KubevirtClient, namespace string, 
 		Expect(err).ToNot(HaveOccurred())
 		return snapshot.Status
 	}, 180*time.Second, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"ReadyToUse": gstruct.PointTo(BeTrue()),
 		"Conditions": ContainElements(
 			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 				"Type":   Equal(snapshotv1.ConditionReady),

--- a/tests/libstorage/virtualmachinesnapshot.go
+++ b/tests/libstorage/virtualmachinesnapshot.go
@@ -33,8 +33,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-const operationComplete = "Operation complete"
-
 var groupName = "kubevirt.io"
 
 func WaitSnapshotSucceeded(virtClient kubecli.KubevirtClient, namespace string, snapshotName string) *snapshotv1.VirtualMachineSnapshot {
@@ -50,11 +48,11 @@ func WaitSnapshotSucceeded(virtClient kubecli.KubevirtClient, namespace string, 
 			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 				"Type":   Equal(snapshotv1.ConditionReady),
 				"Status": Equal(corev1.ConditionTrue),
-				"Reason": Equal(operationComplete)}),
+				"Reason": Equal("Ready")}),
 			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 				"Type":   Equal(snapshotv1.ConditionProgressing),
 				"Status": Equal(corev1.ConditionFalse),
-				"Reason": Equal(operationComplete)}),
+				"Reason": Equal("Operation complete")}),
 		),
 	})))
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -610,7 +610,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 							"Type":   Equal(snapshotv1.ConditionProgressing),
 							"Status": Equal(corev1.ConditionFalse),
-							"Reason": Equal(snapshotDeadlineExceeded)}),
+							"Reason": Equal("Operation failed")}),
 						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 							"Type":   Equal(snapshotv1.ConditionReady),
 							"Status": Equal(corev1.ConditionFalse),
@@ -1303,7 +1303,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 							"Type":   Equal(snapshotv1.ConditionProgressing),
 							"Status": Equal(corev1.ConditionFalse),
-							"Reason": Equal(snapshotDeadlineExceeded)}),
+							"Reason": Equal("Operation failed")}),
 						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 							"Type":   Equal(snapshotv1.ConditionFailure),
 							"Status": Equal(corev1.ConditionTrue),

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -71,16 +71,6 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		webhook    *admissionregistrationv1.ValidatingWebhookConfiguration
 	)
 
-	waitSnapshotReady := func() {
-		Eventually(func() *snapshotv1.VirtualMachineSnapshotStatus {
-			snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return snapshot.Status
-		}, 180*time.Second, time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"ReadyToUse": gstruct.PointTo(BeTrue()),
-		})))
-	}
-
 	deleteSnapshot := func() {
 		err := virtClient.VirtualMachineSnapshot(snapshot.Namespace).Delete(context.Background(), snapshot.Name, metav1.DeleteOptions{})
 		if errors.IsNotFound(err) {
@@ -207,7 +197,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			_, err := virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			waitSnapshotReady()
+			snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 
 			Expect(snapshot.Status.SourceUID).ToNot(BeNil())
 			Expect(*snapshot.Status.SourceUID).To(Equal(vm.UID))
@@ -466,7 +456,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 				checkVMFreeze(snapshot, vmi, true, ensureFreezeFedora)
 
 				Expect(snapshot.Status.CreationTime).ToNot(BeNil())
@@ -517,7 +507,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 				checkVMFreeze(snapshot, vmi, false, ensureNoFreezeAlpine)
 
 				Expect(snapshot.Status.CreationTime).ToNot(BeNil())
@@ -541,7 +531,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 				checkVMFreeze(snapshot, vmi, true, ensureNoFreezeAlpine)
 
 				Expect(snapshot.Status.CreationTime).ToNot(BeNil())
@@ -1024,7 +1014,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 
 				Expect(snapshot.Status.CreationTime).ToNot(BeNil())
 				contentName := *snapshot.Status.VirtualMachineSnapshotContentName
@@ -1072,7 +1062,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				ss, err := virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 
 				ss, err = virtClient.VirtualMachineSnapshot(ss.Namespace).Get(context.Background(), ss.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1132,7 +1122,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 
 				cn := snapshot.Status.VirtualMachineSnapshotContentName
 				Expect(cn).ToNot(BeNil())
@@ -1165,7 +1155,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 
 				cn := snapshot.Status.VirtualMachineSnapshotContentName
 				Expect(cn).ToNot(BeNil())
@@ -1594,7 +1584,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				snapshot, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				waitSnapshotReady()
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 			},
 				Entry("with running source VM", true),
 				Entry("with stopped source VM", false),


### PR DESCRIPTION
### What this PR does
Before this PR: When doing a vmsnapshot with unbound volumes the volumes will just be skipped, and so possibly getting a vmsnapshot without any storage.

After this PR: When doing a snapshot the snapshot will not start until all the volumes exist and are bound. In case of WFFC the user will be required to start the VM.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-55923


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: VMSnapshot: wait for volumes to be bound instead of skip
```

