### PR TITLE
Fetch non-cluster instance type and preferences with namespace key

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -250,30 +250,38 @@ func getVMIPod(vmi *k6tv1.VirtualMachineInstance) string {
 
 func getVMIInstancetype(vmi *k6tv1.VirtualMachineInstance) string {
 	if instancetypeName, ok := vmi.Annotations[k6tv1.InstancetypeAnnotation]; ok {
-		return fetchResourceName(instancetypeName, instancetypeMethods.InstancetypeStore)
+		key := types.NamespacedName{
+			Namespace: vmi.Namespace,
+			Name:      instancetypeName,
+		}
+		return fetchResourceName(key.String(), instancetypeMethods.InstancetypeStore)
 	}
 
-	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterInstancetypeAnnotation]; ok {
-		return fetchResourceName(instancetypeName, instancetypeMethods.ClusterInstancetypeStore)
+	if clusterInstancetypeName, ok := vmi.Annotations[k6tv1.ClusterInstancetypeAnnotation]; ok {
+		return fetchResourceName(clusterInstancetypeName, instancetypeMethods.ClusterInstancetypeStore)
 	}
 
 	return none
 }
 
 func getVMIPreference(vmi *k6tv1.VirtualMachineInstance) string {
-	if instancetypeName, ok := vmi.Annotations[k6tv1.PreferenceAnnotation]; ok {
-		return fetchResourceName(instancetypeName, instancetypeMethods.PreferenceStore)
+	if preferenceName, ok := vmi.Annotations[k6tv1.PreferenceAnnotation]; ok {
+		key := types.NamespacedName{
+			Namespace: vmi.Namespace,
+			Name:      preferenceName,
+		}
+		return fetchResourceName(key.String(), instancetypeMethods.PreferenceStore)
 	}
 
-	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterPreferenceAnnotation]; ok {
-		return fetchResourceName(instancetypeName, instancetypeMethods.ClusterPreferenceStore)
+	if clusterPreferenceName, ok := vmi.Annotations[k6tv1.ClusterPreferenceAnnotation]; ok {
+		return fetchResourceName(clusterPreferenceName, instancetypeMethods.ClusterPreferenceStore)
 	}
 
 	return none
 }
 
-func fetchResourceName(name string, store cache.Store) string {
-	obj, ok, err := store.GetByKey(name)
+func fetchResourceName(key string, store cache.Store) string {
+	obj, ok, err := store.GetByKey(key)
 	if err != nil || !ok {
 		return other
 	}
@@ -285,7 +293,7 @@ func fetchResourceName(name string, store cache.Store) string {
 
 	vendorName := apiObj.GetLabels()[instancetypeVendorLabel]
 	if _, isWhitelisted := whitelistedInstanceTypeVendors[vendorName]; isWhitelisted {
-		return name
+		return apiObj.GetName()
 	}
 
 	return other

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -257,6 +257,7 @@ var _ = Describe("VMI Stats Collector", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "running",
+						Namespace:   "test-ns",
 						Annotations: annotations,
 					},
 				},
@@ -293,6 +294,7 @@ var _ = Describe("VMI Stats Collector", func() {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "running",
+						Namespace:   "test-ns",
 						Annotations: annotations,
 					},
 				},
@@ -525,14 +527,14 @@ func setupTestCollector() {
 	clusterPreferenceInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
 
 	_ = instanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineInstancetype{
-		ObjectMeta: newObjectMetaForInstancetypes("i-managed", "kubevirt.io"),
+		ObjectMeta: newObjectMetaForInstancetypes("i-managed", "test-ns", "kubevirt.io"),
 	})
 	_ = instanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineInstancetype{
-		ObjectMeta: newObjectMetaForInstancetypes("i-unmanaged", "some-user"),
+		ObjectMeta: newObjectMetaForInstancetypes("i-unmanaged", "test-ns", "some-user"),
 	})
 
 	_ = clusterInstanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterInstancetype{
-		ObjectMeta: newObjectMetaForInstancetypes("ci-managed", "kubevirt.io"),
+		ObjectMeta: newObjectMetaForInstancetypes("ci-managed", "", "kubevirt.io"),
 		Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
 			CPU: instancetypev1beta1.CPUInstancetype{
 				Guest: 2,
@@ -543,18 +545,18 @@ func setupTestCollector() {
 		},
 	})
 	_ = clusterInstanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterInstancetype{
-		ObjectMeta: newObjectMetaForInstancetypes("ci-unmanaged", ""),
+		ObjectMeta: newObjectMetaForInstancetypes("ci-unmanaged", "", ""),
 	})
 
 	_ = preferenceInformer.GetStore().Add(&instancetypev1beta1.VirtualMachinePreference{
-		ObjectMeta: newObjectMetaForInstancetypes("p-managed", "kubevirt.io"),
+		ObjectMeta: newObjectMetaForInstancetypes("p-managed", "test-ns", "kubevirt.io"),
 	})
 	_ = preferenceInformer.GetStore().Add(&instancetypev1beta1.VirtualMachinePreference{
-		ObjectMeta: newObjectMetaForInstancetypes("p-unmanaged", "some-vendor.com"),
+		ObjectMeta: newObjectMetaForInstancetypes("p-unmanaged", "test-ns", "some-vendor.com"),
 	})
 
 	_ = clusterPreferenceInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterPreference{
-		ObjectMeta: newObjectMetaForInstancetypes("cp-managed", "kubevirt.io"),
+		ObjectMeta: newObjectMetaForInstancetypes("cp-managed", "", "kubevirt.io"),
 	})
 
 	instancetypeMethods = &instancetype.InstancetypeMethods{
@@ -583,11 +585,17 @@ func setupTestCollector() {
 	})
 }
 
-func newObjectMetaForInstancetypes(name, vendor string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
+func newObjectMetaForInstancetypes(name, namespace, vendor string) metav1.ObjectMeta {
+	om := metav1.ObjectMeta{
 		Name:   name,
 		Labels: map[string]string{instancetypeVendorLabel: vendor},
 	}
+
+	if namespace != "" {
+		om.Namespace = namespace
+	}
+
+	return om
 }
 
 func newPodMetaForInformer(name, namespace, createdByUID string) metav1.ObjectMeta {

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -25,6 +25,7 @@ import (
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 
 	k6tv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -238,7 +239,11 @@ func getVMInstancetype(vm *k6tv1.VirtualMachine) string {
 	}
 
 	if instancetype.Kind == "VirtualMachineInstancetype" {
-		return fetchResourceName(instancetype.Name, instancetypeMethods.InstancetypeStore)
+		key := types.NamespacedName{
+			Namespace: vm.Namespace,
+			Name:      instancetype.Name,
+		}
+		return fetchResourceName(key.String(), instancetypeMethods.InstancetypeStore)
 	}
 
 	if instancetype.Kind == "VirtualMachineClusterInstancetype" {
@@ -256,7 +261,11 @@ func getVMPreference(vm *k6tv1.VirtualMachine) string {
 	}
 
 	if preference.Kind == "VirtualMachinePreference" {
-		return fetchResourceName(preference.Name, instancetypeMethods.PreferenceStore)
+		key := types.NamespacedName{
+			Namespace: vm.Namespace,
+			Name:      preference.Name,
+		}
+		return fetchResourceName(key.String(), instancetypeMethods.PreferenceStore)
 	}
 
 	if preference.Kind == "VirtualMachineClusterPreference" {

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -190,7 +190,10 @@ var _ = Describe("VM Stats Collector", func() {
 				}
 			}
 
-			vms := []*k6tv1.VirtualMachine{{Spec: k6tv1.VirtualMachineSpec{Instancetype: instanceType}}}
+			vms := []*k6tv1.VirtualMachine{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+				Spec:       k6tv1.VirtualMachineSpec{Instancetype: instanceType},
+			}}
 			crs := CollectVMsInfo(vms)
 			Expect(crs).To(HaveLen(1), "Expected 1 metric")
 
@@ -218,7 +221,10 @@ var _ = Describe("VM Stats Collector", func() {
 				}
 			}
 
-			vms := []*k6tv1.VirtualMachine{{Spec: k6tv1.VirtualMachineSpec{Preference: preference}}}
+			vms := []*k6tv1.VirtualMachine{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+				Spec:       k6tv1.VirtualMachineSpec{Preference: preference},
+			}}
 			crs := CollectVMsInfo(vms)
 			Expect(crs).To(HaveLen(1), "Expected 1 metric")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Non-cluster instance types and preferences were not being created in the `kubevirt_vm_info` and `kubevirt_vmi_info` because they required a namespaced key to be used when doing a lookup in the store.

After this PR:

Lookup is being made with a namespaced key and metrics labels are being now correctly set

![Screenshot from 2025-02-11 14-49-29](https://github.com/user-attachments/assets/97302294-b13e-454b-95f3-c09ccadcff97)

/cc @lyarwood 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-54195

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fetch non-cluster instance type and preferences with namespace key
```

