### PR TITLE
GA ClusterProfiler FG and add a config to enable it

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13202,6 +13202,10 @@
     "description": "DeveloperConfiguration holds developer options",
     "type": "object",
     "properties": {
+     "clusterProfiler": {
+      "description": "Enable the ability to pprof profile KubeVirt control plane",
+      "type": "boolean"
+     },
      "cpuAllocationRatio": {
       "description": "For each requested virtual CPU, CPUAllocationRatio defines how much physical CPU to request per VMI from the hosting node. The value is in fraction of a CPU thread (or core on non-hyperthreaded nodes). For example, a value of 1 means 1 physical CPU thread per VMI CPU thread. A value of 100 would be 1% of a physical thread allocated for each requested VMI thread. This option has no effect on VMIs that request dedicated CPUs. More information at: https://kubevirt.io/user-guide/operations/node_overcommit/#node-cpu-allocation-ratio Defaults to 10",
       "type": "integer",

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -288,6 +288,10 @@ spec:
                   developerConfiguration:
                     description: DeveloperConfiguration holds developer options
                     properties:
+                      clusterProfiler:
+                        description: Enable the ability to pprof profile KubeVirt
+                          control plane
+                        type: boolean
                       cpuAllocationRatio:
                         description: |-
                           For each requested virtual CPU, CPUAllocationRatio defines how much physical CPU to request per VMI
@@ -3553,6 +3557,10 @@ spec:
                   developerConfiguration:
                     description: DeveloperConfiguration holds developer options
                     properties:
+                      clusterProfiler:
+                        description: Enable the ability to pprof profile KubeVirt
+                          control plane
+                        type: boolean
                       cpuAllocationRatio:
                         description: |-
                           For each requested virtual CPU, CPUAllocationRatio defines how much physical CPU to request per VMI

--- a/pkg/monitoring/profiler/profile-manager_test.go
+++ b/pkg/monitoring/profiler/profile-manager_test.go
@@ -36,10 +36,10 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("profiler manager http handler callbacks", func() {
-	It("should deny request when ClusterProfiler feature gate is not enabled", func() {
+	It("should deny request when ClusterProfiler is not enabled", func() {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: []string{"MadeUpGate"},
+				ClusterProfiler: false,
 			},
 		})
 

--- a/pkg/virt-api/rest/profiler_test.go
+++ b/pkg/virt-api/rest/profiler_test.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("Cluster Profiler Subresources", func() {
@@ -96,12 +95,13 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 		recorder = httptest.NewRecorder()
 		response = restful.NewResponse(recorder)
 	})
-	enableFeatureGate := func(featureGate string) {
+
+	enableClusterProfiler := func() {
 		kvConfig := kv.DeepCopy()
-		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
+		kvConfig.Spec.Configuration.DeveloperConfiguration.ClusterProfiler = true
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
-	disableFeatureGates := func() {
+	disableClusterProfiler := func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 
@@ -155,7 +155,7 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 				),
 			)
 
-			enableFeatureGate(featuregate.ClusterProfiler)
+			enableClusterProfiler()
 			expectPodList()
 			fn(request, response)
 			Expect(recorder.Code).To(Equal(http.StatusOK))
@@ -181,7 +181,7 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 				),
 			)
 
-			enableFeatureGate(featuregate.ClusterProfiler)
+			enableClusterProfiler()
 			expectPodList()
 			fn(request, response)
 			Expect(recorder.Code).To(Equal(http.StatusOK))
@@ -227,7 +227,7 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 
 	AfterEach(func() {
 		server.Close()
-		disableFeatureGates()
+		disableClusterProfiler()
 		backend.Close()
 	})
 })

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -202,7 +202,6 @@ func fuzzKubeVirtConfig(seed int64) *virtconfig.ClusterConfig {
 				featuregate.DownwardMetricsFeatureGate,
 				featuregate.NonRoot,
 				featuregate.Root,
-				featuregate.ClusterProfiler,
 				featuregate.WorkloadEncryptionSEV,
 				featuregate.DockerSELinuxMCSWorkaround,
 				featuregate.PSA,

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -749,21 +749,16 @@ var _ = Describe("test configuration", func() {
 			`{"defaultNetworkInterface":"bridge","permitSlirpInterface":true,"permitBridgeInterfaceOnPodNetwork":false}`),
 	)
 
-	DescribeTable("when ClusterProfiler feature-gate", func(openFeatureGates []string, isEnabled bool) {
+	DescribeTable("when ClusterProfiler config", func(config *v1.DeveloperConfiguration, isEnabled bool) {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: openFeatureGates,
-			},
+			DeveloperConfiguration: config,
 		})
 
 		Expect(clusterConfig.ClusterProfilerEnabled()).To(Equal(isEnabled))
 	},
-		Entry("ClusterProfiler feature gate not set should result in cluster profiler being disabled",
-			nil, false),
-		Entry("ClusterProfiler feature gate empty should result in cluster profiler being disabled",
-			[]string{}, false),
-		Entry("ClusterProfiler feature gate enabled should result in cluster profiler being enabled",
-			[]string{featuregate.ClusterProfiler}, true),
+		Entry("is not set it should result in cluster profiler being disabled", &v1.DeveloperConfiguration{ClusterProfiler: false}, false),
+		Entry("is empty it should result in cluster profiler being disabled", &v1.DeveloperConfiguration{}, false),
+		Entry("is enabled it should result in cluster profiler being enabled", &v1.DeveloperConfiguration{ClusterProfiler: true}, true),
 	)
 
 	Context("GAed feature gates should be considered as enabled by default", func() {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -25,15 +25,22 @@ import "kubevirt.io/kubevirt/pkg/virt-config/featuregate"
  This module is intended for determining whether an optional feature is enabled or not at the cluster-level.
 */
 
+func (config *ClusterConfig) isFeatureGateDefined(featureGate string) bool {
+	for _, fg := range config.GetConfig().DeveloperConfiguration.FeatureGates {
+		if fg == featureGate {
+			return true
+		}
+	}
+	return false
+}
+
 func (config *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
 	if fg := featuregate.FeatureGateInfo(featureGate); fg != nil && fg.State == featuregate.GA {
 		return true
 	}
 
-	for _, fg := range config.GetConfig().DeveloperConfiguration.FeatureGates {
-		if fg == featureGate {
-			return true
-		}
+	if config.isFeatureGateDefined(featureGate) {
+		return true
 	}
 	return false
 }
@@ -124,10 +131,6 @@ func (config *ClusterConfig) HostDevicesPassthroughEnabled() bool {
 
 func (config *ClusterConfig) RootEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.Root)
-}
-
-func (config *ClusterConfig) ClusterProfilerEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.ClusterProfiler)
 }
 
 func (config *ClusterConfig) WorkloadEncryptionSEVEnabled() bool {

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -33,7 +33,6 @@ const (
 
 	DownwardMetricsFeatureGate = "DownwardMetrics"
 	Root                       = "Root"
-	ClusterProfiler            = "ClusterProfiler"
 	WorkloadEncryptionSEV      = "WorkloadEncryptionSEV"
 	VSOCKGate                  = "VSOCK"
 	// KubevirtSeccompProfile indicate that Kubevirt will install its custom profile and
@@ -82,7 +81,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HostDiskGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DownwardMetricsFeatureGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: Root, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: ClusterProfiler, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionSEV, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VSOCKGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: KubevirtSeccompProfile, State: Alpha})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -82,6 +82,8 @@ const (
 
 	// DisableCustomSELinuxPolicy disables the installation of the custom SELinux policy for virt-launcher
 	DisableCustomSELinuxPolicy = "DisableCustomSELinuxPolicy"
+
+	ClusterProfiler = "ClusterProfiler"
 )
 
 func init() {
@@ -102,6 +104,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: VolumeMigration, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: DisableCustomSELinuxPolicy, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: AutoResourceLimitsGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: ClusterProfiler, State: GA})
 
 	RegisterFeatureGate(FeatureGate{Name: DockerSELinuxMCSWorkaround, State: Deprecated, Message: fmt.Sprintf(
 		"DockerSELinuxMCSWorkaround has been deprecated since v1.4.")})

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -495,3 +495,7 @@ func (c *ClusterConfig) GetInstancetypeReferencePolicy() v1.InstancetypeReferenc
 	}
 	return policy
 }
+
+func (c *ClusterConfig) IsClusterProfilerEnabled() bool {
+	return c.GetConfig().DeveloperConfiguration.ClusterProfiler
+}

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -496,6 +496,7 @@ func (c *ClusterConfig) GetInstancetypeReferencePolicy() v1.InstancetypeReferenc
 	return policy
 }
 
-func (c *ClusterConfig) IsClusterProfilerEnabled() bool {
-	return c.GetConfig().DeveloperConfiguration.ClusterProfiler
+func (c *ClusterConfig) ClusterProfilerEnabled() bool {
+	return c.GetConfig().DeveloperConfiguration.ClusterProfiler ||
+		c.isFeatureGateDefined(featuregate.ClusterProfiler)
 }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -883,6 +883,10 @@ var CRDsValidation map[string]string = map[string]string{
             developerConfiguration:
               description: DeveloperConfiguration holds developer options
               properties:
+                clusterProfiler:
+                  description: Enable the ability to pprof profile KubeVirt control
+                    plane
+                  type: boolean
                 cpuAllocationRatio:
                   description: |-
                     For each requested virtual CPU, CPUAllocationRatio defines how much physical CPU to request per VMI

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
@@ -109,7 +109,8 @@
           "nodeVerbosity": {
             "nodeVerbosityKey": 18446744073709551603
           }
-        }
+        },
+        "clusterProfiler": true
       },
       "emulatedMachines": [
         "emulatedMachinesValue"

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
@@ -89,6 +89,7 @@ spec:
     cpuRequest: "0"
     defaultRuntimeClass: defaultRuntimeClassValue
     developerConfiguration:
+      clusterProfiler: true
       cpuAllocationRatio: -18
       diskVerification:
         memoryLimit: "0"

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2789,6 +2789,9 @@ type DeveloperConfiguration struct {
 	MinimumClusterTSCFrequency *int64            `json:"minimumClusterTSCFrequency,omitempty"`
 	DiskVerification           *DiskVerification `json:"diskVerification,omitempty"`
 	LogVerbosity               *LogVerbosity     `json:"logVerbosity,omitempty"`
+
+	// Enable the ability to pprof profile KubeVirt control plane
+	ClusterProfiler bool `json:"clusterProfiler,omitempty"`
 }
 
 // LogVerbosity sets log verbosity level of  various components

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -885,6 +885,7 @@ func (DeveloperConfiguration) SwaggerDoc() map[string]string {
 		"useEmulation":                    "UseEmulation can be set to true to allow fallback to software emulation\nin case hardware-assisted emulation is not available. Defaults to false",
 		"cpuAllocationRatio":              "For each requested virtual CPU, CPUAllocationRatio defines how much physical CPU to request per VMI\nfrom the hosting node. The value is in fraction of a CPU thread (or core on non-hyperthreaded nodes).\nFor example, a value of 1 means 1 physical CPU thread per VMI CPU thread.\nA value of 100 would be 1% of a physical thread allocated for each requested VMI thread.\nThis option has no effect on VMIs that request dedicated CPUs. More information at:\nhttps://kubevirt.io/user-guide/operations/node_overcommit/#node-cpu-allocation-ratio\nDefaults to 10",
 		"minimumClusterTSCFrequency":      "Allow overriding the automatically determined minimum TSC frequency of the cluster\nand fixate the minimum to this frequency.",
+		"clusterProfiler":                 "Enable the ability to pprof profile KubeVirt control plane",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18896,6 +18896,13 @@ func schema_kubevirtio_api_core_v1_DeveloperConfiguration(ref common.ReferenceCa
 							Ref: ref("kubevirt.io/api/core/v1.LogVerbosity"),
 						},
 					},
+					"clusterProfiler": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enable the ability to pprof profile KubeVirt control plane",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/tests/infrastructure/cluster-profiler.go
+++ b/tests/infrastructure/cluster-profiler.go
@@ -22,6 +22,7 @@ package infrastructure
 import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,13 +33,22 @@ import (
 
 var _ = DescribeSerialInfra("cluster profiler for pprof data aggregation", func() {
 	var virtClient kubecli.KubevirtClient
+	var kvConfig v1.KubeVirtConfiguration
+
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
+		kv := libkubevirt.GetCurrentKv(virtClient)
+		kvConfig = kv.Spec.Configuration
+
+		if kvConfig.DeveloperConfiguration == nil {
+			kvConfig.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+		}
 	})
 
-	Context("when ClusterProfiler feature gate", func() {
+	Context("when ClusterProfiler configuration", func() {
 		It("is disabled it should prevent subresource access", func() {
-			config.DisableFeatureGate("ClusterProfiler")
+			kvConfig.DeveloperConfiguration.ClusterProfiler = false
+			config.UpdateKubeVirtConfigValueAndWait(kvConfig)
 
 			err := virtClient.ClusterProfiler().Start()
 			Expect(err).To(HaveOccurred())
@@ -50,7 +60,8 @@ var _ = DescribeSerialInfra("cluster profiler for pprof data aggregation", func(
 			Expect(err).To(HaveOccurred())
 		})
 		It("[QUARANTINE]is enabled it should allow subresource access", decorators.Quarantine, func() {
-			config.EnableFeatureGate("ClusterProfiler")
+			kvConfig.DeveloperConfiguration.ClusterProfiler = true
+			config.UpdateKubeVirtConfigValueAndWait(kvConfig)
 
 			err := virtClient.ClusterProfiler().Start()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

The ClusterProfiler feature had to be enabled using a feature gate

After this PR:

The ClusterProfiler feature gate is GA and to enable the functionality there is now a new configuration field
in the KubeVirt CR in the DeveloperConfiguration section.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
GA ClusterProfiler FG and add a config to enable it
```

