### PR TITLE
config: Graduate AutoResourceLimits featuregate to GA

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -166,10 +166,6 @@ func (config *ClusterConfig) MultiArchitectureEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.MultiArchitecture)
 }
 
-func (config *ClusterConfig) AutoResourceLimitsEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.AutoResourceLimitsGate)
-}
-
 func (config *ClusterConfig) AlignCPUsEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.AlignCPUsGate)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -47,8 +47,6 @@ const (
 	// VMPersistentState enables persisting backend state files of VMs, such as the contents of the vTPM
 	VMPersistentState = "VMPersistentState"
 	MultiArchitecture = "MultiArchitecture"
-	// AutoResourceLimitsGate enables automatic setting of vmi limits if there is a ResourceQuota with limits associated with the vmi namespace.
-	AutoResourceLimitsGate = "AutoResourceLimitsGate"
 
 	// AlignCPUsGate allows emulator thread to assign two extra CPUs if needed to complete even parity.
 	AlignCPUsGate = "AlignCPUs"
@@ -92,7 +90,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: PersistentReservation, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VMPersistentState, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: MultiArchitecture, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: AutoResourceLimitsGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: AlignCPUsGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: NodeRestrictionGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: InstancetypeReferencePolicy, State: Alpha})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -50,6 +50,10 @@ const (
 	// GA:    v1.4.0
 	BochsDisplayForEFIGuests = "BochsDisplayForEFIGuests"
 
+	// AutoResourceLimitsGate enables automatic setting of vmi limits if there is a ResourceQuota with limits associated with the vmi namespace.
+	// GA:    v1.5.0
+	AutoResourceLimitsGate = "AutoResourceLimitsGate"
+
 	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
 	// Deprecated: v1.4.0
 	DockerSELinuxMCSWorkaround = "DockerSELinuxMCSWorkaround"
@@ -97,6 +101,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: VolumesUpdateStrategy, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VolumeMigration, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: DisableCustomSELinuxPolicy, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: AutoResourceLimitsGate, State: GA})
 
 	RegisterFeatureGate(FeatureGate{Name: DockerSELinuxMCSWorkaround, State: Deprecated, Message: fmt.Sprintf(
 		"DockerSELinuxMCSWorkaround has been deprecated since v1.4.")})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1507,9 +1507,6 @@ func (t *templateService) doesVMIRequireAutoMemoryLimits(vmi *v1.VirtualMachineI
 }
 
 func (t *templateService) doesVMIRequireAutoResourceLimits(vmi *v1.VirtualMachineInstance, resource k8sv1.ResourceName) bool {
-	if !t.clusterConfig.AutoResourceLimitsEnabled() {
-		return false
-	}
 	if _, resourceLimitsExists := vmi.Spec.Domain.Resources.Limits[resource]; resourceLimitsExists {
 		return false
 	}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4718,14 +4718,7 @@ var _ = Describe("Template", func() {
 			})
 		})
 
-		When("the auto resource limits feature gate is enabled", func() {
-			BeforeEach(func() {
-				By("enabling the auto resource limits feature gate")
-				kvConfig := kv.DeepCopy()
-				kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.AutoResourceLimitsGate}
-				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
-			})
-
+		When("using auto resource limits", func() {
 			Context("when the creation namespace has a resource quota with CPU limits associated to it", func() {
 				When("vmi has CPU limits set", func() {
 					It("should not override limits", func() {
@@ -4796,7 +4789,6 @@ var _ = Describe("Template", func() {
 					kvConfig.Spec.Configuration.AutoCPULimitNamespaceLabelSelector = &metav1.LabelSelector{
 						MatchLabels: map[string]string{"testAutoLimits": "true"},
 					}
-					kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.AutoResourceLimitsGate}
 					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 				})
 
@@ -4872,41 +4864,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
-
-		When("the auto resource limits feature gate is disabled", func() {
-
-			It("should not set memory limits", func() {
-				vmi := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "testvmi",
-						Namespace: rqNamespace,
-						UID:       "1234",
-					},
-					Spec: v1.VirtualMachineInstanceSpec{
-						Domain: v1.DomainSpec{
-							Resources: v1.ResourceRequirements{
-								Requests: k8sv1.ResourceList{k8sv1.ResourceMemory: guestMemory},
-							},
-						},
-					},
-				}
-
-				pod, err := svc.RenderLaunchManifest(&vmi)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeZero())
-			})
-		})
-
-		When("the auto resource limits feature gate is enabled", func() {
-
-			BeforeEach(func() {
-				By("enabling the auto resource limits feature gate")
-				kvConfig := kv.DeepCopy()
-				kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.AutoResourceLimitsGate}
-				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
-			})
-
+		When("using auto resource limits ", func() {
 			Context("when the creation namespace has a resource quota with memory limits associated to it", func() {
 
 				DescribeTable("should not override limits", func(withLimits, withDedicatedCPU bool) {

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -58,7 +58,6 @@ var (
 	RequiresTwoSchedulableNodes          = Label("requires-two-schedulable-nodes")
 	VMLiveUpdateRolloutStrategy          = Label("VMLiveUpdateRolloutStrategy")
 	USB                                  = Label("USB")
-	AutoResourceLimitsGate               = Label("AutoResourceLimitsGate")
 	RequiresTwoWorkerNodesWithCPUManager = Label("requires-two-worker-nodes-with-cpu-manager")
 	RequiresNodeWithCPUManager           = Label("requires-node-with-cpu-manager")
 	RequiresDualStackCluster             = Label("requires-dual-stack-cluster")

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -111,7 +111,6 @@ func AdjustKubeVirtResource() {
 		featuregate.VMExportGate,
 		featuregate.KubevirtSeccompProfile,
 		featuregate.VMPersistentState,
-		featuregate.AutoResourceLimitsGate,
 	)
 
 	if kv.Spec.Configuration.NetworkConfiguration == nil {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1901,7 +1901,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 	})
 
-	Context("with automatic resource limits FG enabled", decorators.AutoResourceLimitsGate, func() {
+	Context("using automatic resource limits", func() {
 
 		When("there is no ResourceQuota with memory and cpu limits associated with the creation namespace", func() {
 			It("[test_id:11215]should not automatically set memory limits in the virt-launcher pod", func() {


### PR DESCRIPTION
First introduced by #10447 way back in 2023 the AutoResourceLimits feature gate is now deprecated with the feature state graduated to GA and as such always enabled.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `AutoResourceLimits` feature gate is now deprecated with the feature state graduated to `GA` and thus enabled by default
```

