### PR TITLE
[release-1.4]virt-controller: Increase virtqemud memory overhead to 40Mi

### DIFF
--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -479,7 +479,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 		}
 		staticOverhead = pointer.P(resource.MustParse(staticOverheadString))
 		// MemoryReq / 512bit
-		baseOverhead = pointer.P(resource.MustParse("2Mi"))
+		baseOverhead = pointer.P(resource.MustParse("7Mi"))
 		coresOverhead = pointer.P(resource.MustParse("8Mi"))
 		videoRAMOverhead = pointer.P(resource.MustParse("16Mi"))
 		cpuArchOverhead = pointer.P(resource.MustParse("128Mi"))

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -113,7 +113,7 @@ const (
 	VirtLauncherMonitorOverhead = "25Mi"  // The `ps` RSS for virt-launcher-monitor
 	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
 	VirtlogdOverhead            = "20Mi"  // The `ps` RSS for virtlogd
-	VirtqemudOverhead           = "35Mi"  // The `ps` RSS for virtqemud
+	VirtqemudOverhead           = "40Mi"  // The `ps` RSS for virtqemud
 	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 	// Default: limits.memory = 2*requests.memory
 	DefaultMemoryLimitOverheadRatio = float64(2.0)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1785,8 +1785,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1255708517", "2255708517"),
-				Entry("on arm64", "arm64", "1389926245", "2389926245"),
+				Entry("on amd64", "amd64", "1260951397", "2260951397"),
+				Entry("on arm64", "arm64", "1395169125", "2395169125"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvStore, svc = configFactory(arch)
@@ -1822,8 +1822,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2255708517"),
-				Entry("on arm64", "arm64", "2389926245"),
+				Entry("on amd64", "amd64", "2260951397"),
+				Entry("on arm64", "arm64", "2395169125"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvStore, svc = configFactory(arch)
@@ -1861,8 +1861,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 335),
-				Entry("on arm64", "arm64", 469),
+				Entry("on amd64", "amd64", 340),
+				Entry("on arm64", "arm64", 475),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1898,12 +1898,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 335),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.P(true), 335),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.P(false), 318),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 469),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.P(true), 469),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.P(false), 453),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 340),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.P(true), 340),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.P(false), 324),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 475),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.P(true), 475),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.P(false), 458),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvStore, svc = configFactory(defaultArch)
@@ -2112,10 +2112,10 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 254),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 254),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 389),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 389),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 260),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 260),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 394),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 394),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2191,8 +2191,8 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("on amd64", "amd64", 254),
-				Entry("on arm64", "arm64", 389),
+				Entry("on amd64", "amd64", 260),
+				Entry("on arm64", "arm64", 394),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -341,7 +341,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(406)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(411)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
### What this PR does:

This is a cherry-pick of 10b0d9b1812c559f1da96fa33dbeec8890771fcb

There have been a number of test failures in the v1.4 compute lanes due to virtqemud using more RAM than expected[1][2]

This has already been increased to 40Mi on the main branch[3] - increase it to 40Mi for release-1.4

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13804/pull-kubevirt-e2e-k8s-1.29-sig-compute-1.4/1884286608010645504
[2] https://search.ci.kubevirt.io/?search=the+virtqemud+process+is+taking+too+much+RAM&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=1.4&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
[3] https://github.com/kubevirt/kubevirt/blob/668570a602d8bed9fbdb2e58bfca9a502fd028f6/pkg/virt-controller/services/template.go#L117


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase virtqemud memory overhead to 40Mi
```

