### PR TITLE
[release-1.3] tests/infra/prometheus: add prometheus namespace flag to [test_id:4135]

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -39,6 +39,7 @@ var KubeVirtVirtctlPath = ""
 var KubeVirtExampleGuestAgentPath = ""
 var KubeVirtGoCliPath = ""
 var KubeVirtInstallNamespace string
+var PrometheusNamespace string
 var PreviousReleaseTag = ""
 var PreviousReleaseRegistry = ""
 var PreviousUtilityRegistry = ""
@@ -78,6 +79,7 @@ func init() {
 	flag.StringVar(&KubeVirtExampleGuestAgentPath, "example-guest-agent-path", "", "Set path to the example-guest-agent binary which is used for vsock testing")
 	flag.StringVar(&KubeVirtGoCliPath, "gocli-path", "", "Set path to gocli binary")
 	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "", "Set the namespace KubeVirt is installed in")
+	flag.StringVar(&PrometheusNamespace, "prometheus-installed-namespace", "monitoring", "Set the namespace Prometheus is installed in")
 	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
 	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -124,7 +124,7 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 		var ep *k8sv1.Endpoints
 		By("finding Prometheus endpoint")
 		Eventually(func() bool {
-			ep, err = virtClient.CoreV1().Endpoints("monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
+			ep, err = virtClient.CoreV1().Endpoints(flags.PrometheusNamespace).Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "failed to retrieve Prometheus endpoint")
 
 			if len(ep.Subsets) == 0 || len(ep.Subsets[0].Addresses) == 0 {
@@ -132,6 +132,11 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 			}
 			return true
 		}, 10*time.Second, time.Second).Should(BeTrue())
+
+		urlSchema := "https"
+		if flags.PrometheusNamespace == "monitoring" {
+			urlSchema = "http"
+		}
 
 		promIP := ep.Subsets[0].Addresses[0].IP
 		Expect(promIP).ToNot(Equal(""), "could not get Prometheus IP from endpoint")
@@ -152,7 +157,7 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 			"curl",
 			"-L",
 			"-k",
-			fmt.Sprintf("http://%s:%d/api/v1/query", promIP, promPort),
+			fmt.Sprintf("%s://%s:%d/api/v1/query", urlSchema, promIP, promPort),
 			"-H",
 			fmt.Sprintf("Authorization: Bearer %s", token),
 			"--data-urlencode",


### PR DESCRIPTION
This is a manual backport of #13772

automatic backport failed due to minor conflict in the flags.go

/cherry-pick release-1.2

### Release note
```release-note
None
```