### PR TITLE
code clean: remove redundant types in composite literals, redundant type conversions

### DIFF
--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -155,12 +155,12 @@ var _ = Describe("Domain informer", func() {
 			record, exists := ghostRecordGlobalCache["test1-namespace/test1"]
 			Expect(exists).To(BeTrue())
 			Expect(string(record.UID)).To(Equal("1234-1"))
-			Expect(string(record.SocketFile)).To(Equal("somefile1"))
+			Expect(record.SocketFile).To(Equal("somefile1"))
 
 			record, exists = ghostRecordGlobalCache["test2-namespace/test2"]
 			Expect(exists).To(BeTrue())
 			Expect(string(record.UID)).To(Equal("1234-2"))
-			Expect(string(record.SocketFile)).To(Equal("somefile2"))
+			Expect(record.SocketFile).To(Equal("somefile2"))
 		})
 
 		It("Should delete ghost record from cache and disk", func() {

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -187,7 +187,7 @@ func MarkSocketUnresponsive(socket string) error {
 }
 
 func SocketDirectoryOnHost(podUID string) string {
-	return fmt.Sprintf("/%s/%s/volumes/kubernetes.io~empty-dir/sockets", podsBaseDir, string(podUID))
+	return fmt.Sprintf("/%s/%s/volumes/kubernetes.io~empty-dir/sockets", podsBaseDir, podUID)
 }
 
 func SocketFilePathOnHost(podUID string) string {
@@ -688,7 +688,7 @@ func (c *VirtLauncherClient) Exec(domainName, command string, args []string, tim
 		DomainName:     domainName,
 		Command:        command,
 		Args:           args,
-		TimeoutSeconds: int32(timeoutSeconds),
+		TimeoutSeconds: timeoutSeconds,
 	}
 	exitCode := -1
 	stdOut := ""

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Virt remote commands", func() {
 
 	BeforeEach(func() {
 		vmi = api.NewMinimalVMI("testvmi")
-		vmi.UID = types.UID("1234")
+		vmi.UID = "1234"
 		vmi.Status = v1.VirtualMachineInstanceStatus{
 			ActivePods: map[types.UID]string{
 				types.UID(podUID): host,

--- a/pkg/virt-handler/device-manager/usb_device_test.go
+++ b/pkg/virt-handler/device-manager/usb_device_test.go
@@ -79,7 +79,7 @@ var _ = Describe("USB Device", func() {
 				},
 			},
 			map[string][]*PluginDevices{
-				resourceName1: []*PluginDevices{
+				resourceName1: {
 					newPluginDevices(resourceName1, 0, []*USBDevice{usbs[0]}),
 				},
 			},
@@ -97,7 +97,7 @@ var _ = Describe("USB Device", func() {
 				},
 			},
 			map[string][]*PluginDevices{
-				resourceName1: []*PluginDevices{
+				resourceName1: {
 					newPluginDevices(resourceName1, 0, []*USBDevice{usbs[1]}),
 					newPluginDevices(resourceName1, 1, []*USBDevice{usbs[2]}),
 				},
@@ -120,7 +120,7 @@ var _ = Describe("USB Device", func() {
 				},
 			},
 			map[string][]*PluginDevices{
-				resourceName1: []*PluginDevices{
+				resourceName1: {
 					newPluginDevices(resourceName1, 0, []*USBDevice{usbs[0], usbs[1]}),
 				},
 			},
@@ -147,10 +147,10 @@ var _ = Describe("USB Device", func() {
 				},
 			},
 			map[string][]*PluginDevices{
-				resourceName1: []*PluginDevices{
+				resourceName1: {
 					newPluginDevices(resourceName1, 0, []*USBDevice{usbs[0]}),
 				},
-				resourceName2: []*PluginDevices{
+				resourceName2: {
 					newPluginDevices(resourceName2, 1, []*USBDevice{usbs[1]}),
 					newPluginDevices(resourceName2, 2, []*USBDevice{usbs[2]}),
 				},
@@ -179,7 +179,7 @@ var _ = Describe("USB Device", func() {
 				},
 			},
 			map[string][]*PluginDevices{
-				resourceName1: []*PluginDevices{
+				resourceName1: {
 					newPluginDevices(resourceName1, 0, []*USBDevice{usbs[0]}),
 				},
 			},
@@ -210,7 +210,7 @@ var _ = Describe("USB Device", func() {
 				},
 			},
 			map[string][]*PluginDevices{
-				resourceName1: []*PluginDevices{
+				resourceName1: {
 					newPluginDevices(resourceName1, 0, []*USBDevice{usbs[0]}),
 				},
 			},

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1202,7 +1202,7 @@ func Convert_v1_Firmware_To_related_apis(vmi *v1.VirtualMachineInstance, domain 
 	if len(firmware.Serial) > 0 {
 		domain.Spec.SysInfo.System = append(domain.Spec.SysInfo.System, api.Entry{
 			Name:  "serial",
-			Value: string(firmware.Serial),
+			Value: firmware.Serial,
 		})
 	}
 
@@ -1483,23 +1483,23 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		domain.Spec.SysInfo.Chassis = []api.Entry{
 			{
 				Name:  "manufacturer",
-				Value: string(vmi.Spec.Domain.Chassis.Manufacturer),
+				Value: vmi.Spec.Domain.Chassis.Manufacturer,
 			},
 			{
 				Name:  "version",
-				Value: string(vmi.Spec.Domain.Chassis.Version),
+				Value: vmi.Spec.Domain.Chassis.Version,
 			},
 			{
 				Name:  "serial",
-				Value: string(vmi.Spec.Domain.Chassis.Serial),
+				Value: vmi.Spec.Domain.Chassis.Serial,
 			},
 			{
 				Name:  "asset",
-				Value: string(vmi.Spec.Domain.Chassis.Asset),
+				Value: vmi.Spec.Domain.Chassis.Asset,
 			},
 			{
 				Name:  "sku",
-				Value: string(vmi.Spec.Domain.Chassis.Sku),
+				Value: vmi.Spec.Domain.Chassis.Sku,
 			},
 		}
 	}
@@ -2043,7 +2043,7 @@ func domainVCPUTopologyForHotplug(vmi *v1.VirtualMachineInstance, domain *api.Do
 		// There should not be fewer vCPU than cores and threads within a single socket
 		isHotpluggable := id >= minEnabledCpuCount
 		vcpu := api.VCPUsVCPU{
-			ID:           uint32(id),
+			ID:           id,
 			Enabled:      boolToYesNo(&isEnabled, true),
 			Hotpluggable: boolToYesNo(&isHotpluggable, false),
 		}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1641,7 +1641,7 @@ var _ = Describe("Converter", func() {
 			Expect(domain).ToNot(BeNil())
 			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(2))
 			Expect(domain.Spec.Devices.Interfaces[0].BootOrder).NotTo(BeNil())
-			Expect(domain.Spec.Devices.Interfaces[0].BootOrder.Order).To(Equal(uint(bootOrder)))
+			Expect(domain.Spec.Devices.Interfaces[0].BootOrder.Order).To(Equal(bootOrder))
 			Expect(domain.Spec.Devices.Interfaces[1].BootOrder).To(BeNil())
 		})
 		It("Should create network configuration for masquerade interface", func() {
@@ -3395,12 +3395,12 @@ var _ = Describe("SetDriverCacheMode", func() {
 			Expect(disk.Driver.Cache).To(Equal(expectedCache))
 		}
 	},
-		Entry("detect 'none' with direct io", string(""), string(v1.CacheNone), expectCheckTrue),
-		Entry("detect 'writethrough' without direct io", string(""), string(v1.CacheWriteThrough), expectCheckFalse),
-		Entry("fallback to 'writethrough' on error", string(""), string(v1.CacheWriteThrough), expectCheckError),
+		Entry("detect 'none' with direct io", "", string(v1.CacheNone), expectCheckTrue),
+		Entry("detect 'writethrough' without direct io", "", string(v1.CacheWriteThrough), expectCheckFalse),
+		Entry("fallback to 'writethrough' on error", "", string(v1.CacheWriteThrough), expectCheckError),
 		Entry("keep 'none' with direct io", string(v1.CacheNone), string(v1.CacheNone), expectCheckTrue),
-		Entry("return error without direct io", string(v1.CacheNone), string(""), expectCheckFalse),
-		Entry("return error on error", string(v1.CacheNone), string(""), expectCheckError),
+		Entry("return error without direct io", string(v1.CacheNone), "", expectCheckFalse),
+		Entry("return error on error", string(v1.CacheNone), "", expectCheckError),
 		Entry("'writethrough' with direct io", string(v1.CacheWriteThrough), string(v1.CacheWriteThrough), expectCheckTrue),
 		Entry("'writethrough' without direct io", string(v1.CacheWriteThrough), string(v1.CacheWriteThrough), expectCheckFalse),
 		Entry("'writethrough' on error", string(v1.CacheWriteThrough), string(v1.CacheWriteThrough), expectCheckError),


### PR DESCRIPTION
### What this PR does
remove redundant types in composite literals, redundant type conversions

/kind cleanup

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

