### PR TITLE
net, controllers, VM: Refactor NIC hotplug / hotunplug tests

### DIFF
--- a/pkg/network/controllers/hotplug_test.go
+++ b/pkg/network/controllers/hotplug_test.go
@@ -47,17 +47,6 @@ var _ = Describe("Network interface hot{un}plug", func() {
 			Expect(updatedVMI.Networks).To(Equal(expectedVMI.Spec.Networks))
 			Expect(updatedVMI.Domain.Devices.Interfaces).To(Equal(expectedVMI.Spec.Domain.Devices.Interfaces))
 		},
-		Entry("when a bridge binding interface has to be hotplugged",
-			libvmi.New(
-				libvmi.WithInterface(bridgeInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			libvmi.New(),
-			libvmi.New(
-				libvmi.WithInterface(bridgeInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			!ordinal),
 		Entry("when an SRIOV  binding interface has to be hotplugged",
 			libvmi.New(
 				libvmi.WithInterface(sriovInterface(testNetworkName1)),

--- a/pkg/network/controllers/hotplug_test.go
+++ b/pkg/network/controllers/hotplug_test.go
@@ -80,20 +80,6 @@ var _ = Describe("Network interface hot{un}plug", func() {
 				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
 			),
 			!ordinal),
-		Entry("when an interface has to be hotunplugged but it has ordinal name",
-			libvmi.New(
-				libvmi.WithInterface(bridgeAbsentInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			libvmi.New(
-				libvmi.WithInterface(bridgeInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			libvmi.New(
-				libvmi.WithInterface(bridgeInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			ordinal),
 		Entry("when one interface has to be plugged and other hotunplugged",
 			libvmi.New(
 				libvmi.WithInterface(bridgeAbsentInterface(testNetworkName1)),

--- a/pkg/network/controllers/hotplug_test.go
+++ b/pkg/network/controllers/hotplug_test.go
@@ -47,17 +47,6 @@ var _ = Describe("Network interface hot{un}plug", func() {
 			Expect(updatedVMI.Networks).To(Equal(expectedVMI.Spec.Networks))
 			Expect(updatedVMI.Domain.Devices.Interfaces).To(Equal(expectedVMI.Spec.Domain.Devices.Interfaces))
 		},
-		Entry("when an SRIOV  binding interface has to be hotplugged",
-			libvmi.New(
-				libvmi.WithInterface(sriovInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			libvmi.New(),
-			libvmi.New(
-				libvmi.WithInterface(sriovInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			!ordinal),
 		Entry("when an interface has to be hotplugged but it has no SRIOV or bridge binding",
 			libvmi.New(
 				libvmi.WithInterface(v1.Interface{
@@ -176,10 +165,6 @@ var _ = Describe("Network interface hot{un}plug", func() {
 
 func bridgeInterface(name string) v1.Interface {
 	return v1.Interface{Name: name, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}
-}
-
-func sriovInterface(name string) v1.Interface {
-	return v1.Interface{Name: name, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}
 }
 
 func bridgeAbsentInterface(name string) v1.Interface {

--- a/pkg/network/controllers/hotplug_test.go
+++ b/pkg/network/controllers/hotplug_test.go
@@ -47,20 +47,6 @@ var _ = Describe("Network interface hot{un}plug", func() {
 			Expect(updatedVMI.Networks).To(Equal(expectedVMI.Spec.Networks))
 			Expect(updatedVMI.Domain.Devices.Interfaces).To(Equal(expectedVMI.Spec.Domain.Devices.Interfaces))
 		},
-		Entry("when the are no interfaces to hotplug/unplug",
-			libvmi.New(
-				libvmi.WithInterface(bridgeInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			libvmi.New(
-				libvmi.WithInterface(bridgeInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			libvmi.New(
-				libvmi.WithInterface(bridgeInterface(testNetworkName1)),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-			),
-			false),
 		Entry("when a bridge binding interface has to be hotplugged",
 			libvmi.New(
 				libvmi.WithInterface(bridgeInterface(testNetworkName1)),

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -43,11 +43,6 @@ import (
 )
 
 var _ = Describe("VM Network Controller", func() {
-	It("sync does nothing when the hotplug FG is unset", func() {
-		c := controllers.NewVMController(fake.NewSimpleClientset(), stubPodGetter{})
-		Expect(c.Sync(newEmptyVM(), libvmi.New())).To(Equal(newEmptyVM()))
-	})
-
 	DescribeTable("sync does nothing when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, podGetter stubPodGetter) {
 		c := controllers.NewVMController(fake.NewSimpleClientset(), podGetter)
 		originalVM := vm.DeepCopy()

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -116,7 +116,7 @@ var _ = Describe("VM Network Controller", func() {
 		)
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
 
-		vm = plugNetworkInterface(vm, "foonet")
+		vm = plugNetworkInterface(vm, libvmi.InterfaceDeviceWithBridgeBinding("foonet"))
 
 		// Simulate the existence of the VMI on the server (to allow the Sync to patch it).
 		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
@@ -129,7 +129,7 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(updatedVM).To(Equal(originalVM))
 	})
 
-	It("sync succeeds to hotplug new interface", func() {
+	DescribeTable("sync succeeds to hotplug new interface", func(ifaceToPlug v1.Interface) {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(
 			clientset,
@@ -141,7 +141,7 @@ var _ = Describe("VM Network Controller", func() {
 		)
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
 
-		vm = plugNetworkInterface(vm, "foonet")
+		vm = plugNetworkInterface(vm, ifaceToPlug)
 
 		// Simulate the existence of the VMI on the server (to allow the Sync to patch it).
 		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
@@ -161,7 +161,10 @@ var _ = Describe("VM Network Controller", func() {
 
 		Expect(updatedVMI.Spec.Networks).To(Equal(updatedVM.Spec.Template.Spec.Networks))
 		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(Equal(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces))
-	})
+	},
+		Entry("when the plugged interface uses bridge binding", libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName)),
+		Entry("when the plugged interface uses SR-IOV binding", libvmi.InterfaceDeviceWithSRIOVBinding(secondaryNetName)),
+	)
 
 	It("sync succeeds to clear hotunplug interfaces", func() {
 		clientset := fake.NewSimpleClientset()
@@ -324,11 +327,13 @@ func isSyncErrorType(e error) bool {
 	return errors.As(e, &errWithReason)
 }
 
-func plugNetworkInterface(vm *v1.VirtualMachine, netName string) *v1.VirtualMachine {
+func plugNetworkInterface(vm *v1.VirtualMachine, ifaceToPlug v1.Interface) *v1.VirtualMachine {
 	vm.Spec.Template.Spec.Domain.Devices.Interfaces = append(
 		vm.Spec.Template.Spec.Domain.Devices.Interfaces,
-		libvmi.InterfaceDeviceWithBridgeBinding(netName),
+		ifaceToPlug,
 	)
+
+	netName := ifaceToPlug.Name
 	vm.Spec.Template.Spec.Networks = append(
 		vm.Spec.Template.Spec.Networks,
 		*libvmi.MultusNetwork(netName, netName+"-nad"),

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -43,6 +43,10 @@ import (
 )
 
 var _ = Describe("VM Network Controller", func() {
+	const (
+		secondaryNetName = "foonet"
+		nadName          = "foonet-nad"
+	)
 	DescribeTable("sync does nothing when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, podGetter stubPodGetter) {
 		c := controllers.NewVMController(fake.NewSimpleClientset(), podGetter)
 		originalVM := vm.DeepCopy()
@@ -66,11 +70,15 @@ var _ = Describe("VM Network Controller", func() {
 			"the VM & VMI have identical interfaces",
 			libvmi.NewVirtualMachine(libvmi.New(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName, nadName)),
 			)),
 			libvmi.New(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName, nadName)),
 			),
 			stubPodGetter{pod: &k8sv1.Pod{}},
 		),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, there are two unit test files testing the NIC hotplug / hotunplug logic:
- pkg/network/controllers/vm_test.go
- pkg/network/controllers/hotplug_test.go

Move tests testing lower level logic from `hotplug_test.go` to the higher level `vm_test.go` file that tests the network VM controller as a whole.

The end goal is have all logic tested via the network VM controller.
In order to limit this PR's scope, not all tests were moved and a follow-up will be required to complete the work.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

