### PR TITLE
Declarative Volume Hotplug with Inject/Eject CD-ROM Support for VirtualMachines

### DIFF
--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -119,6 +119,13 @@ func WithCDRomAndVolume(bus v1.DiskBus, volume v1.Volume) Option {
 	}
 }
 
+// WithEmptyCDRom specifies a CDRom drive with no volume
+func WithEmptyCDRom(bus v1.DiskBus, name string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDisk(vmi, newCDRom(name, bus))
+	}
+}
+
 // WithEphemeralCDRom specifies a CDRom drive to be used.
 func WithEphemeralCDRom(cdRomName string, bus v1.DiskBus, claimName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -62,7 +62,15 @@ func WithContainerSATADisk(diskName, imageName string, diskOpts ...DiskOption) O
 func WithPersistentVolumeClaim(diskName, pvcName string, diskOpts ...DiskOption) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDisk(vmi, newDisk(diskName, v1.DiskBusVirtio, diskOpts...))
-		addVolume(vmi, newPersistentVolumeClaimVolume(diskName, pvcName))
+		addVolume(vmi, newPersistentVolumeClaimVolume(diskName, pvcName, false))
+	}
+}
+
+// WithHotplugPersistentVolumeClaim specifies the name of the hotpluggable PersistentVolumeClaim to be used.
+func WithHotplugPersistentVolumeClaim(diskName, pvcName string, diskOpts ...DiskOption) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDisk(vmi, newDisk(diskName, v1.DiskBusVirtio, diskOpts...))
+		addVolume(vmi, newPersistentVolumeClaimVolume(diskName, pvcName, true))
 	}
 }
 
@@ -100,7 +108,7 @@ func WithEmptyDisk(diskName string, bus v1.DiskBus, capacity resource.Quantity, 
 
 // WithCDRom specifies a CDRom drive backed by a PVC to be used.
 func WithCDRom(cdRomName string, bus v1.DiskBus, claimName string) Option {
-	return WithCDRomAndVolume(bus, newPersistentVolumeClaimVolume(cdRomName, claimName))
+	return WithCDRomAndVolume(bus, newPersistentVolumeClaimVolume(cdRomName, claimName, false))
 }
 
 // WithCDRomAndVolume specifies a CDRom drive backed by given volume and given bus.
@@ -123,7 +131,7 @@ func WithEphemeralCDRom(cdRomName string, bus v1.DiskBus, claimName string) Opti
 func WithFilesystemPVC(claimName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addFilesystem(vmi, newVirtiofsFilesystem(claimName))
-		addVolume(vmi, newPersistentVolumeClaimVolume(claimName, claimName))
+		addVolume(vmi, newPersistentVolumeClaimVolume(claimName, claimName, false))
 	}
 }
 
@@ -138,7 +146,7 @@ func WithFilesystemDV(dataVolumeName string) Option {
 func WithPersistentVolumeClaimLun(diskName, pvcName string, reservation bool) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDisk(vmi, newLun(diskName, reservation))
-		addVolume(vmi, newPersistentVolumeClaimVolume(diskName, pvcName))
+		addVolume(vmi, newPersistentVolumeClaimVolume(diskName, pvcName, false))
 	}
 }
 
@@ -307,7 +315,7 @@ func newContainerVolume(name, image string, imagePullPolicy k8sv1.PullPolicy) v1
 	return container
 }
 
-func newPersistentVolumeClaimVolume(name, claimName string) v1.Volume {
+func newPersistentVolumeClaimVolume(name, claimName string, hotpluggable bool) v1.Volume {
 	return v1.Volume{
 		Name: name,
 		VolumeSource: v1.VolumeSource{
@@ -315,6 +323,7 @@ func newPersistentVolumeClaimVolume(name, claimName string) v1.Volume {
 				PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 					ClaimName: claimName,
 				},
+				Hotpluggable: hotpluggable,
 			},
 		},
 	}

--- a/pkg/storage/hotplug/BUILD.bazel
+++ b/pkg/storage/hotplug/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hotplug.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/storage/hotplug",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/storage/types:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "hotplug_suite_test.go",
+        "hotplug_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/go.uber.org/mock/gomock:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/pkg/storage/hotplug/hotplug.go
+++ b/pkg/storage/hotplug/hotplug.go
@@ -1,0 +1,197 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package hotplug
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+)
+
+func HandleDeclarativeVolumes(client kubecli.KubevirtClient, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
+	// TEMP as to not conflict with subresource
+	if len(vm.Status.VolumeRequests) > 0 {
+		return nil
+	}
+
+	if vm.Spec.UpdateVolumesStrategy != nil && *vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyMigration {
+		// Are there some cases we can proceed?
+		return nil
+	}
+
+	if err := patchHotplugVolumes(client, vm, vmi); err != nil {
+		log.Log.Object(vm).Errorf("failed to update hotplug volumes for vmi:%v", err)
+		return err
+	}
+
+	return nil
+}
+
+func patchHotplugVolumes(client kubecli.KubevirtClient, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
+	if vmi == nil || !vmi.IsRunning() {
+		return nil
+	}
+
+	newVmiVolumes := append(filterHotplugVMIVolumes(vm, vmi), getNewHotplugVMVolumes(vm, vmi)...)
+	newVmiDisks := append(filterHotplugVMIDisks(vm, vmi, newVmiVolumes), getNewHotplugVMDisks(vm, vmi, newVmiVolumes)...)
+
+	if equality.Semantic.DeepEqual(vmi.Spec.Volumes, newVmiVolumes) &&
+		equality.Semantic.DeepEqual(vmi.Spec.Domain.Devices.Disks, newVmiDisks) {
+		log.Log.Object(vm).V(3).Info("No hotplug volumes to patch")
+		return nil
+	}
+
+	patchSet := patch.New(
+		patch.WithTest("/spec/volumes", vmi.Spec.Volumes),
+		patch.WithTest("/spec/domain/devices/disks", vmi.Spec.Domain.Devices.Disks),
+	)
+
+	if len(vmi.Spec.Volumes) > 0 {
+		patchSet.AddOption(patch.WithReplace("/spec/volumes", newVmiVolumes))
+	} else {
+		patchSet.AddOption(patch.WithAdd("/spec/volumes", newVmiVolumes))
+	}
+
+	if len(vmi.Spec.Domain.Devices.Disks) > 0 {
+		patchSet.AddOption(patch.WithReplace("/spec/domain/devices/disks", newVmiDisks))
+	} else {
+		patchSet.AddOption(patch.WithAdd("/spec/domain/devices/disks", newVmiDisks))
+	}
+
+	patchBytes, err := patchSet.GeneratePayload()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func filterHotplugVMIVolumes(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) []virtv1.Volume {
+	var volumes []virtv1.Volume
+	vmVolumesByName := storagetypes.GetVolumesByName(&vm.Spec.Template.Spec)
+
+	// remove any volumes missing/changed in the VM spec
+	for _, vmiVolume := range vmi.Spec.Volumes {
+		if storagetypes.IsDeclarativeHotplugVolume(&vmiVolume) {
+			vmVolume, exists := vmVolumesByName[vmiVolume.Name]
+			if !exists {
+				// volume not in VM spec, remove it
+				log.Log.Object(vm).Infof("Removing hotplug volume %s from VMI, no longer in VM", vmiVolume.Name)
+				continue
+			}
+
+			// volume changed in VM spec - remove it to be re-added with new values later
+			if storagetypes.IsDeclarativeHotplugVolume(vmVolume) && !equality.Semantic.DeepEqual(vmVolume, &vmiVolume) {
+				log.Log.Object(vm).Infof("Removing hotplug volume %s from VMI, volume changed", vmiVolume.Name)
+				continue
+			}
+		}
+
+		volumes = append(volumes, *vmiVolume.DeepCopy())
+	}
+
+	return volumes
+}
+
+func getNewHotplugVMVolumes(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) []virtv1.Volume {
+	var volumes []virtv1.Volume
+	vmiVolumesByName := storagetypes.GetVolumesByName(&vmi.Spec)
+
+	var volumesWithStatus = make(map[string]struct{})
+	for _, vs := range vmi.Status.VolumeStatus {
+		volumesWithStatus[vs.Name] = struct{}{}
+	}
+
+	for _, vmVolume := range vm.Spec.Template.Spec.Volumes {
+		if storagetypes.IsDeclarativeHotplugVolume(&vmVolume) {
+			_, vmiVolumeExists := vmiVolumesByName[vmVolume.Name]
+
+			// vmi will report status on volume after removed from spec
+			// if in process of hot unplugging
+			_, vmiVolumeHasStatus := volumesWithStatus[vmVolume.Name]
+
+			if !vmiVolumeExists && !vmiVolumeHasStatus {
+				log.Log.Object(vm).Infof("Adding hotplug volume %s to VMI", vmVolume.Name)
+				volumes = append(volumes, *vmVolume.DeepCopy())
+			}
+		}
+	}
+
+	return volumes
+}
+
+func volumesByName(volumes []virtv1.Volume) map[string]*virtv1.Volume {
+	volumeMap := make(map[string]*virtv1.Volume)
+	for _, v := range volumes {
+		volumeMap[v.Name] = v.DeepCopy()
+	}
+	return volumeMap
+}
+
+func filterHotplugVMIDisks(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, vmiNewVolumes []virtv1.Volume) []virtv1.Disk {
+	var disks []virtv1.Disk
+	vmiNewVolumesByName := volumesByName(vmiNewVolumes)
+	vmDisksByName := storagetypes.GetDisksByName(&vm.Spec.Template.Spec)
+
+	for _, vmiDisk := range vmi.Spec.Domain.Devices.Disks {
+		_, vmDiskExists := vmDisksByName[vmiDisk.Name]
+		_, vmiVolumeExists := vmiNewVolumesByName[vmiDisk.Name]
+
+		if !vmDiskExists || !vmiVolumeExists {
+			continue
+		}
+
+		disks = append(disks, *vmiDisk.DeepCopy())
+	}
+
+	return disks
+}
+
+func getNewHotplugVMDisks(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, vmiNewVolumes []virtv1.Volume) []virtv1.Disk {
+	var disks []virtv1.Disk
+	vmiNewVolumesByName := volumesByName(vmiNewVolumes)
+	vmiDisksByName := storagetypes.GetDisksByName(&vmi.Spec)
+
+	for _, vmDisk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+		vmVolume, vmVolumeExists := vmiNewVolumesByName[vmDisk.Name]
+		_, vmiDiskExists := vmiDisksByName[vmDisk.Name]
+
+		if vmVolumeExists && storagetypes.IsDeclarativeHotplugVolume(vmVolume) && !vmiDiskExists {
+			log.Log.Object(vm).Infof("Adding hotplug disk %s to VMI", vmDisk.Name)
+			disks = append(disks, *vmDisk.DeepCopy())
+		}
+	}
+
+	return disks
+}

--- a/pkg/storage/hotplug/hotplug_suite_test.go
+++ b/pkg/storage/hotplug/hotplug_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 The KubeVirt Contributors
+ *
+ */
+
+package hotplug_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestHotplug(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/storage/hotplug/hotplug_test.go
+++ b/pkg/storage/hotplug/hotplug_test.go
@@ -1,0 +1,221 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 The KubeVirt Contributors
+ *
+ */
+package hotplug
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/kubevirt/fake"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
+)
+
+type addVolFunc func(diskName, pvcName string, diskOpts ...libvmi.DiskOption) libvmi.Option
+
+var _ = Describe("Volume Hotplug", func() {
+	var virtClient *kubecli.MockKubevirtClient
+	var virtFakeClient *fake.Clientset
+
+	BeforeEach(func() {
+		virtClient = kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
+		virtFakeClient = fake.NewSimpleClientset()
+
+		// Set up mock client
+		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(
+			virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault),
+		).AnyTimes()
+		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(
+			virtFakeClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault),
+		).AnyTimes()
+	})
+
+	Context("declarative volume hotplug", func() {
+		handle := func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(HandleDeclarativeVolumes(virtClient, vm, vmi)).To(Succeed())
+
+			vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			return vmi
+		}
+
+		It("should do nothing if VMI not running", func() {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+			}
+			allOpts := append(opts, libvmi.WithHotplugDataVolume("hotplugdisk_1", "hotplugvolume_1"))
+			origVMI := libvmi.New(opts...)
+			postVMI := libvmi.New(allOpts...)
+			postVMI.Name = origVMI.Name
+			vm := libvmi.NewVirtualMachine(postVMI)
+			result := handle(vm, origVMI)
+			Expect(result.Spec).To(Equal(origVMI.Spec))
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
+			Expect(result.Spec.Volumes).To(HaveLen(1))
+		})
+
+		It("should do nothing if non hotplug volume added", func() {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+			}
+			allOpts := append(opts, libvmi.WithDataVolume("hotplugdisk_1", "hotplugvolume_1"))
+			origVMI := libvmi.New(opts...)
+			postVMI := libvmi.New(allOpts...)
+			postVMI.Name = origVMI.Name
+			vm := libvmi.NewVirtualMachine(postVMI)
+			result := handle(vm, origVMI)
+			Expect(result.Spec).To(Equal(origVMI.Spec))
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
+			Expect(result.Spec.Volumes).To(HaveLen(1))
+		})
+
+		DescribeTable("should add hotplug volumes to VMI", func(f addVolFunc, numDisks int) {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+			}
+			allOpts := opts
+			for i := 1; i <= numDisks; i++ {
+				allOpts = append(allOpts, f(fmt.Sprintf("hotplugdisk_%d", i), fmt.Sprintf("hotplugvolume_%d", i)))
+			}
+			origVMI := libvmi.New(opts...)
+			postVMI := libvmi.New(allOpts...)
+			postVMI.Name = origVMI.Name
+			vm := libvmi.NewVirtualMachine(postVMI)
+			result := handle(vm, origVMI)
+			Expect(result.Spec).To(Equal(postVMI.Spec))
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(numDisks + 1)) // +1 for the existing disk
+			Expect(result.Spec.Volumes).To(HaveLen(numDisks + 1))              // +1 for the existing volume
+		},
+			Entry("With one DataVolume", libvmi.WithHotplugDataVolume, 1),
+			Entry("With five DataVolumes", libvmi.WithHotplugDataVolume, 5),
+			Entry("With one PVC", libvmi.WithHotplugPersistentVolumeClaim, 1),
+			Entry("With five PVC", libvmi.WithHotplugPersistentVolumeClaim, 5),
+		)
+
+		DescribeTable("should remove hotplug volumes from VMI", func(f addVolFunc, numDisks, index int) {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+			}
+			for i := 1; i <= numDisks; i++ {
+				opts = append(opts, f(fmt.Sprintf("hotplugdisk_%d", i), fmt.Sprintf("hotplugvolume_%d", i)))
+			}
+			origVMI := libvmi.New(opts...)
+			postVMI := origVMI.DeepCopy()
+			postVMI.Spec.Domain.Devices.Disks = removeFromSlice(postVMI.Spec.Domain.Devices.Disks, index+1)
+			postVMI.Spec.Volumes = removeFromSlice(postVMI.Spec.Volumes, index+1)
+			vm := libvmi.NewVirtualMachine(postVMI)
+			result := handle(vm, origVMI)
+			Expect(result.Spec).To(Equal(postVMI.Spec))
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(numDisks))
+			Expect(result.Spec.Volumes).To(HaveLen(numDisks))
+		},
+			Entry("With one DataVolume", libvmi.WithHotplugDataVolume, 1, 0),
+			Entry("With three DataVolumes index 0", libvmi.WithHotplugDataVolume, 3, 0),
+			Entry("With three DataVolumes index 1", libvmi.WithHotplugDataVolume, 3, 1),
+			Entry("With three DataVolumes index 2", libvmi.WithHotplugDataVolume, 3, 2),
+			Entry("With one PVC", libvmi.WithHotplugPersistentVolumeClaim, 1, 0),
+			Entry("With three PVCs index 0", libvmi.WithHotplugPersistentVolumeClaim, 3, 0),
+			Entry("With three PVCs index 1", libvmi.WithHotplugPersistentVolumeClaim, 3, 1),
+			Entry("With three PVCs index 2", libvmi.WithHotplugPersistentVolumeClaim, 3, 2),
+		)
+
+		It("should not add hotplug volume to VMI if vmi has status for the volume", func() {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+				libvmistatus.WithStatus(
+					libvmistatus.New(
+						libvmistatus.WithPhase(v1.Running),
+						libvmistatus.WithVolumeStatus(
+							v1.VolumeStatus{
+								Name: "hotplugdisk_1",
+							},
+						),
+					),
+				),
+			}
+			allOpts := append(opts, libvmi.WithHotplugDataVolume("hotplugdisk_1", "hotplugvolume_1"))
+			origVMI := libvmi.New(opts...)
+			postVMI := libvmi.New(allOpts...)
+			postVMI.Name = origVMI.Name
+			vm := libvmi.NewVirtualMachine(postVMI)
+			result := handle(vm, origVMI)
+			Expect(result.Spec).To(Equal(origVMI.Spec))
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
+			Expect(result.Spec.Volumes).To(HaveLen(1))
+		})
+
+		It("should remove volume when volume changes", func() {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+				libvmi.WithHotplugDataVolume("hotplugdisk_1", "hotplugvolume_1"),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+			}
+			origVMI := libvmi.New(opts...)
+			postVMI := origVMI.DeepCopy()
+			postVMI.Spec.Volumes[1].VolumeSource.DataVolume.Name = "changed"
+			vm := libvmi.NewVirtualMachine(postVMI)
+			result := handle(vm, origVMI)
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
+			Expect(result.Spec.Domain.Devices.Disks[0].Name).To(Equal("perm"))
+			Expect(result.Spec.Volumes).To(HaveLen(1))
+			Expect(result.Spec.Volumes[0].Name).To(Equal("perm"))
+		})
+
+		It("should not add hotplug volume to VMI with migration updatestrategy", func() {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+			}
+			allOpts := append(opts, libvmi.WithDataVolume("hotplugdisk_1", "hotplugvolume_1"))
+			origVMI := libvmi.New(opts...)
+			postVMI := libvmi.New(allOpts...)
+			postVMI.Name = origVMI.Name
+			vm := libvmi.NewVirtualMachine(postVMI, libvmi.WithUpdateVolumeStrategy(v1.UpdateVolumesStrategyMigration))
+			result := handle(vm, origVMI)
+			Expect(result.Spec).To(Equal(origVMI.Spec))
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
+			Expect(result.Spec.Volumes).To(HaveLen(1))
+		})
+	})
+})
+
+func removeFromSlice[T any](slice []T, index int) []T {
+	if index < 0 || index >= len(slice) {
+		return slice
+	}
+	return append(slice[:index], slice[index+1:]...)
+}

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -283,7 +283,7 @@ func RenderPVC(size *resource.Quantity, claimName, namespace, storageClass, acce
 	return pvc
 }
 
-func IsHotplugVolume(vol *virtv1.Volume) bool {
+func IsDeclarativeHotplugVolume(vol *virtv1.Volume) bool {
 	if vol == nil {
 		return false
 	}
@@ -294,6 +294,18 @@ func IsHotplugVolume(vol *virtv1.Volume) bool {
 	if volSrc.DataVolume != nil && volSrc.DataVolume.Hotpluggable {
 		return true
 	}
+
+	return false
+}
+
+func IsHotplugVolume(vol *virtv1.Volume) bool {
+	if vol == nil {
+		return false
+	}
+	if IsDeclarativeHotplugVolume(vol) {
+		return true
+	}
+	volSrc := vol.VolumeSource
 	if volSrc.MemoryDump != nil && volSrc.MemoryDump.PersistentVolumeClaimVolumeSource.Hotpluggable {
 		return true
 	}

--- a/pkg/virt-api/rest/memorydump.go
+++ b/pkg/virt-api/rest/memorydump.go
@@ -170,8 +170,8 @@ func (app *SubresourceAPIApp) MemoryDumpVMRequestHandler(request *restful.Reques
 	name := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
 
-	if !app.clusterConfig.HotplugVolumesEnabled() {
-		writeError(errors.NewBadRequest("Unable to memory dump because HotplugVolumes feature gate is not enabled."), response)
+	if !app.clusterConfig.DeclarativeHotplugVolumesEnabled() && !app.clusterConfig.HotplugVolumesEnabled() {
+		writeError(errors.NewBadRequest(hotplugVolumeNotEnabledError), response)
 		return
 	}
 

--- a/pkg/virt-api/rest/volumes.go
+++ b/pkg/virt-api/rest/volumes.go
@@ -36,6 +36,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 
+const (
+	hotplugVolumeNotEnabledError = "Enable DeclarativeHotplugVolumes or HotplugVolumes feature gate to use this API."
+)
+
 // VMAddVolumeRequestHandler handles the subresource for hot plugging a volume and disk.
 func (app *SubresourceAPIApp) VMAddVolumeRequestHandler(request *restful.Request, response *restful.Response) {
 	app.addVolumeRequestHandler(request, response, false)
@@ -56,12 +60,20 @@ func (app *SubresourceAPIApp) VMIRemoveVolumeRequestHandler(request *restful.Req
 	app.removeVolumeRequestHandler(request, response, true)
 }
 
+func (app *SubresourceAPIApp) hotplugVolumesEnabled() bool {
+	return app.clusterConfig.HotplugVolumesEnabled() || app.clusterConfig.DeclarativeHotplugVolumesEnabled()
+}
+
+func (app *SubresourceAPIApp) ephemeralHotplugSupported() bool {
+	return app.clusterConfig.HotplugVolumesEnabled()
+}
+
 func (app *SubresourceAPIApp) addVolumeRequestHandler(request *restful.Request, response *restful.Response, ephemeral bool) {
 	name := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
 
-	if !app.clusterConfig.HotplugVolumesEnabled() {
-		writeError(errors.NewBadRequest("Unable to Add Volume because HotplugVolumes feature gate is not enabled."), response)
+	if !app.hotplugVolumesEnabled() {
+		writeError(errors.NewBadRequest(hotplugVolumeNotEnabledError), response)
 		return
 	}
 
@@ -104,8 +116,13 @@ func (app *SubresourceAPIApp) addVolumeRequestHandler(request *restful.Request, 
 			writeError(err, response)
 			return
 		}
-	} else {
+	} else if app.clusterConfig.HotplugVolumesEnabled() {
 		if err := app.vmVolumePatchStatus(name, namespace, &volumeRequest); err != nil {
+			writeError(err, response)
+			return
+		}
+	} else {
+		if err := app.vmVolumePatch(name, namespace, &volumeRequest); err != nil {
 			writeError(err, response)
 			return
 		}
@@ -118,8 +135,8 @@ func (app *SubresourceAPIApp) removeVolumeRequestHandler(request *restful.Reques
 	name := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
 
-	if !app.clusterConfig.HotplugVolumesEnabled() {
-		writeError(errors.NewBadRequest("Unable to Remove Volume because HotplugVolumes feature gate is not enabled."), response)
+	if !app.hotplugVolumesEnabled() {
+		writeError(errors.NewBadRequest(hotplugVolumeNotEnabledError), response)
 		return
 	}
 
@@ -149,8 +166,13 @@ func (app *SubresourceAPIApp) removeVolumeRequestHandler(request *restful.Reques
 			writeError(err, response)
 			return
 		}
-	} else {
+	} else if app.clusterConfig.HotplugVolumesEnabled() {
 		if err := app.vmVolumePatchStatus(name, namespace, &volumeRequest); err != nil {
+			writeError(err, response)
+			return
+		}
+	} else {
+		if err := app.vmVolumePatch(name, namespace, &volumeRequest); err != nil {
 			writeError(err, response)
 			return
 		}
@@ -159,10 +181,44 @@ func (app *SubresourceAPIApp) removeVolumeRequestHandler(request *restful.Reques
 	response.WriteHeader(http.StatusAccepted)
 }
 
+func (app *SubresourceAPIApp) vmVolumePatch(name, namespace string, volumeRequest *v1.VirtualMachineVolumeRequest) *errors.StatusError {
+	vm, statErr := app.fetchVirtualMachine(name, namespace)
+	if statErr != nil {
+		return statErr
+	}
+
+	err := verifyVolumeOption(vm.Spec.Template.Spec.Volumes, volumeRequest)
+	if err != nil {
+		return errors.NewConflict(v1.Resource("virtualmachine"), name, err)
+	}
+
+	patchBytes, err := generateVolumeRequestPatchVM(&vm.Spec.Template.Spec, volumeRequest)
+	if err != nil {
+		return errors.NewConflict(v1.Resource("virtualmachine"), name, err)
+	}
+
+	dryRunOption := getDryRunOption(volumeRequest)
+	log.Log.Object(vm).V(4).Infof("Patching VM: %s", string(patchBytes))
+	if _, err := app.virtCli.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRunOption}); err != nil {
+		log.Log.Object(vm).Errorf("unable to patch vm: %v", err)
+		if errors.IsInvalid(err) {
+			if statErr, ok := err.(*errors.StatusError); ok {
+				return statErr
+			}
+		}
+		return errors.NewInternalError(fmt.Errorf("unable to patch vm: %v", err))
+	}
+	return nil
+}
+
 func (app *SubresourceAPIApp) vmiVolumePatch(name, namespace string, volumeRequest *v1.VirtualMachineVolumeRequest) *errors.StatusError {
 	vmi, statErr := app.FetchVirtualMachineInstance(namespace, name)
 	if statErr != nil {
 		return statErr
+	}
+
+	if ownedByVirtualMachine(vmi) && !app.ephemeralHotplugSupported() {
+		return errors.NewBadRequest(fmt.Sprintf("VMI %s/%s is owned by a VM", vmi.Namespace, vmi.Name))
 	}
 
 	if !vmi.IsRunning() {
@@ -174,7 +230,7 @@ func (app *SubresourceAPIApp) vmiVolumePatch(name, namespace string, volumeReque
 		return errors.NewConflict(v1.Resource("virtualmachineinstance"), name, err)
 	}
 
-	patchBytes, err := generateVMIVolumeRequestPatch(vmi, volumeRequest)
+	patchBytes, err := generateVolumeRequestPatchVMI(&vmi.Spec, volumeRequest)
 	if err != nil {
 		return errors.NewConflict(v1.Resource("virtualmachineinstance"), name, err)
 	}
@@ -283,25 +339,34 @@ func volumeSourceName(volumeSource *v1.HotplugVolumeSource) string {
 	return ""
 }
 
-func generateVMIVolumeRequestPatch(vmi *v1.VirtualMachineInstance, volumeRequest *v1.VirtualMachineVolumeRequest) ([]byte, error) {
-	vmiCopy := vmi.DeepCopy()
-	vmiCopy.Spec = *controller.ApplyVolumeRequestOnVMISpec(&vmiCopy.Spec, volumeRequest)
+func generateVolumeRequestPatchVM(vmiSpec *v1.VirtualMachineInstanceSpec, volumeRequest *v1.VirtualMachineVolumeRequest) ([]byte, error) {
+	return generateVolumeRequestPatch("/spec/template", vmiSpec, volumeRequest)
+}
+
+func generateVolumeRequestPatchVMI(vmiSpec *v1.VirtualMachineInstanceSpec, volumeRequest *v1.VirtualMachineVolumeRequest) ([]byte, error) {
+	return generateVolumeRequestPatch("", vmiSpec, volumeRequest)
+}
+
+func generateVolumeRequestPatch(prefix string, vmiSpec *v1.VirtualMachineInstanceSpec, volumeRequest *v1.VirtualMachineVolumeRequest) ([]byte, error) {
+	volumePath := prefix + "/spec/volumes"
+	diskPath := prefix + "/spec/domain/devices/disks"
+	vmiSpecCopy := *controller.ApplyVolumeRequestOnVMISpec(vmiSpec.DeepCopy(), volumeRequest)
 
 	patchSet := patch.New(
-		patch.WithTest("/spec/volumes", vmi.Spec.Volumes),
-		patch.WithTest("/spec/domain/devices/disks", vmi.Spec.Domain.Devices.Disks),
+		patch.WithTest(volumePath, vmiSpec.Volumes),
+		patch.WithTest(diskPath, vmiSpec.Domain.Devices.Disks),
 	)
 
-	if len(vmi.Spec.Volumes) > 0 {
-		patchSet.AddOption(patch.WithReplace("/spec/volumes", vmiCopy.Spec.Volumes))
+	if len(vmiSpec.Volumes) > 0 {
+		patchSet.AddOption(patch.WithReplace(volumePath, vmiSpecCopy.Volumes))
 	} else {
-		patchSet.AddOption(patch.WithAdd("/spec/volumes", vmiCopy.Spec.Volumes))
+		patchSet.AddOption(patch.WithAdd(volumePath, vmiSpecCopy.Volumes))
 	}
 
-	if len(vmi.Spec.Domain.Devices.Disks) > 0 {
-		patchSet.AddOption(patch.WithReplace("/spec/domain/devices/disks", vmiCopy.Spec.Domain.Devices.Disks))
+	if len(vmiSpec.Domain.Devices.Disks) > 0 {
+		patchSet.AddOption(patch.WithReplace(diskPath, vmiSpecCopy.Domain.Devices.Disks))
 	} else {
-		patchSet.AddOption(patch.WithAdd("/spec/domain/devices/disks", vmiCopy.Spec.Domain.Devices.Disks))
+		patchSet.AddOption(patch.WithAdd(diskPath, vmiSpecCopy.Domain.Devices.Disks))
 	}
 
 	return patchSet.GeneratePayload()
@@ -384,4 +449,13 @@ func removeVolumeRequestExists(request v1.VirtualMachineVolumeRequest, name stri
 
 func addVolumeRequestExists(request v1.VirtualMachineVolumeRequest, name string) bool {
 	return request.AddVolumeOptions != nil && request.AddVolumeOptions.Name == name
+}
+
+func ownedByVirtualMachine(vmi *v1.VirtualMachineInstance) bool {
+	owner := metav1.GetControllerOf(vmi)
+	if owner != nil && owner.Kind == "VirtualMachine" && owner.APIVersion == v1.SchemeGroupVersion.String() {
+		return true
+	}
+
+	return false
 }

--- a/pkg/virt-api/rest/volumes_test.go
+++ b/pkg/virt-api/rest/volumes_test.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -46,6 +47,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
@@ -77,9 +79,10 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 
 	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
-	enableFeatureGate := func(featureGate string) {
+	enableFeatureGates := func(featureGates ...string) {
+		fgs := slices.Clone(featureGates)
 		kvConfig := kv.DeepCopy()
-		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
+		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = fgs
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 	disableFeatureGates := func() {
@@ -124,10 +127,194 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 		return &readCloserWrapper{bytes.NewReader(optsJson)}
 	}
 
-	DescribeTable("Should succeed with add volume request", func(addOpts *v1.AddVolumeOptions, removeOpts *v1.RemoveVolumeOptions, isVM bool, code int, enableGate bool) {
-		if enableGate {
-			enableFeatureGate(featuregate.HotplugVolumesGate)
-		}
+	VolumeUpdateTests := func(featureGate string) {
+		DescribeTable("Should succeed with add/volume request", func(addOpts *v1.AddVolumeOptions, removeOpts *v1.RemoveVolumeOptions, isVM bool, code int, enableGate bool) {
+			if enableGate {
+				enableFeatureGates(featureGate)
+			}
+			if addOpts != nil {
+				request.Request.Body = newAddVolumeBody(addOpts)
+			} else {
+				request.Request.Body = newRemoveVolumeBody(removeOpts)
+			}
+
+			vmi := libvmi.New(
+				libvmi.WithName(request.PathParameter("name")),
+				libvmi.WithNamespace(metav1.NamespaceDefault),
+				libvmi.WithPersistentVolumeClaim("existingvol", "testpvcdiskclaim"),
+				libvmi.WithPersistentVolumeClaim("hotpluggedPVC", "hotpluggedPVC"),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+			)
+			vmi.Spec.Volumes[1].VolumeSource.PersistentVolumeClaim.Hotpluggable = true
+
+			if isVM {
+				vm := libvmi.NewVirtualMachine(vmi)
+				vm.Name = request.PathParameter("name")
+				vm.Namespace = metav1.NamespaceDefault
+
+				vmClient.EXPECT().Get(context.Background(), vm.Name, metav1.GetOptions{}).Return(vm, nil).AnyTimes()
+
+				if featureGate == featuregate.HotplugVolumesGate {
+					patchedVM := vm.DeepCopy()
+					patchedVM.Status.VolumeRequests = append(patchedVM.Status.VolumeRequests, v1.VirtualMachineVolumeRequest{AddVolumeOptions: addOpts, RemoveVolumeOptions: removeOpts})
+
+					if addOpts != nil {
+						vmClient.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions) (interface{}, interface{}) {
+								//check that dryRun option has been propagated to patch request
+								Expect(opts.DryRun).To(BeEquivalentTo(addOpts.DryRun))
+								return patchedVM, nil
+							}).AnyTimes()
+						app.VMAddVolumeRequestHandler(request, response)
+					} else {
+						vmClient.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions) (interface{}, interface{}) {
+								//check that dryRun option has been propagated to patch request
+								Expect(opts.DryRun).To(BeEquivalentTo(removeOpts.DryRun))
+								return patchedVM, nil
+							})
+						app.VMRemoveVolumeRequestHandler(request, response)
+					}
+				} else {
+					if addOpts != nil {
+						vmClient.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions, _ ...string) (interface{}, interface{}) {
+								//check that dryRun option has been propagated to patch request
+								Expect(opts.DryRun).To(BeEquivalentTo(addOpts.DryRun))
+								return vm, nil
+							}).AnyTimes()
+						app.VMAddVolumeRequestHandler(request, response)
+					} else {
+						vmClient.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions, _ ...string) (interface{}, interface{}) {
+								//check that dryRun option has been propagated to patch request
+								Expect(opts.DryRun).To(BeEquivalentTo(removeOpts.DryRun))
+								return vm, nil
+							})
+						app.VMRemoveVolumeRequestHandler(request, response)
+					}
+				}
+			} else {
+				vmiClient.EXPECT().Get(context.Background(), vmi.Name, metav1.GetOptions{}).Return(vmi, nil).AnyTimes()
+				if addOpts != nil {
+					vmiClient.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+						func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions, _ ...string) (interface{}, interface{}) {
+							//check that dryRun option has been propagated to patch request
+							Expect(opts.DryRun).To(BeEquivalentTo(addOpts.DryRun))
+							return vmi, nil
+						}).AnyTimes()
+					app.VMIAddVolumeRequestHandler(request, response)
+				} else {
+					vmiClient.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+						func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions, _ ...string) (interface{}, interface{}) {
+							//check that dryRun option has been propagated to patch request
+							Expect(opts.DryRun).To(BeEquivalentTo(removeOpts.DryRun))
+							return vmi, nil
+						}).AnyTimes()
+					app.VMIRemoveVolumeRequestHandler(request, response)
+				}
+			}
+
+			Expect(response.StatusCode()).To(Equal(code))
+		},
+			Entry("VM with a valid add volume request", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				Disk:         &v1.Disk{},
+				VolumeSource: &v1.HotplugVolumeSource{},
+			}, nil, true, http.StatusAccepted, true),
+			Entry("VMI with a valid add volume request", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				Disk:         &v1.Disk{},
+				VolumeSource: &v1.HotplugVolumeSource{},
+			}, nil, false, http.StatusAccepted, true),
+			Entry("VMI with an invalid add volume request that's missing a name", &v1.AddVolumeOptions{
+				VolumeSource: &v1.HotplugVolumeSource{},
+				Disk:         &v1.Disk{},
+			}, nil, false, http.StatusBadRequest, true),
+			Entry("VMI with an invalid add volume request that's missing a disk", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				VolumeSource: &v1.HotplugVolumeSource{},
+			}, nil, false, http.StatusBadRequest, true),
+			Entry("VMI with an invalid add volume request that's missing a volume", &v1.AddVolumeOptions{
+				Name: "vol1",
+				Disk: &v1.Disk{},
+			}, nil, false, http.StatusBadRequest, true),
+			Entry("VM with a valid remove volume request", nil, &v1.RemoveVolumeOptions{
+				Name: "hotpluggedPVC",
+			}, true, http.StatusAccepted, true),
+			Entry("VMI with a valid remove volume request", nil, &v1.RemoveVolumeOptions{
+				Name: "hotpluggedPVC",
+			}, false, http.StatusAccepted, true),
+			Entry("VMI with a invalid remove volume request missing a name", nil, &v1.RemoveVolumeOptions{}, false, http.StatusBadRequest, true),
+			Entry("VMI with a valid remove volume request but no feature gate", nil, &v1.RemoveVolumeOptions{
+				Name: "existingvol",
+			}, false, http.StatusBadRequest, false),
+			Entry("VM with a valid add volume request but no feature gate", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				Disk:         &v1.Disk{},
+				VolumeSource: &v1.HotplugVolumeSource{},
+			}, nil, true, http.StatusBadRequest, false),
+			Entry("VM with a valid add volume request with DryRun", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				Disk:         &v1.Disk{},
+				VolumeSource: &v1.HotplugVolumeSource{},
+				DryRun:       withDryRun(),
+			}, nil, true, http.StatusAccepted, true),
+			Entry("VMI with a valid add volume request with DryRun", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				Disk:         &v1.Disk{},
+				VolumeSource: &v1.HotplugVolumeSource{},
+				DryRun:       withDryRun(),
+			}, nil, false, http.StatusAccepted, true),
+			Entry("VMI with an invalid add volume request that's missing a name with DryRun", &v1.AddVolumeOptions{
+				VolumeSource: &v1.HotplugVolumeSource{},
+				Disk:         &v1.Disk{},
+				DryRun:       withDryRun(),
+			}, nil, false, http.StatusBadRequest, true),
+			Entry("VMI with an invalid add volume request that's missing a disk with DryRun", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				VolumeSource: &v1.HotplugVolumeSource{},
+				DryRun:       withDryRun(),
+			}, nil, false, http.StatusBadRequest, true),
+			Entry("VMI with an invalid add volume request that's missing a volume with DryRun", &v1.AddVolumeOptions{
+				Name:   "vol1",
+				Disk:   &v1.Disk{},
+				DryRun: withDryRun(),
+			}, nil, false, http.StatusBadRequest, true),
+			Entry("VM with a valid remove volume request with DryRun", nil, &v1.RemoveVolumeOptions{
+				Name:   "hotpluggedPVC",
+				DryRun: withDryRun(),
+			}, true, http.StatusAccepted, true),
+			Entry("VMI with a valid remove volume request with DryRun", nil, &v1.RemoveVolumeOptions{
+				Name:   "hotpluggedPVC",
+				DryRun: withDryRun(),
+			}, false, http.StatusAccepted, true),
+			Entry("VMI with a invalid remove volume request missing a name with DryRun", nil, &v1.RemoveVolumeOptions{
+				DryRun: withDryRun(),
+			}, false, http.StatusBadRequest, true),
+			Entry("VMI with a valid remove volume request but no feature gate with DryRun", nil, &v1.RemoveVolumeOptions{
+				Name:   "existingvol",
+				DryRun: withDryRun(),
+			}, false, http.StatusBadRequest, false),
+			Entry("VM with a valid add volume request but no feature gate with DryRun", &v1.AddVolumeOptions{
+				Name:         "vol1",
+				Disk:         &v1.Disk{},
+				VolumeSource: &v1.HotplugVolumeSource{},
+				DryRun:       withDryRun(),
+			}, nil, true, http.StatusBadRequest, false),
+		)
+	}
+
+	Context("With DeclarativeHotplugVolumes feature gate", func() {
+		VolumeUpdateTests(featuregate.DeclarativeHotplugVolumesGate)
+	})
+
+	Context("With HotplugVolumes feature gate", func() {
+		VolumeUpdateTests(featuregate.HotplugVolumesGate)
+	})
+
+	DescribeTable("Should handle VMI with owner and", func(addOpts *v1.AddVolumeOptions, removeOpts *v1.RemoveVolumeOptions, code int, featuregates ...string) {
+		enableFeatureGates(featuregates...)
 		if addOpts != nil {
 			request.Request.Body = newAddVolumeBody(addOpts)
 		} else {
@@ -142,141 +329,54 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 			libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
 		)
 		vmi.Spec.Volumes[1].VolumeSource.PersistentVolumeClaim.Hotpluggable = true
+		vmi.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: "kubevirt.io/v1",
+				Kind:       "VirtualMachine",
+				Name:       request.PathParameter("name"),
+				UID:        types.UID("1234"),
+				Controller: pointer.P(true),
+			},
+		}
 
-		if isVM {
-			vm := libvmi.NewVirtualMachine(vmi)
-			vm.Name = request.PathParameter("name")
-			vm.Namespace = metav1.NamespaceDefault
+		vmiClient.EXPECT().Get(context.Background(), vmi.Name, metav1.GetOptions{}).Return(vmi, nil).AnyTimes()
 
-			patchedVM := vm.DeepCopy()
-			patchedVM.Status.VolumeRequests = append(patchedVM.Status.VolumeRequests, v1.VirtualMachineVolumeRequest{AddVolumeOptions: addOpts, RemoveVolumeOptions: removeOpts})
-			vmClient.EXPECT().Get(context.Background(), vm.Name, metav1.GetOptions{}).Return(vm, nil).AnyTimes()
+		if code == http.StatusAccepted {
+			vmiClient.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Return(vmi, nil).AnyTimes()
+		}
 
-			if addOpts != nil {
-				vmClient.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions) (interface{}, interface{}) {
-						//check that dryRun option has been propagated to patch request
-						Expect(opts.DryRun).To(BeEquivalentTo(addOpts.DryRun))
-						return patchedVM, nil
-					}).AnyTimes()
-				app.VMAddVolumeRequestHandler(request, response)
-			} else {
-				vmClient.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions) (interface{}, interface{}) {
-						//check that dryRun option has been propagated to patch request
-						Expect(opts.DryRun).To(BeEquivalentTo(removeOpts.DryRun))
-						return patchedVM, nil
-					})
-				app.VMRemoveVolumeRequestHandler(request, response)
-			}
+		if addOpts != nil {
+			app.VMIAddVolumeRequestHandler(request, response)
 		} else {
-			vmiClient.EXPECT().Get(context.Background(), vmi.Name, metav1.GetOptions{}).Return(vmi, nil).AnyTimes()
-			if addOpts != nil {
-				vmiClient.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions, _ ...string) (interface{}, interface{}) {
-						//check that dryRun option has been propagated to patch request
-						Expect(opts.DryRun).To(BeEquivalentTo(addOpts.DryRun))
-						return vmi, nil
-					}).AnyTimes()
-				app.VMIAddVolumeRequestHandler(request, response)
-			} else {
-				vmiClient.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions, _ ...string) (interface{}, interface{}) {
-						//check that dryRun option has been propagated to patch request
-						Expect(opts.DryRun).To(BeEquivalentTo(removeOpts.DryRun))
-						return vmi, nil
-					}).AnyTimes()
-				app.VMIRemoveVolumeRequestHandler(request, response)
-			}
+			app.VMIRemoveVolumeRequestHandler(request, response)
 		}
 
 		Expect(response.StatusCode()).To(Equal(code))
 	},
-		Entry("VM with a valid add volume request", &v1.AddVolumeOptions{
+		Entry("Reject Add with DeclarativeHotplugVolumes", &v1.AddVolumeOptions{
 			Name:         "vol1",
 			Disk:         &v1.Disk{},
 			VolumeSource: &v1.HotplugVolumeSource{},
-		}, nil, true, http.StatusAccepted, true),
-		Entry("VMI with a valid add volume request", &v1.AddVolumeOptions{
+		}, nil, http.StatusBadRequest, featuregate.DeclarativeHotplugVolumesGate),
+		Entry("Accept Add with HotplugVolumes", &v1.AddVolumeOptions{
 			Name:         "vol1",
 			Disk:         &v1.Disk{},
 			VolumeSource: &v1.HotplugVolumeSource{},
-		}, nil, false, http.StatusAccepted, true),
-		Entry("VMI with an invalid add volume request that's missing a name", &v1.AddVolumeOptions{
-			VolumeSource: &v1.HotplugVolumeSource{},
-			Disk:         &v1.Disk{},
-		}, nil, false, http.StatusBadRequest, true),
-		Entry("VMI with an invalid add volume request that's missing a disk", &v1.AddVolumeOptions{
+		}, nil, http.StatusAccepted, featuregate.HotplugVolumesGate),
+		Entry("Accept Add with both featuregates", &v1.AddVolumeOptions{
 			Name:         "vol1",
+			Disk:         &v1.Disk{},
 			VolumeSource: &v1.HotplugVolumeSource{},
-		}, nil, false, http.StatusBadRequest, true),
-		Entry("VMI with an invalid add volume request that's missing a volume", &v1.AddVolumeOptions{
-			Name: "vol1",
-			Disk: &v1.Disk{},
-		}, nil, false, http.StatusBadRequest, true),
-		Entry("VM with a valid remove volume request", nil, &v1.RemoveVolumeOptions{
+		}, nil, http.StatusAccepted, featuregate.HotplugVolumesGate, featuregate.DeclarativeHotplugVolumesGate),
+		Entry("Reject Remove with DeclarativeHotplugVolumes", nil, &v1.RemoveVolumeOptions{
 			Name: "hotpluggedPVC",
-		}, true, http.StatusAccepted, true),
-		Entry("VMI with a valid remove volume request", nil, &v1.RemoveVolumeOptions{
+		}, http.StatusBadRequest, featuregate.DeclarativeHotplugVolumesGate),
+		Entry("Accept Remove with HotplugVolumes", nil, &v1.RemoveVolumeOptions{
 			Name: "hotpluggedPVC",
-		}, false, http.StatusAccepted, true),
-		Entry("VMI with a invalid remove volume request missing a name", nil, &v1.RemoveVolumeOptions{}, false, http.StatusBadRequest, true),
-		Entry("VMI with a valid remove volume request but no feature gate", nil, &v1.RemoveVolumeOptions{
-			Name: "existingvol",
-		}, false, http.StatusBadRequest, false),
-		Entry("VM with a valid add volume request but no feature gate", &v1.AddVolumeOptions{
-			Name:         "vol1",
-			Disk:         &v1.Disk{},
-			VolumeSource: &v1.HotplugVolumeSource{},
-		}, nil, true, http.StatusBadRequest, false),
-		Entry("VM with a valid add volume request with DryRun", &v1.AddVolumeOptions{
-			Name:         "vol1",
-			Disk:         &v1.Disk{},
-			VolumeSource: &v1.HotplugVolumeSource{},
-			DryRun:       withDryRun(),
-		}, nil, true, http.StatusAccepted, true),
-		Entry("VMI with a valid add volume request with DryRun", &v1.AddVolumeOptions{
-			Name:         "vol1",
-			Disk:         &v1.Disk{},
-			VolumeSource: &v1.HotplugVolumeSource{},
-			DryRun:       withDryRun(),
-		}, nil, false, http.StatusAccepted, true),
-		Entry("VMI with an invalid add volume request that's missing a name with DryRun", &v1.AddVolumeOptions{
-			VolumeSource: &v1.HotplugVolumeSource{},
-			Disk:         &v1.Disk{},
-			DryRun:       withDryRun(),
-		}, nil, false, http.StatusBadRequest, true),
-		Entry("VMI with an invalid add volume request that's missing a disk with DryRun", &v1.AddVolumeOptions{
-			Name:         "vol1",
-			VolumeSource: &v1.HotplugVolumeSource{},
-			DryRun:       withDryRun(),
-		}, nil, false, http.StatusBadRequest, true),
-		Entry("VMI with an invalid add volume request that's missing a volume with DryRun", &v1.AddVolumeOptions{
-			Name:   "vol1",
-			Disk:   &v1.Disk{},
-			DryRun: withDryRun(),
-		}, nil, false, http.StatusBadRequest, true),
-		Entry("VM with a valid remove volume request with DryRun", nil, &v1.RemoveVolumeOptions{
-			Name:   "hotpluggedPVC",
-			DryRun: withDryRun(),
-		}, true, http.StatusAccepted, true),
-		Entry("VMI with a valid remove volume request with DryRun", nil, &v1.RemoveVolumeOptions{
-			Name:   "hotpluggedPVC",
-			DryRun: withDryRun(),
-		}, false, http.StatusAccepted, true),
-		Entry("VMI with a invalid remove volume request missing a name with DryRun", nil, &v1.RemoveVolumeOptions{
-			DryRun: withDryRun(),
-		}, false, http.StatusBadRequest, true),
-		Entry("VMI with a valid remove volume request but no feature gate with DryRun", nil, &v1.RemoveVolumeOptions{
-			Name:   "existingvol",
-			DryRun: withDryRun(),
-		}, false, http.StatusBadRequest, false),
-		Entry("VM with a valid add volume request but no feature gate with DryRun", &v1.AddVolumeOptions{
-			Name:         "vol1",
-			Disk:         &v1.Disk{},
-			VolumeSource: &v1.HotplugVolumeSource{},
-			DryRun:       withDryRun(),
-		}, nil, true, http.StatusBadRequest, false),
+		}, http.StatusAccepted, featuregate.HotplugVolumesGate),
+		Entry("Accept Remove with both featuregates", nil, &v1.RemoveVolumeOptions{
+			Name: "hotpluggedPVC",
+		}, http.StatusAccepted, featuregate.HotplugVolumesGate, featuregate.DeclarativeHotplugVolumesGate),
 	)
 
 	DescribeTable("Should generate expected vmi patch", func(volumeRequest *v1.VirtualMachineVolumeRequest, expectedPatchSet *patch.PatchSet) {
@@ -296,7 +396,7 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 			},
 		})
 
-		patch, err := generateVMIVolumeRequestPatch(vmi, volumeRequest)
+		patch, err := generateVolumeRequestPatchVMI(&vmi.Spec, volumeRequest)
 		Expect(err).ToNot(HaveOccurred())
 
 		patchBytes, err := expectedPatchSet.GeneratePayload()
@@ -356,7 +456,7 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 			)),
 	)
 
-	DescribeTable("Should generate expected vm patch", func(volumeRequest *v1.VirtualMachineVolumeRequest, existingVolumeRequests []v1.VirtualMachineVolumeRequest, expectedPatchSet *patch.PatchSet, expectError bool) {
+	DescribeTable("Should generate expected vm patch (volume request)", func(volumeRequest *v1.VirtualMachineVolumeRequest, existingVolumeRequests []v1.VirtualMachineVolumeRequest, expectedPatchSet *patch.PatchSet, expectError bool) {
 
 		vm := newMinimalVM(request.PathParameter("name"))
 		vm.Namespace = metav1.NamespaceDefault
@@ -504,6 +604,82 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 			}},
 			nil,
 			true),
+	)
+
+	DescribeTable("Should generate expected vm patch (declarative)", func(volumeRequest *v1.VirtualMachineVolumeRequest, expectedPatchSet *patch.PatchSet) {
+
+		vm := libvmi.NewVirtualMachine(api.NewMinimalVMI(request.PathParameter("name")))
+		vm.Namespace = metav1.NamespaceDefault
+		vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "existingvol",
+		})
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+			Name: "existingvol",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "testpvcdiskclaim",
+				}},
+			},
+		})
+
+		patch, err := generateVolumeRequestPatchVM(&vm.Spec.Template.Spec, volumeRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		patchBytes, err := expectedPatchSet.GeneratePayload()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(patch).To(Equal(patchBytes))
+	},
+		Entry("add volume request",
+			&v1.VirtualMachineVolumeRequest{
+				AddVolumeOptions: &v1.AddVolumeOptions{
+					Name:         "vol1",
+					Disk:         &v1.Disk{},
+					VolumeSource: &v1.HotplugVolumeSource{},
+				},
+			},
+			patch.New(
+				patch.WithTest("/spec/template/spec/volumes", []v1.Volume{{
+					Name: "existingvol",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "testpvcdiskclaim",
+						}},
+					},
+				}}),
+				patch.WithTest("/spec/template/spec/domain/devices/disks", []v1.Disk{{Name: "existingvol"}}),
+				patch.WithReplace("/spec/template/spec/volumes", []v1.Volume{
+					{
+						Name: "existingvol",
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "testpvcdiskclaim",
+							}},
+						},
+					},
+					{Name: "vol1"},
+				}),
+				patch.WithReplace("/spec/template/spec/domain/devices/disks", []v1.Disk{{Name: "existingvol"}, {Name: "vol1"}}),
+			),
+		),
+		Entry("remove volume request",
+			&v1.VirtualMachineVolumeRequest{
+				RemoveVolumeOptions: &v1.RemoveVolumeOptions{
+					Name: "existingvol",
+				},
+			},
+			patch.New(
+				patch.WithTest("/spec/template/spec/volumes", []v1.Volume{{
+					Name: "existingvol",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "testpvcdiskclaim",
+						}},
+					},
+				}}),
+				patch.WithTest("/spec/template/spec/domain/devices/disks", []v1.Disk{{Name: "existingvol"}}),
+				patch.WithReplace("/spec/template/spec/volumes", []v1.Volume{}),
+				patch.WithReplace("/spec/template/spec/domain/devices/disks", []v1.Disk{}),
+			)),
 	)
 
 	DescribeTable("Should verify volume option", func(volumeRequest *v1.VirtualMachineVolumeRequest, existingVolumes []v1.Volume, expectedError string) {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -180,3 +180,7 @@ func (config *ClusterConfig) NodeRestrictionEnabled() bool {
 func (config *ClusterConfig) ObjectGraphEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.ObjectGraph)
 }
+
+func (config *ClusterConfig) DeclarativeHotplugVolumesEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.DeclarativeHotplugVolumesGate)
+}

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -85,6 +85,10 @@ const (
 	// This subresource returns a structured list of k8s objects that are related
 	// to the specified VM or VMI, enabling better dependency tracking.
 	ObjectGraph = "ObjectGraph"
+
+	// DeclarativeHotplugVolumes enables adding/removing volumes declaratively
+	// also implicitly handles inject/eject CDROM
+	DeclarativeHotplugVolumesGate = "DeclarativeHotplugVolumes"
 )
 
 func init() {
@@ -112,4 +116,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSConfigVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSStorageVolumeGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DecentralizedLiveMigration, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: DeclarativeHotplugVolumesGate, State: Alpha})
 }

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/network/admitter:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/network/vmliveupdate:go_default_library",
+        "//pkg/storage/hotplug:go_default_library",
         "//pkg/storage/memorydump:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -64,6 +64,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
+	storagehotplug "kubevirt.io/kubevirt/pkg/storage/hotplug"
 	"kubevirt.io/kubevirt/pkg/storage/memorydump"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -3116,6 +3117,10 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 
 	if err := c.handleVolumeRequests(vmCopy, vmi); err != nil {
 		return vm, vmi, common.NewSyncError(fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), hotplugVolumeErrorReason), nil
+	}
+
+	if err := storagehotplug.HandleDeclarativeVolumes(c.clientset, vmCopy, vmi); err != nil {
+		return vm, vmi, common.NewSyncError(fmt.Errorf("Error encountered while handling declarative hotplug volumes: %v", err), hotplugVolumeErrorReason), nil
 	}
 
 	if err := memorydump.HandleRequest(c.clientset, vmCopy, vmi, c.pvcStore); err != nil {

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6192,7 +6192,6 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vmiList.Items).To(BeEmpty())
 			})
 		})
-
 	})
 	Context("syncConditions", func() {
 		var vm *v1.VirtualMachine

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6267,6 +6267,14 @@ var _ = Describe("VirtualMachine", func() {
 				Name: name,
 			}
 		}
+		createCDRom := func(name string) v1.Disk {
+			return v1.Disk{
+				Name: name,
+				DiskDevice: v1.DiskDevice{
+					CDRom: &v1.CDRomTarget{},
+				},
+			}
+		}
 		DescribeTable("should be validated for volume updates", func(oldVols, newVols []v1.Volume, expectValid bool) {
 			oldVm, _ := watchtesting.DefaultVirtualMachine(true)
 			newVm := oldVm.DeepCopy()
@@ -6316,6 +6324,10 @@ var _ = Describe("VirtualMachine", func() {
 				createPVCVol("vol2", "test2", false)}, []v1.Disk{createDisk("vol2")}, []v1.Disk{createDisk("vol1"), createDisk("vol2")}, true),
 			Entry("for a removed hotpluggable pvc", []v1.Volume{createPVCVol("vol1", "test1", true)}, []v1.Volume{},
 				[]v1.Disk{createDisk("vol1")}, []v1.Disk{}, true),
+			Entry("cd-rom eject", []v1.Volume{createPVCVol("vol1", "test1", false), createPVCVol("vol2", "test2", true)}, []v1.Volume{createPVCVol("vol1", "test1", false)},
+				[]v1.Disk{createDisk("vol1"), createCDRom("vol2")}, []v1.Disk{createDisk("vol1"), createCDRom("vol2")}, true),
+			Entry("cd-rom inject", []v1.Volume{createPVCVol("vol1", "test1", false)}, []v1.Volume{createPVCVol("vol1", "test1", false), createPVCVol("vol2", "test2", true)},
+				[]v1.Disk{createDisk("vol1"), createCDRom("vol2")}, []v1.Disk{createDisk("vol1"), createCDRom("vol2")}, true),
 		)
 	})
 

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -70,6 +70,7 @@ go_library(
         "//tools/cache:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -44,6 +44,7 @@ const (
 	CirrosVolumeSize = "512Mi"
 	AlpineVolumeSize = "512Mi"
 	BlankVolumeSize  = "16Mi"
+	VirtioVolumeSize = "750Mi"
 )
 
 // ContainerDiskFor takes the name of an image and returns the full

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "datavolume.go",
+        "declarative-hotplug.go",
         "events.go",
         "export.go",
         "framework.go",

--- a/tests/storage/declarative-hotplug.go
+++ b/tests/storage/declarative-hotplug.go
@@ -1,0 +1,339 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	expect "github.com/google/goexpect"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/libdv"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+	"kubevirt.io/kubevirt/tests/console"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/libstorage"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+const (
+	cdRomName       = "cdrom"
+	hotplugDiskName = "hotplug-disk"
+	volumeSize      = "1Gi"
+)
+
+var _ = Describe(SIG("Declarative Hotplug", Serial, func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		virtClient = kubevirt.Client()
+		kvconfig.DisableFeatureGate(featuregate.HotplugVolumesGate)
+		kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
+	})
+
+	createVM := func(options ...libvmi.Option) *v1.VirtualMachine {
+		vm := libvmi.NewVirtualMachine(
+			libvmifact.NewCirros(options...),
+			libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+		return vm
+	}
+
+	createAndStartVMWithEmptyCDRom := func() *v1.VirtualMachine {
+		return createVM(libvmi.WithEmptyCDRom(v1.DiskBusSATA, cdRomName))
+	}
+
+	createCDRomVolume := func(namespace string, cdisk cd.ContainerDisk) *cdiv1.DataVolume {
+		url := "docker://" + cd.ContainerDiskFor(cdisk)
+		dv := libdv.NewDataVolume(
+			libdv.WithRegistryURLSourceAndPullMethod(url, cdiv1.RegistryPullNode),
+			libdv.WithStorage(
+				libdv.StorageWithVolumeSize(volumeSize),
+			),
+		)
+
+		var err error
+		dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return dv
+	}
+
+	createBlankVolume := func(namespace string) *cdiv1.DataVolume {
+		dv := libdv.NewDataVolume(
+			libdv.WithBlankImageSource(),
+			libdv.WithStorage(
+				libdv.StorageWithVolumeSize(volumeSize),
+			),
+		)
+
+		var err error
+		dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return dv
+	}
+
+	patchVM := func(vm *v1.VirtualMachine, disks []v1.Disk, volumes []v1.Volume) *v1.VirtualMachine {
+		patchObj := patch.New()
+		if disks != nil {
+			patchObj.AddOption(patch.WithReplace("/spec/template/spec/domain/devices/disks", disks))
+		}
+		if volumes != nil {
+			patchObj.AddOption(patch.WithReplace("/spec/template/spec/volumes", volumes))
+		}
+		patchBytes, err := patchObj.GeneratePayload()
+		Expect(err).ToNot(HaveOccurred())
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return vm
+	}
+
+	addHotplugVolume := func(vm *v1.VirtualMachine, volumeName, pvcName string) *v1.VirtualMachine {
+		var err error
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		newVolumes := vm.DeepCopy().Spec.Template.Spec.Volumes
+		newVolumes = append(newVolumes, v1.Volume{
+			Name: volumeName,
+			VolumeSource: v1.VolumeSource{
+				DataVolume: &v1.DataVolumeSource{
+					Name:         pvcName,
+					Hotpluggable: true,
+				},
+			},
+		})
+		return patchVM(vm, nil, newVolumes)
+	}
+
+	hotplugDisk := func(vm *v1.VirtualMachine, volumeName, pvcName string) *v1.VirtualMachine {
+		vmCpy := vm.DeepCopy()
+		disks := vmCpy.Spec.Template.Spec.Domain.Devices.Disks
+		volumes := vmCpy.Spec.Template.Spec.Volumes
+		disks = append(disks, v1.Disk{
+			Name: volumeName,
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{
+					Bus: "scsi",
+				},
+			},
+		})
+		volumes = append(volumes, v1.Volume{
+			Name: volumeName,
+			VolumeSource: v1.VolumeSource{
+				DataVolume: &v1.DataVolumeSource{
+					Name:         pvcName,
+					Hotpluggable: true,
+				},
+			},
+		})
+		return patchVM(vm, disks, volumes)
+	}
+
+	removeHotplugVolume := func(vm *v1.VirtualMachine, volumeName string) *v1.VirtualMachine {
+		var err error
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		var newVolumes []v1.Volume
+		for _, volume := range vm.Spec.Template.Spec.Volumes {
+			if volume.Name != volumeName {
+				newVolumes = append(newVolumes, volume)
+			}
+		}
+		return patchVM(vm, nil, newVolumes)
+	}
+
+	removeHotplugDiskAndVolume := func(vm *v1.VirtualMachine, volumeName string) *v1.VirtualMachine {
+		var err error
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		var newDisks []v1.Disk
+		for _, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+			if disk.Name != volumeName {
+				newDisks = append(newDisks, disk)
+			}
+		}
+
+		var newVolumes []v1.Volume
+		for _, volume := range vm.Spec.Template.Spec.Volumes {
+			if volume.Name != volumeName {
+				newVolumes = append(newVolumes, volume)
+			}
+		}
+		return patchVM(vm, newDisks, newVolumes)
+	}
+
+	waitForHotplugToComplete := func(vm *v1.VirtualMachine, volumeName, claimName string, added bool) {
+		Eventually(func() error {
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			found := false
+			for _, volume := range vmi.Spec.Volumes {
+				if volume.Name == volumeName && volume.DataVolume.Name == claimName {
+					found = true
+					break
+				}
+			}
+			if found != added {
+				return fmt.Errorf("volume %s in VM %s not in expected state %t, spec not updated", volumeName, vm.Name, added)
+			}
+			found = false
+			for _, vs := range vmi.Status.VolumeStatus {
+				if vs.Name == volumeName {
+					if added && vs.Phase == v1.VolumeReady {
+						return nil
+					}
+					if !added {
+						found = true
+						break
+					}
+				}
+			}
+			if !added && !found {
+				return nil
+			}
+			return fmt.Errorf("volume %s in VM %s not in expected state %t, status not updated", volumeName, vm.Name, added)
+		}, 240*time.Second, 2*time.Second).Should(Succeed())
+	}
+
+	swapClaim := func(vm *v1.VirtualMachine, volumeName, newClaimName string) *v1.VirtualMachine {
+		vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		var newVolumes []v1.Volume
+		for _, volume := range vm.Spec.Template.Spec.Volumes {
+			if volume.Name == volumeName {
+				volume.VolumeSource.DataVolume.Name = newClaimName
+			}
+			newVolumes = append(newVolumes, volume)
+		}
+		return patchVM(vm, nil, newVolumes)
+	}
+
+	loginToVM := func(vm *v1.VirtualMachine) {
+		vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		err = console.LoginToCirros(vmi)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	validateVMHasCDRom := func(vm *v1.VirtualMachine, numItems string) {
+		vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			return console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "ls -A /mnt/ | wc -l\n"},
+				&expect.BExp{R: console.RetValue("0")},
+				&expect.BSnd{S: "sudo mount /dev/sr0 /mnt\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: console.EchoLastReturnValue},
+				&expect.BExp{R: console.RetValue("0")},
+				&expect.BSnd{S: "ls -A /mnt/ | wc -l\n"},
+				&expect.BExp{R: console.RetValue(numItems)},
+				&expect.BSnd{S: "sudo umount /mnt\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: console.EchoLastReturnValue},
+				&expect.BExp{R: console.RetValue("0")},
+			}, 10)
+		}, 40*time.Second, 2*time.Second).Should(Succeed())
+	}
+
+	validateVMHasNoCDRom := func(vm *v1.VirtualMachine) {
+		vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			return console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "ls -A /mnt/ | wc -l\n"},
+				&expect.BExp{R: console.RetValue("0")},
+				&expect.BSnd{S: "sudo mount /dev/sr0 /mnt\n"},
+				&expect.BExp{R: console.RetValue("mount: mounting /dev/sr0 on /mnt failed: No medium found")},
+			}, 10)
+		}, 40*time.Second, 2*time.Second).Should(Succeed())
+	}
+
+	Context("Inject/Eject CD-ROM", func() {
+		It("Should inject, swap, and eject a CD-ROM", func() {
+			By("Creating a VM with an empty CD-ROM")
+			vm := createAndStartVMWithEmptyCDRom()
+
+			By("creating cd-rom volumes")
+			dv1 := createCDRomVolume(vm.Namespace, cd.ContainerDiskVirtio)
+			dv2 := createCDRomVolume(vm.Namespace, cd.ContainerDiskAlpine)
+
+			By("Hotplugging a CD-ROM")
+			vm = addHotplugVolume(vm, cdRomName, dv1.Name)
+			waitForHotplugToComplete(vm, cdRomName, dv1.Name, true)
+			libstorage.EventuallyDV(dv1, 240, matcher.HaveSucceeded())
+
+			By("Validate the first CD-ROM is present in the VM")
+			loginToVM(vm)
+			validateVMHasCDRom(vm, "27")
+
+			By("Swapping the CD-ROM")
+			vm = swapClaim(vm, cdRomName, dv2.Name)
+			waitForHotplugToComplete(vm, cdRomName, dv2.Name, true)
+			libstorage.EventuallyDV(dv2, 240, matcher.HaveSucceeded())
+
+			By("Validate the second CD-ROM is present in the VM")
+			loginToVM(vm)
+			validateVMHasCDRom(vm, "4")
+
+			By("Ejecting the CD-ROM")
+			vm = removeHotplugVolume(vm, cdRomName)
+			waitForHotplugToComplete(vm, cdRomName, dv2.Name, false)
+
+			By("Validate the CD-ROM is not present in the VM")
+			validateVMHasNoCDRom(vm)
+		})
+	})
+
+	Context("Hotplug disks", func() {
+		It("Should add and remove a hotplug disk", func() {
+			By("Creating a VM")
+			vm := createVM()
+
+			By("Hotplugging a disk")
+			dv1 := createBlankVolume(vm.Namespace)
+			vm = hotplugDisk(vm, hotplugDiskName, dv1.Name)
+			waitForHotplugToComplete(vm, hotplugDiskName, dv1.Name, true)
+			libstorage.EventuallyDV(dv1, 240, matcher.HaveSucceeded())
+
+			By("Unplug the disk")
+			vm = removeHotplugDiskAndVolume(vm, hotplugDiskName)
+			waitForHotplugToComplete(vm, hotplugDiskName, dv1.Name, false)
+		})
+	})
+}))

--- a/tests/storage/declarative-hotplug.go
+++ b/tests/storage/declarative-hotplug.go
@@ -37,12 +37,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libdv"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
-	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -54,13 +52,11 @@ const (
 	volumeSize      = "1Gi"
 )
 
-var _ = Describe(SIG("Declarative Hotplug", Serial, func() {
+var _ = Describe(SIG("Declarative Hotplug", func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		kvconfig.DisableFeatureGate(featuregate.HotplugVolumesGate)
-		kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
 	})
 
 	createVM := func(options ...libvmi.Option) *v1.VirtualMachine {
@@ -266,6 +262,8 @@ var _ = Describe(SIG("Declarative Hotplug", Serial, func() {
 				&expect.BSnd{S: "sudo umount /mnt\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: console.EchoLastReturnValue},
+				&expect.BExp{R: console.RetValue("0")},
+				&expect.BSnd{S: "ls -A /mnt/ | wc -l\n"},
 				&expect.BExp{R: console.RetValue("0")},
 			}, 10)
 		}, 40*time.Second, 2*time.Second).Should(Succeed())

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -9,6 +9,7 @@ import (
 	"kubevirt.io/kubevirt/tests/events"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
+	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libvmops"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -44,6 +45,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
 	typesStorage "kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -1705,15 +1707,24 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Expect(restore.Status.Restores).To(HaveLen(1))
 			})
 
-			DescribeTable("should restore vm with hot plug disks", func(restoreToNewVM bool) {
+			DescribeTable("should restore vm with hot plug disks", func(restoreToNewVM, withEphemeralHotplug bool) {
+				if withEphemeralHotplug {
+					kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
+					kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
+				}
+
 				vm, vmi = createAndStartVM(renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass))
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
 				persistVolName := AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, false)
-				By("Add temporary hotplug disk")
-				tempVolName := AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, true)
+
+				var tempVolName string
+				if withEphemeralHotplug {
+					By("Add temporary hotplug disk")
+					tempVolName = AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, true)
+				}
 
 				doRestore("", console.LoginToFedora, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))
 				Expect(restore.Status.Restores).To(HaveLen(2))
@@ -1737,8 +1748,9 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Expect(foundHotPlug).To(BeTrue())
 				Expect(foundTempHotPlug).To(BeFalse())
 			},
-				Entry("[test_id:7425] to the same VM", false),
-				Entry("to a new VM", true),
+				Entry("[test_id:7425] to the same VM", false, false),
+				Entry("to a new VM", true, false),
+				Entry("to the same VM with ephemeral", Serial, false, false),
 			)
 
 			It("with run strategy and snapshot should successfully restore", func() {

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -110,13 +110,13 @@ func AdjustKubeVirtResource() {
 		featuregate.HostDiskGate,
 		featuregate.VirtIOFSConfigVolumesGate,
 		featuregate.VirtIOFSStorageVolumeGate,
-		featuregate.HotplugVolumesGate,
 		featuregate.DownwardMetricsFeatureGate,
 		featuregate.ExpandDisksGate,
 		featuregate.WorkloadEncryptionSEV,
 		featuregate.VMExportGate,
 		featuregate.KubevirtSeccompProfile,
 		featuregate.ObjectGraph,
+		featuregate.DeclarativeHotplugVolumesGate,
 	)
 
 	storageClass, exists := libstorage.GetVMStateStorageClass()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Only possible to hotplug volumes via the VM/VMI subresource API. Updating the VM spec directly would require a reboot to take effect.

CD-ROMs were required to have a volume. Was not possible to hotplug CD-ROMs. So updating a CD-ROM required a reboot.

After this PR:

New feature gate called `DeclarativeHotplugVolumes` enables this functionality. This new feature gate is intended to replace the existing `HotplugVolumes` feature gate which will be deprecated and removed.

Why the new feature gate, you may ask? This is because the declarative behavior is not compatible with the old way. Previously, you could hotplug a VMI that was owned by the VM. This is considered an "ephemeral" hotplug. But that doesn't work with declarative hotplug. If the VM controller sees that the VMI has a hotplug volume that is not in the VM spec, that volume is removed.

If both `DeclarativeHotplugVolumes` and `HotplugVolumes` are enabled, `HotplugVolumes` will take precedence to maintain backward compatibility.

To try it out:

Set Feature Gates
```bash
k patch -n kubevirt kubevirt kubevirt -p '{"spec": {"configuration": { "developerConfiguration": { "featureGates": ["DeclarativeHotplugVolumes"] }}}}' -o json --type merge
```

Create a VM and populate PVC with CD-ROM image
```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: testvm
spec:
  runStrategy: Always
  template:
    spec:
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: disk0
          - cdrom:
              bus: sata
            name: cdrom
          - disk:
              bus: virtio
            name: cloudinitdisk
        resources:
          requests:
            memory: 128Mi
      volumes:
      - containerDisk:
          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
        name: disk0
      - cloudInitNoCloud:
          userDataBase64: IyEvYmluL2Jhc2gKZWNobyAnaGVsbG8nCg==
        name: cloudinitdisk
---
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataVolume
metadata:
  name: cdrom-volume
spec:
  source:
    registry:
      url: docker://registry:5000/kubevirt/virtio-container-disk:devel
      pullMethod: node
  storage:
    resources:
      requests:
        storage: 750Mi
---
apiVersion: cdi.kubevirt.io/v1beta1
kind: DataVolume
metadata:
  name: blank-volume
spec:
  source:
    blank: {}
  storage:
    resources:
      requests:
        storage: 1Gi
```

Observe that VM has empty cdrom
```bash
./hack/virtctl.sh console testvm

# sudo mount /dev/sr0 /mnt/
mount: mounting /dev/sr0 on /mnt/ failed: No medium found
```

Add CD-ROM volume to vm
```bash 
k edit vm testvm
volumes:
...
      - dataVolume:
          name: cdrom-volume
          hotpluggable: true
        name: cdrom 
```

Log back into VM and mount the CD-ROM
```bash
./hack/virtctl.sh console testvm

# sudo mount /dev/sr0 /mnt/
# ls /mnt
...
```

To hotplug the blank disk, edit the VM yaml to add a new disk and volume
```bash
k edit vm testvm

disks:
...
          - disk:
              bus: scsi
            name: blank-disk
...
volumes:
      - dataVolume:
          hotpluggable: true
          name: blank-volume
        name: blank-disk
```

Login to VM to use new disk
```
./hack/virtctl.sh console testvm

# lsblk
sda       8:0    0    1G  0 disk
...
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Tracking VEP issue: https://github.com/kubevirt/enhancements/issues/31


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Declarative Volume Hotplug with CD-ROM Inject/Eject
```

