### PR TITLE
api, net: Manage Link State for vNICs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14221,7 +14221,7 @@
       "$ref": "#/definitions/v1.InterfaceSRIOV"
      },
      "state": {
-      "description": "State represents the requested operational state of the interface. The (only) value supported is `absent`, expressing a request to remove the interface.",
+      "description": "State represents the requested operational state of the interface. The supported values are: `absent`, expressing a request to remove the interface. `down`, expressing a request to set the link down. `up`, expressing a request to set the link up. Empty value functions as `up`.",
       "type": "string"
      },
      "tag": {

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -45,6 +45,8 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],

--- a/pkg/network/admitter/admit.go
+++ b/pkg/network/admitter/admit.go
@@ -33,13 +33,26 @@ import (
 func validateInterfaceStateValue(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	for idx, iface := range spec.Domain.Devices.Interfaces {
-		if iface.State != "" && iface.State != v1.InterfaceStateAbsent {
+		if iface.State != "" &&
+			iface.State != v1.InterfaceStateAbsent &&
+			iface.State != v1.InterfaceStateLinkDown &&
+			iface.State != v1.InterfaceStateLinkUp {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: fmt.Sprintf("logical %s interface state value is unsupported: %s", iface.Name, iface.State),
 				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("state").String(),
 			})
 		}
+
+		if iface.SRIOV != nil &&
+			(iface.State == v1.InterfaceStateLinkDown || iface.State == v1.InterfaceStateLinkUp) {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("%q interface's state %q is not supported for SR-IOV NICs", iface.Name, iface.State),
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("state").String(),
+			})
+		}
+
 		if iface.State == v1.InterfaceStateAbsent && iface.Bridge == nil {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -22,6 +22,8 @@ package admitter_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
@@ -51,6 +53,8 @@ var _ = Describe("Validating VMI network spec", func() {
 	},
 		Entry("is empty", v1.InterfaceState("")),
 		Entry("is absent when bridge binding is used", v1.InterfaceStateAbsent),
+		Entry("is up when bridge binding is used", v1.InterfaceStateLinkUp),
+		Entry("is down when bridge binding is used", v1.InterfaceStateLinkDown),
 	)
 
 	It("network interface state value is invalid", func() {
@@ -66,24 +70,28 @@ var _ = Describe("Validating VMI network spec", func() {
 			}))
 	})
 
-	It("network interface state value of absent is not supported when bridge-binding is not used", func() {
+	DescribeTable("network interface state ", func(state v1.InterfaceState, messageRegex types.GomegaMatcher) {
 		vm := api.NewMinimalVMI("testvm")
 		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
 			Name:                   "foo",
-			State:                  v1.InterfaceStateAbsent,
+			State:                  state,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
 		}}
 		vm.Spec.Networks = []v1.Network{
 			{Name: "foo", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}}},
 		}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
-		Expect(validator.Validate()).To(
-			ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
-				Message: "\"foo\" interface's state \"absent\" is supported only for bridge binding",
-				Field:   "fake.domain.devices.interfaces[0].state",
-			}))
-	})
+		statusCause := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{}).Validate()
+		Expect(statusCause).To(HaveLen(1))
+		Expect(statusCause[0]).To(MatchAllFields(Fields{
+			"Type":    Equal(metav1.CauseType("FieldValueInvalid")),
+			"Field":   Equal("fake.domain.devices.interfaces[0].state"),
+			"Message": messageRegex,
+		}))
+	},
+		Entry("down is not supported for sriov", v1.InterfaceStateLinkDown, MatchRegexp("down.+SR-IOV")),
+		Entry("up is not supported for sriov", v1.InterfaceStateLinkUp, MatchRegexp("up.+SR-IOV")),
+		Entry("absent is not supported when bridge-binding is not used", v1.InterfaceStateAbsent, MatchRegexp("absent.+bridge")),
+	)
 
 	It("network interface state value of absent is not supported on the default network", func() {
 		vm := api.NewMinimalVMI("testvm")

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1556,7 +1556,19 @@ var _ = Describe("Converter", func() {
 				},
 			}
 		})
+		It("Should set domain interface state down", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+				*v1.DefaultBridgeNetworkInterface(),
+			}
+			vmi.Spec.Domain.Devices.Interfaces[0].State = v1.InterfaceStateLinkDown
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
+			domain := vmiToDomain(vmi, c)
+			Expect(domain).ToNot(BeNil())
+			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(1))
+			Expect(domain.Spec.Devices.Interfaces[0].LinkState.State).To(Equal("down"))
+		})
 		It("Should set domain interface source correctly for multus", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -100,6 +100,10 @@ func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, c *ConverterContext)
 				}
 			}
 		}
+
+		if iface.State == v1.InterfaceStateLinkDown {
+			domainIface.LinkState = &api.LinkState{State: "down"}
+		}
 		domainInterfaces = append(domainInterfaces, domainIface)
 	}
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6400,7 +6400,11 @@ var CRDsValidation map[string]string = map[string]string{
                               state:
                                 description: |-
                                   State represents the requested operational state of the interface.
-                                  The (only) value supported is 'absent', expressing a request to remove the interface.
+                                  The supported values are:
+                                  'absent', expressing a request to remove the interface.
+                                  'down', expressing a request to set the link down.
+                                  'up', expressing a request to set the link up.
+                                  Empty value functions as 'up'.
                                 type: string
                               tag:
                                 description: If specified, the virtual network interface
@@ -11620,7 +11624,11 @@ var CRDsValidation map[string]string = map[string]string{
                       state:
                         description: |-
                           State represents the requested operational state of the interface.
-                          The (only) value supported is 'absent', expressing a request to remove the interface.
+                          The supported values are:
+                          'absent', expressing a request to remove the interface.
+                          'down', expressing a request to set the link down.
+                          'up', expressing a request to set the link up.
+                          Empty value functions as 'up'.
                         type: string
                       tag:
                         description: If specified, the virtual network interface address
@@ -14820,7 +14828,11 @@ var CRDsValidation map[string]string = map[string]string{
                       state:
                         description: |-
                           State represents the requested operational state of the interface.
-                          The (only) value supported is 'absent', expressing a request to remove the interface.
+                          The supported values are:
+                          'absent', expressing a request to remove the interface.
+                          'down', expressing a request to set the link down.
+                          'up', expressing a request to set the link up.
+                          Empty value functions as 'up'.
                         type: string
                       tag:
                         description: If specified, the virtual network interface address
@@ -17234,7 +17246,11 @@ var CRDsValidation map[string]string = map[string]string{
                               state:
                                 description: |-
                                   State represents the requested operational state of the interface.
-                                  The (only) value supported is 'absent', expressing a request to remove the interface.
+                                  The supported values are:
+                                  'absent', expressing a request to remove the interface.
+                                  'down', expressing a request to set the link down.
+                                  'up', expressing a request to set the link up.
+                                  Empty value functions as 'up'.
                                 type: string
                               tag:
                                 description: If specified, the virtual network interface
@@ -21728,7 +21744,11 @@ var CRDsValidation map[string]string = map[string]string{
                                       state:
                                         description: |-
                                           State represents the requested operational state of the interface.
-                                          The (only) value supported is 'absent', expressing a request to remove the interface.
+                                          The supported values are:
+                                          'absent', expressing a request to remove the interface.
+                                          'down', expressing a request to set the link down.
+                                          'up', expressing a request to set the link up.
+                                          Empty value functions as 'up'.
                                         type: string
                                       tag:
                                         description: If specified, the virtual network
@@ -26914,7 +26934,11 @@ var CRDsValidation map[string]string = map[string]string{
                                           state:
                                             description: |-
                                               State represents the requested operational state of the interface.
-                                              The (only) value supported is 'absent', expressing a request to remove the interface.
+                                              The supported values are:
+                                              'absent', expressing a request to remove the interface.
+                                              'down', expressing a request to set the link down.
+                                              'up', expressing a request to set the link up.
+                                              Empty value functions as 'up'.
                                             type: string
                                           tag:
                                             description: If specified, the virtual

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -1280,7 +1280,11 @@ type Interface struct {
 	// +optional
 	ACPIIndex int `json:"acpiIndex,omitempty"`
 	// State represents the requested operational state of the interface.
-	// The (only) value supported is `absent`, expressing a request to remove the interface.
+	// The supported values are:
+	// `absent`, expressing a request to remove the interface.
+	// `down`, expressing a request to set the link down.
+	// `up`, expressing a request to set the link up.
+	// Empty value functions as `up`.
 	// +optional
 	State InterfaceState `json:"state,omitempty"`
 }
@@ -1288,7 +1292,9 @@ type Interface struct {
 type InterfaceState string
 
 const (
-	InterfaceStateAbsent InterfaceState = "absent"
+	InterfaceStateAbsent   InterfaceState = "absent"
+	InterfaceStateLinkUp   InterfaceState = "up"
+	InterfaceStateLinkDown InterfaceState = "down"
 )
 
 // Extra DHCP options to use in the interface.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -678,7 +678,7 @@ func (Interface) SwaggerDoc() map[string]string {
 		"dhcpOptions": "If specified the network interface will pass additional DHCP options to the VMI\n+optional",
 		"tag":         "If specified, the virtual network interface address and its tag will be provided to the guest via config drive\n+optional",
 		"acpiIndex":   "If specified, the ACPI index is used to provide network interface device naming, that is stable across changes\nin PCI addresses assigned to the device.\nThis value is required to be unique across all devices and be between 1 and (16*1024-1).\n+optional",
-		"state":       "State represents the requested operational state of the interface.\nThe (only) value supported is `absent`, expressing a request to remove the interface.\n+optional",
+		"state":       "State represents the requested operational state of the interface.\nThe supported values are:\n`absent`, expressing a request to remove the interface.\n`down`, expressing a request to set the link down.\n`up`, expressing a request to set the link up.\nEmpty value functions as `up`.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20709,7 +20709,7 @@ func schema_kubevirtio_api_core_v1_Interface(ref common.ReferenceCallback) commo
 					},
 					"state": {
 						SchemaProps: spec.SchemaProps{
-							Description: "State represents the requested operational state of the interface. The (only) value supported is `absent`, expressing a request to remove the interface.",
+							Description: "State represents the requested operational state of the interface. The supported values are: `absent`, expressing a request to remove the interface. `down`, expressing a request to set the link down. `up`, expressing a request to set the link up. Empty value functions as `up`.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "framework.go",
         "hotplug_bridge.go",
         "hotplug_sriov.go",
+        "link_state.go",
         "networkpolicy.go",
         "port_forward.go",
         "primary_pod_network.go",

--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -1,0 +1,136 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = SIGDescribe("interface state up/down", func() {
+
+	It("status and guest should show correct iface state", func() {
+		const (
+			primaryLogicalNetName    = "default"
+			secondary2LogicalNetName = "bridge2"
+			nadName                  = "bridge-nad"
+		)
+
+		testNamespace := testsuite.GetTestNamespace(nil)
+
+		var err error
+		_, err = libnet.CreateNetAttachDef(context.Background(), testNamespace,
+			libnet.NewBridgeNetAttachDef(nadName, "br02"))
+		Expect(err).NotTo(HaveOccurred())
+
+		mac1, err := libnet.GenerateRandomMac()
+		Expect(err).NotTo(HaveOccurred())
+		mac2, err := libnet.GenerateRandomMac()
+		Expect(err).NotTo(HaveOccurred())
+
+		vmi := libvmifact.NewFedora(
+			libvmi.WithInterface(v1.Interface{
+				Name: primaryLogicalNetName,
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{
+					Masquerade: &v1.InterfaceMasquerade{},
+				},
+				MacAddress: mac1.String(),
+				State:      v1.InterfaceStateLinkUp,
+			}),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithInterface(v1.Interface{
+				Name: secondary2LogicalNetName,
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{
+					Bridge: &v1.InterfaceBridge{},
+				},
+				MacAddress: mac2.String(),
+				State:      v1.InterfaceStateLinkDown,
+			}),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondary2LogicalNetName, nadName)),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		vm, err = kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+		Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+		vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+		expectedIfaceStatuses := []v1.VirtualMachineInstanceNetworkInterface{
+			{Name: primaryLogicalNetName, LinkState: string(v1.InterfaceStateLinkUp)},
+			{Name: secondary2LogicalNetName, LinkState: string(v1.InterfaceStateLinkDown)},
+		}
+
+		Eventually(func() ([]v1.VirtualMachineInstanceNetworkInterface, error) {
+			vmi, err := kubevirt.Client().VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return normalizeIfaceStatuses(vmi.Status.Interfaces), nil
+		}).WithTimeout(60 * time.Second).Should(ConsistOf(expectedIfaceStatuses))
+
+		timeout := 5 * time.Second
+		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac1.String(), v1.InterfaceStateLinkUp), timeout)).To(Succeed())
+		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac2.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
+
+	})
+
+})
+
+func normalizeIfaceStatuses(ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface) []v1.VirtualMachineInstanceNetworkInterface {
+	var result []v1.VirtualMachineInstanceNetworkInterface
+	for _, ifaceStatus := range ifaceStatuses {
+		result = append(result, v1.VirtualMachineInstanceNetworkInterface{Name: ifaceStatus.Name, LinkState: ifaceStatus.LinkState})
+	}
+	return result
+}
+
+func assertLinkStateCmd(mac string, desiredLinkState v1.InterfaceState) string {
+	const (
+		linkStateUPRegex   = "'state[[:space:]]+UP'"
+		linkStateDOWNRegex = "'NO-CARRIER.+state[[:space:]]+DOWN'"
+		ipLinkTemplate     = "ip -one link | grep %s | grep -E %s\n"
+	)
+
+	var linkStateRegex string
+
+	switch desiredLinkState {
+	case v1.InterfaceStateLinkUp:
+		linkStateRegex = linkStateUPRegex
+	case v1.InterfaceStateLinkDown:
+		linkStateRegex = linkStateDOWNRegex
+	}
+	return fmt.Sprintf(ipLinkTemplate, mac, linkStateRegex)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Iniital part of  of [Enhancement: Adding Link State Management for vNICs](https://github.com/kubevirt/enhancements/pull/2) Implementation, to support setting an interface link state to `up` or `down`, in addition to the existing `absent` value.
Link management in runtime and associated interface hot-plug functionality follows in https://github.com/kubevirt/kubevirt/pull/13744
The reporting part of this enhancement is implemented in https://github.com/kubevirt/kubevirt/pull/13708.


### What this PR does
Before this PR:
VM network interface link state could not be changed via kubevirt API.
After this PR:
Link state can be changed through API with immediate effect.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
[Enhancement: Adding Link State Management for vNICs](https://github.com/kubevirt/enhancements/pull/2)
[virt-handler, netstat: Report interfaces' link state #13708](https://github.com/kubevirt/kubevirt/pull/13708)

### Special notes for your reviewer


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network interfaces state can be set to `down` or `up` in order to set the link state accordingly.
```