### PR TITLE
Simplify and improve multiarch unit-tests

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -48,7 +48,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	instancetypeVMWebhooks "kubevirt.io/kubevirt/pkg/instancetype/webhooks/vm"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
 
 var _ = Describe("VirtualMachine Mutator", func() {
@@ -161,19 +160,15 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		Expect(resp.Patch).To(BeEmpty())
 	})
 
-	It("should apply defaults on VM create", func() {
-		vmSpec, _ := getVMSpecMetaFromResponse(rt.GOARCH)
-		switch {
-		case webhooks.IsPPC64(&vmSpec.Template.Spec):
-			Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal("pseries"))
-		case webhooks.IsARM64(&vmSpec.Template.Spec):
-			Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal("virt"))
-		case webhooks.IsS390X(&vmSpec.Template.Spec):
-			Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal("s390-ccw-virtio"))
-		default:
-			Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal("q35"))
-		}
-	})
+	DescribeTable("should apply defaults on VM create", func(arch string, result string) {
+		vmSpec, _ := getVMSpecMetaFromResponse(arch)
+		Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal(result))
+	},
+		Entry("ppc64le", "ppc64le", "pseries"),
+		Entry("arm64", "arm64", "virt"),
+		Entry("s390x", "s390x", "s390-ccw-virtio"),
+		Entry("amd64", "amd64", "q35"),
+	)
 
 	DescribeTable("should apply configurable defaults on VM create", func(arch string, amd64MachineType string, arm64MachineType string, ppc64leMachineType string, s390xMachineType string, result string) {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -77,10 +77,3 @@ type Informers struct {
 func IsARM64(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
 	return vmiSpec.Architecture == "arm64"
 }
-
-func IsPPC64(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
-	return vmiSpec.Architecture == "ppc64le"
-}
-func IsS390X(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
-	return vmiSpec.Architecture == "s390x"
-}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -481,21 +481,23 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	})
 
 	Context("with VirtualMachineInstance spec", func() {
-		It("should accept valid machine type", func() {
+		DescribeTable("should accept valid machine type", func(arch string, machineType string) {
+			enableFeatureGate(featuregate.MultiArchitecture)
+
 			vmi := api.NewMinimalVMI("testvmi")
-			if webhooks.IsPPC64(&vmi.Spec) {
-				vmi.Spec.Domain.Machine = &v1.Machine{Type: "pseries"}
-			} else if webhooks.IsARM64(&vmi.Spec) {
-				vmi.Spec.Domain.Machine = &v1.Machine{Type: "virt"}
-			} else if webhooks.IsS390X(&vmi.Spec) {
-				vmi.Spec.Domain.Machine = &v1.Machine{Type: "s390-ccw-virtio"}
-			} else {
-				vmi.Spec.Domain.Machine = &v1.Machine{Type: "q35"}
-			}
+
+			vmi.Spec.Architecture = arch
+			vmi.Spec.Domain.Machine = &v1.Machine{Type: machineType}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty())
-		})
+		},
+			Entry("when architecture is amd64", "amd64", "q35"),
+			Entry("when architecture is arm64", "arm64", "virt"),
+			Entry("when architecture is ppc64le", "ppc64le", "pseries"),
+			Entry("when architecture is s390x", "s390x", "s390-ccw-virtio"),
+		)
+
 		It("should reject invalid machine type", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Machine = &v1.Machine{Type: "test"}

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -93,20 +93,8 @@ const (
 	DefaultVMRolloutStrategy = v1.VMRolloutStrategyStage
 )
 
-func IsAMD64(arch string) bool {
-	return arch == "amd64"
-}
-
 func IsARM64(arch string) bool {
 	return arch == "arm64"
-}
-
-func IsPPC64(arch string) bool {
-	return arch == "ppc64le"
-}
-
-func IsS390X(arch string) bool {
-	return arch == "s390x"
 }
 
 func (c *ClusterConfig) GetMemBalloonStatsPeriod() uint32 {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -143,8 +143,6 @@ type TemplateService interface {
 	RenderExporterManifest(vmExport *exportv1.VirtualMachineExport, namePrefix string) *k8sv1.Pod
 	GetLauncherImage() string
 	IsPPC64() bool
-	IsARM64() bool
-	IsS390X() bool
 }
 
 type templateService struct {
@@ -317,14 +315,6 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 func (t *templateService) IsPPC64() bool {
 	return t.clusterConfig.GetClusterCPUArch() == "ppc64le"
-}
-
-func (t *templateService) IsARM64() bool {
-	return t.clusterConfig.GetClusterCPUArch() == "arm64"
-}
-
-func (t *templateService) IsS390X() bool {
-	return t.clusterConfig.GetClusterCPUArch() == "s390x"
 }
 
 func generateQemuTimeoutWithJitter(qemuTimeoutBaseSeconds int) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Architecture specific unit-test results are hidden in the testcode
After this PR:
Architecture specific unit-test results are separate testcases using Tables.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
This improves the readability of testcases and moves into making the unit-tests more indepented of the architecture of the host it is being run on.

The following tradeoffs were made:
- 1 instance each of arm64 and ppc64le code has been left as is, since it is only a special case for them and i'm no expert on these 2 architectures, so i left it as is.
- `pkg/defaults` has been left unchanged, since the code is already in architecture specific files and it would be more complicated to use the interfaces approach here.
The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
<!-- optional -->
I have split the PR into commits per package, but i can happily squash them if needed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

