### PR TITLE
godoc: fixes for decorators.go

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -7,7 +7,8 @@ var (
 	Periodic    = Label("PERIODIC")
 	Conformance = Label("conformance")
 
-	// SIGs
+	/* SIGs */
+
 	SigCompute           = Label("sig-compute")
 	SigOperator          = Label("sig-operator")
 	SigNetwork           = Label("sig-network")
@@ -17,7 +18,8 @@ var (
 	SigMonitoring        = Label("sig-monitoring")
 	SigPerformance       = Label("sig-performance")
 
-	// HW
+	/* HW */
+
 	GPU         = Label("GPU")
 	VGPU        = Label("VGPU")
 	SEV         = Label("SEV")
@@ -30,11 +32,13 @@ var (
 	KSMRequired = Label("KSM-required")
 	ACPI        = Label("ACPI")
 
-	// Deployment
+	/* Deployment */
+
 	SingleReplica = Label("single-replica")
 	MultiReplica  = Label("multi-replica")
 
-	// Features
+	/* Features */
+
 	CPUModel                             = Label("cpumodel")
 	VSOCK                                = Label("vsock")
 	VirtioFS                             = Label("virtiofs")
@@ -64,33 +68,40 @@ var (
 	RequiresHugepages2Mi                 = Label("requireHugepages2Mi")
 	RequiresHugepages1Gi                 = Label("requireHugepages1Gi")
 
-	// Storage classes
-	// Requires a storage class with support for snapshots
+	/* Storage classes */
+
+	// RequiresSnapshotStorageClass requires a storage class with support for snapshots
 	RequiresSnapshotStorageClass = Label("RequiresSnapshotStorageClass")
-	// Requires a storage class without support for snapshots
+	// RequiresNoSnapshotStorageClass requires a storage class without support for snapshots
 	RequiresNoSnapshotStorageClass = Label("RequiresNoSnapshotStorageClass")
-	// Requires a storage class with ReadWriteMany Block support
+	// RequiresRWXBlock requires a storage class with ReadWriteMany Block support
 	RequiresRWXBlock = Label("RequiresRWXBlock")
-	// Requires the VMStateStorageClass to be set to ReadWriteOnce Filesystem storage class
+	// RequiresRWOFsVMStateStorageClass requires the VMStateStorageClass to be set to ReadWriteOnce Filesystem storage class
 	RequiresRWOFsVMStateStorageClass = Label("RequiresRWOFsVMStateStorageClass")
-	// Requires the VMStateStorageClass to be set to ReadWriteMany Filesystem storage class
+	// RequiresRWXFsVMStateStorageClass requires the VMStateStorageClass to be set to ReadWriteMany Filesystem storage class
 	RequiresRWXFsVMStateStorageClass = Label("RequiresRWXFsVMStateStorageClass")
 
-	// Requires a storage class with Block storage support
+	// RequiresBlockStorage requires a storage class with Block storage support
 	RequiresBlockStorage = Label("RequiresBlockStorage")
-	// Tests that ensure sig-storage functionality which are conformance-unready
+	// StorageCritical tests that ensure sig-storage functionality which are conformance-unready
 	StorageCritical = Label("StorageCritical")
-	// Requires a storage class with volume expansion support
+	// RequiresVolumeExpansion requires a storage class with volume expansion support
 	RequiresVolumeExpansion = Label("RequiresVolumeExpansion")
+
+	/* Kubernetes versions */
+
 	// Kubernetes versions
 	Kubernetes130 = Label("kubernetes130")
-	// WG archs
+
+	/* architecture working groups */
+
 	WgS390x = Label("wg-s390x")
 	WgArm64 = Label("wg-arm64")
+
 	// Virtctl related tests
 	Virtctl = Label("virtctl")
 
-	// NoFlakeChecker decorates tests that are not compatible with the check-tests-for-flakes test lane.
+	// NoFlakeCheck decorates tests that are not compatible with the check-tests-for-flakes test lane.
 	// This should only be used for legitimate purposes, like on tests that have a flake-checker-friendly clone.
 	NoFlakeCheck = Label("no-flake-check")
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Several linter warning wrt godoc errors were showing up.

After this PR:

Linter warnings fixed

/kind cleanup
/wg code-quality

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

