### PR TITLE
VMSnapshot: allow creating snapshot when source doesnt exist yet

### DIFF
--- a/pkg/storage/admitters/vmsnapshot_test.go
+++ b/pkg/storage/admitters/vmsnapshot_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.apiGroup"))
 		})
 
-		It("should reject when VM does not exist", func() {
+		It("should allow when VM does not exist", func() {
 			snapshot := &snapshotv1.VirtualMachineSnapshot{
 				Spec: snapshotv1.VirtualMachineSnapshotSpec{
 					Source: corev1.TypedLocalObjectReference{
@@ -132,9 +132,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 
 			ar := createSnapshotAdmissionReview(snapshot)
 			resp := createTestVMSnapshotAdmitter(config, nil).Admit(context.Background(), ar)
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Details.Causes).To(HaveLen(1))
-			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.name"))
+			Expect(resp.Allowed).To(BeTrue())
 		})
 
 		It("should reject spec update", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: Webhook rejects creation of vmsnapshot if source doesnt exist yet.

After this PR: Snapshot is allowed to be created and the controller updates the snapshot conditions that the source doesnt exist.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-41560



### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMSnapshot: allow creating snapshot when source doesnt exist yet
```

