### PR TITLE
Reject VMClone creation when source uses backend storage PVC

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -442,5 +442,13 @@ func validateCloneVolumeSnapshotSupportVMSnapshotContent(snapshotContents *snaps
 		}
 	}
 
+	if backendstorage.IsBackendStorageNeededForVMI(&vm.Spec.Template.Spec) {
+		result = append(result, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Source Virtual Machine requires backend storage, operation not supported",
+			Field:   sourceField.String(),
+		})
+	}
+
 	return result
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -353,6 +353,12 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 
 			admitter.admitAndExpect(vmClone, false)
 		})
+
+		It("should reject if vmsnapshot contents include vmSpec with backend storage PVC", func() {
+			vmClone.Spec.Source.Kind = virtualMachineSnapshotKind
+			vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+			admitter.admitAndExpect(vmClone, false)
+		})
 	})
 
 	Context("Annotations and labels filters", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

The VMClone admitter webhook was supposed to reject VMClone creation if the source used backend PVC (https://github.com/kubevirt/kubevirt/pull/13207)

Currently, the webhook only rejects this operation when the source of the clone is a VM. This Pull Request updates the webhook to reject it in all cases.

Fixes # https://issues.redhat.com/browse/CNV-55940

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reject VM clone when source uses backend storage PVC
```

