### PR TITLE
Make dev directory dynamic for the pr-helper container

### DIFF
--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -25,6 +25,7 @@ const (
 	runtimesPath    = "/var/run/kubevirt-libvirt-runtimes"
 	PrHelperName    = "pr-helper"
 	prVolumeName    = "pr-helper-socket-vol"
+	devDirVol       = "dev-dir"
 	SidecarShimName = "sidecar-shim"
 )
 
@@ -43,6 +44,11 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 				Name:             prVolumeName,
 				MountPath:        reservation.GetPrHelperSocketDir(),
 				MountPropagation: &bidi,
+			},
+			{
+				Name:             devDirVol,
+				MountPath:        "/dev",
+				MountPropagation: pointer.P(corev1.MountPropagationHostToContainer),
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
@@ -345,6 +351,12 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: reservation.GetPrHelperSocketDir(),
 					Type: &directoryOrCreate,
+				},
+			}}, corev1.Volume{
+			Name: devDirVol,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/dev",
 				},
 			},
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The pr-helper couldn't see newly added devices and it was required to restart the entire virt-handler pod

After this PR:
Mount the `/dev` directory in the pr-helper container 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-55705

### Why we need it and why it was done in this way
Newly created devices under /dev must be monitored and accessible by the qemu-pr-helper. The /dev directory is created on devtmpfs by default for containers, and it does not receive additional devices.

Mount it in the pr-helper container after adding the host's /dev path. Please be aware that the qemu-pr-helper daemon is looking for the device under '/dev', but the pr-helper is a privileged container and may already have access to the devices through /proc/1/root/dev.


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

