### PR TITLE
virt-controller/watch/vmi: Bug Fix: Ensure Stuck Finalized Launcher Pods Are Deleted in virt-controller

### DIFF
--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -68,13 +68,8 @@ var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 			return err
 		}, 120*time.Second, 1*time.Second).Should(MatchError(ContainSubstring("failed to find pod with the label")))
 
+		By("Comparing the new UID with the old one")
 		Eventually(matcher.ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(matcher.BeRestarted(vmi.UID))
-
-		By("Comparing the new UID and CreationTimeStamp with the old one")
-		newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(newVMI.CreationTimestamp).ToNot(Equal(vmi.CreationTimestamp))
-		Expect(newVMI.UID).ToNot(Equal(vmi.UID))
 	})
 
 	It("should force stop a VM with terminationGracePeriodSeconds>0", func() {


### PR DESCRIPTION
This PR fixes a bug in virt-controller where finalized launcher pods (Succeeded/Failed) could remain stuck in the cluster.

Previously, the controller only checked for pod deletion but did not handle cases where terminated pods were lingering due to slow garbage collection, collection thresholds, or other factors.

Now, the controller explicitly deletes finalized pods if they are detected as stuck, ensuring they do not block further operations.

Fixes #12931

### Release note
```release-note
Ensure launcher pods are finalized and deleted before removing the VMI finalizer when the VMI is marked for deletion.  
```

