### PR TITLE
feat(virtctl): Deprecate --local-ssh flag and use local ssh by default

### DIFF
--- a/pkg/virtctl/ssh/native.go
+++ b/pkg/virtctl/ssh/native.go
@@ -18,10 +18,6 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-const (
-	wrapLocalSSHDefault = false
-)
-
 func additionalUsage() string {
 	return fmt.Sprintf(`
 	# Connect to 'testvmi' using the local ssh binary found in $PATH:

--- a/pkg/virtctl/ssh/native_unsupported.go
+++ b/pkg/virtctl/ssh/native_unsupported.go
@@ -9,10 +9,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-const (
-	wrapLocalSSHDefault = true
-)
-
 func additionalUsage() string {
 	return ""
 }

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -92,7 +92,7 @@ func DefaultSSHOptions() SSHOptions {
 		KnownHostsFilePath:        "",
 		KnownHostsFilePathDefault: "",
 		AdditionalSSHLocalOptions: []string{},
-		WrapLocalSSH:              wrapLocalSSHDefault,
+		WrapLocalSSH:              true,
 		LocalClientName:           "ssh",
 	}
 
@@ -130,6 +130,9 @@ func (o *SSH) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if cmd.Flags().Changed(wrapLocalSSHFlag) {
+		cmd.PrintErrln("The --local-ssh flag is deprecated and now defaults to true.")
+	}
 	if o.options.WrapLocalSSH {
 		clientArgs := o.buildSSHTarget(kind, namespace, name)
 		return RunLocalClient(kind, namespace, name, &o.options, clientArgs)

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -126,9 +126,9 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 		By("comparing the two files")
 		compareFile(keyFile, copyBackFile)
 	},
-		Entry("using the native scp method", decorators.NativeSSH, copyNative),
-		Entry("using the local scp method with --local-ssh flag", decorators.NativeSSH, copyLocal(true)),
-		Entry("using the local scp method without --local-ssh flag", decorators.ExcludeNativeSSH, copyLocal(false)),
+		Entry("using the local scp method", copyLocal(false)),
+		Entry("using the local scp method with --local-ssh=true flag", decorators.NativeSSH, copyLocal(true)),
+		Entry("using the native scp method with --local-ssh=false flag", decorators.NativeSSH, copyNative),
 	)
 
 	DescribeTable("[test_id:11660]should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
@@ -163,9 +163,9 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 		compareFile(filepath.Join(copyFromDir, "file1"), filepath.Join(copyToDir, "file1"))
 		compareFile(filepath.Join(copyFromDir, "file2"), filepath.Join(copyToDir, "file2"))
 	},
-		Entry("using the native scp method", decorators.NativeSSH, copyNative),
-		Entry("using the local scp method with --local-ssh flag", decorators.NativeSSH, copyLocal(true)),
-		Entry("using the local scp method without --local-ssh flag", decorators.ExcludeNativeSSH, copyLocal(false)),
+		Entry("using the local scp method", copyLocal(false)),
+		Entry("using the local scp method with --local-ssh=true flag", decorators.NativeSSH, copyLocal(true)),
+		Entry("using the native scp method with --local-ssh=false flag", decorators.NativeSSH, copyNative),
 	)
 
 	It("[test_id:11665]local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSSH, func() {

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -112,9 +112,9 @@ var _ = VirtctlDescribe("[sig-compute]SSH", decorators.SigCompute, func() {
 		By("ssh into the VM")
 		cmdFn(vmi.Name)
 	},
-		Entry("using the native ssh method", decorators.NativeSSH, cmdNative),
-		Entry("using the local ssh method with --local-ssh flag", decorators.NativeSSH, cmdLocal(true)),
-		Entry("using the local ssh method without --local-ssh flag", decorators.ExcludeNativeSSH, cmdLocal(false)),
+		Entry("using the local ssh method", cmdLocal(false)),
+		Entry("using the local ssh method with --local-ssh=true flag", decorators.NativeSSH, cmdLocal(true)),
+		Entry("using the native ssh method with --local-ssh=false flag", decorators.NativeSSH, cmdNative),
 	)
 
 	It("[test_id:11666]local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSSH, func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This deprecates the --local-ssh flag, which previously defaulted to
false, meaning that the native SSH client built into virtctl was used by
default in virtctl ssh. The flag now defaults to true.

The reason for the deprecation of the flag is that the native SSH client
in virtctl has some short comings and long standing issues compared to a
real OpenSSH client, which are not trivial to address.

Instead of trying to fix all of these issues, it was decided to
deprecate the native client in order to discourage the use of it.

Before this PR:

The `--local-ssh` flag in `virtctl ssh` defaults to `false`. By default the builtin SSH client in `virtctl ssh` is used.

After this PR:

The `--local-ssh` flag in `virtctl ssh` defaults to `true`. By default the local SSH client on the machine running `virtctl ssh` is used. The `--local-ssh` flag is deprecated and a warning is emitted when it is used.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
By default the local SSH client on the machine running `virtctl ssh` is now used. The `--local-ssh` flag is now deprecated.
```

