### PR TITLE
Document descheduler integration

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -92,6 +92,8 @@ func (admitter *PodEvictionAdmitter) Admit(ctx context.Context, ar *admissionv1.
 		markForEviction = true
 	}
 
+	// This message format is expected from descheduler.
+	const evictionFmt = "Eviction triggered evacuation of VMI \"%s/%s\""
 	if markForEviction && !vmi.IsMarkedForEviction() && vmi.Status.NodeName == pod.Spec.NodeName {
 		err := admitter.markVMI(ctx, vmi.Namespace, vmi.Name, vmi.Status.NodeName, isDryRun(ar))
 		if err != nil {
@@ -99,7 +101,7 @@ func (admitter *PodEvictionAdmitter) Admit(ctx context.Context, ar *admissionv1.
 			return denied(fmt.Sprintf("kubevirt failed marking the vmi for eviction: %s", err.Error()))
 		}
 
-		return denied(fmt.Sprintf("Eviction triggered evacuation of VMI \"%s/%s\"", vmi.Namespace, vmi.Name))
+		return denied(fmt.Sprintf(evictionFmt, vmi.Namespace, vmi.Name))
 	}
 
 	// We can let the request go through because the pod is protected by a PDB if the VMI wants to be live-migrated on


### PR DESCRIPTION
### What this PR does
Document descheduler integration in order to express that we don't use random string and this is assumption.
While we have unit test this should be more straightforward for readers 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

