### PR TITLE
virt-launcher: Deprecate old method to set SSH key in VM

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -461,7 +461,27 @@ func main() {
 		stopChan,
 		hookFuncs...,
 	)
-	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn, *virtShareDir, *ephemeralDiskDir, &agentStore, *ovmfPath, ephemeralDiskCreator, metadataCache, signalStopChan, *diskMemoryLimitBytes, util.GetPodCPUSet, *imageVolumeEnabled, *libvirtHooksServerAndClientEnabled, preMigrationHookServer, *hypervisor, nbdclient.RegisterNBDServer, domainName, *vmStatsCollectorEnabled, *firmwareAutoSelectionEnabled, *allowCrossArchEmulation)
+	domainManager, err := virtwrap.NewLibvirtDomainManager(
+		domainConn,
+		*virtShareDir,
+		*ephemeralDiskDir,
+		&agentStore,
+		*ovmfPath,
+		ephemeralDiskCreator,
+		metadataCache,
+		signalStopChan,
+		*diskMemoryLimitBytes,
+		util.GetPodCPUSet,
+		*imageVolumeEnabled,
+		*libvirtHooksServerAndClientEnabled,
+		preMigrationHookServer,
+		*hypervisor,
+		nbdclient.RegisterNBDServer,
+		domainName,
+		*vmStatsCollectorEnabled,
+		*firmwareAutoSelectionEnabled,
+		*allowCrossArchEmulation,
+		notifier)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -80,6 +80,7 @@ import (
 	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
 	"kubevirt.io/kubevirt/pkg/virt-handler/plugins"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 )
 
 type noopNodeHookExecutor struct{}
@@ -920,13 +921,17 @@ var _ = Describe("VirtualMachineInstance", func() {
 			)
 
 			BeforeEach(func() {
-				vmi = api2.NewMinimalVMI("testvmi")
+				vmi = libvmi.New(
+					libvmi.WithNamespace(k8sv1.NamespaceDefault),
+					libvmistatus.WithStatus(libvmistatus.New(
+						libvmistatus.WithPhase(v1.Running),
+						libvmistatus.WithActivePod(podTestUUID, host),
+					)),
+				)
 				vmi.UID = vmiTestUUID
 				vmi.ObjectMeta.ResourceVersion = "1"
-				vmi.Status.Phase = v1.Running
-				vmi = addActivePods(vmi, podTestUUID, host)
 
-				domain = api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain = api.NewMinimalDomainWithUUID(vmi.Name, vmiTestUUID)
 				domain.Status.Status = api.Running
 			})
 
@@ -951,34 +956,15 @@ var _ = Describe("VirtualMachineInstance", func() {
 				expectEvent(string(v1.AccessCredentialsSyncSuccess), true)
 				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(updatedVMI.Status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(v1.VirtualMachineInstanceAccessCredentialsSynchronized),
-						"Status": Equal(k8sv1.ConditionTrue)},
-					),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
-						"Status": Equal(k8sv1.ConditionTrue)},
-					),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
-						"Status": Equal(k8sv1.ConditionTrue)},
-					),
-				))
+				Expect(updatedVMI).To(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAccessCredentialsSynchronized))
 			})
 
 			It("should do nothing if condition already exists", func() {
-				vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
-					{
-						Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
-						LastProbeTime: metav1.Now(),
-						Status:        k8sv1.ConditionTrue,
-					},
-					{
-						Type:   v1.VirtualMachineInstanceIsMigratable,
-						Status: k8sv1.ConditionTrue,
-					},
-				}
+				vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{
+					Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
+					LastProbeTime: metav1.Now(),
+					Status:        k8sv1.ConditionTrue,
+				}}
 
 				domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
 					Succeeded: true,
@@ -993,21 +979,16 @@ var _ = Describe("VirtualMachineInstance", func() {
 			})
 
 			It("should update condition if agent disconnects", func() {
-				vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
-					{
-						Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
-						LastProbeTime: metav1.Now(),
-						Status:        k8sv1.ConditionTrue,
-					},
-					{
-						Type:   v1.VirtualMachineInstanceIsMigratable,
-						Status: k8sv1.ConditionTrue,
-					},
-				}
+				vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{
+					Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
+					LastProbeTime: metav1.Now(),
+					Status:        k8sv1.ConditionTrue,
+				}}
 
+				const message = "some message"
 				domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
 					Succeeded: false,
-					Message:   "some message",
+					Message:   message,
 				}
 
 				prepare()
@@ -1017,21 +998,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 				expectEvent(string(v1.AccessCredentialsSyncFailed), true)
 				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(updatedVMI.Status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
-						"Status": Equal(k8sv1.ConditionTrue)},
-					),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(v1.VirtualMachineInstanceAccessCredentialsSynchronized),
-						"Status":  Equal(k8sv1.ConditionFalse),
-						"Message": Equal("some message")},
-					),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
-						"Status": Equal(k8sv1.ConditionTrue)},
-					),
-				))
+				Expect(updatedVMI).To(matcher.HaveConditionFalseWithMessage(
+					v1.VirtualMachineInstanceAccessCredentialsSynchronized, message))
 			})
 		})
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -913,134 +913,126 @@ var _ = Describe("VirtualMachineInstance", func() {
 			))
 		})
 
-		It("should add access credential synced condition when credentials report success", func() {
-			vmi := api2.NewMinimalVMI("testvmi")
-			vmi.UID = vmiTestUUID
-			vmi.ObjectMeta.ResourceVersion = "1"
-			vmi.Status.Phase = v1.Running
-			vmi = addActivePods(vmi, podTestUUID, host)
+		Context("access credential synced condition", func() {
+			var (
+				vmi    *v1.VirtualMachineInstance
+				domain *api.Domain
+			)
 
-			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
-			domain.Status.Status = api.Running
-			domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
-				Succeeded: true,
-				Message:   "",
+			BeforeEach(func() {
+				vmi = api2.NewMinimalVMI("testvmi")
+				vmi.UID = vmiTestUUID
+				vmi.ObjectMeta.ResourceVersion = "1"
+				vmi.Status.Phase = v1.Running
+				vmi = addActivePods(vmi, podTestUUID, host)
+
+				domain = api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain.Status.Status = api.Running
+			})
+
+			prepare := func() {
+				addVMI(vmi, domain)
+
+				client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
+				mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
+				mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
 			}
 
-			addVMI(vmi, domain)
+			It("should add condition when credentials report success", func() {
+				domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
+					Succeeded: true,
+					Message:   "",
+				}
 
-			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
-			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
-			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
+				prepare()
 
-			sanityExecute()
+				sanityExecute()
 
-			expectEvent(string(v1.AccessCredentialsSyncSuccess), true)
-			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.Conditions).To(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceAccessCredentialsSynchronized),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-			))
-		})
+				expectEvent(string(v1.AccessCredentialsSyncSuccess), true)
+				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedVMI.Status.Conditions).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(v1.VirtualMachineInstanceAccessCredentialsSynchronized),
+						"Status": Equal(k8sv1.ConditionTrue)},
+					),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
+						"Status": Equal(k8sv1.ConditionTrue)},
+					),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
+						"Status": Equal(k8sv1.ConditionTrue)},
+					),
+				))
+			})
 
-		It("should do nothing if access credential condition already exists", func() {
-			vmi := api2.NewMinimalVMI("testvmi")
-			vmi.UID = vmiTestUUID
-			vmi.ObjectMeta.ResourceVersion = "1"
-			vmi.Status.Phase = v1.Running
-			vmi = addActivePods(vmi, podTestUUID, host)
-			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
-				{
-					Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
-					LastProbeTime: metav1.Now(),
-					Status:        k8sv1.ConditionTrue,
-				},
-				{
-					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: k8sv1.ConditionTrue,
-				},
-			}
+			It("should do nothing if condition already exists", func() {
+				vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+					{
+						Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
+						LastProbeTime: metav1.Now(),
+						Status:        k8sv1.ConditionTrue,
+					},
+					{
+						Type:   v1.VirtualMachineInstanceIsMigratable,
+						Status: k8sv1.ConditionTrue,
+					},
+				}
 
-			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
-			domain.Status.Status = api.Running
-			domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
-				Succeeded: true,
-				Message:   "",
-			}
+				domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
+					Succeeded: true,
+					Message:   "",
+				}
 
-			addVMI(vmi, domain)
+				prepare()
 
-			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
-			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
-			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
+				sanityExecute()
+				// should not make another event entry unless something changes
+				expectEvent(string(v1.AccessCredentialsSyncSuccess), false)
+			})
 
-			sanityExecute()
-			// should not make another event entry unless something changes
-			expectEvent(string(v1.AccessCredentialsSyncSuccess), false)
-		})
+			It("should update condition if agent disconnects", func() {
+				vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+					{
+						Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
+						LastProbeTime: metav1.Now(),
+						Status:        k8sv1.ConditionTrue,
+					},
+					{
+						Type:   v1.VirtualMachineInstanceIsMigratable,
+						Status: k8sv1.ConditionTrue,
+					},
+				}
 
-		It("should update access credential condition if agent disconnects", func() {
-			vmi := api2.NewMinimalVMI("testvmi")
-			vmi.UID = vmiTestUUID
-			vmi.ObjectMeta.ResourceVersion = "1"
-			vmi.Status.Phase = v1.Running
-			vmi = addActivePods(vmi, podTestUUID, host)
-			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
-				{
-					Type:          v1.VirtualMachineInstanceAccessCredentialsSynchronized,
-					LastProbeTime: metav1.Now(),
-					Status:        k8sv1.ConditionTrue,
-				},
-				{
-					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: k8sv1.ConditionTrue,
-				},
-			}
+				domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
+					Succeeded: false,
+					Message:   "some message",
+				}
 
-			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
-			domain.Status.Status = api.Running
-			domain.Spec.Metadata.KubeVirt.AccessCredential = &api.AccessCredentialMetadata{
-				Succeeded: false,
-				Message:   "some message",
-			}
+				prepare()
 
-			addVMI(vmi, domain)
+				sanityExecute()
 
-			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
-			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
-			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
-
-			sanityExecute()
-
-			expectEvent(string(v1.AccessCredentialsSyncFailed), true)
-			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.Conditions).To(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-				MatchFields(IgnoreExtras, Fields{
-					"Type":    Equal(v1.VirtualMachineInstanceAccessCredentialsSynchronized),
-					"Status":  Equal(k8sv1.ConditionFalse),
-					"Message": Equal("some message")},
-				),
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-			))
+				expectEvent(string(v1.AccessCredentialsSyncFailed), true)
+				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedVMI.Status.Conditions).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
+						"Status": Equal(k8sv1.ConditionTrue)},
+					),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(v1.VirtualMachineInstanceAccessCredentialsSynchronized),
+						"Status":  Equal(k8sv1.ConditionFalse),
+						"Message": Equal("some message")},
+					),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
+						"Status": Equal(k8sv1.ConditionTrue)},
+					),
+				))
+			})
 		})
 
 		type domainIsPausedTest struct {

--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )
 
@@ -42,6 +43,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	k8sv1 "k8s.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
@@ -71,14 +72,26 @@ type AccessCredentialManager struct {
 
 	domainModifyLock *sync.Mutex
 	metadataCache    *metadata.Cache
+
+	eventSent   bool
+	eventSender EventSender
 }
 
-func NewManager(connection cli.Connection, domainModifyLock *sync.Mutex, metadataCache *metadata.Cache) *AccessCredentialManager {
+type EventSender interface {
+	SendK8sEvent(vmi *v1.VirtualMachineInstance, severity, reason, message string) error
+}
+
+func NewManager(connection cli.Connection,
+	domainModifyLock *sync.Mutex,
+	metadataCache *metadata.Cache,
+	eventSender EventSender,
+) *AccessCredentialManager {
 	return &AccessCredentialManager{
 		virConn:                    connection,
 		resyncCheckIntervalSeconds: 15,
 		domainModifyLock:           domainModifyLock,
 		metadataCache:              metadataCache,
+		eventSender:                eventSender,
 	}
 }
 
@@ -292,7 +305,8 @@ func (l *AccessCredentialManager) pingAgent(domName string) error {
 	return err
 }
 
-func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName, user string, authorizedKeys []string) error {
+// agentSetAuthorizedKeys sets the SSH keys and returns "true" if the old deprecated flow was used.
+func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName, user string, authorizedKeys []string) (bool, error) {
 	err := func() (err error) {
 		domain, err := l.virConn.LookupDomainByName(domName)
 		if err != nil {
@@ -304,7 +318,7 @@ func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName, user string, a
 		return domain.AuthorizedSSHKeysSet(user, authorizedKeys, 0)
 	}()
 	if err == nil {
-		return nil
+		return false, nil
 	}
 
 	log.Log.V(logVerbosityDebug).Infof("Could not set SSH key using guest-ssh-add-authorized-keys: %v", err)
@@ -313,10 +327,10 @@ func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName, user string, a
 	desiredAuthorizedKeys := strings.Join(authorizedKeys, "\n")
 	secondErr := l.agentWriteAuthorizedKeysFile(domName, user, desiredAuthorizedKeys)
 	if secondErr == nil {
-		return nil
+		return true, nil
 	}
 
-	return fmt.Errorf(
+	return false, fmt.Errorf(
 		"failed to set SSH keys: error from guest-ssh-add-authorized-keys: %w; error from using guest-file-write: %w",
 		err,
 		secondErr,
@@ -391,13 +405,36 @@ func getSecret(accessCred *v1.AccessCredential) string {
 	return secretName
 }
 
-func (l *AccessCredentialManager) reportAccessCredentialResult(succeeded bool, message string) {
+func (l *AccessCredentialManager) reportAccessCredentialResult(
+	vmi *v1.VirtualMachineInstance,
+	succeeded bool,
+	message string,
+	usedDeprecatedFlow bool,
+) {
 	acMetadata := api.AccessCredentialMetadata{
 		Succeeded: succeeded,
 		Message:   message,
 	}
 	l.metadataCache.AccessCredential.Store(acMetadata)
 	log.Log.V(logVerbosityDebug).Infof("Access credential set in metadata: %v", acMetadata)
+
+	if !succeeded || !usedDeprecatedFlow {
+		l.eventSent = false
+	}
+
+	if succeeded && usedDeprecatedFlow && !l.eventSent {
+		err := l.eventSender.SendK8sEvent(
+			vmi,
+			k8sv1.EventTypeWarning,
+			v1.AccessCredentialsSyncSuccess.String(),
+			"Used deprecated method to set SSH keys. It will be removed in a future release. Update qemu guest agent to 5.2 or newer to keep SSH key injection working.", //nolint:lll
+		)
+		if err != nil {
+			log.Log.Reason(err).Errorf("Error encountered sending k8s event about using deprecated flow to update SSH key.")
+		} else {
+			l.eventSent = true
+		}
+	}
 }
 
 func (l *AccessCredentialManager) watchSecrets(vmi *v1.VirtualMachineInstance) {
@@ -451,12 +488,13 @@ func (l *AccessCredentialManager) watchSecrets(vmi *v1.VirtualMachineInstance) {
 func (l *AccessCredentialManager) reloadCredentialFiles(vmi *v1.VirtualMachineInstance, domName string, logger *log.FilteredLogger) bool {
 	err := l.pingAgent(domName)
 	if err != nil {
-		l.reportAccessCredentialResult(false, "Guest agent is offline")
+		l.reportAccessCredentialResult(vmi, false, "Guest agent is offline", false)
 		return true
 	}
 
 	reload := false
 	reportedErr := false
+	usedDeprecatedFlow := false
 
 	credentialInfo := newAccessCredentialsInfo()
 
@@ -468,7 +506,7 @@ func (l *AccessCredentialManager) reloadCredentialFiles(vmi *v1.VirtualMachineIn
 			reload = true
 			reportedErr = true
 			logger.Reason(err).Errorf("Error encountered")
-			l.reportAccessCredentialResult(false, err.Error())
+			l.reportAccessCredentialResult(vmi, false, err.Error(), false)
 		}
 	}
 
@@ -480,15 +518,18 @@ func (l *AccessCredentialManager) reloadCredentialFiles(vmi *v1.VirtualMachineIn
 			allAuthorizedKeys = append(allAuthorizedKeys, pubKeys...)
 		}
 
-		err := l.agentSetAuthorizedKeys(domName, user, allAuthorizedKeys)
+		deprecated, err := l.agentSetAuthorizedKeys(domName, user, allAuthorizedKeys)
 		if err != nil {
 			// if writing failed, reset reload to true so this change will be retried again
 			reload = true
 			reportedErr = true
 			logger.Reason(err).Errorf("Error encountered writing access credentials using guest agent")
-			l.reportAccessCredentialResult(false, fmt.Sprintf(
+			l.reportAccessCredentialResult(vmi, false, fmt.Sprintf(
 				"Error encountered writing ssh pub key access credentials for user [%s]: %v",
-				user, err))
+				user, err), false)
+		}
+		if deprecated {
+			usedDeprecatedFlow = true
 		}
 	}
 
@@ -501,11 +542,11 @@ func (l *AccessCredentialManager) reloadCredentialFiles(vmi *v1.VirtualMachineIn
 			reportedErr = true
 			logger.Reason(err).Errorf("Error encountered setting password for user [%s]", user)
 
-			l.reportAccessCredentialResult(false, fmt.Sprintf("Error encountered setting password for user [%s]: %v", user, err))
+			l.reportAccessCredentialResult(vmi, false, fmt.Sprintf("Error encountered setting password for user [%s]: %v", user, err), false)
 		}
 	}
 	if !reportedErr {
-		l.reportAccessCredentialResult(true, "")
+		l.reportAccessCredentialResult(vmi, true, "", usedDeprecatedFlow)
 	}
 
 	return reload

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -32,12 +32,14 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	k8sv1 "k8s.io/api/core/v1"
 	"libvirt.org/go/libvirt"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -65,7 +67,7 @@ var _ = Describe("AccessCredentials", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockLibvirt = testing.NewLibvirt(ctrl)
 
-		manager = NewManager(mockLibvirt.VirtConnection, &lock, metadata.NewCache())
+		manager = NewManager(mockLibvirt.VirtConnection, &lock, metadata.NewCache(), nil)
 		manager.resyncCheckIntervalSeconds = 1
 		tmpDir, err = os.MkdirTemp("", "credential-test")
 		Expect(err).ToNot(HaveOccurred())
@@ -125,7 +127,9 @@ var _ = Describe("AccessCredentials", func() {
 		mockLibvirt.DomainEXPECT().AuthorizedSSHKeysSet(user, authorizedKeys, gomock.Any()).Return(nil).Times(1)
 		mockLibvirt.DomainEXPECT().Free().Times(1)
 
-		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
+		deprecated, err := manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)
+		Expect(deprecated).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should dynamically update ssh key with old qemu agent", func() {
@@ -206,7 +210,9 @@ var _ = Describe("AccessCredentials", func() {
 		mockLibvirt.ConnectionEXPECT().QemuAgentCommand(expectedFileChmodCmd, domName).Return(expectedExecReturn, nil).Times(1)
 		mockLibvirt.ConnectionEXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedFileChmodRes, nil).Times(1)
 
-		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
+		deprecated, err := manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)
+		Expect(deprecated).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should fail to update ssh key if both methods return error", func() {
@@ -223,8 +229,9 @@ var _ = Describe("AccessCredentials", func() {
 		// Detect user home dir
 		mockLibvirt.ConnectionEXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return("", libvirt.ERR_INTERNAL_ERROR).AnyTimes()
 
-		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).
-			To(MatchError(ContainSubstring("failed to set SSH keys")))
+		deprecated, err := manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)
+		Expect(deprecated).To(BeFalse())
+		Expect(err).To(MatchError(ContainSubstring("failed to set SSH keys")))
 	})
 
 	It("should support multiple ssh keys in one secret value", func() {
@@ -371,4 +378,28 @@ var _ = Describe("AccessCredentials", func() {
 
 		manager.watchSecrets(vmi)
 	})
+
+	It("should send event if deprecated flow was used", func() {
+		fakeVmi := &v1.VirtualMachineInstance{}
+
+		var eventSent atomic.Bool
+		manager.eventSender = &fakeEventSender{SendK8sEventFunc: func(vmi *v1.VirtualMachineInstance, severity, reason, message string) error {
+			Expect(vmi).To(BeIdenticalTo(fakeVmi))
+			Expect(severity).To(Equal(k8sv1.EventTypeWarning))
+			Expect(reason).To(Equal(v1.AccessCredentialsSyncSuccess.String()))
+			eventSent.Store(true)
+			return nil
+		}}
+
+		manager.reportAccessCredentialResult(fakeVmi, true, "", true)
+		Expect(eventSent.Load()).Should(BeTrue())
+	})
 })
+
+type fakeEventSender struct {
+	SendK8sEventFunc func(vmi *v1.VirtualMachineInstance, severity, reason, message string) error
+}
+
+func (f *fakeEventSender) SendK8sEvent(vmi *v1.VirtualMachineInstance, severity, reason, message string) error {
+	return f.SendK8sEventFunc(vmi, severity, reason, message)
+}

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -111,6 +111,7 @@ var _ = Describe("Live migration source", func() {
 			"", false,
 			false, // firmware auto-selection
 			false,
+			nil,
 		)
 		libvirtDomainManager = manager.(*LibvirtDomainManager)
 		libvirtDomainManager.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)
@@ -203,6 +204,7 @@ var _ = Describe("Live migration source", func() {
 				"", false,
 				false, // firmware auto-selection
 				false,
+				nil,
 			)
 			libvirtDomainManager = manager.(*LibvirtDomainManager)
 			libvirtDomainManager.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -286,17 +286,74 @@ func (s pausedVMIs) contains(uid types.UID) bool {
 	return ok
 }
 
-func NewLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralDiskDir string, agentStore *agentpoller.AsyncAgentStore,
-	ovmfPath string, ephemeralDiskCreator ephemeraldisk.EphemeralDiskCreatorInterface, metadataCache *metadata.Cache,
-	stopChan chan struct{}, diskMemoryLimitBytes int64, cpuSetGetter func() ([]int, error), imageVolumeEnabled bool, libvirtHooksServerAndClientEnabled bool, hookServer *premigrationhookserver.PreMigrationHookServer, hypervisorName string, registerNBD storage.RegisterNBDFunc, domainName string, vmStatsCollectorEnabled bool, firmwareAutoSelectionEnabled bool, allowCrossArchEmulation bool) (DomainManager, error) {
+func NewLibvirtDomainManager(
+	connection cli.Connection,
+	virtShareDir,
+	ephemeralDiskDir string,
+	agentStore *agentpoller.AsyncAgentStore,
+	ovmfPath string,
+	ephemeralDiskCreator ephemeraldisk.EphemeralDiskCreatorInterface,
+	metadataCache *metadata.Cache,
+	stopChan chan struct{},
+	diskMemoryLimitBytes int64,
+	cpuSetGetter func() ([]int, error),
+	imageVolumeEnabled bool,
+	libvirtHooksServerAndClientEnabled bool,
+	hookServer *premigrationhookserver.PreMigrationHookServer,
+	hypervisorName string,
+	registerNBD storage.RegisterNBDFunc,
+	domainName string,
+	vmStatsCollectorEnabled bool,
+	firmwareAutoSelectionEnabled bool,
+	allowCrossArchEmulation bool,
+	eventSender accesscredentials.EventSender,
+) (DomainManager, error) {
 	directIOChecker := converter.NewDirectIOChecker()
-	return newLibvirtDomainManager(connection, virtShareDir, ephemeralDiskDir, agentStore, ovmfPath, ephemeralDiskCreator, directIOChecker, metadataCache, stopChan, diskMemoryLimitBytes, cpuSetGetter, imageVolumeEnabled, libvirtHooksServerAndClientEnabled, hookServer, hypervisorName, registerNBD, domainName, vmStatsCollectorEnabled, firmwareAutoSelectionEnabled, allowCrossArchEmulation)
+	return newLibvirtDomainManager(connection,
+		virtShareDir,
+		ephemeralDiskDir,
+		agentStore,
+		ovmfPath,
+		ephemeralDiskCreator,
+		directIOChecker,
+		metadataCache,
+		stopChan,
+		diskMemoryLimitBytes,
+		cpuSetGetter,
+		imageVolumeEnabled,
+		libvirtHooksServerAndClientEnabled,
+		hookServer,
+		hypervisorName,
+		registerNBD,
+		domainName,
+		vmStatsCollectorEnabled,
+		firmwareAutoSelectionEnabled,
+		allowCrossArchEmulation,
+		eventSender)
 }
 
-func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralDiskDir string, agentStore *agentpoller.AsyncAgentStore, ovmfPath string,
-	ephemeralDiskCreator ephemeraldisk.EphemeralDiskCreatorInterface, directIOChecker converter.DirectIOChecker, metadataCache *metadata.Cache,
-	stopChan chan struct{}, diskMemoryLimitBytes int64, cpuSetGetter func() ([]int, error), imageVolumeEnabled bool, libvirtHooksServerAndClientEnabled bool, hookServer *premigrationhookserver.PreMigrationHookServer, hypervisorName string, registerNBD storage.RegisterNBDFunc, domainName string, vmStatsCollectorEnabled bool, firmwareAutoSelectionEnabled bool, allowCrossArchEmulation bool) (DomainManager, error) {
-
+func newLibvirtDomainManager(
+	connection cli.Connection,
+	virtShareDir, ephemeralDiskDir string,
+	agentStore *agentpoller.AsyncAgentStore,
+	ovmfPath string,
+	ephemeralDiskCreator ephemeraldisk.EphemeralDiskCreatorInterface,
+	directIOChecker converter.DirectIOChecker,
+	metadataCache *metadata.Cache,
+	stopChan chan struct{},
+	diskMemoryLimitBytes int64,
+	cpuSetGetter func() ([]int, error),
+	imageVolumeEnabled bool,
+	libvirtHooksServerAndClientEnabled bool,
+	hookServer *premigrationhookserver.PreMigrationHookServer,
+	hypervisorName string,
+	registerNBD storage.RegisterNBDFunc,
+	domainName string,
+	vmStatsCollectorEnabled bool,
+	firmwareAutoSelectionEnabled bool,
+	allowCrossArchEmulation bool,
+	eventSender accesscredentials.EventSender,
+) (DomainManager, error) {
 	// Check hypervisor device availability
 	hypervisorDevicePath := "/dev/" + hypervisor.NewLauncherHypervisorResources(hypervisorName).GetHypervisorDevice()
 	hypervisorDeviceAvailable := true
@@ -340,7 +397,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
 
 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
 	manager.storageManager = storage.NewStorageManager(connection, metadataCache, registerNBD)
-	manager.credManager = accesscredentials.NewManager(connection, &manager.domainModifyLock, metadataCache)
+	manager.credManager = accesscredentials.NewManager(connection, &manager.domainModifyLock, metadataCache, eventSender)
 
 	reCalcDomainStats := func() (*stats.DomainStats, error) {
 		list, err := manager.getDomainStats()

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Manager", func() {
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
 	ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
 	newLibvirtDomainManagerDefault := func() (DomainManager, error) {
-		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 	}
 
 	BeforeEach(func() {
@@ -682,7 +682,7 @@ var _ = Describe("Manager", func() {
 				func() {
 					isFreeCalled <- true
 				})
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			Expect(manager.UnpauseVMI(vmi)).To(Succeed())
 			Eventually(func() bool {
 				select {
@@ -773,7 +773,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{
 				VirtualMachineSMBios: &cmdv1.SMBios{},
 				PreallocatedVolumes:  []string{"permvolume1"},
@@ -904,7 +904,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AttachDeviceFlags(strings.ToLower(string(attachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1012,7 +1012,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1086,7 +1086,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1187,7 +1187,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1326,7 +1326,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1456,7 +1456,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1534,7 +1534,7 @@ var _ = Describe("Manager", func() {
 			defer os.RemoveAll(ovmfDir)
 			err = os.WriteFile(filepath.Join(ovmfDir, efi.EFICodeSEV), loaderBytes, 0644)
 			Expect(err).ToNot(HaveOccurred())
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			sevMeasurementInfo, err := manager.GetLaunchMeasurement(vmi)
 			if runtime.GOARCH == "amd64" {
 				Expect(err).ToNot(HaveOccurred())
@@ -1745,7 +1745,7 @@ var _ = Describe("Manager", func() {
 					hotplugHostDevicesInProgress: make(chan struct{}, maxConcurrentHotplugHostDevices),
 				}
 				manager.storageManager = storage.NewStorageManager(mockLibvirt.VirtConnection, metadataCache, nil)
-				manager.credManager = accesscredentials.NewManager(mockLibvirt.VirtConnection, &manager.domainModifyLock, metadataCache)
+				manager.credManager = accesscredentials.NewManager(mockLibvirt.VirtConnection, &manager.domainModifyLock, metadataCache, nil)
 			})
 
 			AfterEach(func() {
@@ -1851,7 +1851,7 @@ var _ = Describe("Manager", func() {
 				Physical: 20 * 1024 * 1024 * 1024,
 			}, nil)
 
-			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
@@ -2747,7 +2747,7 @@ var _ = Describe("Manager", func() {
 				options := &cmdv1.VirtualMachineOptions{
 					ClusterConfig: &cmdv1.ClusterConfig{VGPULiveMigrationEnabled: true},
 				}
-				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, true, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, true, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 				Expect(err).ToNot(HaveOccurred())
 				libvirtManager := manager.(*LibvirtDomainManager)
 
@@ -2793,7 +2793,7 @@ var _ = Describe("Manager", func() {
 			func(state libvirt.DomainState) {
 				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 				mockLibvirt.DomainEXPECT().UndefineFlags(libvirt.DOMAIN_UNDEFINE_KEEP_NVRAM | libvirt.DOMAIN_UNDEFINE_CHECKPOINTS_METADATA).Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 				Expect(manager.DeleteVMI(newVMI(testNamespace, testVmName))).To(Succeed())
 			},
 			Entry("crashed", libvirt.DOMAIN_CRASHED),
@@ -2975,7 +2975,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			})
 
 			It("should report nil when no OS info exists in the cache", func() {
@@ -2999,7 +2999,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			})
 
 			It("should return nil when no interfaces exists in the cache", func() {
@@ -3043,7 +3043,7 @@ var _ = Describe("Manager", func() {
 				},
 			},
 		})
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3079,7 +3079,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3106,7 +3106,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3133,7 +3133,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3179,7 +3179,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3522,7 +3522,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should use firmware auto-selection for standard secure boot when feature gate is enabled", func() {
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			options := &cmdv1.VirtualMachineOptions{
@@ -3549,7 +3549,7 @@ var _ = Describe("Manager", func() {
 			Expect(os.WriteFile(filepath.Join(ovmfDir, efiCodeFile), []byte("code"), 0644)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(ovmfDir, efiVarsFile), []byte("vars"), 0644)).To(Succeed())
 
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, firmwareAutoSelection, false)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, firmwareAutoSelection, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			libvirtManager := manager.(*LibvirtDomainManager)
@@ -3585,7 +3585,7 @@ var _ = Describe("Manager", func() {
 				Expect(os.WriteFile(filepath.Join(ovmfDir, f), []byte("data"), 0644)).To(Succeed())
 			}
 
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			libvirtManager := manager.(*LibvirtDomainManager)


### PR DESCRIPTION
### What this PR does
The old flow uses guest agent command `guest-file-write` to write directly to the `~/.ssh/authorized_keys` file. By default, the command is not enabled in the guest agent, or it is blocked by selinux.

This commit adds a deprecation warning when a VM uses this flow to set a SSH key.
The warning is shown in the VMI's conditions, and an event is raised.

Fixes: https://issues.redhat.com/browse/CNV-55538

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Deprecated old method to set SSH key in a VM.
```

