### PR TITLE
kubevirt_vmi_vcpu_seconds_total should use nanosecondsToSeconds

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/domainstats/unit_converter.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/unit_converter.go
@@ -4,10 +4,6 @@ func nanosecondsToSeconds(ns uint64) float64 {
 	return float64(ns) / 1000000000
 }
 
-func microsecondsToSeconds(us uint64) float64 {
-	return float64(us) / 1000000
-}
-
 func kibibytesToBytes(kibibytes uint64) float64 {
 	return float64(kibibytes) * 1024
 }

--- a/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics.go
@@ -75,7 +75,7 @@ func (vcpuMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operatorme
 				"id":    stringVcpuIdx,
 				"state": humanReadableState(vcpu.State),
 			}
-			crs = append(crs, vmiReport.newCollectorResultWithLabels(vcpuSeconds, microsecondsToSeconds(vcpu.Time), additionalLabels))
+			crs = append(crs, vmiReport.newCollectorResultWithLabels(vcpuSeconds, nanosecondsToSeconds(vcpu.Time), additionalLabels))
 		}
 
 		if vcpu.WaitSet {

--- a/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics_test.go
@@ -61,7 +61,7 @@ var _ = Describe("vcpu metrics", func() {
 			crs := vcpuMetrics{}.Collect(vmiReport)
 			Expect(crs).To(ContainElement(testing.GomegaContainsCollectorResultMatcher(metric, expectedValue)))
 		},
-			Entry("kubevirt_vmi_vcpu_seconds_total", vcpuSeconds, microsecondsToSeconds(1)),
+			Entry("kubevirt_vmi_vcpu_seconds_total", vcpuSeconds, nanosecondsToSeconds(1)),
 			Entry("kubevirt_vmi_vcpu_wait_seconds_total", vcpuWaitSeconds, nanosecondsToSeconds(2)),
 			Entry("kubevirt_vmi_vcpu_delay_seconds_total", vcpuDelaySeconds, nanosecondsToSeconds(3)),
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: invoke `microsecondsToSeconds` in `kubevirt_vmi_vcpu_seconds_total`

After this PR: invoke `nanosecondsToSeconds` in `kubevirt_vmi_vcpu_seconds_total`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/13731

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changed the time unit conversion in the kubevirt_vmi_vcpu_seconds_total metric from microseconds to nanoseconds.
```

