### PR TITLE
tests/operator.go improvements

### DIFF
--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmigration:go_default_library",
-        "//tests/libnet:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libsecret:go_default_library",

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -413,13 +414,9 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					for _, env := range vc.Spec.Template.Spec.Containers[0].Env {
-						if env.Name == envVarDeploymentKeyToUpdate {
-							return false
-						}
-					}
-
-					return true
+					return !slices.ContainsFunc(vc.Spec.Template.Spec.Containers[0].Env, func(env k8sv1.EnvVar) bool {
+						return env.Name == envVarDeploymentKeyToUpdate
+					})
 				}),
 
 			Entry("[test_id:6255] customresourcedefinitions",
@@ -445,13 +442,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					vmcrd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					for _, sn := range vmcrd.Spec.Names.ShortNames {
-						if sn == shortNameAdded {
-							return false
-						}
-					}
-
-					return true
+					return !slices.Contains(vmcrd.Spec.Names.ShortNames, shortNameAdded)
 				}),
 			Entry("[test_id:6256] poddisruptionbudgets", decorators.MultiReplica,
 				func() {
@@ -516,13 +507,9 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					vc, err := virtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					for _, env := range vc.Spec.Template.Spec.Containers[0].Env {
-						if env.Name == envVarDeploymentKeyToUpdate {
-							return false
-						}
-					}
-
-					return true
+					return !slices.ContainsFunc(vc.Spec.Template.Spec.Containers[0].Env, func(env k8sv1.EnvVar) bool {
+						return env.Name == envVarDeploymentKeyToUpdate
+					})
 				}),
 		)
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -526,12 +526,12 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			Expect(service.Spec.Ports[0].Port).To(Equal(int32(123)))
 
 			By("Test that the port is revered to the original")
-			Eventually(func() bool {
+			Eventually(func() int32 {
 				service, err := virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				return service.Spec.Ports[0].Port == originalPort
-			}, 120*time.Second, 5*time.Second).Should(BeTrue(), "waiting for service to revert to original state")
+				return service.Spec.Ports[0].Port
+			}).WithTimeout(120*time.Second).WithPolling(5*time.Second).Should(Equal(originalPort), "waiting for service to revert to original state")
 
 			By("Test that the revert of the service stays consistent")
 			Consistently(func() int32 {
@@ -539,7 +539,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				Expect(err).ToNot(HaveOccurred())
 
 				return service.Spec.Ports[0].Port
-			}, 20*time.Second, 5*time.Second).Should(Equal(originalPort))
+			}).WithTimeout(20 * time.Second).WithPolling(5 * time.Second).Should(Equal(originalPort))
 		})
 	})
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -558,7 +558,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 			By("getting virt-launcher")
 			uid := vmi.GetObjectMeta().GetUID()
-			labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
+			labelSelector := fmt.Sprintf("%s=%v", v1.CreatedByLabel, uid)
 			pods, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 			Expect(err).ToNot(HaveOccurred(), "Should list pods")
 			Expect(pods.Items).To(HaveLen(1))


### PR DESCRIPTION
### What this PR does

make several ipmrovements in tests/operator.go:
* use the standard library `slices.Contains` instead of manual searching loops
* Improve several `Eventually`s 
* avoid parsing the same quantity string in a loop
* fix wrong usage of `fmt.Sprintf`
* Change the `generateMigratableVMIs` function var, to be a regular function
* Change the `verifyVMIsUpdated` function var, to be a regular function

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/kind cleanup

