### PR TITLE
Storage: add requiresWFFCStorageClass decorator and change skips to fail

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -787,11 +787,13 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 					expectEqualTemplateAnnotations(targetVMCloneFromClone, sourceVM)
 				})
 
-				Context("with WaitForFirstConsumer binding mode", func() {
+				Context("with WaitForFirstConsumer binding mode", decorators.RequiresWFFCStorageClass, func() {
 					BeforeEach(func() {
 						snapshotStorageClass, err = libstorage.GetWFFCStorageSnapshotClass(virtClient)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(snapshotStorageClass).ToNot(BeEmpty(), "no storage class with snapshot support and wffc binding mode")
+						if snapshotStorageClass == "" {
+							Fail("Failing test, no storage class with snapshot support and wffc binding mode")
+						}
 					})
 
 					It("should not delete the vmsnapshot and vmrestore until all the pvc(s) are bound", func() {

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -71,6 +71,8 @@ var (
 
 	// RequiresSnapshotStorageClass requires a storage class with support for snapshots
 	RequiresSnapshotStorageClass = Label("RequiresSnapshotStorageClass")
+	// RequiresWFFCStorageClass requires a storage class with support for WFFC bindingMode
+	RequiresWFFCStorageClass = Label("RequiresWFFCStorageClass")
 	// RequiresNoSnapshotStorageClass requires a storage class without support for snapshots
 	RequiresNoSnapshotStorageClass = Label("RequiresNoSnapshotStorageClass")
 	// RequiresRWXBlock requires a storage class with ReadWriteMany Block support

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -669,7 +669,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		})
 	})
 
-	Context("WFFC storage", func() {
+	Context("WFFC storage", decorators.RequiresWFFCStorageClass, func() {
 		var (
 			vm *v1.VirtualMachine
 			sc string
@@ -682,7 +682,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			var exists bool
 			sc, exists = libstorage.GetRWOFileSystemStorageClass()
 			if !exists || !libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
-				Skip("Skip no wffc storage class available")
+				Fail("fail test, no wffc storage class available")
 			}
 			libstorage.CheckNoProvisionerStorageClassPVs(sc, numPVs)
 


### PR DESCRIPTION
Added and used this decorator in tests that require WFFC. Replaced Skip with Fail.
Lanes without WFFC SC can use it to filter the tests.



### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

