### PR TITLE
net, e2e: Remove deprecated SkipIfOpenShift functions

### DIFF
--- a/pkg/util/cluster/BUILD.bazel
+++ b/pkg/util/cluster/BUILD.bazel
@@ -7,9 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/openshift/api/security/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
     ],
 )

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -1,23 +1,13 @@
 package cluster
 
 import (
-	"context"
-	"encoding/json"
-	"strings"
-
 	secv1 "github.com/openshift/api/security/v1"
-	k8sversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/client-go/log"
 )
 
-const (
-	OpenShift3Major = 3
-	OpenShift4Major = 4
-	k8sBaseForOKD   = "1.12"
-)
+const OpenShift4Major = 4
 
 func IsOnOpenShift(clientset kubecli.KubevirtClient) (bool, error) {
 	_, apis, err := clientset.DiscoveryClient().ServerGroupsAndResources()
@@ -46,40 +36,4 @@ func IsOnOpenShift(clientset kubecli.KubevirtClient) (bool, error) {
 	}
 
 	return false, nil
-}
-
-func GetKubernetesVersion() (string, error) {
-	var info k8sversion.Info
-
-	virtClient, err := kubecli.GetKubevirtClient()
-	if err != nil {
-		return "", err
-	}
-
-	response, err := virtClient.RestClient().Get().AbsPath("/version").DoRaw(context.Background())
-	if err != nil {
-		return "", err
-	}
-
-	if err := json.Unmarshal(response, &info); err != nil {
-		return "", err
-	}
-
-	curVersion := strings.Split(info.GitVersion, "+")[0]
-	curVersion = strings.Trim(curVersion, "v")
-
-	return curVersion, nil
-}
-
-func GetOpenShiftMajorVersion(clientset kubecli.KubevirtClient) int {
-	k8sVersion, err := GetKubernetesVersion()
-	if err != nil {
-		log.Log.Errorf("Unable to detect major OpenShift version: %v", err)
-		return -1
-	}
-
-	if k8sVersion >= k8sBaseForOKD {
-		return OpenShift4Major
-	}
-	return OpenShift3Major
 }

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -14,8 +14,6 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/util/cluster"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -71,17 +69,6 @@ func SkipIfPrometheusRuleIsNotEnabled(virtClient kubecli.KubevirtClient) {
 		ginkgo.Skip("Skip monitoring tests when PrometheusRule CRD is not available in the cluster")
 	} else if err != nil {
 		util.PanicOnError(err)
-	}
-}
-
-// Deprecated: SkipIfOpenShift4 should be converted to check & fail
-func SkipIfOpenShift4(message string) {
-	virtClient := kubevirt.Client()
-
-	if t, err := cluster.IsOnOpenShift(virtClient); err != nil {
-		util.PanicOnError(err)
-	} else if t && cluster.GetOpenShiftMajorVersion(virtClient) == cluster.OpenShift4Major {
-		ginkgo.Skip(message)
 	}
 }
 

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -74,13 +74,6 @@ func SkipIfPrometheusRuleIsNotEnabled(virtClient kubecli.KubevirtClient) {
 	}
 }
 
-// Deprecated: SkipIfOpenShift should be converted to check & fail
-func SkipIfOpenShift(message string) {
-	if IsOpenShift() {
-		ginkgo.Skip("Openshift detected: " + message)
-	}
-}
-
 // Deprecated: SkipIfOpenShift4 should be converted to check & fail
 func SkipIfOpenShift4(message string) {
 	virtClient := kubevirt.Client()

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -38,7 +38,6 @@ import (
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 
@@ -234,7 +233,6 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 			})
 
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
-				checks.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -92,11 +91,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 
 			DescribeTable("should be able to reach", func(vmiRef **v1.VirtualMachineInstance) {
-				vmi := *vmiRef
-				if vmiHasCustomMacAddress(vmi) {
-					checks.SkipIfOpenShift("Custom MAC addresses on pod networks are not supported")
-				}
-				vmi = runVMI(vmi)
+				vmi := runVMI(*vmiRef)
 				addr := vmi.Status.Interfaces[0].IP
 
 				payloadSize := 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Users who execute these tests on OpenShift could skip them by name.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

