### PR TITLE
feat(virtctl): Change syntax for namespaces in port-forward, ssh and scp

### DIFF
--- a/pkg/virtctl/portforward/portforward_test.go
+++ b/pkg/virtctl/portforward/portforward_test.go
@@ -8,31 +8,38 @@ import (
 )
 
 var _ = Describe("Port forward", func() {
-	DescribeTable("ParseTarget", func(arg, targetNamespace, targetName, targetKind, expectedError string) {
-		kind, namespace, name, err := portforward.ParseTarget(arg)
+	DescribeTable("ParseTarget", func(arg, targetNamespace, targetName, expectedError string) {
+		namespace, name, err := portforward.ParseTarget(arg)
 		Expect(namespace).To(Equal(targetNamespace))
 		Expect(name).To(Equal(targetName))
-		Expect(kind).To(Equal(targetKind))
 		if expectedError == "" {
 			Expect(err).NotTo(HaveOccurred())
 		} else {
 			Expect(err).To(MatchError(expectedError))
 		}
 	},
-		Entry("only name", "testvmi", "", "testvmi", "vmi", ""),
-		Entry("name and namespace", "testvmi.default", "default", "testvmi", "vmi", ""),
-		Entry("name with dot and namespace", "testvmi.dot.default", "default", "testvmi.dot", "vmi", ""),
-		Entry("name with dots and namespace", "testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", ""),
-		Entry("kind vmi with name", "vmi/testvmi", "", "testvmi", "vmi", ""),
-		Entry("kind vmi with name and namespace", "vmi/testvmi.default", "default", "testvmi", "vmi", ""),
-		Entry("kind vm with name", "vm/testvm", "", "testvm", "vm", ""),
-		Entry("kind vm with name and namespace", "vm/testvm.default", "default", "testvm", "vm", ""),
-		Entry("kind invalid with name and namespace", "invalid/testvm.default", "", "", "", "unsupported resource kind invalid"),
-		Entry("name with separator but missing namespace", "testvm.", "", "", "", "expected namespace after '.'"),
-		Entry("namespace with separator but missing name", ".default", "", "", "", "expected name before '.'"),
-		Entry("only valid kind", "vmi/", "", "", "", "expected name after '/'"),
-		Entry("only separators", "/.", "", "", "", "unsupported resource kind "),
-		Entry("only dot", ".", "", "", "", "expected name before '.'"),
-		Entry("only slash", "/", "", "", "", "unsupported resource kind "),
+		Entry("only name", "testvmi", "", "testvmi", ""),
+		Entry("dot after name", "testvm.", "", "testvm.", ""),
+		Entry("dot before name", ".testvm", "", ".testvm", ""),
+		Entry("name and namespace", "default/testvmi", "default", "testvmi", ""),
+		Entry("name with dot and namespace", "default/testvmi.dot", "default", "testvmi.dot", ""),
+		Entry("name with dots and namespace", "default/testvmi.with.dots", "default", "testvmi.with.dots", ""),
+		Entry("only dot", ".", "", ".", ""),
+		Entry("only slash", "/", "", "", "namespace cannot be empty"),
+		Entry("empty namespace before slash", "/testvm", "", "", "namespace cannot be empty"),
+		Entry("empty target", "", "", "", "name cannot be empty or expected name after '/'"),
+		Entry("empty name after slash", "default/", "", "", "name cannot be empty or expected name after '/'"),
+		Entry("more than one slash", "namespace/name/something", "", "", "target is not valid with more than one '/'"),
+		// Legacy syntax test cases
+		Entry("only reserved namespace vmi", "vmi/", "", "", "name cannot be empty or expected name after '/'"),
+		Entry("only reserved namespace vm", "vm/", "", "", "name cannot be empty or expected name after '/'"),
+		Entry("reserved namespace vmi with name", "vmi/testvmi", "", "testvmi", ""),
+		Entry("reserved namespace vmi with name and namespace", "vmi/testvmi.default", "default", "testvmi", ""),
+		Entry("reserved namespace vmi with name with dot and namespace", "vmi/testvmi.dot.default", "default", "testvmi.dot", ""),
+		Entry("reserved namespace vmi with name with dots and namespace", "vmi/testvmi.with.dots.default", "default", "testvmi.with.dots", ""),
+		Entry("reserved namespace vm with name", "vm/testvm", "", "testvm", ""),
+		Entry("reserved namespace vm with name and namespace", "vm/testvm.default", "default", "testvm", ""),
+		Entry("reserved namespace vm with name with dot and namespace", "vmi/testvm.dot.default", "default", "testvm.dot", ""),
+		Entry("reserved namespace vm with name with dots and namespace", "vmi/testvm.with.dots.default", "default", "testvm.with.dots", ""),
 	)
 })

--- a/pkg/virtctl/portforward/portforwarder.go
+++ b/pkg/virtctl/portforward/portforwarder.go
@@ -5,17 +5,14 @@ import (
 	"net"
 	"strings"
 
-	kvcorev1 "kubevirt.io/client-go/kubevirt/typed/core/v1"
+	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 )
 
 type portForwarder struct {
-	kind, namespace, name string
-	resource              portforwardableResource
-}
-
-type portforwardableResource interface {
-	PortForward(name string, port int, protocol string) (kvcorev1.StreamInterface, error)
+	namespace string
+	name      string
+	client    kubecli.KubevirtClient
 }
 
 func (p *portForwarder) startForwarding(address *net.IPAddr, port forwardedPort) error {

--- a/pkg/virtctl/portforward/tcp.go
+++ b/pkg/virtctl/portforward/tcp.go
@@ -32,9 +32,9 @@ func (p *portForwarder) waitForConnection(listener net.Listener, port forwardedP
 			return
 		}
 		log.Log.Infof("opening new tcp tunnel to %d", port.remote)
-		stream, err := p.resource.PortForward(p.name, port.remote, port.protocol)
+		stream, err := p.client.VirtualMachineInstance(p.namespace).PortForward(p.name, port.remote, port.protocol)
 		if err != nil {
-			log.Log.Errorf("can't access %s/%s.%s: %v", p.kind, p.name, p.namespace, err)
+			log.Log.Errorf("can't access VMI %s/%s: %v", p.namespace, p.name, err)
 			return
 		}
 		go p.handleConnection(conn, stream.AsConn(), port)

--- a/pkg/virtctl/portforward/udp.go
+++ b/pkg/virtctl/portforward/udp.go
@@ -26,9 +26,9 @@ func (p *portForwarder) startForwardingUDP(address *net.IPAddr, port forwardedPo
 		listener: listener,
 		remoteDialer: func() (net.Conn, error) {
 			log.Log.Infof("opening new udp tunnel to %d", port.remote)
-			stream, err := p.resource.PortForward(p.name, port.remote, port.protocol)
+			stream, err := p.client.VirtualMachineInstance(p.namespace).PortForward(p.name, port.remote, port.protocol)
 			if err != nil {
-				log.Log.Errorf("can't access %s/%s.%s: %v", p.kind, p.name, p.namespace, err)
+				log.Log.Errorf("can't access VMI %s/%s: %v", p.namespace, p.name, err)
 				return nil, err
 			}
 			return stream.AsConn(), nil

--- a/pkg/virtctl/scp/BUILD.bazel
+++ b/pkg/virtctl/scp/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/virtctl/ssh:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/povsister/scp:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],

--- a/pkg/virtctl/scp/native.go
+++ b/pkg/virtctl/scp/native.go
@@ -20,7 +20,7 @@ func (o *SCP) nativeSCP(local *LocalArgument, remote *RemoteArgument, toRemote b
 		Client:  client,
 		Options: o.options,
 	}
-	sshClient, err := conn.PrepareSSHClient(remote.Kind, remote.Namespace, remote.Name)
+	sshClient, err := conn.PrepareSSHClient(remote.Namespace, remote.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/virtctl/scp/scp_test.go
+++ b/pkg/virtctl/scp/scp_test.go
@@ -16,18 +16,18 @@ var _ = Describe("SCP", func() {
 		Expect(toRemote).To(Equal(expToRemote))
 	},
 		Entry("copy to remote location",
-			"myfile.yaml", "cirros@remote.mynamespace:myfile.yaml",
+			"myfile.yaml", "cirros@mynamespace/remote:myfile.yaml",
 			&scp.LocalArgument{Path: "myfile.yaml"},
 			&scp.RemoteArgument{
-				Kind: "vmi", Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",
+				Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",
 			},
 			true,
 		),
 		Entry("copy from remote location",
-			"cirros@remote.mynamespace:myfile.yaml", "myfile.yaml",
+			"cirros@mynamespace/remote:myfile.yaml", "myfile.yaml",
 			&scp.LocalArgument{Path: "myfile.yaml"},
 			&scp.RemoteArgument{
-				Kind: "vmi", Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",
+				Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",
 			},
 			false,
 		),

--- a/pkg/virtctl/scp/wrapped.go
+++ b/pkg/virtctl/scp/wrapped.go
@@ -15,9 +15,9 @@ func (o *SCP) buildSCPTarget(local *LocalArgument, remote *RemoteArgument, toRem
 		target.WriteString(o.options.SSHUsername)
 		target.WriteRune('@')
 	}
-	target.WriteString(remote.Name)
-	target.WriteRune('.')
 	target.WriteString(remote.Namespace)
+	target.WriteRune('/')
+	target.WriteString(remote.Name)
 	target.WriteRune(':')
 	target.WriteString(remote.Path)
 

--- a/pkg/virtctl/scp/wrapped_test.go
+++ b/pkg/virtctl/scp/wrapped_test.go
@@ -33,12 +33,12 @@ var _ = Describe("Wrapped SCP", func() {
 		It("with SCP username", func() {
 			scp.options = ssh.SSHOptions{SSHUsername: "testuser"}
 			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
-			Expect(scpTarget[0]).To(Equal("testuser@fake-name.fake-ns:/remote/fakepath"))
+			Expect(scpTarget[0]).To(Equal("testuser@fake-ns/fake-name:/remote/fakepath"))
 		})
 
 		It("without SCP username", func() {
 			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
-			Expect(scpTarget[0]).To(Equal("fake-name.fake-ns:/remote/fakepath"))
+			Expect(scpTarget[0]).To(Equal("fake-ns/fake-name:/remote/fakepath"))
 		})
 
 		It("with recursive", func() {
@@ -63,7 +63,7 @@ var _ = Describe("Wrapped SCP", func() {
 
 		It("toRemote = false", func() {
 			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
-			Expect(scpTarget[0]).To(Equal("fake-name.fake-ns:/remote/fakepath"))
+			Expect(scpTarget[0]).To(Equal("fake-ns/fake-name:/remote/fakepath"))
 			Expect(scpTarget[1]).To(Equal("/local/fakepath"))
 		})
 
@@ -71,7 +71,7 @@ var _ = Describe("Wrapped SCP", func() {
 			fakeToRemote = true
 			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
 			Expect(scpTarget[0]).To(Equal("/local/fakepath"))
-			Expect(scpTarget[1]).To(Equal("fake-name.fake-ns:/remote/fakepath"))
+			Expect(scpTarget[1]).To(Equal("fake-ns/fake-name:/remote/fakepath"))
 		})
 	})
 })

--- a/pkg/virtctl/ssh/BUILD.bazel
+++ b/pkg/virtctl/ssh/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/virtctl/portforward:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/pkg/virtctl/ssh/native_unsupported.go
+++ b/pkg/virtctl/ssh/native_unsupported.go
@@ -22,6 +22,6 @@ func addAdditionalCommandlineArgs(flagset *pflag.FlagSet, opts *SSHOptions) {
 		fmt.Sprintf(`--%s="-o StrictHostKeyChecking=no" : Additional options to be passed to the local ssh`, additionalOpts))
 }
 
-func (o *SSH) nativeSSH(_, _, _ string, _ kubecli.KubevirtClient) error {
+func (o *SSH) nativeSSH(_, _ string, _ kubecli.KubevirtClient) error {
 	panic("Native SSH is unsupported in this build!")
 }

--- a/pkg/virtctl/ssh/ssh_test.go
+++ b/pkg/virtctl/ssh/ssh_test.go
@@ -8,11 +8,10 @@ import (
 )
 
 var _ = Describe("SSH", func() {
-	DescribeTable("ParseTarget", func(arg, targetNamespace, targetName, targetKind, targetUsername, expectedError string) {
-		kind, namespace, name, username, err := ssh.ParseTarget(arg)
+	DescribeTable("ParseTarget", func(arg, targetNamespace, targetName, targetUsername, expectedError string) {
+		namespace, name, username, err := ssh.ParseTarget(arg)
 		Expect(namespace).To(Equal(targetNamespace))
 		Expect(name).To(Equal(targetName))
-		Expect(kind).To(Equal(targetKind))
 		Expect(username).To(Equal(targetUsername))
 		if expectedError == "" {
 			Expect(err).NotTo(HaveOccurred())
@@ -20,33 +19,44 @@ var _ = Describe("SSH", func() {
 			Expect(err).To(MatchError(expectedError))
 		}
 	},
-		Entry("name", "testvmi", "", "testvmi", "vmi", "", ""),
-		Entry("name and namespace", "testvmi.default", "default", "testvmi", "vmi", "", ""),
-		Entry("name with dot and namespace", "testvmi.dot.default", "default", "testvmi.dot", "vmi", "", ""),
-		Entry("name with dots and namespace", "testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", "", ""),
-		Entry("username and name", "user@testvmi", "", "testvmi", "vmi", "user", ""),
-		Entry("username and name and namespace", "user@testvmi.default", "default", "testvmi", "vmi", "user", ""),
-		Entry("username and name with dot and namespace", "user@testvmi.dot.default", "default", "testvmi.dot", "vmi", "user", ""),
-		Entry("username and name with dots and namespace", "user@testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", "user", ""),
-		Entry("kind vmi with name", "vmi/testvmi", "", "testvmi", "vmi", "", ""),
-		Entry("kind vmi with name and namespace", "vmi/testvmi.default", "default", "testvmi", "vmi", "", ""),
-		Entry("kind vmi with name and username", "user@vmi/testvmi", "", "testvmi", "vmi", "user", ""),
-		Entry("kind vmi with name and namespace and username", "user@vmi/testvmi.default", "default", "testvmi", "vmi", "user", ""),
-		Entry("kind vmi with name with dot and namespace and username", "user@vmi/testvmi.dot.default", "default", "testvmi.dot", "vmi", "user", ""),
-		Entry("kind vmi with name with dots and namespace and username", "user@vmi/testvmi.with.dots.default", "default", "testvmi.with.dots", "vmi", "user", ""),
-		Entry("kind vm with name", "vm/testvm", "", "testvm", "vm", "", ""),
-		Entry("kind vm with name and namespace", "vm/testvm.default", "default", "testvm", "vm", "", ""),
-		Entry("kind vm with name and username", "user@vm/testvm", "", "testvm", "vm", "user", ""),
-		Entry("kind vm with name and namespace and username", "user@vm/testvm.default", "default", "testvm", "vm", "user", ""),
-		Entry("kind vm with name with dot and namespace and username", "user@vm/testvm.dot.default", "default", "testvm.dot", "vm", "user", ""),
-		Entry("kind vm with name with dots and namespace and username", "user@vm/testvm.with.dots.default", "default", "testvm.with.dots", "vm", "user", ""),
-		Entry("only valid kind", "vmi/", "", "", "", "", "expected name after '/'"),
-		Entry("only dot", ".", "", "", "", "", "expected name before '.'"),
-		Entry("only slash", "/", "", "", "", "", "unsupported resource kind "),
-		Entry("only separators", "/.", "", "", "", "", "unsupported resource kind "),
-		Entry("only separators and at", "@/.", "", "", "", "", "expected username before '@'"),
-		Entry("only username", "user@", "", "", "", "", "expected target after '@'"),
-		Entry("only at", "@", "", "", "", "", "expected username before '@'"),
-		Entry("only at and target", "@testvmi", "", "", "", "", "expected username before '@'"),
+		Entry("username and name", "user@testvmi", "", "testvmi", "user", ""),
+		Entry("username and dot after name", "user@testvmi.", "", "testvmi.", "user", ""),
+		Entry("username and dot before name", "user@.testvmi", "", ".testvmi", "user", ""),
+		Entry("username and name and namespace", "user@default/testvmi", "default", "testvmi", "user", ""),
+		Entry("username and name with dot and namespace", "user@default/testvmi.dot", "default", "testvmi.dot", "user", ""),
+		Entry("username and name with dots and namespace", "user@default/testvmi.with.dots", "default", "testvmi.with.dots", "user", ""),
+		Entry("username and only dot", "user@.", "", ".", "user", ""),
+		Entry("empty target", "", "", "", "", "target cannot be empty or expected target after '@'"),
+		Entry("only separators and at", "@/.", "", "", "", "expected username before '@'"),
+		Entry("only username", "user@", "", "", "", "target cannot be empty or expected target after '@'"),
+		Entry("only at", "@", "", "", "", "expected username before '@'"),
+		Entry("only at and target", "@testvmi", "", "", "", "expected username before '@'"),
+		// These cases should work the same as for portforward.ParseTarget
+		Entry("only name", "testvmi", "", "testvmi", "", ""),
+		Entry("dot after name", "testvmi.", "", "testvmi.", "", ""),
+		Entry("dot before name", ".testvmi", "", ".testvmi", "", ""),
+		Entry("name and namespace", "default/testvmi", "default", "testvmi", "", ""),
+		Entry("name with dot and namespace", "default/testvmi.dot", "default", "testvmi.dot", "", ""),
+		Entry("name with dots and namespace", "default/testvmi.with.dots", "default", "testvmi.with.dots", "", ""),
+		Entry("only dot", ".", "", ".", "", ""),
+		Entry("only slash", "/", "", "", "", "namespace cannot be empty"),
+		Entry("empty namespace before slash", "/testvm", "", "", "", "namespace cannot be empty"),
+		Entry("empty name after slash", "default/", "", "", "", "name cannot be empty or expected name after '/'"),
+		Entry("more than one slash", "namespace/name/something", "", "", "", "target is not valid with more than one '/'"),
+		// Legacy syntax test cases
+		Entry("only reserved namespace vmi", "vmi/", "", "", "", "name cannot be empty or expected name after '/'"),
+		Entry("only reserved namespace vm", "vm/", "", "", "", "name cannot be empty or expected name after '/'"),
+		Entry("reserved namespace vmi with name", "vmi/testvmi", "", "testvmi", "", ""),
+		Entry("reserved namespace vmi with name and namespace", "vmi/testvmi.default", "default", "testvmi", "", ""),
+		Entry("reserved namespace vmi with name and username", "user@vmi/testvmi", "", "testvmi", "user", ""),
+		Entry("reserved namespace vmi with name and namespace and username", "user@vmi/testvmi.default", "default", "testvmi", "user", ""),
+		Entry("reserved namespace vmi with name with dot and namespace and username", "user@vmi/testvmi.dot.default", "default", "testvmi.dot", "user", ""),
+		Entry("reserved namespace vmi with name with dots and namespace and username", "user@vmi/testvmi.with.dots.default", "default", "testvmi.with.dots", "user", ""),
+		Entry("reserved namespace vm with name", "vm/testvm", "", "testvm", "", ""),
+		Entry("reserved namespace vm with name and namespace", "vm/testvm.default", "default", "testvm", "", ""),
+		Entry("reserved namespace vm with name and username", "user@vm/testvm", "", "testvm", "user", ""),
+		Entry("reserved namespace vm with name and namespace and username", "user@vm/testvm.default", "default", "testvm", "user", ""),
+		Entry("reserved namespace vm with name with dot and namespace and username", "user@vm/testvm.dot.default", "default", "testvm.dot", "user", ""),
+		Entry("reserved namespace vm with name with dots and namespace and username", "user@vm/testvm.with.dots.default", "default", "testvm.with.dots", "user", ""),
 	)
 })

--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -14,9 +14,9 @@ var runCommand = func(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-func RunLocalClient(kind, namespace, name string, options *SSHOptions, clientArgs []string) error {
+func RunLocalClient(namespace, name string, options *SSHOptions, clientArgs []string) error {
 	args := []string{"-o"}
-	args = append(args, buildProxyCommandOption(kind, namespace, name, options.SSHPort))
+	args = append(args, buildProxyCommandOption(namespace, name, options.SSHPort))
 
 	if len(options.AdditionalSSHLocalOptions) > 0 {
 		args = append(args, options.AdditionalSSHLocalOptions...)
@@ -36,12 +36,12 @@ func RunLocalClient(kind, namespace, name string, options *SSHOptions, clientArg
 	return runCommand(cmd)
 }
 
-func buildProxyCommandOption(kind, namespace, name string, port int) string {
+func buildProxyCommandOption(namespace, name string, port int) string {
 	proxyCommand := strings.Builder{}
 	proxyCommand.WriteString("ProxyCommand=")
 	proxyCommand.WriteString(os.Args[0])
 	proxyCommand.WriteString(" port-forward --stdio=true ")
-	proxyCommand.WriteString(fmt.Sprintf("%s/%s.%s", kind, name, namespace))
+	proxyCommand.WriteString(fmt.Sprintf("%s/%s", namespace, name))
 	proxyCommand.WriteString(" ")
 
 	proxyCommand.WriteString(strconv.Itoa(port))
@@ -49,17 +49,15 @@ func buildProxyCommandOption(kind, namespace, name string, port int) string {
 	return proxyCommand.String()
 }
 
-func (o *SSH) buildSSHTarget(kind, namespace, name string) (opts []string) {
+func (o *SSH) buildSSHTarget(namespace, name string) (opts []string) {
 	target := strings.Builder{}
 	if len(o.options.SSHUsername) > 0 {
 		target.WriteString(o.options.SSHUsername)
 		target.WriteRune('@')
 	}
-	target.WriteString(kind)
+	target.WriteString(namespace)
 	target.WriteRune('/')
 	target.WriteString(name)
-	target.WriteRune('.')
-	target.WriteString(namespace)
 
 	opts = append(opts, target.String())
 	if o.command != "" {

--- a/pkg/virtctl/ssh/wrapped_test.go
+++ b/pkg/virtctl/ssh/wrapped_test.go
@@ -11,11 +11,14 @@ import (
 
 var _ = Describe("Wrapped SSH", func() {
 
-	var fakeKind, fakeNamespace, fakeName string
-	var ssh SSH
+	var (
+		fakeNamespace string
+		fakeName      string
+
+		ssh SSH
+	)
 
 	BeforeEach(func() {
-		fakeKind = "fake-kind"
 		fakeNamespace = "fake-ns"
 		fakeName = "fake-name"
 		ssh = SSH{}
@@ -25,21 +28,21 @@ var _ = Describe("Wrapped SSH", func() {
 
 		It("with SSH username", func() {
 			ssh.options = SSHOptions{SSHUsername: "testuser"}
-			sshTarget := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
-			Expect(sshTarget[0]).To(Equal("testuser@fake-kind/fake-name.fake-ns"))
+			sshTarget := ssh.buildSSHTarget(fakeNamespace, fakeName)
+			Expect(sshTarget[0]).To(Equal("testuser@fake-ns/fake-name"))
 		})
 
 		It("without SSH username", func() {
-			sshTarget := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
-			Expect(sshTarget[0]).To(Equal("fake-kind/fake-name.fake-ns"))
+			sshTarget := ssh.buildSSHTarget(fakeNamespace, fakeName)
+			Expect(sshTarget[0]).To(Equal("fake-ns/fake-name"))
 		})
 
 	})
 
 	It("buildProxyCommandOption", func() {
 		const sshPort = 12345
-		proxyCommand := buildProxyCommandOption(fakeKind, fakeNamespace, fakeName, sshPort)
-		expected := fmt.Sprintf("port-forward --stdio=true fake-kind/fake-name.fake-ns %d", sshPort)
+		proxyCommand := buildProxyCommandOption(fakeNamespace, fakeName, sshPort)
+		expected := fmt.Sprintf("port-forward --stdio=true fake-ns/fake-name %d", sshPort)
 		Expect(proxyCommand).To(ContainSubstring(expected))
 	})
 
@@ -48,16 +51,16 @@ var _ = Describe("Wrapped SSH", func() {
 			Expect(cmd).ToNot(BeNil())
 			Expect(cmd.Args).To(HaveLen(4))
 			Expect(cmd.Args[0]).To(Equal("ssh"))
-			Expect(cmd.Args[2]).To(Equal(buildProxyCommandOption(fakeKind, fakeNamespace, fakeName, ssh.options.SSHPort)))
-			Expect(cmd.Args[3]).To(Equal(ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)[0]))
+			Expect(cmd.Args[2]).To(Equal(buildProxyCommandOption(fakeNamespace, fakeName, ssh.options.SSHPort)))
+			Expect(cmd.Args[3]).To(Equal(ssh.buildSSHTarget(fakeNamespace, fakeName)[0]))
 
 			return nil
 		}
 
 		ssh.options = DefaultSSHOptions()
 		ssh.options.SSHPort = 12345
-		clientArgs := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
-		err := RunLocalClient(fakeKind, fakeNamespace, fakeName, &ssh.options, clientArgs)
+		clientArgs := ssh.buildSSHTarget(fakeNamespace, fakeName)
+		err := RunLocalClient(fakeNamespace, fakeName, &ssh.options, clientArgs)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Change the syntax for specifying namespaces in virtctl port-forward, ssh and scp from `$name.$namespace` to `$namespace/$vm`, to be more in line with tools like kubectl and to avoid confusion when VMs or VMIs have dots in their name.

This removes support for the ability to choose between a VM or VMI when connecting to a target and cleans up the code of virtctl a little, since connections are always made to a VMI anyway. Calling PortFoward on the VM subresource API forwards the call to the corresponding VMI, therefore this change is transparent to users.

Namespaces with names that were used as a way to dinstinguish between the kind to connect to (VM or VMI) are now reserved and trigger the old behavior to keep compatibility with existing scripts. A warning is emitted when the old syntax is used. The old syntax will be removed in a future release.

The syntax `$namespace/$vm` was chosen to not break `known_hosts` files, where two VMs in different namespaces but with the same name would have collided with the original proposal made on kubevirt-dev.

Before this PR:

virtctl port-forward, ssh and scp use syntax '$name.$namespace' to specify a host and a namespace to connect to.

After this PR:

virtctl port-forward, ssh and scp use syntax '$namespace/$name' to specify a host and a namespace to connect to.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

https://groups.google.com/g/kubevirt-dev/c/etcVfpRakUs

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl port-forward, ssh and scp now use the syntax '$namespace/$name' to specify a host and a namespace to connect to.
```

