### PR TITLE
feat(virtctl): Deprecate optional type in port-forward/ssh/scp

### DIFF
--- a/pkg/virtctl/portforward/portforward.go
+++ b/pkg/virtctl/portforward/portforward.go
@@ -50,7 +50,7 @@ func NewCommand() *cobra.Command {
 	log.InitializeLogging("portforward")
 	c := PortForward{}
 	cmd := &cobra.Command{
-		Use:     "port-forward [kind/]name[.namespace] [protocol/]localPort[:targetPort]...",
+		Use:     "port-forward [type/]name[.namespace] [protocol/]localPort[:targetPort]...",
 		Short:   "Forward local ports to a virtualmachine or virtualmachineinstance.",
 		Long:    usage(),
 		Example: examples(),
@@ -245,6 +245,9 @@ func ParseTarget(target string) (string, string, string, error) {
 			return "", "", "", errors.New("unsupported resource kind " + kind)
 		}
 		target = parts[1]
+	} else {
+		log.Log.Warningf("Defaulting to type '%s'.\nOmitting the type in the target is deprecated."+
+			"\nSpecifying the type will become mandatory with the next release.", kind)
 	}
 	if target == "" {
 		return "", "", "", errors.New("expected name after '/'")

--- a/pkg/virtctl/scp/scp.go
+++ b/pkg/virtctl/scp/scp.go
@@ -116,19 +116,19 @@ func PrepareCommand(cmd *cobra.Command, fallbackNamespace string, opts *ssh.SSHO
 
 func usage() string {
 	return `  # Copy a file to the remote home folder of user jdoe
-  {{ProgramName}} scp myfile.bin jdoe@testvmi:myfile.bin
+  {{ProgramName}} scp myfile.bin jdoe@vmi/testvmi:myfile.bin
 
   # Copy a directory to the remote home folder of user jdoe
-  {{ProgramName}} scp --recursive ~/mydir/ jdoe@testvmi:./mydir
+  {{ProgramName}} scp --recursive ~/mydir/ jdoe@vmi/testvmi:./mydir
 
   # Copy a file to the remote home folder of user jdoe without specifying a file name on the target
-  {{ProgramName}} scp myfile.bin jdoe@testvmi:.
+  {{ProgramName}} scp myfile.bin jdoe@vmi/testvmi:.
 
   # Copy a file to 'testvm' in 'mynamespace' namespace
-  {{ProgramName}} scp myfile.bin jdoe@testvmi.mynamespace:myfile.bin
+  {{ProgramName}} scp myfile.bin jdoe@vmi/testvmi.mynamespace:myfile.bin
 
   # Copy a file from the remote location to a local folder
-  {{ProgramName}} scp jdoe@testvmi:myfile.bin ~/myfile.bin`
+  {{ProgramName}} scp jdoe@vmi/testvmi:myfile.bin ~/myfile.bin`
 }
 
 func ParseTarget(source, destination string) (*LocalArgument, *RemoteArgument, bool, error) {

--- a/pkg/virtctl/ssh/native.go
+++ b/pkg/virtctl/ssh/native.go
@@ -25,7 +25,7 @@ const (
 func additionalUsage() string {
 	return fmt.Sprintf(`
 	# Connect to 'testvmi' using the local ssh binary found in $PATH:
-	{{ProgramName}} ssh --%s=true jdoe@testvmi`,
+	{{ProgramName}} ssh --%s=true jdoe@vmi/testvmi`,
 		wrapLocalSSHFlag,
 	)
 }

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -158,13 +158,13 @@ func PrepareCommand(cmd *cobra.Command, fallbackNamespace string, opts *SSHOptio
 
 func usage() string {
 	return fmt.Sprintf(`  # Connect to 'testvmi':
-  {{ProgramName}} ssh jdoe@testvmi [--%s]
+  {{ProgramName}} ssh jdoe@vmi/testvmi [--%s]
 
   # Connect to 'testvm' in 'mynamespace' namespace
   {{ProgramName}} ssh jdoe@vm/testvm.mynamespace [--%s]
 
   # Specify a username and namespace:
-  {{ProgramName}} ssh --namespace=mynamespace --%s=jdoe testvmi`,
+  {{ProgramName}} ssh --namespace=mynamespace --%s=jdoe vmi/testvmi`,
 		IdentityFilePathFlag,
 		IdentityFilePathFlag,
 		usernameFlag,

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -116,12 +116,14 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 
 		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
+		remoteFile := "vmi/" + vmi.Name + ":./keyfile"
+
 		By("copying a file to the VMI")
-		copyFn(keyFile, vmi.Name+":"+"./keyfile", false)
+		copyFn(keyFile, remoteFile, false)
 
 		By("copying the file back")
 		copyBackFile := filepath.Join(GinkgoT().TempDir(), "remote_id_rsa")
-		copyFn(vmi.Name+":"+"./keyfile", copyBackFile, false)
+		copyFn(remoteFile, copyBackFile, false)
 
 		By("comparing the two files")
 		compareFile(keyFile, copyBackFile)
@@ -154,10 +156,10 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 		Expect(os.WriteFile(filepath.Join(copyFromDir, "file2"), []byte("test1"), permRW)).To(Succeed())
 
 		By("copying a file to the VMI")
-		copyFn(copyFromDir, vmi.Name+":"+"./sourcedir", true)
+		copyFn(copyFromDir, "vmi/"+vmi.Name+":"+"./sourcedir", true)
 
 		By("copying the file back")
-		copyFn(vmi.Name+":"+"./sourcedir", copyToDir, true)
+		copyFn("vmi/"+vmi.Name+":"+"./sourcedir", copyToDir, true)
 
 		By("comparing the two directories")
 		compareFile(filepath.Join(copyFromDir, "file1"), filepath.Join(copyToDir, "file1"))

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -58,7 +58,7 @@ var _ = VirtctlDescribe("[sig-compute]SSH", decorators.SigCompute, func() {
 			"--identity-file", keyFile,
 			"--known-hosts=",
 			"--command", "true",
-			vmiName,
+			"vmi/"+vmiName,
 		)()).To(Succeed())
 	}
 
@@ -76,7 +76,7 @@ var _ = VirtctlDescribe("[sig-compute]SSH", decorators.SigCompute, func() {
 			if appendLocalSSH {
 				args = append(args, "--local-ssh=true")
 			}
-			args = append(args, vmiName)
+			args = append(args, "vmi/"+vmiName)
 
 			// The virtctl binary needs to run here because of the way local SSH client wrapping works.
 			// Running the command through newRepeatableVirtctlCommand does not suffice.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Deprecate type being optional in the syntax of virtctl port-forward/ssh/scp in preparation of making it mandatory in the future.

Before this PR:

`type` in in the syntax of virtctl port-forward/ssh/scp is optional.

After this PR:

`type` in in the syntax of virtctl port-forward/ssh/scp is STILL optional but a deprecation warning is emitted.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`type` being optional in the syntax of virtctl port-forward/ssh/scp is now deprecated.
```

