### PR TITLE
tests: fix flaky test by increasing time for vm volumes bound time

### DIFF
--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1359,7 +1359,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				return snapshot.Status
-			}, 30*time.Second, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			}, 120*time.Second, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 				"Conditions": ContainElements(
 					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 						"Type":   Equal(snapshotv1.ConditionReady),


### PR DESCRIPTION
As found by @akalenyu (thanks) this test started [flaking](https://search.ci.kubevirt.io/?search=%5C%5BFAIL%5C%5D.*%5C%5Btest_id%3A6952%5C%5D&maxAge=336h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) after recent merged changes.
The time should have been increased when this test changes were introduced. 
Since now before locking the source we are waiting for volumes to be bound and populated which can take time we should have a bit bigger timeout.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

