### PR TITLE
tests,network: quarantine istio+passt tests

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -210,6 +210,8 @@ var istioTests = func(vmType VmType) {
 			}
 
 			BeforeEach(func() {
+				skipTestByVMType(vmType)
+
 				bastionVMI = libvmifact.NewCirros(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
@@ -262,6 +264,7 @@ var istioTests = func(vmType VmType) {
 
 			Context("With VMI having explicit ports specified", func() {
 				BeforeEach(func() {
+					skipTestByVMType(vmType)
 					vmiPorts = explicitPorts
 				})
 				DescribeTable("request to VMI should reach HTTP server", func(targetPort int) {
@@ -295,6 +298,7 @@ var istioTests = func(vmType VmType) {
 				})
 				Context("With VMI having explicit ports specified", func() {
 					BeforeEach(func() {
+						skipTestByVMType(vmType)
 						vmiPorts = explicitPorts
 					})
 					DescribeTable("client outside mesh should NOT reach VMI HTTP server", func(targetPort int) {
@@ -395,6 +399,7 @@ var istioTests = func(vmType VmType) {
 
 			Context("VMI with explicit ports", func() {
 				BeforeEach(func() {
+					skipTestByVMType(vmType)
 					vmiPorts = explicitPorts
 				})
 				It("Should be able to reach http server outside of mesh", func() {
@@ -429,6 +434,7 @@ var istioTests = func(vmType VmType) {
 
 				Context("VMI with explicit ports", func() {
 					BeforeEach(func() {
+						skipTestByVMType(vmType)
 						vmiPorts = explicitPorts
 					})
 					It("Should not be able to reach http service outside of mesh", func() {
@@ -450,6 +456,12 @@ var istioTests = func(vmType VmType) {
 			})
 		})
 	})
+}
+
+func skipTestByVMType(vmType VmType) {
+	if vmType == Passt {
+		Skip("this test is quarantine due to https://github.com/kubevirt/kubevirt/issues/13927")
+	}
 }
 
 var istioTestsWithMasqueradeBinding = func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The following tradeoffs were made:
CI runs very old version of Istio that does not support new k8s features and block development that utilize such features (e.g.: restart policy for init containers).

There is an effort to upgrade Istio version CI use, but it fails due to because some Istio+passt tests failing [[1]](https://github.com/kubevirt/kubevirtci/pull/1331#issuecomment-2636048471)
Please see [[2]](https://github.com/kubevirt/kubevirt/issues/13927) for more details about the root cause.

Quarantine istio+passt failing tests to unblock istio upgrade and development.

Tracking issue for istio upgrade [[3]](https://github.com/kubevirt/kubevirt/issues/13832)

[1] https://github.com/kubevirt/kubevirtci/pull/1331#issuecomment-2636048471
[2] https://github.com/kubevirt/kubevirt/issues/13927
[3] https://github.com/kubevirt/kubevirt/issues/13832

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way


The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

