### PR TITLE
refactor: replace guest agent commands

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -16,6 +16,7 @@ pkg/network/netns
 pkg/network/pod/annotations
 pkg/network/vmispec
 pkg/storage/pod/annotations
+pkg/virt-launcher/virtwrap/agent-poller
 pkg/virtctl/clientconfig
 pkg/virtctl/credentials
 pkg/virtctl/create/params

--- a/pkg/virt-launcher/virtwrap/agent-poller/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/agent-poller/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )
 
@@ -28,8 +29,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -12,32 +12,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
-// GuestOsInfo is the response from 'guest-get-osinfo'
-type GuestOsInfo struct {
-	Name          string `json:"name"`
-	KernelRelease string `json:"kernel-release"`
-	Version       string `json:"version"`
-	PrettyName    string `json:"pretty-name"`
-	VersionId     string `json:"version-id"`
-	KernelVersion string `json:"kernel-version"`
-	Machine       string `json:"machine"`
-	Id            string `json:"id"`
-}
-
-// Interface for json unmarshalling
-type Interface struct {
-	MAC  string `json:"hardware-address"`
-	IPs  []IP   `json:"ip-addresses"`
-	Name string `json:"name"`
-}
-
-// IP for json unmarshalling
-type IP struct {
-	IP     string `json:"ip-address"`
-	Type   string `json:"ip-address-type"`
-	Prefix int    `json:"prefix"`
-}
-
 var stripRE = regexp.MustCompile(`{\s*\"return\":\s*([{\[][\s\S]*[}\]])\s*}`)
 var stripStringRE = regexp.MustCompile(`{\s*\"return\":\s*\"([\s\S]*)\"\s*}`)
 
@@ -59,24 +33,6 @@ func stripAgentStringResponse(agentReply string) string {
 	}
 
 	return result[1]
-}
-
-// Hostname of the guest vm
-type Hostname struct {
-	Hostname string `json:"host-name"`
-}
-
-// Timezone of the host
-type Timezone struct {
-	Zone   string `json:"zone,omitempty"`
-	Offset int    `json:"offset"`
-}
-
-// User on the guest host
-type User struct {
-	Name      string  `json:"user"`
-	Domain    string  `json:"domain"`
-	LoginTime float64 `json:"login-time"`
 }
 
 // Filesystem disk of the host
@@ -102,60 +58,6 @@ type AgentInfo struct {
 	SupportedCommands []v1.GuestAgentCommandInfo `json:"supported_commands,omitempty"`
 }
 
-// parseGuestOSInfo parse agent reply string, extract guest os info
-// and converts the response to API domain guest os info
-func parseGuestOSInfo(agentReply string) (api.GuestOSInfo, error) {
-	guestOSInfo := GuestOsInfo{}
-	response := stripAgentResponse(agentReply)
-
-	err := json.Unmarshal([]byte(response), &guestOSInfo)
-	if err != nil {
-		return api.GuestOSInfo{}, err
-	}
-
-	resultInfo := api.GuestOSInfo{
-		Name:          guestOSInfo.Name,
-		KernelRelease: guestOSInfo.KernelRelease,
-		Version:       guestOSInfo.Version,
-		PrettyName:    guestOSInfo.PrettyName,
-		VersionId:     guestOSInfo.VersionId,
-		KernelVersion: guestOSInfo.KernelVersion,
-		Machine:       guestOSInfo.Machine,
-		Id:            guestOSInfo.Id,
-	}
-
-	return resultInfo, nil
-}
-
-// parseInterfaces parses agent reply string, extracts network interfaces
-// and converts the response to API domain list of interfaces
-func parseInterfaces(agentReply string) ([]api.InterfaceStatus, error) {
-	interfaces := []Interface{}
-	response := stripAgentResponse(agentReply)
-
-	err := json.Unmarshal([]byte(response), &interfaces)
-	if err != nil {
-		return []api.InterfaceStatus{}, err
-	}
-
-	resultInterfaces := convertInterfaceStatusesFromAgentJSON(interfaces)
-
-	return resultInterfaces, nil
-}
-
-// parseHostname from the agent response
-func parseHostname(agentReply string) (string, error) {
-	result := Hostname{}
-	response := stripAgentResponse(agentReply)
-
-	err := json.Unmarshal([]byte(response), &result)
-	if err != nil {
-		return "", err
-	}
-
-	return result.Hostname, nil
-}
-
 // parseFSFreezeStatus from the agent response
 func ParseFSFreezeStatus(agentReply string) (api.FSFreeze, error) {
 	response := stripAgentStringResponse(agentReply)
@@ -165,22 +67,6 @@ func ParseFSFreezeStatus(agentReply string) (api.FSFreeze, error) {
 
 	return api.FSFreeze{
 		Status: response,
-	}, nil
-}
-
-// parseTimezone from the agent response
-func parseTimezone(agentReply string) (api.Timezone, error) {
-	result := Timezone{}
-	response := stripAgentResponse(agentReply)
-
-	err := json.Unmarshal([]byte(response), &result)
-	if err != nil {
-		return api.Timezone{}, err
-	}
-
-	return api.Timezone{
-		Zone:   result.Zone,
-		Offset: result.Offset,
 	}, nil
 }
 
@@ -222,29 +108,6 @@ func parseFSDisks(fsDisks []FSDisk) []api.FSDisk {
 	return disks
 }
 
-// parseUsers from the agent response
-func parseUsers(agentReply string) ([]api.User, error) {
-	result := []User{}
-	response := stripAgentResponse(agentReply)
-
-	err := json.Unmarshal([]byte(response), &result)
-	if err != nil {
-		return []api.User{}, err
-	}
-
-	convertedResult := []api.User{}
-
-	for _, user := range result {
-		convertedResult = append(convertedResult, api.User{
-			Name:      user.Name,
-			Domain:    user.Domain,
-			LoginTime: user.LoginTime,
-		})
-	}
-
-	return convertedResult, nil
-}
-
 // parseAgent gets the agent version from response
 func parseAgent(agentReply string) (AgentInfo, error) {
 	gaInfo := AgentInfo{}
@@ -258,41 +121,4 @@ func parseAgent(agentReply string) (AgentInfo, error) {
 	log.Log.V(3).Infof("guest agent info: %v", gaInfo)
 
 	return gaInfo, nil
-}
-
-// convertInterfaceStatusesFromAgentJSON does the conversion from agent info to api domain interfaces
-func convertInterfaceStatusesFromAgentJSON(agentResult []Interface) []api.InterfaceStatus {
-	interfaceStatuses := []api.InterfaceStatus{}
-	for _, ifc := range agentResult {
-		if ifc.Name == "lo" {
-			continue
-		}
-
-		interfaceIP, interfaceIPs := extractIPs(ifc.IPs)
-		interfaceStatuses = append(interfaceStatuses, api.InterfaceStatus{
-			Mac:           ifc.MAC,
-			Ip:            interfaceIP,
-			IPs:           interfaceIPs,
-			InterfaceName: ifc.Name,
-		})
-	}
-	return interfaceStatuses
-}
-
-func extractIPs(ipAddresses []IP) (string, []string) {
-	interfaceIPs := []string{}
-	var interfaceIP string
-	for _, ipAddr := range ipAddresses {
-		ip := ipAddr.IP
-		// Prefer ipv4 as the main interface IP
-		if ipAddr.Type == "ipv4" && interfaceIP == "" {
-			interfaceIP = ip
-		}
-		interfaceIPs = append(interfaceIPs, ip)
-	}
-	// If no ipv4 interface was found, set any IP as the main IP of interface
-	if interfaceIP == "" && len(interfaceIPs) > 0 {
-		interfaceIP = interfaceIPs[0]
-	}
-	return interfaceIP, interfaceIPs
 }

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -12,8 +12,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
-var stripRE = regexp.MustCompile(`{\s*\"return\":\s*([{\[][\s\S]*[}\]])\s*}`)
-var stripStringRE = regexp.MustCompile(`{\s*\"return\":\s*\"([\s\S]*)\"\s*}`)
+var (
+	stripRE       = regexp.MustCompile(`{\s*\"return\":\s*([{\[][\s\S]*[}\]])\s*}`)
+	stripStringRE = regexp.MustCompile(`{\s*\"return\":\s*\"([\s\S]*)\"\s*}`)
+)
 
 // stripAgentResponse use regex to strip the wrapping item and returns the
 // embedded object.
@@ -27,8 +29,10 @@ func stripAgentResponse(agentReply string) string {
 // unlike stripAgentResponse the response is a simple string
 // rather then a complex object
 func stripAgentStringResponse(agentReply string) string {
+	const minMatchGroups = 2
+
 	result := stripStringRE.FindStringSubmatch(agentReply)
-	if len(result) < 2 {
+	if len(result) < minMatchGroups {
 		return ""
 	}
 
@@ -62,7 +66,7 @@ type AgentInfo struct {
 func ParseFSFreezeStatus(agentReply string) (api.FSFreeze, error) {
 	response := stripAgentStringResponse(agentReply)
 	if response == "" {
-		return api.FSFreeze{}, fmt.Errorf("Failed to strip FSFreeze status: %v", agentReply)
+		return api.FSFreeze{}, fmt.Errorf("failed to strip FSFreeze status: %v", agentReply)
 	}
 
 	return api.FSFreeze{
@@ -110,6 +114,8 @@ func parseFSDisks(fsDisks []FSDisk) []api.FSDisk {
 
 // parseAgent gets the agent version from response
 func parseAgent(agentReply string) (AgentInfo, error) {
+	const logLevelDebug = 3
+
 	gaInfo := AgentInfo{}
 	response := stripAgentResponse(agentReply)
 
@@ -118,7 +124,7 @@ func parseAgent(agentReply string) (AgentInfo, error) {
 		return AgentInfo{}, err
 	}
 
-	log.Log.V(3).Infof("guest agent info: %v", gaInfo)
+	log.Log.V(logLevelDebug).Infof("guest agent info: %v", gaInfo)
 
 	return gaInfo, nil
 }

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var _ = Describe("Qemu agent poller", func() {
-	Context("recieving a reply from the agent", func() {
+	Context("receiving a reply from the agent", func() {
 		It("should parse FSFreezeStatus", func() {
 			jsonInput := `{"return":"frozen"}`
 			expectedFSFreezeStatus := api.FSFreeze{Status: "frozen"}
@@ -67,7 +67,6 @@ var _ = Describe("Qemu agent poller", func() {
 		})
 
 		It("should parse Filesystem", func() {
-
 			jsonInput := `{
                 "return":[
                     {

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -28,173 +28,6 @@ import (
 
 var _ = Describe("Qemu agent poller", func() {
 	Context("recieving a reply from the agent", func() {
-		JSONInput := `{
-            "return": [
-                {
-                    "name":"lo",
-                    "ip-addresses": [
-                        {
-                            "ip-address-type": "ipv4",
-                            "ip-address": "127.0.0.1",
-                            "prefix": 8
-                        },
-                        {
-                            "ip-address-type": "ipv6",
-                            "ip-address": "::1",
-                            "prefix": 128
-                        }
-                    ],
-                    "hardware-address": "00:00:00:00:00:00"
-                },
-                {
-                    "name":"eth0",
-                    "ip-addresses": [
-                        {
-                            "ip-address-type": "ipv4",
-                            "ip-address": "10.244.0.81",
-                            "prefix": 24
-                        },
-                        {
-                            "ip-address-type": "ipv6",
-                            "ip-address": "fe80::858:aff:fef4:51",
-                            "prefix": 64
-                        }
-                    ],
-                    "hardware-address": "0a:58:0a:f4:00:51"
-                },
-                {
-                    "name":"eth1",
-                    "ip-addresses": [
-                        {
-                            "ip-address-type": "ipv6",
-                            "ip-address": "fe80::ff:feb0:1766",
-                            "prefix": 64
-                        }
-                    ],
-                    "hardware-address": "02:00:00:b0:17:66"
-                },
-                {
-                    "name": "eth5",
-                    "ip-addresses": [
-                        {
-                            "ip-address-type": "ipv4",
-                            "ip-address": "1.2.3.4",
-                            "prefix": 24
-                        },
-                        {
-                            "ip-address-type": "ipv6",
-                            "ip-address": "fe80::ff:1111:2222",
-                            "prefix":64
-                        }
-                    ],
-                    "hardware-address": "02:00:00:22:11:11"
-                }
-            ]
-        }`
-
-		It("should not parse network interface data into a list of interfaces", func() {
-			malformedJSONInput := `{
-                "return": [
-                    {
-                        "name":"lo",
-                        "ip-addresses": [
-                            {
-                                "ip-address-type": "ipv4",
-                                "ip-address": "127.0.0.1",
-                                "prefix": 8
-                            },
-
-                                "ip-address-type": "ipv6",
-                                "ip-address": "::1",
-                                "prefix": 128
-                            }
-                        ],
-                        "hardware-address": "00:00:00:00:00:00"
-                    }
-                ]
-            }`
-			_, err := parseInterfaces(malformedJSONInput)
-			Expect(err).To(HaveOccurred(), "should not parse network interfaces")
-
-		})
-
-		It("should parse it into a list of interfaces", func() {
-			// eth5 only present in agent data
-			interfaceStatuses, err := parseInterfaces(JSONInput)
-			Expect(err).ToNot(HaveOccurred(), "should parse network interfaces")
-
-			expectedStatuses := []api.InterfaceStatus{}
-			expectedStatuses = append(expectedStatuses,
-				api.InterfaceStatus{
-					Mac:           "0a:58:0a:f4:00:51",
-					Ip:            "10.244.0.81",
-					IPs:           []string{"10.244.0.81", "fe80::858:aff:fef4:51"},
-					InterfaceName: "eth0",
-				})
-			expectedStatuses = append(expectedStatuses,
-				api.InterfaceStatus{
-					Mac:           "02:00:00:b0:17:66",
-					Ip:            "fe80::ff:feb0:1766",
-					IPs:           []string{"fe80::ff:feb0:1766"},
-					InterfaceName: "eth1",
-				})
-			expectedStatuses = append(expectedStatuses,
-				api.InterfaceStatus{
-					Mac:           "02:00:00:22:11:11",
-					Ip:            "1.2.3.4",
-					IPs:           []string{"1.2.3.4", "fe80::ff:1111:2222"},
-					InterfaceName: "eth5",
-				})
-			Expect(interfaceStatuses).To(Equal(expectedStatuses))
-		})
-
-		It("should parse Guest OS Info", func() {
-
-			JSONInput := `{
-                "return": {
-                    "name": "TestGuestOSName",
-                    "kernel-release": "1.1.0-Generic",
-                    "version": "1.0.0",
-                    "pretty-name": "TestGuestOSName 1.0.0",
-                    "version-id": "1.0.0",
-                    "kernel-version": "1.1.0",
-                    "machine": "x86_64",
-                    "id": "testguestos"
-                }
-            }`
-
-			guestOSInfoStatus, err := parseGuestOSInfo(JSONInput)
-			Expect(err).ToNot(HaveOccurred(), "Should parse the info")
-
-			expectedGuestOSInfo := api.GuestOSInfo{Name: "TestGuestOSName",
-				KernelRelease: "1.1.0-Generic",
-				Version:       "1.0.0",
-				PrettyName:    "TestGuestOSName 1.0.0",
-				VersionId:     "1.0.0",
-				KernelVersion: "1.1.0",
-				Machine:       "x86_64",
-				Id:            "testguestos"}
-			Expect(guestOSInfoStatus).To(Equal(expectedGuestOSInfo))
-		})
-
-		It("should not parse Guest OS Info", func() {
-			malformedJSONInput := `{
-                "return": {{
-                    "name": "TestGuestOSName",
-                    "kernel-release": "1.1.0-Generic",
-                    "version": "1.0.0"
-                    "pretty-name": "TestGuestOSName 1.0.0",
-                    "version-id": "1.0.0",
-                    "kernel-version": "1.1.0",
-                    "machine": "x86_64",
-                    "id": "testguestos"
-                }
-            }`
-
-			_, err := parseGuestOSInfo(malformedJSONInput)
-			Expect(err).To(HaveOccurred(), "Should not parse the info")
-		})
-
 		It("should parse FSFreezeStatus", func() {
 			jsonInput := `{"return":"frozen"}`
 			expectedFSFreezeStatus := api.FSFreeze{Status: "frozen"}
@@ -211,16 +44,6 @@ var _ = Describe("Qemu agent poller", func() {
 
 			_, err = ParseFSFreezeStatus(malformedJSONInput)
 			Expect(err).To(HaveOccurred(), "FSFreezeStatus should not be parsed")
-		})
-
-		It("should parse Hostname", func() {
-			jsonInput := `{
-                "return":{
-                    "host-name":"TestHost"
-                }
-            }`
-
-			Expect(parseHostname(jsonInput)).To(Equal("TestHost"))
 		})
 
 		It("should parse Agent", func() {
@@ -241,22 +64,6 @@ var _ = Describe("Qemu agent poller", func() {
 			expectedResponse := `{"version":"4.1"}`
 
 			Expect(response).To(Equal(expectedResponse))
-		})
-
-		It("should parse Timezone", func() {
-
-			jsonInput := `{
-                "return":{
-                    "zone":"Prague",
-                    "offset":2
-                }
-            }`
-
-			expectedTimezone := api.Timezone{
-				Zone:   "Prague",
-				Offset: 2,
-			}
-			Expect(parseTimezone(jsonInput)).To(Equal(expectedTimezone))
 		})
 
 		It("should parse Filesystem", func() {
@@ -295,28 +102,6 @@ var _ = Describe("Qemu agent poller", func() {
 				},
 			}
 			Expect(parseFilesystem(jsonInput)).To(Equal(expectedFilesystem))
-		})
-
-		It("should parse Users", func() {
-
-			jsonInput := `{
-                "return":[
-                    {
-                        "user":"bob",
-                        "domain":"bobs",
-                        "login-time":99999
-                    }
-                ]
-            }`
-
-			expectedUsers := []api.User{
-				{
-					Name:      "bob",
-					Domain:    "bobs",
-					LoginTime: 99999,
-				},
-			}
-			Expect(parseUsers(jsonInput)).To(Equal(expectedUsers))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
+	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/client-go/log"
 
@@ -35,15 +36,9 @@ import (
 type AgentCommand string
 
 // Aliases for commands executed on guest agent
-// TODO: when updated to libvirt 5.6.0 this can change to libvirt types
 // Aliases are also used as keys to the store, it does not matter how the keys are named,
 // only whether it relates to the right data
 const (
-	GET_OSINFO          AgentCommand = "guest-get-osinfo"
-	GET_HOSTNAME        AgentCommand = "guest-get-host-name"
-	GET_INTERFACES      AgentCommand = "guest-network-get-interfaces"
-	GET_TIMEZONE        AgentCommand = "guest-get-timezone"
-	GET_USERS           AgentCommand = "guest-get-users"
 	GET_FILESYSTEM      AgentCommand = "guest-get-fsinfo"
 	GET_AGENT           AgentCommand = "guest-info"
 	GET_FSFREEZE_STATUS AgentCommand = "guest-fsfreeze-status"
@@ -74,7 +69,7 @@ func NewAsyncAgentStore() AsyncAgentStore {
 
 // Store saves the value with a key to the storage, when there is a change in data
 // it fires up updated event
-func (s *AsyncAgentStore) Store(key AgentCommand, value interface{}) {
+func (s *AsyncAgentStore) Store(key, value any) {
 
 	oldData, _ := s.store.Load(key)
 	updated := (oldData == nil) || !equality.Semantic.DeepEqual(oldData, value)
@@ -84,7 +79,7 @@ func (s *AsyncAgentStore) Store(key AgentCommand, value interface{}) {
 	if updated {
 		domainInfo := api.DomainGuestInfo{}
 		switch key {
-		case GET_OSINFO, GET_INTERFACES, GET_FSFREEZE_STATUS:
+		case libvirt.DOMAIN_GUEST_INFO_OS, libvirt.DOMAIN_GUEST_INFO_INTERFACES, GET_FSFREEZE_STATUS:
 			domainInfo.OSInfo = s.GetGuestOSInfo()
 			domainInfo.Interfaces = s.GetInterfaceStatus()
 			domainInfo.FSFreezeStatus = s.GetFSFreezeStatus()
@@ -102,19 +97,19 @@ func (s *AsyncAgentStore) Store(key AgentCommand, value interface{}) {
 //   - Guest OS version and architecture
 //   - Guest Timezone
 func (s *AsyncAgentStore) GetSysInfo() api.DomainSysInfo {
-	data, ok := s.store.Load(GET_OSINFO)
+	data, ok := s.store.Load(libvirt.DOMAIN_GUEST_INFO_OS)
 	osinfo := api.GuestOSInfo{}
 	if ok {
 		osinfo = data.(api.GuestOSInfo)
 	}
 
-	data, ok = s.store.Load(GET_HOSTNAME)
+	data, ok = s.store.Load(libvirt.DOMAIN_GUEST_INFO_HOSTNAME)
 	hostname := ""
 	if ok {
 		hostname = data.(string)
 	}
 
-	data, ok = s.store.Load(GET_TIMEZONE)
+	data, ok = s.store.Load(libvirt.DOMAIN_GUEST_INFO_TIMEZONE)
 	timezone := api.Timezone{}
 	if ok {
 		timezone = data.(api.Timezone)
@@ -129,7 +124,7 @@ func (s *AsyncAgentStore) GetSysInfo() api.DomainSysInfo {
 
 // GetInterfaceStatus returns the interfaces Guest Agent reported
 func (s *AsyncAgentStore) GetInterfaceStatus() []api.InterfaceStatus {
-	data, ok := s.store.Load(GET_INTERFACES)
+	data, ok := s.store.Load(libvirt.DOMAIN_GUEST_INFO_INTERFACES)
 	if ok {
 		return data.([]api.InterfaceStatus)
 	}
@@ -139,7 +134,7 @@ func (s *AsyncAgentStore) GetInterfaceStatus() []api.InterfaceStatus {
 
 // GetGuestOSInfo returns the Guest OS version and architecture
 func (s *AsyncAgentStore) GetGuestOSInfo() *api.GuestOSInfo {
-	data, ok := s.store.Load(GET_OSINFO)
+	data, ok := s.store.Load(libvirt.DOMAIN_GUEST_INFO_OS)
 	if ok {
 		osInfo := data.(api.GuestOSInfo)
 		return &osInfo
@@ -193,7 +188,7 @@ func (s *AsyncAgentStore) GetFS(limit int) []api.Filesystem {
 // GetUsers return the use list limited to the limit set
 // set limit to -1 to return all users
 func (s *AsyncAgentStore) GetUsers(limit int) []api.User {
-	data, ok := s.store.Load(GET_USERS)
+	data, ok := s.store.Load(libvirt.DOMAIN_GUEST_INFO_USERS)
 	users := []api.User{}
 	if !ok {
 		return users
@@ -214,18 +209,18 @@ func (s *AsyncAgentStore) GetUsers(limit int) []api.User {
 type PollerWorker struct {
 	// AgentCommands is a list of commands executed on the guestAgent
 	AgentCommands []AgentCommand
+
+	// InfoTypes defines the type of guest info to fetch (if applicable)
+	InfoTypes libvirt.DomainGuestInfoTypes
+
 	// CallTick is how often to call this set of commands
 	CallTick time.Duration
 }
 
-type agentCommandsExecutor func(commands []AgentCommand)
-
 // Poll is the call to the guestagent.
-func (p *PollerWorker) Poll(execAgentCommands agentCommandsExecutor, closeChan chan struct{}, initialInterval time.Duration) {
-	log.Log.Infof("Polling command: %v", p.AgentCommands)
-
+func (p *PollerWorker) Poll(execFunc func(), closeChan chan struct{}, initialInterval time.Duration) {
 	// Do the first round to fill the cache immediately.
-	execAgentCommands(p.AgentCommands)
+	execFunc()
 
 	pollMaxInterval := p.CallTick
 	pollInterval := pollMaxInterval
@@ -235,12 +230,13 @@ func (p *PollerWorker) Poll(execAgentCommands agentCommandsExecutor, closeChan c
 
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
+
 	for {
 		select {
 		case <-closeChan:
 			return
 		case <-ticker.C:
-			execAgentCommands(p.AgentCommands)
+			execFunc()
 		}
 		if pollInterval < pollMaxInterval {
 			pollInterval = incrementPollInterval(pollInterval, pollMaxInterval)
@@ -268,7 +264,7 @@ type AgentPoller struct {
 
 // CreatePoller creates the new structure that holds guest agent pollers
 func CreatePoller(
-	connecton cli.Connection,
+	connection cli.Connection,
 	vmiUID types.UID,
 	domainName string,
 	store *AsyncAgentStore,
@@ -278,59 +274,66 @@ func CreatePoller(
 	qemuAgentVersionInterval time.Duration,
 	qemuAgentFSFreezeStatusInterval time.Duration,
 ) *AgentPoller {
-	p := &AgentPoller{
-		Connection: connecton,
+	return &AgentPoller{
+		Connection: connection,
 		VmiUID:     vmiUID,
 		domainName: domainName,
 		agentStore: store,
-		workers:    []PollerWorker{},
+		workers: []PollerWorker{
+			// Polling for QEMU agent commands
+			{
+				CallTick:      qemuAgentVersionInterval,
+				AgentCommands: []AgentCommand{GET_AGENT},
+			},
+			{
+				CallTick:      qemuAgentFileInterval,
+				AgentCommands: []AgentCommand{GET_FILESYSTEM},
+			},
+			{
+				CallTick:      qemuAgentFSFreezeStatusInterval,
+				AgentCommands: []AgentCommand{GET_FSFREEZE_STATUS},
+			},
+			// Polling for guest info API
+			{
+				CallTick: qemuAgentSysInterval,
+				InfoTypes: libvirt.DOMAIN_GUEST_INFO_INTERFACES |
+					libvirt.DOMAIN_GUEST_INFO_OS |
+					libvirt.DOMAIN_GUEST_INFO_HOSTNAME |
+					libvirt.DOMAIN_GUEST_INFO_TIMEZONE,
+			},
+			{
+				CallTick:  qemuAgentUserInterval,
+				InfoTypes: libvirt.DOMAIN_GUEST_INFO_USERS,
+			},
+		},
 	}
-
-	// version command group
-	p.workers = append(p.workers, PollerWorker{
-		CallTick:      qemuAgentVersionInterval,
-		AgentCommands: []AgentCommand{GET_AGENT},
-	})
-	// sys command group
-	p.workers = append(p.workers, PollerWorker{
-		CallTick:      qemuAgentSysInterval,
-		AgentCommands: []AgentCommand{GET_INTERFACES, GET_OSINFO, GET_TIMEZONE, GET_HOSTNAME},
-	})
-	// filesystem command group
-	p.workers = append(p.workers, PollerWorker{
-		CallTick:      qemuAgentFileInterval,
-		AgentCommands: []AgentCommand{GET_FILESYSTEM},
-	})
-	// user command group
-	p.workers = append(p.workers, PollerWorker{
-		CallTick:      qemuAgentUserInterval,
-		AgentCommands: []AgentCommand{GET_USERS},
-	})
-	// fsfreeze command group
-	p.workers = append(p.workers, PollerWorker{
-		CallTick:      qemuAgentFSFreezeStatusInterval,
-		AgentCommands: []AgentCommand{GET_FSFREEZE_STATUS},
-	})
-
-	return p
 }
 
-// Start the poller workers
+// Start the poller workers and libvirt API operations
 func (p *AgentPoller) Start() {
 	if p.agentDone != nil {
 		return
 	}
 	p.agentDone = make(chan struct{})
 
-	for i := 0; i < len(p.workers); i++ {
-		log.Log.Infof("Starting agent poller with commands: %v", p.workers[i].AgentCommands)
-		go p.workers[i].Poll(func(commands []AgentCommand) {
-			executeAgentCommands(commands, p.Connection, p.agentStore, p.domainName)
+	for _, worker := range p.workers {
+		if len(worker.AgentCommands) != 0 {
+			log.Log.Infof("Starting agent poller with commands: %v", worker.AgentCommands)
+		} else {
+			log.Log.Infof("Starting agent poller with API operations: %v", worker.InfoTypes)
+		}
+
+		go worker.Poll(func() {
+			if len(worker.AgentCommands) != 0 {
+				executeAgentCommands(worker.AgentCommands, p)
+			} else {
+				fetchAndStoreGuestInfo(worker.InfoTypes, p)
+			}
 		}, p.agentDone, pollInitialInterval)
 	}
 }
 
-// Stop all poller workers
+// Stop all poller workers and libvirt API operations
 func (p *AgentPoller) Stop() {
 	if p.agentDone != nil {
 		close(p.agentDone)
@@ -338,75 +341,173 @@ func (p *AgentPoller) Stop() {
 	}
 }
 
-// With libvirt 5.6.0 direct call to agent can be replaced with call to libvirt Domain.GetGuestInfo
-func executeAgentCommands(commands []AgentCommand, con cli.Connection, agentStore *AsyncAgentStore, domainName string) {
+// TODO: Remove all commands with this function
+//
+// GET_FSFREEZE_STATUS - This is not implemented in libvirt API and won't be
+// implemented (KubeVirt is expected to provide its own implementation for it).
+//
+// GET_FILESYSTEM - We are missing busType field in the response, which will
+// be included in libvirt 11.2 upstream later (https://gitlab.com/libvirt/libvirt-go-module/-/issues/18).
+//
+// GET_AGENT - According to libvirt engineers this command shouldn't be used
+// by KubeVirt, because it provides irrelevant information (version and supported commands).
+func executeAgentCommands(commands []AgentCommand, agentPoller *AgentPoller) {
+	log.Log.Infof("Polling command: %v", commands)
+
 	for _, command := range commands {
-		// replace with direct call to libvirt function when 5.6.0 is available
-		cmdResult, err := con.QemuAgentCommand(`{"execute":"`+string(command)+`"}`, domainName)
+		cmdResult, err := agentPoller.Connection.QemuAgentCommand(`{"execute":"`+string(command)+`"}`, agentPoller.domainName)
 		if err != nil {
 			// skip the command on error, it is not vital
 			continue
 		}
 
-		// parse the json data and convert to domain api
-		// for libvirt 5.6.0 json conversion deprecated
 		switch command {
-		case GET_INTERFACES:
-			interfaces, err := parseInterfaces(cmdResult)
-			if err != nil {
-				log.Log.Errorf("Cannot parse guest agent interface %s", err.Error())
-				continue
-			}
-			agentStore.Store(GET_INTERFACES, interfaces)
-		case GET_OSINFO:
-			osInfo, err := parseGuestOSInfo(cmdResult)
-			if err != nil {
-				log.Log.Errorf("Cannot parse guest agent guestosinfo %s", err.Error())
-				continue
-			}
-			agentStore.Store(GET_OSINFO, osInfo)
-		case GET_HOSTNAME:
-			hostname, err := parseHostname(cmdResult)
-			if err != nil {
-				log.Log.Errorf("Cannot parse guest agent hostname %s", err.Error())
-				continue
-			}
-			agentStore.Store(GET_HOSTNAME, hostname)
-		case GET_TIMEZONE:
-			timezone, err := parseTimezone(cmdResult)
-			if err != nil {
-				log.Log.Errorf("Cannot parse guest agent timezone %s", err.Error())
-				continue
-			}
-			agentStore.Store(GET_TIMEZONE, timezone)
-		case GET_USERS:
-			users, err := parseUsers(cmdResult)
-			if err != nil {
-				log.Log.Errorf("Cannot parse guest agent users %s", err.Error())
-				continue
-			}
-			agentStore.Store(GET_USERS, users)
 		case GET_FSFREEZE_STATUS:
 			fsfreezeStatus, err := ParseFSFreezeStatus(cmdResult)
 			if err != nil {
 				log.Log.Errorf("Cannot parse guest agent fsfreeze status %s", err.Error())
 				continue
 			}
-			agentStore.Store(GET_FSFREEZE_STATUS, fsfreezeStatus)
+			agentPoller.agentStore.Store(GET_FSFREEZE_STATUS, fsfreezeStatus)
 		case GET_FILESYSTEM:
 			filesystems, err := parseFilesystem(cmdResult)
 			if err != nil {
 				log.Log.Errorf("Cannot parse guest agent filesystem %s", err.Error())
 				continue
 			}
-			agentStore.Store(GET_FILESYSTEM, filesystems)
+			agentPoller.agentStore.Store(GET_FILESYSTEM, filesystems)
 		case GET_AGENT:
 			agent, err := parseAgent(cmdResult)
 			if err != nil {
 				log.Log.Errorf("Cannot parse guest agent information %s", err.Error())
 				continue
 			}
-			agentStore.Store(GET_AGENT, agent)
+			agentPoller.agentStore.Store(GET_AGENT, agent)
 		}
 	}
+}
+
+func fetchAndStoreGuestInfo(types libvirt.DomainGuestInfoTypes, agentPoller *AgentPoller) {
+	log.Log.Infof("Polling API operations: %v", types)
+
+	domain, err := agentPoller.Connection.LookupDomainByName(agentPoller.domainName)
+	if err != nil {
+		log.Log.Errorf("Domain lookup failed: %v", err)
+		return
+	}
+
+	// Ignoring errors from domain.Free() is safe because it
+	// only fails if called multiple times or if the domain object
+	// is invalid, neither of which is the case here.
+	defer func() { _ = domain.Free() }()
+
+	guestInfo, err := domain.GetGuestInfo(types, 0)
+	if err != nil {
+		log.Log.Errorf("Fetching guest info failed: %v", err)
+		return
+	}
+
+	if types&libvirt.DOMAIN_GUEST_INFO_INTERFACES != 0 {
+		agentPoller.agentStore.Store(libvirt.DOMAIN_GUEST_INFO_INTERFACES, convertToInterfaces(guestInfo))
+	}
+
+	if types&libvirt.DOMAIN_GUEST_INFO_OS != 0 {
+		agentPoller.agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, convertToOSInfo(guestInfo))
+	}
+
+	if types&libvirt.DOMAIN_GUEST_INFO_HOSTNAME != 0 {
+		agentPoller.agentStore.Store(libvirt.DOMAIN_GUEST_INFO_HOSTNAME, guestInfo.Hostname)
+	}
+
+	if types&libvirt.DOMAIN_GUEST_INFO_TIMEZONE != 0 {
+		agentPoller.agentStore.Store(libvirt.DOMAIN_GUEST_INFO_TIMEZONE, convertToTimezone(guestInfo))
+	}
+
+	if types&libvirt.DOMAIN_GUEST_INFO_USERS != 0 {
+		agentPoller.agentStore.Store(libvirt.DOMAIN_GUEST_INFO_USERS, convertToUsers(guestInfo))
+	}
+}
+
+func convertToInterfaces(guestInfo *libvirt.DomainGuestInfo) []api.InterfaceStatus {
+	var interfaceStatuses []api.InterfaceStatus
+	if guestInfo.Interfaces != nil {
+		for _, netInterface := range guestInfo.Interfaces {
+			if netInterface.Name == "lo" {
+				continue
+			}
+
+			interfaceIP, interfaceIPs := convertToIPAddresses(netInterface.Addrs)
+			interfaceStatuses = append(interfaceStatuses, api.InterfaceStatus{
+				Mac:           netInterface.Hwaddr,
+				Ip:            interfaceIP,
+				IPs:           interfaceIPs,
+				InterfaceName: netInterface.Name,
+			})
+		}
+	}
+	return interfaceStatuses
+}
+
+func convertToIPAddresses(ipAddresses []libvirt.DomainGuestInfoIPAddress) (string, []string) {
+	var interfaceIPs []string
+	var interfaceIP string
+
+	for _, ipAddr := range ipAddresses {
+		ip := ipAddr.Addr
+
+		// Prefer ipv4 as the main interface IP
+		if ipAddr.Type == "ipv4" && interfaceIP == "" {
+			interfaceIP = ip
+		}
+
+		interfaceIPs = append(interfaceIPs, ip)
+	}
+
+	// If no ipv4 interface was found, set any IP as the main IP of interface
+	if interfaceIP == "" && len(interfaceIPs) > 0 {
+		interfaceIP = interfaceIPs[0]
+	}
+	return interfaceIP, interfaceIPs
+}
+
+func convertToOSInfo(guestInfo *libvirt.DomainGuestInfo) api.GuestOSInfo {
+	guestInfoOS := api.GuestOSInfo{}
+	if guestInfo.OS != nil {
+		guestInfoOS = api.GuestOSInfo{
+			Name:          guestInfo.OS.Name,
+			KernelRelease: guestInfo.OS.KernelRelease,
+			Version:       guestInfo.OS.Version,
+			PrettyName:    guestInfo.OS.PrettyName,
+			VersionId:     guestInfo.OS.VersionID,
+			KernelVersion: guestInfo.OS.KernelVersion,
+			Machine:       guestInfo.OS.Machine,
+			Id:            guestInfo.OS.ID,
+		}
+	}
+	return guestInfoOS
+}
+
+func convertToTimezone(guestInfo *libvirt.DomainGuestInfo) api.Timezone {
+	timezone := api.Timezone{}
+	if guestInfo.TimeZone != nil {
+		timezone = api.Timezone{
+			Zone:   guestInfo.TimeZone.Name,
+			Offset: guestInfo.TimeZone.Offset,
+		}
+	}
+	return timezone
+}
+
+func convertToUsers(guestInfo *libvirt.DomainGuestInfo) []api.User {
+	var users []api.User
+	if guestInfo.Users != nil {
+		for _, user := range guestInfo.Users {
+			users = append(users, api.User{
+				Name:      user.Name,
+				Domain:    user.Domain,
+				LoginTime: float64(user.LoginTime),
+			})
+		}
+	}
+	return users
 }

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -108,19 +108,16 @@ var _ = Describe("Qemu agent poller", func() {
 	})
 
 	Context("with AsyncAgentStore", func() {
-
 		It("should store and load the data", func() {
-			var agentStore = NewAsyncAgentStore()
 			agentVersion := AgentInfo{Version: "4.1"}
-			agentStore.Store(GET_AGENT, agentVersion)
+			agentStore.Store(GetAgent, agentVersion)
 			agent := agentStore.GetGA()
 
 			Expect(agent).To(Equal(agentVersion))
 		})
 
 		It("should fire an event for new fsfreezestatus", func() {
-			var agentStore = NewAsyncAgentStore()
-			agentStore.Store(GET_FSFREEZE_STATUS, fakeFSFreezeStatus)
+			agentStore.Store(GetFSFreezeStatus, fakeFSFreezeStatus)
 
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{
@@ -132,8 +129,7 @@ var _ = Describe("Qemu agent poller", func() {
 		})
 
 		It("should not fire an event for the same fsfreezestatus", func() {
-			var agentStore = NewAsyncAgentStore()
-			agentStore.Store(GET_FSFREEZE_STATUS, fakeFSFreezeStatus)
+			agentStore.Store(GetFSFreezeStatus, fakeFSFreezeStatus)
 
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{
@@ -143,12 +139,11 @@ var _ = Describe("Qemu agent poller", func() {
 				},
 			})))
 
-			agentStore.Store(GET_FSFREEZE_STATUS, fakeFSFreezeStatus)
+			agentStore.Store(GetFSFreezeStatus, fakeFSFreezeStatus)
 			Expect(agentStore.AgentUpdated).ToNot(Receive())
 		})
 
 		It("should fire an event for new sysinfo data", func() {
-			var agentStore = NewAsyncAgentStore()
 			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{OSInfo: &fakeInfo},
@@ -156,7 +151,6 @@ var _ = Describe("Qemu agent poller", func() {
 		})
 
 		It("should not fire an event for the same sysinfo data", func() {
-			var agentStore = NewAsyncAgentStore()
 			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{OSInfo: &fakeInfo},
@@ -167,7 +161,6 @@ var _ = Describe("Qemu agent poller", func() {
 		})
 
 		It("should fire an event with new updated key and old non updated keys", func() {
-			var agentStore = NewAsyncAgentStore()
 			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_INTERFACES, fakeInterfaces)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{
@@ -175,7 +168,7 @@ var _ = Describe("Qemu agent poller", func() {
 				},
 			})))
 
-			agentStore.Store(GET_FSFREEZE_STATUS, fakeFSFreezeStatus)
+			agentStore.Store(GetFSFreezeStatus, fakeFSFreezeStatus)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{
 					Interfaces:     fakeInterfaces,
@@ -194,14 +187,12 @@ var _ = Describe("Qemu agent poller", func() {
 		})
 
 		It("should report nil slice when no interfaces exists", func() {
-			var agentStore = NewAsyncAgentStore()
 			interfacesStatus := agentStore.GetInterfaceStatus()
 
 			Expect(interfacesStatus).To(BeNil())
 		})
 
 		It("should report interfaces info when interfaces exists", func() {
-			var agentStore = NewAsyncAgentStore()
 			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_INTERFACES, fakeInterfaces)
 			interfacesStatus := agentStore.GetInterfaceStatus()
 
@@ -209,14 +200,12 @@ var _ = Describe("Qemu agent poller", func() {
 		})
 
 		It("should report nil when no osInfo exists", func() {
-			var agentStore = NewAsyncAgentStore()
 			osInfo := agentStore.GetGuestOSInfo()
 
 			Expect(osInfo).To(BeNil())
 		})
 
 		It("should report osInfo when osInfo exists", func() {
-			var agentStore = NewAsyncAgentStore()
 			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			osInfo := agentStore.GetGuestOSInfo()
 

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -22,16 +22,24 @@ package agentpoller
 import (
 	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"libvirt.org/go/libvirt"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 )
 
 var _ = Describe("Qemu agent poller", func() {
 	var fakeInterfaces []api.InterfaceStatus
 	var fakeFSFreezeStatus api.FSFreeze
 	var fakeInfo api.GuestOSInfo
+	var agentStore AsyncAgentStore
+	var ctrl *gomock.Controller
+	var mockConnection *cli.MockConnection
+	var mockDomain *cli.MockVirDomain
 
 	BeforeEach(func() {
 		fakeInterfaces = []api.InterfaceStatus{
@@ -39,11 +47,9 @@ var _ = Describe("Qemu agent poller", func() {
 				Mac: "00:00:00:00:00:01",
 			},
 		}
-
 		fakeFSFreezeStatus = api.FSFreeze{
 			Status: "frozen",
 		}
-
 		fakeInfo = api.GuestOSInfo{
 			Name:          "TestGuestOSName",
 			KernelRelease: "1.1.0-Generic",
@@ -54,7 +60,53 @@ var _ = Describe("Qemu agent poller", func() {
 			Machine:       "x86_64",
 			Id:            "testguestos",
 		}
+		agentStore = NewAsyncAgentStore()
+		ctrl = gomock.NewController(GinkgoT())
+		mockConnection = cli.NewMockConnection(ctrl)
+		mockDomain = cli.NewMockVirDomain(ctrl)
+		mockConnection.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil).AnyTimes()
 	})
+
+	Context("with libvirt API", func() {
+		It("should store the retrieved guest info when requested", func() {
+			guestInfo := &libvirt.DomainGuestInfo{
+				Interfaces: []libvirt.DomainGuestInfoInterface{{Name: "net0"}},
+				OS:         &libvirt.DomainGuestInfoOS{Name: "fedora"},
+				Hostname:   "test-host",
+				TimeZone:   &libvirt.DomainGuestInfoTimeZone{Name: "EST"},
+				Users:      []libvirt.DomainGuestInfoUser{{Name: "admin"}},
+			}
+			agentPoller := &AgentPoller{
+				Connection: mockConnection,
+				domainName: "fake",
+				agentStore: &agentStore,
+			}
+			libvirtTypes := libvirt.DOMAIN_GUEST_INFO_INTERFACES |
+				libvirt.DOMAIN_GUEST_INFO_OS |
+				libvirt.DOMAIN_GUEST_INFO_HOSTNAME |
+				libvirt.DOMAIN_GUEST_INFO_TIMEZONE |
+				libvirt.DOMAIN_GUEST_INFO_USERS
+
+			mockDomain.EXPECT().Free()
+			mockDomain.EXPECT().GetGuestInfo(libvirtTypes, uint32(0)).Return(guestInfo, nil)
+
+			fetchAndStoreGuestInfo(libvirtTypes, agentPoller)
+
+			interfacesStatus := agentStore.GetInterfaceStatus()
+			Expect(interfacesStatus[0].InterfaceName).To(Equal("net0"))
+
+			osInfo := agentStore.GetGuestOSInfo()
+			Expect(osInfo.Name).To(Equal("fedora"))
+
+			sysInfo := agentStore.GetSysInfo()
+			Expect(sysInfo.Hostname).To(Equal("test-host"))
+			Expect(sysInfo.Timezone.Zone).To(Equal("EST"))
+
+			users := agentStore.GetUsers(1)
+			Expect(users[0].Name).To(Equal("admin"))
+		})
+	})
+
 	Context("with AsyncAgentStore", func() {
 
 		It("should store and load the data", func() {
@@ -97,7 +149,7 @@ var _ = Describe("Qemu agent poller", func() {
 
 		It("should fire an event for new sysinfo data", func() {
 			var agentStore = NewAsyncAgentStore()
-			agentStore.Store(GET_OSINFO, fakeInfo)
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{OSInfo: &fakeInfo},
 			})))
@@ -105,18 +157,18 @@ var _ = Describe("Qemu agent poller", func() {
 
 		It("should not fire an event for the same sysinfo data", func() {
 			var agentStore = NewAsyncAgentStore()
-			agentStore.Store(GET_OSINFO, fakeInfo)
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{OSInfo: &fakeInfo},
 			})))
 
-			agentStore.Store(GET_OSINFO, fakeInfo)
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			Expect(agentStore.AgentUpdated).ToNot(Receive())
 		})
 
 		It("should fire an event with new updated key and old non updated keys", func() {
 			var agentStore = NewAsyncAgentStore()
-			agentStore.Store(GET_INTERFACES, fakeInterfaces)
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_INTERFACES, fakeInterfaces)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{
 					Interfaces: fakeInterfaces,
@@ -131,7 +183,7 @@ var _ = Describe("Qemu agent poller", func() {
 				},
 			})))
 
-			agentStore.Store(GET_OSINFO, fakeInfo)
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			Expect(agentStore.AgentUpdated).To(Receive(Equal(AgentUpdatedEvent{
 				DomainInfo: api.DomainGuestInfo{
 					Interfaces:     fakeInterfaces,
@@ -150,7 +202,7 @@ var _ = Describe("Qemu agent poller", func() {
 
 		It("should report interfaces info when interfaces exists", func() {
 			var agentStore = NewAsyncAgentStore()
-			agentStore.Store(GET_INTERFACES, fakeInterfaces)
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_INTERFACES, fakeInterfaces)
 			interfacesStatus := agentStore.GetInterfaceStatus()
 
 			Expect(interfacesStatus).To(Equal(fakeInterfaces))
@@ -165,7 +217,7 @@ var _ = Describe("Qemu agent poller", func() {
 
 		It("should report osInfo when osInfo exists", func() {
 			var agentStore = NewAsyncAgentStore()
-			agentStore.Store(GET_OSINFO, fakeInfo)
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 			osInfo := agentStore.GetGuestOSInfo()
 
 			Expect(*osInfo).To(Equal(fakeInfo))
@@ -212,7 +264,7 @@ var _ = Describe("Qemu agent poller", func() {
 // The operation is limited by the provided or self calculated timeout and the expected executions.
 // The timeout needs to be large enough to allow the expected executions to occur and to accommodate the
 // inaccuracy of the go-routine execution.
-func runPollAndCountCommandExecution(interval, expectedExecutions int, timeout time.Duration, initialInterval time.Duration) int {
+func runPollAndCountCommandExecution(interval, expectedExecutions int, timeout, initialInterval time.Duration) int {
 	const fakeAgentCommandName = "foo"
 	w := PollerWorker{
 		CallTick:      time.Duration(interval),
@@ -224,7 +276,7 @@ func runPollAndCountCommandExecution(interval, expectedExecutions int, timeout t
 	defer close(c)
 	done := make(chan struct{})
 
-	go w.Poll(func(commands []AgentCommand) { done <- struct{}{} }, c, initialInterval)
+	go w.Poll(func() { done <- struct{}{} }, c, initialInterval)
 
 	if timeout == 0 {
 		// Calculate the time needed for the poll to execute the commands.

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -523,6 +523,17 @@ func (_mr *_MockVirDomainRecorder) GetJobInfo() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetJobInfo")
 }
 
+func (_m *MockVirDomain) GetGuestInfo(types libvirt.DomainGuestInfoTypes, flags uint32) (*libvirt.DomainGuestInfo, error) {
+	ret := _m.ctrl.Call(_m, "GetGuestInfo", types, flags)
+	ret0, _ := ret[0].(*libvirt.DomainGuestInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirDomainRecorder) GetGuestInfo(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGuestInfo", arg0, arg1)
+}
+
 func (_m *MockVirDomain) GetDiskErrors(flags uint32) ([]libvirt.DomainDiskError, error) {
 	ret := _m.ctrl.Call(_m, "GetDiskErrors", flags)
 	ret0, _ := ret[0].([]libvirt.DomainDiskError)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -525,6 +525,7 @@ type VirDomain interface {
 	MemoryStats(nrStats uint32, flags uint32) ([]libvirt.DomainMemoryStat, error)
 	GetJobStats(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error)
 	GetJobInfo() (*libvirt.DomainJobInfo, error)
+	GetGuestInfo(types libvirt.DomainGuestInfoTypes, flags uint32) (*libvirt.DomainGuestInfo, error)
 	GetDiskErrors(flags uint32) ([]libvirt.DomainDiskError, error)
 	SetTime(secs int64, nsecs uint, flags libvirt.DomainSetTimeFlags) error
 	AuthorizedSSHKeysSet(user string, keys []string, flags libvirt.DomainAuthorizedSSHKeysFlags) error

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1716,7 +1716,7 @@ func (l *LibvirtDomainManager) cancelSafetyUnfreeze() {
 }
 
 func (l *LibvirtDomainManager) getParsedFSStatus(domainName string) (string, error) {
-	cmdResult, err := l.virConn.QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, domainName)
+	cmdResult, err := l.virConn.QemuAgentCommand(`{"execute":"`+string(agentpoller.GetFSFreezeStatus)+`"}`, domainName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -582,7 +582,7 @@ var _ = Describe("Manager", func() {
 		It("should freeze a VirtualMachineInstance", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
+			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GetFSFreezeStatus)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, testDomainName).Return("1", nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes)
 
@@ -602,7 +602,7 @@ var _ = Describe("Manager", func() {
 		It("should unfreeze a VirtualMachineInstance", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
+			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GetFSFreezeStatus)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, testDomainName).Return("1", nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes)
 
@@ -611,9 +611,9 @@ var _ = Describe("Manager", func() {
 		It("should automatically unfreeze after a timeout a frozen VirtualMachineInstance", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
+			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GetFSFreezeStatus)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, testDomainName).Return("1", nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
+			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GetFSFreezeStatus)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, testDomainName).Return("1", nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes)
 
@@ -625,9 +625,9 @@ var _ = Describe("Manager", func() {
 		It("should freeze and unfreeze a VirtualMachineInstance without a trigger to the unfreeze timeout", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
+			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GetFSFreezeStatus)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, testDomainName).Return("1", nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
+			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GetFSFreezeStatus)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, testDomainName).Return("1", nil)
 
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes)
@@ -2328,7 +2328,7 @@ var _ = Describe("Manager", func() {
 				LoginTime: 0,
 			},
 		})
-		agentStore.Store(agentpoller.GET_FILESYSTEM, []api.Filesystem{
+		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2391,7 +2391,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes GetFilesystems", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GET_FILESYSTEM, []api.Filesystem{
+		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2418,7 +2418,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes generateCloudInitEmptyISO and succeeds", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GET_FILESYSTEM, []api.Filesystem{
+		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2464,7 +2464,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes generateCloudInitEmptyISO and fails", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GET_FILESYSTEM, []api.Filesystem{
+		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2239,7 +2239,7 @@ var _ = Describe("Manager", func() {
 				fakeInfo := api.GuestOSInfo{
 					Name: "TestGuestOSName",
 				}
-				agentStore.Store(agentpoller.GET_OSINFO, fakeInfo)
+				agentStore.Store(libvirt.DOMAIN_GUEST_INFO_OS, fakeInfo)
 
 				osInfo := libvirtmanager.GetGuestOSInfo()
 				Expect(*osInfo).To(Equal(fakeInfo))
@@ -2264,7 +2264,7 @@ var _ = Describe("Manager", func() {
 					InterfaceName: "eth1",
 					Mac:           "00:00:00:00:00:01",
 				}}
-				agentStore.Store(agentpoller.GET_INTERFACES, fakeInterfaces)
+				agentStore.Store(libvirt.DOMAIN_GUEST_INFO_INTERFACES, fakeInterfaces)
 				interfacesStatus := agentStore.GetInterfaceStatus()
 
 				Expect(interfacesStatus).To(Equal(fakeInterfaces))
@@ -2321,7 +2321,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes GetGuestInfo", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GET_USERS, []api.User{
+		agentStore.Store(libvirt.DOMAIN_GUEST_INFO_USERS, []api.User{
 			{
 				Name:      "test",
 				Domain:    "test",
@@ -2372,7 +2372,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes GetUsers", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GET_USERS, []api.User{
+		agentStore.Store(libvirt.DOMAIN_GUEST_INFO_USERS, []api.User{
 			{
 				Name:      "test",
 				Domain:    "test",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Replace guest agent commands with libvirt
API requests using Domain.GetGuestInfo,
to get and set Network Interfaces, Operating
System Info, Hostname, TimeZone, and
Users.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```