### PR TITLE
cleanup(virtctl): Follow ups to deprecation of optional type in virtctl port-forward

### DIFF
--- a/pkg/virtctl/portforward/portforward.go
+++ b/pkg/virtctl/portforward/portforward.go
@@ -222,13 +222,7 @@ func examples() string {
 
   # Note: {{ProgramName}} port-forward sends all traffic over the Kubernetes API Server. 
   # This means any traffic will add additional pressure to the control plane.
-  # For continous traffic intensive connections, consider using a dedicated Kubernetes Service.
-
-  # Open an SSH connection using PortForward and ProxyCommand:
-  ssh -o 'ProxyCommand={{ProgramName}} port-forward --stdio=true testvmi.mynamespace 22' user@testvmi.mynamespace
-
-  # Use as SCP ProxyCommand:
-  scp -o 'ProxyCommand={{ProgramName}} port-forward --stdio=true testvmi.mynamespace 22' local.file user@testvmi.mynamespace`
+  # For continous traffic intensive connections, consider using a dedicated Kubernetes Service.`
 }
 
 // ParseTarget argument supporting the form of vmi/name.namespace (or simpler)

--- a/pkg/virtctl/scp/scp_test.go
+++ b/pkg/virtctl/scp/scp_test.go
@@ -16,7 +16,7 @@ var _ = Describe("SCP", func() {
 		Expect(toRemote).To(Equal(expToRemote))
 	},
 		Entry("copy to remote location",
-			"myfile.yaml", "cirros@remote.mynamespace:myfile.yaml",
+			"myfile.yaml", "cirros@vmi/remote.mynamespace:myfile.yaml",
 			&scp.LocalArgument{Path: "myfile.yaml"},
 			&scp.RemoteArgument{
 				Kind: "vmi", Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",
@@ -24,7 +24,7 @@ var _ = Describe("SCP", func() {
 			true,
 		),
 		Entry("copy from remote location",
-			"cirros@remote.mynamespace:myfile.yaml", "myfile.yaml",
+			"cirros@vmi/remote.mynamespace:myfile.yaml", "myfile.yaml",
 			&scp.LocalArgument{Path: "myfile.yaml"},
 			&scp.RemoteArgument{
 				Kind: "vmi", Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -843,7 +843,7 @@ func runSSHCommand(namespace, name, user, keyFile string) {
 		"-t", "-o StrictHostKeyChecking=no",
 		"-t", "-o UserKnownHostsFile=/dev/null",
 		"--command", "true",
-		name,
+		"vm/"+name,
 	)
 	Expect(err).ToNot(HaveOccurred())
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

These are cleanups discovered after https://github.com/kubevirt/kubevirt/pull/13918 was already merged.

Discourage the use of virtctl with tthe SSH/SCP ProxyCommand to avoid
situations where syntaxes might break for users. The preferred way is to
let virtctl generate the ProxyCommand and to wrap SSH/SCP clients.

Also, clean up tests of virtctl by adding the type in calls to
ParseTarget and to virtctl itself where it is missing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

