### PR TITLE
VAP: return a consistent reason for failures

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
+++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicy.go
@@ -152,26 +152,32 @@ func NewHandlerV1ValidatingAdmissionPolicy(virtHandlerServiceAccount string) *ad
 				{
 					Expression: "object.spec == oldObject.spec",
 					Message:    NodeRestrictionErrModifySpec,
+					Reason:     pointer.P(metav1.StatusReasonForbidden),
 				},
 				{
 					Expression: `oldObject.metadata.filter(k, k != "labels" && k != "annotations" && k != "managedFields" && k != "resourceVersion").all(k, k in object.metadata) && object.metadata.filter(k, k != "labels" && k != "annotations" && k != "managedFields" && k != "resourceVersion").all(k, k in oldObject.metadata && oldObject.metadata[k] == object.metadata[k])`,
 					Message:    NodeRestrictionErrChangeMetadataFields,
+					Reason:     pointer.P(metav1.StatusReasonForbidden),
 				},
 				{
 					Expression: `size(variables.newNonKubevirtLabels) == size(variables.oldNonKubevirtLabels)`,
 					Message:    NodeRestrictionErrAddDeleteLabels,
+					Reason:     pointer.P(metav1.StatusReasonForbidden),
 				},
 				{
 					Expression: `variables.newNonKubevirtLabels.all(k, k in variables.oldNonKubevirtLabels && variables.newLabels[k] == variables.oldLabels[k])`,
 					Message:    NodeRestrictionErrUpdateLabels,
+					Reason:     pointer.P(metav1.StatusReasonForbidden),
 				},
 				{
 					Expression: `size(variables.newNonKubevirtAnnotations) == size(variables.oldNonKubevirtAnnotations)`,
 					Message:    NodeRestrictionErrAddDeleteAnnotations,
+					Reason:     pointer.P(metav1.StatusReasonForbidden),
 				},
 				{
 					Expression: `variables.newNonKubevirtAnnotations.all(k, k in variables.oldNonKubevirtAnnotations && variables.newAnnotations[k] == variables.oldAnnotations[k])`,
 					Message:    NodeRestrictionErrUpdateAnnotations,
+					Reason:     pointer.P(metav1.StatusReasonForbidden),
 				},
 			},
 		},

--- a/tests/validatingadmissionpolicy/BUILD.bazel
+++ b/tests/validatingadmissionpolicy/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//tests/libnode:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",

--- a/tests/validatingadmissionpolicy/noderestrictions.go
+++ b/tests/validatingadmissionpolicy/noderestrictions.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -147,6 +148,7 @@ var _ = Describe("[sig-compute] virt-handler node restrictions via validatingAdm
 			Expect(err).ToNot(HaveOccurred())
 			_, err = handlerClient.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.JSONPatchType, nodePatch, metav1.PatchOptions{})
 			Expect(err).To(HaveOccurred(), fmt.Sprintf("%s should fail on node specific node restriction", description))
+			Expect(err).To(MatchError(errors.IsForbidden, "k8serrors.IsForbidden"))
 			Expect(err.Error()).To(ContainSubstring(patchItem.expectedError), fmt.Sprintf("%s should match specific error", description))
 		}
 	})


### PR DESCRIPTION
### What this PR does
Before this PR:
`kubevirt-node-restriction-policy` Validating Admission Policy was always returning the default failure reason (`Invalid`) when the virt-handler SA was used to try to amend some aspect of node object that it should not be able to edit.
The received object are likely valid so `Invalid` could be misleading.

After this PR:
Since we are for sure failing due to a lack of permissions, `Forbidden` reasons (`the server can be reached and understood the request, but refuses to take any further action. It is the result of the server being configured to deny access for some reason to the requested resource by the client`) are more appropriate.

### Why we need it and why it was done in this way
The following tradeoffs were made:
None

The following alternatives were considered:
None

### Special notes for your reviewer
It's only for the sake of consistency, I don't expect any harmful side effect.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The node-restriction Validating Admission Policy will return consistent reasons on failures
```

