### PR TITLE
NIC hotunplug: Rm plumbing after detachment from domain

### DIFF
--- a/pkg/network/setup/filters_test.go
+++ b/pkg/network/setup/filters_test.go
@@ -119,14 +119,17 @@ var _ = Describe("Network setup filters", func() {
 			Expect(network.FilterNetsForLiveUpdate(vmi)).To(Equal([]v1.Network{*libvmi.MultusNetwork(net2Name, nad2Name)}))
 		})
 
-		It("Should return a network to hotunplug when its interface is marked as absent", func() {
-			absentIface := libvmi.InterfaceDeviceWithBridgeBinding(net1Name)
-			absentIface.State = v1.InterfaceStateAbsent
+		It("Should return a network to hotunplug when its interface is marked as absent and not in the domain", func() {
+			absentIface1 := libvmi.InterfaceDeviceWithBridgeBinding(net1Name)
+			absentIface1.State = v1.InterfaceStateAbsent
+
+			absentIface2 := libvmi.InterfaceDeviceWithBridgeBinding(net2Name)
+			absentIface2.State = v1.InterfaceStateAbsent
 
 			vmi := libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(absentIface),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(net2Name)),
+				libvmi.WithInterface(absentIface1),
+				libvmi.WithInterface(absentIface2),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net1Name, nad1Name)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net2Name, nad2Name)),
@@ -138,7 +141,7 @@ var _ = Describe("Network setup filters", func() {
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
 							Name:       net1Name,
-							InfoSource: multusAndDomainInfoSource,
+							InfoSource: vmispec.InfoSourceMultusStatus,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
 							Name:       net2Name,
@@ -170,7 +173,7 @@ var _ = Describe("Network setup filters", func() {
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
 							Name:       net1Name,
-							InfoSource: multusAndDomainInfoSource,
+							InfoSource: vmispec.InfoSourceMultusStatus,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
 							Name:       net2Name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, when performing a NIC hotunplug operation, virt-handler removes the network plumbing prior to virt-launcher detaching the interface from the domain.

Adjust the virt-handler's filtering logic to only unplug networks whose interfaces were already detached from the domain.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially addresses #13721

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/issues/13721

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

