### PR TITLE
Truncate large volume names in export pod 

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -788,6 +788,15 @@ func (ctrl *VMExportController) getExportPodName(vmExport *exportv1.VirtualMachi
 	return naming.GetName(exportPrefix, vmExport.Name, validation.DNS1035LabelMaxLength)
 }
 
+func (ctrl *VMExportController) getExportPodVolumeName(pvc *corev1.PersistentVolumeClaim) string {
+	pvcName := strings.ReplaceAll(pvc.Name, ".", "-")
+	// Using the formatted PVC name if it's under the max length.
+	if len(pvcName) <= validation.DNS1035LabelMaxLength {
+		return pvcName
+	}
+	return naming.GetName(exportPrefix, pvcName, validation.DNS1035LabelMaxLength)
+}
+
 // getExportLabelValue will return the virtual machine's name if it is under the
 // DNS1035-specified max length, or a normalized name otherwise.
 func (ctrl *VMExportController) getExportLabelValue(vmExport *exportv1.VirtualMachineExport) string {
@@ -921,7 +930,7 @@ func (ctrl *VMExportController) createExporterPodManifest(vmExport *exportv1.Vir
 	}
 	for i, pvc := range pvcs {
 		var mountPoint string
-		volumeName := strings.ReplaceAll(pvc.Name, ".", "-")
+		volumeName := ctrl.getExportPodVolumeName(pvc)
 		if types.IsPVCBlock(pvc.Spec.VolumeMode) {
 			mountPoint = fmt.Sprintf("%s/%s", blockVolumeMountPath, volumeName)
 			podManifest.Spec.Containers[0].VolumeDevices = append(podManifest.Spec.Containers[0].VolumeDevices, corev1.VolumeDevice{

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -954,6 +954,65 @@ var _ = Describe("Export controller", func() {
 		Entry("Snapshot", populateVmExportVMSnapshot, controller.getPVCFromSourceVMSnapshot, 4),
 	)
 
+	DescribeTable("Volumemount names should be trimmed depending on the PVC name", func(pvcName string) {
+		testVMExport := createPVCVMExportWithName(pvcName)
+		testPVC := &k8sv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: testNamespace,
+			},
+			Spec: k8sv1.PersistentVolumeClaimSpec{
+				VolumeMode: (*k8sv1.PersistentVolumeMode)(pointer.P(string(k8sv1.PersistentVolumeBlock))),
+			},
+		}
+		populateInitialVMExportStatus(testVMExport)
+		err := controller.handleVMExportToken(testVMExport, controller.getPVCFromSourceVMSnapshot)
+		Expect(testVMExport.Status.TokenSecretRef).ToNot(BeNil())
+		Expect(err).ToNot(HaveOccurred())
+		k8sClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			pod, ok := create.GetObject().(*k8sv1.Pod)
+			Expect(ok).To(BeTrue())
+			Expect(pod.GetName()).To(Equal(controller.getExportPodName(testVMExport)))
+			Expect(len(pod.GetName())).To(BeNumerically("<=", validation.DNS1035LabelMaxLength))
+			Expect(pod.GetNamespace()).To(Equal(testNamespace))
+			return true, pod, nil
+		})
+		var service *k8sv1.Service
+		k8sClient.Fake.PrependReactor("create", "services", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			service, ok = create.GetObject().(*k8sv1.Service)
+			Expect(ok).To(BeTrue())
+			service.Status.Conditions = make([]metav1.Condition, 1)
+			service.Status.Conditions[0].Type = "test"
+			Expect(service.GetName()).To(Equal(controller.getExportServiceName(testVMExport)))
+			Expect(service.GetNamespace()).To(Equal(testNamespace))
+			return true, service, nil
+		})
+		service, err = controller.getOrCreateExportService(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		pod, err := controller.createExporterPod(testVMExport, service, []*k8sv1.PersistentVolumeClaim{testPVC})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod).ToNot(BeNil())
+		Expect(pod.Spec.Containers).To(HaveLen(1))
+		Expect(pod.Spec.Containers[0].VolumeDevices).To(HaveLen(1))
+		Expect(pod.Spec.Containers[0].VolumeDevices).To(ContainElement(k8sv1.VolumeDevice{
+			Name:       controller.getExportPodVolumeName(testPVC),
+			DevicePath: fmt.Sprintf("%s/%s", blockVolumeMountPath, controller.getExportPodVolumeName(testPVC)),
+		}))
+		if len(pvcName) > validation.DNS1035LabelMaxLength {
+			Expect(len(pod.Spec.Containers[0].VolumeDevices[0].Name)).To(BeNumerically("<", 63))
+		} else {
+			Expect(pod.Spec.Containers[0].VolumeDevices[0].Name).To(Equal(pvcName))
+		}
+	},
+		Entry("PVC name within limit", "pvc-name-within-limit"),
+		Entry("PVC name exceeding limit", strings.Repeat("a", validation.DNS1035LabelMaxLength+1)),
+		Entry("PVC name with same length as limit", strings.Repeat("a", validation.DNS1035LabelMaxLength)),
+	)
+
 	It("Should create a secret based on the vm export", func() {
 		cp := &CertParams{Duration: 24 * time.Hour, RenewBefore: 2 * time.Hour}
 		scp, err := serializeCertParams(cp)

--- a/pkg/storage/utils/BUILD.bazel
+++ b/pkg/storage/utils/BUILD.bazel
@@ -10,8 +10,10 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/openshift/library-go/pkg/build/naming:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
     ],
 )
 
@@ -29,5 +31,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/storage/utils/volumes.go
+++ b/pkg/storage/utils/volumes.go
@@ -25,8 +25,11 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/openshift/library-go/pkg/build/naming"
+
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	validation "k8s.io/apimachinery/pkg/util/validation"
 	v1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/kubecli"
@@ -168,7 +171,7 @@ func createBackendPVCVolume(pvcName, vmName string) *v1.Volume {
 // BackendPVCVolumeName return the name of the volume that will be arbitrarily used to represent
 // the backend PVC during volume enumeration.
 func BackendPVCVolumeName(vmName string) string {
-	return fmt.Sprintf("%s-%s", backendstorage.PVCPrefix, vmName)
+	return naming.GetName(backendstorage.PVCPrefix, vmName, validation.DNS1035LabelMaxLength)
 }
 
 // Helper function to select the newest non-terminating PVC

--- a/pkg/storage/utils/volumes_test.go
+++ b/pkg/storage/utils/volumes_test.go
@@ -20,8 +20,11 @@
 package utils
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -32,8 +35,11 @@ var _ = Describe("GetVolumes", func() {
 
 	const backendVolume = "persistent-state-for-"
 
-	createVMI := func(hasEFI, hasTPM bool) *v1.VirtualMachineInstance {
+	createVMI := func(hasEFI, hasTPM bool, name string) *v1.VirtualMachineInstance {
 		vmi := &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
 			Spec: v1.VirtualMachineInstanceSpec{
 				Volumes: []v1.Volume{
 					{Name: "rootdisk"},
@@ -52,7 +58,7 @@ var _ = Describe("GetVolumes", func() {
 			Status: v1.VirtualMachineInstanceStatus{
 				VolumeStatus: []v1.VolumeStatus{
 					{
-						Name: backendVolume,
+						Name: backendVolume + name,
 					},
 				},
 			},
@@ -75,7 +81,7 @@ var _ = Describe("GetVolumes", func() {
 
 	DescribeTable("should handle volume exclusions based on flags",
 		func(hasEFI, hasTPM bool, expectedVolumes []string, opts ...VolumeOption) {
-			vmi := createVMI(hasEFI, hasTPM)
+			vmi := createVMI(hasEFI, hasTPM, "")
 			client := kubecli.NewMockKubevirtClient(nil) // Mock client for testing
 			volumes, _ := GetVolumes(vmi, client, opts...)
 
@@ -120,4 +126,13 @@ var _ = Describe("GetVolumes", func() {
 			WithAllVolumes,
 		),
 	)
+
+	It("should trim backend volume name", func() {
+		vmi := createVMI(true, true, strings.Repeat("a", 63))
+		client := kubecli.NewMockKubevirtClient(nil)
+		volumes, err := GetVolumes(vmi, client, WithBackendVolume)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(volumes).To(HaveLen(1))
+		Expect(len(volumes[0].Name)).To(BeNumerically("<", 63))
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

We've been using unsanitized volume names in the exporter pod which could exceed 63 characters, causing pod validation failures.

This PR adds sanitization to trim volume names when necessary. It also trims the backend storage PVC volume name in the volume-enumeration helpers as a precaution.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-56635

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Truncate volume names in export pod
```

