### PR TITLE
Fix(12982) - Refactor `decodeControllerRevisionObject()` to Use Delegated Type Handling

### DIFF
--- a/pkg/instancetype/compatibility/compatibility.go
+++ b/pkg/instancetype/compatibility/compatibility.go
@@ -88,56 +88,99 @@ func decodeControllerRevisionObject(revision *appsv1.ControllerRevision) error {
 	case *v1beta1.VirtualMachineInstancetype, *v1beta1.VirtualMachineClusterInstancetype, *v1beta1.VirtualMachinePreference, *v1beta1.VirtualMachineClusterPreference:
 		return nil
 	case *v1alpha2.VirtualMachineInstancetype:
-		dest := &v1beta1.VirtualMachineInstancetype{}
-		if err := v1alpha2.Convert_v1alpha2_VirtualMachineInstancetype_To_v1beta1_VirtualMachineInstancetype(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachineInstancetype(obj, revision)
 	case *v1alpha2.VirtualMachineClusterInstancetype:
-		dest := &v1beta1.VirtualMachineClusterInstancetype{}
-		if err := v1alpha2.Convert_v1alpha2_VirtualMachineClusterInstancetype_To_v1beta1_VirtualMachineClusterInstancetype(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachineClusterInstancetype(obj, revision)
 	case *v1alpha2.VirtualMachinePreference:
-		dest := &v1beta1.VirtualMachinePreference{}
-		if err := v1alpha2.Convert_v1alpha2_VirtualMachinePreference_To_v1beta1_VirtualMachinePreference(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachinePreference(obj, revision)
 	case *v1alpha2.VirtualMachineClusterPreference:
-		dest := &v1beta1.VirtualMachineClusterPreference{}
-		if err := v1alpha2.Convert_v1alpha2_VirtualMachineClusterPreference_To_v1beta1_VirtualMachineClusterPreference(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachineClusterPreference(obj, revision)
 	case *v1alpha1.VirtualMachineInstancetype:
-		dest := &v1beta1.VirtualMachineInstancetype{}
-		if err := v1alpha1.Convert_v1alpha1_VirtualMachineInstancetype_To_v1beta1_VirtualMachineInstancetype(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachineInstancetype(obj, revision)
 	case *v1alpha1.VirtualMachineClusterInstancetype:
-		dest := &v1beta1.VirtualMachineClusterInstancetype{}
-		if err := v1alpha1.Convert_v1alpha1_VirtualMachineClusterInstancetype_To_v1beta1_VirtualMachineClusterInstancetype(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachineClusterInstancetype(obj, revision)
 	case *v1alpha1.VirtualMachinePreference:
-		dest := &v1beta1.VirtualMachinePreference{}
-		if err := v1alpha1.Convert_v1alpha1_VirtualMachinePreference_To_v1beta1_VirtualMachinePreference(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachinePreference(obj, revision)
 	case *v1alpha1.VirtualMachineClusterPreference:
-		dest := &v1beta1.VirtualMachineClusterPreference{}
-		if err := v1alpha1.Convert_v1alpha1_VirtualMachineClusterPreference_To_v1beta1_VirtualMachineClusterPreference(obj, dest, nil); err != nil {
-			return err
-		}
-		revision.Data.Object = dest
+		return convertVirtualMachineClusterPreference(obj, revision)
 	default:
 		return fmt.Errorf("unexpected type in ControllerRevision: %T", obj)
 	}
+}
+
+func convertVirtualMachineInstancetype(obj interface{}, revision *appsv1.ControllerRevision) error {
+	dest := &v1beta1.VirtualMachineInstancetype{}
+
+	switch v := obj.(type) {
+	case *v1alpha2.VirtualMachineInstancetype:
+		if err := v1alpha2.Convert_v1alpha2_VirtualMachineInstancetype_To_v1beta1_VirtualMachineInstancetype(v, dest, nil); err != nil {
+			return err
+		}
+	case *v1alpha1.VirtualMachineInstancetype:
+		if err := v1alpha1.Convert_v1alpha1_VirtualMachineInstancetype_To_v1beta1_VirtualMachineInstancetype(v, dest, nil); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unexpected type for VirtualMachineInstancetype conversion: %T", v)
+	}
+	revision.Data.Object = dest
+	return nil
+}
+
+func convertVirtualMachineClusterInstancetype(obj interface{}, revision *appsv1.ControllerRevision) error {
+	dest := &v1beta1.VirtualMachineClusterInstancetype{}
+
+	switch v := obj.(type) {
+	case *v1alpha2.VirtualMachineClusterInstancetype:
+		if err := v1alpha2.Convert_v1alpha2_VirtualMachineClusterInstancetype_To_v1beta1_VirtualMachineClusterInstancetype(v, dest, nil); err != nil {
+			return err
+		}
+	case *v1alpha1.VirtualMachineClusterInstancetype:
+		if err := v1alpha1.Convert_v1alpha1_VirtualMachineClusterInstancetype_To_v1beta1_VirtualMachineClusterInstancetype(v, dest, nil); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unexpected type for VirtualMachineClusterInstancetype conversion: %T", v)
+	}
+	revision.Data.Object = dest
+	return nil
+}
+
+func convertVirtualMachinePreference(obj interface{}, revision *appsv1.ControllerRevision) error {
+	dest := &v1beta1.VirtualMachinePreference{}
+
+	switch v := obj.(type) {
+	case *v1alpha2.VirtualMachinePreference:
+		if err := v1alpha2.Convert_v1alpha2_VirtualMachinePreference_To_v1beta1_VirtualMachinePreference(v, dest, nil); err != nil {
+			return err
+		}
+	case *v1alpha1.VirtualMachinePreference:
+		if err := v1alpha1.Convert_v1alpha1_VirtualMachinePreference_To_v1beta1_VirtualMachinePreference(v, dest, nil); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unexpected type for VirtualMachinePreference conversion: %T", v)
+	}
+	revision.Data.Object = dest
+	return nil
+}
+
+func convertVirtualMachineClusterPreference(obj interface{}, revision *appsv1.ControllerRevision) error {
+	dest := &v1beta1.VirtualMachineClusterPreference{}
+
+	switch v := obj.(type) {
+	case *v1alpha2.VirtualMachineClusterPreference:
+		if err := v1alpha2.Convert_v1alpha2_VirtualMachineClusterPreference_To_v1beta1_VirtualMachineClusterPreference(v, dest, nil); err != nil {
+			return err
+		}
+	case *v1alpha1.VirtualMachineClusterPreference:
+		if err := v1alpha1.Convert_v1alpha1_VirtualMachineClusterPreference_To_v1beta1_VirtualMachineClusterPreference(v, dest, nil); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unexpected type for VirtualMachineClusterPreference conversion: %T", v)
+	}
+	revision.Data.Object = dest
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Fixes #12982 

### Why we need it and why it was done in this way

This PR introduces a delegated type handling approach to streamline and optimize the decoding and type conversion logic in the decodeControllerRevisionObject function. The aim is to avoid repetitive switch conditionals while maintaining flexibility for future scalability. By leveraging helper functions to handle type-specific conversions, the code is now more modular, readable, and easier to extend as new types or versions are introduced.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

