### PR TITLE
Replace all the patch operations in pkg/virt-operator/resource/apply/delete.go with the patchset

### DIFF
--- a/pkg/virt-operator/resource/apply/delete.go
+++ b/pkg/virt-operator/resource/apply/delete.go
@@ -21,7 +21,6 @@ package apply
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -634,12 +633,13 @@ func crdHandleDeletion(kvkey string,
 		crdCopy := crd.DeepCopy()
 		controller.AddFinalizer(crdCopy, v1.VirtOperatorComponentFinalizer)
 
-		patchBytes, err := json.Marshal(crdCopy.Finalizers)
+		patchBytes, err := patch.New(
+			patch.WithAdd(finalizerPath, crdCopy.Finalizers),
+		).GeneratePayload()
 		if err != nil {
 			return err
 		}
-		ops := fmt.Sprintf(`[{ "op": "add", "path": "%s", "value": %s }]`, finalizerPath, string(patchBytes))
-		_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, []byte(ops), metav1.PatchOptions{})
+		_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
@@ -661,31 +661,23 @@ func crdHandleDeletion(kvkey string,
 	}
 
 	for _, crd := range needFinalizerRemoved {
-		var ops string
+		patchset := patch.New()
 		if len(crd.Finalizers) > 1 {
 			crdCopy := crd.DeepCopy()
 			controller.RemoveFinalizer(crdCopy, v1.VirtOperatorComponentFinalizer)
-
-			newPatchBytes, err := json.Marshal(crdCopy.Finalizers)
-			if err != nil {
-				return err
-			}
-
-			oldPatchBytes, err := json.Marshal(crd.Finalizers)
-			if err != nil {
-				return err
-			}
-
-			ops = fmt.Sprintf(`[{ "op": "test", "path": "%s", "value": %s }, { "op": "replace", "path": "%s", "value": %s }]`,
-				finalizerPath,
-				string(oldPatchBytes),
-				finalizerPath,
-				string(newPatchBytes))
+			patchset.AddOption(
+				patch.WithTest(finalizerPath, crd.Finalizers),
+				patch.WithReplace(finalizerPath, crdCopy.Finalizers),
+			)
 		} else {
-			ops = fmt.Sprintf(`[{ "op": "remove", "path": "%s" }]`, finalizerPath)
+			patchset.AddOption(patch.WithRemove(finalizerPath))
 		}
 
-		_, err := ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, []byte(ops), metav1.PatchOptions{})
+		patchBytes, err := patchset.GeneratePayload()
+		if err != nil {
+			return err
+		}
+		_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
used hardcoded patch operations

After this PR:
removed the unconvectional method of using patch and replaced it with the patchset

Relates to issue #13947 

### Why we need it and why it was done in this way
A couple of leftover in the code which required refactoring to use patchset

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/13947

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

