### PR TITLE
tests: quarantine flaky "VirtApiDown should be triggered.."

### DIFF
--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -144,7 +144,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, decorators.SigM
 			libmonitoring.VerifyAlertExist(virtClient, virtController.lowCountAlert)
 		})
 
-		It("VirtApiDown should be triggered when virt-api is down", func() {
+		It("[QUARANTINE] VirtApiDown should be triggered when virt-api is down", decorators.Quarantine, func() {
 			scales.UpdateScale(virtApi.deploymentName, int32(0))
 			libmonitoring.VerifyAlertExist(virtClient, virtApi.downAlert)
 		})


### PR DESCRIPTION
This test is flaky and failing https://github.com/kubevirt/kubevirt/pull/13911 for many times

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
VirtApiDown alert test is flaky

After this PR:
VirtApiDown alert test is quarantine

### Special notes for your reviewer
A ticket open to fix this test

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

