### PR TITLE
virt-handler/node-labeller: Move arch specific content into separate files

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -313,8 +312,7 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	// Node labelling is only relevant on x86_64 and s390x arches.
-	if virtconfig.IsAMD64(runtime.GOARCH) || virtconfig.IsS390X(runtime.GOARCH) {
+	if nodeLabellerController.ShouldLabelNodes() {
 		hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
 
 		go nodeLabellerController.Run(10, stop)

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -3,12 +3,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "amd64.go",
+        "arch_labeller.go",
+        "arm64.go",
         "cpu_plugin.go",
         "kvm-caps-info-plugin_amd64.go",
         "kvm-caps-info-plugin_arm64.go",
         "kvm-caps-info-plugin_s390x.go",
         "model.go",
         "node_labeller.go",
+        "s390x.go",
     ],
     cgo = True,
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller",
@@ -34,21 +38,23 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "arch_labeller_test.go",
         "cpu_plugin_test.go",
         "node_labeller_suite_test.go",
         "node_labeller_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = select({
+    deps = [
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "//pkg/testutils:go_default_library",
             "//pkg/virt-handler/node-labeller/util:go_default_library",
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",
             "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-            "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
-            "//vendor/github.com/onsi/gomega:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -63,8 +69,6 @@ go_test(
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",
             "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-            "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
-            "//vendor/github.com/onsi/gomega:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/virt-handler/node-labeller/amd64.go
+++ b/pkg/virt-handler/node-labeller/amd64.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&archLabellerAMD64{})
+
+type archLabellerAMD64 struct {
+	defaultArchLabeller
+}
+
+func (archLabellerAMD64) shouldLabelNodes() bool {
+	return true
+}
+
+func (archLabellerAMD64) hasHostSupportedFeatures() bool {
+	return true
+}
+
+func (archLabellerAMD64) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerAMD64) arch() string {
+	return amd64
+}

--- a/pkg/virt-handler/node-labeller/arch_labeller.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller.go
@@ -1,0 +1,83 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+import (
+	"runtime"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
+)
+
+const (
+	amd64 = "amd64"
+	arm64 = "arm64"
+	s390x = "s390x"
+)
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&defaultArchLabeller{})
+
+type archLabeller interface {
+	shouldLabelNodes() bool
+	defaultVendor() string
+	requirePolicy(policy string) bool
+	hasHostSupportedFeatures() bool
+	supportsHostModel() bool
+	arch() string
+}
+
+func newArchLabeller(arch string) archLabeller {
+	switch arch {
+	case amd64:
+		return archLabellerAMD64{}
+	case arm64:
+		return archLabellerARM64{}
+	case s390x:
+		return archLabellerS390X{}
+	default:
+		return defaultArchLabeller{}
+	}
+}
+
+type defaultArchLabeller struct{}
+
+func (defaultArchLabeller) shouldLabelNodes() bool {
+	return false
+}
+
+func (defaultArchLabeller) defaultVendor() string {
+	return ""
+}
+
+func (defaultArchLabeller) requirePolicy(policy string) bool {
+	return policy == util.RequirePolicy
+}
+
+func (defaultArchLabeller) hasHostSupportedFeatures() bool {
+	return false
+}
+
+func (defaultArchLabeller) supportsHostModel() bool {
+	return false
+}
+
+func (defaultArchLabeller) arch() string {
+	return runtime.GOARCH
+}

--- a/pkg/virt-handler/node-labeller/arch_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller_test.go
@@ -1,0 +1,42 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+import (
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Arch Node Labeller", func() {
+
+	DescribeTable("Should create a new archLabeller for the correct architecture", func(arch string, result archLabeller) {
+		ac := newArchLabeller(arch)
+
+		Expect(ac).To(Equal(result))
+		if arch == "unknown" {
+			arch = runtime.GOARCH
+		}
+		Expect(ac.arch()).To(Equal(arch))
+	},
+		Entry(amd64, amd64, archLabellerAMD64{}),
+		Entry(arm64, arm64, archLabellerARM64{}),
+		Entry(s390x, s390x, archLabellerS390X{}),
+		Entry("unknown", "unknown", defaultArchLabeller{}),
+	)
+})

--- a/pkg/virt-handler/node-labeller/arm64.go
+++ b/pkg/virt-handler/node-labeller/arm64.go
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&archLabellerARM64{})
+
+type archLabellerARM64 struct {
+	defaultArchLabeller
+}
+
+func (archLabellerARM64) arch() string {
+	return arm64
+}

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Node-labeller config", func() {
 			domCapabilitiesFileName: "virsh_domcapabilities.xml",
 			cpuCounter:              nil,
 			hostCPUModel:            hostCPUModel{requiredFeatures: make(map[string]bool, 0)},
-			arch:                    runtime.GOARCH,
+			arch:                    newArchLabeller(runtime.GOARCH),
 		}
 	})
 
@@ -99,7 +99,7 @@ var _ = Describe("Node-labeller config", func() {
 	})
 
 	It("Should return the cpu features on s390x even without policy='require' property", func() {
-		nlController.arch = "s390x"
+		nlController.arch = newArchLabeller(s390x)
 		nlController.volumePath = "testdata/s390x"
 
 		err := nlController.loadHostSupportedFeatures()
@@ -110,7 +110,7 @@ var _ = Describe("Node-labeller config", func() {
 		Expect(cpuFeatures).To(HaveLen(89), "number of features doesn't match")
 	})
 	It("Should return the cpu features on amd64 only with policy='require' property", func() {
-		nlController.arch = "amd64"
+		nlController.arch = newArchLabeller(amd64)
 		nlController.volumePath = "testdata/s390x"
 
 		err := nlController.loadHostSupportedFeatures()
@@ -122,7 +122,7 @@ var _ = Describe("Node-labeller config", func() {
 	})
 
 	It("Should default to IBM as CPU Vendor on s390x if none is given", func() {
-		nlController.arch = "s390x"
+		nlController.arch = newArchLabeller(s390x)
 		nlController.volumePath = "testdata/s390x"
 
 		err := nlController.loadDomCapabilities()

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -290,6 +290,16 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
+
+	DescribeTable("should only label arches that support it", func(arch string, shouldLabel bool) {
+		nlController.arch = newArchLabeller(arch)
+		Expect(nlController.ShouldLabelNodes()).To(Equal(shouldLabel))
+	},
+		Entry(amd64, amd64, true),
+		Entry(arm64, arm64, false),
+		Entry(s390x, s390x, true),
+		Entry("unknown", "unknown", false),
+	)
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/s390x.go
+++ b/pkg/virt-handler/node-labeller/s390x.go
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+import "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&archLabellerS390X{})
+
+type archLabellerS390X struct{}
+
+func (archLabellerS390X) shouldLabelNodes() bool {
+	return true
+}
+
+func (archLabellerS390X) defaultVendor() string {
+	// On s390x the xml does not include a CPU Vendor, however there is only one company selling them anyway.
+	return "IBM"
+}
+
+func (archLabellerS390X) requirePolicy(policy string) bool {
+	// On s390x, the policy is not set
+	return policy == util.RequirePolicy || policy == ""
+}
+
+func (archLabellerS390X) hasHostSupportedFeatures() bool {
+	return true
+}
+
+func (archLabellerS390X) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerS390X) arch() string {
+	return s390x
+}

--- a/pkg/virt-launcher/virtwrap/converter/arch/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/converter_test.go
@@ -32,6 +32,6 @@ var _ = Describe("Arch Converter", func() {
 		Entry("arm64", "arm64", converterARM64{}),
 		Entry("ppc64le", "ppc64le", converterPPC64{}),
 		Entry("s390x", "s390x", converterS390X{}),
-		Entry("unkown", "unknown", converterAMD64{}),
+		Entry("unknown", "unknown", converterAMD64{}),
 	)
 })


### PR DESCRIPTION
Use arch specific files for arch specific configuration.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
arch specific code is mixed together with common code in node-labeller.
After this PR:
arch specific code can be called over a generic interface.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Split of from https://github.com/kubevirt/kubevirt/pull/13852
### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

