### PR TITLE
replace hardcoded patch ops in pkg/virt-operator/resource/apply/delete.go with patchset

### DIFF
--- a/pkg/virt-operator/resource/apply/delete.go
+++ b/pkg/virt-operator/resource/apply/delete.go
@@ -634,12 +634,21 @@ func crdHandleDeletion(kvkey string,
 		crdCopy := crd.DeepCopy()
 		controller.AddFinalizer(crdCopy, v1.VirtOperatorComponentFinalizer)
 
+		patchSet := patch.New()
+
 		patchBytes, err := json.Marshal(crdCopy.Finalizers)
 		if err != nil {
 			return err
 		}
-		ops := fmt.Sprintf(`[{ "op": "add", "path": "%s", "value": %s }]`, finalizerPath, string(patchBytes))
-		_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, []byte(ops), metav1.PatchOptions{})
+
+		patchSet.AddOption(patch.WithAdd(finalizerPath, string(patchBytes)))
+
+		payload, err := patchSet.GeneratePayload()
+		if err != nil {
+			return fmt.Errorf("failed to generate patch payload: %v", err)
+		}
+
+		_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, payload, metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
@@ -661,7 +670,7 @@ func crdHandleDeletion(kvkey string,
 	}
 
 	for _, crd := range needFinalizerRemoved {
-		var ops string
+		patchSet := patch.New() 
 		if len(crd.Finalizers) > 1 {
 			crdCopy := crd.DeepCopy()
 			controller.RemoveFinalizer(crdCopy, v1.VirtOperatorComponentFinalizer)
@@ -676,16 +685,18 @@ func crdHandleDeletion(kvkey string,
 				return err
 			}
 
-			ops = fmt.Sprintf(`[{ "op": "test", "path": "%s", "value": %s }, { "op": "replace", "path": "%s", "value": %s }]`,
-				finalizerPath,
-				string(oldPatchBytes),
-				finalizerPath,
-				string(newPatchBytes))
+			patchSet.AddOption(
+				patch.WithTest(finalizerPath, string(oldPatchBytes)),
+				patch.WithReplace(finalizerPath, string(newPatchBytes)),
+		)
 		} else {
-			ops = fmt.Sprintf(`[{ "op": "remove", "path": "%s" }]`, finalizerPath)
+			patchSet.AddOption(patch.WithRemove(finalizerPath))
 		}
-
-		_, err := ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, []byte(ops), metav1.PatchOptions{})
+		payload, err := patchSet.GeneratePayload()
+		if err != nil {
+			return fmt.Errorf("failed to generate patch payload: %v", err)
+		}
+		_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, payload, metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: Patch operations in `pkg/virt-operator/resource/apply/delete.go` were hard coded

After this PR: Replaced hard coded operations with patchset 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/13947

### Why we need it and why it was done in this way
Patch operations were hard to read and extend, this should make it easier

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

