### PR TITLE
Add RequiresSizeRoundUp decorator

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -87,6 +87,11 @@ var (
 	// RequiresVolumeExpansion requires a storage class with volume expansion support
 	RequiresVolumeExpansion = Label("RequiresVolumeExpansion")
 
+	/* Provisioner */
+
+	// RequiresSizeRoundUp requires a provisioner that rounds up the size of the volume
+	RequiresSizeRoundUp = Label("RequiresSizeRoundUp")
+
 	/* Kubernetes versions */
 
 	// Kubernetes versions

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1230,7 +1230,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			// the PVC. Currently we only test vmsnapshot tests which ceph which has this
 			// behavior. In case of running this test with other provisioner or if ceph
 			// will change this behavior it will fail.
-			DescribeTable("should restore a vm with restore size bigger then PVC size", func(restoreToNewVM bool) {
+			DescribeTable("should restore a vm with restore size bigger then PVC size", decorators.RequiresSizeRoundUp, func(restoreToNewVM bool) {
 				vm = createVMWithCloudInit(cd.ContainerDiskCirros, snapshotStorageClass)
 				quantity, err := resource.ParseQuantity("1528Mi")
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
We have tests that assume provisioner-specific behavior such as pvc size round-up, which causes failures in clusters using valid storage classes with other provisioners. This PR adds a  `RequiresSizeRoundUp` decorator to allow skipping tests that require this behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

