### PR TITLE
[release-1.3] Add kubevirt_vmi_migration_(start|end)_time_seconds metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -177,11 +177,17 @@ The rate of memory being dirty in the Guest OS. Type: Gauge.
 ### kubevirt_vmi_migration_disk_transfer_rate_bytes
 The rate at which the memory is being transferred. Type: Gauge.
 
+### kubevirt_vmi_migration_end_time_seconds
+The time at which the migration ended. Type: Gauge.
+
 ### kubevirt_vmi_migration_failed
 Indicates if the VMI migration failed. Type: Gauge.
 
 ### kubevirt_vmi_migration_phase_transition_time_from_creation_seconds
 Histogram of VM migration phase transitions duration from creation time in seconds. Type: Histogram.
+
+### kubevirt_vmi_migration_start_time_seconds
+The time at which the migration started. Type: Gauge.
 
 ### kubevirt_vmi_migration_succeeded
 Indicates if the VMI migration succeeded. Type: Gauge.

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -234,6 +234,81 @@ var _ = Describe("VMI Stats Collector", func() {
 			Entry("VMI Eviction policy is not set and vm migratable status is not known", nil, k8sv1.ConditionUnknown, 0.0),
 		)
 	})
+
+	Context("VMI migration start and end time metrics", func() {
+		now := metav1.Unix(1000, 0)
+		nowFloatValue := float64(now.Unix())
+
+		Describe("kubevirt_vmi_migration_start_time and kubevirt_vmi_migration_end_time metrics", func() {
+			It("should not create migration metrics for a VMI with no migration state", func() {
+				vmi := &k6tv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "testvmi",
+					},
+					Status: k6tv1.VirtualMachineInstanceStatus{
+						NodeName: "testNode",
+					},
+				}
+
+				metrics := collectVMIMigrationTime(vmi)
+				Expect(metrics).To(BeEmpty())
+			})
+
+			It("should create kubevirt_vmi_migration_start_time metric for a migration in progress", func() {
+				vmi := &k6tv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "testvmi",
+					},
+					Status: k6tv1.VirtualMachineInstanceStatus{
+						NodeName: "testNode",
+						MigrationState: &k6tv1.VirtualMachineInstanceMigrationState{
+							MigrationUID:   "test-migration-uid",
+							StartTimestamp: &now,
+						},
+					},
+				}
+
+				metrics := collectVMIMigrationTime(vmi)
+				Expect(metrics).To(HaveLen(1))
+
+				Expect(metrics[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_migration_start_time"))
+				Expect(metrics[0].Value).To(BeEquivalentTo(nowFloatValue))
+				Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "test-migration"}))
+			})
+
+			It("should create kubevirt_vmi_migration_end_time metric for a completedmigration", func() {
+				vmi := &k6tv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-ns",
+						Name:      "testvmi",
+					},
+					Status: k6tv1.VirtualMachineInstanceStatus{
+						NodeName: "testNode",
+						MigrationState: &k6tv1.VirtualMachineInstanceMigrationState{
+							MigrationUID:   "test-migration-uid",
+							StartTimestamp: &now,
+							EndTimestamp:   &now,
+							Completed:      true,
+							Failed:         false,
+						},
+					},
+				}
+
+				metrics := collectVMIMigrationTime(vmi)
+				Expect(metrics).To(HaveLen(2))
+
+				Expect(metrics[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_migration_start_time"))
+				Expect(metrics[0].Value).To(BeEquivalentTo(nowFloatValue))
+				Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "test-migration"}))
+
+				Expect(metrics[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_migration_end_time"))
+				Expect(metrics[1].Value).To(BeEquivalentTo(nowFloatValue))
+				Expect(metrics[1].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "test-migration", "succeeded"}))
+			})
+		})
+	})
 })
 
 func createVMISForEviction(evictionStrategy *k6tv1.EvictionStrategy, migratableCondStatus k8sv1.ConditionStatus) []*k6tv1.VirtualMachineInstance {
@@ -269,6 +344,7 @@ func setupTestVMICollector() {
 	clusterInstanceTypeInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterInstancetype{})
 	preferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
 	clusterPreferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
+	vmiMigrationInformer, _ = testutils.NewFakeInformerFor(&k6tv1.VirtualMachineInstanceMigration{})
 
 	_ = instanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineInstancetype{
 		ObjectMeta: newObjectMetaForInstancetypes("i-managed", "kubevirt.io"),
@@ -293,6 +369,14 @@ func setupTestVMICollector() {
 
 	_ = clusterPreferenceInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterPreference{
 		ObjectMeta: newObjectMetaForInstancetypes("cp-managed", "kubevirt.io"),
+	})
+
+	_ = vmiMigrationInformer.GetStore().Add(&k6tv1.VirtualMachineInstanceMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-migration",
+			Namespace: "test-ns",
+			UID:       "test-migration-uid",
+		},
 	})
 }
 

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -75,6 +75,8 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_migrations_in_running_phase":                           true,
 			"kubevirt_vmi_migration_succeeded":                                   true,
 			"kubevirt_vmi_migration_failed":                                      true,
+			"kubevirt_vmi_migration_start_time_seconds":                          true,
+			"kubevirt_vmi_migration_end_time_seconds":                            true,
 		}
 
 		It("should contain virt components metrics", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual cherry pick of https://github.com/kubevirt/kubevirt/pull/13428

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-56403
jira-ticket: https://issues.redhat.com/browse/CNV-56007

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vmi_migration_(start|end)_time_seconds metrics
```

