### PR TITLE
export tests: correct stdout/err printing syntax

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -306,7 +306,7 @@ var _ = SIGDescribe("Export", func() {
 		Eventually(func() error {
 			out, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, md5Command(fileName))
 			return err
-		}, 15*time.Second, 1*time.Second).Should(BeNil(), "md5sum command should succeed", out, stderr)
+		}, 15*time.Second, 1*time.Second).Should(BeNil(), "md5sum command should succeed; out: %s stderr: %s", out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
 
@@ -340,7 +340,7 @@ var _ = SIGDescribe("Export", func() {
 			fileAndPathName = blockVolumeMountPath
 		}
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
 		Expect(md5sum).To(Equal(expectedMD5))
@@ -353,7 +353,7 @@ var _ = SIGDescribe("Export", func() {
 			filepath.Join(dataPath, fileName),
 		}
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 
 		fileName = strings.Replace(fileName, ".gz", "", 1)
 		fileAndPathName := filepath.Join(dataPath, fileName)
@@ -361,7 +361,7 @@ var _ = SIGDescribe("Export", func() {
 			fileAndPathName = blockVolumeMountPath
 		}
 		out, stderr, err = exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
 		Expect(md5sum).To(Equal(expectedMD5))
@@ -380,14 +380,14 @@ var _ = SIGDescribe("Export", func() {
 			"./" + extractedFileName,
 		}
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 
 		fileAndPathName := filepath.Join(dataPath, extractedFileName)
 		if volumeMode == k8sv1.PersistentVolumeBlock {
 			fileAndPathName = blockVolumeMountPath
 		}
 		out, stderr, err = exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
 		Expect(md5sum).To(Equal(expectedMD5))
@@ -564,7 +564,7 @@ var _ = SIGDescribe("Export", func() {
 		By(fmt.Sprintf("Downloading from URL: %s", downloadUrl))
 		Eventually(ThisPod(downloadPod), 30*time.Second, 1*time.Second).Should(HaveConditionTrue(k8sv1.PodReady))
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 
 		verifyFunction(fileName, comparison, downloadPod, volumeMode)
 	},
@@ -586,7 +586,7 @@ var _ = SIGDescribe("Export", func() {
 		command := append([]string{"/usr/bin/tar", "-xvzf", archivePath, "-C", "./data"}, expectedDirs...)
 		time.Sleep(time.Second * 20)
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		for _, dir := range expectedDirs {
 			Expect(out).To(ContainSubstring(dir), fmt.Sprintf("Expected directory %q in archive", dir))
 		}
@@ -685,7 +685,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 
 		// Verify contents of the downloaded archive
 		By("Verifying the contents of the downloaded archive")
@@ -1713,7 +1713,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		split := strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(3))
 		resCM := &k8sv1.ConfigMap{}
@@ -1741,7 +1741,7 @@ var _ = SIGDescribe("Export", func() {
 			url,
 		}
 		out, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		split = strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(2))
 		resSecret := &k8sv1.Secret{}
@@ -1771,7 +1771,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		list := &k8sv1.List{}
 		err = json.Unmarshal([]byte(out), list)
 		Expect(err).ToNot(HaveOccurred())
@@ -1804,7 +1804,7 @@ var _ = SIGDescribe("Export", func() {
 			url,
 		}
 		out, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		resSecret := &k8sv1.Secret{}
 		err = yaml.Unmarshal([]byte(out), resSecret)
 		Expect(err).ToNot(HaveOccurred())
@@ -2015,7 +2015,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		split := strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(5))
 		resCM := &k8sv1.ConfigMap{}
@@ -2061,7 +2061,7 @@ var _ = SIGDescribe("Export", func() {
 			url,
 		}
 		out, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), out, stderr)
+		Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", out, stderr)
 		split = strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(2))
 		resSecret := &k8sv1.Secret{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
these get passed to sprintf so syntax was off, making it harder to debug failures

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

