### PR TITLE
[release-1.4] Add RequiresSizeRoundUp decorator

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -67,6 +67,11 @@ var (
 	// WG archs
 	WgS390x = Label("wg-s390x")
 
+	/* Provisioner */
+
+	// RequiresSizeRoundUp requires a provisioner that rounds up the size of the volume
+	RequiresSizeRoundUp = Label("RequiresSizeRoundUp")
+
 	// NoFlakeChecker decorates tests that are not compatible with the check-tests-for-flakes test lane.
 	// This should only be used for legitimate purposes, like on tests that have a flake-checker-friendly clone.
 	NoFlakeCheck = Label("no-flake-check")

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1172,7 +1172,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			// the PVC. Currently we only test vmsnapshot tests which ceph which has this
 			// behavior. In case of running this test with other provisioner or if ceph
 			// will change this behavior it will fail.
-			DescribeTable("should restore a vm with restore size bigger then PVC size", func(restoreToNewVM bool) {
+			DescribeTable("should restore a vm with restore size bigger then PVC size", decorators.RequiresSizeRoundUp, func(restoreToNewVM bool) {
 				vm = createVMWithCloudInit(cd.ContainerDiskCirros, snapshotStorageClass)
 				quantity, err := resource.ParseQuantity("1528Mi")
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/13990.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

