### PR TITLE
Refactored virtctl configuration and improved formatting

### DIFF
--- a/pkg/virtctl/configuration/configuration.go
+++ b/pkg/virtctl/configuration/configuration.go
@@ -26,9 +26,7 @@ func NewListPermittedDevices() *cobra.Command {
 }
 
 func usage() string {
-	usage := "  # Print the permitted devices for VMIs:\n"
-	usage += "  {{ProgramName}} permitted-devices"
-	return usage
+	return "# Print the permitted devices for VMIs:\n  {{ProgramName}} permitted-devices"
 }
 
 func run(cmd *cobra.Command, _ []string) error {
@@ -43,13 +41,15 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 
 	if len(kvList.Items) == 0 {
-		return fmt.Errorf("No KubeVirt resource in %q namespace", namespace)
+		return fmt.Errorf("no KubeVirt resource in %q namespace", namespace)
 	}
 
 	kv := kvList.Items[0]
 
-	hostDeviceList := []string{}
-	gpuDeviceList := []string{}
+	var (
+		hostDeviceList []string
+		gpuDeviceList  []string
+	)
 
 	if kv.Spec.Configuration.PermittedHostDevices != nil {
 		for _, hd := range kv.Spec.Configuration.PermittedHostDevices.PciHostDevices {
@@ -61,9 +61,9 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	fmt.Printf("Permitted Devices: \nHost Devices: \n%s \nGPU Devices: \n%s\n",
-		fmt.Sprint(strings.Join(hostDeviceList, ", ")),
-		fmt.Sprint(strings.Join(gpuDeviceList, ", ")),
+	cmd.Printf("Permitted Devices: \nHost Devices: \n%s \nGPU Devices: \n%s\n",
+		strings.Join(hostDeviceList, ", "),
+		strings.Join(gpuDeviceList, ", "),
 	)
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:  
- The `pkg/virtctl/configuration` package had inconsistencies, including:  
  - Unnecessary string concatenation in `usage()`  
  - Use of `fmt.Printf` instead of `cmd.Printf` for logging  
  - Minor formatting and readability issues  

After this PR:  
- **Refactored `usage()`** to be more concise  
- **Replaced `fmt.Printf` with `cmd.Printf`** for better CLI output handling  
- **Improved error message consistency**  


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13095

### Why we need it and why it was done in this way

These changes improve code readability, maintainability, and ensure consistency in how CLI output is handled within the `virtctl` package. Using `cmd.Printf` aligns with Cobra's best practices for CLI tools. 

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Kindly review this PR and let me know if there are any concerns or areas that need improvement.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

