### PR TITLE
virt-launcher: converter: add unit tests for kvm/qemu

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
@@ -1,4 +1,4 @@
-<domain type="%s" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>mynamespace_testvmi</name>
   <memory unit="b">8388608</memory>
   <os>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
@@ -1,4 +1,4 @@
-<domain type="%s" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>mynamespace_testvmi</name>
   <memory unit="b">8388608</memory>
   <os>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
@@ -1,4 +1,4 @@
-<domain type="%s" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>mynamespace_testvmi</name>
   <memory unit="b">8388608</memory>
   <os>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64.xml.tmpl
@@ -1,4 +1,4 @@
-<domain type="%s" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>mynamespace_testvmi</name>
   <memory unit="b">8388608</memory>
   <os>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64_root.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64_root.xml.tmpl
@@ -1,4 +1,4 @@
-<domain type="%s" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>mynamespace_testvmi</name>
   <memory unit="b">8388608</memory>
   <os>

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1089,6 +1089,15 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		c.GPUHostDevices = gpuHostDevices
 	}
 
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		c.DevKvmExists = false
+	} else {
+		c.DevKvmExists = true
+	}
+
 	return c, nil
 }
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -413,6 +413,7 @@ var _ = Describe("Manager", func() {
 			Architecture:      arch.NewConverter(runtime.GOARCH),
 			VirtualMachine:    vmi,
 			AllowEmulation:    true,
+			DevKvmExists:      true,
 			SMBios:            &cmdv1.SMBios{},
 			HotplugVolumes:    hotplugVolumes,
 			PermanentVolumes:  permanentVolumes,


### PR DESCRIPTION
This PR attempts to add unit tests for the expected behavior of the converter given the AllowEmulation cluster-wide configuration and the /dev/kvm availability in virt-launcher. The expected behavior is a bit convoluted, as explained in https://github.com/kubevirt/kubevirt/issues/13837

The PR adds unit tests for the cases where emulation is allowed and kvm exists in virt-launcher (or not). The production code is refactored to make the unit (!) tests independent of the existence of /dev/kvm on the test machine. This had a side effect of checking for /dev/kvm existence only once per VMI launch.

```release-note
NONE
```

