### PR TITLE
virtctl, guestfs: Add --vm cmd line arg to guestfs

### DIFF
--- a/pkg/virtctl/guestfs/BUILD.bazel
+++ b/pkg/virtctl/guestfs/BUILD.bazel
@@ -30,9 +30,12 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/virtctl/testing:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,7 +27,7 @@ const (
 	testNamespace = "default"
 )
 
-func fakeAttacherCreator(client *guestfs.K8sClient, p *corev1.Pod, command string) error {
+func fakeAttacherCreator(client *guestfs.K8sClient, p *v1.Pod, command string) error {
 	return nil
 }
 
@@ -129,8 +128,7 @@ var _ = Describe("Guestfs shell", func() {
 
 		It("Succesfully attach to PVC", func() {
 			guestfs.CreateClientFunc = fakeCreateClientPVC
-			cmd := testing.NewRepeatableVirtctlCommand(commandName, pvcName)
-			Expect(cmd()).To(Succeed())
+			Expect(testing.NewRepeatableVirtctlCommand(commandName, pvcName)()).To(Succeed())
 		})
 
 		It("PVC in use", func() {
@@ -153,15 +151,13 @@ var _ = Describe("Guestfs shell", func() {
 			guestfs.CreateClientFunc = fakeCreateClientPVC
 			cmd := testing.NewRepeatableVirtctlCommand(commandName, pvcName, "--root=true", "--uid=1001")
 			err := cmd()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(Equal(fmt.Sprintf("cannot set uid if root is true")))
+			Expect(err).To(MatchError("cannot set uid if root is true"))
 		})
 		It("GID can be use only together with the uid flag", func() {
 			guestfs.CreateClientFunc = fakeCreateClientPVC
 			cmd := testing.NewRepeatableVirtctlCommand(commandName, pvcName, "--gid=1001")
 			err := cmd()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(Equal(fmt.Sprintf("gid requires the uid to be set")))
+			Expect(err).To(MatchError("gid requires the uid to be set"))
 		})
 
 		It("Successfully apply VM's constraints", func() {

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -1,8 +1,10 @@
 package guestfs_test
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -13,7 +15,9 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"kubevirt.io/client-go/kubecli"
+	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virtctl/guestfs"
 	"kubevirt.io/kubevirt/pkg/virtctl/testing"
 )
@@ -37,6 +41,7 @@ var _ = Describe("Guestfs shell", func() {
 		kubeClient     *fake.Clientset
 		kubevirtClient *kubecli.MockKubevirtClient
 	)
+	var libguestfsPod *v1.Pod
 	mode := v1.PersistentVolumeFilesystem
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -96,6 +101,15 @@ var _ = Describe("Guestfs shell", func() {
 		kubeClient = fake.NewSimpleClientset(pvc, otherPod)
 		return &guestfs.K8sClient{Client: kubeClient, VirtClient: kubevirtClient}, nil
 	}
+	fakeCreateClientPVCWithMockVirtClient := func(_ kubecli.KubevirtClient) (*guestfs.K8sClient, error) {
+		kubeClient = fake.NewSimpleClientset(pvc)
+		kubeClient.Fake.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			libguestfsPod = action.(k8stesting.CreateAction).GetObject().(*v1.Pod)
+			libguestfsPod.Status.Phase = v1.PodRunning
+			return false, libguestfsPod, nil
+		})
+		return &guestfs.K8sClient{Client: kubeClient, VirtClient: kubecli.MockKubevirtClientInstance}, nil
+	}
 	fakeCreateClient := func(_ kubecli.KubevirtClient) (*guestfs.K8sClient, error) {
 		kubeClient = fake.NewSimpleClientset()
 		return &guestfs.K8sClient{Client: kubeClient, VirtClient: kubevirtClient}, nil
@@ -148,6 +162,32 @@ var _ = Describe("Guestfs shell", func() {
 			err := cmd()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal(fmt.Sprintf("gid requires the uid to be set")))
+		})
+
+		It("Successfully apply VM's constraints", func() {
+			vmi := libvmi.New(
+				libvmi.WithNamespace(testNamespace),
+				libvmi.WithName("test-vm"),
+				libvmi.WithToleration(v1.Toleration{Key: "tol_key", Value: "tol_val"}),
+				libvmi.WithLabel("label_key", "label_val"),
+				libvmi.WithNodeAffinityForLabel("node_key", "node_val"),
+				libvmi.WithNodeSelector("select_key", "select_val"),
+			)
+			vm := libvmi.NewVirtualMachine(vmi)
+			ctrl := gomock.NewController(GinkgoT())
+			kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
+			kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
+			guestfs.CreateClientFunc = fakeCreateClientPVCWithMockVirtClient
+			kubevirtClient := kubevirtfake.NewSimpleClientset()
+			kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(testNamespace).Return(kubevirtClient.KubevirtV1().VirtualMachines(testNamespace)).AnyTimes()
+			vm, err := kubevirtClient.KubevirtV1().VirtualMachines(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testing.NewRepeatableVirtctlCommand(commandName, pvcName, "--vm", vm.Name)()).To(Succeed())
+			Expect(libguestfsPod.Spec.Tolerations).To(ContainElements(vm.Spec.Template.Spec.Tolerations))
+			Expect(libguestfsPod.Spec.Affinity).To(Equal(vm.Spec.Template.Spec.Affinity))
+			Expect(libguestfsPod.ObjectMeta.Labels).To(Equal(vm.Spec.Template.ObjectMeta.Labels))
+			Expect(libguestfsPod.Spec.NodeSelector).To(Equal(vm.Spec.Template.Spec.NodeSelector))
 		})
 	})
 


### PR DESCRIPTION
libguestfs-tool pods don't receive tolerations, so they won't be scheduled if all available nodes are tainted. This patch lets the user specfiy their VM so the VMs tolerations can be applied to the libguestfs-tool pod.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
If all available nodes were tainted, then the pod created by `virtctl guestfs` would not be scheduled due to missing tolerations.
After this PR:
User can now specify the VM (the one they want to inspect with `virtctl guestfs`) as a cmd line arg. The libguestfs-tool pod will receive that VMs tolerations and get scheduled.

### Why we need it and why it was done in this way
The following tradeoffs were made: The user has to specify a VM but since `virtctl guestfs` is primarily to inspect VMs, this is reasonable.

The following alternatives were considered: 
- allowing the user to specify the tolerations instead of the VM.
- Not adding any cmd line arg but instead iterating through every VM to find the one associated with the PVC. This could be expensive and pointless if the VM being searched for doesn't even exist. 

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/13861 https://github.com/kubevirt/kubevirt/pull/13994

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```