### PR TITLE
Add cssid, ssid and devno fields to Address struct for s390-ccw-virtio

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -1146,6 +1146,9 @@ type Address struct {
 	Unit       string `xml:"unit,attr,omitempty"`
 	UUID       string `xml:"uuid,attr,omitempty"`
 	Device     string `xml:"device,attr,omitempty"`
+	CSSID      string `xml:"cssid,attr,omitempty"`
+	SSID       string `xml:"ssid,attr,omitempty"`
+	DevNo      string `xml:"devno,attr,omitempty"`
 }
 
 //END Video -------------------


### PR DESCRIPTION
device.

To support hot-unplugging of interfaces on s390x architecture, added CSSID, SSID, and DevNo fields to the Address struct. These fields are necessary for proper interface management on s390x systems for ccw device type.
These fields are implicitly used when the domain is read from libvirt and unmarshaled, Also these fields' values are only used for the NIC hotunplug flow in s390x.



### What this PR does
This PR addresses the following issue/error:

After attempting to hot-unplug a secondary network interface (dyniface1) from a VirtualMachineInstance (VMI) the VMI enters a state where it fails to sync, showing the error:

`LibvirtError(Code=99, Domain=20, Message='device not found: no device found at address '0.0.0000' matching MAC address '02:6c:5b:00:00:06' and alias 'ua-dyniface1')`

 Libvirt couldn't locate the device at address '0.0.0000' (represented as `<cssid>.<ssid>.<devno>`) because we are not passing these fields to the libvirt API for the s390x-ccw device.

As a result, subsequent live migration attempts for the VM fail.


Partially addresses https://github.com/kubevirt/kubevirt/issues/13721

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: #13721 

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

