### PR TITLE
[release-1.4] tests/migration: manual backport of #13841

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -62,7 +62,7 @@ var DNSServiceName = ""
 var DNSServiceNamespace = ""
 
 var MigrationNetworkNIC = "eth1"
-
+var MigrationNetworkName string
 var DisableCustomSELinuxPolicy bool
 
 func init() {
@@ -101,6 +101,7 @@ func init() {
 	flag.StringVar(&DNSServiceName, "dns-service-name", "kube-dns", "cluster DNS service name")
 	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
 	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
+	flag.StringVar(&MigrationNetworkName, "migration-network-name", "", "name of the NetworkAttachmentDefinition CR to be used for dedicated migration network tests")
 	flag.BoolVar(&DisableCustomSELinuxPolicy, "disable-custom-selinux-policy", false, "disables the installation and use of the custom SELinux policy for virt-launcher")
 }
 

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -3,6 +3,7 @@ package libmigration
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -200,27 +201,30 @@ func ClearDedicatedMigrationNetwork() *v1.KubeVirt {
 }
 
 func GenerateMigrationCNINetworkAttachmentDefinition() *k8snetworkplumbingwgv1.NetworkAttachmentDefinition {
-	nad := &k8snetworkplumbingwgv1.NetworkAttachmentDefinition{
+	config := map[string]interface{}{
+		"cniVersion": "0.3.1",
+		"name":       "migration-bridge",
+		"type":       "macvlan",
+		"master":     flags.MigrationNetworkNIC,
+		"mode":       "bridge",
+		"ipam": map[string]string{
+			"type":  "whereabouts",
+			"range": "172.21.42.0/24",
+		},
+	}
+
+	configJSON, err := json.Marshal(config)
+	Expect(err).ToNot(HaveOccurred())
+
+	return &k8snetworkplumbingwgv1.NetworkAttachmentDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "migration-cni",
 			Namespace: flags.KubeVirtInstallNamespace,
 		},
 		Spec: k8snetworkplumbingwgv1.NetworkAttachmentDefinitionSpec{
-			Config: `{
-      "cniVersion": "0.3.1",
-      "name": "migration-bridge",
-      "type": "macvlan",
-      "master": "` + flags.MigrationNetworkNIC + `",
-      "mode": "bridge",
-      "ipam": {
-        "type": "whereabouts",
-        "range": "172.21.42.0/24"
-      }
-}`,
+			Config: string(configJSON),
 		},
 	}
-
-	return nad
 }
 
 func EnsureNoMigrationMetadataInPersistentXML(vmi *v1.VirtualMachineInstance) {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -3106,26 +3106,33 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 		})
 	})
 
-	Context("[Serial] with a dedicated migration network", Serial, func() {
+	Context("with a dedicated migration network", Serial, func() {
+		var nadName string
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
 
-			By("Creating the Network Attachment Definition")
-			nad := libmigration.GenerateMigrationCNINetworkAttachmentDefinition()
-			_, err = virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(flags.KubeVirtInstallNamespace).Create(context.TODO(), nad, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Failed to create the Network Attachment Definition")
+			if flags.MigrationNetworkName != "" {
+				By(fmt.Sprintf("Using the provided Network Attachment Definition: %s", flags.MigrationNetworkName))
+				nadName = flags.MigrationNetworkName
+			} else {
+				By("Creating the Network Attachment Definition")
+				nad := libmigration.GenerateMigrationCNINetworkAttachmentDefinition()
+				nadName = nad.Name
+				_, err := virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(flags.KubeVirtInstallNamespace).Create(context.Background(), nad, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred(), "Failed to create the Network Attachment Definition")
+				DeferCleanup(func() {
+					By("Deleting the Network Attachment Definition")
+					Expect(virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(flags.KubeVirtInstallNamespace).Delete(context.Background(), nadName, metav1.DeleteOptions{})).To(Succeed(), "Failed to delete the Network Attachment Definition")
+				})
+			}
 
 			By("Setting it as the migration network in the KubeVirt CR")
-			libmigration.SetDedicatedMigrationNetwork(nad.Name)
+			libmigration.SetDedicatedMigrationNetwork(nadName)
 		})
+
 		AfterEach(func() {
 			By("Clearing the migration network in the KubeVirt CR")
 			libmigration.ClearDedicatedMigrationNetwork()
-
-			By("Deleting the Network Attachment Definition")
-			nad := libmigration.GenerateMigrationCNINetworkAttachmentDefinition()
-			err = virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(flags.KubeVirtInstallNamespace).Delete(context.TODO(), nad.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Failed to delete the Network Attachment Definition")
 		})
 		It("Should migrate over that network", func() {
 			vmi := libvmifact.NewAlpine(
@@ -3141,7 +3148,9 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 			By("Checking if the migration happened, and over the right network")
 			vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
-			Expect(vmi.Status.MigrationState.TargetNodeAddress).To(HavePrefix("172.21.42."), "The migration did not appear to go over the dedicated migration network")
+			targetHandler, err := libnode.GetVirtHandlerPod(kubevirt.Client(), vmi.Status.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmi.Status.MigrationState.TargetNodeAddress).ToNot(Equal(targetHandler.Status.PodIP), "The migration did not appear to go over the dedicated migration network")
 		})
 	})
 


### PR DESCRIPTION
This PR is a Manual backport of #13841

Since there was a conflict in tests/flags.go:103, the automatic cherry-pick failed.

/assign
/hold first #14034

/cherry-pick release-1.3
/cherry-pick release-1.2

### Release note
```release-note
None
```

