### PR TITLE
s390x: Implement support for Secure Execution VMs

### DIFF
--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -3,7 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "amd64.go",
         "os_helper.go",
+        "s390x.go",
         "util.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/util",

--- a/pkg/util/amd64.go
+++ b/pkg/util/amd64.go
@@ -1,0 +1,29 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package util
+
+import v1 "kubevirt.io/api/core/v1"
+
+// Check if a VMI spec requests AMD SEV
+func IsSEVVMI(vmi *v1.VirtualMachineInstance) bool {
+	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Domain.LaunchSecurity.SEV != nil
+}
+
+// Check if a VMI spec requests SEV with attestation
+func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
+	return IsSEVVMI(vmi) && vmi.Spec.Domain.LaunchSecurity.SEV.Attestation != nil
+}

--- a/pkg/util/s390x.go
+++ b/pkg/util/s390x.go
@@ -1,0 +1,24 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package util
+
+import v1 "kubevirt.io/api/core/v1"
+
+// Check if a VMI spec requests Secure Execution
+func IsSecureExecutionVMI(vmi *v1.VirtualMachineInstance) bool {
+	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Architecture == "s390x"
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -83,14 +83,8 @@ func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-// Check if a VMI spec requests AMD SEV
-func IsSEVVMI(vmi *v1.VirtualMachineInstance) bool {
-	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Domain.LaunchSecurity.SEV != nil
-}
-
-// Check if a VMI spec requests SEV with attestation
-func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
-	return IsSEVVMI(vmi) && vmi.Spec.Domain.LaunchSecurity.SEV.Attestation != nil
+func UseLaunchSecurity(vmi *v1.VirtualMachineInstance) bool {
+	return IsSEVVMI(vmi) || IsSecureExecutionVMI(vmi)
 }
 
 // NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.

--- a/pkg/virt-api/webhooks/s390x.go
+++ b/pkg/virt-api/webhooks/s390x.go
@@ -48,3 +48,7 @@ func validateWatchdogS390x(field *k8sfield.Path, spec *v1.VirtualMachineInstance
 func isOnlyDiag288Watchdog(watchdog *v1.Watchdog) bool {
 	return watchdog.WatchdogDevice.Diag288 != nil && watchdog.WatchdogDevice.I6300ESB == nil
 }
+
+func IsS390X(spec *v1.VirtualMachineInstanceSpec) bool {
+	return spec.Architecture == "s390x"
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -77,9 +77,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	vmiCreateAdmitter := &VMICreateAdmitter{ClusterConfig: config, KubeVirtServiceAccounts: kubeVirtServiceAccounts}
 
 	dnsConfigTestOption := "test"
-	enableFeatureGate := func(featureGate string) {
+	enableFeatureGates := func(featureGates ...string) {
 		kvConfig := kv.DeepCopy()
-		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
+		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = featureGates
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 	disableFeatureGates := func() {
@@ -459,7 +459,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		)
 
 		DescribeTable("should accept annotations which require feature gate enabled", func(annotations map[string]string, featureGate string) {
-			enableFeatureGate(featureGate)
+			enableFeatureGates(featureGate)
 			vmi := newBaseVmi()
 			vmi.Annotations = annotations
 
@@ -489,7 +489,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi = api.NewMinimalVMI("testvmi")
 		})
 		DescribeTable("should accept valid machine type", func(arch string, machineType string) {
-			enableFeatureGate(featuregate.MultiArchitecture)
+			enableFeatureGates(featuregate.MultiArchitecture)
 
 			vmi.Spec.Architecture = arch
 			vmi.Spec.Domain.Machine = &v1.Machine{Type: machineType}
@@ -504,7 +504,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		)
 
 		DescribeTable("should reject invalid machine type", func(arch string, machineType string) {
-			enableFeatureGate(featuregate.MultiArchitecture)
+			enableFeatureGates(featuregate.MultiArchitecture)
 
 			vmi.Spec.Architecture = arch
 			vmi.Spec.Domain.Machine = &v1.Machine{Type: machineType}
@@ -577,7 +577,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testdisk",
 			})
 
-			enableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
+			enableFeatureGates(featuregate.DeclarativeHotplugVolumesGate)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})
@@ -1082,7 +1082,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				VmiSpecUsed: func(_ *v1.VirtualMachineInstanceSpec) bool { return true },
 			})
 			DeferCleanup(featuregate.UnregisterFeatureGate, testsFGName)
-			enableFeatureGate(testsFGName)
+			enableFeatureGates(testsFGName)
 
 			ar, err := newAdmissionReviewForVMICreation(vmi)
 			Expect(err).NotTo(HaveOccurred())
@@ -1221,7 +1221,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		DescribeTable("virtiofs filesystems using", func(featureGate string, shouldAllow bool, vmiOption libvmi.Option) {
 			if featureGate != "" {
-				enableFeatureGate(featureGate)
+				enableFeatureGates(featureGate)
 			}
 
 			vmi := libvmi.New(vmiOption)
@@ -1550,7 +1550,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject vmi with threads > 1 for arm64 arch", func() {
-			enableFeatureGate(featuregate.MultiArchitecture)
+			enableFeatureGates(featuregate.MultiArchitecture)
 			vmi.Spec.Domain.CPU.Threads = 2
 			vmi.Spec.Architecture = "arm64"
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
@@ -1560,7 +1560,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept vmi with threads == 1 for arm64 arch", func() {
-			enableFeatureGate(featuregate.MultiArchitecture)
+			enableFeatureGates(featuregate.MultiArchitecture)
 			vmi.Spec.Domain.CPU.Threads = 1
 			vmi.Spec.Architecture = "arm64"
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
@@ -1568,7 +1568,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept vmi with threads > 1 for amd64 arch", func() {
-			enableFeatureGate(featuregate.MultiArchitecture)
+			enableFeatureGates(featuregate.MultiArchitecture)
 			vmi.Spec.Domain.CPU.Threads = 2
 			vmi.Spec.Architecture = "amd64"
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
@@ -2518,7 +2518,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept a single virtio serial", func() {
-			enableFeatureGate(featuregate.DownwardMetricsFeatureGate)
+			enableFeatureGates(featuregate.DownwardMetricsFeatureGate)
 			causes := validate()
 			Expect(causes).To(BeEmpty())
 		})
@@ -2540,7 +2540,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept a single downwardmetrics volume", func() {
-			enableFeatureGate(featuregate.DownwardMetricsFeatureGate)
+			enableFeatureGates(featuregate.DownwardMetricsFeatureGate)
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name: "testDownwardMetrics",
@@ -2567,7 +2567,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject downwardMetrics volumes if more than one exist", func() {
-			enableFeatureGate(featuregate.DownwardMetricsFeatureGate)
+			enableFeatureGates(featuregate.DownwardMetricsFeatureGate)
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes,
 				v1.Volume{
@@ -2604,7 +2604,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept hostDisk volumes if the feature gate is enabled", func() {
-			enableFeatureGate(featuregate.HostDiskGate)
+			enableFeatureGates(featuregate.HostDiskGate)
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name: "testHostDisk",
@@ -2999,7 +2999,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			enableFeatureGate(featuregate.WorkloadEncryptionSEV)
+			enableFeatureGates(featuregate.WorkloadEncryptionSEV)
 		})
 
 		It("should accept when the feature gate is enabled and OVMF is configured", func() {
@@ -3071,12 +3071,36 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 	})
 
+	Context("with Secure Execution LaunchSecurity", func() {
+		var vmi *v1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			vmi = api.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{}
+			vmi.Spec.Architecture = "s390x"
+		})
+
+		It("should accept when the feature gate is enabled", func() {
+			enableFeatureGates(featuregate.MultiArchitecture, featuregate.SecureExecution)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(BeEmpty())
+		})
+
+		It("should reject when the feature gate is disabled", func() {
+			enableFeatureGates(featuregate.MultiArchitecture)
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.SecureExecution)))
+		})
+	})
+
 	Context("with vsocks defined", func() {
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
 			vmi = api.NewMinimalVMI("testvmi")
-			enableFeatureGate(featuregate.VSOCKGate)
+			enableFeatureGates(featuregate.VSOCKGate)
 		})
 
 		Context("feature gate enabled", func() {
@@ -3746,7 +3770,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		BeforeEach(func() {
 			vmi = api.NewMinimalVMI("testvmi")
-			enableFeatureGate(featuregate.PersistentReservation)
+			enableFeatureGates(featuregate.PersistentReservation)
 		})
 
 		Context("feature gate enabled", func() {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -184,3 +184,7 @@ func (config *ClusterConfig) ObjectGraphEnabled() bool {
 func (config *ClusterConfig) DeclarativeHotplugVolumesEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.DeclarativeHotplugVolumesGate)
 }
+
+func (config *ClusterConfig) SecureExecutionEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.SecureExecution)
+}

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -89,6 +89,12 @@ const (
 	// DeclarativeHotplugVolumes enables adding/removing volumes declaratively
 	// also implicitly handles inject/eject CDROM
 	DeclarativeHotplugVolumesGate = "DeclarativeHotplugVolumes"
+
+	// Owner: sig-conpute / @jschintag
+	// Alpha: v1.6.0
+	//
+	// SecureExecution introduces secure execution of VMs on IBM Z architecture
+	SecureExecution = "SecureExecution"
 )
 
 func init() {

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -12,17 +12,18 @@ import (
 )
 
 type NodeSelectorRenderer struct {
-	cpuFeatureLabels []string
-	cpuModelLabel    string
-	machineTypeLabel string
-	hasDedicatedCPU  bool
-	hyperv           bool
-	podNodeSelectors map[string]string
-	tscFrequency     *int64
-	vmiFeatures      *v1.Features
-	realtimeEnabled  bool
-	sevEnabled       bool
-	sevESEnabled     bool
+	cpuFeatureLabels       []string
+	cpuModelLabel          string
+	machineTypeLabel       string
+	hasDedicatedCPU        bool
+	hyperv                 bool
+	podNodeSelectors       map[string]string
+	tscFrequency           *int64
+	vmiFeatures            *v1.Features
+	realtimeEnabled        bool
+	sevEnabled             bool
+	sevESEnabled           bool
+	SecureExecutionEnabled bool
 }
 
 type NodeSelectorRendererOption func(renderer *NodeSelectorRenderer)
@@ -79,6 +80,9 @@ func (nsr *NodeSelectorRenderer) Render() map[string]string {
 	if nsr.sevESEnabled {
 		nsr.enableSelectorLabel(v1.SEVESLabel)
 	}
+	if nsr.SecureExecutionEnabled {
+		nsr.enableSelectorLabel(v1.SecureExecutionLabel)
+	}
 
 	return nsr.podNodeSelectors
 }
@@ -104,6 +108,12 @@ func WithSEVSelector() NodeSelectorRendererOption {
 func WithSEVESSelector() NodeSelectorRendererOption {
 	return func(renderer *NodeSelectorRenderer) {
 		renderer.sevESEnabled = true
+	}
+}
+
+func WithSecureExecutionSelector() NodeSelectorRendererOption {
+	return func(renderer *NodeSelectorRenderer) {
+		renderer.SecureExecutionEnabled = true
 	}
 }
 

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -223,6 +223,11 @@ func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.
 		context.RunAsGroup = &userId
 		context.AllowPrivilegeEscalation = pointer.P(false)
 	}
+	// As privileged is already the highest privilege, allowPrivilegeEscalation makes no sense.
+	// Therefore kubernetes enforces that a pod can only have one of those attributes.
+	if context.AllowPrivilegeEscalation != nil && privileged {
+		context.AllowPrivilegeEscalation = &privileged
+	}
 
 	return context
 }

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Container spec renderer", func() {
 		containerName = "exampleContainer"
 		img           = "megaimage2000"
 		pullPolicy    = k8sv1.PullAlways
+		nonRootUser   = 207
 	)
 
 	Context("without any options", func() {
@@ -38,8 +39,6 @@ var _ = Describe("Container spec renderer", func() {
 	})
 
 	Context("with non root user option", func() {
-		const nonRootUser = 207
-
 		BeforeEach(func() {
 			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithNonRoot(nonRootUser))
 		})
@@ -74,6 +73,11 @@ var _ = Describe("Container spec renderer", func() {
 			Expect(specRenderer.Render(exampleCommand).SecurityContext).Should(
 				Equal(privilegedRootUserSecurityContext()),
 			)
+		})
+
+		It("should set allowPrivilegeEscalation to true when non root", func() {
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithPrivileged(), WithNonRoot(nonRootUser))
+			Expect(*specRenderer.Render(exampleCommand).SecurityContext.AllowPrivilegeEscalation).Should(BeTrue())
 		})
 	})
 
@@ -111,7 +115,7 @@ var _ = Describe("Container spec renderer", func() {
 
 		Context("a VMI belonging to a non root user", func() {
 			BeforeEach(func() {
-				const nonRootUser = 207
+
 				specRenderer = NewContainerSpecRenderer(
 					containerName,
 					img,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -720,6 +720,10 @@ func (t *templateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		log.Log.V(4).Info("Add SEV-ES node label selector")
 		opts = append(opts, WithSEVESSelector())
 	}
+	if util.IsSecureExecutionVMI(vmi) {
+		log.Log.V(4).Info("Add Secure Execution node label selector")
+		opts = append(opts, WithSecureExecutionSelector())
+	}
 
 	return NewNodeSelectorRenderer(
 		vmi.Spec.NodeSelector,

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -119,6 +119,7 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 
 	n.hostCapabilities.items = usableModels
 	n.SEV = hostDomCapabilities.SEV
+	n.SecureExecution = hostDomCapabilities.SecureExecution
 
 	return nil
 }

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -202,6 +202,26 @@ var _ = Describe("Node-labeller config", func() {
 		)
 	})
 
+	DescribeTable("return correct SecureExecution capabilities",
+		func(isSupported bool) {
+			if isSupported {
+				nlController.domCapabilitiesFileName = "s390x/domcapabilities_s390-pv.xml"
+			} else {
+				nlController.domCapabilitiesFileName = "s390x/virsh_domcapabilities.xml"
+			}
+			err := nlController.loadDomCapabilities()
+			Expect(err).ToNot(HaveOccurred())
+
+			if isSupported {
+				Expect(nlController.SecureExecution.Supported).To(Equal("yes"))
+			} else {
+				Expect(nlController.SecureExecution.Supported).To(Equal("no"))
+			}
+		},
+		Entry("when Secure Execution is supported", true),
+		Entry("when Secure Execution is not supported", false),
+	)
+
 	It("Make sure proper labels are removed on removeLabellerLabels()", func() {
 		node := &k8sv1.Node{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -32,8 +32,9 @@ type hostCPUModel struct {
 
 // HostDomCapabilities represents structure for parsing output of virsh capabilities
 type HostDomCapabilities struct {
-	CPU CPU              `xml:"cpu"`
-	SEV SEVConfiguration `xml:"features>sev"`
+	CPU             CPU                          `xml:"cpu"`
+	SEV             SEVConfiguration             `xml:"features>sev"`
+	SecureExecution SecureExecutionConfiguration `xml:"features>s390-pv"`
 }
 
 // CPU represents slice of cpu modes
@@ -91,4 +92,8 @@ type SEVConfiguration struct {
 	MaxGuests       uint   `xml:"maxGuests"`
 	MaxESGuests     uint   `xml:"maxESGuests"`
 	SupportedES     string `xml:"-"`
+}
+
+type SecureExecutionConfiguration struct {
+	Supported string `xml:"supported,attr"`
 }

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -78,6 +78,7 @@ type NodeLabeller struct {
 	guestCaps               []libvirtxml.CapsGuest
 	hostCPUModel            hostCPUModel
 	SEV                     SEVConfiguration
+	SecureExecution         SecureExecutionConfiguration
 	arch                    archLabeller
 }
 
@@ -295,6 +296,9 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
 
 	if n.SEV.SupportedES == "yes" {
 		newLabels[kubevirtv1.SEVESLabel] = ""
+	}
+	if n.SecureExecution.Supported == "yes" {
+		newLabels[kubevirtv1.SecureExecutionLabel] = "true"
 	}
 
 	return newLabels

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -164,6 +164,28 @@ var _ = Describe("Node-labeller ", func() {
 		Expect(node.Labels).To(HaveKey(v1.SEVESLabel))
 	})
 
+	It("should not add SecureExecution label", func() {
+		nlController.volumePath = "testdata/s390x"
+		Expect(nlController.loadAll()).Should(Succeed())
+
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(Not(HaveKey(v1.SecureExecutionLabel)))
+	})
+
+	It("should  add SecureExecution label", func() {
+		nlController.domCapabilitiesFileName = "s390x/domcapabilities_s390-pv.xml"
+		Expect(nlController.loadAll()).Should(Succeed())
+
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(HaveKey(v1.SecureExecutionLabel))
+	})
+
 	It("should add usable cpu model labels for the host cpu model", func() {
 		res := nlController.execute()
 		Expect(res).To(BeTrue())

--- a/pkg/virt-handler/node-labeller/testdata/s390x/domcapabilities_s390-pv.xml
+++ b/pkg/virt-handler/node-labeller/testdata/s390x/domcapabilities_s390-pv.xml
@@ -1,0 +1,268 @@
+<domainCapabilities>
+  <path>/usr/libexec/qemu-kvm</path>
+  <domain>qemu</domain>
+  <machine>s390-ccw-virtio-rhel9.4.0</machine>
+  <arch>s390x</arch>
+  <vcpu max='248'/>
+  <iothreads supported='yes'/>
+  <os supported='yes'>
+    <enum name='firmware'/>
+    <loader supported='yes'>
+      <enum name='type'>
+        <value>rom</value>
+        <value>pflash</value>
+      </enum>
+      <enum name='readonly'>
+        <value>yes</value>
+        <value>no</value>
+      </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
+    </loader>
+  </os>
+  <cpu>
+    <mode name='host-passthrough' supported='no'/>
+    <mode name='maximum' supported='yes'>
+      <enum name='maximumMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='host-model' supported='yes'>
+      <model fallback='forbid'>gen15a-base</model>
+      <feature policy='disable' name='dateh2'/>
+      <feature policy='require' name='aen'/>
+      <feature policy='disable' name='gen13ptff'/>
+      <feature policy='disable' name='kmac-tdea-192'/>
+      <feature policy='require' name='kimd-sha-512'/>
+      <feature policy='disable' name='kmc-tdea-192'/>
+      <feature policy='disable' name='parseh'/>
+      <feature policy='require' name='klmd-sha-512'/>
+      <feature policy='require' name='aefsi'/>
+      <feature policy='disable' name='hfpm'/>
+      <feature policy='disable' name='hfpue'/>
+      <feature policy='disable' name='dfp'/>
+      <feature policy='disable' name='km-dea'/>
+      <feature policy='require' name='vx'/>
+      <feature policy='disable' name='emon'/>
+      <feature policy='disable' name='kimd-sha-1'/>
+      <feature policy='disable' name='cmpsceh'/>
+      <feature policy='disable' name='dfppc'/>
+      <feature policy='disable' name='dfpzc'/>
+      <feature policy='disable' name='dfphp'/>
+      <feature policy='disable' name='kmc-dea'/>
+      <feature policy='disable' name='klmd-sha-1'/>
+      <feature policy='disable' name='opc'/>
+      <feature policy='disable' name='asnlxr'/>
+      <feature policy='require' name='vxeh'/>
+      <feature policy='require' name='esop'/>
+      <feature policy='disable' name='km-tdea-192'/>
+      <feature policy='disable' name='km-tdea-128'/>
+      <feature policy='require' name='vxeh2'/>
+      <feature policy='disable' name='tsi'/>
+      <feature policy='disable' name='kmac-dea'/>
+      <feature policy='require' name='iep'/>
+      <feature policy='disable' name='kmc-tdea-128'/>
+      <feature policy='require' name='prno-trng'/>
+      <feature policy='require' name='ais'/>
+      <feature policy='disable' name='kmac-tdea-128'/>
+      <feature policy='disable' name='sema'/>
+      <feature policy='disable' name='eec'/>
+      <feature policy='require' name='zpci'/>
+      <feature policy='disable' name='nonqks'/>
+      <feature policy='require' name='sea_esop2'/>
+      <feature policy='disable' name='pfpo'/>
+      <feature policy='require' name='msa8-base'/>
+      <feature policy='require' name='msa4-base'/>
+      <feature policy='require' name='msa3-base'/>
+      <feature policy='require' name='msa5-base'/>
+      <feature policy='disable' name='tods'/>
+    </mode>
+    <mode name='custom' supported='yes'>
+      <model usable='no' vendor='IBM'>gen16a-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z890.2-base</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z800-base</model>
+      <model usable='no' vendor='IBM'>gen16a</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9EC.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z13.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.5-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9BC-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z890</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z890.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9BC</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z13</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z196</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z13s</model>
+      <model usable='no' vendor='IBM'>gen16b-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.3</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z13s-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9EC</model>
+      <model usable='no' vendor='IBM'>gen15a</model>
+      <model usable='no' vendor='IBM'>z14ZR1-base</model>
+      <model usable='no' vendor='IBM'>z14.2-base</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z900.3-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z13.2-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z196.2-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>zBC12-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9BC.2-base</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z900.2-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9EC.3</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>zEC12</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z900</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z114-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>zEC12-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10EC.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10EC-base</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z900.3</model>
+      <model usable='no' vendor='IBM'>z14ZR1</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10BC</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10BC.2-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9BC.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.2</model>
+      <model usable='no' vendor='IBM'>z14</model>
+      <model usable='no' vendor='IBM'>gen15b-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.4</model>
+      <model usable='yes' vendor='unknown'>max</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10EC.2-base</model>
+      <model usable='no' vendor='IBM'>gen15a-base</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z800</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10EC</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>zEC12.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.2-base</model>
+      <model usable='no' vendor='IBM'>gen16b</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z900-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10BC.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9EC-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9EC.3-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z114</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z890.3</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z196-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z9EC.2-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z196.2</model>
+      <model usable='no' vendor='IBM'>z14.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990-base</model>
+      <model usable='yes' deprecated='yes' vendor='IBM'>z900.2</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z890-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10EC.3</model>
+      <model usable='no' vendor='IBM'>z14-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.4-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10EC.3-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z10BC-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z13-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.3-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>zEC12.2-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>zBC12</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z890.3-base</model>
+      <model usable='no' deprecated='yes' vendor='IBM'>z990.5</model>
+      <model usable='no' vendor='IBM'>gen15b</model>
+      <model usable='yes' vendor='unknown'>qemu</model>
+    </mode>
+  </cpu>
+  <memoryBacking supported='yes'>
+    <enum name='sourceType'>
+      <value>file</value>
+      <value>anonymous</value>
+      <value>memfd</value>
+    </enum>
+  </memoryBacking>
+  <devices>
+    <disk supported='yes'>
+      <enum name='diskDevice'>
+        <value>disk</value>
+        <value>cdrom</value>
+        <value>floppy</value>
+        <value>lun</value>
+      </enum>
+      <enum name='bus'>
+        <value>fdc</value>
+        <value>scsi</value>
+        <value>virtio</value>
+      </enum>
+      <enum name='model'>
+        <value>virtio</value>
+      </enum>
+    </disk>
+    <graphics supported='yes'>
+      <enum name='type'>
+        <value>vnc</value>
+        <value>dbus</value>
+      </enum>
+    </graphics>
+    <video supported='yes'>
+      <enum name='modelType'>
+        <value>virtio</value>
+        <value>none</value>
+      </enum>
+    </video>
+    <hostdev supported='yes'>
+      <enum name='mode'>
+        <value>subsystem</value>
+      </enum>
+      <enum name='startupPolicy'>
+        <value>default</value>
+        <value>mandatory</value>
+        <value>requisite</value>
+        <value>optional</value>
+      </enum>
+      <enum name='subsysType'>
+        <value>pci</value>
+        <value>scsi</value>
+      </enum>
+      <enum name='capsType'/>
+      <enum name='pciBackend'/>
+    </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+        <value>builtin</value>
+      </enum>
+    </rng>
+    <filesystem supported='yes'>
+      <enum name='driverType'>
+        <value>path</value>
+        <value>handle</value>
+        <value>virtiofs</value>
+      </enum>
+    </filesystem>
+    <tpm supported='no'/>
+    <redirdev supported='no'/>
+    <channel supported='yes'>
+      <enum name='type'>
+        <value>pty</value>
+        <value>unix</value>
+      </enum>
+    </channel>
+    <crypto supported='yes'>
+      <enum name='model'/>
+      <enum name='type'>
+        <value>qemu</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>builtin</value>
+      </enum>
+    </crypto>
+  </devices>
+  <features>
+    <gic supported='no'/>
+    <vmcoreinfo supported='no'/>
+    <genid supported='no'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='yes'/>
+    <async-teardown supported='yes'/>
+    <s390-pv supported='yes'/>
+    <sev supported='no'/>
+    <sgx supported='no'/>
+    <launchSecurity supported='yes'>
+      <enum name='sectype'>
+        <value>s390-pv</value>
+      </enum>
+    </launchSecurity>
+  </features>
+</domainCapabilities>
+

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1551,6 +1551,10 @@ func (c *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.Virtu
 		return newNonMigratableCondition("VMI uses SEV", v1.VirtualMachineInstanceReasonSEVNotMigratable), isBlockMigration
 	}
 
+	if util.IsSecureExecutionVMI(vmi) {
+		return newNonMigratableCondition("VMI uses Secure Execution", v1.VirtualMachineInstanceReasonSecureExecutionNotMigratable), isBlockMigration
+	}
+
 	if reservation.HasVMIPersistentReservation(vmi) {
 		return newNonMigratableCondition("VMI uses SCSI persitent reservation", v1.VirtualMachineInstanceReasonPRNotMigratable), isBlockMigration
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2794,6 +2794,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(condition.Reason).To(Equal(v1.VirtualMachineInstanceReasonSEVNotMigratable))
 		})
 
+		It("should not be allowed to live-migrate if the VMI uses Secure Execution", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{}
+			vmi.Spec.Architecture = "s390x"
+
+			condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
+			Expect(isBlockMigration).To(BeFalse())
+			Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+			Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(v1.VirtualMachineInstanceReasonSecureExecutionNotMigratable))
+		})
+
 		It("should not be allowed to live-migrate if the VMI uses SCSI persistent reservation", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 

--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//pkg/virt-launcher/virtwrap/converter/arch:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
-        "//pkg/virt-launcher/virtwrap/launchsecurity:go_default_library",
         "//pkg/virtiofs:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/arch/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/arch/BUILD.bazel
@@ -13,8 +13,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/pointer:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
+        "//pkg/virt-launcher/virtwrap/launchsecurity:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],

--- a/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
@@ -119,3 +119,7 @@ func (converterARM64) ConvertWatchdog(source *v1.Watchdog, watchdog *api.Watchdo
 func (converterARM64) SupportPCIHole64Disabling() bool {
 	return false
 }
+
+func (converterARM64) LaunchSecurity(_ *v1.VirtualMachineInstance) *api.LaunchSecurity {
+	return nil
+}

--- a/pkg/virt-launcher/virtwrap/converter/arch/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/converter.go
@@ -47,6 +47,7 @@ type Converter interface {
 	ShouldVerboseLogsBeEnabled() bool
 	ConvertWatchdog(source *v1.Watchdog, watchdog *api.Watchdog) error
 	SupportPCIHole64Disabling() bool
+	LaunchSecurity(vmi *v1.VirtualMachineInstance) *api.LaunchSecurity
 }
 
 func NewConverter(arch string) Converter {

--- a/pkg/virt-launcher/virtwrap/converter/arch/ppc64le.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/ppc64le.go
@@ -95,3 +95,7 @@ func (converterPPC64) ConvertWatchdog(source *v1.Watchdog, watchdog *api.Watchdo
 func (converterPPC64) SupportPCIHole64Disabling() bool {
 	return false
 }
+
+func (converterPPC64) LaunchSecurity(_ *v1.VirtualMachineInstance) *api.LaunchSecurity {
+	return nil
+}

--- a/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
@@ -80,6 +80,7 @@ func (converterS390X) TransitionalModelType(_ bool) string {
 }
 
 func (converterS390X) IsROMTuningSupported() bool {
+	// s390x does not support setting ROM tuning, as it is for PCI Devices only
 	return false
 }
 
@@ -108,4 +109,10 @@ func (converterS390X) ConvertWatchdog(source *v1.Watchdog, watchdog *api.Watchdo
 
 func (converterS390X) SupportPCIHole64Disabling() bool {
 	return false
+}
+
+func (converterS390X) LaunchSecurity(vmi *v1.VirtualMachineInstance) *api.LaunchSecurity {
+	// We would want to set launchsecurity with type "s390-pv" here, but this does not work in privileged pod.
+	// Instead virt-launcher will set iommu=on for all devices manually, which is the same action as what libvirt would do when the launchsecurity type is set.
+	return nil
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -64,7 +64,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/arch"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/launchsecurity"
 )
 
 const (
@@ -1456,20 +1455,13 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		return err
 	}
 
-	// Set SEV launch security parameters: https://libvirt.org/formatdomain.html#launch-security
 	if c.UseLaunchSecurity {
-		sevPolicyBits := launchsecurity.SEVPolicyToBits(vmi.Spec.Domain.LaunchSecurity.SEV.Policy)
-		// Cbitpos and ReducedPhysBits will be filled automatically by libvirt from the domain capabilities
-		domain.Spec.LaunchSecurity = &api.LaunchSecurity{
-			Type:    "sev",
-			Policy:  "0x" + strconv.FormatUint(uint64(sevPolicyBits), 16),
-			DHCert:  vmi.Spec.Domain.LaunchSecurity.SEV.DHCert,
-			Session: vmi.Spec.Domain.LaunchSecurity.SEV.Session,
-		}
 		controllerDriver = &api.ControllerDriver{
 			IOMMU: "on",
 		}
+		domain.Spec.LaunchSecurity = c.Architecture.LaunchSecurity(vmi)
 	}
+
 	if c.SMBios != nil {
 		domain.Spec.SysInfo.System = append(domain.Spec.SysInfo.System,
 			api.Entry{

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -84,14 +84,15 @@ func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, c *ConverterContext)
 			if iface.BootOrder != nil {
 				domainIface.BootOrder = &api.BootOrder{Order: *iface.BootOrder}
 			} else if arch.NewConverter(vmi.Spec.Architecture).IsROMTuningSupported() {
-				// s390x does not support setting ROM tuning, as it is for PCI Devices only
 				domainIface.Rom = &api.Rom{Enabled: "no"}
 			}
 		}
 
 		if c.UseLaunchSecurity {
-			// It's necessary to disable the iPXE option ROM as iPXE is not aware of SEV
-			domainIface.Rom = &api.Rom{Enabled: "no"}
+			if arch.NewConverter(vmi.Spec.Architecture).IsROMTuningSupported() {
+				// It's necessary to disable the iPXE option ROM as iPXE is not aware of SEV
+				domainIface.Rom = &api.Rom{Enabled: "no"}
+			}
 			if ifaceType == v1.VirtIO {
 				if domainIface.Driver != nil {
 					domainIface.Driver.IOMMU = "on"

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1051,7 +1051,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		UseVirtioTransitional: vmi.Spec.Domain.Devices.UseVirtioTransitional != nil && *vmi.Spec.Domain.Devices.UseVirtioTransitional,
 		PermanentVolumes:      permanentVolumes,
 		EphemeraldiskCreator:  l.ephemeralDiskCreator,
-		UseLaunchSecurity:     kutil.IsSEVVMI(vmi),
+		UseLaunchSecurity:     kutil.UseLaunchSecurity(vmi),
 		FreePageReporting:     isFreePageReportingEnabled(false, vmi),
 		SerialConsoleLog:      isSerialConsoleLogEnabled(false, vmi),
 	}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -625,6 +625,8 @@ const (
 	VirtualMachineInstanceReasonHostDeviceNotMigratable = "HostDeviceNotLiveMigratable"
 	// Reason means that VMI is not live migratable because it uses Secure Encrypted Virtualization (SEV)
 	VirtualMachineInstanceReasonSEVNotMigratable = "SEVNotLiveMigratable"
+	// Reason means that VMI is not live migratable because it uses IBM Secure Execution
+	VirtualMachineInstanceReasonSecureExecutionNotMigratable = "SecureExecutionNotLiveMigratable"
 	// Reason means that VMI is not live migratable because it uses HyperV Reenlightenment while TSC Frequency is not available
 	VirtualMachineInstanceReasonNoTSCFrequencyMigratable = "NoTSCFrequencyNotLiveMigratable"
 	// Reason means that VMI is not live migratable because it uses HyperV Reenlightenment while TSC Frequency is not available

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1136,6 +1136,9 @@ const (
 	// SEVESLabel marks the node as capable of running workloads with SEV-ES
 	SEVESLabel string = "kubevirt.io/sev-es"
 
+	// SecureExecutionLabel marks the node as capable of running workloads with IBM Secure Execution
+	SecureExecutionLabel string = "kubevirt.io/s390-pv"
+
 	// KSMEnabledLabel marks the node as KSM-handling enabled
 	KSMEnabledLabel string = "kubevirt.io/ksm-enabled"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md a
-->


### What this PR does
Before this PR:
Secure Execution does not work with kubevirt
After this PR:
User can use Secure Execution VMs on IBM Z
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/enhancements/pull/15
### Special notes for your reviewer
Implementation for [VEP 19](https://github.com/kubevirt/enhancements/issues/19)
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Secure Execution VMs on IBM Z
```

