### PR TITLE
virt-controller/watch/vmi: propagate vmi.Spec.TerminationGracePeriodSeconds to launcher DeleteOptions

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14635,7 +14635,7 @@
       "$ref": "#/definitions/v1.VirtualMachineOptions"
      },
      "vmRolloutStrategy": {
-      "description": "VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory, tolerations, and affinity, are propagated from a VM to its VMI.",
+      "description": "VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory, tolerations, terminationGracePeriodSeconds and affinity, are propagated from a VM to its VMI.",
       "type": "string"
      },
      "vmStateStorageClass": {

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -978,7 +978,7 @@ spec:
                   vmRolloutStrategy:
                     description: |-
                       VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory,
-                      tolerations, and affinity, are propagated from a VM to its VMI.
+                      tolerations, terminationGracePeriodSeconds and affinity, are propagated from a VM to its VMI.
                     enum:
                     - Stage
                     - LiveUpdate
@@ -4246,7 +4246,7 @@ spec:
                   vmRolloutStrategy:
                     description: |-
                       VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory,
-                      tolerations, and affinity, are propagated from a VM to its VMI.
+                      tolerations, terminationGracePeriodSeconds and affinity, are propagated from a VM to its VMI.
                     enum:
                     - Stage
                     - LiveUpdate

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1571,7 +1571,7 @@ var CRDsValidation map[string]string = map[string]string{
             vmRolloutStrategy:
               description: |-
                 VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory,
-                tolerations, and affinity, are propagated from a VM to its VMI.
+                tolerations, terminationGracePeriodSeconds and affinity, are propagated from a VM to its VMI.
               enum:
               - Stage
               - LiveUpdate

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2594,7 +2594,7 @@ type KubeVirtConfiguration struct {
 	LiveUpdateConfiguration *LiveUpdateConfiguration `json:"liveUpdateConfiguration,omitempty"`
 
 	// VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory,
-	// tolerations, and affinity, are propagated from a VM to its VMI.
+	// tolerations, terminationGracePeriodSeconds and affinity, are propagated from a VM to its VMI.
 	// +nullable
 	// +kubebuilder:validation:Enum=Stage;LiveUpdate
 	VMRolloutStrategy *VMRolloutStrategy `json:"vmRolloutStrategy,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -790,7 +790,7 @@ func (KubeVirtConfiguration) SwaggerDoc() map[string]string {
 		"ksmConfiguration":                   "KSMConfiguration holds the information regarding the enabling the KSM in the nodes (if available).",
 		"autoCPULimitNamespaceLabelSelector": "When set, AutoCPULimitNamespaceLabelSelector will set a CPU limit on virt-launcher for VMIs running inside\nnamespaces that match the label selector.\nThe CPU limit will equal the number of requested vCPUs.\nThis setting does not apply to VMIs with dedicated CPUs.",
 		"liveUpdateConfiguration":            "LiveUpdateConfiguration holds defaults for live update features",
-		"vmRolloutStrategy":                  "VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory,\ntolerations, and affinity, are propagated from a VM to its VMI.\n+nullable\n+kubebuilder:validation:Enum=Stage;LiveUpdate",
+		"vmRolloutStrategy":                  "VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory,\ntolerations, terminationGracePeriodSeconds and affinity, are propagated from a VM to its VMI.\n+nullable\n+kubebuilder:validation:Enum=Stage;LiveUpdate",
 		"commonInstancetypesDeployment":      "CommonInstancetypesDeployment controls the deployment of common-instancetypes resources\n+nullable",
 		"instancetype":                       "Instancetype configuration\n+nullable",
 	}

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21486,7 +21486,7 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 					},
 					"vmRolloutStrategy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory, tolerations, and affinity, are propagated from a VM to its VMI.",
+							Description: "VMRolloutStrategy defines how live-updatable fields, like CPU sockets, memory, tolerations, terminationGracePeriodSeconds and affinity, are propagated from a VM to its VMI.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
### What this PR does
When deleting the launcher, we should use `vmi.Spec.TerminationGracePeriodSeconds` in the DeleteOptions.
without it the launcher pod  will have the grace preiod from the initial manifest.
This limits users who start  with a high grace period in a template but later want to terminate quickly.
With a simple patch of the  `TerminationGracePeriodSeconds`  field, users will be able to override the grace time.

#### Before this PR:
- The `TerminationGracePeriodSeconds` value from the VMI spec was not  used in `DeleteOptions` when deleting the `virt-launcher` pod. 
- The launcher pod always used the value defined in its initial manifest.  
- Users could not change the termination grace period dynamically. 

#### After this PR:
- The `TerminationGracePeriodSeconds` field is now propagated to `DeleteOptions` when deleting the `virt-launcher` pod.  
- Users can patch the `TerminationGracePeriodSeconds` field in the VM and have it affect the pod's graceful termination time.
- This allows quicker termination of VMs when needed.

In the future it will be possible to create a virctl command like:

`virctl delete myvm --grace-preiod=0` which will patch the grace time from the flag and issue a delete api call.


### Release note
```release-note
None
```
