### PR TITLE
featuregates: Graduate InstancetypeReferencePolicy to GA

### DIFF
--- a/pkg/instancetype/controller/vm/BUILD.bazel
+++ b/pkg/instancetype/controller/vm/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
-        "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-controller/watch/common:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/pkg/instancetype/controller/vm/controller_test.go
+++ b/pkg/instancetype/controller/vm/controller_test.go
@@ -35,7 +35,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/common"
 )
 
@@ -915,12 +914,9 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			}
 		}
 
-		kvWithFGEnabledReferencePolicyExpand := &virtv1.KubeVirt{
+		kvWithReferencePolicyExpand := &virtv1.KubeVirt{
 			Spec: virtv1.KubeVirtSpec{
 				Configuration: virtv1.KubeVirtConfiguration{
-					DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-						FeatureGates: []string{featuregate.InstancetypeReferencePolicy},
-					},
 					Instancetype: &virtv1.InstancetypeConfiguration{
 						ReferencePolicy: pointer.P(virtv1.Expand),
 					},
@@ -928,12 +924,9 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			},
 		}
 
-		kvWithFGEnabledReferencePolicyExpandAll := &virtv1.KubeVirt{
+		kvWithReferencePolicyExpandAll := &virtv1.KubeVirt{
 			Spec: virtv1.KubeVirtSpec{
 				Configuration: virtv1.KubeVirtConfiguration{
-					DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-						FeatureGates: []string{featuregate.InstancetypeReferencePolicy},
-					},
 					Instancetype: &virtv1.InstancetypeConfiguration{
 						ReferencePolicy: pointer.P(virtv1.ExpandAll),
 					},
@@ -975,9 +968,9 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			Expect(vm.Spec.Preference.RevisionName).To(BeEmpty())
 			Expect(revision.HasControllerRevisionRef(vm.Status.PreferenceRef)).To(BeTrue())
 		},
-			Entry("with FG disabled and default referencePolicy",
+			Entry("default referencePolicy",
 				&virtv1.KubeVirt{Spec: virtv1.KubeVirtSpec{Configuration: virtv1.KubeVirtConfiguration{}}}, func() {}),
-			Entry("with FG disabled and referencePolicy reference",
+			Entry("referencePolicy reference",
 				&virtv1.KubeVirt{
 					Spec: virtv1.KubeVirtSpec{
 						Configuration: virtv1.KubeVirtConfiguration{
@@ -987,47 +980,8 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 						},
 					},
 				}, func() {}),
-			Entry("with FG disabled and referencePolicy expand",
-				&virtv1.KubeVirt{
-					Spec: virtv1.KubeVirtSpec{
-						Configuration: virtv1.KubeVirtConfiguration{
-							Instancetype: &virtv1.InstancetypeConfiguration{
-								ReferencePolicy: pointer.P(virtv1.Expand),
-							},
-						},
-					},
-				}, func() {}),
-			Entry("with FG disabled and referencePolicy expandAll",
-				&virtv1.KubeVirt{
-					Spec: virtv1.KubeVirtSpec{
-						Configuration: virtv1.KubeVirtConfiguration{
-							Instancetype: &virtv1.InstancetypeConfiguration{
-								ReferencePolicy: pointer.P(virtv1.ExpandAll),
-							},
-						},
-					},
-				}, func() {}),
-			Entry("with FG enabled and default referencePolicy", &virtv1.KubeVirt{
-				Spec: virtv1.KubeVirtSpec{Configuration: virtv1.KubeVirtConfiguration{
-					DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-						FeatureGates: []string{featuregate.InstancetypeReferencePolicy},
-					},
-				}},
-			}, func() {}),
-			Entry("with FG enabled and referencePolicy reference", &virtv1.KubeVirt{
-				Spec: virtv1.KubeVirtSpec{
-					Configuration: virtv1.KubeVirtConfiguration{
-						DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-							FeatureGates: []string{featuregate.InstancetypeReferencePolicy},
-						},
-						Instancetype: &virtv1.InstancetypeConfiguration{
-							ReferencePolicy: pointer.P(virtv1.Reference),
-						},
-					},
-				},
-			}, func() {}),
-			Entry("with FG enabled, referencePolicy expand and revisionNames already captured",
-				kvWithFGEnabledReferencePolicyExpand, addRevisionsToVMFunc,
+			Entry("referencePolicy expand and revisionNames already captured",
+				kvWithReferencePolicyExpand, addRevisionsToVMFunc,
 			),
 		)
 
@@ -1067,10 +1021,10 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
 			}
 		},
-			Entry("with FG enabled and referencePolicy expand", kvWithFGEnabledReferencePolicyExpand, func() {}),
-			Entry("with FG enabled and referencePolicy expandAll", kvWithFGEnabledReferencePolicyExpandAll, func() {}),
-			Entry("with FG enabled and referencePolicy expandAll and revisionNames already captured",
-				kvWithFGEnabledReferencePolicyExpandAll, addRevisionsToVMFunc),
+			Entry("referencePolicy expand", kvWithReferencePolicyExpand, func() {}),
+			Entry("referencePolicy expandAll", kvWithReferencePolicyExpandAll, func() {}),
+			Entry("referencePolicy expandAll and revisionNames already captured",
+				kvWithReferencePolicyExpandAll, addRevisionsToVMFunc),
 		)
 	})
 })

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -32,7 +32,6 @@ go_test(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
-        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -17,7 +17,6 @@ import (
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
@@ -779,28 +778,18 @@ var _ = Describe("test configuration", func() {
 		})
 	})
 
-	disableInstancetypeRferencePolicyFG := []string{}
-	enableInstancetypeReferencePolicyFG := []string{featuregate.InstancetypeReferencePolicy}
-
 	DescribeTable("GetInstancetypeReferencePolicy should return", func(
-		instancetypeConfig *v1.InstancetypeConfiguration, featureGates []string, expectedPolicy v1.InstancetypeReferencePolicy) {
+		instancetypeConfig *v1.InstancetypeConfiguration, expectedPolicy v1.InstancetypeReferencePolicy) {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(
 			&v1.KubeVirtConfiguration{
 				Instancetype: instancetypeConfig,
-				DeveloperConfiguration: &v1.DeveloperConfiguration{
-					FeatureGates: featureGates,
-				},
 			},
 		)
 		Expect(clusterConfig.GetInstancetypeReferencePolicy()).To(Equal(expectedPolicy))
 	},
-		Entry("reference when FG unset and InstancetypeConfiguration is nil", nil, disableInstancetypeRferencePolicyFG, v1.Reference),
-		Entry("reference when FG unset and InstancetypeConfiguration.ReferencePolicy is nil", &v1.InstancetypeConfiguration{}, disableInstancetypeRferencePolicyFG, v1.Reference),
-		Entry("reference when FG unset and InstancetypeConfiguration.ReferencePolicy is reference", &v1.InstancetypeConfiguration{ReferencePolicy: pointer.P(v1.Reference)}, disableInstancetypeRferencePolicyFG, v1.Reference),
-		Entry("reference when FG unset andInstancetypeConfiguration.ReferencePolicy is expand", &v1.InstancetypeConfiguration{ReferencePolicy: pointer.P(v1.Expand)}, disableInstancetypeRferencePolicyFG, v1.Reference),
-		Entry("reference when FG set and InstancetypeConfiguration is nil", nil, enableInstancetypeReferencePolicyFG, v1.Reference),
-		Entry("reference when FG set and InstancetypeConfiguration.ReferencePolicy is nil", &v1.InstancetypeConfiguration{}, enableInstancetypeReferencePolicyFG, v1.Reference),
-		Entry("reference when FG set andInstancetypeConfiguration.ReferencePolicy is reference", &v1.InstancetypeConfiguration{ReferencePolicy: pointer.P(v1.Reference)}, enableInstancetypeReferencePolicyFG, v1.Reference),
-		Entry("expand when FG set andInstancetypeConfiguration.ReferencePolicy is expand", &v1.InstancetypeConfiguration{ReferencePolicy: pointer.P(v1.Expand)}, enableInstancetypeReferencePolicyFG, v1.Expand),
+		Entry("reference when InstancetypeConfiguration is nil", nil, v1.Reference),
+		Entry("reference when InstancetypeConfiguration.ReferencePolicy is nil", &v1.InstancetypeConfiguration{}, v1.Reference),
+		Entry("reference when InstancetypeConfiguration.ReferencePolicy is reference", &v1.InstancetypeConfiguration{ReferencePolicy: pointer.P(v1.Reference)}, v1.Reference),
+		Entry("expand InstancetypeConfiguration.ReferencePolicy is expand", &v1.InstancetypeConfiguration{ReferencePolicy: pointer.P(v1.Expand)}, v1.Expand),
 	)
 })

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -56,13 +56,6 @@ const (
 	// This feature requires following Kubernetes feature gate "ServiceAccountTokenPodNodeInfo". The feature gate is available
 	// in Kubernetes 1.30 as Beta.
 	NodeRestrictionGate = "NodeRestriction"
-	// Owner: @lyarwood
-	// Alpha: v1.4.0
-	// Beta: v1.5.0
-	//
-	// InstancetypeReferencePolicy allows a cluster admin to control how a VirtualMachine references instance types and preferences
-	// through the kv.spec.configuration.instancetype.referencePolicy configurable.
-	InstancetypeReferencePolicy = "InstancetypeReferencePolicy"
 
 	VirtIOFSConfigVolumesGate = "EnableVirtioFsConfigVolumes"
 	VirtIOFSStorageVolumeGate = "EnableVirtioFsStorageVolumes"
@@ -89,7 +82,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MultiArchitecture, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: AlignCPUsGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: NodeRestrictionGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: InstancetypeReferencePolicy, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSConfigVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSStorageVolumeGate, State: Alpha})
 }

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -86,6 +86,15 @@ const (
 	ClusterProfiler = "ClusterProfiler"
 
 	VMPersistentState = "VMPersistentState"
+
+	// Owner: @lyarwood
+	// Alpha: v1.4.0
+	// Beta: v1.5.0
+	// GA: v1.6.0
+	//
+	// InstancetypeReferencePolicy allows a cluster admin to control how a VirtualMachine references instance types and preferences
+	// through the kv.spec.configuration.instancetype.referencePolicy configurable.
+	InstancetypeReferencePolicy = "InstancetypeReferencePolicy"
 )
 
 func init() {
@@ -115,4 +124,6 @@ func init() {
 
 	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Discontinued, Message: PasstDiscontinueMessage, VmiSpecUsed: passtApiUsed})
 	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})
+
+	RegisterFeatureGate(FeatureGate{Name: InstancetypeReferencePolicy, State: GA})
 }

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -487,13 +487,12 @@ func (config *ClusterConfig) VGADisplayForEFIGuestsEnabled() bool {
 }
 
 func (c *ClusterConfig) GetInstancetypeReferencePolicy() v1.InstancetypeReferencePolicy {
-	// Default to the Reference InstancetypeReferencePolicy
-	policy := v1.Reference
 	instancetypeConfig := c.GetConfig().Instancetype
-	if c.isFeatureGateEnabled(featuregate.InstancetypeReferencePolicy) && instancetypeConfig != nil && instancetypeConfig.ReferencePolicy != nil {
-		policy = *instancetypeConfig.ReferencePolicy
+	if instancetypeConfig != nil && instancetypeConfig.ReferencePolicy != nil {
+		return *instancetypeConfig.ReferencePolicy
 	}
-	return policy
+	// Default to the Reference InstancetypeReferencePolicy
+	return v1.Reference
 }
 
 func (c *ClusterConfig) ClusterProfilerEnabled() bool {

--- a/tests/instancetype/BUILD.bazel
+++ b/tests/instancetype/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1alpha1:go_default_library",

--- a/tests/instancetype/reference_policy.go
+++ b/tests/instancetype/reference_policy.go
@@ -16,7 +16,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/revision"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -33,7 +32,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
-			kvconfig.EnableFeatureGate(featuregate.InstancetypeReferencePolicy)
 		})
 
 		DescribeTable("should result in running VirtualMachine when set to", func(policy virtv1.InstancetypeReferencePolicy) {


### PR DESCRIPTION
/area instancetype

### What this PR does

This change graduates the instance type reference policy feature to GA
removing the need for the associated feature gate to be enabled before
it is configurable by a cluster admin.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `InstancetypeReferencePolicy` feature has graduated to GA and no longer requires the associated feature gate to be enabled.
```

