### PR TITLE
Make VMI controller lighter by moving storage logic into own files.

### DIFF
--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "datavolumes.go",
         "vmi.go",
+        "volume-hotplug.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/vmi",
     visibility = ["//visibility:public"],

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["vmi.go"],
+    srcs = [
+        "datavolumes.go",
+        "vmi.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/vmi",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/virt-controller/watch/vmi/datavolumes.go
+++ b/pkg/virt-controller/watch/vmi/datavolumes.go
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package vmi
+
+import (
+	"fmt"
+
+	k8sv1 "k8s.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/common"
+)
+
+func (c *Controller) handleSyncDataVolumes(vmi *v1.VirtualMachineInstance, dataVolumes []*cdiv1.DataVolume) (bool, bool, common.SyncError) {
+
+	ready := true
+	wffc := false
+
+	for _, volume := range vmi.Spec.Volumes {
+		// Check both DVs and PVCs
+		if volume.VolumeSource.DataVolume != nil || volume.VolumeSource.PersistentVolumeClaim != nil {
+			volumeReady, volumeWffc, err := storagetypes.VolumeReadyToAttachToNode(vmi.Namespace, volume, dataVolumes, c.dataVolumeIndexer, c.pvcIndexer)
+			if err != nil {
+				if _, ok := err.(storagetypes.PvcNotFoundError); ok {
+					// due to the eventually consistent nature of controllers, CDI or users may need some time to actually crate the PVC.
+					// We wait for them to appear.
+					c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, controller.FailedPvcNotFoundReason, "PVC %s/%s does not exist, waiting for it to appear", vmi.Namespace, storagetypes.PVCNameFromVirtVolume(&volume))
+					return false, false, &informalSyncError{err: fmt.Errorf("PVC %s/%s does not exist, waiting for it to appear", vmi.Namespace, storagetypes.PVCNameFromVirtVolume(&volume)), reason: controller.FailedPvcNotFoundReason}
+				} else {
+					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, controller.FailedPvcNotFoundReason, "Error determining if volume is ready: %v", err)
+					return false, false, common.NewSyncError(fmt.Errorf("Error determining if volume is ready %v", err), controller.FailedDataVolumeImportReason)
+				}
+			}
+			wffc = wffc || volumeWffc
+			// Ready only becomes false if WFFC is also false.
+			ready = ready && (volumeReady || volumeWffc)
+		}
+	}
+
+	return ready, wffc, nil
+}
+
+func (c *Controller) aggregateDataVolumesConditions(vmiCopy *v1.VirtualMachineInstance, dvs []*cdiv1.DataVolume) {
+	if len(dvs) == 0 {
+		return
+	}
+
+	dvsReadyCondition := v1.VirtualMachineInstanceCondition{
+		Status:  k8sv1.ConditionTrue,
+		Type:    v1.VirtualMachineInstanceDataVolumesReady,
+		Reason:  v1.VirtualMachineInstanceReasonAllDVsReady,
+		Message: "All of the VMI's DVs are bound and not running",
+	}
+
+	for _, dv := range dvs {
+		cStatus := statusOfReadyCondition(dv.Status.Conditions)
+		if cStatus != k8sv1.ConditionTrue {
+			dvsReadyCondition.Reason = v1.VirtualMachineInstanceReasonNotAllDVsReady
+			if cStatus == k8sv1.ConditionFalse {
+				dvsReadyCondition.Status = cStatus
+			} else if dvsReadyCondition.Status == k8sv1.ConditionTrue {
+				dvsReadyCondition.Status = cStatus
+			}
+		}
+	}
+
+	if dvsReadyCondition.Status != k8sv1.ConditionTrue {
+		dvsReadyCondition.Message = "Not all of the VMI's DVs are ready"
+	}
+
+	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
+	vmiConditions.UpdateCondition(vmiCopy, &dvsReadyCondition)
+}
+
+func statusOfReadyCondition(conditions []cdiv1.DataVolumeCondition) k8sv1.ConditionStatus {
+	for _, condition := range conditions {
+		if condition.Type == cdiv1.DataVolumeReady {
+			return condition.Status
+		}
+	}
+	return k8sv1.ConditionUnknown
+}
+
+// listVMIsMatchingDV

--- a/pkg/virt-controller/watch/vmi/datavolumes.go
+++ b/pkg/virt-controller/watch/vmi/datavolumes.go
@@ -31,7 +31,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/common"
 )
 
-func (c *Controller) handleSyncDataVolumes(vmi *v1.VirtualMachineInstance, dataVolumes []*cdiv1.DataVolume) (bool, bool, common.SyncError) {
+func (c *Controller) areDataVolumesReady(vmi *v1.VirtualMachineInstance, dataVolumes []*cdiv1.DataVolume) (bool, bool, common.SyncError) {
 
 	ready := true
 	wffc := false
@@ -60,7 +60,7 @@ func (c *Controller) handleSyncDataVolumes(vmi *v1.VirtualMachineInstance, dataV
 	return ready, wffc, nil
 }
 
-func (c *Controller) aggregateDataVolumesConditions(vmiCopy *v1.VirtualMachineInstance, dvs []*cdiv1.DataVolume) {
+func aggregateDataVolumesConditions(vmiCopy *v1.VirtualMachineInstance, dvs []*cdiv1.DataVolume) {
 	if len(dvs) == 0 {
 		return
 	}
@@ -100,5 +100,3 @@ func statusOfReadyCondition(conditions []cdiv1.DataVolumeCondition) k8sv1.Condit
 	}
 	return k8sv1.ConditionUnknown
 }
-
-// listVMIsMatchingDV

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -1892,8 +1892,6 @@ func (c *Controller) deleteAttachmentPod(vmi *virtv1.VirtualMachineInstance, att
 
 func (c *Controller) createAttachmentPodTemplate(vmi *virtv1.VirtualMachineInstance, virtlauncherPod *k8sv1.Pod, volumes []*virtv1.Volume) (*k8sv1.Pod, error) {
 	logger := log.Log.Object(vmi)
-	var pod *k8sv1.Pod
-	var err error
 
 	volumeNamesPVCMap, err := storagetypes.VirtVolumesToPVCMap(volumes, c.pvcIndexer, virtlauncherPod.Namespace)
 	if err != nil {
@@ -1918,9 +1916,9 @@ func (c *Controller) createAttachmentPodTemplate(vmi *virtv1.VirtualMachineInsta
 	}
 
 	if len(volumeNamesPVCMap) > 0 {
-		pod, err = c.templateService.RenderHotplugAttachmentPodTemplate(volumes, virtlauncherPod, vmi, volumeNamesPVCMap)
+		return c.templateService.RenderHotplugAttachmentPodTemplate(volumes, virtlauncherPod, vmi, volumeNamesPVCMap)
 	}
-	return pod, err
+	return nil, nil
 }
 
 func (c *Controller) createAttachmentPopulateTriggerPodTemplate(volume *virtv1.Volume, virtlauncherPod *k8sv1.Pod, vmi *virtv1.VirtualMachineInstance) (*k8sv1.Pod, error) {

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -496,7 +496,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 		}
 	}
 
-	c.aggregateDataVolumesConditions(vmiCopy, dataVolumes)
+	aggregateDataVolumesConditions(vmiCopy, dataVolumes)
 
 	if pvc := backendstorage.PVCForVMI(c.pvcIndexer, vmi); pvc != nil {
 		c.backendStorage.UpdateVolumeStatus(vmiCopy, pvc)
@@ -974,7 +974,7 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 		// do not return; just log the error
 	}
 
-	dataVolumesReady, isWaitForFirstConsumer, syncErr := c.handleSyncDataVolumes(vmi, dataVolumes)
+	dataVolumesReady, isWaitForFirstConsumer, syncErr := c.areDataVolumesReady(vmi, dataVolumes)
 	if syncErr != nil {
 		return syncErr, pod
 	}

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -2484,7 +2484,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		}
 
 		DescribeTable("should calculate deleted volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []k8sv1.Volume) {
-			res := controller.getDeletedHotplugVolumes(hotplugPods, hotplugVolumes)
+			res := getDeletedHotplugVolumes(hotplugPods, hotplugVolumes)
 			Expect(res).To(HaveLen(len(expected)))
 			for i, volume := range res {
 				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
@@ -2496,7 +2496,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 
 		DescribeTable("should calculate new volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []*virtv1.Volume) {
-			res := controller.getNewHotplugVolumes(hotplugPods, hotplugVolumes)
+			res := getNewHotplugVolumes(hotplugPods, hotplugVolumes)
 			Expect(res).To(HaveLen(len(expected)))
 			for i, volume := range res {
 				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
@@ -2597,7 +2597,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 
 		DescribeTable("needsHandleHotplug", func(hotplugVolumes []*virtv1.Volume, hotplugAttachmentPods []*k8sv1.Pod, expected bool) {
-			res := controller.needsHandleHotplug(hotplugVolumes, hotplugAttachmentPods)
+			res := needsHandleHotplug(hotplugVolumes, hotplugAttachmentPods)
 			Expect(res).To(Equal(expected))
 		},
 			Entry("should return false if volumes and attachmentpods are empty", makeVolumes(), makePods(), false),
@@ -2796,7 +2796,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 
 		DescribeTable("Should properly calculate if it needs to handle hotplug volumes", func(hotplugVolumes []*virtv1.Volume, attachmentPods []*k8sv1.Pod, match gomegaTypes.GomegaMatcher) {
-			Expect(controller.needsHandleHotplug(hotplugVolumes, attachmentPods)).To(match)
+			Expect(needsHandleHotplug(hotplugVolumes, attachmentPods)).To(match)
 		},
 			Entry("nil volumes, nil attachmentPods", nil, nil, BeFalse()),
 			Entry("empty volumes, empty attachmentPods", []*virtv1.Volume{}, []*k8sv1.Pod{}, BeFalse()),
@@ -2824,7 +2824,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 
 		DescribeTable("Should find active and old pods", func(hotplugVolumes []*virtv1.Volume, attachmentPods []*k8sv1.Pod, expectedActive *k8sv1.Pod, expectedOld []*k8sv1.Pod) {
-			active, old := controller.getActiveAndOldAttachmentPods(hotplugVolumes, attachmentPods)
+			active, old := getActiveAndOldAttachmentPods(hotplugVolumes, attachmentPods)
 			Expect(active).To(Equal(expectedActive))
 			Expect(old).To(ContainElements(expectedOld))
 		},

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -2483,31 +2483,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return res
 		}
 
-		DescribeTable("should calculate deleted volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []k8sv1.Volume) {
-			res := getDeletedHotplugVolumes(hotplugPods, hotplugVolumes)
-			Expect(res).To(HaveLen(len(expected)))
-			for i, volume := range res {
-				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
-			}
-		},
-			Entry("should return empty if pods and volumes is empty", make([]*k8sv1.Pod, 0), make([]*virtv1.Volume, 0), make([]k8sv1.Volume, 0)),
-			Entry("should return empty if pods and volumes match", makePods(1), makeVolumes(1), make([]k8sv1.Volume, 0)),
-			Entry("should return empty if pods < volumes", makePods(1), makeVolumes(1, 2), make([]k8sv1.Volume, 0)),
-		)
-
-		DescribeTable("should calculate new volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []*virtv1.Volume) {
-			res := getNewHotplugVolumes(hotplugPods, hotplugVolumes)
-			Expect(res).To(HaveLen(len(expected)))
-			for i, volume := range res {
-				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
-			}
-		},
-			Entry("should return empty if pods and volumes is empty", make([]*k8sv1.Pod, 0), make([]*virtv1.Volume, 0), make([]*virtv1.Volume, 0)),
-			Entry("should return empty if pods and volumes match", makePods(1), makeVolumes(1), make([]*virtv1.Volume, 0)),
-			Entry("should return empty if pods > volumes", makePods(1), makeVolumes(1, 2), makeVolumes(2)),
-			Entry("should return 1 value if pods < volumes by 1", makePods(1, 2), makeVolumes(1), make([]*virtv1.Volume, 0)),
-		)
-
 		makeVolumeStatuses := func() []virtv1.VolumeStatus {
 			volumeStatuses := make([]virtv1.VolumeStatus, 0)
 			volumeStatuses = append(volumeStatuses, virtv1.VolumeStatus{

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -1,0 +1,379 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package vmi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	k8sv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/pointer"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/common"
+)
+
+func (c *Controller) needsHandleHotplug(hotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod) bool {
+	if len(hotplugAttachmentPods) > 1 {
+		return true
+	}
+	// Determine if the ready volumes have changed compared to the current pod
+	if len(hotplugAttachmentPods) == 1 && c.podVolumesMatchesReadyVolumes(hotplugAttachmentPods[0], hotplugVolumes) {
+		return false
+	}
+	return len(hotplugVolumes) > 0 || len(hotplugAttachmentPods) > 0
+}
+
+func (c *Controller) getActiveAndOldAttachmentPods(readyHotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod) (*k8sv1.Pod, []*k8sv1.Pod) {
+	var currentPod *k8sv1.Pod
+	oldPods := make([]*k8sv1.Pod, 0)
+	for _, attachmentPod := range hotplugAttachmentPods {
+		if !c.podVolumesMatchesReadyVolumes(attachmentPod, readyHotplugVolumes) {
+			oldPods = append(oldPods, attachmentPod)
+		} else {
+			currentPod = attachmentPod
+		}
+	}
+	sort.Slice(oldPods, func(i, j int) bool {
+		return oldPods[i].CreationTimestamp.Time.After(oldPods[j].CreationTimestamp.Time)
+	})
+	return currentPod, oldPods
+}
+
+// cleanupAttachmentPods deletes all old attachment pods when the following is true
+// 1. There is a currentPod that is running. (not nil and phase.Status == Running)
+// 2. There are no readyVolumes (numReadyVolumes == 0)
+// 3. The newest oldPod is not running and not marked for deletion.
+// If any of those are true, it will not delete the newest oldPod, since that one is the latest
+// pod that is closest to the desired state.
+func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8sv1.Pod, vmi *v1.VirtualMachineInstance, numReadyVolumes int) common.SyncError {
+	foundRunning := false
+	currentPodIsNotRunning := currentPod == nil || currentPod.Status.Phase != k8sv1.PodRunning
+	for _, attachmentPod := range oldPods {
+		if !foundRunning &&
+			attachmentPod.Status.Phase == k8sv1.PodRunning && attachmentPod.DeletionTimestamp == nil &&
+			numReadyVolumes > 0 &&
+			currentPodIsNotRunning {
+			foundRunning = true
+			continue
+		}
+		if err := c.deleteAttachmentPod(vmi, attachmentPod); err != nil {
+			return common.NewSyncError(fmt.Errorf("Error deleting attachment pod %v", err), controller.FailedDeletePodReason)
+		}
+	}
+	return nil
+}
+
+func (c *Controller) handleHotplugVolumes(hotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod, vmi *v1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod, dataVolumes []*cdiv1.DataVolume) common.SyncError {
+	logger := log.Log.Object(vmi)
+
+	readyHotplugVolumes := make([]*v1.Volume, 0)
+	// Find all ready volumes
+	for _, volume := range hotplugVolumes {
+		var err error
+		ready, wffc, err := storagetypes.VolumeReadyToAttachToNode(vmi.Namespace, *volume, dataVolumes, c.dataVolumeIndexer, c.pvcIndexer)
+		if err != nil {
+			return common.NewSyncError(fmt.Errorf("Error determining volume status %v", err), controller.PVCNotReadyReason)
+		}
+		if wffc {
+			// Volume in WaitForFirstConsumer, it has not been populated by CDI yet. create a dummy pod
+			logger.V(1).Infof("Volume %s/%s is in WaitForFistConsumer, triggering population", vmi.Namespace, volume.Name)
+			syncError := c.triggerHotplugPopulation(volume, vmi, virtLauncherPod)
+			if syncError != nil {
+				return syncError
+			}
+			continue
+		}
+		if !ready {
+			// Volume not ready, skip until it is.
+			logger.V(3).Infof("Skipping hotplugged volume: %s, not ready", volume.Name)
+			continue
+		}
+		readyHotplugVolumes = append(readyHotplugVolumes, volume)
+	}
+
+	currentPod, oldPods := c.getActiveAndOldAttachmentPods(readyHotplugVolumes, hotplugAttachmentPods)
+	if currentPod == nil && !hasPendingPods(oldPods) && len(readyHotplugVolumes) > 0 {
+		if rateLimited, waitTime := c.requeueAfter(oldPods, time.Duration(len(readyHotplugVolumes)/-10)); rateLimited {
+			key, err := controller.KeyFunc(vmi)
+			if err != nil {
+				logger.Object(vmi).Reason(err).Error("failed to extract key from virtualmachine.")
+				return common.NewSyncError(fmt.Errorf("failed to extract key from virtualmachine. %v", err), controller.FailedHotplugSyncReason)
+			}
+			c.Queue.AddAfter(key, waitTime)
+		} else {
+			if newPod, err := c.createAttachmentPod(vmi, virtLauncherPod, readyHotplugVolumes); err != nil {
+				return err
+			} else {
+				currentPod = newPod
+			}
+		}
+	}
+	if err := c.cleanupAttachmentPods(currentPod, oldPods, vmi, len(readyHotplugVolumes)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) createAttachmentPod(vmi *v1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod, volumes []*v1.Volume) (*k8sv1.Pod, common.SyncError) {
+	attachmentPodTemplate, _ := c.createAttachmentPodTemplate(vmi, virtLauncherPod, volumes)
+	if attachmentPodTemplate == nil {
+		return nil, nil
+	}
+	vmiKey := controller.VirtualMachineInstanceKey(vmi)
+	c.podExpectations.ExpectCreations(vmiKey, 1)
+
+	pod, err := c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.Background(), attachmentPodTemplate, metav1.CreateOptions{})
+	if err != nil {
+		c.podExpectations.CreationObserved(vmiKey)
+		c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, controller.FailedCreatePodReason, "Error creating attachment pod: %v", err)
+		return nil, common.NewSyncError(fmt.Errorf("Error creating attachment pod %v", err), controller.FailedCreatePodReason)
+	}
+	c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, controller.SuccessfulCreatePodReason, "Created attachment pod %s", pod.Name)
+	return pod, nil
+}
+
+func (c *Controller) triggerHotplugPopulation(volume *v1.Volume, vmi *v1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) common.SyncError {
+	populateHotplugPodTemplate, err := c.createAttachmentPopulateTriggerPodTemplate(volume, virtLauncherPod, vmi)
+	if err != nil {
+		return common.NewSyncError(fmt.Errorf("Error creating trigger pod template %v", err), controller.FailedCreatePodReason)
+	}
+	if populateHotplugPodTemplate != nil { // nil means the PVC is not populated yet.
+		vmiKey := controller.VirtualMachineInstanceKey(vmi)
+		c.podExpectations.ExpectCreations(vmiKey, 1)
+
+		_, err = c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.Background(), populateHotplugPodTemplate, metav1.CreateOptions{})
+		if err != nil {
+			c.podExpectations.CreationObserved(vmiKey)
+			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, controller.FailedCreatePodReason, "Error creating hotplug population trigger pod for volume %s: %v", volume.Name, err)
+			return common.NewSyncError(fmt.Errorf("Error creating hotplug population trigger pod %v", err), controller.FailedCreatePodReason)
+		}
+		c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, controller.SuccessfulCreatePodReason, "Created hotplug trigger pod for volume %s", volume.Name)
+	}
+	return nil
+}
+
+func (c *Controller) syncHotplugCondition(vmi *v1.VirtualMachineInstance, conditionType v1.VirtualMachineInstanceConditionType) {
+	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
+	condition := v1.VirtualMachineInstanceCondition{
+		Type:   conditionType,
+		Status: k8sv1.ConditionTrue,
+	}
+	if !vmiConditions.HasCondition(vmi, condition.Type) {
+		vmiConditions.UpdateCondition(vmi, &condition)
+		log.Log.Object(vmi).V(4).Infof("adding hotplug condition %s", conditionType)
+	}
+}
+
+func (c *Controller) canMoveToAttachedPhase(currentPhase v1.VolumePhase) bool {
+	return currentPhase == "" || currentPhase == v1.VolumeBound || currentPhase == v1.VolumePending
+}
+
+func (c *Controller) findAttachmentPodByVolumeName(volumeName string, attachmentPods []*k8sv1.Pod) *k8sv1.Pod {
+	for _, pod := range attachmentPods {
+		for _, podVolume := range pod.Spec.Volumes {
+			if podVolume.Name == volumeName {
+				return pod
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Controller) createAttachmentPodTemplate(vmi *v1.VirtualMachineInstance, virtlauncherPod *k8sv1.Pod, volumes []*v1.Volume) (*k8sv1.Pod, error) {
+	logger := log.Log.Object(vmi)
+
+	volumeNamesPVCMap, err := storagetypes.VirtVolumesToPVCMap(volumes, c.pvcIndexer, virtlauncherPod.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PVC map: %v", err)
+	}
+	for volumeName, pvc := range volumeNamesPVCMap {
+		//Verify the PVC is ready to be used.
+		populated, err := cdiv1.IsSucceededOrPendingPopulation(pvc, func(name, namespace string) (*cdiv1.DataVolume, error) {
+			dv, exists, _ := c.dataVolumeIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+			if !exists {
+				return nil, fmt.Errorf("unable to find datavolume %s/%s", namespace, name)
+			}
+			return dv.(*cdiv1.DataVolume), nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if !populated {
+			logger.Infof("Unable to hotplug, claim %s found, but not ready", pvc.Name)
+			delete(volumeNamesPVCMap, volumeName)
+		}
+	}
+
+	if len(volumeNamesPVCMap) > 0 {
+		return c.templateService.RenderHotplugAttachmentPodTemplate(volumes, virtlauncherPod, vmi, volumeNamesPVCMap)
+	}
+	return nil, err
+}
+
+func (c *Controller) createAttachmentPopulateTriggerPodTemplate(volume *v1.Volume, virtlauncherPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error) {
+	claimName := storagetypes.PVCNameFromVirtVolume(volume)
+	if claimName == "" {
+		return nil, errors.New("Unable to hotplug, claim not PVC or Datavolume")
+	}
+
+	pvc, exists, isBlock, err := storagetypes.IsPVCBlockFromStore(c.pvcIndexer, virtlauncherPod.Namespace, claimName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("Unable to trigger hotplug population, claim %s not found", claimName)
+	}
+	pod, err := c.templateService.RenderHotplugAttachmentTriggerPodTemplate(volume, virtlauncherPod, vmi, pvc.Name, isBlock, true)
+	return pod, err
+}
+
+func (c *Controller) deleteAllAttachmentPods(vmi *v1.VirtualMachineInstance) error {
+	virtlauncherPod, err := controller.CurrentVMIPod(vmi, c.podIndexer)
+	if err != nil {
+		return err
+	}
+	if virtlauncherPod != nil {
+		attachmentPods, err := controller.AttachmentPods(virtlauncherPod, c.podIndexer)
+		if err != nil {
+			return err
+		}
+		for _, attachmentPod := range attachmentPods {
+			err := c.deleteAttachmentPod(vmi, attachmentPod)
+			if err != nil && !k8serrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Controller) deleteOrphanedAttachmentPods(vmi *v1.VirtualMachineInstance) error {
+	pods, err := c.listPodsFromNamespace(vmi.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to list pods from namespace %s: %v", vmi.Namespace, err)
+	}
+
+	for _, pod := range pods {
+		if !controller.IsControlledBy(pod, vmi) {
+			continue
+		}
+
+		if !controller.PodIsDown(pod) {
+			continue
+		}
+
+		attachmentPods, err := controller.AttachmentPods(pod, c.podIndexer)
+		if err != nil {
+			log.Log.Reason(err).Errorf("failed to get attachment pods %s: %v", controller.PodKey(pod), err)
+			// do not return; continue the cleanup...
+			continue
+		}
+
+		for _, attachmentPod := range attachmentPods {
+			if err := c.deleteAttachmentPod(vmi, attachmentPod); err != nil {
+				log.Log.Reason(err).Errorf("failed to delete attachment pod %s: %v", controller.PodKey(attachmentPod), err)
+				// do not return; continue the cleanup...
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) getNewHotplugVolumes(hotplugAttachmentPods []*k8sv1.Pod, hotplugVolumes []*v1.Volume) []*v1.Volume {
+	var newVolumes []*v1.Volume
+	hotplugVolumeMap := make(map[string]*v1.Volume)
+	for _, volume := range hotplugVolumes {
+		hotplugVolumeMap[volume.Name] = volume
+	}
+	// Remove all the volumes that we have a pod for.
+	for _, pod := range hotplugAttachmentPods {
+		for _, volume := range pod.Spec.Volumes {
+			delete(hotplugVolumeMap, volume.Name)
+		}
+	}
+	// Any remaining volumes are new.
+	for _, v := range hotplugVolumeMap {
+		newVolumes = append(newVolumes, v)
+	}
+	return newVolumes
+}
+
+func (c *Controller) getDeletedHotplugVolumes(hotplugPods []*k8sv1.Pod, hotplugVolumes []*v1.Volume) []k8sv1.Volume {
+	var deletedVolumes []k8sv1.Volume
+	hotplugVolumeMap := make(map[string]*v1.Volume)
+	for _, volume := range hotplugVolumes {
+		hotplugVolumeMap[volume.Name] = volume
+	}
+	for _, pod := range hotplugPods {
+		for _, volume := range pod.Spec.Volumes {
+			if _, ok := hotplugVolumeMap[volume.Name]; !ok && volume.PersistentVolumeClaim != nil {
+				deletedVolumes = append(deletedVolumes, volume)
+			}
+		}
+	}
+	return deletedVolumes
+}
+
+func (c *Controller) deleteAttachmentPod(vmi *v1.VirtualMachineInstance, attachmentPod *k8sv1.Pod) error {
+	if attachmentPod.DeletionTimestamp != nil {
+		return nil
+	}
+
+	vmiKey := controller.VirtualMachineInstanceKey(vmi)
+
+	err := c.deletePod(vmiKey, attachmentPod, metav1.DeleteOptions{
+		GracePeriodSeconds: pointer.P(int64(0)),
+	})
+	if err != nil {
+		c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, controller.FailedDeletePodReason, "Failed to delete attachment pod %s", attachmentPod.Name)
+		return err
+	}
+	c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, controller.SuccessfulDeletePodReason, "Deleted attachment pod %s", attachmentPod.Name)
+	return nil
+}
+
+func (c *Controller) podVolumesMatchesReadyVolumes(attachmentPod *k8sv1.Pod, volumes []*v1.Volume) bool {
+	// -2 for empty dir and token
+	if len(attachmentPod.Spec.Volumes)-2 != len(volumes) {
+		return false
+	}
+	podVolumeMap := make(map[string]k8sv1.Volume)
+	for _, volume := range attachmentPod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			podVolumeMap[volume.Name] = volume
+		}
+	}
+	for _, volume := range volumes {
+		delete(podVolumeMap, volume.Name)
+	}
+	return len(podVolumeMap) == 0
+}

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -308,41 +308,6 @@ func (c *Controller) deleteOrphanedAttachmentPods(vmi *v1.VirtualMachineInstance
 	return nil
 }
 
-func getNewHotplugVolumes(hotplugAttachmentPods []*k8sv1.Pod, hotplugVolumes []*v1.Volume) []*v1.Volume {
-	var newVolumes []*v1.Volume
-	hotplugVolumeMap := make(map[string]*v1.Volume)
-	for _, volume := range hotplugVolumes {
-		hotplugVolumeMap[volume.Name] = volume
-	}
-	// Remove all the volumes that we have a pod for.
-	for _, pod := range hotplugAttachmentPods {
-		for _, volume := range pod.Spec.Volumes {
-			delete(hotplugVolumeMap, volume.Name)
-		}
-	}
-	// Any remaining volumes are new.
-	for _, v := range hotplugVolumeMap {
-		newVolumes = append(newVolumes, v)
-	}
-	return newVolumes
-}
-
-func getDeletedHotplugVolumes(hotplugPods []*k8sv1.Pod, hotplugVolumes []*v1.Volume) []k8sv1.Volume {
-	var deletedVolumes []k8sv1.Volume
-	hotplugVolumeMap := make(map[string]*v1.Volume)
-	for _, volume := range hotplugVolumes {
-		hotplugVolumeMap[volume.Name] = volume
-	}
-	for _, pod := range hotplugPods {
-		for _, volume := range pod.Spec.Volumes {
-			if _, ok := hotplugVolumeMap[volume.Name]; !ok && volume.PersistentVolumeClaim != nil {
-				deletedVolumes = append(deletedVolumes, volume)
-			}
-		}
-	}
-	return deletedVolumes
-}
-
 func (c *Controller) deleteAttachmentPod(vmi *v1.VirtualMachineInstance, attachmentPod *k8sv1.Pod) error {
 	if attachmentPod.DeletionTimestamp != nil {
 		return nil


### PR DESCRIPTION
### What this PR does
Refactors the storage related logic out of vmi.go.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

