### PR TITLE
fix: repair ginkgo outline by introducing decorator.SIG

### DIFF
--- a/tests/compute/console.go
+++ b/tests/compute/console.go
@@ -44,7 +44,7 @@ import (
 
 const startupTimeout = 60
 
-var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]Console", func() {
+var _ = Describe(SIG("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]Console", func() {
 
 	expectConsoleOutput := func(vmi *v1.VirtualMachineInstance, expected string) {
 		By("Checking that the console output equals to expected one")
@@ -138,4 +138,4 @@ var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@re
 			})
 		})
 	})
-})
+}))

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("Guest Access Credentials", func() {
+var _ = Describe(SIG("Guest Access Credentials", func() {
 
 	const (
 		fedoraRunningTimeout     = 120
@@ -186,7 +186,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 				))),
 		)
 	})
-})
+}))
 
 func createNewSecret(namespace string, name string, data libsecret.DataBytes) error {
 	secret := libsecret.New(name, data)

--- a/tests/compute/eviction.go
+++ b/tests/compute/eviction.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = SIGDescribe("Eviction", func() {
+var _ = Describe(SIG("Eviction", func() {
 
 	It("should not shutdown VM", func() {
 		vmi := libvmifact.NewAlpine(
@@ -117,4 +117,4 @@ var _ = SIGDescribe("Eviction", func() {
 		Expect(console.LoginToAlpine(vmi)).To(Succeed())
 		Expect(errChan).To(BeEmpty())
 	})
-})
+}))

--- a/tests/compute/framework.go
+++ b/tests/compute/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright the KubeVirt Authors.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -24,5 +24,5 @@ import (
 )
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG("[sig-compute]", decorators.SigCompute, text, args)
+	return decorators.SIG("[sig-compute]", text, decorators.SigCompute, args)
 }

--- a/tests/compute/framework.go
+++ b/tests/compute/framework.go
@@ -20,18 +20,8 @@
 package compute
 
 import (
-	ginkgo "github.com/onsi/ginkgo/v2"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 )
-
-func SIGDescribe(text string, args ...interface{}) bool {
-	return ginkgo.Describe(SIG(text, args))
-}
-
-func FSIGDescribe(text string, args ...interface{}) bool {
-	return ginkgo.FDescribe(SIG(text, args))
-}
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
 	return decorators.SIG("[sig-compute]", decorators.SigCompute, text, args)

--- a/tests/compute/subresources/expandspec.go
+++ b/tests/compute/subresources/expandspec.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = compute.SIGDescribe("ExpandSpec subresource", func() {
+var _ = Describe(compute.SIG("ExpandSpec subresource", func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -316,4 +316,4 @@ var _ = compute.SIGDescribe("ExpandSpec subresource", func() {
 			)
 		})
 	})
-})
+}))

--- a/tests/compute/subresources/openapi.go
+++ b/tests/compute/subresources/openapi.go
@@ -33,7 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 )
 
-var _ = compute.SIGDescribe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources", func() {
+var _ = Describe(compute.SIG("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources", func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -48,4 +48,4 @@ var _ = compute.SIGDescribe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com
 			// The first item in the SubresourceGroupVersions array is the preferred version
 		}, 60*time.Second, 1*time.Second).Should(ContainSubstring("subresources.kubevirt.io/" + v1.SubresourceGroupVersions[0].Version))
 	})
-})
+}))

--- a/tests/compute/subresources/rbac.go
+++ b/tests/compute/subresources/rbac.go
@@ -39,7 +39,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = compute.SIGDescribe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac authorization", func() {
+var _ = Describe(compute.SIG("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac authorization", func() {
 	var saClient kubecli.KubevirtClient
 
 	When("correct permissions are provided", func() {
@@ -101,7 +101,7 @@ var _ = compute.SIGDescribe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com
 			Expect(errors.ReasonForError(err)).To(Equal(metav1.StatusReasonForbidden))
 		})
 	})
-})
+}))
 
 func getClientForSA(virtCli kubecli.KubevirtClient, saName string) kubecli.KubevirtClient {
 	secret, err := virtCli.CoreV1().Secrets(testsuite.GetTestNamespace(nil)).Get(context.Background(), saName, metav1.GetOptions{})

--- a/tests/compute/subresources/reset.go
+++ b/tests/compute/subresources/reset.go
@@ -36,7 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = compute.SIGDescribe("Reset subresource", func() {
+var _ = Describe(compute.SIG("Reset subresource", func() {
 
 	Describe("Reset a VirtualMachineInstance", func() {
 		const vmiLaunchTimeout = 360
@@ -72,4 +72,4 @@ var _ = compute.SIGDescribe("Reset subresource", func() {
 			Expect(vmi.UID).To(Equal(oldUID))
 		})
 	})
-})
+}))

--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("[rfe_id:1177][crit:medium] VirtualMachine", func() {
+var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -212,7 +212,7 @@ var _ = SIGDescribe("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
 		})
 	})
-})
+}))
 
 func withStartStrategy(strategy *v1.StartStrategy) libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/tests/compute/vmidefaults.go
+++ b/tests/compute/vmidefaults.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("VMIDefaults", func() {
+var _ = Describe(SIG("VMIDefaults", func() {
 	var virtClient kubecli.KubevirtClient
 
 	var vmi *v1.VirtualMachineInstance
@@ -257,4 +257,4 @@ var _ = SIGDescribe("VMIDefaults", func() {
 		})
 
 	})
-})
+}))

--- a/tests/decorators/BUILD.bazel
+++ b/tests/decorators/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["decorators.go"],
+    srcs = [
+        "decorators.go",
+        "sigs.go",
+    ],
     importpath = "kubevirt.io/kubevirt/tests/decorators",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/onsi/ginkgo/v2:go_default_library"],

--- a/tests/decorators/sigs.go
+++ b/tests/decorators/sigs.go
@@ -17,22 +17,13 @@
  *
  */
 
-package compute
+package decorators
 
-import (
-	ginkgo "github.com/onsi/ginkgo/v2"
+import "github.com/onsi/ginkgo/v2"
 
-	"kubevirt.io/kubevirt/tests/decorators"
-)
-
-func SIGDescribe(text string, args ...interface{}) bool {
-	return ginkgo.Describe(SIG(text, args))
-}
-
-func FSIGDescribe(text string, args ...interface{}) bool {
-	return ginkgo.FDescribe(SIG(text, args))
-}
-
-func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG("[sig-compute]", decorators.SigCompute, text, args)
+func SIG(identifier string, decorator ginkgo.Labels, text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	newArgs = []interface{}{decorator}
+	newArgs = append(newArgs, args...)
+	extendedText = identifier + " " + text
+	return
 }

--- a/tests/decorators/sigs.go
+++ b/tests/decorators/sigs.go
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright the KubeVirt Authors.
+ * Copyright The KubeVirt Authors.
  *
  */
 
 package decorators
 
-import "github.com/onsi/ginkgo/v2"
-
-func SIG(identifier string, decorator ginkgo.Labels, text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	newArgs = []interface{}{decorator}
-	newArgs = append(newArgs, args...)
+// SIG is the building block for reusing the test name generation across a group of tests sharing the same test name
+// prefix and the same decorator(s).
+func SIG(identifier, text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	newArgs = args
 	extendedText = identifier + " " + text
 	return
 }

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/compute:go_default_library",
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/events:go_default_library",

--- a/tests/infrastructure/certificates.go
+++ b/tests/infrastructure/certificates.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -47,7 +47,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = DescribeSerialInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates", func() {
+var _ = Describe(SIGSerial("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates", func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		aggregatorClient *aggregatorclient.Clientset
@@ -191,7 +191,7 @@ var _ = DescribeSerialInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com
 		Entry("[test_id:4105] virt-handlers client side", components.VirtHandlerCertSecretName),
 		Entry("[test_id:4106] virt-handlers server side", components.VirtHandlerServerCertSecretName),
 	)
-})
+}))
 
 func getCertFromSecret(secretName string) []byte {
 	virtClient := kubevirt.Client()

--- a/tests/infrastructure/cluster-profiler.go
+++ b/tests/infrastructure/cluster-profiler.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017-2023 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -31,7 +31,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-var _ = DescribeSerialInfra("cluster profiler for pprof data aggregation", func() {
+var _ = Describe(SIGSerial("cluster profiler for pprof data aggregation", func() {
 	var virtClient kubecli.KubevirtClient
 	var kvConfig v1.KubeVirtConfiguration
 
@@ -73,4 +73,4 @@ var _ = DescribeSerialInfra("cluster profiler for pprof data aggregation", func(
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
-})
+}))

--- a/tests/infrastructure/crds.go
+++ b/tests/infrastructure/crds.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -33,7 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 )
 
-var _ = DescribeInfra("CRDs", func() {
+var _ = Describe(SIG("CRDs", func() {
 	It("[test_id:5177]Should have structural schema", func() {
 		ourCRDs := []string{
 			crds.VIRTUALMACHINE, crds.VIRTUALMACHINEINSTANCE, crds.VIRTUALMACHINEINSTANCEPRESET,
@@ -51,4 +51,4 @@ var _ = DescribeInfra("CRDs", func() {
 			Expect(crd).To(matcher.HaveConditionMissingOrFalse(v1ext.NonStructuralSchema))
 		}
 	})
-})
+}))

--- a/tests/infrastructure/downward-metrics.go
+++ b/tests/infrastructure/downward-metrics.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -37,7 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = DescribeInfra("downwardMetrics", func() {
+var _ = Describe(SIG("downwardMetrics", func() {
 	const vmiStartTimeout = 180
 
 	DescribeTable("should start a vmi and get the metrics", func(via libvmi.Option, metricsGetter libinfra.MetricsGetter) {
@@ -75,4 +75,4 @@ var _ = DescribeInfra("downwardMetrics", func() {
 			"Value": Equal("1"),
 		})))
 	})
-})
+}))

--- a/tests/infrastructure/infrastructure.go
+++ b/tests/infrastructure/infrastructure.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2023 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -22,13 +22,13 @@ package infrastructure
 import (
 	. "github.com/onsi/ginkgo/v2"
 
-	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/compute"
 )
 
-func DescribeSerialInfra(text string, args ...interface{}) bool {
-	return Describe("[sig-compute]Infrastructure "+text, Serial, decorators.SigCompute, args)
+func SIGSerial(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return compute.SIG("Infrastructure "+text, Serial, args)
 }
 
-func DescribeInfra(text string, args ...interface{}) bool {
-	return Describe("[sig-compute]Infrastructure "+text, decorators.SigCompute, args)
+func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return compute.SIG("Infrastructure "+text, args)
 }

--- a/tests/infrastructure/k8s-client-changes.go
+++ b/tests/infrastructure/k8s-client-changes.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017-2023 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -43,7 +43,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = DescribeSerialInfra("changes to the kubernetes client", func() {
+var _ = Describe(SIGSerial("changes to the kubernetes client", func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		err        error
@@ -143,4 +143,4 @@ var _ = DescribeSerialInfra("changes to the kubernetes client", func() {
 		minExpectedDuration := 1.5 * fastDuration.Seconds()
 		Expect(slowDuration.Seconds()).To(BeNumerically(">", minExpectedDuration))
 	})
-})
+}))

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -49,7 +49,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = DescribeSerialInfra("Node-labeller", func() {
+var _ = Describe(SIGSerial("Node-labeller", func() {
 	const trueStr = "true"
 
 	var (
@@ -411,4 +411,4 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 			events.DeleteEvents(node, k8sv1.EventTypeWarning, "HostModelIsObsolete")
 		})
 	})
-})
+}))

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -184,7 +184,7 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 	})
 })
 
-var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", func() {
+var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		err        error
@@ -620,7 +620,7 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 		Entry("[test_id:4555] by IPv4", k8sv1.IPv4Protocol),
 		Entry("[test_id:6245] by IPv6", k8sv1.IPv6Protocol),
 	)
-})
+}))
 
 func countReadyAndLeaderPods(pod *k8sv1.Pod, component string) (foundMetrics map[string]int, err error) {
 	virtClient := kubevirt.Client()

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 	const minNodesWithVirtHandler = 2
 
@@ -105,4 +105,4 @@ var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulabl
 			ContainSubstring("Node restriction, virt-handler is only allowed to modify VMIs it owns"),
 		))
 	})
-})
+}))

--- a/tests/infrastructure/taints-and-tolerations.go
+++ b/tests/infrastructure/taints-and-tolerations.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = DescribeSerialInfra("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration", func() {
+var _ = Describe(SIGSerial("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration", func() {
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -177,7 +177,7 @@ var _ = DescribeSerialInfra("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com
 			}, timeout, time.Second).Should(Succeed())
 		})
 	})
-})
+}))
 
 func getNodeWithOneOfPods(virtClient kubecli.KubevirtClient, pods []k8sv1.Pod) string {
 	schedulableNodesList := libnode.GetAllSchedulableNodes(virtClient)

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libpod"
 )
 
-var _ = DescribeSerialInfra("tls configuration", func() {
+var _ = Describe(SIGSerial("tls configuration", func() {
 	var virtClient kubecli.KubevirtClient
 
 	// FIPS-compliant so we can test on different platforms (otherwise won't revert properly)
@@ -119,4 +119,4 @@ var _ = DescribeSerialInfra("tls configuration", func() {
 			}(i, pod)
 		}
 	})
-})
+}))

--- a/tests/infrastructure/virt-controller-leader-election.go
+++ b/tests/infrastructure/virt-controller-leader-election.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -36,7 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
+var _ = Describe(SIGSerial("Start a VirtualMachineInstance", func() {
 	Context("when the controller pod is not running and an election happens", func() {
 		It("[test_id:4642]should elect a new controller pod", func() {
 			virtClient := kubevirt.Client()
@@ -56,4 +56,4 @@ var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
 			libwait.WaitForSuccessfulVMIStart(vmi)
 		})
 	})
-})
+}))

--- a/tests/infrastructure/virt-handler.go
+++ b/tests/infrastructure/virt-handler.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = DescribeSerialInfra("virt-handler", func() {
+var _ = Describe(SIGSerial("virt-handler", func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		originalKubeVirt *v1.KubeVirt
@@ -163,4 +163,4 @@ var _ = DescribeSerialInfra("virt-handler", func() {
 				v1.KSMHandlerManagedAnnotation, node))
 		}
 	})
-})
+}))

--- a/tests/migration/evacuation.go
+++ b/tests/migration/evacuation.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = SIGMigrationDescribe("VM Live Migration triggered by evacuation", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("VM Live Migration triggered by evacuation", decorators.RequiresTwoSchedulableNodes, func() {
 	Context("during evacuation", func() {
 		It("should add eviction-in-progress annotation to source virt-launcher pod", func() {
 			vmi := libvmifact.NewCirros(
@@ -151,7 +151,7 @@ var _ = SIGMigrationDescribe("VM Live Migration triggered by evacuation", decora
 			})
 		})
 	})
-})
+}))
 
 func setEvacuationAnnotation(migrations ...*v1.VirtualMachineInstanceMigration) {
 	for _, m := range migrations {

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -73,7 +73,7 @@ func evacuationIsClear() types.GomegaMatcher {
 	}))
 }
 
-var _ = SIGMigrationDescribe("Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -617,7 +617,7 @@ var _ = SIGMigrationDescribe("Live Migration", decorators.RequiresTwoSchedulable
 			})
 		})
 	})
-})
+}))
 
 func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {
 	return libvmifact.NewFedora(libnet.WithMasqueradeNetworking(),

--- a/tests/migration/framework.go
+++ b/tests/migration/framework.go
@@ -20,21 +20,11 @@
 package migration
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 )
 
-const describeName = "[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] "
+const describeName = "[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute]"
 
-func SIGMigrationDescribe(text string, args ...interface{}) bool {
-	return Describe(describeName+text, decorators.SigComputeMigrations, decorators.SigCompute, args)
-}
-
-func FSIGMigrationDescribe(text string, args ...interface{}) bool {
-	return FDescribe(describeName+text, decorators.SigComputeMigrations, decorators.SigCompute, args)
-}
-
-func PSIGMigrationDescribe(text string, args ...interface{}) bool {
-	return PDescribe(describeName+text, decorators.SigComputeMigrations, decorators.SigCompute, args)
+func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return decorators.SIG(describeName, decorators.SigCompute, text, decorators.SigComputeMigrations, args)
 }

--- a/tests/migration/framework.go
+++ b/tests/migration/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2023 Red Hat, Inc.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -26,5 +26,5 @@ import (
 const describeName = "[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute]"
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG(describeName, decorators.SigCompute, text, decorators.SigComputeMigrations, args)
+	return decorators.SIG(describeName, text, decorators.SigCompute, decorators.SigComputeMigrations, args)
 }

--- a/tests/migration/host_model.go
+++ b/tests/migration/host_model.go
@@ -47,7 +47,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = SIGMigrationDescribe("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 	Context("with a host-model cpu", func() {
 		It("[test_id:6981]should migrate only to nodes supporting right cpu model", func() {
 			sourceNode, targetNode, err := libmigration.GetValidSourceNodeAndTargetNodeForHostModelMigration(kubevirt.Client())
@@ -346,7 +346,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", decorators.RequiresTwoSchedula
 			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
 		})
 	})
-})
+}))
 
 func getNodeHostModel(node *k8sv1.Node) (hostModel string) {
 	for key := range node.Labels {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -105,7 +105,7 @@ const (
 	stressDefaultSleepDuration = 15
 )
 
-var _ = SIGMigrationDescribe("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 	var (
 		virtClient              kubecli.KubevirtClient
 		migrationBandwidthLimit resource.Quantity
@@ -2855,7 +2855,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", decorators.RequiresTwoSchedula
 			}, 200)).To(Succeed())
 		})
 	})
-})
+}))
 
 func createResourceQuota(resourceQuota *k8sv1.ResourceQuota) *k8sv1.ResourceQuota {
 	virtCli := kubevirt.Client()

--- a/tests/migration/nodeselector.go
+++ b/tests/migration/nodeselector.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGMigrationDescribe("Live Migration with addedNodeSelector", decorators.RequiresThreeSchedulableNodes, Serial, func() {
+var _ = Describe(SIG("Live Migration with addedNodeSelector", decorators.RequiresThreeSchedulableNodes, Serial, func() {
 	var virtClient kubecli.KubevirtClient
 	var nodes *k8sv1.NodeList
 
@@ -138,4 +138,4 @@ var _ = SIGMigrationDescribe("Live Migration with addedNodeSelector", decorators
 		Expect(virtLauncherPod.Spec.NodeSelector).To(HaveKeyWithValue(zoneLabelKey, vmiLabelValue))
 	})
 
-})
+}))

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -52,7 +52,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("Live Migrate A Paused VMI", decorators.RequiresTwoSchedulableNodes, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)
@@ -154,4 +154,4 @@ var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", decorators.RequiresTwo
 			})
 		})
 	})
-})
+}))

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -60,7 +60,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGMigrationDescribe("VM Post Copy Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 	var (
 		virtClient      kubecli.KubevirtClient
 		err             error
@@ -252,7 +252,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", decorators.RequiresT
 			})
 		})
 	})
-})
+}))
 
 func VMIMigrationWithGuestAgent(virtClient kubecli.KubevirtClient, pvName string, memoryRequestSize string, migrationPolicy *migrationsv1.MigrationPolicy) {
 	By("Creating the VMI")

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -43,7 +43,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("network binding plugin", Serial, decorators.NetCustomBindingPlugins, func() {
+var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindingPlugins, func() {
 	Context("with CNI and Sidecar", func() {
 		const passtNetAttDefName = "netbindingpasst"
 
@@ -237,4 +237,4 @@ var _ = SIGDescribe("network binding plugin", Serial, decorators.NetCustomBindin
 			Expect(libnet.PingFromVMConsole(clientVMI, serverIPAddr)).To(Succeed())
 		})
 	})
-})
+}))

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin", decorators.Macvtap, decorators.NetCustomBindingPlugins, Serial, func() {
+var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin", decorators.Macvtap, decorators.NetCustomBindingPlugins, Serial, func() {
 	const (
 		macvtapLowerDevice = "eth0"
 		macvtapNetworkName = "net1"
@@ -184,7 +184,7 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 			})
 		})
 	})
-})
+}))
 
 func waitForPodCompleted(podNamespace, podName string) error {
 	pod, err := kubevirt.Client().CoreV1().Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -52,7 +52,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe(" VirtualMachineInstance with passt network binding plugin", decorators.NetCustomBindingPlugins, Serial, func() {
+var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin", decorators.NetCustomBindingPlugins, Serial, func() {
 	const passtNetAttDefName = "netbindingpasst"
 
 	var err error
@@ -374,7 +374,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 			Entry("[IPv6]", k8sv1.IPv6Protocol),
 		)
 	})
-})
+}))
 
 func assertSourcePodContainersTerminate(labelSelector, fieldSelector string, vmi *v1.VirtualMachineInstance) bool {
 	return Eventually(func() k8sv1.PodPhase {

--- a/tests/network/bindingplugin_slirp.go
+++ b/tests/network/bindingplugin_slirp.go
@@ -47,7 +47,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("Slirp", decorators.Networking, decorators.NetCustomBindingPlugins, Serial, func() {
+var _ = Describe(SIG("Slirp", decorators.Networking, decorators.NetCustomBindingPlugins, Serial, func() {
 	BeforeEach(libnet.SkipWhenClusterNotSupportIpv4)
 
 	const slirpBindingName = "slirp"
@@ -121,7 +121,7 @@ var _ = SIGDescribe("Slirp", decorators.Networking, decorators.NetCustomBindingP
 		log.Log.Infof("%v", output)
 		Expect(err).To(HaveOccurred())
 	})
-})
+}))
 
 func lookupComputeContainer(containers []k8sv1.Container) *k8sv1.Container {
 	for idx := range containers {

--- a/tests/network/dual_stack_cluster.go
+++ b/tests/network/dual_stack_cluster.go
@@ -9,7 +9,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-var _ = SIGDescribe("Dual stack cluster network configuration", func() {
+var _ = Describe(SIG("Dual stack cluster network configuration", func() {
 	Context("when dual stack cluster configuration is enabled", func() {
 		Specify("the cluster must be dual stack", func() {
 			if flags.SkipDualStackTests {
@@ -21,4 +21,4 @@ var _ = SIGDescribe("Dual stack cluster network configuration", func() {
 			Expect(isClusterDualStack).To(BeTrue(), "the live cluster should be in dual stack mode")
 		})
 	})
-})
+}))

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright the KubeVirt Authors.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -24,5 +24,5 @@ import (
 )
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG("[sig-network]", decorators.SigNetwork, text, args)
+	return decorators.SIG("[sig-network]", text, decorators.SigNetwork, args)
 }

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -20,18 +20,8 @@
 package network
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 )
-
-func SIGDescribe(text string, args ...interface{}) bool {
-	return Describe(SIG(text, args))
-}
-
-func FSIGDescribe(text string, args ...interface{}) bool {
-	return FDescribe(SIG(text, args))
-}
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
 	return decorators.SIG("[sig-network]", decorators.SigNetwork, text, args)

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2020 Red Hat, Inc.
+ * Copyright the KubeVirt Authors.
  *
  */
 
@@ -26,9 +26,13 @@ import (
 )
 
 func SIGDescribe(text string, args ...interface{}) bool {
-	return Describe("[sig-network] "+text, decorators.SigNetwork, args)
+	return Describe(SIG(text, args))
 }
 
 func FSIGDescribe(text string, args ...interface{}) bool {
-	return FDescribe("[sig-network] "+text, decorators.SigNetwork, args)
+	return FDescribe(SIG(text, args))
+}
+
+func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return decorators.SIG("[sig-network]", decorators.SigNetwork, text, args)
 }

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -57,7 +57,7 @@ const (
 	inPlace        hotplugMethod = "inPlace"
 )
 
-var _ = SIGDescribe("bridge nic-hotplug", func() {
+var _ = Describe(SIG("bridge nic-hotplug", func() {
 	const (
 		ifaceName = "iface1"
 		nadName   = "skynet"
@@ -223,9 +223,9 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),
 		)
 	})
-})
+}))
 
-var _ = SIGDescribe("bridge nic-hotunplug", func() {
+var _ = Describe(SIG("bridge nic-hotunplug", func() {
 	const (
 		linuxBridgeNetworkName1 = "red"
 		linuxBridgeNetworkName2 = "blue"
@@ -292,7 +292,7 @@ var _ = SIGDescribe("bridge nic-hotunplug", func() {
 			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),
 		)
 	})
-})
+}))
 
 func newBridgeNetworkInterface(name, netAttachDefName string) (v1.Network, v1.Interface) {
 	network := v1.Network{

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -43,7 +43,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
+var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 	sriovResourceName := readSRIOVResourceName()
 
 	BeforeEach(func() {
@@ -114,7 +114,7 @@ var _ = SIGDescribe(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 			}, time.Second*30, time.Second*3).Should(Succeed())
 		})
 	})
-})
+}))
 
 func createSRIOVNetworkAttachmentDefinition(namespace, networkName, sriovResourceName string) error {
 	netAttachDef := libnet.NewSriovNetAttachDef(networkName, 0)

--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("interface state up/down", func() {
+var _ = Describe(SIG("interface state up/down", func() {
 
 	It("status and guest should show correct iface state", func() {
 		const (
@@ -131,7 +131,7 @@ var _ = SIGDescribe("interface state up/down", func() {
 
 	})
 
-})
+}))
 
 func normalizeIfaceStatuses(ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface) []v1.VirtualMachineInstanceNetworkInterface {
 	var result []v1.VirtualMachineInstanceNetworkInterface

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -31,7 +31,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
+var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
 	var (
 		virtClient      kubecli.KubevirtClient
 		serverVMILabels map[string]string
@@ -271,7 +271,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 	})
-})
+}))
 
 func assertPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance) {
 	ConsistentlyWithOffset(1, func() error {

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -50,7 +50,7 @@ import (
 
 const skipIPv6Message = "port-forwarding over ipv6 is not supported yet. Tracking issue https://github.com/kubevirt/kubevirt/issues/7276"
 
-var _ = SIGDescribe("Port-forward", func() {
+var _ = Describe(SIG("Port-forward", func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -143,7 +143,7 @@ var _ = SIGDescribe("Port-forward", func() {
 			)
 		})
 	})
-})
+}))
 
 func portForwardCommand(pod *k8sv1.Pod, sourcePort, targetPort int) (*exec.Cmd, error) {
 	_, cmd, err := clientcmd.CreateCommandWithNS(pod.Namespace, clientcmd.GetK8sCmdClient(), "port-forward", pod.Name, fmt.Sprintf("%d:%d", sourcePort, targetPort))

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("Primary Pod Network", func() {
+var _ = Describe(SIG("Primary Pod Network", func() {
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -153,7 +153,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			})
 		})
 	})
-})
+}))
 
 func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 	By("Creating the VMI")

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -38,7 +38,7 @@ const (
 	stopAgent  = "stop"
 )
 
-var _ = SIGDescribe("[ref_id:1182]Probes", func() {
+var _ = Describe(SIG("[ref_id:1182]Probes", func() {
 	var (
 		err           error
 		virtClient    kubecli.KubevirtClient
@@ -253,7 +253,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 			Entry("[test_id:5880]with working Exec probe and invalid command", createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmifact.NewFedora),
 		)
 	})
-})
+}))
 
 func isExecProbe(probe *v1.Probe) bool {
 	return probe.Exec != nil

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -55,7 +55,7 @@ const (
 	jobFailureRetry = 0
 )
 
-var _ = SIGDescribe("Services", func() {
+var _ = Describe(SIG("Services", func() {
 	Context("bridge interface binding", func() {
 		var inboundVMI *v1.VirtualMachineInstance
 
@@ -197,7 +197,7 @@ var _ = SIGDescribe("Services", func() {
 			})
 		})
 	})
-})
+}))
 
 func createServiceConnectivityJob(serviceName, namespace string, servicePort int, retries int32) (*batchv1.Job, error) {
 	serviceFQDN := fmt.Sprintf("%s.%s", serviceName, namespace)

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -49,7 +49,7 @@ import (
 
 const dummyInterfaceName = "dummy0"
 
-var _ = SIGDescribe("Infosource", func() {
+var _ = Describe(SIG("Infosource", func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -172,7 +172,7 @@ var _ = SIGDescribe("Infosource", func() {
 			Expect(vmi.Status.Interfaces).To(ConsistOf(expectedInterfaces))
 		})
 	})
-})
+}))
 
 func dummyInterfaceExists(vmi *kvirtv1.VirtualMachineInstance) bool {
 	for i := range vmi.Status.Interfaces {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -492,9 +492,9 @@ var istioTestsWithPasstBinding = func() {
 	istioTests(Passt)
 }
 
-var _ = SIGDescribe(" Istio with masquerade binding", decorators.Istio, Serial, istioTestsWithMasqueradeBinding)
+var _ = Describe(SIG(" Istio with masquerade binding", decorators.Istio, Serial, istioTestsWithMasqueradeBinding))
 
-var _ = SIGDescribe(" Istio with passt binding", decorators.Istio, decorators.NetCustomBindingPlugins, Serial, istioTestsWithPasstBinding)
+var _ = Describe(SIG(" Istio with passt binding", decorators.Istio, decorators.NetCustomBindingPlugins, Serial, istioTestsWithPasstBinding))
 
 func istioServiceMeshDeployed() bool {
 	return strings.ToLower(os.Getenv(istioDeployedEnvVariable)) == "true"

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -47,7 +47,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("[crit:high][vendor:cnv-qe@redhat.com][level:component]", decorators.WgArm64, func() {
+var _ = Describe(SIG("[crit:high][vendor:cnv-qe@redhat.com][level:component]", decorators.WgArm64, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -137,7 +137,7 @@ var _ = SIGDescribe("[crit:high][vendor:cnv-qe@redhat.com][level:component]", de
 			})
 		})
 	})
-})
+}))
 
 func verifyDummyNicForBridgeNetwork(vmi *v1.VirtualMachineInstance) {
 	output := libpod.RunCommandOnVmiPod(vmi, []string{"/bin/bash", "-c", "/usr/sbin/ip link show|grep DOWN|grep -c eth0"})

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -87,7 +87,7 @@ const (
 	bridge10MacSpoofCheck = false
 )
 
-var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
+var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -727,7 +727,7 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 			})
 		})
 	})
-})
+}))
 
 func changeInterfaceMACAddress(vmi *v1.VirtualMachineInstance, interfaceName, newMACAddress string) error {
 	const maxCommandTimeout = 5 * time.Second

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -59,7 +59,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", decorators.Networking, func() {
+var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", decorators.Networking, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -799,7 +799,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("off"))
 		})
 	})
-})
+}))
 
 func createExpectConnectToServer(serverIP string, tcpPort int, expectSuccess bool) []expect.Batcher {
 	expectResult := console.ShellFail

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("Subdomain", func() {
+var _ = Describe(SIG("Subdomain", func() {
 	var virtClient kubecli.KubevirtClient
 
 	const (
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Subdomain", func() {
 		Expect(assertFQDNinGuest(vmi, expectedFQDN)).To(Not(Succeed()), "found unexpected FQDN")
 		Expect(assertSearchEntriesinGuest(vmi, "search example.com")).To(Succeed(), "failed to get expected search entries")
 	})
-})
+}))
 
 func fedoraMasqueradeVMI() *v1.VirtualMachineInstance {
 	return libvmifact.NewFedora(

--- a/tests/performance/density-kwok.go
+++ b/tests/performance/density-kwok.go
@@ -42,7 +42,7 @@ const (
 	defaultVMCount      = 1000
 )
 
-var _ = KWOKDescribe("Control Plane Performance Density Testing using kwok", func() {
+var _ = Describe(KWOK("Control Plane Performance Density Testing using kwok", func() {
 	var (
 		virtClient  kubecli.KubevirtClient
 		startTime   time.Time
@@ -112,7 +112,7 @@ var _ = KWOKDescribe("Control Plane Performance Density Testing using kwok", fun
 			})
 		})
 	})
-})
+}))
 
 func createFakeVMIBatchWithKWOK(virtClient kubecli.KubevirtClient, vmCount int) {
 	for i := 1; i <= vmCount; i++ {

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -55,7 +55,7 @@ const (
 	vmiCreationToRunningSecondsP95Threshold = 60
 )
 
-var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
+var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		startTime  time.Time
@@ -123,7 +123,7 @@ var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
 			})
 		})
 	})
-})
+}))
 
 func collectMetrics(startTime time.Time, filepath string) {
 	// ensure the metrics get scraped by Prometheus till the end, since the default Prometheus scrape interval is 30s

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -55,18 +55,6 @@ func init() {
 	}
 }
 
-func SIGDescribe(text string, args ...interface{}) bool {
-	return Describe(SIG(text, args))
-}
-
-func FSIGDescribe(text string, args ...interface{}) bool {
-	return FDescribe(SIG(text, args))
-}
-
-func KWOKDescribe(text string, args ...interface{}) bool {
-	return Describe(KWOK(text, args))
-}
-
 func KWOK(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
 	return decorators.SIG("[sig-performance]", decorators.SigPerformance, text, Serial, Label("KWOK"), args)
 }

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2021 Red Hat, Inc.
+ * Copyright the KubeVirt Authors.
  *
  */
 
@@ -56,11 +56,23 @@ func init() {
 }
 
 func SIGDescribe(text string, args ...interface{}) bool {
-	return Describe("[sig-performance] "+text, decorators.SigPerformance, Serial, args)
+	return Describe(SIG(text, args))
 }
 
 func FSIGDescribe(text string, args ...interface{}) bool {
-	return FDescribe("[sig-performance] "+text, Serial, args)
+	return FDescribe(SIG(text, args))
+}
+
+func KWOKDescribe(text string, args ...interface{}) bool {
+	return Describe(KWOK(text, args))
+}
+
+func KWOK(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return decorators.SIG("[sig-performance]", decorators.SigPerformance, text, Serial, Label("KWOK"), args)
+}
+
+func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return decorators.SIG("[sig-performance]", decorators.SigPerformance, text, Serial, args)
 }
 
 func skipIfNoPerformanceTests() {
@@ -73,8 +85,4 @@ func skipIfNoRealtimePerformanceTests() {
 	if !RunPerfRealtime {
 		Skip("Realtime performance tests are not enabled")
 	}
-}
-
-func KWOKDescribe(text string, args ...interface{}) bool {
-	return Describe("[sig-performance]"+text, Label("KWOK"), decorators.SigPerformance, Serial, args)
 }

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright the KubeVirt Authors.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -56,11 +56,11 @@ func init() {
 }
 
 func KWOK(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG("[sig-performance]", decorators.SigPerformance, text, Serial, Label("KWOK"), args)
+	return decorators.SIG("[sig-performance]", text, decorators.SigPerformance, Serial, Label("KWOK"), args)
 }
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG("[sig-performance]", decorators.SigPerformance, text, Serial, args)
+	return decorators.SIG("[sig-performance]", text, decorators.SigPerformance, Serial, args)
 }
 
 func skipIfNoPerformanceTests() {

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -42,7 +42,7 @@ func byStartingTheVMI(vmi *v1.VirtualMachineInstance, virtClient kubecli.Kubevir
 	libwait.WaitForSuccessfulVMIStart(vmi)
 }
 
-var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresHugepages2Mi, func() {
+var _ = Describe(SIG("CPU latency tests for measuring realtime VMs performance", decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresHugepages2Mi, func() {
 
 	var (
 		vmi        *v1.VirtualMachineInstance
@@ -94,7 +94,7 @@ var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", 
 		Expect(max).NotTo(BeNumerically(">", realtimeThreshold), fmt.Sprintf("Maximum CPU latency of %d is greater than threshold %d", max, realtimeThreshold))
 	})
 
-})
+}))
 
 type psOutput struct {
 	priority    int64

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -86,7 +86,7 @@ const (
 
 const InvalidDataVolumeUrl = "docker://127.0.0.1/invalid:latest"
 
-var _ = SIGDescribe("DataVolume Integration", func() {
+var _ = Describe(SIG("DataVolume Integration", func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error
@@ -1262,7 +1262,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			Expect(*vm.Spec.DataVolumeTemplates[0].Spec.Storage.StorageClassName).NotTo(Equal(virtualMachinePreference.Spec.Volumes.PreferredStorageClassName))
 		})
 	})
-})
+}))
 
 var explicitCloneRole = &rbacv1.Role{
 	ObjectMeta: metav1.ObjectMeta{

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -48,7 +48,7 @@ const (
 	deviceName = "errdev0"
 )
 
-var _ = SIGDescribe("K8s IO events", Serial, func() {
+var _ = Describe(SIG("K8s IO events", Serial, func() {
 	var (
 		nodeName   string
 		virtClient kubecli.KubevirtClient
@@ -98,7 +98,7 @@ var _ = SIGDescribe("K8s IO events", Serial, func() {
 		Expect(err).ToNot(HaveOccurred(), "Failed to delete VMI")
 		libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 	})
-})
+}))
 
 func createFaultyDisk(nodeName, deviceName string) {
 	By(fmt.Sprintf("Creating faulty disk %s on %s node", deviceName, nodeName))

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -115,7 +115,7 @@ var (
 	})
 )
 
-var _ = SIGDescribe("Export", func() {
+var _ = Describe(SIG("Export", func() {
 	var err error
 	var token *k8sv1.Secret
 	var virtClient kubecli.KubevirtClient
@@ -2195,7 +2195,7 @@ var _ = SIGDescribe("Export", func() {
 			Expect(postCertParamms).ToNot(Equal(preCertParamms))
 		})
 	})
-})
+}))
 
 func logToGinkgoWritter(format string, parameters ...interface{}) {
 	_, _ = fmt.Fprintf(GinkgoWriter, format, parameters...)

--- a/tests/storage/framework.go
+++ b/tests/storage/framework.go
@@ -20,22 +20,8 @@
 package storage
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 )
-
-func SIGDescribe(text string, args ...interface{}) bool {
-	return Describe(SIG(text, args))
-}
-
-func FSIGDescribe(text string, args ...interface{}) bool {
-	return FDescribe(SIG(text, args))
-}
-
-func PSIGDescribe(text string, args ...interface{}) bool {
-	return PDescribe(SIG(text, args))
-}
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
 	return decorators.SIG("[sig-storage]", decorators.SigStorage, text, args)

--- a/tests/storage/framework.go
+++ b/tests/storage/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2020 Red Hat, Inc.
+ * Copyright the KubeVirt Authors.
  *
  */
 
@@ -26,13 +26,17 @@ import (
 )
 
 func SIGDescribe(text string, args ...interface{}) bool {
-	return Describe("[sig-storage] "+text, decorators.SigStorage, args)
+	return Describe(SIG(text, args))
 }
 
 func FSIGDescribe(text string, args ...interface{}) bool {
-	return FDescribe("[sig-storage] "+text, decorators.SigStorage, args)
+	return FDescribe(SIG(text, args))
 }
 
 func PSIGDescribe(text string, args ...interface{}) bool {
-	return PDescribe("[sig-storage] "+text, decorators.SigStorage, args)
+	return PDescribe(SIG(text, args))
+}
+
+func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return decorators.SIG("[sig-storage]", decorators.SigStorage, text, args)
 }

--- a/tests/storage/framework.go
+++ b/tests/storage/framework.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright the KubeVirt Authors.
+ * Copyright The KubeVirt Authors.
  *
  */
 
@@ -24,5 +24,5 @@ import (
 )
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG("[sig-storage]", decorators.SigStorage, text, args)
+	return decorators.SIG("[sig-storage]", text, decorators.SigStorage, args)
 }

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -90,7 +90,7 @@ type addVolumeFunction func(name, namespace, volumeName, claimName string, bus v
 type removeVolumeFunction func(name, namespace, volumeName string, dryRun bool)
 type storageClassFunction func() (string, bool)
 
-var _ = SIGDescribe("Hotplug", func() {
+var _ = Describe(SIG("Hotplug", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -1938,7 +1938,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			verifyVolumeNolongerAccessible(vmi, targets[0])
 		})
 	})
-})
+}))
 
 func verifyVolumeAndDiskVMAdded(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, volumeNames ...string) {
 	nameMap := make(map[string]bool)

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -67,7 +67,7 @@ const (
 type memoryDumpFunction func(name, namespace, claimNames string)
 type removeMemoryDumpFunction func(name, namespace string)
 
-var _ = SIGDescribe("Memory dump", func() {
+var _ = Describe(SIG("Memory dump", func() {
 	var (
 		virtClient         kubecli.KubevirtClient
 		memoryDumpPVCName  string
@@ -449,7 +449,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			}
 		})
 	})
-})
+}))
 
 // createExecutorPodWithPVC creates a Pod with the passed in PVC mounted under /pvc. You can then use the executor utilities to
 // run commands against the PVC through this Pod.

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -73,7 +73,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
+var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var virtClient kubecli.KubevirtClient
 	var testSc string
 	getCSIStorageClass := libstorage.GetSnapshotStorageClass
@@ -911,7 +911,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 		})
 	})
 
-})
+}))
 
 func createUnschedulablePVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
 	pvc := libstorage.NewPVC(name, size, "dontexist")

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -38,7 +38,7 @@ import (
 // feature gate PersistentReservation. The enablement/disablement of this
 // feature gate redeploys virt-handler pod, and this might interfer with other
 // tests.
-var _ = SIGDescribe("SCSI persistent reservation", Serial, func() {
+var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 	const randLen = 8
 	var (
 		naa          string
@@ -340,4 +340,4 @@ var _ = SIGDescribe("SCSI persistent reservation", Serial, func() {
 		})
 	})
 
-})
+}))

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -73,7 +73,7 @@ const (
 	stopVMAfterRestore  = false
 )
 
-var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
+var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -2008,4 +2008,4 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			})
 		})
 	})
-})
+}))

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -62,7 +62,7 @@ const (
 	notReady                 = "Not ready"
 )
 
-var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
+var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 
 	var (
 		err        error
@@ -1622,7 +1622,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			)
 		})
 	})
-})
+}))
 
 func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, vm *v1.VirtualMachine, addVMIOnly bool) string {
 	dv := libdv.NewDataVolume(

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -87,7 +87,7 @@ const (
 
 type VMICreationFunc func(string) *v1.VirtualMachineInstance
 
-var _ = SIGDescribe("Storage", func() {
+var _ = Describe(SIG("Storage", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -1355,7 +1355,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 	})
-})
+}))
 
 func waitForPodToDisappearWithTimeout(podName string, seconds int) {
 	virtClient := kubevirt.Client()

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -64,7 +64,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = VirtctlDescribe("[sig-compute]create vm", decorators.SigCompute, func() {
+var _ = Describe(SIG("[sig-compute]create vm", decorators.SigCompute, func() {
 	const (
 		randNameTail         = 5
 		size                 = "128Mi"
@@ -752,7 +752,7 @@ chpasswd: { expire: False }`
 			},
 		}))
 	})
-})
+}))
 
 func setFlag(flag, parameter string) string {
 	return fmt.Sprintf("--%s=%s", flag, parameter)

--- a/tests/virtctl/framework.go
+++ b/tests/virtctl/framework.go
@@ -24,5 +24,5 @@ import (
 )
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
-	return decorators.SIG("[virtctl]", decorators.Virtctl, text, args)
+	return decorators.SIG("[virtctl]", text, decorators.Virtctl, args)
 }

--- a/tests/virtctl/framework.go
+++ b/tests/virtctl/framework.go
@@ -20,15 +20,9 @@
 package virtctl
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 )
 
-func VirtctlDescribe(text string, args ...interface{}) bool {
-	return Describe("[virtctl] "+text, decorators.Virtctl, args)
-}
-
-func FVirtctlDescribe(text string, args ...interface{}) bool {
-	return FDescribe("[virtctl] "+text, decorators.Virtctl, args)
+func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+	return decorators.SIG("[virtctl]", decorators.Virtctl, text, args)
 }

--- a/tests/virtctl/guestfs.go
+++ b/tests/virtctl/guestfs.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = VirtctlDescribe("[sig-storage]Guestfs", decorators.SigStorage, func() {
+var _ = Describe(SIG("[sig-storage]Guestfs", decorators.SigStorage, func() {
 	var (
 		pvcClaim string
 		done     chan struct{}
@@ -115,7 +115,7 @@ var _ = VirtctlDescribe("[sig-storage]Guestfs", decorators.SigStorage, func() {
 		runGuestfsOnPVC(done, pvcClaim, testsuite.NamespacePrivileged, false, "--root")
 		verifyCanRunOnFSPVC(getGuestfsPodName(pvcClaim), testsuite.NamespacePrivileged)
 	})
-})
+}))
 
 func getGuestfsPodName(pvc string) string {
 	return "libguestfs-tools-" + pvc

--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -54,7 +54,7 @@ const (
 	pvcSize = "100Mi"
 )
 
-var _ = VirtctlDescribe("[sig-storage]ImageUpload", decorators.SigStorage, Serial, func() {
+var _ = Describe(SIG("[sig-storage]ImageUpload", decorators.SigStorage, Serial, func() {
 	const (
 		timeout      = 180
 		randNameTail = 5
@@ -273,7 +273,7 @@ var _ = VirtctlDescribe("[sig-storage]ImageUpload", decorators.SigStorage, Seria
 			Entry("PVC", "pvc", "Provisioning failed"),
 		)
 	})
-})
+}))
 
 func copyAlpineDisk() string {
 	virtClient := kubevirt.Client()

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -50,7 +50,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func() {
+var _ = Describe(SIG("[sig-storage]Memory dump", decorators.SigStorage, func() {
 	const (
 		randNameTail    = 5
 		claimNameFlag   = "--claim-name"
@@ -166,7 +166,7 @@ var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func(
 		Expect(vm.Status.MemoryDumpRequest.FileName).ToNot(BeNil())
 		verifyMemoryDumpFile(output, *vm.Status.MemoryDumpRequest.FileName)
 	})
-})
+}))
 
 func runMemoryDumpGetCmd(name string, args ...string) error {
 	_args := append([]string{

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
+var _ = Describe(SIG("[sig-compute]SCP", decorators.SigCompute, func() {
 	var pub ssh.PublicKey
 	var keyFile string
 	var virtClient kubecli.KubevirtClient
@@ -179,7 +179,7 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 		Expect(err).To(HaveOccurred(), "out[%s]", string(out))
 		Expect(string(out)).To(Equal("unknown flag: --local-ssh\n"))
 	})
-})
+}))
 
 func compareFile(file1, file2 string) {
 	expected, err := os.ReadFile(file1)

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = VirtctlDescribe("[sig-compute]SSH", decorators.SigCompute, func() {
+var _ = Describe(SIG("[sig-compute]SSH", decorators.SigCompute, func() {
 	var pub ssh.PublicKey
 	var keyFile string
 	var virtClient kubecli.KubevirtClient
@@ -126,4 +126,4 @@ var _ = VirtctlDescribe("[sig-compute]SSH", decorators.SigCompute, func() {
 		Expect(err).To(HaveOccurred(), "out[%s]", string(out))
 		Expect(string(out)).To(Equal("unknown flag: --local-ssh\n"))
 	})
-})
+}))

--- a/tests/virtctl/vnc.go
+++ b/tests/virtctl/vnc.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = VirtctlDescribe("[sig-compute]VNC", decorators.SigCompute, decorators.WgArm64, func() {
+var _ = Describe(SIG("[sig-compute]VNC", decorators.SigCompute, decorators.WgArm64, func() {
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
@@ -131,7 +131,7 @@ var _ = VirtctlDescribe("[sig-compute]VNC", decorators.SigCompute, decorators.Wg
 			return img.Bounds().Size()
 		}, 60*time.Second).Should(Equal(size), "screenshot.png should have the expected size")
 	})
-})
+}))
 
 func verifyProxyConnection(port, vmiName string) {
 	Eventually(func(g Gomega) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

We are currently using `SIGDescribe` funcs to generalize the decoration of
`Describe` ginkgo nodes for each SIG in order to adhere to 'dry' principle
by avoiding repetition of SIG label and decorator per each `Describe`.
This is done in all cases where there's multiple test files for a SIG,
since each of those has a `Describe` node.

Above approach breaks ginkgo outline generation, which is essential for our
CI tooling, both current and in development.
The specific case here is that if a node is missing in the outline, we might miss changes that occur inside the node but outside the child nodes.

When ginkgo outline parses the AST to determine the nodes it looks up func
names matching with `Describe` exactly [1] - therefore the generated outline
is missing `SIGDescribe` nodes.
This would also happen for all other cases where funcs with names
differing from the ginkgo DSL would return a `Describe` or any other
ginkgo func.

[1]: https://github.com/onsi/ginkgo/blob/cbcf39a17b9a3aeea0281ce7779a42eb838334b7/ginkgo/outline/ginkgo.go#L147

After this PR:

The new approach extends the parameter list of the ginkgo node function
call with a wrapper function `SIG`, located in the `decorators` package.

This will make the `SIGDescribe` (and matching `FSIGDescribe` and
`PSIGDescribe`) obsolete, while repairing the outline tool for k/kubevirt.

Following commits inline the `SIGDescribe` et al function calls, replacing
it with direct usage of the `SIG` function. After that `SIGDescribe`
will be obsolete and therefore removed. As cleanup also the `FSIGDescribe`
and `PSIGDescribe` are removed, since it now is easier to modify the
`Describe` call itself.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes kubevirt/project-infra#3664

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

While studying the ginkgo code I considered extending the node generation function [1] - since it is a DSL IMHO we should rather fix this on our side in order to avoid maintenance burden for such a feature at https://github.com/onsi/ginkgo  

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

It makes sense to review this PR starting at the first commit and then looking at which folder is touched in order to determine whether you should be concerned. I.e. sig-network might only take a look at 1st commit and commit containing tests/network in commit message.

/cc @brianmcarey 

FYI @0xFelix @akalenyu @EdDev @fossedihelm @xpivarc

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```