### PR TITLE
memorydump_test: use fake client

### DIFF
--- a/pkg/virt-api/rest/memorydump_test.go
+++ b/pkg/virt-api/rest/memorydump_test.go
@@ -34,19 +34,21 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 
 	v1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
 	"kubevirt.io/client-go/kubecli"
+	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
@@ -67,14 +69,13 @@ var _ = Describe("Memory dump Subresource api", func() {
 	)
 
 	var (
-		request    *restful.Request
-		response   *restful.Response
-		kubeClient *fake.Clientset
-		virtClient *kubecli.MockKubevirtClient
-		vmClient   *kubecli.MockVirtualMachineInterface
-		vmiClient  *kubecli.MockVirtualMachineInstanceInterface
-		cdiClient  *cdifake.Clientset
-		app        *SubresourceAPIApp
+		request        *restful.Request
+		response       *restful.Response
+		kubeClient     *fake.Clientset
+		fakeVirtClient *kubevirtfake.Clientset
+		virtClient     *kubecli.MockKubevirtClient
+		cdiClient      *cdifake.Clientset
+		app            *SubresourceAPIApp
 
 		kv = &v1.KubeVirt{
 			ObjectMeta: metav1.ObjectMeta{
@@ -136,14 +137,11 @@ var _ = Describe("Memory dump Subresource api", func() {
 
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		kubeClient = fake.NewSimpleClientset()
-		vmClient = kubecli.NewMockVirtualMachineInterface(ctrl)
-		vmiClient = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		fakeVirtClient = kubevirtfake.NewSimpleClientset()
 
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
-		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(vmClient).AnyTimes()
-		virtClient.EXPECT().VirtualMachine("").Return(vmClient).AnyTimes()
-		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(vmiClient).AnyTimes()
-		virtClient.EXPECT().VirtualMachineInstance("").Return(vmiClient).AnyTimes()
+		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(fakeVirtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).AnyTimes()
+		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(fakeVirtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 
 		cdiConfig := cdiConfigInit()
 		cdiClient = cdifake.NewSimpleClientset(cdiConfig)
@@ -195,15 +193,12 @@ var _ = Describe("Memory dump Subresource api", func() {
 		vm := libvmi.NewVirtualMachine(vmi)
 		vm.Name = request.PathParameter("name")
 		vm.Namespace = metav1.NamespaceDefault
+		vm, err := fakeVirtClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
-		patchedVM := vm.DeepCopy()
-		patchedVM.Status.MemoryDumpRequest = memDumpReq
-		patchedVM.Status.MemoryDumpRequest.Phase = v1.MemoryDumpAssociating
-
-		vmClient.EXPECT().Get(context.Background(), vm.Name, metav1.GetOptions{}).Return(vm, nil).AnyTimes()
 		if vmiRunning {
 			vmi = libvmi.New(
-				libvmi.WithName(testVMIName),
+				libvmi.WithName(testVMName),
 				libvmi.WithResourceMemory("1Gi"),
 				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
 			)
@@ -217,18 +212,24 @@ var _ = Describe("Memory dump Subresource api", func() {
 				}
 				return true, pvc, nil
 			})
+			vmi, err = fakeVirtClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.TODO(), vmi, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		}
+
 		if statusCode == http.StatusAccepted || (pvc != nil && pvc.Spec.Resources.Requests[k8sv1.ResourceStorage] == resource.MustParse("1Gi")) {
 			virtClient.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
 		}
-		vmiClient.EXPECT().Get(context.Background(), vm.Name, metav1.GetOptions{}).Return(vmi, nil).AnyTimes()
-		vmClient.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions) (interface{}, interface{}) {
-				return patchedVM, nil
-			}).AnyTimes()
 		app.MemoryDumpVMRequestHandler(request, response)
 
 		Expect(response.StatusCode()).To(Equal(statusCode))
+		if statusCode == http.StatusAccepted {
+			patchedVM, err := fakeVirtClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patchedVM.Status.MemoryDumpRequest).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"ClaimName": Equal(memDumpReq.ClaimName),
+				"Phase":     Equal(v1.MemoryDumpAssociating),
+			})))
+		}
 	},
 		Entry("VM with a valid memory dump request should succeed", &v1.VirtualMachineMemoryDumpRequest{
 			ClaimName: testPVCName,
@@ -238,7 +239,7 @@ var _ = Describe("Memory dump Subresource api", func() {
 		}, http.StatusBadRequest, false, true, createTestPVC("2Gi", fs, notReadOnly)),
 		Entry("VM with a valid memory dump request vmi not running should fail", &v1.VirtualMachineMemoryDumpRequest{
 			ClaimName: testPVCName,
-		}, http.StatusConflict, true, false, createTestPVC("2Gi", fs, notReadOnly)),
+		}, http.StatusNotFound, true, false, createTestPVC("2Gi", fs, notReadOnly)),
 		Entry("VM with a memory dump request with a non existing PVC", &v1.VirtualMachineMemoryDumpRequest{
 			ClaimName: testPVCName,
 		}, http.StatusNotFound, true, true, nil),
@@ -257,7 +258,7 @@ var _ = Describe("Memory dump Subresource api", func() {
 		enableFeatureGate(featuregate.HotplugVolumesGate)
 		request.Request.Body = newMemoryDumpBody(memDumpReq)
 		vmi := libvmi.New(
-			libvmi.WithName(testVMIName),
+			libvmi.WithName(testVMName),
 			libvmi.WithResourceMemory("1Gi"),
 			libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
 		)
@@ -268,27 +269,30 @@ var _ = Describe("Memory dump Subresource api", func() {
 			vm.Status.MemoryDumpRequest = prevMemDumpReq
 		}
 
-		patchedVM := vm.DeepCopy()
-		patchedVM.Status.MemoryDumpRequest = memDumpReq
-		patchedVM.Status.MemoryDumpRequest.Phase = v1.MemoryDumpAssociating
+		vm, err := fakeVirtClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		vmi, err = fakeVirtClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.TODO(), vmi, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
-		vmClient.EXPECT().Get(context.Background(), vm.Name, metav1.GetOptions{}).Return(vm, nil).AnyTimes()
 		kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (bool, runtime.Object, error) {
 			_, ok := action.(testing.GetAction)
 			Expect(ok).To(BeTrue())
 			return true, createTestPVC("2Gi", fs, notReadOnly), nil
 		})
-		vmiClient.EXPECT().Get(context.Background(), vm.Name, metav1.GetOptions{}).Return(vmi, nil).AnyTimes()
-		vmClient.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, name string, patchType types.PatchType, body interface{}, opts metav1.PatchOptions) (interface{}, interface{}) {
-				return patchedVM, nil
-			}).AnyTimes()
 		if statusCode == http.StatusAccepted {
 			virtClient.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
 		}
 		app.MemoryDumpVMRequestHandler(request, response)
 
 		Expect(response.StatusCode()).To(Equal(statusCode))
+		if statusCode == http.StatusAccepted {
+			patchedVM, err := fakeVirtClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patchedVM.Status.MemoryDumpRequest).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"ClaimName": Equal(prevMemDumpReq.ClaimName),
+				"Phase":     Equal(v1.MemoryDumpAssociating),
+			})))
+		}
 	},
 		Entry("VM with a memory dump request without claim name with assocaited memory dump should succeed",
 			&v1.VirtualMachineMemoryDumpRequest{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Use fakeclient instead of mockinterface for memorydump unit test

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

