### PR TITLE
cleanup(tests): Keep calm, don't panic and expect errors not to occur

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -191,7 +191,6 @@ go_test(
         "//tests/storage:go_default_library",
         "//tests/testsuite:go_default_library",
         "//tests/usb:go_default_library",
-        "//tests/util:go_default_library",
         "//tests/validatingadmissionpolicy:go_default_library",
         "//tests/virtctl:go_default_library",
         "//tests/virtiofs:go_default_library",

--- a/tests/events/BUILD.bazel
+++ b/tests/events/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",

--- a/tests/events/events.go
+++ b/tests/events/events.go
@@ -12,8 +12,6 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/tests/util"
-
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,7 +38,7 @@ func ExpectEvent(object k8sObject, eventType, reason string) {
 func DeleteEvents(object k8sObject, eventType, reason string) {
 	By("Expecting events to be removed")
 	virtClient, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
+	Expect(err).ToNot(HaveOccurred())
 
 	fieldSelector, namespace := constructFieldSelectorAndNamespace(object, eventType, reason)
 

--- a/tests/framework/checks/BUILD.bazel
+++ b/tests/framework/checks/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//tests/libnode:go_default_library",
-        "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -13,8 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
-
-	"kubevirt.io/kubevirt/tests/util"
 )
 
 // Deprecated: SkipTestIfNoFeatureGate should be converted to check & fail
@@ -48,13 +46,13 @@ func SkipIfUseFlannel(virtClient kubecli.KubevirtClient) {
 // Deprecated: SkipIfPrometheusRuleIsNotEnabled should be converted to check & fail
 func SkipIfPrometheusRuleIsNotEnabled(virtClient kubecli.KubevirtClient) {
 	ext, err := clientset.NewForConfig(virtClient.Config())
-	util.PanicOnError(err)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "prometheusrules.monitoring.coreos.com", metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		ginkgo.Skip("Skip monitoring tests when PrometheusRule CRD is not available in the cluster")
 	} else if err != nil {
-		util.PanicOnError(err)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 }
 

--- a/tests/libinfra/BUILD.bazel
+++ b/tests/libinfra/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
-        "//tests/util:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/libinfra/leader.go
+++ b/tests/libinfra/leader.go
@@ -22,19 +22,20 @@ package libinfra
 import (
 	"context"
 
+	. "github.com/onsi/gomega"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/leaderelectionconfig"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/util"
 )
 
 func GetLeader() string {
 	virtClient := kubevirt.Client()
 
 	controllerLease, err := virtClient.CoordinationV1().Leases(flags.KubeVirtInstallNamespace).Get(context.Background(), leaderelectionconfig.DefaultLeaseName, v1.GetOptions{})
-	util.PanicOnError(err)
+	Expect(err).ToNot(HaveOccurred())
 
 	return *controllerLease.Spec.HolderIdentity
 }

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -39,7 +39,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/util"
 )
 
 func AddDataVolumeTemplate(vm *v1.VirtualMachine, dataVolume *v1beta1.DataVolume) {
@@ -90,19 +89,14 @@ func GetCDI(virtCli kubecli.KubevirtClient) *v1beta1.CDI {
 	return cdi
 }
 
-func HasDataVolumeCRD() bool {
+func HasCDI() bool {
 	virtClient := kubevirt.Client()
 
 	ext, err := clientset.NewForConfig(virtClient.Config())
-	util.PanicOnError(err)
+	Expect(err).ToNot(HaveOccurred())
 
 	_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "datavolumes.cdi.kubevirt.io", v12.GetOptions{})
-
 	return err == nil
-}
-
-func HasCDI() bool {
-	return HasDataVolumeCRD()
 }
 
 func GoldenImageRBAC(namespace string) (*rbacv1.Role, *rbacv1.RoleBinding) {

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "//tests/libvmops:go_default_library",
         "//tests/libwait:go_default_library",
         "//tests/testsuite:go_default_library",
-        "//tests/util:go_default_library",
         "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -42,7 +42,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libmonitoring"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
 )
 
 type alerts struct {
@@ -164,7 +163,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, decorators.SigM
 			virtClient = kubevirt.Client()
 
 			crb, err = virtClient.RbacV1().ClusterRoleBindings().Get(context.Background(), "kubevirt-operator", metav1.GetOptions{})
-			util.PanicOnError(err)
+			Expect(err).ToNot(HaveOccurred())
 			operatorRoleBinding, err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Get(context.Background(), operatorRoleBindingName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -70,7 +70,6 @@ go_library(
         "//tests/libwait:go_default_library",
         "//tests/migration:go_default_library",
         "//tests/testsuite:go_default_library",
-        "//tests/util:go_default_library",
         "//tests/watcher:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -65,7 +65,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
 	"kubevirt.io/kubevirt/tests/watcher"
 )
 
@@ -1379,14 +1378,16 @@ func deletePvAndPvc(name string) {
 	virtCli := kubevirt.Client()
 
 	err := virtCli.CoreV1().PersistentVolumes().Delete(context.Background(), name, metav1.DeleteOptions{})
-	if !errors.IsNotFound(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(errors.IsNotFound, "errors.IsNotFound"),
+	))
 
 	err = virtCli.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Delete(context.Background(), name, metav1.DeleteOptions{})
-	if !errors.IsNotFound(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(errors.IsNotFound, "errors.IsNotFound"),
+	))
 }
 
 func runPodAndExpectPhase(pod *k8sv1.Pod, phase k8sv1.PodPhase) *k8sv1.Pod {

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -51,7 +51,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
-	"kubevirt.io/kubevirt/tests/util"
 )
 
 const (
@@ -326,8 +325,7 @@ func deployOrWipeTestingInfrastrucure(actionOnObject func(unstructured.Unstructu
 	for _, manifest := range manifests {
 		objects := ReadManifestYamlFile(manifest)
 		for _, obj := range objects {
-			err := actionOnObject(obj)
-			util.PanicOnError(err)
+			Expect(actionOnObject(obj)).To(Succeed())
 		}
 	}
 
@@ -349,7 +347,7 @@ func waitForAllDaemonSetsReady(timeout time.Duration) {
 		virtClient := kubevirt.Client()
 
 		dsList, err := virtClient.AppsV1().DaemonSets(k8sv1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
-		util.PanicOnError(err)
+		Expect(err).ToNot(HaveOccurred())
 		for _, ds := range dsList.Items {
 			if ds.Status.DesiredNumberScheduled != ds.Status.NumberReady {
 				dsNotReady = append(dsNotReady, ds.Name)
@@ -367,7 +365,7 @@ func waitForAllPodsReady(timeout time.Duration, listOptions metav1.ListOptions) 
 		virtClient := kubevirt.Client()
 
 		podsList, err := virtClient.CoreV1().Pods(k8sv1.NamespaceAll).List(context.Background(), listOptions)
-		util.PanicOnError(err)
+		Expect(err).ToNot(HaveOccurred())
 		for _, pod := range podsList.Items {
 			for _, status := range pod.Status.ContainerStatuses {
 				if status.State.Terminated != nil {

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -43,7 +43,6 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libstorage"
-	"kubevirt.io/kubevirt/tests/util"
 )
 
 var (
@@ -130,7 +129,7 @@ func AdjustKubeVirtResource() {
 	Expect(err).ToNot(HaveOccurred())
 	patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
 	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
-	util.PanicOnError(err)
+	Expect(err).ToNot(HaveOccurred())
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
 	if checks.HasFeature(featuregate.CPUManager) {
 		// CPUManager is not enabled in the control-plane node(s)
@@ -156,7 +155,7 @@ func RestoreKubeVirtResource() {
 		Expect(err).ToNot(HaveOccurred())
 		patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
 		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(context.Background(), originalKV.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
-		util.PanicOnError(err)
+		Expect(err).ToNot(HaveOccurred())
 	}
 }
 

--- a/tests/testsuite/serviceaccount.go
+++ b/tests/testsuite/serviceaccount.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
@@ -95,9 +96,10 @@ func createServiceAccount(saName string) {
 	}
 
 	_, err := virtCli.CoreV1().ServiceAccounts(GetTestNamespace(nil)).Create(context.Background(), &sa, metav1.CreateOptions{})
-	if !k8serrors.IsAlreadyExists(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsAlreadyExists, "k8serrors.IsAlreadyExists"),
+	))
 
 	secret := k8sv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -110,9 +112,10 @@ func createServiceAccount(saName string) {
 	}
 
 	_, err = virtCli.CoreV1().Secrets(GetTestNamespace(nil)).Create(context.Background(), &secret, metav1.CreateOptions{})
-	if !k8serrors.IsAlreadyExists(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsAlreadyExists, "k8serrors.IsAlreadyExists"),
+	))
 }
 
 func createClusterRoleBinding(saName string, clusterRole string) {
@@ -140,9 +143,10 @@ func createClusterRoleBinding(saName string, clusterRole string) {
 	}
 
 	_, err := virtCli.RbacV1().ClusterRoleBindings().Create(context.Background(), &clusterRoleBinding, metav1.CreateOptions{})
-	if !k8serrors.IsAlreadyExists(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsAlreadyExists, "k8serrors.IsAlreadyExists"),
+	))
 }
 
 func createRoleBinding(saName string, clusterRole string) {
@@ -170,9 +174,10 @@ func createRoleBinding(saName string, clusterRole string) {
 	}
 
 	_, err := virtCli.RbacV1().RoleBindings(GetTestNamespace(nil)).Create(context.Background(), &roleBinding, metav1.CreateOptions{})
-	if !k8serrors.IsAlreadyExists(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsAlreadyExists, "k8serrors.IsAlreadyExists"),
+	))
 }
 
 func createSubresourceRole(saName string) {
@@ -195,9 +200,10 @@ func createSubresourceRole(saName string) {
 	}
 
 	_, err := virtCli.RbacV1().Roles(GetTestNamespace(nil)).Create(context.Background(), &role, metav1.CreateOptions{})
-	if !k8serrors.IsAlreadyExists(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsAlreadyExists, "k8serrors.IsAlreadyExists"),
+	))
 
 	roleBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -221,36 +227,42 @@ func createSubresourceRole(saName string) {
 	}
 
 	_, err = virtCli.RbacV1().RoleBindings(GetTestNamespace(nil)).Create(context.Background(), &roleBinding, metav1.CreateOptions{})
-	if !k8serrors.IsAlreadyExists(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsAlreadyExists, "k8serrors.IsAlreadyExists"),
+	))
 }
 
 func cleanupServiceAccount(saName string) {
 	virtCli := kubevirt.Client()
 
 	err := virtCli.CoreV1().ServiceAccounts(GetTestNamespace(nil)).Delete(context.Background(), saName, metav1.DeleteOptions{})
-	if !k8serrors.IsNotFound(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsNotFound, "k8serrors.IsNotFound"),
+	))
 
 	err = virtCli.CoreV1().Secrets(GetTestNamespace(nil)).Delete(context.Background(), saName, metav1.DeleteOptions{})
-	if !k8serrors.IsNotFound(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsNotFound, "k8serrors.IsNotFound"),
+	))
 
 	err = virtCli.RbacV1().Roles(GetTestNamespace(nil)).Delete(context.Background(), saName, metav1.DeleteOptions{})
-	if !k8serrors.IsNotFound(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsNotFound, "k8serrors.IsNotFound"),
+	))
 
 	err = virtCli.RbacV1().RoleBindings(GetTestNamespace(nil)).Delete(context.Background(), saName, metav1.DeleteOptions{})
-	if !k8serrors.IsNotFound(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsNotFound, "k8serrors.IsNotFound"),
+	))
 
 	err = virtCli.RbacV1().ClusterRoleBindings().Delete(context.Background(), getClusterRoleBindingName(saName), metav1.DeleteOptions{})
-	if !k8serrors.IsNotFound(err) {
-		util.PanicOnError(err)
-	}
+	Expect(err).To(Or(
+		Not(HaveOccurred()),
+		MatchError(k8serrors.IsNotFound, "k8serrors.IsNotFound"),
+	))
 }

--- a/tests/util/BUILD.bazel
+++ b/tests/util/BUILD.bazel
@@ -2,10 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "labels.go",
-        "util.go",
-    ],
+    srcs = ["labels.go"],
     importpath = "kubevirt.io/kubevirt/tests/util",
     visibility = ["//visibility:public"],
 )

--- a/tests/util/util.go
+++ b/tests/util/util.go
@@ -1,7 +1,0 @@
-package util
-
-func PanicOnError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -79,7 +79,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/storage"
 	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
 	"kubevirt.io/kubevirt/tests/watcher"
 )
 
@@ -310,12 +309,8 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						break
 					}
 				}
-				if computeContainer == nil {
-					util.PanicOnError(fmt.Errorf("could not find the compute container"))
-				}
+				Expect(computeContainer).ToNot(BeNil(), "could not find the compute container")
 				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(416)))
-
-				Expect(err).ToNot(HaveOccurred())
 			})
 			It("[test_id:4624]should set a correct memory units", func() {
 				vmi := libvmifact.NewAlpine(
@@ -729,9 +724,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						break
 					}
 				}
-				if computeContainer == nil {
-					util.PanicOnError(fmt.Errorf("could not find the compute container"))
-				}
+				Expect(computeContainer).ToNot(BeNil(), "could not find the computer container")
 				Expect(computeContainer.Resources.Requests.Cpu().String()).To(Equal("600m"))
 			})
 
@@ -2432,9 +2425,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						computeContainer = &container
 					}
 				}
-				if computeContainer == nil {
-					util.PanicOnError(fmt.Errorf("could not find the compute container"))
-				}
+				Expect(computeContainer).ToNot(BeNil(), "could not find the computer container")
 
 				output, err := getPodCPUSet(readyPod)
 				log.Log.Infof("%v", output)
@@ -2554,9 +2545,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						computeContainer = &container
 					}
 				}
-				if computeContainer == nil {
-					util.PanicOnError(fmt.Errorf("could not find the compute container"))
-				}
+				Expect(computeContainer).ToNot(BeNil(), "could not find the compute container")
 
 				output, err := getPodCPUSet(readyPod)
 				log.Log.Infof("%v", output)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Do as the title says.

Before this PR:

Test code panics if it sees errors.

After this PR:

Test code expects errors not to occur.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

