### PR TITLE
VM Rollout Strategy: default to LiveUpdate

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -152,7 +152,6 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -326,8 +326,8 @@ var _ = Describe("test configuration", func() {
 		})
 		Expect(clusterConfig.IsVMRolloutStrategyLiveUpdate()).To(BeEquivalentTo(expected))
 	},
-		Entry("is nil, IsVMRolloutStrategyLiveUpdate should return false",
-			nil, false,
+		Entry("is nil, IsVMRolloutStrategyLiveUpdate should return true",
+			nil, true,
 		),
 		Entry("is Stage, IsVMRolloutStrategyLiveUpdate should return false",
 			pointer.P(v1.VMRolloutStrategyStage), false,

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -90,7 +90,7 @@ const (
 	DefaultVirtWebhookClientBurst         = 400
 
 	DefaultMaxHotplugRatio   = 4
-	DefaultVMRolloutStrategy = v1.VMRolloutStrategyStage
+	DefaultVMRolloutStrategy = v1.VMRolloutStrategyLiveUpdate
 )
 
 func IsAMD64(arch string) bool {
@@ -466,7 +466,7 @@ func (c *ClusterConfig) GetMaxHotplugRatio() uint32 {
 
 func (c *ClusterConfig) IsVMRolloutStrategyLiveUpdate() bool {
 	liveConfig := c.GetConfig().VMRolloutStrategy
-	return liveConfig != nil && *liveConfig == v1.VMRolloutStrategyLiveUpdate
+	return liveConfig == nil || *liveConfig == v1.VMRolloutStrategyLiveUpdate
 }
 
 func (c *ClusterConfig) GetNetworkBindings() map[string]v1.InterfaceBindingPlugin {

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -5758,7 +5758,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(err).To(Succeed())
 				addVirtualMachine(vm)
 
-				By("Executing the controller expecting the RestartRequired condition to appear")
+				By("Executing the controller expecting the RestartRequired condition to appear as needed")
 				sanityExecute(vm)
 				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
@@ -5770,8 +5770,8 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(uint32(4)))
 				}
 			},
-				Entry("should appear if the VM rollout strategy is not set",
-					nil, restartRequiredMatcher(k8sv1.ConditionTrue)),
+				Entry("should not appear if the VM rollout strategy is not set",
+					nil, Not(restartRequiredMatcher(k8sv1.ConditionTrue))),
 				Entry("should appear if the VM rollout strategy is set to Stage",
 					&stage, restartRequiredMatcher(k8sv1.ConditionTrue)),
 				Entry("should not appear if VM rollout strategy is set to LiveUpdate",

--- a/tests/hotplug/affinity.go
+++ b/tests/hotplug/affinity.go
@@ -19,26 +19,21 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
+var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		kv := libkubevirt.GetCurrentKv(virtClient)
-		kv.Spec.Configuration.VMRolloutStrategy = pointer.P(v1.VMRolloutStrategyLiveUpdate)
-		testsuite.UpdateKubeVirtConfigValue(kv.Spec.Configuration)
 	})
 
 	Context("Updating VMs node affinity", func() {

--- a/tests/hotplug/tolerations.go
+++ b/tests/hotplug/tolerations.go
@@ -40,21 +40,17 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]VM Tolerations", decorators.SigCompute, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
+var _ = Describe("[sig-compute]VM Tolerations", decorators.SigCompute, decorators.VMLiveUpdateRolloutStrategy, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		kv := libkubevirt.GetCurrentKv(virtClient)
-		kv.Spec.Configuration.VMRolloutStrategy = pointer.P(v1.VMRolloutStrategyLiveUpdate)
-		testsuite.UpdateKubeVirtConfigValue(kv.Spec.Configuration)
 	})
 
 	Context("Updating VMs tolerations", func() {


### PR DESCRIPTION
### What this PR does
Before this PR:
The default rollout strategy is `Stage` and must be changed to `LiveUpdate` to enable live propagation and therefore CPU/memory hotplug.

After this PR:
The rollout strategy is now `LiveUpdate` by default and must be set to `Stage` to opt-out of hotplug.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default VM Rollout Strategy is now LiveUpdate. Important: to preserve previous behavior, rolloutStrategy needs to be set to "Stage" in the KubeVirt CR.
```

