### PR TITLE
pr-helper: create entrypoint to generate symlink to multipath socket

### DIFF
--- a/cmd/pr-helper/BUILD.bazel
+++ b/cmd/pr-helper/BUILD.bazel
@@ -11,6 +11,13 @@ pkg_tar(
     package_dir = "/etc",
 )
 
+pkg_tar(
+    name = "entrypoint",
+    srcs = [":entrypoint.sh"],
+    mode = "0700",
+    package_dir = "/",
+)
+
 container_image(
     name = "version-container",
     base = "//:passwd-image",
@@ -21,10 +28,12 @@ container_image(
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             ":multipath",
+            ":entrypoint",
             "//rpm:pr-helper_aarch64",
         ],
         "//conditions:default": [
             ":multipath",
+            ":entrypoint",
             "//rpm:pr-helper_x86_64",
         ],
     }),

--- a/cmd/pr-helper/entrypoint.sh
+++ b/cmd/pr-helper/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+MULTIPATH_HOST="${MULTIPATH_HOST:-/run/multipathd.socket}"
+MULTIPATH_SOCKET_NAME="${MULTIPATH_SOCKET_NAME:-/run/multipathd.socket}"
+ln -s /proc/1/root${MULTIPATH_HOST} ${MULTIPATH_SOCKET_NAME}
+
+set -e
+
+exec /usr/bin/qemu-pr-helper $@

--- a/cmd/pr-helper/multipath.conf
+++ b/cmd/pr-helper/multipath.conf
@@ -2,6 +2,7 @@ defaults {
         user_friendly_names yes
         find_multipaths yes
         enable_foreign "^$"
+	reservation_key file
 }
 
 blacklist_exceptions {

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -35,7 +35,7 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 		Name:            PrHelperName,
 		Image:           image,
 		ImagePullPolicy: pullPolicy,
-		Command:         []string{"/usr/bin/qemu-pr-helper"},
+		Command:         []string{"/entrypoint.sh"},
 		Args: []string{
 			"-k", reservation.GetPrHelperSocketPath(),
 		},


### PR DESCRIPTION
The qemu-pr-helper forwards the persistent reservation request to the [multipath daemon](https://linux.die.net/man/8/multipathd). In order to perform the request the pr-helper and the multipathd needs to talk via a unix socket.
This change allows to configure the persistent reservation with multipath by creating a symlink to the  unix socket which will be made available inside the pr-helper container.

Alternative PR to https://github.com/kubevirt/kubevirt/pull/14060 .

In parallel to this PR there is an ongoing effort to support different network namespace and regular sockets in multipath, see https://github.com/opensvc/multipath-tools/issues/111.

What this PR does
Before this PR:
Persistent reservation didn't work with multipath scsi device

After this PR:
Persistent reservation work with multipath scsi device

Fixes https://issues.redhat.com/browse/VIRTPRIO-12

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add entrypoint to the pr-helper for creating the symlink to the multipath socket
```

