### PR TITLE
tests, network, istio: Remove programmatic skip

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -218,6 +218,8 @@ label_filter="${KUBEVIRT_LABEL_FILTER:-}"
 add_to_label_filter '(!QUARANTINE)' '&&'
 add_to_label_filter '(!exclude-native-ssh)' '&&'
 add_to_label_filter '(!no-flake-check)' '&&'
+# check-tests-for-flake does not support Istio tests, remove this filtering once it does.
+add_to_label_filter '(!Istio)' '&&'
 rwofs_sc=$(jq -er .storageRWOFileSystem "${kubevirt_test_config}")
 if [[ "${rwofs_sc}" == "local" ]]; then
     # local is a primitive non CSI storage class that doesn't support expansion

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -156,7 +156,7 @@ var istioTests = func(vmType VmType) {
 			By("Waiting for VMI to be ready")
 			libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 		})
-		Describe("Live Migration", decorators.RequiresTwoSchedulableNodes, decorators.SigComputeMigrations, func() {
+		Describe("Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 			var sourcePodName string
 			allContainersCompleted := func(podName string) error {
 				pod, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -22,8 +22,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -61,7 +59,6 @@ import (
 )
 
 const (
-	istioDeployedEnvVariable  = "KUBEVIRT_DEPLOY_ISTIO"
 	vmiAppSelectorKey         = "app"
 	vmiAppSelectorValue       = "istio-vmi-app"
 	vmiServerAppSelectorValue = "vmi-server-app"
@@ -108,12 +105,6 @@ var istioTests = func(vmType VmType) {
 	)
 	BeforeEach(func() {
 		namespace = testsuite.GetTestNamespace(nil)
-	})
-
-	BeforeEach(func() {
-		if !istioServiceMeshDeployed() {
-			Skip("Istio service mesh is required for service-mesh tests to run")
-		}
 	})
 
 	Context("Virtual Machine with istio supported interface", func() {
@@ -495,10 +486,6 @@ var istioTestsWithPasstBinding = func() {
 var _ = SIGDescribe(" Istio with masquerade binding", decorators.Istio, Serial, istioTestsWithMasqueradeBinding)
 
 var _ = SIGDescribe(" Istio with passt binding", decorators.Istio, decorators.NetCustomBindingPlugins, Serial, istioTestsWithPasstBinding)
-
-func istioServiceMeshDeployed() bool {
-	return strings.ToLower(os.Getenv(istioDeployedEnvVariable)) == "true"
-}
 
 func newVMIWithIstioSidecar(ports []v1.Port, vmType VmType) (*v1.VirtualMachineInstance, error) {
 	if vmType == Masquerade {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Istio tests are decorated with Ginkgo label Istio, enabling filtering out Istio tests in case the env doesn't support it.

In Kubevirt CI, the automation creates a cluster with Istio installed and tests are running by default.

Hence, remove programmatic skip in istio tests.

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
As of today check-tests-for-flakes lane does not account for Istio tests, this PR retain this behavior.
A follow-up PR should add support for check-tests-for-flakes to cover Istio tests as well.
Given CI runs on Istio version that is not supported, IMO check-tests-for-flakes should should cover Istio tests once CI runs supported version of Istio.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

