### PR TITLE
tests, network, sriov: Rm programmatic skip

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -412,6 +412,8 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(Multus,Networking,VMIlifecycle,Expose,Macvtap)'
   elif [[ $TARGET =~ sig-network ]]; then
     label_filter='(sig-network,netCustomBindingPlugins)'
+    # SR-IOV tests runs on dedicated lane (matching the pattern: *kind-sriov*)
+    add_to_label_filter "(!SRIOV)" "&&"
     if [[ $KUBEVIRT_WITH_MULTUS_V3 == "true" ]]; then
       add_to_label_filter "(!in-place-hotplug-NICs)" "&&"
     else

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -48,7 +48,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 	BeforeEach(func() {
 		// Check if the hardware supports SRIOV
-		Expect(validateSRIOVSetup(kubevirt.Client(), sriovResourceName, 1)).To(Succeed(),
+		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
 			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
 
 	})

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -21,6 +21,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
@@ -49,7 +50,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 	BeforeEach(func() {
 		// Check if the hardware supports SRIOV
 		if err := validateSRIOVSetup(kubevirt.Client(), sriovResourceName, 1); err != nil {
-			Skip("Sriov is not enabled in this environment. Skip these tests using - export FUNC_TEST_ARGS='--skip=SRIOV'")
+			Fail(fmt.Sprintf("Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--skip=SRIOV'", err))
 		}
 	})
 

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -21,7 +21,6 @@ package network
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
@@ -49,9 +48,9 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 	BeforeEach(func() {
 		// Check if the hardware supports SRIOV
-		if err := validateSRIOVSetup(kubevirt.Client(), sriovResourceName, 1); err != nil {
-			Fail(fmt.Sprintf("Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--skip=SRIOV'", err))
-		}
+		Expect(validateSRIOVSetup(kubevirt.Client(), sriovResourceName, 1)).To(Succeed(),
+			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
+
 	})
 
 	Context("a running VM", func() {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -89,7 +89,7 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 
 		// Check if the hardware supports SRIOV
 		if err := validateSRIOVSetup(virtClient, sriovResourceName, 1); err != nil {
-			Skip("Sriov is not enabled in this environment. Skip these tests using - export FUNC_TEST_ARGS='--skip=SRIOV'")
+			Fail(fmt.Sprintf("Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--skip=SRIOV'", err))
 		}
 	})
 

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -87,7 +87,7 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 
-		Expect(validateSRIOVSetup(virtClient, sriovResourceName, 1)).To(Succeed(),
+		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
 			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
 	})
 
@@ -256,7 +256,7 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 
 		Context("migration", decorators.RequiresTwoSchedulableNodes, func() {
 			BeforeEach(func() {
-				Expect(validateSRIOVSetup(virtClient, sriovResourceName, 2)).To(Succeed(),
+				Expect(validateSRIOVSetup(sriovResourceName, 2)).To(Succeed(),
 					"Migration tests require at least 2 nodes with SR-IOV resources")
 			})
 
@@ -514,7 +514,7 @@ func getInterfaceNetworkNameByMAC(vmi *v1.VirtualMachineInstance, macAddress str
 	return ""
 }
 
-func validateSRIOVSetup(virtClient kubecli.KubevirtClient, sriovResourceName string, minRequiredNodes int) error {
+func validateSRIOVSetup(sriovResourceName string, minRequiredNodes int) error {
 	sriovNodes := getNodesWithAllocatedResource(sriovResourceName)
 	if len(sriovNodes) < minRequiredNodes {
 		return fmt.Errorf("not enough compute nodes with SR-IOV support detected")

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -87,10 +87,8 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 
-		// Check if the hardware supports SRIOV
-		if err := validateSRIOVSetup(virtClient, sriovResourceName, 1); err != nil {
-			Fail(fmt.Sprintf("Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--skip=SRIOV'", err))
-		}
+		Expect(validateSRIOVSetup(virtClient, sriovResourceName, 1)).To(Succeed(),
+			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
 	})
 
 	Context("VMI connected to single SRIOV network", func() {
@@ -258,9 +256,8 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 
 		Context("migration", decorators.RequiresTwoSchedulableNodes, func() {
 			BeforeEach(func() {
-				if err := validateSRIOVSetup(virtClient, sriovResourceName, 2); err != nil {
-					Fail("Migration tests require at least 2 nodes: " + err.Error())
-				}
+				Expect(validateSRIOVSetup(virtClient, sriovResourceName, 2)).To(Succeed(),
+					"Migration tests require at least 2 nodes with SR-IOV resources")
 			})
 
 			var vmi *v1.VirtualMachineInstance

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -256,10 +256,10 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 				vmispec.InfoSourceDomain, vmispec.InfoSourceGuestAgent, vmispec.InfoSourceMultusStatus)))
 		})
 
-		Context("migration", func() {
+		Context("migration", decorators.RequiresTwoSchedulableNodes, func() {
 			BeforeEach(func() {
 				if err := validateSRIOVSetup(virtClient, sriovResourceName, 2); err != nil {
-					Skip("Migration tests require at least 2 nodes: " + err.Error())
+					Fail("Migration tests require at least 2 nodes: " + err.Error())
 				}
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR remove programmatic skips in SR-IOV test suite, including hotplug and migration tests.

The programmatic skip is replaces with error enable tests to fail faster in case env doest support the tests:
All tests, nodes doesnt expose the expected SR-IOV resource pool.
In migration and hotplug tests, cluster has less then two nodes


Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

