### PR TITLE
volume-migration: fix evaluation of RWX filesystem PVCs during the generation of the  parameters for the migration

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -270,12 +270,11 @@ func classifyVolumesForMigration(vmi *v1.VirtualMachineInstance) *migrationDisks
 				disks.shared[volume.Name] = true
 			}
 		case volSrc.HostDisk != nil:
-			if volSrc.HostDisk.Shared != nil && *volSrc.HostDisk.Shared {
-				disks.shared[volume.Name] = true
-			} else if _, ok := migrateDisks[volume.Name]; ok {
+			if _, ok := migrateDisks[volume.Name]; ok {
 				disks.localToMigrate[volume.Name] = true
+			} else if volSrc.HostDisk.Shared != nil && *volSrc.HostDisk.Shared {
+				disks.shared[volume.Name] = true
 			}
-
 		case volSrc.ConfigMap != nil || volSrc.Secret != nil || volSrc.DownwardAPI != nil ||
 			volSrc.ServiceAccount != nil || volSrc.CloudInitNoCloud != nil ||
 			volSrc.CloudInitConfigDrive != nil || volSrc.ContainerDisk != nil:

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Live Migration for the source", func() {
 		It("should classify shared volumes to migrated when they are part of the migrated volumes set", func() {
 			const vol = "vol"
 			vmi := libvmi.New(
-				libvmi.WithHostDiskAndCapacity(vol, "/disk.img", v1.HostDiskExistsOrCreate, "1G"), libvmistatus.WithStatus(
+				libvmi.WithHostDiskAndCapacity(vol, "/disk.img", v1.HostDiskExistsOrCreate, "1G", libvmi.WithSharedHostDisk(true)), libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithMigratedVolume(v1.StorageMigratedVolumeInfo{
 							VolumeName: vol,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
RWX filesystem volumes were incorrectly evaluated during volume migration causing the error: 
```
{"component":"virt-launcher","level":"error","msg":"invalid argument: NBD URI must be supplied when migration URI uses UNIX transport method", "pos":"qemuDomainMigratePerform3Params:11252","subcomponent":"libvirt","thread":"26","timestamp":"2024-12-13T20:36:31.764000Z"}
````

After this PR:
Fixed shared hostdisk evaluation when generating migration parameters.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-53156

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

