### PR TITLE
VMSnapshot: add QuiesceFailed indication to snapshot if freeze failed

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -32,6 +32,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
@@ -796,11 +797,7 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 				updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, source.LockMsg()))
 			}
 
-			indications, err := updateVMSnapshotIndications(source)
-			if err != nil {
-				return vmSnapshot, err
-			}
-			vmSnapshotCpy.Status.Indications = indications
+			updateSnapshotIndications(vmSnapshotCpy, source)
 		} else {
 			updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "Source does not exist"))
 		}
@@ -831,19 +828,23 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 	return vmSnapshot, nil
 }
 
-func updateVMSnapshotIndications(source snapshotSource) ([]snapshotv1.Indication, error) {
-	var indications []snapshotv1.Indication
-
+func updateSnapshotIndications(snapshot *snapshotv1.VirtualMachineSnapshot, source snapshotSource) {
 	if source.Online() {
-		indications = append(indications, snapshotv1.VMSnapshotOnlineSnapshotIndication)
+		indications := sets.New(snapshot.Status.Indications...)
+		indications = sets.Insert(indications, snapshotv1.VMSnapshotOnlineSnapshotIndication)
 
 		if source.GuestAgent() {
-			indications = append(indications, snapshotv1.VMSnapshotGuestAgentIndication)
+			indications = sets.Insert(indications, snapshotv1.VMSnapshotGuestAgentIndication)
+			snapErr := snapshot.Status.Error
+			if snapErr != nil && snapErr.Message != nil &&
+				strings.Contains(*snapErr.Message, failedFreezeMsg) {
+				indications = sets.Insert(indications, snapshotv1.VMSnapshotQuiesceFailedIndication)
+			}
 		} else {
-			indications = append(indications, snapshotv1.VMSnapshotNoGuestAgentIndication)
+			indications = sets.Insert(indications, snapshotv1.VMSnapshotNoGuestAgentIndication)
 		}
+		snapshot.Status.Indications = sets.List(indications)
 	}
-	return indications, nil
 }
 
 func (ctrl *VMSnapshotController) updateSnapshotSnapshotableVolumes(snapshot *snapshotv1.VirtualMachineSnapshot, content *snapshotv1.VirtualMachineSnapshotContent) error {

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -163,12 +163,11 @@ var _ = Describe("Snapshot controlleer", func() {
 		return createVirtualMachineSnapshotContent(vmSnapshot, vm, pvcs)
 	}
 
-	createErrorVMSnapshotContent := func() *snapshotv1.VirtualMachineSnapshotContent {
+	createErrorVMSnapshotContent := func(errorMessage string) *snapshotv1.VirtualMachineSnapshotContent {
 		content := createVMSnapshotContent()
 		content.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
 			ReadyToUse: pointer.P(false),
 		}
-		errorMessage := "VolumeSnapshot vol1 error: error"
 		content.Status.Error = &snapshotv1.Error{
 			Time:    timeFunc(),
 			Message: &errorMessage,
@@ -187,10 +186,10 @@ var _ = Describe("Snapshot controlleer", func() {
 
 	createVMSnapshotErrored := func() *snapshotv1.VirtualMachineSnapshot {
 		vms := createVMSnapshotInProgress()
-		content := createErrorVMSnapshotContent()
+		errorMessage := "VolumeSnapshot vol1 error: error"
+		content := createErrorVMSnapshotContent(errorMessage)
 		vms.Status.VirtualMachineSnapshotContentName = &content.Name
 		vms.Status.ReadyToUse = pointer.P(false)
-		vms.Status.Indications = nil
 		vms.Status.Conditions = []snapshotv1.Condition{
 			newProgressingCondition(corev1.ConditionFalse, "In error state"),
 			newReadyCondition(corev1.ConditionFalse, "Not ready"),
@@ -587,7 +586,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot := vmSnapshot.DeepCopy()
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status.Phase = snapshotv1.Deleting
-				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "VM snapshot is deleting"),
 					newReadyCondition(corev1.ConditionFalse, "Not ready"),
@@ -768,8 +766,8 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.Indications = nil
 				if vmiExists {
 					updatedSnapshot.Status.Indications = []snapshotv1.Indication{
-						snapshotv1.VMSnapshotOnlineSnapshotIndication,
 						snapshotv1.VMSnapshotNoGuestAgentIndication,
+						snapshotv1.VMSnapshotOnlineSnapshotIndication,
 					}
 				}
 				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
@@ -982,8 +980,8 @@ var _ = Describe("Snapshot controlleer", func() {
 					},
 				}
 				updatedSnapshot.Status.Indications = []snapshotv1.Indication{
-					snapshotv1.VMSnapshotOnlineSnapshotIndication,
 					snapshotv1.VMSnapshotNoGuestAgentIndication,
+					snapshotv1.VMSnapshotOnlineSnapshotIndication,
 				}
 				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
 
@@ -1105,7 +1103,8 @@ var _ = Describe("Snapshot controlleer", func() {
 			It("should update VirtualMachineSnapshot error when VirtualMachineSnapshotContent error", func() {
 				vmSnapshot := createVMSnapshotInProgress()
 				vm := createLockedVM()
-				vmSnapshotContent := createErrorVMSnapshotContent()
+				errorMessage := "VolumeSnapshot vol1 error: error"
+				vmSnapshotContent := createErrorVMSnapshotContent(errorMessage)
 
 				vmSnapshotContentSource.Add(vmSnapshotContent)
 				vmSource.Add(vm)
@@ -1132,7 +1131,8 @@ var _ = Describe("Snapshot controlleer", func() {
 				negativeDeadline, _ := time.ParseDuration("-1m")
 				vmSnapshot.Spec.FailureDeadline = &metav1.Duration{Duration: negativeDeadline}
 				vm := createLockedVM()
-				vmSnapshotContent := createErrorVMSnapshotContent()
+				errorMessage := "VolumeSnapshot vol1 error: error"
+				vmSnapshotContent := createErrorVMSnapshotContent(errorMessage)
 
 				vmSnapshotContentSource.Add(vmSnapshotContent)
 				vmSource.Add(vm)
@@ -1363,6 +1363,119 @@ var _ = Describe("Snapshot controlleer", func() {
 				Expect(*snapshotCreates).To(Equal(1))
 			})
 
+			It("should set content error if failed freeze vm", func() {
+				storageClass := createStorageClass()
+				storageClassSource.Add(storageClass)
+
+				vmSnapshot := createVMSnapshotInProgress()
+				vmSnapshotSource.Add(vmSnapshot)
+
+				vmSnapshotContent := createVMSnapshotContent()
+				vmSnapshotContent.UID = contentUID
+				vmSnapshotContentSource.Add(vmSnapshotContent)
+
+				vm := createLockedVM()
+				vmSource.Add(vm)
+
+				vmi := createVMI(vm)
+				agentCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstanceAgentConnected,
+					LastProbeTime: metav1.Now(),
+					Status:        corev1.ConditionTrue,
+				}
+				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
+				vmiSource.Add(vmi)
+
+				updatedContent := vmSnapshotContent.DeepCopy()
+				updatedContent.ResourceVersion = "1"
+				errorMessage := "Failed freezing vm"
+				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					ReadyToUse: pointer.P(false),
+					Error: &snapshotv1.Error{
+						Time:    timeFunc(),
+						Message: &errorMessage,
+					},
+				}
+
+				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
+				addVolumeSnapshotClass(volumeSnapshotClass)
+
+				vmiInterface.EXPECT().Freeze(context.Background(), vm.Name, 0*time.Second).Return(fmt.Errorf(errorMessage)).Times(1)
+				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
+
+				controller.processVMSnapshotContentWorkItem()
+				Expect(*updateStatusCalls).To(Equal(1))
+			})
+
+			It("should set QuiesceFailed indication if failed freeze vm", func() {
+				vm := createLockedVM()
+				vmSource.Add(vm)
+				vmi := createVMI(vm)
+				agentCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstanceAgentConnected,
+					LastProbeTime: metav1.Now(),
+					Status:        corev1.ConditionTrue,
+				}
+				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
+				vmiSource.Add(vmi)
+
+				errorMessage := "Failed freezing vm"
+				vmSnapshotContent := createErrorVMSnapshotContent(errorMessage)
+				vmSnapshotContentSource.Add(vmSnapshotContent)
+
+				vmSnapshot := createVMSnapshotInProgress()
+				addVirtualMachineSnapshot(vmSnapshot)
+
+				updatedSnapshot := vmSnapshot.DeepCopy()
+				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
+				updatedSnapshot.Status.ReadyToUse = pointer.P(false)
+				updatedSnapshot.Status.Indications = []snapshotv1.Indication{
+					snapshotv1.VMSnapshotGuestAgentIndication,
+					snapshotv1.VMSnapshotOnlineSnapshotIndication,
+					snapshotv1.VMSnapshotQuiesceFailedIndication,
+				}
+				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionFalse, "In error state"),
+					newReadyCondition(corev1.ConditionFalse, "Not ready"),
+				}
+				updatedSnapshot.Status.Error = vmSnapshotContent.Status.Error
+
+				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
+
+				controller.processVMSnapshotWorkItem()
+				Expect(*updateStatusCalls).To(Equal(1))
+			})
+
+			It("should not unset QuiesceFailed indication if freeze succeeded afterwards", func() {
+				vm := createLockedVM()
+				vmSource.Add(vm)
+				vmi := createVMI(vm)
+				agentCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstanceAgentConnected,
+					LastProbeTime: metav1.Now(),
+					Status:        corev1.ConditionTrue,
+				}
+				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
+				vmiSource.Add(vmi)
+
+				vmSnapshot := createVMSnapshotInProgress()
+				vmSnapshot.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
+					newReadyCondition(corev1.ConditionFalse, "Not ready"),
+				}
+				vmSnapshot.Status.Indications = []snapshotv1.Indication{
+					snapshotv1.VMSnapshotGuestAgentIndication,
+					snapshotv1.VMSnapshotOnlineSnapshotIndication,
+					snapshotv1.VMSnapshotQuiesceFailedIndication,
+				}
+				addVirtualMachineSnapshot(vmSnapshot)
+
+				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, vmSnapshot)
+
+				controller.processVMSnapshotWorkItem()
+				Expect(*updateStatusCalls).To(Equal(0))
+			})
+
 			It("should freeze vm with online snapshot and guest agent", func() {
 				storageClass := createStorageClass()
 				vmSnapshot := createVMSnapshotInProgress()
@@ -1381,8 +1494,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
 				vmiSource.Add(vmi)
-
-				vmSnapshot.Status.Indications = append(vmSnapshot.Status.Indications, snapshotv1.VMSnapshotOnlineSnapshotIndication)
 
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
@@ -1616,7 +1727,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				Entry("created and ready", timeFunc(), true),
 			)
 
-			DescribeTable("should attempt to unfreeze vm and remove content finalizer if vmsnapshot deleting", func(freezeError error) {
+			DescribeTable("should attempt to unfreeze vm and remove content finalizer if vmsnapshot deleting", func(unfreezeError error) {
 				vm := createLockedVM()
 				vmSource.Add(vm)
 				vmi := createVMI(vm)
@@ -1642,14 +1753,14 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Finalizers = []string{}
 
-				vmiInterface.EXPECT().Unfreeze(context.Background(), vm.Name).Return(freezeError).Times(1)
+				vmiInterface.EXPECT().Unfreeze(context.Background(), vm.Name).Return(unfreezeError).Times(1)
 				patchCalls := expectVMSnapshotContentPatch(vmSnapshotClient, vmSnapshotContent, updatedContent)
 				addVirtualMachineSnapshot(vmSnapshot)
 				controller.processVMSnapshotContentWorkItem()
 				Expect(*patchCalls).To(Equal(1))
 			},
-				Entry("Freeze success", nil),
-				Entry("Freeze error", fmt.Errorf("error")),
+				Entry("UnFreeze success", nil),
+				Entry("UnFreeze error", fmt.Errorf("error")),
 			)
 
 			DescribeTable("should delete informer", func(crdName string) {

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -52,6 +52,7 @@ import (
 
 const (
 	sourceFinalizer = "snapshot.kubevirt.io/snapshot-source-protection"
+	failedFreezeMsg = "Failed freezing vm"
 )
 
 var (
@@ -439,7 +440,7 @@ func (s *vmSnapshotSource) Freeze() error {
 	err := s.controller.Client.VirtualMachineInstance(s.vm.Namespace).Freeze(context.Background(), s.vm.Name, getFailureDeadline(s.snapshot))
 	timeTrack(startTime, fmt.Sprintf("Freezing vmi %s", s.vm.Name))
 	if err != nil {
-		log.Log.Errorf("Freezing vm %s failed: %v", s.vm.Name, err.Error())
+		log.Log.Errorf("%s %s: %v", failedFreezeMsg, s.vm.Name, err.Error())
 		return err
 	}
 	s.state.frozen = true

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -81,6 +81,7 @@ const (
 	VMSnapshotOnlineSnapshotIndication Indication = "Online"
 	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
 	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
+	VMSnapshotQuiesceFailedIndication  Indication = "QuiesceFailed"
 )
 
 // VirtualMachineSnapshotPhase is the current phase of the VirtualMachineSnapshot

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -169,7 +169,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 			contentName := *snapshot.Status.VirtualMachineSnapshotContentName
 			if running {
-				expectedIndications := []snapshotv1.Indication{snapshotv1.VMSnapshotOnlineSnapshotIndication, snapshotv1.VMSnapshotNoGuestAgentIndication}
+				expectedIndications := []snapshotv1.Indication{snapshotv1.VMSnapshotNoGuestAgentIndication, snapshotv1.VMSnapshotOnlineSnapshotIndication}
 				Expect(snapshot.Status.Indications).To(Equal(expectedIndications))
 				checkOnlineSnapshotExpectedContentSource(vm, contentName, false)
 			} else {
@@ -267,9 +267,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			checkVMFreeze := func(snapshot *snapshotv1.VirtualMachineSnapshot, vmi *v1.VirtualMachineInstance, hasGuestAgent bool, assertionFunc func(*v1.VirtualMachineInstance)) {
 				var expectedIndications []snapshotv1.Indication
 				if hasGuestAgent {
-					expectedIndications = []snapshotv1.Indication{snapshotv1.VMSnapshotOnlineSnapshotIndication, snapshotv1.VMSnapshotGuestAgentIndication}
+					expectedIndications = []snapshotv1.Indication{snapshotv1.VMSnapshotGuestAgentIndication, snapshotv1.VMSnapshotOnlineSnapshotIndication}
 				} else {
-					expectedIndications = []snapshotv1.Indication{snapshotv1.VMSnapshotOnlineSnapshotIndication, snapshotv1.VMSnapshotNoGuestAgentIndication}
+					expectedIndications = []snapshotv1.Indication{snapshotv1.VMSnapshotNoGuestAgentIndication, snapshotv1.VMSnapshotOnlineSnapshotIndication}
 				}
 				Expect(snapshot.Status.Indications).To(Equal(expectedIndications))
 
@@ -597,7 +597,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
-				expectedIndications := []snapshotv1.Indication{snapshotv1.VMSnapshotOnlineSnapshotIndication, snapshotv1.VMSnapshotGuestAgentIndication}
+				expectedIndications := []snapshotv1.Indication{snapshotv1.VMSnapshotGuestAgentIndication, snapshotv1.VMSnapshotOnlineSnapshotIndication}
 				Expect(snapshot.Status.Indications).To(Equal(expectedIndications))
 
 				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})


### PR DESCRIPTION
We want to have a better indication that quiescing the guest failed, it should be marked clearly in the snapshot indications on top to the error.
Furthermore it is possible that the freeze will fail but will retry and succeed and the snapshot will be completed and marked as ready it while there is a small risk that the snapshot will be inconsistent. We should mark that there was a failure when freezing so the user will be aware of that risk, and might consider retrying. Added a UTs to cover this scenario. Functional test seems redundant.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
Jira-ticket: https://issues.redhat.com/browse/CNV-56774

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMSnapshot: add QuiesceFailed indication to snapshot if freeze failed
```

