### PR TITLE
automation: Remove the filter for kubernetes version lower than v1.30

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -462,10 +462,6 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(!(Multus,SRIOV,Macvtap,GPU,VGPU,netCustomBindingPlugins))'
   fi
 
-  if [[ ! $TARGET =~ k8s-1\.3[0-9].* ]]; then
-    add_to_label_filter "(!kubernetes130)" "&&"
-  fi
-
   # execute tests labelled as PERIODIC only on periodic test lanes (according to lane name)
   if [[ ! $JOB_NAME =~ .*periodic.* ]]; then
     add_to_label_filter "(!PERIODIC)" "&&"

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -95,11 +95,6 @@ var (
 	// RequiresSizeRoundUp requires a provisioner that rounds up the size of the volume
 	RequiresSizeRoundUp = Label("RequiresSizeRoundUp")
 
-	/* Kubernetes versions */
-
-	// Kubernetes versions
-	Kubernetes130 = Label("kubernetes130")
-
 	/* architecture working groups */
 
 	WgS390x = Label("wg-s390x")

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulableNodes, decorators.Kubernetes130, func() {
+var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 	const minNodesWithVirtHandler = 2
 

--- a/tests/validatingadmissionpolicy/noderestrictions.go
+++ b/tests/validatingadmissionpolicy/noderestrictions.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = Describe("[sig-compute] virt-handler node restrictions via validatingAdmissionPolicy", decorators.SigCompute, decorators.Kubernetes130, Serial, func() {
+var _ = Describe("[sig-compute] virt-handler node restrictions via validatingAdmissionPolicy", decorators.SigCompute, Serial, func() {
 	const (
 		notAllowedLabelPath      = "/metadata/labels/other.io~1notAllowedLabel"
 		notAllowedAnnotationPath = "/metadata/annotations/other.io~1notAllowedAnnotation"


### PR DESCRIPTION
### What this PR does

Kubernetes versions lower than v1.30 are no longer supported or tested in the main branch so this filter is no longer needed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @dhiller @xpivarc 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

