### PR TITLE
pkg/virtctl/version: code cleanups and refactoring (#14085)

### DIFF
--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -21,36 +21,37 @@ func VersionCommand() *cobra.Command {
 		Use:     "version",
 		Short:   "Print the client and server version information.",
 		Example: usage(),
-		Args:    cobra.ExactArgs(0),
+		Args:    cobra.NoArgs,
 		RunE:    v.Run,
 	}
 	cmd.Flags().BoolVarP(&v.clientOnly, "client", "c", v.clientOnly, "Client version only (no server required).")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
+
 	return cmd
 }
 
 func usage() string {
-	usage := "  # Print the client and server versions for the current context:\n"
-	usage += "  {{ProgramName}} version"
-	return usage
+	return `  # Print the client and server versions for the current context:
+  {{ProgramName}} version`
 }
 
 func (v *version) Run(cmd *cobra.Command, _ []string) error {
-	cmd.Printf("Client Version: %s\n", fmt.Sprintf("%#v", client_version.Get()))
+	cmd.Printf("Client Version: %#v\n", client_version.Get())
 
-	if !v.clientOnly {
-		virCli, _, _, err := clientconfig.ClientAndNamespaceFromContext(cmd.Context())
-		if err != nil {
-			return err
-		}
-
-		serverInfo, err := virCli.ServerVersion().Get()
-		if err != nil {
-			return err
-		}
-
-		cmd.Printf("Server Version: %s\n", fmt.Sprintf("%#v", *serverInfo))
+	if v.clientOnly {
+		return nil
 	}
 
+	virtClient, _, _, err := clientconfig.ClientAndNamespaceFromContext(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to get virtClient config: %w", err)
+	}
+
+	serverInfo, err := virtClient.ServerVersion().Get()
+	if err != nil {
+		return fmt.Errorf("failed to get server version: %w", err)
+	}
+
+	cmd.Printf("Server Version: %#v\n", *serverInfo)
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
### What this PR does  
Before this PR:  
- `virtctl version` command contained unnecessary complexity.  
- Used `fmt.Sprintf("%#v", value)` redundantly.  
- Error handling could be improved for better debugging.  
- Used `cobra.ExactArgs(0)` instead of `cobra.NoArgs`.  

After this PR:  
- **Refactored `usage()`** to use a multiline string for better readability.  
- **Improved error handling** using `fmt.Errorf("%w", err)` for better error wrapping.  
- **Used `cobra.NoArgs`** for idiomatic Go practices.  
- **Removed unnecessary `fmt.Sprintf("%#v", value)` calls** in `printf`.  
- **Applied early return pattern** to simplify the `Run()` function.  


<!-- (optional, in `fixes #14085 (, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #14085 

### Why we need it and why it was done in this way  
The following tradeoffs were made:  
- Improved code maintainability and readability without changing functionality.  
- Focused on Go best practices to align with idiomatic coding styles.  

The following alternatives were considered:  
- Keeping the existing code but it was less readable.  
- Introducing a larger refactor, but that would be out of scope.  

Links to places where the discussion took place:   #14085 

### Special notes for your reviewer  
- Focus on readability improvements.  
- Ensure error wrapping changes align with best practices.  
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

