### PR TITLE
Fix KUBEVIRTCI_PATH to not contain `/` suffix

### DIFF
--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -22,4 +22,4 @@ set -x
 
 source hack/config-kubevirtci.sh
 KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-true}
-source "${KUBEVIRTCI_PATH}up.sh"
+source "${KUBEVIRTCI_PATH}/up.sh"

--- a/hack/config-kubevirtci.sh
+++ b/hack/config-kubevirtci.sh
@@ -18,5 +18,5 @@
 #
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-KUBEVIRTCI_PATH="${BASE_DIR}/kubevirtci/cluster-up/"
+KUBEVIRTCI_PATH="${BASE_DIR}/kubevirtci/cluster-up"
 KUBEVIRTCI_CONFIG_PATH="${BASE_DIR}/kubevirtci/_ci-configs"

--- a/kubevirtci/cluster-up/cli.sh
+++ b/kubevirtci/cluster-up/cli.sh
@@ -22,7 +22,7 @@ set -e
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 

--- a/kubevirtci/cluster-up/cluster/kind-ovn/provider.sh
+++ b/kubevirtci/cluster-up/cluster/kind-ovn/provider.sh
@@ -85,4 +85,4 @@ function _kubectl() {
     kubectl "$@"
 }
 
-source ${KUBEVIRTCI_PATH}cluster/kind-ovn/install-ovn.sh
+source ${KUBEVIRTCI_PATH}/cluster/kind-ovn/install-ovn.sh

--- a/kubevirtci/cluster-up/cluster/kind/check-cluster-up.sh
+++ b/kubevirtci/cluster-up/cluster/kind/check-cluster-up.sh
@@ -20,7 +20,7 @@ set -exuo pipefail
 
 SCRIPT_PATH=$(dirname "$(realpath "$0")")
 
-kubevirtci_path="$(realpath "${SCRIPT_PATH}/../../..")/"
+kubevirtci_path="$(realpath "${SCRIPT_PATH}/../../..")"
 PROVIDER_PATH="${kubevirtci_path}/cluster-up/cluster/${KUBEVIRT_PROVIDER}"
 
 RUN_KUBEVIRT_CONFORMANCE=${RUN_KUBEVIRT_CONFORMANCE:-"false"}

--- a/kubevirtci/cluster-up/down.sh
+++ b/kubevirtci/cluster-up/down.sh
@@ -3,10 +3,10 @@
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 
-source ${KUBEVIRTCI_PATH}hack/common.sh
+source ${KUBEVIRTCI_PATH}/hack/common.sh
 source ${KUBEVIRTCI_CLUSTER_PATH}/$KUBEVIRT_PROVIDER/provider.sh
 down

--- a/kubevirtci/cluster-up/hack/common.sh
+++ b/kubevirtci/cluster-up/hack/common.sh
@@ -3,7 +3,7 @@
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/../"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 

--- a/kubevirtci/cluster-up/hack/config.sh
+++ b/kubevirtci/cluster-up/hack/config.sh
@@ -2,7 +2,7 @@ unset docker_prefix master_ip network_provider kubeconfig manifest_docker_prefix
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
 
-source ${KUBEVIRTCI_PATH}hack/config-default.sh
+source ${KUBEVIRTCI_PATH}/hack/config-default.sh
 
 # Allow different providers to override default config values
 test -f "${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/config-provider-${KUBEVIRT_PROVIDER}.sh" && source ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/config-provider-${KUBEVIRT_PROVIDER}.sh

--- a/kubevirtci/cluster-up/kubeconfig.sh
+++ b/kubevirtci/cluster-up/kubeconfig.sh
@@ -22,7 +22,7 @@ set -e
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 

--- a/kubevirtci/cluster-up/kubectl.sh
+++ b/kubevirtci/cluster-up/kubectl.sh
@@ -22,7 +22,7 @@ set -e
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 

--- a/kubevirtci/cluster-up/ssh.sh
+++ b/kubevirtci/cluster-up/ssh.sh
@@ -4,7 +4,7 @@ set -e
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 

--- a/kubevirtci/cluster-up/up.sh
+++ b/kubevirtci/cluster-up/up.sh
@@ -24,12 +24,12 @@ function validate_single_stack_ipv6() {
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 
 
-source ${KUBEVIRTCI_PATH}hack/common.sh
+source ${KUBEVIRTCI_PATH}/hack/common.sh
 source ${KUBEVIRTCI_CLUSTER_PATH}/$KUBEVIRT_PROVIDER/provider.sh
 up
 

--- a/kubevirtci/cluster-up/virtctl.sh
+++ b/kubevirtci/cluster-up/virtctl.sh
@@ -25,7 +25,7 @@ set -e
 if [ -z "$KUBEVIRTCI_PATH" ]; then
     KUBEVIRTCI_PATH="$(
         cd "$(dirname "$BASH_SOURCE[0]")/"
-        echo "$(pwd)/"
+        echo "$(pwd)"
     )"
 fi
 


### PR DESCRIPTION
KUBEVIRTCI_PATH contain `/` suffix, so in some places it used like this "${KUBEVIRTCI_PATH}up.sh" which does not look good. and in some places it used "${KUBEVIRTCI_PATH}/cluster" which is wrong. 

This pr fix the double `//` backslashes cases and align all cases to look the same.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
${KUBEVIRTCI_PATH} included '/' suffix 
After this PR:
${KUBEVIRTCI_PATH} does not unclude '/' suffix
 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

