### PR TITLE
Add interface name label to kubevirt_vmi_status_addresses

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -372,14 +372,14 @@ var _ = Describe("VMI Stats Collector", func() {
 			}
 		},
 			Entry("no interfaces", [][]string{}),
-			Entry("one interface", [][]string{{"default", "192.168.1.2", "InternalIP"}}),
+			Entry("one interface", [][]string{{"default", "", "192.168.1.2", "ExternalInterface"}}),
 			Entry("two interfaces", [][]string{
-				{"networkA", "170.170.170.170", "InternalIP"},
-				{"networkB", "180.180.180.180", "InternalIP"},
+				{"networkA", "", "170.170.170.170", "ExternalInterface"},
+				{"networkB", "", "180.180.180.180", "ExternalInterface"},
 			}),
 		)
 
-		It("should not create metric for an interface with empty IP address", func() {
+		It("should create metric for interfaces with empty name, but with interface name", func() {
 			vmi := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
@@ -389,16 +389,14 @@ var _ = Describe("VMI Stats Collector", func() {
 					NodeName: "testNode",
 					Interfaces: []k6tv1.VirtualMachineInstanceNetworkInterface{
 						{
-							InfoSource: "domain",
-							Name:       "default",
-							IP:         "10.244.140.86",
+							InfoSource:    "guest-agent",
+							InterfaceName: "br-int",
+							MAC:           "00:00:00:00:00:01",
 						},
 						{
-							InfoSource: "domain, multus-status",
-							Name:       "networkA",
-						},
-						{
-							InfoSource: "domain, multus-status",
+							InfoSource:    "guest-agent",
+							InterfaceName: "ovs-system",
+							MAC:           "00:00:00:00:00:02",
 						},
 					},
 				},
@@ -406,8 +404,45 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			metrics := collectVMIInterfacesInfo(vmi)
 			Expect(metrics).To(HaveLen(2))
-			Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "default", "10.244.140.86", "InternalIP"}))
-			Expect(metrics[1].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "networkA", "", "InternalIP"}))
+			Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "br-int", "", "SystemInterface"}))
+			Expect(metrics[1].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "ovs-system", "", "SystemInterface"}))
+		})
+
+		It("should not create metric for an interface with empty IP address, name and interface name", func() {
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "testvmi",
+				},
+				Status: k6tv1.VirtualMachineInstanceStatus{
+					NodeName: "testNode",
+					Interfaces: []k6tv1.VirtualMachineInstanceNetworkInterface{
+						{
+							InfoSource:    "domain, guest-agent, multus-status",
+							Name:          "net-0",
+							InterfaceName: "br-ex",
+							IP:            "10.11.126.126",
+						},
+						{
+							InfoSource:    "guest-agent",
+							InterfaceName: "ovs-system",
+						},
+						{
+							InfoSource:    "guest-agent",
+							InterfaceName: "br-int",
+						},
+						{
+							InfoSource: "guest-agent",
+						},
+					},
+				},
+			}
+
+			metrics := collectVMIInterfacesInfo(vmi)
+			Expect(metrics).To(HaveLen(3))
+			Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "net-0", "br-ex", "10.11.126.126", "ExternalInterface"}))
+			Expect(metrics[1].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "ovs-system", "", "SystemInterface"}))
+			Expect(metrics[2].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "br-int", "", "SystemInterface"}))
 		})
 	})
 
@@ -589,8 +624,9 @@ func interfacesFor(values [][]string) []k6tv1.VirtualMachineInstanceNetworkInter
 	interfaces := make([]k6tv1.VirtualMachineInstanceNetworkInterface, len(values))
 	for i, v := range values {
 		interfaces[i] = k6tv1.VirtualMachineInstanceNetworkInterface{
-			Name: v[0],
-			IP:   v[1],
+			Name:          v[0],
+			InterfaceName: v[1],
+			IP:            v[2],
 		}
 	}
 	return interfaces


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Some metrics might have both the IP and the name missing and only the interface name. After https://github.com/kubevirt/kubevirt/pull/13386, this will no longer cause errors, but a metric for them will not be created.

After this PR:

A metric for these interfaces is also created.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-57036
jira-ticket: https://issues.redhat.com/browse/CNV-57377

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add interface name label to kubevirt_vmi_status_addresses
```

