### PR TITLE
Marked Virtiofs field in FIlesystem as omitempty to allow non-virtiof…

### DIFF
--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3453,7 +3453,8 @@ var _ = Describe("Template", func() {
 								DisableHotplug: true,
 								Filesystems: []v1.Filesystem{
 									{
-										Name: "fakeVol1",
+										Name:     "fakeVol1",
+										Virtiofs: &v1.FilesystemVirtiofs{},
 									},
 								},
 							},

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -18,7 +18,9 @@ import (
 func generateVirtioFSContainers(vmi *v1.VirtualMachineInstance, image string, config *virtconfig.ClusterConfig) []k8sv1.Container {
 	passthroughFSVolumes := make(map[string]struct{})
 	for i := range vmi.Spec.Domain.Devices.Filesystems {
-		passthroughFSVolumes[vmi.Spec.Domain.Devices.Filesystems[i].Name] = struct{}{}
+		if vmi.Spec.Domain.Devices.Filesystems[i].Virtiofs != nil {
+			passthroughFSVolumes[vmi.Spec.Domain.Devices.Filesystems[i].Name] = struct{}{}
+		}
 	}
 	if len(passthroughFSVolumes) == 0 {
 		return nil

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -584,7 +584,7 @@ type Filesystem struct {
 	// Name is the device name
 	Name string `json:"name"`
 	// Virtiofs is supported
-	Virtiofs *FilesystemVirtiofs `json:"virtiofs"`
+	Virtiofs *FilesystemVirtiofs `json:"virtiofs,omitempty"`
 }
 
 type FilesystemVirtiofs struct{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
We're having our own CSI driver providing socket for vhost-user-fs protocol and we'd like to be able to not to start unused virtiofsd container by kubevirt. We're using sidecar to inject our filesystem device settings in domain XML. Unfortunately, despite being a pointer to struct Virtiofs field is not marked with omitempty, so not setting this one can be properly serialized, but then being rejected by virtualmachines-mutator.kubevirt.io admissioner.

After this PR:
Marked Virtiofs field in FIlesystem as omitempty to allow non-virtiofsd vhost devices
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/14015

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Marked Virtiofs field in FIlesystem as omitempty
```

