### PR TITLE
net, e2e, vmi_infosource: Apply linter

### DIFF
--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -28,7 +28,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kvirtv1 "kubevirt.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
@@ -57,7 +56,7 @@ var _ = Describe(SIG("Infosource", func() {
 	})
 
 	Context("VMI with 3 interfaces", func() {
-		var vmi *kvirtv1.VirtualMachineInstance
+		var vmi *v1.VirtualMachineInstance
 
 		const (
 			nadName                 = "infosrc"
@@ -85,7 +84,7 @@ var _ = Describe(SIG("Infosource", func() {
 			secondaryLinuxBridgeInterface2 := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork2.Name)
 			vmiSpec := libvmifact.NewFedora(
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&defaultBridgeInterface, primaryInterfaceMac)),
-				libvmi.WithNetwork(kvirtv1.DefaultPodNetwork()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface1, secondaryInterface1Mac)),
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface2, secondaryInterface2Mac)),
 				libvmi.WithNetwork(secondaryNetwork1),
@@ -106,7 +105,7 @@ var _ = Describe(SIG("Infosource", func() {
 
 			const linkStateUp = "up"
 
-			expectedInterfaces := []kvirtv1.VirtualMachineInstanceNetworkInterface{
+			expectedInterfaces := []v1.VirtualMachineInstanceNetworkInterface{
 				{
 					InfoSource:       netvmispec.InfoSourceDomain,
 					MAC:              primaryInterfaceMac,
@@ -174,7 +173,7 @@ var _ = Describe(SIG("Infosource", func() {
 	})
 }))
 
-func dummyInterfaceExists(vmi *kvirtv1.VirtualMachineInstance) bool {
+func dummyInterfaceExists(vmi *v1.VirtualMachineInstance) bool {
 	for i := range vmi.Status.Interfaces {
 		if vmi.Status.Interfaces[i].InterfaceName == dummyInterfaceName {
 			return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The `kubevirt.io/api/core/v1` package was imported twice under different aliases.
Remove the redundant import statement.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

