### PR TITLE
Expose filesystem PVCs using rootless containers and moving virtiofs as part of the infrastructure

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -176,6 +176,7 @@ container_image(
     files = [
         ":virt-handler",
         "//cmd/virt-chroot",
+        "//cmd/virtiofs-dispatcher",
     ],
     visibility = ["//visibility:public"],
 )

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -63,6 +63,7 @@ pkg_tar(
         "//cmd/virt-launcher-monitor",
         "//cmd/virt-probe",
         "//cmd/virt-tail",
+        "//cmd/virtiofs-placeholder",
     ],
     package_dir = "/usr/bin",
 )

--- a/cmd/virtiofs-dispatcher/BUILD.bazel
+++ b/cmd/virtiofs-dispatcher/BUILD.bazel
@@ -1,0 +1,8 @@
+cc_binary(
+    name = "virtiofs-dispatcher",
+    srcs = ["main.c"],
+    linkopts = [
+        "-static",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/virtiofs-dispatcher/main.c
+++ b/cmd/virtiofs-dispatcher/main.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#define _GNU_SOURCE
+#include <getopt.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+#include <sched.h>
+#include <sys/syscall.h>
+#include <fcntl.h>
+#include <sys/file.h>
+
+struct arguments {
+    char socket_flag[PATH_MAX + 1];
+    char shareddir_flag[PATH_MAX + 1];
+    int pid;
+};
+
+struct option long_options[] = {
+    {"socket-path", required_argument, 0, 's'},
+    {"shared-dir", required_argument, 0, 'd'},
+    {"pid", required_argument, 0, 'p'},
+    {0, 0, 0, 0}
+};
+
+void usage()
+{
+    printf("virtiofsd dispatcher\n"
+           "Usage:\n"
+           "\t-p, --pid:\t\tPid of the container\n"
+           "\t-d  --shared-dir\tShared directory flag for virtiofs\n"
+           "\t-s  --socket-path\tSocket path flag for virtiofs\n"
+          );
+}
+
+#define FMT_SZ 50
+void error_log(const char *format, ...)
+{
+    char time_fmt[FMT_SZ + 1] = {0};
+    time_t ltime = time(NULL);
+    strftime(time_fmt, FMT_SZ, "%b %d %H:%M:%S ", localtime(&ltime));
+    fprintf(stderr, "%s", time_fmt);
+
+    fprintf(stderr, "error: ");
+
+    va_list arglist;
+    va_start(arglist, format);
+    vfprintf(stderr, format, arglist);
+    va_end(arglist);
+}
+
+int parse_arguments(int argc, char **argv, struct arguments *args)
+{
+    while(1) {
+        int c = getopt_long(argc, argv, "p:d:s:", long_options, NULL);
+        if (c == -1) break;
+
+        switch (c) {
+            case 'p':
+                args->pid = atoi(optarg);
+                break;
+            case 'd':
+                strncpy(args->shareddir_flag, optarg, PATH_MAX);
+                break;
+            case 's':
+                strncpy(args->socket_flag, optarg, PATH_MAX);
+                break;
+            case '?':  // fallthrough
+            default:
+                return -1;
+        }
+    }
+
+    if (args->pid < 1) {
+        error_log("pid needs to be set\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int do_move_into_cgroup(char *cgroup_entry)
+{
+    // We must remove the trailing '\n'
+    cgroup_entry[strlen(cgroup_entry) - 1] = '\0';
+
+    char syspath[PATH_MAX + 1] = {0};
+    if (cgroup_entry[4] == '\0') {
+        // Handling "0::/"
+        strncpy(syspath, "/sys/fs/cgroup/cgroup.procs", PATH_MAX);
+    } else {
+        // Let's skip the first 4 characters "0::/" to get the relative path
+        snprintf(syspath, PATH_MAX, "/sys/fs/cgroup/%s/cgroup.procs", (cgroup_entry + 4));
+    }
+
+    fprintf(stderr, "moving the process into the cgroup: %s\n", syspath);
+
+    FILE *fptr = fopen(syspath, "ae");
+    if (fptr == NULL ) goto err;
+
+    char pid[20 + 1] = {0};
+    snprintf(pid, 20, "%d", getpid());
+    if (fputs(pid, fptr) < 0) {
+        fclose(fptr);
+        goto err;
+    }
+
+    fclose(fptr);
+
+    return 0;
+err:
+    error_log("failed to move process into cgroup path %s: %s\n", syspath, strerror(errno));
+    return -1;
+}
+
+int move_into_cgroup(pid_t pid)
+{
+    char path[PATH_MAX + 1] = {0};
+    snprintf(path, PATH_MAX, "/proc/%d/cgroup", pid);
+    FILE *fptr = fopen(path, "re");
+    if (fptr == NULL) goto err;
+
+    bool found = false;
+    char entry[PATH_MAX + 1] = {0};
+    while(fgets(entry, PATH_MAX, fptr) != NULL) {
+        // We only support cgroup v2
+        if ((strlen(entry) < 5) || (entry[0] != '0')) continue;
+
+        if (do_move_into_cgroup(entry) < 0) break;
+        found = true;
+        break;
+    }
+
+    fclose(fptr);
+
+    if (!found) {
+        error_log("failed to move process into cgroup or cgroup v2 not found\n");
+        return -1;
+    }
+
+    return 0;
+err:
+    error_log("failed to move process into cgroup: %s\n", strerror(errno));
+    return -1;
+}
+
+int move_into_namespaces_compat(int pid)
+{
+    char path[PATH_MAX + 1] = {0};
+    snprintf(path, PATH_MAX, "/proc/%d/ns", pid);
+    int nsfd = open(path, O_RDONLY | O_CLOEXEC);
+    if (nsfd == -1) goto err;
+
+    // We must not join the user namespace so virtiofsd can keep its capabilities
+    char *ns[6] = {"cgroup", "ipc", "mnt", "net", "pid", "uts"};
+    for (int i = 0; i < 6; i++) {
+        int fd = openat(nsfd, ns[i], O_RDONLY | O_CLOEXEC);
+        if (fd == -1) goto err;
+        if (setns(fd, 0) == -1) goto err;
+        close(fd);
+    }
+    close(nsfd);
+
+    return 0;
+err:
+    error_log("failed to move process into the namespace: %s\n", strerror(errno));
+    return -1;
+}
+
+int move_into_namespaces(pid_t pid)
+{
+    fprintf(stderr, "move the process into same namespaces as %d\n", pid);
+    int fd = syscall(SYS_pidfd_open, pid, 0);
+    if (fd < 0) {
+        if (errno == ENOSYS) {
+            // pidfd_open() requires kernel 5.3 and above,
+            // let's join each NS one by one on older kernels.
+            return move_into_namespaces_compat(pid);
+        }
+        goto err;
+    }
+
+    // We must not join the user namespace so virtiofsd can keep its capabilities
+    if (setns(fd, CLONE_NEWNET
+                  | CLONE_NEWPID
+                  | CLONE_NEWIPC
+                  | CLONE_NEWNS
+                  | CLONE_NEWCGROUP
+                  | CLONE_NEWUTS) < 0) goto err;
+
+    return 0;
+err:
+    error_log("failed to move process into the namespace: %s\n", strerror(errno));
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    struct arguments args = {0};
+    if (parse_arguments(argc, argv, &args) < 0) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+
+    if(move_into_cgroup(args.pid) < 0 ) exit(EXIT_FAILURE);
+    if(move_into_namespaces(args.pid) < 0 ) exit(EXIT_FAILURE);
+
+    // Let's make sure we only run one instance of virtiofsd.
+    //
+    // The main idea is to lock a file and "leak" the file descriptor
+    // into virtiofsd, since the lock is preserved across the execve()
+    // call. It will be automatically released when the file descriptor
+    // is closed at virtiofsd exit.
+    //
+    // We must do this here, after entering the mount namespace
+    // but before re-parenting under the placeholder, otherwise
+    // the placeholder will exit if we quit.
+    int fd = open("/var/run/virtiofsd.lock", O_RDONLY | O_CREAT, S_IRUSR);
+    if (fd < 0) {
+        error_log("failed to open the lock file: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    int ret = flock(fd, LOCK_EX | LOCK_NB);
+    if (ret < 0) {
+        if (errno == EWOULDBLOCK) {
+            // virtiofsd is already running, we must not return an error here,
+            // otherwise the dispatcher will be re-queued and executed again
+            // and again endlessly.
+            exit(EXIT_SUCCESS);
+        }
+        exit(EXIT_FAILURE);
+    }
+
+    // The PID namespace is special in the sense that a fork() is
+    // required after calling setns() to actually enter the PID NS.
+    //
+    // Since we want to re-parent virtiofsd to be a child of the
+    // PID 1 inside the container, we really need to fork() twice (see
+    // daemon()), because when a child process becomes orphaned, it is
+    // re-parented to the "init" process in the PID NS of its _parent_,
+    // so make sure the virtiofsd's parent process is already inside the
+    // PId NS.
+    pid_t child =  fork();
+    if (child < 0) exit(EXIT_FAILURE);
+    if (child > 0) exit(EXIT_SUCCESS);
+
+    if (daemon(0, -1) != 0) {
+        error_log("failed daemon: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    if (freopen("/proc/1/fd/1", "a", stdout) == NULL) {
+        error_log("failed redirecting stdout: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    if (freopen("/proc/1/fd/2", "a", stderr) == NULL){
+        error_log("failed redirecting stdout: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    fprintf(stderr, "start virtiofsd\n");
+
+    // Let's run virtiofsd:
+    // - chrooting it inside the shared dir, without
+    // CAP_MKNOD to disable the creation of devices (besides FIFOs).
+    // - use file handles, if the filesystem supports them
+    // (i.e., --inode-file-handles=prefer).
+    // - use file handles for migration, and report any error to the
+    // target guest. We keep CAP_DAC_READ_SEARCH since is required in the
+    // target to open the file handles.
+    // - squash all UIDs/GIDs in the guest to the non-root UID defined in
+    // 'util.NonRootUID' (i.e., 107). So, all files will be created with that UID/GID
+    // even if virtiofsd runs as root.
+    char bin[] = "/usr/libexec/virtiofsd";
+    char *virtiofs_argv[] = {
+        bin,
+        "--socket-path", args.socket_flag,
+        "--shared-dir", args.shareddir_flag,
+        "--cache", "auto",
+        "--sandbox", "chroot",
+        "--modcaps=+dac_read_search:-mknod",
+        "--inode-file-handles=prefer",
+        "--migration-mode=file-handles",
+        "--migration-on-error=guest-error",
+        "--translate-uid=squash-guest:0:107:4294967295",
+        "--translate-gid=squash-guest:0:107:4294967295",
+        "--xattr", NULL };
+    char *env[] = { NULL };
+
+    if (execve(bin, virtiofs_argv, env) < 0) {
+        error_log("failed executing virtiofsd: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    exit(EXIT_SUCCESS);
+}

--- a/cmd/virtiofs-placeholder/BUILD.bazel
+++ b/cmd/virtiofs-placeholder/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
 cc_binary(
     name = "virtiofs-placeholder",
     srcs = ["main.c"],
@@ -5,4 +7,22 @@ cc_binary(
         "-static",
     ],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "main_test.go",
+        "virtiofs-placeholder_suite_test.go",
+    ],
+    args = [
+        "--placeholder-binary",
+        "$(location //cmd/virtiofs-placeholder:virtiofs-placeholder)",
+    ],
+    data = ["//cmd/virtiofs-placeholder"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )

--- a/cmd/virtiofs-placeholder/BUILD.bazel
+++ b/cmd/virtiofs-placeholder/BUILD.bazel
@@ -1,0 +1,8 @@
+cc_binary(
+    name = "virtiofs-placeholder",
+    srcs = ["main.c"],
+    linkopts = [
+        "-static",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/virtiofs-placeholder/main.c
+++ b/cmd/virtiofs-placeholder/main.c
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * virtiofsd placeholder
+ *
+ * The purpose of this command is to function as PID 1 inside the container having
+ * the same lifetime as virtiofsd.
+ *
+ * The dispatcher will get the PID of this command by connecting to the socket,
+ * and will run a privileged virtiofsd on the same namespaces and cgroup as this command.
+ *
+ * Since virtiofsd will be re-parented as a child of this command, it should terminate
+ * when it receives the SIGCHLD signal indicating that virtiofsd is finished.
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/signalfd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+
+struct arguments {
+    char socket[PATH_MAX + 1];
+};
+
+struct option long_options[] = {
+    {"socket-path", required_argument, 0, 's'},
+    {0, 0, 0, 0}
+};
+
+void usage()
+{
+    printf("Placeholder for virtiofs\n"
+           "Usage:\n"
+           "\t-s, --socket:\tContainer socket path to retrieve the pid\n");
+}
+
+int parse_arguments(int argc, char **argv, struct arguments *args)
+{
+    while(1) {
+        int c = getopt_long(argc, argv, "s:", long_options, NULL);
+        if (c == -1) break;
+
+        switch (c) {
+            case 's':
+                strncpy(args->socket, optarg, PATH_MAX);
+                break;
+            case '?': // fallthrough
+            default:
+                return -1;
+        }
+    }
+    return 0;
+}
+
+#define FMT_SZ 50
+void error_log(const char *format, ...)
+{
+    char time_fmt[FMT_SZ + 1] = {0};
+    time_t ltime = time(NULL);
+    strftime(time_fmt, FMT_SZ, "%b %d %H:%M:%S ", localtime(&ltime));
+    fprintf(stderr, "%s", time_fmt);
+
+    fprintf(stderr, "error: ");
+
+    va_list arglist;
+    va_start(arglist, format);
+    vfprintf(stderr, format, arglist);
+    va_end(arglist);
+}
+
+int get_signalfd(int signal)
+{
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, signal);
+    if (sigprocmask(SIG_BLOCK, &sigset, NULL) == -1) {
+        error_log("sigprocmask failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    int fd = signalfd(-1, &sigset, SFD_NONBLOCK);
+    if (fd < 0) {
+        error_log("signalfd failed: %s\n", strerror(errno));
+    }
+
+    return fd;
+}
+
+int create_socket(const char *path)
+{
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) goto err;
+
+    struct sockaddr_un addr = {0};
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+    if (bind(fd, (struct sockaddr *) &addr, sizeof(addr)) < 0) goto err_close;
+
+    if (listen(fd, 1) < 0) goto err_close;
+
+    return fd;
+err_close:
+    close(fd);
+err:
+    error_log("create_socket failed: %s\n", strerror(errno));
+    return -1;
+}
+
+int monitor(int socket_fd, int sig_fd)
+{
+    int efd = epoll_create1(0);
+    if (efd < 0) goto err;
+
+    // Watch the socket
+    // Even if we expect just one connection, we cannot use EPOLLONESHOT, because the dispatcher
+    // could have died after connect() but before spawning virtiofsd, so we need to allow successive
+    // connections.
+    struct epoll_event socket_event = {.events = EPOLLIN, .data.fd = socket_fd};
+    if (epoll_ctl(efd, EPOLL_CTL_ADD, socket_fd, &socket_event) < 0) goto err;
+
+    struct epoll_event signal_event = {.events = EPOLLIN, .data.fd = sig_fd};
+    if (epoll_ctl(efd, EPOLL_CTL_ADD, sig_fd, &signal_event) < 0) goto err;
+
+    struct epoll_event epoll_events;
+    while (true) {
+        int ret = epoll_wait(efd, &epoll_events, 1, -1);
+        if (ret < 0 && errno == EINTR) continue;
+        if (ret < 0) goto err;
+
+        if (epoll_events.data.fd == sig_fd) {
+            // We received a SIGCHLD if virtiofsd exited, we must exit too
+            struct signalfd_siginfo sfdi;
+            int len = read(epoll_events.data.fd, &sfdi, sizeof(sfdi));
+            // Let's assume that only virtiofsd will run with privileges (i.e., uid == 0)
+            if (len == sizeof(sfdi) && sfdi.ssi_uid == 0) break;
+        } else if (epoll_events.data.fd == socket_fd) {
+            int accept_fd = accept(socket_fd, NULL, NULL);
+            if (accept_fd < 0) goto err;
+
+            // Get a notification if the socket is closed, to avoid leaking the FD
+            struct epoll_event acceptfd_event = {.events = EPOLLRDHUP | EPOLLONESHOT, .data.fd = accept_fd};
+            // Ignore the error, If epoll_ctl fails we will just leak the accept_fd
+            if (epoll_ctl(efd, EPOLL_CTL_ADD, accept_fd, &acceptfd_event) < 0) {
+                error_log("monitor failed to add accepted connection: %s\n", strerror(errno));
+            }
+        } else if (epoll_events.events & EPOLLRDHUP) {
+            // An event from the accepted connection, the other side closed the connection
+            close(epoll_events.data.fd);
+        }
+    }
+
+    return 0;
+err:
+    error_log("monitor failed: %s\n", strerror(errno));
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    fprintf(stderr, "start monitoring for virtiofs\n");
+
+    struct arguments args = {0};
+    if(parse_arguments(argc, argv, &args) < 0) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+
+    // sig_fd and socket_fd will close on exit
+    int sig_fd = get_signalfd(SIGCHLD);
+    if (sig_fd == -1) exit(EXIT_FAILURE);
+
+    int socket_fd = create_socket(args.socket);
+    if (socket_fd == -1) exit(EXIT_FAILURE);
+
+    if (monitor(socket_fd, sig_fd) == -1) exit(EXIT_FAILURE);
+
+    exit(EXIT_SUCCESS);
+}

--- a/cmd/virtiofs-placeholder/main_test.go
+++ b/cmd/virtiofs-placeholder/main_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package virtiofs_placeholder_test
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("the virtiofs placeholder binary", func() {
+	var (
+		sock string
+		cmd  *exec.Cmd
+	)
+	BeforeEach(func() {
+		if !strings.Contains(placeholderBinary, "../../") {
+			placeholderBinary = filepath.Join("../../", placeholderBinary)
+		}
+		dir := GinkgoT().TempDir()
+		sock = filepath.Join(dir, "placeholder.sock")
+		cmd = exec.Command(placeholderBinary, "--socket", sock)
+		Expect(cmd.Start()).To(Succeed())
+
+	})
+	It("should be able to handle 200 connections in 5 seconds without rejecting one of them", func() {
+		time.Sleep(1 * time.Second)
+		for i := 0; i < 200; i++ {
+			conn, err := net.Dial("unix", sock)
+			Expect(err).ToNot(HaveOccurred())
+			conn.Close()
+			time.Sleep(25 * time.Millisecond)
+		}
+		Expect(cmd.Process.Kill()).To(Succeed())
+	})
+	It("should exit if it receives a SIGCHLD", func() {
+		done := make(chan bool, 1)
+		Expect(cmd.Process).ToNot(BeNil())
+		go func() {
+			Expect(cmd.Wait()).To(Succeed())
+			done <- true
+		}()
+		Eventually(func() int {
+			return cmd.Process.Pid
+		}).WithTimeout(20 * time.Second).Should(BeNumerically(">", 0))
+		By(fmt.Sprintf("Sending SIGCHLD to pid: %d", cmd.Process.Pid))
+		out, err := exec.Command("/bin/bash", "-c", fmt.Sprintf("kill -SIGCHLD %d", cmd.Process.Pid)).CombinedOutput()
+		Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("output:%s", string(out)))
+
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			Fail("Timout expired waiting for the process to terminates")
+		}
+	})
+})

--- a/cmd/virtiofs-placeholder/virtiofs-placeholder_suite_test.go
+++ b/cmd/virtiofs-placeholder/virtiofs-placeholder_suite_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package virtiofs_placeholder_test
+
+import (
+	"flag"
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+var placeholderBinary string
+
+func init() {
+	flag.StringVar(&placeholderBinary, "placeholder-binary", "_out/cmd/virtiofs-placeholder", "path to virtiofs placeholder binary")
+}
+
+func TestVirtiofsPlaceholder(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
+        "//pkg/storage/utils:go_default_library",
         "//pkg/tpm:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -669,6 +669,9 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	pod.Spec.Volumes = append(pod.Spec.Volumes, sidecarVolumes...)
+	if virtiofsRequiresExtraVolume(vmi) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, virtiofsExtraVolume())
+	}
 
 	return &pod, nil
 }

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -9,6 +9,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/storage/utils"
 	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virtiofs"
@@ -74,24 +75,22 @@ func isAutoMount(volume *v1.Volume) bool {
 	return volume.ServiceAccount != nil
 }
 
+// virtiofsRequiresExtraVolume returns if the container needs an extra virtiofs volume
+// where the socket for the virtiofs placeholder will be located
+func virtiofsRequiresExtraVolume(vmi *v1.VirtualMachineInstance) bool {
+	return virtiofs.HasFilesystemPersistentVolumes(vmi)
+}
+
+func virtiofsExtraVolume() k8sv1.Volume {
+	return k8sv1.Volume{
+		Name: virtiofs.PlaceholderSocketVolumeName,
+		VolumeSource: k8sv1.VolumeSource{
+			EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
 func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv1.ResourceRequirements) k8sv1.Container {
-
-	volumeMountPath := virtiofs.FSMountPoint(volume)
-	socketPathArg := fmt.Sprintf("--socket-path=%s", virtiofs.VirtioFSSocketPath(volume.Name))
-	sourceArg := fmt.Sprintf("--shared-dir=%s", volumeMountPath)
-
-	args := []string{socketPathArg, sourceArg, "--sandbox=none", "--cache=auto"}
-
-	// If some files cannot be migrated, let's allow the migration to finish.
-	// Mark these files as invalid, the guest will not be able to access any such files,
-	// receiving only errors
-	args = append(args, "--migration-on-error=guest-error")
-
-	// This mode look up its file references paths by reading the symlinks in /proc/self/fd,
-	// falling back to iterating through the shared directory (exhaustive search) to find those paths.
-	// This migration mode doesn't require any privileges.
-	args = append(args, "--migration-mode=find-paths")
-
 	volumeMounts := []k8sv1.VolumeMount{
 		// This is required to pass socket to compute
 		{
@@ -100,6 +99,7 @@ func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv
 		},
 	}
 
+	volumeMountPath := virtiofs.FSMountPoint(volume)
 	if !isAutoMount(volume) {
 		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 			Name:      volume.Name,
@@ -107,11 +107,43 @@ func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv
 		})
 	}
 
+	var (
+		cmd  []string
+		args []string
+	)
+
+	switch {
+	case utils.IsStorageVolume(volume):
+		cmd = []string{"/usr/bin/virtiofs-placeholder"}
+		args = []string{"--socket", virtiofs.PlaceholderSocketPath(volume.Name)}
+
+		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+			Name:      virtiofs.PlaceholderSocketVolumeName,
+			MountPath: virtiofs.PlaceholderSocketVolumeMountPoint,
+		})
+	case utils.IsConfigVolume(volume):
+		cmd = []string{"/usr/libexec/virtiofsd"}
+
+		socketPathArg := "--socket-path=" + virtiofs.VirtioFSSocketPath(volume.Name)
+		sourceArg := "--shared-dir=" + volumeMountPath
+		args = []string{socketPathArg, sourceArg, "--sandbox=none", "--cache=auto"}
+
+		// If some files cannot be migrated, let's allow the migration to finish.
+		// Mark these files as invalid, the guest will not be able to access any such files,
+		// receiving only errors
+		args = append(args, "--migration-on-error=guest-error")
+
+		// This mode look up its file references paths by reading the symlinks in /proc/self/fd,
+		// falling back to iterating through the shared directory (exhaustive search) to find those paths.
+		// This migration mode doesn't require any privileges.
+		args = append(args, "--migration-mode=find-paths")
+	}
+
 	return k8sv1.Container{
 		Name:            fmt.Sprintf("virtiofs-%s", volume.Name),
 		Image:           image,
 		ImagePullPolicy: k8sv1.PullIfNotPresent,
-		Command:         []string{"/usr/libexec/virtiofsd"},
+		Command:         cmd,
 		Args:            args,
 		VolumeMounts:    volumeMounts,
 		Resources:       resources,

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//pkg/virt-handler/migration-proxy:go_default_library",
         "//pkg/virt-handler/multipath-monitor:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",
+        "//pkg/virt-handler/virtiofs:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virtiofs:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-handler/virtiofs/BUILD.bazel
+++ b/pkg/virt-handler/virtiofs/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dispatcher.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-handler/virtiofs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virt-handler/isolation:go_default_library",
+        "//pkg/virtiofs:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "dispatcher_suite_test.go",
+        "dispatcher_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
+        "//pkg/virtiofs:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/pkg/virt-handler/virtiofs/dispatcher.go
+++ b/pkg/virt-handler/virtiofs/dispatcher.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package virtiofs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
+	"kubevirt.io/kubevirt/pkg/virtiofs"
+)
+
+const dispatcher = "virtiofs-dispatcher"
+
+var virtiofsKubeletVolumePath = filepath.Join("volumes/kubernetes.io~empty-dir", virtiofs.PlaceholderSocketVolumeName)
+
+type execCommandFn func(string, ...string) *exec.Cmd
+type getPeerPidFn func(string) (int, error)
+
+type VirtiofsManager struct {
+	mountBaseDir string
+	execCommand  execCommandFn
+	getPeerPid   getPeerPidFn
+}
+
+func NewVirtiofsManager(mountBaseDir string) *VirtiofsManager {
+	return newManager(mountBaseDir, exec.Command, isolation.GetPeerPid)
+}
+
+func newManager(mountBaseDir string, execCommand execCommandFn, getPeerPid getPeerPidFn) *VirtiofsManager {
+	return &VirtiofsManager{
+		mountBaseDir: mountBaseDir,
+		execCommand:  execCommand,
+		getPeerPid:   getPeerPid,
+	}
+}
+
+func (m *VirtiofsManager) virtiofsPlaceholderSocketFromHost(podUID, volumeName string) string {
+	return filepath.Join(m.mountBaseDir, podUID, virtiofsKubeletVolumePath, virtiofs.PlaceholderSocketName(volumeName))
+}
+
+func (m *VirtiofsManager) StartVirtiofsDispatcher(vmi *v1.VirtualMachineInstance) error {
+	vols := virtiofs.GetFilesystemPersistentVolumes(vmi)
+	pid := -1
+	var err error
+	for _, v := range vols {
+		for podUID := range vmi.Status.ActivePods {
+			socket := m.virtiofsPlaceholderSocketFromHost(string(podUID), v.Name)
+			pid, err = m.getPeerPid(socket)
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("failed getting the virtiofs placeholder socket %s error: %v", socket, err)
+			}
+		}
+		if pid == -1 {
+			return fmt.Errorf("pid not found")
+		}
+
+		path := virtiofs.VirtioFSSocketPath(v.Name)
+		cmd := m.execCommand(dispatcher, "--pid", strconv.Itoa(pid),
+			"--socket-path", path,
+			"--shared-dir", virtiofs.FSMountPoint(&v))
+		log.Log.Object(vmi).Infof("Dispatcher: %s", cmd.String())
+		stdoutStderr, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("virtiofs-dispatcher failed output:%s error: %v", stdoutStderr, err)
+		}
+		log.Log.Object(vmi).Infof("Launch virtiofs dispatcher: %s", stdoutStderr)
+	}
+
+	return nil
+}

--- a/pkg/virt-handler/virtiofs/dispatcher_suite_test.go
+++ b/pkg/virt-handler/virtiofs/dispatcher_suite_test.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package virtiofs
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVirtiofs(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-handler/virtiofs/dispatcher_test.go
+++ b/pkg/virt-handler/virtiofs/dispatcher_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package virtiofs
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
+	"kubevirt.io/kubevirt/pkg/virtiofs"
+)
+
+var _ = Describe("Virtiofs dispatcher", func() {
+	const (
+		podUID  = "123456789"
+		volName = "vol"
+		pid     = 123
+	)
+	var (
+		f   fakeExecCommandExecutor
+		vmi *v1.VirtualMachineInstance
+		dir string
+	)
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+		path := filepath.Join(dir, podUID, "volumes/kubernetes.io~empty-dir", virtiofs.PlaceholderSocketVolumeName)
+		Expect(os.MkdirAll(path, 0664)).To(Succeed())
+		vmi = libvmi.New(
+			libvmi.WithFilesystemPVC(volName),
+			libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithActivePod(podUID, "node01"),
+			)),
+		)
+	})
+
+	Context("StartVirtiofsDispatcher", func() {
+		It("should succeed", func() {
+			f.pid = pid
+			var getPeerPidFunc = func(socket string) (int, error) {
+				return pid, nil
+			}
+			vfsdManager := newManager(dir, f.fakeExecDispatcherCommand, getPeerPidFunc)
+			Expect(vfsdManager.StartVirtiofsDispatcher(vmi)).ToNot(HaveOccurred())
+		})
+
+		It("should fail if no pid for any active pods is found", func() {
+			var getPeerPidFunc = func(socket string) (int, error) {
+				return -1, os.ErrNotExist
+			}
+			vfsdManager := newManager(dir, f.fakeExecDispatcherCommand, getPeerPidFunc)
+			Expect(vfsdManager.StartVirtiofsDispatcher(vmi)).Should(MatchError("pid not found"))
+		})
+
+		It("should fail for any other error in getting the pid of the socket", func() {
+			var getPeerPidFunc = func(socket string) (int, error) {
+				return -1, errors.New("error")
+			}
+			vfsdManager := newManager(dir, f.fakeExecDispatcherCommand, getPeerPidFunc)
+			Expect(vfsdManager.StartVirtiofsDispatcher(vmi)).Should(HaveOccurred())
+		})
+
+		It("should succeeded if virtiofs has already been started", func() {
+			virtiofs.VirtioFSContainersMountBaseDir = GinkgoT().TempDir()
+			path := virtiofs.VirtioFSSocketPath(volName)
+			Expect(os.WriteFile(path, []byte{}, 0755)).ToNot(HaveOccurred())
+
+			var getPeerPidFunc = func(socket string) (int, error) {
+				return pid, nil
+			}
+			vfsdManager := newManager(dir, f.fakeExecDispatcherCommand, getPeerPidFunc)
+			Expect(vfsdManager.StartVirtiofsDispatcher(vmi)).ToNot(HaveOccurred())
+		})
+	})
+})
+
+type fakeExecCommandExecutor struct {
+	pid int
+}
+
+func (f *fakeExecCommandExecutor) fakeExecDispatcherCommand(_ string, args ...string) *exec.Cmd {
+	for i, arg := range args {
+		if arg == "--pid" {
+			Expect(args[i+1]).To(Equal(strconv.Itoa(f.pid)))
+		}
+	}
+	return exec.Command("true")
+}

--- a/pkg/virtiofs/BUILD.bazel
+++ b/pkg/virtiofs/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtiofs",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virtiofs/BUILD.bazel
+++ b/pkg/virtiofs/BUILD.bazel
@@ -5,5 +5,9 @@ go_library(
     srcs = ["virtiofs.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virtiofs",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util:go_default_library"],
+    deps = [
+        "//pkg/storage/types:go_default_library",
+        "//pkg/util:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+    ],
 )

--- a/pkg/virtiofs/virtiofs.go
+++ b/pkg/virtiofs/virtiofs.go
@@ -23,7 +23,15 @@ import (
 	"fmt"
 	"path/filepath"
 
+	v1 "kubevirt.io/api/core/v1"
+
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
+)
+
+const (
+	PlaceholderSocketVolumeMountPoint = "/var/run/sockets"
+	PlaceholderSocketVolumeName       = "virtiofs-sockets"
 )
 
 // This is empty dir
@@ -33,4 +41,32 @@ var VirtioFSContainersMountBaseDir = filepath.Join(util.VirtShareDir, VirtioFSCo
 func VirtioFSSocketPath(volumeName string) string {
 	socketName := fmt.Sprintf("%s.sock", volumeName)
 	return filepath.Join(VirtioFSContainersMountBaseDir, socketName)
+}
+
+func PlaceholderSocketName(volumeName string) string {
+	return fmt.Sprintf("%s.sock", volumeName)
+}
+
+func PlaceholderSocketPath(volumeName string) string {
+	return filepath.Join(PlaceholderSocketVolumeMountPoint, PlaceholderSocketName(volumeName))
+}
+
+func GetFilesystemPersistentVolumes(vmi *v1.VirtualMachineInstance) []v1.Volume {
+	var vols []v1.Volume
+	fss := storagetypes.GetFilesystemsFromVolumes(vmi)
+	for _, volume := range vmi.Spec.Volumes {
+		if _, ok := fss[volume.Name]; !ok {
+			continue
+		}
+		if volume.VolumeSource.PersistentVolumeClaim != nil ||
+			volume.VolumeSource.DataVolume != nil {
+			vols = append(vols, volume)
+		}
+	}
+
+	return vols
+}
+
+func HasFilesystemPersistentVolumes(vmi *v1.VirtualMachineInstance) bool {
+	return len(GetFilesystemPersistentVolumes(vmi)) > 0
 }

--- a/pkg/virtiofs/virtiofs.go
+++ b/pkg/virtiofs/virtiofs.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/config"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
 )
@@ -69,4 +70,19 @@ func GetFilesystemPersistentVolumes(vmi *v1.VirtualMachineInstance) []v1.Volume 
 
 func HasFilesystemPersistentVolumes(vmi *v1.VirtualMachineInstance) bool {
 	return len(GetFilesystemPersistentVolumes(vmi)) > 0
+}
+
+func FSMountPoint(volume *v1.Volume) string {
+	switch {
+	case volume.ConfigMap != nil:
+		return config.GetConfigMapSourcePath(volume.Name)
+	case volume.Secret != nil:
+		return config.GetSecretSourcePath(volume.Name)
+	case volume.ServiceAccount != nil:
+		return config.ServiceAccountSourceDir
+	case volume.DownwardAPI != nil:
+		return config.GetDownwardAPISourcePath(volume.Name)
+	default:
+		return fmt.Sprintf("/%s", volume.Name)
+	}
 }

--- a/tests/virtiofs/BUILD.bazel
+++ b/tests/virtiofs/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//tests/libconfigmap:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
+        "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libsecret:go_default_library",
         "//tests/libstorage:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Virtiofs container runs as unprivileged, so it cannot use file handles for both sharing a PVC with the VM and for safe live migration 

After this PR:
Virtiofsd is moved as part of the infrastructure. The virtiofs container will remain rootless starting a dummy process. Then, the virtiofsd binary will be launched by virt-handler, and it will join the virtiofs container namespace and cgroup.

Here explained steps by steps how virtiofsd is launched:
![virtiofsd-as-kubevirt-infra](https://github.com/user-attachments/assets/1b3f9304-eb20-403c-9a11-3477aac154ac)


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
    - https://github.com/kubevirt/enhancements/pull/54
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose filesystem PVCs using virtiofsd as part of the infrastructure, allowing file handle live migration mode.
```

