### PR TITLE
e2e,compute: Unquarantine subresource access test

### DIFF
--- a/tests/infrastructure/cluster-profiler.go
+++ b/tests/infrastructure/cluster-profiler.go
@@ -20,7 +20,6 @@
 package infrastructure
 
 import (
-	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -59,7 +58,7 @@ var _ = Describe(SIGSerial("cluster profiler for pprof data aggregation", func()
 			_, err = virtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
 			Expect(err).To(HaveOccurred())
 		})
-		It("[QUARANTINE]is enabled it should allow subresource access", decorators.Quarantine, func() {
+		It("is enabled it should allow subresource access", func() {
 			kvConfig.DeveloperConfiguration.ClusterProfiler = true
 			config.UpdateKubeVirtConfigValueAndWait(kvConfig)
 


### PR DESCRIPTION
### What this PR does

From checking the results in testgrid, this test has not failed once in the last two weeks of periodics so it should no longer be quarantined.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13865

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @dhiller @fossedihelm 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

