### PR TITLE
e2e: set a http client timeout for github requests

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -2392,8 +2393,9 @@ func verifyOperatorWebhookCertificate() {
 }
 
 func getUpstreamReleaseAssetURL(tag string, assetName string) string {
-	client := github.NewClient(nil)
-
+	client := github.NewClient(&http.Client{
+		Timeout: 5 * time.Second,
+	})
 	var err error
 	var release *github.RepositoryRelease
 
@@ -2414,7 +2416,9 @@ func getUpstreamReleaseAssetURL(tag string, assetName string) string {
 }
 
 func detectLatestUpstreamOfficialTag() (string, error) {
-	client := github.NewClient(nil)
+	client := github.NewClient(&http.Client{
+		Timeout: 5 * time.Second,
+	})
 
 	var err error
 	var releases []*github.RepositoryRelease


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In upgrade tests, we install the previous kv version and then update to the current one.
We rely on github API to do this, fetching the latest upstream release tag.
These third-party requests are encapsulated in an Eventually loop with 10 sec timeout, but since there is no client timeout set, it could happen that we simply try one request (which lasts more than 10 secs).
Let's explicitly set a timeout in the http client, so that we try at least two times.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/13867

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

