### PR TITLE
make use of context for vnc

### DIFF
--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -103,7 +103,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	// setup connection with VM
 	vnc, err := virtCli.VirtualMachineInstance(namespace).VNC(vmi)
 	if err != nil {
-		return fmt.Errorf("Can't access VMI %s: %s", vmi, err.Error())
+		return fmt.Errorf("can't access VMI %s: %s", vmi, err.Error())
 	}
 	// Format the listening address to account for the port (ex: 127.0.0.0:5900)
 	// Set listenAddress to localhost if proxy-only flag is not set
@@ -114,13 +114,13 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	listenAddressFmt = listenAddress + ":%d"
 	lnAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf(listenAddressFmt, customPort))
 	if err != nil {
-		return fmt.Errorf("Can't resolve the address: %s", err.Error())
+		return fmt.Errorf("can't resolve the address: %s", err.Error())
 	}
 
 	// The local tcp server is used to proxy the podExec websock connection to vnc client
 	ln, err := net.ListenTCP("tcp", lnAddr)
 	if err != nil {
-		return fmt.Errorf("Can't listen on unix socket: %s", err.Error())
+		return fmt.Errorf("can't listen on unix socket: %s", err.Error())
 	}
 	// End of pre-flight checks. Everything looks good, we can start
 	// the goroutines and let the data flow
@@ -160,7 +160,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 		}
 		defer fd.Close()
 
-		log.Log.V(2).Infof("VNC Client connected in %v", time.Now().Sub(start))
+		log.Log.V(2).Infof("VNC Client connected in %v", time.Since(start))
 		templates.PrintWarningForPausedVMI(virtCli, vmi, namespace)
 
 		// write to FD <- pipeOutReader
@@ -186,7 +186,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 			Port int `json:"port"`
 		}{port})
 		if err != nil {
-			return fmt.Errorf("Error encountered: %s", err.Error())
+			return fmt.Errorf("error encountered: %s", err.Error())
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), string(optionString))
 	} else {
@@ -206,7 +206,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if err != nil && !errors.Is(err, context.Canceled) {
-		return fmt.Errorf("Error encountered: %s", err.Error())
+		return fmt.Errorf("error encountered: %s", err.Error())
 	}
 	return nil
 }
@@ -266,7 +266,7 @@ func checkAndRunVNCViewer(ctx context.Context, errChan chan error, port int) {
 
 	if vncBin == "" {
 		log.Log.Errorf("No supported VNC app found in %s", osType)
-		err = fmt.Errorf("No supported VNC app found in %s", osType)
+		err = fmt.Errorf("no supported VNC app found in %s", osType)
 	} else {
 		log.Log.V(4).Infof("Executing commandline: '%s %v'", vncBin, args)
 		// #nosec No risk for attacker injection. vncBin and args include predefined strings


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- `virtctl vnc` does not use a context, potentially leaking goroutines.

After this PR:
- `virtctl vnc` now uses a context, ensuring it can be shut down in a controlled manner without leaking goroutines.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13414 

### Why we need it and why it was done in this way
Using a context ensures that virtctl vnc can be canceled gracefully, avoiding goroutine leaks. This approach follows idiomatic Go practices for managing the lifecycle of operations.

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/pull/13378#discussion_r1863782022

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

