### PR TITLE
Add LowReadyVirtControllersCount e2e test

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -12,7 +12,7 @@ tests:
     input_series:
       - series: 'up{namespace="ci", pod="virt-api-1"}'
         values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
-      - series: 'up{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
         values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
       - series: 'up{namespace="ci", pod="virt-operator-1"}'
         values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
@@ -197,9 +197,9 @@ tests:
         values: '1+0x11'
       - series: 'kubevirt_virt_controller_ready_status{namespace="ci", pod="virt-controller-2"}'
         values: '0+0x11'
-      - series: 'up{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
         values: '1+0x11'
-      - series: 'up{namespace="ci", pod="virt-controller-2"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-2", phase="Running"}'
         values: '1+0x11'
 
     alert_rule_test:

--- a/pkg/monitoring/rules/recordingrules/virt.go
+++ b/pkg/monitoring/rules/recordingrules/virt.go
@@ -45,7 +45,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 			},
 			MetricType: operatormetrics.GaugeType,
 			Expr: intstr.FromString(
-				fmt.Sprintf("sum(up{pod=~'virt-controller-.*', namespace='%s'}) or vector(0)", namespace),
+				fmt.Sprintf("sum(kube_pod_status_phase{pod=~'virt-controller-.*', namespace='%s', phase='Running'}) or vector(0)", namespace),
 			),
 		},
 		{
@@ -55,7 +55,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 			},
 			MetricType: operatormetrics.GaugeType,
 			Expr: intstr.FromString(
-				fmt.Sprintf("sum(kubevirt_virt_controller_ready_status{namespace='%s'}) or vector(0)", namespace),
+				fmt.Sprintf("count(kube_pod_status_ready{pod=~'virt-controller-.*', namespace='%s', condition='true'} + on(pod, namespace) kubevirt_virt_controller_ready_status{namespace='%s'}) or vector(0)", namespace, namespace),
 			),
 		},
 		{

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//tests/libmonitoring:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnode:go_default_library",
+        "//tests/libregistry:go_default_library",
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libvmops:go_default_library",

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -21,6 +21,7 @@ package monitoring
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -41,6 +43,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmonitoring"
+	"kubevirt.io/kubevirt/tests/libregistry"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -51,6 +54,7 @@ type alerts struct {
 	noReadyAlert         string
 	restErrorsBurtsAlert string
 	lowCountAlert        string
+	lowReadyAlert        string
 }
 
 var (
@@ -66,6 +70,7 @@ var (
 		noReadyAlert:         "NoReadyVirtController",
 		restErrorsBurtsAlert: "VirtControllerRESTErrorsBurst",
 		lowCountAlert:        "LowVirtControllersCount",
+		lowReadyAlert:        "LowReadyVirtControllersCount",
 	}
 	virtHandler = alerts{
 		deploymentName:       "virt-handler",
@@ -184,6 +189,48 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtApi.lowCountAlert)
+		})
+	})
+
+	Context("Low ready alerts", decorators.RequiresTwoSchedulableNodes, func() {
+		var virtClient kubecli.KubevirtClient
+
+		BeforeEach(func() {
+			virtClient = kubevirt.Client()
+
+			scales = libmonitoring.NewScaling(virtClient, []string{virtOperator.deploymentName, virtController.deploymentName, virtApi.deploymentName})
+			scales.UpdateScale(virtOperator.deploymentName, int32(0))
+
+			libmonitoring.ReduceAlertPendingTime(virtClient)
+		})
+
+		AfterEach(func() {
+			scales.RestoreAllScales()
+			waitUntilComponentsAlertsDoNotExist(virtClient)
+		})
+
+		It("LowReadyVirtControllersCount should be triggered when virt-controller pods exist but are not ready", func() {
+			virtControllerDeployment, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), virtController.deploymentName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			container := &virtControllerDeployment.Spec.Template.Spec.Containers[0]
+			container.Image = libregistry.GetUtilityImageFromRegistry("vm-killer") // any random image
+			container.Command = []string{"tail", "-f", "/dev/null"}
+			container.Args = []string{}
+			container.ReadinessProbe = nil
+			container.LivenessProbe = nil
+
+			GinkgoWriter.Printf("virtControllerDeployment: %+v",
+				virtControllerDeployment.Spec.Template.Spec.Containers,
+			)
+
+			patch, err := json.Marshal(virtControllerDeployment)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), virtControllerDeployment.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			libmonitoring.VerifyAlertExist(virtClient, virtController.lowReadyAlert)
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

kubevirt_virt_controller_up was based on whether Prometheus was able to query virt-controller's metric endpoint.
No LowReadyVirtControllersCount e2e test.

After this PR:

kubevirt_virt_controller_up is based on the pod statuses.
An e2e test for LowReadyVirtControllersCount was added.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-56648

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add LowReadyVirtControllersCount e2e test
```

