### PR TITLE
standardized ssh key creation in tests using existing library

### DIFF
--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -34,6 +34,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"golang.org/x/crypto/ssh"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -41,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libsecret"
+	"kubevirt.io/kubevirt/tests/libssh"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -58,10 +60,11 @@ var _ = Describe(SIG("Guest Access Credentials", func() {
 		userData                 = "#cloud-config\nchpasswd: { expire: False }\n"
 	)
 
+	_, pub, _ := libssh.NewKeyPair()
 	keysSecretData := libsecret.DataBytes{
-		"my-key1": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key1"),
-		"my-key2": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key2"),
-		"my-key3": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key3"),
+		"my-key1": ssh.MarshalAuthorizedKey(pub),
+		"my-key2": ssh.MarshalAuthorizedKey(pub),
+		"my-key3": ssh.MarshalAuthorizedKey(pub),
 	}
 
 	DescribeTable("should have ssh-key under authorized keys added", func(withQEMUAccessCredential bool, options ...libvmi.Option) {
@@ -120,8 +123,9 @@ var _ = Describe(SIG("Guest Access Credentials", func() {
 	Context("with qemu guest agent", func() {
 		const customPassword = "imadethisup"
 
+		_, pub, _ := libssh.NewKeyPair()
 		pubKeyData := libsecret.DataBytes{
-			"my-key1": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key1"),
+			"my-key1": ssh.MarshalAuthorizedKey(pub),
 		}
 
 		userPassData := libsecret.DataBytes{

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -60,11 +60,11 @@ var _ = Describe(SIG("Guest Access Credentials", func() {
 		userData                 = "#cloud-config\nchpasswd: { expire: False }\n"
 	)
 
-	_, pub, _ := libssh.NewKeyPair()
+	_, publicKey, _ := libssh.NewKeyPair()
 	keysSecretData := libsecret.DataBytes{
-		"my-key1": ssh.MarshalAuthorizedKey(pub),
-		"my-key2": ssh.MarshalAuthorizedKey(pub),
-		"my-key3": ssh.MarshalAuthorizedKey(pub),
+		"my-key1": ssh.MarshalAuthorizedKey(publicKey),
+		"my-key2": ssh.MarshalAuthorizedKey(publicKey),
+		"my-key3": ssh.MarshalAuthorizedKey(publicKey),
 	}
 
 	DescribeTable("should have ssh-key under authorized keys added", func(withQEMUAccessCredential bool, options ...libvmi.Option) {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -48,6 +48,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libconfigmap"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libsecret"
+	"kubevirt.io/kubevirt/tests/libssh"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -482,10 +483,10 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				secretPath string
 			)
 
-			var bitSize int = 2048
-			privateKey, _ := generatePrivateKey(bitSize)
-			publicKeyBytes, _ := generatePublicKey(&privateKey.PublicKey)
-			privateKeyBytes := encodePrivateKeyToPEM(privateKey)
+			privateKey, publicKey, _ := libssh.NewKeyPair()
+			publicKeyBytes := ssh.MarshalAuthorizedKey(publicKey)
+			marshalPrivateKey, _ := ssh.MarshalPrivateKey(privateKey, "private-key")
+			privateKeyBytes := marshalPrivateKey.Bytes
 
 			BeforeEach(func() {
 				secretName = "secret-" + uuid.NewString()

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -129,8 +129,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			Context("with injected ssh-key", func() {
 				It("[test_id:1616]should have ssh-key under authorized keys", func() {
-					_, pub, _ := libssh.NewKeyPair()
-					sshAuthorizedKey := ssh.MarshalAuthorizedKey(pub)
+					_, publicKey, _ := libssh.NewKeyPair()
+					sshAuthorizedKey := ssh.MarshalAuthorizedKey(publicKey)
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,
@@ -170,8 +170,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			Context("with injected ssh-key", func() {
 				It("[test_id:3178]should have ssh-key under authorized keys", func() {
-					_, pub, _ := libssh.NewKeyPair()
-					sshAuthorizedKey := ssh.MarshalAuthorizedKey(pub)
+					_, publicKey, _ := libssh.NewKeyPair()
+					sshAuthorizedKey := ssh.MarshalAuthorizedKey(publicKey)
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -49,6 +50,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libsecret"
+	"kubevirt.io/kubevirt/tests/libssh"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -56,7 +58,6 @@ import (
 )
 
 const (
-	sshAuthorizedKey     = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key"
 	fedoraPassword       = "fedora"
 	expectedUserDataFile = "cloud-init-userdata-executed"
 	testNetworkData      = "#Test networkData"
@@ -128,6 +129,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			Context("with injected ssh-key", func() {
 				It("[test_id:1616]should have ssh-key under authorized keys", func() {
+					_, pub, _ := libssh.NewKeyPair()
+					sshAuthorizedKey := ssh.MarshalAuthorizedKey(pub)
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,
@@ -167,6 +170,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			Context("with injected ssh-key", func() {
 				It("[test_id:3178]should have ssh-key under authorized keys", func() {
+					_, pub, _ := libssh.NewKeyPair()
+					sshAuthorizedKey := ssh.MarshalAuthorizedKey(pub)
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Today, SSH key creation differs between test suites:

$ (cd tests; git grep -E '(ssh\.New)|(ssh-rsa)' | grep -v libssh)
compute/credentials.go:         "my-key1": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key1"),
compute/credentials.go:         "my-key2": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key2"),
compute/credentials.go:         "my-key3": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key3"),
compute/credentials.go:                 "my-key1": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key1"),
config_test.go:                                 &expect.BSnd{S: "grep -c ssh-rsa /mnt/ssh-publickey\n"},
config_test.go:// generatePublicKey will return in the format "ssh-rsa ..."
config_test.go: publicRsaKey, err := ssh.NewPublicKey(privatekey)
vmi_cloudinit_test.go:  sshAuthorizedKey     = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key"
This could be avoided if we standardize over the existing libssh library
After this PR:
standardized ssh key creation in tests using existing library 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/14001

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

