### PR TITLE
tests: Add 486-v1-x86_64-cpu to cpuDenyList

### DIFF
--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -429,8 +429,9 @@ func GetSupportedCPUFeatures(nodesList k8sv1.NodeList) []string {
 
 func GetSupportedCPUModels(nodeList k8sv1.NodeList) []string {
 	cpuDenyList := map[string]bool{
-		"qemu64":     true,
-		"Opteron_G2": true,
+		"qemu64":            true,
+		"Opteron_G2":        true,
+		"486-v1-x86_64-cpu": true,
 	}
 	cpuMap := make(map[string]bool)
 	for _, node := range nodeList.Items {


### PR DESCRIPTION
### What this PR does
Add 486-v1-x86_64-cpu to cpuDenyList to remove failures

See https://search.ci.kubevirt.io/?search=CPU+model+486-v1-x86_64-cpu&maxAge=48h&context=5&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

