### PR TITLE
fix: support multiple vnc connection

### DIFF
--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -153,8 +153,45 @@ func (t *ConsoleHandler) VNCHandler(request *restful.Request, response *restful.
 	}
 	uid := vmi.GetUID()
 	stopChn := newStopChan(uid, t.vncLock, t.vncStopChans)
-	defer deleteStopChan(uid, stopChn, t.vncLock, t.vncStopChans)
+
+	t.handleConcurrentConnectionStart(vmi, stopChn)
+	defer t.handleConcurrentConnectionEnd(vmi, stopChn)
+
 	t.stream(vmi, request, response, unixSocketDialer(vmi, unixSocketPath), stopChn)
+}
+
+
+var vncMap sync.Map
+
+// make concurrent vnc connection available
+func (t *ConsoleHandler) handleConcurrentConnectionStart(vmi *v1.VirtualMachineInstance, stopChn chan struct{}) {
+	uid := vmi.GetUID()
+
+	var currentCount int
+	if n, ok := vncMap.Load(uid); ok {
+		currentCount = n.(int)
+	}
+	newCount := currentCount + 1
+	log.Log.Object(vmi).Infof("VNC connection count: %d, newCount: %d", currentCount, newCount)
+	vncMap.Store(uid, newCount)
+}
+
+func (t *ConsoleHandler) handleConcurrentConnectionEnd(vmi *v1.VirtualMachineInstance, stopChn chan struct{}) {
+	uid := vmi.GetUID()
+
+	var currentCount int
+	if n, ok := vncMap.Load(uid); ok {
+		currentCount = n.(int)
+	}
+	newCount := currentCount - 1
+	log.Log.Object(vmi).Infof("VNC connection count: %d, newCount: %d", currentCount, newCount)
+	vncMap.Store(uid, newCount)
+
+	if newCount <= 0 {
+		log.Log.Object(vmi).Infof("VNC connection last one(newCount: %d), delete channel now", newCount)
+		vncMap.Delete(uid)
+		deleteStopChan(uid, stopChn, t.vncLock, t.vncStopChans)
+	}
 }
 
 func (t *ConsoleHandler) SerialHandler(request *restful.Request, response *restful.Response) {
@@ -243,11 +280,11 @@ func (t *ConsoleHandler) VSOCKHandler(request *restful.Request, response *restfu
 func newStopChan(uid types.UID, lock *sync.Mutex, stopChans map[types.UID]chan struct{}) chan struct{} {
 	lock.Lock()
 	defer lock.Unlock()
-	// close current connection, if exists
-	if c, ok := stopChans[uid]; ok {
-		delete(stopChans, uid)
-		close(c)
-	}
+	// // close current connection, if exists
+	// if c, ok := stopChans[uid]; ok {
+	// 	delete(stopChans, uid)
+	// 	close(c)
+	// }
 	// create a stop channel for the new connection
 	stopCh := make(chan struct{})
 	stopChans[uid] = stopCh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Only one vnc connection can be made

After this PR:
Many vnc connection can be made concurrently.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #10553

### Why we need it and why it was done in this way
The following tradeoffs were made:
I've try the minimal change, maybe as temporary implementation.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

There's some discussion at issue #10553, but no follow up to fix it.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

