### PR TITLE
pkg.util.cluster: drop unused const

### DIFF
--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -7,8 +7,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-const OpenShift4Major = 4
-
 func IsOnOpenShift(clientset kubecli.KubevirtClient) (bool, error) {
 	_, apis, err := clientset.DiscoveryClient().ServerGroupsAndResources()
 	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {


### PR DESCRIPTION
I suspect this should have been included in commit 492299361ac5

/kind cleanup

```release-note
NONE
```

