### PR TITLE
migration controller: code cleanup

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -51,11 +51,11 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/util"
-	"kubevirt.io/kubevirt/pkg/util/pdbs"
+	pdbsutil "kubevirt.io/kubevirt/pkg/util/pdbs"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
-	"kubevirt.io/kubevirt/pkg/util/migrations"
+	migrationsutil "kubevirt.io/kubevirt/pkg/util/migrations"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -1066,7 +1066,7 @@ func filterOutOldPDBs(pdbList []*policyv1.PodDisruptionBudget) []*policyv1.PodDi
 	var filteredPdbs []*policyv1.PodDisruptionBudget
 
 	for i := range pdbList {
-		if !pdbs.IsPDBFromOldMigrationController(pdbList[i]) {
+		if !pdbsutil.IsPDBFromOldMigrationController(pdbList[i]) {
 			filteredPdbs = append(filteredPdbs, pdbList[i])
 		}
 	}
@@ -1120,8 +1120,8 @@ func (c *Controller) handleTargetPodCreation(key string, migration *virtv1.Virtu
 	// migration was accepted into the system, now see if we
 	// should create the target pod
 	if vmi.IsRunning() {
-		if migrations.VMIMigratableOnEviction(c.clusterConfig, vmi) {
-			pdbs, err := pdbs.PDBsForVMI(vmi, c.pdbIndexer)
+		if migrationsutil.VMIMigratableOnEviction(c.clusterConfig, vmi) {
+			pdbs, err := pdbsutil.PDBsForVMI(vmi, c.pdbIndexer)
 			if err != nil {
 				return err
 			}
@@ -1992,7 +1992,7 @@ func (c *Controller) outboundMigrationsOnNode(node string, runningMigrations []*
 func (c *Controller) findRunningMigrations() ([]*virtv1.VirtualMachineInstanceMigration, error) {
 
 	// Don't start new migrations if we wait for migration object updates because of new target pods
-	notFinishedMigrations := migrations.ListUnfinishedMigrations(c.migrationIndexer)
+	notFinishedMigrations := migrationsutil.ListUnfinishedMigrations(c.migrationIndexer)
 	var runningMigrations []*virtv1.VirtualMachineInstanceMigration
 	for _, migration := range notFinishedMigrations {
 		if migration.IsRunning() {

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -78,8 +78,8 @@ const defaultUnschedulablePendingTimeoutSeconds = int64(60 * 5)
 // migration objects
 const defaultFinalizedMigrationGarbageCollectionBuffer = 5
 
-// This is catch all timeout used when a target pod is stuck in
-// a in the pending phase for any reason. The theory behind this timeout
+// This catch-all timeout is used when a target pod is stuck in
+// the pending phase for any reason. The theory behind this timeout
 // being longer than the unschedulable timeout is that we don't necessarily
 // know all the reasons a pod will be stuck in pending for an extended
 // period of time, so we want to make this timeout long enough that it doesn't
@@ -1106,7 +1106,7 @@ func (c *Controller) handleTargetPodCreation(key string, migration *virtv1.Virtu
 
 	if outboundMigrations >= int(*c.clusterConfig.GetMigrationConfiguration().ParallelOutboundMigrationsPerNode) {
 		// Let's ensure that we only have two outbound migrations per node
-		// XXX: Make this configurable, thinkg about inbound migration limit, bandwidh per migration, and so on.
+		// XXX: Make this configurable, think about inbound migration limit, bandwidth per migration, and so on.
 		log.Log.Object(migration).Infof("Waiting to schedule target pod for vmi [%s/%s] migration because total running parallel outbound migrations on target node [%d] has hit outbound migrations per node limit.", vmi.Namespace, vmi.Name, outboundMigrations)
 		c.Queue.AddAfter(key, time.Second*5)
 		return nil
@@ -1919,7 +1919,7 @@ func (c *Controller) updateVMI(old, cur interface{}) {
 	}
 	labelChanged := !equality.Semantic.DeepEqual(curVMI.Labels, oldVMI.Labels)
 	if curVMI.DeletionTimestamp != nil {
-		// having a DataVOlume marked for deletion is enough
+		// having a DataVolume marked for deletion is enough
 		// to count as a deletion expectation
 		c.deleteVMI(curVMI)
 		if labelChanged {
@@ -1981,7 +1981,7 @@ func (c *Controller) outboundMigrationsOnNode(node string, runningMigrations []*
 	return sum, nil
 }
 
-// findRunningMigrations calcules how many migrations are running or in flight to be triggered to running
+// findRunningMigrations calculates how many migrations are running or in flight to be triggered to running
 // Migrations which are in running phase are added alongside with migrations which are still pending but
 // where we already see a target pod.
 func (c *Controller) findRunningMigrations() ([]*virtv1.VirtualMachineInstanceMigration, error) {

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -30,11 +30,7 @@ import (
 	"sync"
 	"time"
 
-	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
-
 	"github.com/opencontainers/selinux/go-selinux"
-
-	"kubevirt.io/api/migrations/v1alpha1"
 
 	k8sv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -49,20 +45,19 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
-	"kubevirt.io/kubevirt/pkg/util"
-	pdbsutil "kubevirt.io/kubevirt/pkg/util/pdbs"
-
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
-	migrationsutil "kubevirt.io/kubevirt/pkg/util/migrations"
-
 	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/api/migrations/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/util"
+	migrationsutil "kubevirt.io/kubevirt/pkg/util/migrations"
+	pdbsutil "kubevirt.io/kubevirt/pkg/util/pdbs"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/descheduler"
 )

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -1392,7 +1392,7 @@ var _ = Describe("Migration watcher", func() {
 
 			const oldMigrationUID = "oldmigrationuid"
 			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
-				MigrationUID: types.UID(oldMigrationUID),
+				MigrationUID: oldMigrationUID,
 			}
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
@@ -2323,8 +2323,8 @@ var _ = Describe("Migration watcher", func() {
 	})
 })
 
-func newPDB(name string, vmi *virtv1.VirtualMachineInstance, pods int) *policyv1.PodDisruptionBudget {
-	minAvailable := intstr.FromInt(pods)
+func newPDB(name string, vmi *virtv1.VirtualMachineInstance, pods int32) *policyv1.PodDisruptionBudget {
+	minAvailable := intstr.FromInt32(pods)
 
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -315,10 +315,8 @@ var _ = Describe("Migration watcher", func() {
 		if len(vmi.Labels) == 0 {
 			vmi.Labels = nil
 		}
-		controller.vmiStore.Add(vmi)
-		key, err := virtcontroller.KeyFunc(vmi)
+		err := controller.vmiStore.Add(vmi)
 		Expect(err).To(Not(HaveOccurred()))
-		mockQueue.Add(key)
 		_, err = virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -885,11 +885,11 @@ var _ = Describe("Migration watcher", func() {
 		})
 
 		It("should create target pod merging addedNodeSelector and preserving the labels in the existing NodeSelector and NodeAffinity", func() {
-			const commnonKey = "topology.kubernetes.io/region"
+			const commonKey = "topology.kubernetes.io/region"
 
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			vmiNodeSelector := map[string]string{
-				commnonKey:  "us-east-1",
+				commonKey:   "us-east-1",
 				"vmiLabel1": "vmiValue1",
 				"vmiLabel2": "vmiValue2",
 			}
@@ -924,9 +924,9 @@ var _ = Describe("Migration watcher", func() {
 			}
 
 			addedNodeSelector := map[string]string{
-				commnonKey:        "us-west-1",
-				"additionaLabel1": "additionalValue1",
-				"additionaLabel2": "additionalValue2",
+				commonKey:          "us-west-1",
+				"additionalLabel1": "additionalValue1",
+				"additionalLabel2": "additionalValue2",
 			}
 
 			By("Enforcing we have a key collision between vmiNodeSelector and addedNodeSelector")

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -316,15 +316,16 @@ var _ = Describe("Migration watcher", func() {
 			vmi.Labels = nil
 		}
 		err := controller.vmiStore.Add(vmi)
-		Expect(err).To(Not(HaveOccurred()))
+		Expect(err).ToNot(HaveOccurred())
 		_, err = virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	addMigration := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		controller.migrationIndexer.Add(migration)
+		err := controller.migrationIndexer.Add(migration)
+		Expect(err).ToNot(HaveOccurred())
 		key, err := virtcontroller.KeyFunc(migration)
-		Expect(err).To(Not(HaveOccurred()))
+		Expect(err).ToNot(HaveOccurred())
 		mockQueue.Add(key)
 		_, err = virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -315,15 +315,13 @@ var _ = Describe("Migration watcher", func() {
 		if len(vmi.Labels) == 0 {
 			vmi.Labels = nil
 		}
-		err := controller.vmiStore.Add(vmi)
-		Expect(err).ToNot(HaveOccurred())
-		_, err = virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(controller.vmiStore.Add(vmi)).To(Succeed())
+		_, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	addMigration := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		err := controller.migrationIndexer.Add(migration)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(controller.migrationIndexer.Add(migration)).To(Succeed())
 		key, err := virtcontroller.KeyFunc(migration)
 		Expect(err).ToNot(HaveOccurred())
 		mockQueue.Add(key)
@@ -332,24 +330,21 @@ var _ = Describe("Migration watcher", func() {
 	}
 
 	addNode := func(node *k8sv1.Node) {
-		err := controller.nodeStore.Add(node)
-		Expect(err).ShouldNot(HaveOccurred())
-		_, err = kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+		Expect(controller.nodeStore.Add(node)).To(Succeed())
+		_, err := kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	addPDB := func(pdb *policyv1.PodDisruptionBudget) {
-		err := controller.pdbIndexer.Add(pdb)
-		Expect(err).ShouldNot(HaveOccurred())
-		_, err = kubeClient.PolicyV1().PodDisruptionBudgets(pdb.Namespace).Create(context.Background(), pdb, metav1.CreateOptions{})
+		Expect(controller.pdbIndexer.Add(pdb)).To(Succeed())
+		_, err := kubeClient.PolicyV1().PodDisruptionBudgets(pdb.Namespace).Create(context.Background(), pdb, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	addMigrationPolicies := func(policies ...migrationsv1.MigrationPolicy) {
 		for _, policy := range policies {
-			err := controller.migrationPolicyStore.Add(&policy)
-			Expect(err).ShouldNot(HaveOccurred())
-			_, err = virtClientset.MigrationsV1alpha1().MigrationPolicies().Create(context.Background(), &policy, metav1.CreateOptions{})
+			Expect(controller.migrationPolicyStore.Add(&policy)).To(Succeed())
+			_, err := virtClientset.MigrationsV1alpha1().MigrationPolicies().Create(context.Background(), &policy, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		}
 	}


### PR DESCRIPTION
### What this PR does
Before this PR:
Unhappy IDE

After this PR:
Happy IDE

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

