### PR TITLE
handle nil pointer dereference and added a test

### DIFF
--- a/pkg/virt-handler/options.go
+++ b/pkg/virt-handler/options.go
@@ -84,24 +84,28 @@ func capabilitiesToTopology(capabilities *libvirtxml.Caps) *cmdv1.Topology {
 func cellToCell(cell libvirtxml.CapsHostNUMACell) *cmdv1.Cell {
 	c := &cmdv1.Cell{
 		Id: uint32(cell.ID),
-		Memory: &cmdv1.Memory{
+	}
+
+	if cell.Memory != nil {
+		c.Memory = &cmdv1.Memory{
 			Amount: cell.Memory.Size,
 			Unit:   cell.Memory.Unit,
-		},
+		}
 	}
 
 	for _, page := range cell.PageInfo {
 		c.Pages = append(c.Pages, pageToPage(page))
 	}
-
-	for _, distance := range cell.Distances.Siblings {
-		c.Distances = append(c.Distances, distanceToDistance(distance))
+	if cell.Distances != nil {
+		for _, distance := range cell.Distances.Siblings {
+			c.Distances = append(c.Distances, distanceToDistance(distance))
+		}
 	}
-
-	for _, cpu := range cell.CPUS.CPUs {
-		c.Cpus = append(c.Cpus, cpuToCPU(cpu))
+	if cell.CPUS != nil {
+		for _, cpu := range cell.CPUS.CPUs {
+			c.Cpus = append(c.Cpus, cpuToCPU(cpu))
+		}
 	}
-
 	return c
 }
 

--- a/pkg/virt-handler/options_test.go
+++ b/pkg/virt-handler/options_test.go
@@ -345,4 +345,40 @@ var _ = Describe("Parsing VMI Options", func() {
 			Expect(actualTopology).To(Equal(expectedTopology))
 		})
 	})
+	It("should handle and avoid panic on host NUMA cells with nil values", func() {
+		caps := &libvirtxml.Caps{
+			Host: libvirtxml.CapsHost{
+				NUMA: &libvirtxml.CapsHostNUMATopology{
+					Cells: &libvirtxml.CapsHostNUMACells{
+						Cells: []libvirtxml.CapsHostNUMACell{
+							{
+								Memory:    nil,
+								Distances: nil,
+								CPUS:      nil,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var actualTopology *cmdv1.Topology
+		Expect(func() {
+			actualTopology = capabilitiesToTopology(caps)
+		}).ShouldNot(Panic())
+
+		expectedTopology := &cmdv1.Topology{
+			NumaCells: []*cmdv1.Cell{
+				{
+					Id:        0,
+					Memory:    nil,
+					Pages:     nil,
+					Distances: nil,
+					Cpus:      nil,
+				},
+			},
+		}
+
+		Expect(actualTopology).To(Equal(expectedTopology))
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
virt-handler became CrashLoopBackOff due to invalid memory address or nil pointer dereference

After this PR:
handled the nil pointer dereference

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/14064

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
   handle nil pointer dereference in cellToCell
```

