### PR TITLE
Replace NewMinimalVMI with libvmi in subresource_test.go

### DIFF
--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -23,6 +23,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -286,6 +287,12 @@ func WithTPM(persistent bool) Option {
 		vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{
 			Persistent: pointer.P(persistent),
 		}
+	}
+}
+
+func WithUUID(uuid types.UID) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.ObjectMeta.SetUID(uuid)
 	}
 }
 

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -51,12 +51,12 @@ import (
 	"k8s.io/client-go/testing"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
@@ -236,9 +236,11 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 	Context("Subresource api", func() {
 		It("should find matching pod for running VirtualMachineInstance", func() {
-			vmi := api.NewMinimalVMI(testVMIName)
-			vmi.Status.Phase = v1.Running
-			vmi.ObjectMeta.SetUID(uuid.NewUUID())
+			vmi := libvmi.New(
+				libvmi.WithName(testVMIName),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+				libvmi.WithUUID(uuid.NewUUID()),
+			)
 
 			expectHandlerPod()
 
@@ -250,9 +252,11 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		})
 
 		It("should fail if VirtualMachineInstance is not in running state", func() {
-			vmi := api.NewMinimalVMI(testVMIName)
-			vmi.Status.Phase = v1.Succeeded
-			vmi.ObjectMeta.SetUID(uuid.NewUUID())
+			vmi := libvmi.New(
+				libvmi.WithName(testVMIName),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Succeeded))),
+				libvmi.WithUUID(uuid.NewUUID()),
+			)
 
 			_, err := app.getVirtHandlerConnForVMI(vmi)
 
@@ -260,9 +264,11 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		})
 
 		It("should fail no matching pod is found", func() {
-			vmi := api.NewMinimalVMI(testVMIName)
-			vmi.Status.Phase = v1.Running
-			vmi.ObjectMeta.SetUID(uuid.NewUUID())
+			vmi := libvmi.New(
+				libvmi.WithName(testVMIName),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+				libvmi.WithUUID(uuid.NewUUID()),
+			)
 
 			podList := k8sv1.PodList{}
 			podList.Items = []k8sv1.Pod{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: `/pkg/virt-api/rest/subresource_test.go` used `NewMinimalVMI()` to create vmis

After this PR: Replaced all instances of `NewMinimalVMI()` along with any other methods of vmi instantiation with with libvmi pkg functions. Created new libvmi Option for uuid handling. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/14147

### Why we need it and why it was done in this way
The following tradeoffs were made: 
The Entry @ line 755 tests for a nil `TerminationGracePeriod`. However, `libvmi.New()` sets the default to be 0. I had the choice between

- Setting the default as nil, but this might mess up other tests that use `.New()`
- Add a parameter in `WithTerminationGracePeriod()` to allow the option of `nil` values, but this would require all other references to be updated
- Manually set the termination grace period to nil. Although not the cleanest solution it is the simplest for the one occurence of this use case.

Similarly, `VirtualMachineInstanceCondition` have multiple occurences of being manually set. However, this is not usually done when a vmi is created.  


### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

