### PR TITLE
Vmi create admitter test

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -58,6 +58,7 @@ import (
 const (
 	testVMIName = "testvmi"
 	testVMName  = "testvm"
+	defaultMem  = "8192Ki"
 )
 
 var _ = Describe("Validating VMICreate Admitter", func() {
@@ -1030,7 +1031,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 			DeferCleanup(featuregate.UnregisterFeatureGate, testsFGName)
 			enableFeatureGate(testsFGName)
-			vmi := libvmi.New(libvmi.WithName(testVMIName))
+			vmi := libvmi.New(libvmi.WithName(testVMIName), libvmi.WithResourceMemory(defaultMem))
 
 			ar, err := newAdmissionReviewForVMICreation(vmi)
 			Expect(err).NotTo(HaveOccurred())
@@ -1079,7 +1080,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject invalid ioThreadsPolicy to supplementalPool and invalid number of IOthreads", func() {
-			vmi := libvmi.New(libvmi.WithName(testVMName))
+			vmi := libvmi.New(libvmi.WithName(testVMName), libvmi.WithResourceMemory(defaultMem))
 			vmi.Spec.Domain.IOThreadsPolicy = pointer.P(v1.IOThreadsPolicySupplementalPool)
 			vmi.Spec.Domain.IOThreads = &v1.DiskIOThreads{
 				SupplementalPoolThreadCount: pointer.P(uint32(0)),
@@ -2045,7 +2046,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		)
 
 		DescribeTable("should accept cd-roms using", func(bus string) {
-			vmi := libvmi.New(libvmi.WithName(testVMIName))
+			vmi := libvmi.New(libvmi.WithName(testVMIName), libvmi.WithResourceMemory(defaultMem))
 
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testcdrom",
@@ -3076,7 +3077,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	Context("with affinity checks", func() {
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
-			vmi = libvmi.New(libvmi.WithName(testVMIName))
+			vmi = libvmi.New(libvmi.WithName(testVMIName), libvmi.WithResourceMemory(defaultMem))
 			vmi.Spec.Affinity = &k8sv1.Affinity{}
 		})
 		It("Allow to create when spec.affinity set to nil", func() {
@@ -3546,7 +3547,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	Context("with topologySpreadConstraints checks", func() {
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
-			vmi = libvmi.New(libvmi.WithName(testVMIName))
+			vmi = libvmi.New(libvmi.WithName(testVMIName), libvmi.WithResourceMemory(defaultMem))
 		})
 		It("Allow to create when spec.topologySpreadConstraints set to nil", func() {
 			vmi.Spec.TopologySpreadConstraints = nil
@@ -3783,7 +3784,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	Context("with CPU hotplug", func() {
 		When("number of sockets higher than maxSockets", func() {
 			It("deny VMI creation", func() {
-				vmi := libvmi.New(libvmi.WithName(testVMIName))
+				vmi := libvmi.New(libvmi.WithName(testVMIName), libvmi.WithResourceMemory(defaultMem))
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					MaxSockets: 8,
 					Sockets:    16,
@@ -3807,7 +3808,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		const doNotUseExplicitHyperV, doNotUseHyperVPassthrough = false, false
 
 		DescribeTable("Use of hyperV combined with hyperV passthrough is forbidden", func(explicitHyperv, hypervPassthrough, expectValid bool) {
-			vmi := libvmi.New(libvmi.WithName(testVMIName))
+			vmi := libvmi.New(libvmi.WithName(testVMIName), libvmi.WithResourceMemory(defaultMem))
 			vmi.Spec.Domain.Features = &v1.Features{}
 
 			if explicitHyperv {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: `/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go` used `NewMinimalVMI()` to create vmis

After this PR: 

- Replaced all instances of `NewMinimalVMI()` with `libvmi.New(...)`. 

- Some tests were still failing because `spec.domain.resources.requests.memory` was empty, added `libvmi.WithResourceMemory()` to allow those tests to pass
- Replaced repeated vmi names, vm names and memory values with constants

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/14147

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

