### PR TITLE
refactor: virt-controller services 

### DIFF
--- a/pkg/virt-controller/services/virtiofs_test.go
+++ b/pkg/virt-controller/services/virtiofs_test.go
@@ -6,8 +6,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/api"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
@@ -57,8 +57,9 @@ var _ = Describe("virtiofs container", func() {
 	})
 
 	It("should create unprivileged containers only", func() {
-		vmi := api.NewMinimalVMI("testvm")
-
+		vmi := libvmi.New(
+			libvmi.WithName("testvm"),
+		)
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 			Name: "sharedtestdisk",
 			VolumeSource: v1.VolumeSource{


### PR DESCRIPTION
Fixes #14148 

### Why we need it and why it was done in this way
It will replaces all occurrences of `api.NewMinimalVMI` with `libvmi.New` to promote the usage of the `libvmi` package for creating VirtualMachineInstance objects. The `libvmi` package provides a more structured and readable way to create VMIs using a builder pattern.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

