### PR TITLE
Refactor /pkg/storage to Use libvmi.New(...) Instead of api.NewMinimalVMI

### DIFF
--- a/pkg/storage/admitters/vm-storage-admitter_test.go
+++ b/pkg/storage/admitters/vm-storage-admitter_test.go
@@ -16,8 +16,8 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -48,7 +48,7 @@ var _ = Describe("Validating VM Admitter", func() {
 		apiGroup := "kubevirt.io"
 
 		BeforeEach(func() {
-			vmi := api.NewMinimalVMI("testvmi")
+			vmi := libvmi.New(libvmi.WithName("testvmi"))
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testdisk",
 			})
@@ -93,7 +93,7 @@ var _ = Describe("Validating VM Admitter", func() {
 		})
 
 		It("should reject VM with DataVolumeTemplate in another namespace", func() {
-			vmi := api.NewMinimalVMI("testvmi")
+			vmi := libvmi.New(libvmi.WithName("testvmi"))
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testdisk",
 			})
@@ -314,7 +314,7 @@ var _ = Describe("Validating VM Admitter", func() {
 
 	Context("Validate VM snapshot, restore status", func() {
 		DescribeTable("when snapshot is in progress, should", func(mutateFn func(*v1.VirtualMachine) bool) {
-			vmi := api.NewMinimalVMI("testvmi")
+			vmi := libvmi.New(libvmi.WithName("testvmi"))
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 				{
 					Name: "orginalvolume",
@@ -407,7 +407,7 @@ var _ = Describe("Validating VM Admitter", func() {
 		)
 
 		DescribeTable("when restore is in progress, should", func(mutateFn func(*v1.VirtualMachine) bool, updateRunStrategy bool) {
-			vmi := api.NewMinimalVMI("testvmi")
+			vmi := libvmi.New(libvmi.WithName("testvmi"))
 			vm := &v1.VirtualMachine{
 				Spec: v1.VirtualMachineSpec{
 					Template: &v1.VirtualMachineInstanceTemplateSpec{

--- a/pkg/storage/memorydump/memorydump_test.go
+++ b/pkg/storage/memorydump/memorydump_test.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/kubevirt/fake"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -224,7 +225,7 @@ func ApplyVMIMemoryDumpVol(spec *v1.VirtualMachineInstanceSpec) {
 }
 
 func createVirtualMachineWithMemoryDump(memoryDumpPhase v1.MemoryDumpPhase) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
-	vmi := api.NewMinimalVMI(vmName)
+	vmi := libvmi.New(libvmi.WithName(vmName))
 	vmi.Status.Phase = v1.Running
 	vm := &v1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{Name: vmName, Namespace: vmi.ObjectMeta.Namespace, ResourceVersion: "1", UID: "vm-uid"},


### PR DESCRIPTION
### **What This PR Does** - [#14153]

This PR refactors occurrences of api.NewMinimalVMI within the /pkg/storage package to use libvmi.New(...) instead. This aligns with the ongoing effort to promote the usage of the libvmi package for better code maintainability and consistency.

**Before This PR**

The code used multiple instances of api.NewMinimalVMI, which is being deprecated in favor of libvmi.

**After This PR**

api.NewMinimalVMI is replaced with libvmi.New(...) within the affected test files.

Why We Need It and Why It Was Done This Way
This change is part of a larger effort to standardize the use of libvmi across the codebase. It improves code clarity, maintainability, and aligns with best practices in KubeVirt.

### Affected Files

/pkg/storage/admitters/vm-storage-admitter_test.go

/pkg/storage/memorydump/memorydump_test.go

**_Fixes_**

Fixes ##14153

This is a subissue of #12059, focusing on refactoring the /pkg/storage package.

Special Notes for Reviewers
This PR is limited to the /pkg/storage package only.

The refactoring effort is being split into multiple PRs, so multiple contributors can work on different sections.

**_Checklist_**

[x] Code follows the project’s coding style.

[x] Changes are limited to the /pkg/storage package.

[x] No breaking changes introduced.

[x] Unit tests have been updated if necessary.