### PR TITLE
Replace NewMinimalVMI with libvmi in /pkg/virt-launcher

### DIFF
--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 	"libvirt.org/go/libvirt"
 
-	api2 "kubevirt.io/client-go/api"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/watch"
@@ -302,7 +302,7 @@ var _ = Describe("Notify", func() {
 
 		It("Should send a k8s event", func() {
 
-			vmi := api2.NewMinimalVMI("fake-vmi")
+			vmi := libvmi.New(libvmi.WithName("fake-vmi"))
 			vmi.UID = "4321"
 			vmiStore.Add(vmi)
 
@@ -338,7 +338,7 @@ var _ = Describe("Notify", func() {
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
 			mockDomain.EXPECT().GetDiskErrors(uint32(0)).Return(faultDisk, nil)
 
-			vmi := api2.NewMinimalVMI("fake-vmi")
+			vmi := libvmi.New(libvmi.WithName("fake-vmi"))
 			vmi.UID = "4321"
 			vmiStore.Add(vmi)
 			eventType := "Warning"

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -44,7 +44,6 @@ import (
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
-	kvapi "kubevirt.io/client-go/api"
 
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/defaults"
@@ -3060,7 +3059,7 @@ var _ = Describe("Converter", func() {
 		)
 
 		BeforeEach(func() {
-			vmi = kvapi.NewMinimalVMI("testvmi")
+			vmi = libvmi.New(libvmi.WithName("testvmi"))
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Spec.Domain.Devices.AutoattachMemBalloon = pointer.P(true)
@@ -3174,7 +3173,7 @@ var _ = Describe("Converter", func() {
 		const fakeFrequency = 12345
 
 		BeforeEach(func() {
-			vmi = kvapi.NewMinimalVMI("testvmi")
+			vmi = libvmi.New(libvmi.WithName("testvmi"))
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Status.TopologyHints = &v1.TopologyHints{TSCFrequency: pointer.P(int64(fakeFrequency))}
 			c = &ConverterContext{
@@ -3247,7 +3246,7 @@ var _ = Describe("Converter", func() {
 		)
 
 		BeforeEach(func() {
-			vmi = kvapi.NewMinimalVMI("testvmi")
+			vmi = libvmi.New(libvmi.WithName("testvmi"))
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 		})
 
@@ -3276,7 +3275,7 @@ var _ = Describe("Converter", func() {
 		)
 
 		BeforeEach(func() {
-			vmi = kvapi.NewMinimalVMI("testvmi")
+			vmi = libvmi.New(libvmi.WithName("testvmi"))
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 		})
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -44,13 +44,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
-	api2 "kubevirt.io/client-go/api"
 
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/ephemeral-disk/fake"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
@@ -3180,7 +3180,10 @@ var _ = Describe("Manager helper functions", func() {
 })
 
 func newVMI(namespace, name string) *v1.VirtualMachineInstance {
-	vmi := api2.NewMinimalVMIWithNS(namespace, name)
+	vmi := libvmi.New(
+		libvmi.WithNamespace(namespace),
+		libvmi.WithName(name),
+	)
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
 }

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -17,11 +17,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
-	api2 "kubevirt.io/client-go/api"
 	kubevirtlog "kubevirt.io/client-go/log"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/hooks"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -216,7 +216,10 @@ var _ = Describe("LibvirtHelper", func() {
 		mockConn := cli.NewMockConnection(ctrl)
 		mockDomain := cli.NewMockVirDomain(ctrl)
 
-		vmi := api2.NewMinimalVMIWithNS(vmiNamespace, vmiName)
+		vmi := libvmi.New(
+			libvmi.WithNamespace(vmiNamespace),
+			libvmi.WithName(vmiName),
+		)
 		v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 		domain := &api.Domain{}
 		c := &converter.ConverterContext{


### PR DESCRIPTION
**### What this PR does** -[#14150]

This PR replaces occurrences of api.NewMinimalVMI with libvmi.New(...) in the /pkg/virt-launcher package as part of the effort to promote the usage of the libvmi package.

### Why is this needed?

The libvmi package provides a more flexible and standardized way to create VirtualMachineInstance objects using options like libvmi.WithName(...) and libvmi.WithNamespace(...).
This is a subtask of [#12059](https://github.com/kubevirt/kubevirt/issues/12059) and focuses on refactoring test files under /pkg/virt-launcher.

**_Files Updated_**

/pkg/virt-launcher/notify-client/notify_test.go
/pkg/virt-launcher/virtwrap/manager_test.go
/pkg/virt-launcher/virtwrap/converter/converter_test.go
/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go

**_Changes Made_**

Replaced api.NewMinimalVMI(...) with libvmi.New(...) where applicable.
Used appropriate libvmi options such as libvmi.WithName(...), libvmi.WithNamespace(...), etc., to match the previous behavior.
Ensured that test logic remains unchanged after the refactor.

**_Related Issues_**

**Part of**: [#12059](https://github.com/kubevirt/kubevirt/issues/12059)
**Fixes**: [#14150](https://github.com/kubevirt/kubevirt/issues/14150)

**Testing & Validation**

All relevant test cases have been updated to use libvmi.New(...).
Ran unit tests to confirm no regression.