### PR TITLE
refactor: Convert fake-vmi Creation to Use libvmi.New

### DIFF
--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/config/downwardapi_test.go
+++ b/pkg/config/downwardapi_test.go
@@ -29,8 +29,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 
-	"kubevirt.io/client-go/api"
-
 	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
@@ -66,7 +64,9 @@ var _ = Describe("DownwardAPI", func() {
 	})
 
 	It("Should create a new downwardapi iso disk without a Disk device", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi := libvmi.New(
+			libvmi.WithName("fake-vmi"),
+		)
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 			Name: "downwardapi-volume",
 			VolumeSource: v1.VolumeSource{


### PR DESCRIPTION
Fixes #14151 

### Why we need it and why it was done in this way
This PR updates the creation of the "fake-vmi" VirtualMachineInstance in the test code to use libvmi.New instead of api.NewMinimalVMI. This change aligns with the ongoing effort to standardize VMI creation using the libvmi package, which offers a more flexible and maintainable approach with functional options.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

