### PR TITLE
Use Expect instead of Consistently

### DIFF
--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -462,9 +462,7 @@ var _ = Describe("test configuration", func() {
 		}
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
-		Consistently(func() kubev1.PullPolicy {
-			return clusterConfig.GetImagePullPolicy()
-		}).Should(Equal(kubev1.PullAlways))
+		Expect(clusterConfig.GetImagePullPolicy()).To(Equal(kubev1.PullAlways))
 	})
 
 	It("should return the default config if no config map exists", func() {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -109,9 +109,7 @@ var _ = Describe("Node-labeller ", func() {
 		Expect(node.Labels).ToNot(BeEmpty())
 
 		Expect(res).To(BeTrue(), "labeller should end with true result")
-		Consistently(func() int {
-			return nlController.queue.Len()
-		}, 5*time.Second, time.Second).Should(Equal(0), "labeller should process all nodes from queue")
+		Expect(nlController.queue.Len()).To(BeZero(), "labeller should process all nodes from queue")
 	})
 
 	It("should re-queue node if node-labelling fail", func() {


### PR DESCRIPTION
Use Expect instead of Consistently
There is no reason for the results of the calls to change,
as there are no other goroutines running in these unit tests.
Removing Consistently would reduce testing time and simplify the tests.

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

