### PR TITLE
why do we need util.net.grpc.CreateSocket?

### DIFF
--- a/pkg/util/net/grpc/grpc.go
+++ b/pkg/util/net/grpc/grpc.go
@@ -21,15 +21,9 @@ package grpc
 import (
 	"context"
 	"net"
-	"os"
-	"path/filepath"
 	"time"
 
 	"google.golang.org/grpc"
-
-	"kubevirt.io/client-go/log"
-
-	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -64,22 +58,4 @@ func DialSocketWithTimeout(socketPath string, timeout int) (*grpc.ClientConn, er
 
 	return grpc.DialContext(ctx, socketPath, options...)
 
-}
-
-func CreateSocket(socketPath string) (net.Listener, error) {
-	os.RemoveAll(socketPath)
-
-	err := util.MkdirAllWithNosec(filepath.Dir(socketPath))
-	if err != nil {
-		log.Log.Reason(err).Errorf("unable to create directory for unix socket %v", socketPath)
-		return nil, err
-	}
-
-	socket, err := net.Listen("unix", socketPath)
-
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to create unix socket %v", socketPath)
-		return nil, err
-	}
-	return socket, nil
 }

--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -22,6 +22,7 @@ package eventsserver
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -39,7 +40,6 @@ import (
 	"kubevirt.io/client-go/log"
 
 	notifyv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/v1"
-	grpcutil "kubevirt.io/kubevirt/pkg/util/net/grpc"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -136,7 +136,7 @@ func RunServer(virtShareDir string, stopChan chan struct{}, c chan watch.Event, 
 	notifyv1.RegisterNotifyServer(grpcServer, notifyServer)
 
 	sockFile := filepath.Join(virtShareDir, "domain-notify.sock")
-	sock, err := grpcutil.CreateSocket(sockFile)
+	sock, err := net.Listen("unix", virtShareDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -34,7 +35,6 @@ import (
 	"kubevirt.io/client-go/log"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
-	grpcutil "kubevirt.io/kubevirt/pkg/util/net/grpc"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent"
@@ -612,7 +612,7 @@ func RunServer(socketPath string,
 	// and add them to info.go
 	cmdv1.RegisterCmdServer(grpcServer, server)
 
-	sock, err := grpcutil.CreateSocket(socketPath)
+	sock, err := net.Listen("unix", socketPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This function is problematic: it calls os.RemoveAll() without collecting the error; it creates a deep world-readable path; it does not have a counterpart for deleting what it created, so it does not abstract much.

```release-note
NONE
```

