### PR TITLE
Tests: Set DV size to volume snapshot restore size

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 
 	expect "github.com/google/goexpect"
+	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	storagev1 "k8s.io/api/storage/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -867,6 +868,20 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 						Namespace: snap.Namespace,
 						Name:      snap.Name,
 					},
+				}
+
+				By("Waiting for snapshot to have restore size")
+				Eventually(func() (*vsv1.VolumeSnapshot, error) {
+					snap, err = virtClient.KubernetesSnapshotClient().
+						SnapshotV1().
+						VolumeSnapshots(snap.Namespace).
+						Get(context.Background(), snap.Name, metav1.GetOptions{})
+					return snap, err
+				}).WithTimeout(90 * time.Second).WithPolling(time.Second).Should(HaveField("Status.RestoreSize", Not(BeNil())))
+
+				// set the target DV size to the snapshot restore size if it is not zero
+				if !snap.Status.RestoreSize.IsZero() {
+					dvt.Spec.Storage.Resources.Requests[k8sv1.ResourceStorage] = *snap.Status.RestoreSize
 				}
 			}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

When cloning DVs using volume snapshots as source, we use an abritrary size in the target DV and assume it'll be roughly equal to the source PVC size.

This behavior fails when running tests with a provisioner that sets restore size to a higher value so, in order to increase test consistency, this commit sets the target size to the volume snapshot restore size.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

