### PR TITLE
tests, net, IPv6: Use Alpine instead of Fedora for dynamic IPv6 test

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -681,14 +681,9 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				return mtu
 			}
 
-			configureIpv6 := func(vmi *v1.VirtualMachineInstance) error {
+			configureIpv6Routes := func(vmi *v1.VirtualMachineInstance) error {
 				networkCIDR := api.DefaultVMIpv6CIDR
-
-				err := console.RunCommand(vmi, "dhclient -6 eth0", 30*time.Second)
-				if err != nil {
-					return err
-				}
-				err = console.RunCommand(vmi, "ip -6 route add "+networkCIDR+" dev eth0", 5*time.Second)
+				err := console.RunCommand(vmi, "ip -6 route add "+networkCIDR+" dev eth0", 5*time.Second)
 				if err != nil {
 					return err
 				}
@@ -701,24 +696,10 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			}
 
 			BeforeEach(func() {
-				var err error
-
 				By("Create masquerade VMI")
-				networkData, err := cloudinit.NewNetworkData(
-					cloudinit.WithEthernet("eth0",
-						cloudinit.WithDHCP4Enabled(),
-						cloudinit.WithDHCP6Enabled(),
-						cloudinit.WithAddresses(""), // This is a workaround o make fedora client to configure local IPv6
-					),
-				)
-				Expect(err).ToNot(HaveOccurred())
+				vmi = libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
 
-				vmi = libvmifact.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
-				)
-
+				var err error
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -728,17 +709,17 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for VMIs to be ready")
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 				anotherVmi = libwait.WaitUntilVMIReady(anotherVmi, console.LoginToAlpine)
-
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 			})
 
 			DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {
 				libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 				if ipFamily == k8sv1.IPv6Protocol {
-					// IPv6 address is configured via DHCP6 in this test and not via cloud-init
-					Expect(configureIpv6(vmi)).To(Succeed(), "failed to configure ipv6  on server vmi")
+					// IPv6 address is configured via DHCP6 in this test and not statically.
+					// The routes need to be added statically as RA is not supported.
+					Expect(configureIpv6Routes(vmi)).To(Succeed(), "failed to configure ipv6  on server vmi")
 				}
 
 				By("checking k6t-eth0 MTU inside the pod")


### PR DESCRIPTION
The IPv6 connectivity test used both Alpine and Fedora guests to check connectivity.

The Fedora guest used an odd cloud-init configuration which practically failed the network setup. Moreover, due to the cloud-init network backend (NetworkManager), dynamic IPv6 was not operational. Most likely due to the default NM behavior which requires RA.

Therefore, the test has been simplified to use only the Alpine guest (which has no NM), dropping the cloud-init odd configuration and keeping just the addition of the IPv6 route through the terminal.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

