### PR TITLE
Fix linting issues in pkg/virtctl/clientconfig by naming return values

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -16,6 +16,7 @@ pkg/network/netns
 pkg/network/pod/annotations
 pkg/network/vmispec
 pkg/storage/pod/annotations
+pkg/virtctl/clientconfig
 pkg/virtctl/credentials
 tests/console
 tests/decorators

--- a/pkg/virtctl/clientconfig/clientconfig.go
+++ b/pkg/virtctl/clientconfig/clientconfig.go
@@ -26,16 +26,16 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig) contex
 // ClientAndNamespaceFromContext tries to retrieve a clientcmd.Clientconfig value stored in ctx, if any.
 // It then creates a kubecli.KubevirtClient and gets the namespace from the client config and returns them.
 // Otherwise, it returns an error.
-func ClientAndNamespaceFromContext(ctx context.Context) (kubecli.KubevirtClient, string, bool, error) {
+func ClientAndNamespaceFromContext(ctx context.Context) (virtClient kubecli.KubevirtClient, namespace string, overridden bool, err error) {
 	clientConfig, ok := ctx.Value(clientConfigKey).(clientcmd.ClientConfig)
 	if !ok {
 		return nil, "", false, fmt.Errorf("unable to get client config from context")
 	}
-	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(clientConfig)
+	virtClient, err = kubecli.GetKubevirtClientFromClientConfig(clientConfig)
 	if err != nil {
 		return nil, "", false, err
 	}
-	namespace, overridden, err := clientConfig.Namespace()
+	namespace, overridden, err = clientConfig.Namespace()
 	if err != nil {
 		return nil, "", false, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: Running the linter against pkg/virtctl/clientconfig fails. 

After this PR: Running the linter against pkg/virtctl/clientconfig should succeeds without errors or warnings.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #14186 

### Why we need it and why it was done in this way
The return variables were named in function signature.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```