### PR TITLE
chore(linter): Fix linting errors and warnings within the config

### DIFF
--- a/hack/linter/.golangci.yml
+++ b/hack/linter/.golangci.yml
@@ -34,7 +34,11 @@ linters-settings:
     local-prefixes: kubevirt.io/kubevirt
   mnd:
     # don't include the "operation" and "assign"
-    checks: argument,case,condition,return
+    checks:
+      - argument
+      - case
+      - condition
+      - return
     ignored-functions:
       - '^Eventually$'
       - '^EventuallyWithOffset$'
@@ -46,12 +50,9 @@ linters-settings:
       - shadow
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
@@ -66,10 +67,10 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - exhaustive
     - funlen
     - gochecknoinits


### PR DESCRIPTION
/cc @orelmisan 

### What this PR does

- Replace the deprecated exportloopref with copyloopvar
```
$ golangci-lint run
[..]
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
[..]
```
  https://github.com/kyoh86/exportloopref
  https://golangci-lint.run/usage/linters/#exportloopref 
  https://golangci-lint.run/usage/linters/#copyloopvar

- mnd.checks is an array
  https://golangci-lint.run/usage/linters/#mnd

- maligned is deprecated and no longer used
  https://golangci-lint.run/usage/configuration/#config-file

- nolintlint.allow-leading-space was dropped some time ago
  https://github.com/golangci/golangci-lint/issues/3063

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

