### PR TITLE
virtctl: Fix linting issues in pkg/virtctl/create/params

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -18,6 +18,7 @@ pkg/network/vmispec
 pkg/storage/pod/annotations
 pkg/virtctl/clientconfig
 pkg/virtctl/credentials
+pkg/virtctl/create/params
 tests/console
 tests/decorators
 tests/infrastructure

--- a/pkg/virtctl/create/params/params.go
+++ b/pkg/virtctl/create/params/params.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	paramTag = "param"
+	paramTag            = "param"
+	paramSeparatorCount = 2
 )
 
 type NotFoundError struct {
@@ -124,8 +125,8 @@ func split(paramsStr string) (map[string]string, error) {
 
 	paramsMap := map[string]string{}
 	for _, param := range strings.Split(paramsStr, ",") {
-		sParam := strings.SplitN(param, ":", 2)
-		if len(sParam) != 2 {
+		sParam := strings.SplitN(param, ":", paramSeparatorCount)
+		if len(sParam) != paramSeparatorCount {
 			return nil, fmt.Errorf("params need to have at least one colon: %s", param)
 		}
 		paramsMap[sParam[0]] = sParam[1]
@@ -189,15 +190,16 @@ func apply(paramsMap map[string]string, obj interface{}) error {
 }
 
 // SplitPrefixedName splits prefixedName with "/" as a separator
-func SplitPrefixedName(prefixedName string) (string, string, error) {
-	name := ""
-	prefix := ""
-
+func SplitPrefixedName(prefixedName string) (
+	prefix string,
+	name string,
+	err error,
+) {
 	s := strings.Split(prefixedName, "/")
 	switch l := len(s); l {
 	case 1:
 		name = s[0]
-	case 2:
+	case paramSeparatorCount:
 		prefix = s[0]
 		name = s[1]
 	default:

--- a/pkg/virtctl/create/params/params_test.go
+++ b/pkg/virtctl/create/params/params_test.go
@@ -135,7 +135,7 @@ var _ = Describe("params", func() {
 			param2 := rand.Intn(10)
 			param3 := fmt.Sprintf("%dGi", rand.Intn(10))
 			var param4 []string
-			for _ = range rand.IntnRange(1, 10) {
+			for range rand.IntnRange(1, 10) {
 				param4 = append(param4, rand.String(10))
 			}
 			paramsStr := fmt.Sprintf("param1:%s,param2:%d,param3:%s,param4:%s", param1, param2, param3, strings.Join(param4, ";"))
@@ -173,9 +173,12 @@ var _ = Describe("params", func() {
 			err := params.Map(flagName, paramsStr, testStruct)
 			Expect(err).To(MatchError(parseFlagErr + errMsg))
 		},
-			Entry("uint negative", "uint:-1,quantity:1Gi", "failed to parse param \"uint\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
-			Entry("uint too large", "uint:9999999999999,quantity:1Gi", "failed to parse param \"uint\": strconv.ParseUint: parsing \"9999999999999\": value out of range"),
-			Entry("quantity suffix invalid", "uint:8,quantity:1Gu", "failed to parse param \"quantity\": unable to parse quantity's suffix"),
+			Entry("uint negative", "uint:-1,quantity:1Gi",
+				"failed to parse param \"uint\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
+			Entry("uint too large", "uint:9999999999999,quantity:1Gi",
+				"failed to parse param \"uint\": strconv.ParseUint: parsing \"9999999999999\": value out of range"),
+			Entry("quantity suffix invalid", "uint:8,quantity:1Gu",
+				"failed to parse param \"quantity\": unable to parse quantity's suffix"),
 		)
 
 		It("should fail on unsupported fields with param tag", func() {


### PR DESCRIPTION
- Added named return values to SplitPrefixedName function

- Replaced magic numbers with constants

- Fixed formatting and line length issues in tests

Fixes #14196

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
* package `pkg/virtctl/create/params` was not formatted as per listing rules

After this PR:
* package `pkg/virtctl/create/params` is now formatted as per listing rules, `make lint` passes

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

