### PR TITLE
fixed lint issues in pkg/virtctl/create/preference

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -17,6 +17,7 @@ pkg/network/pod/annotations
 pkg/network/vmispec
 pkg/storage/pod/annotations
 pkg/virtctl/clientconfig
+pkg/virtctl/create/preference
 pkg/virtctl/credentials
 tests/console
 tests/decorators

--- a/pkg/virtctl/create/preference/preference.go
+++ b/pkg/virtctl/create/preference/preference.go
@@ -38,6 +38,8 @@ const (
 	MachineTypeFlag        = "machine-type"
 	NameFlag               = "name"
 	NamespacedFlag         = "namespaced"
+
+	randomNameSuffixLength = 5
 )
 
 type createPreference struct {
@@ -57,7 +59,9 @@ func NewCommand() *cobra.Command {
 		Example: c.usage(),
 		RunE:    c.run,
 	}
-	cmd.Flags().BoolVar(&c.namespaced, NamespacedFlag, c.namespaced, "Specify if VirtualMachinePreference should be created. By default VirtualMachineClusterPreference is created.")
+	cmd.Flags().BoolVar(&c.namespaced, NamespacedFlag, c.namespaced,
+		`Specify if VirtualMachinePreference should be created.
+By default VirtualMachineClusterPreference is created.`)
 	cmd.Flags().StringVar(&c.name, NameFlag, c.name, "Specify the name of the Preference.")
 	cmd.Flags().StringVar(&c.preferredStorageClass, VolumeStorageClassFlag, c.preferredStorageClass, "Defines the preferred storage class")
 	cmd.Flags().StringVar(&c.machineType, MachineTypeFlag, c.machineType, "Defines the preferred machine type to use.")
@@ -81,9 +85,9 @@ func (c *createPreference) setDefaults(cmd *cobra.Command) error {
 	}
 
 	if c.namespaced {
-		c.name = "preference-" + rand.String(5)
+		c.name = "preference-" + rand.String(randomNameSuffixLength)
 	} else {
-		c.name = "clusterpreference-" + rand.String(5)
+		c.name = "clusterpreference-" + rand.String(randomNameSuffixLength)
 	}
 
 	return nil
@@ -184,7 +188,7 @@ func (c *createPreference) run(cmd *cobra.Command, _ []string) error {
 	}
 
 	var out []byte
-	var err error
+	var marshalErr error
 	if c.namespaced {
 		preference := c.newPreference()
 
@@ -192,9 +196,9 @@ func (c *createPreference) run(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		out, err = yaml.Marshal(preference)
-		if err != nil {
-			return err
+		out, marshalErr = yaml.Marshal(preference)
+		if marshalErr != nil {
+			return marshalErr
 		}
 	} else {
 		clusterPreference := c.newClusterPreference()
@@ -203,9 +207,9 @@ func (c *createPreference) run(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		out, err = yaml.Marshal(clusterPreference)
-		if err != nil {
-			return err
+		out, marshalErr = yaml.Marshal(clusterPreference)
+		if marshalErr != nil {
+			return marshalErr
 		}
 	}
 

--- a/pkg/virtctl/create/preference/preference_test.go
+++ b/pkg/virtctl/create/preference/preference_test.go
@@ -130,8 +130,8 @@ var _ = Describe("create preference", func() {
 			Expect(*spec.CPU.PreferredCPUTopology).To(Equal(topology))
 			Expect(validatePreferenceSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachinePreference", instancetypev1beta1.DeprecatedPreferCores, setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineClusterPreference", instancetypev1beta1.DeprecatedPreferThreads),
+			Entry("VirtualMachinePreference", instancetypev1beta1.Cores, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterPreference", instancetypev1beta1.Threads),
 		)
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:  we where having lint issues in  pkg/virtctl/create/preference

After this PR: solved following issues 
- Shadow variable issues:
Renamed the shadowed `err `variable to `marshalErr `in the run function to avoid variable shadowing.
- Magic number issues:
Added a `randomNameSuffixLength` constant with a value of 5.
Replaced all occurrences of the magic number 5 in `rand.String(5)` with this constant.
- Line length issue:
Split the long line in` cmd.Flags().BoolVar() `into multiple lines to stay under the 140 character limit.
- Deprecated constants :
Replaced `DeprecatedPreferCores `with` Cores `and` DeprecatedPreferThreads` with `Threads` in the test file.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
https://github.com/kubevirt/kubevirt/issues/14197
### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

