### PR TITLE
testsuite: disable guest graphics by default

### DIFF
--- a/pkg/libvmi/devices.go
+++ b/pkg/libvmi/devices.go
@@ -33,3 +33,9 @@ func WithTablet(name string, bus v1.InputBus) Option {
 		)
 	}
 }
+
+func WithAutoattachGraphicsDevice(enable bool) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = &enable
+	}
+}

--- a/tests/compute/subresources/expandspec.go
+++ b/tests/compute/subresources/expandspec.go
@@ -215,7 +215,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", func() {
 			var err error
 			preference = instancetypebuilder.NewPreference()
 			preference.Spec.Devices = &instancetypev1beta1.DevicePreferences{
-				PreferredAutoattachGraphicsDevice: pointer.P(true),
+				PreferredAutoattachSerialConsole: pointer.P(true),
 			}
 			preference, err = virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(preference)).
 				Create(context.Background(), preference, metav1.CreateOptions{})
@@ -227,7 +227,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", func() {
 
 			clusterPreference = instancetypebuilder.NewClusterPreference()
 			clusterPreference.Spec.Devices = &instancetypev1beta1.DevicePreferences{
-				PreferredAutoattachGraphicsDevice: pointer.P(true),
+				PreferredAutoattachSerialConsole: pointer.P(true),
 			}
 			clusterPreference, err = virtClient.VirtualMachineClusterPreference().
 				Create(context.Background(), clusterPreference, metav1.CreateOptions{})
@@ -271,7 +271,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", func() {
 					GetWithExpandedSpec(context.Background(), vm.GetName())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(expandedVm.Spec.Preference).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
-				Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeTrue(), "VM should have preference expanded")
+				Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachSerialConsole).To(BeTrue(), "VM should have preference expanded")
 			},
 				Entry("with VirtualMachinePreference", preferenceMatcherFn),
 				Entry("with VirtualMachineClusterPreference", clusterPreferenceMatcherFn),
@@ -296,7 +296,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", func() {
 				expandedVm, err := virtClient.ExpandSpec(testsuite.GetTestNamespace(vm)).ForVirtualMachine(vm)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(expandedVm.Spec.Preference).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
-				Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeTrue(), "VM should have preference expanded")
+				Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachSerialConsole).To(BeTrue(), "VM should have preference expanded")
 			},
 				Entry("with VirtualMachinePreference", preferenceMatcherFn),
 				Entry("with VirtualMachineClusterPreference", clusterPreferenceMatcherFn),

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -20,6 +20,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	virtwait "kubevirt.io/kubevirt/pkg/apimachinery/wait"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -252,7 +253,7 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 		It("Should successfully passthrough a mediated device", func() {
 
 			By("Creating a Fedora VMI")
-			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
+			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), libvmi.WithAutoattachGraphicsDevice(true))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1G")
 			vGPUs := []v1.GPU{
 				{
@@ -333,7 +334,7 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 			libnode.AddLabelToNode(singleNode.Name, cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(vmi)), mdevTestLabel)
 
 			By("Creating a Fedora VMI")
-			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
+			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), libvmi.WithAutoattachGraphicsDevice(true))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1G")
 			vGPUs := []v1.GPU{
 				{

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -159,6 +159,7 @@ func BeforeTestSuiteSetup(_ []byte) {
 
 	libvmifact.RegisterArchitecture(Arch)
 	libvmi.RegisterDefaultOption(addTestAnnotation)
+	libvmi.RegisterDefaultOption(libvmi.WithAutoattachGraphicsDevice(false))
 }
 
 func EnsureKubevirtReady() {

--- a/tests/virt-handler_test.go
+++ b/tests/virt-handler_test.go
@@ -26,23 +26,21 @@ import (
 	"strings"
 	"time"
 
-	kvcorev1 "kubevirt.io/client-go/kubevirt/typed/core/v1"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libnode"
-	"kubevirt.io/kubevirt/tests/libvmops"
-
-	virt_api "kubevirt.io/kubevirt/pkg/virt-api"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+	kvcorev1 "kubevirt.io/client-go/kubevirt/typed/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	virt_api "kubevirt.io/kubevirt/pkg/virt-api"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
 var _ = Describe("[sig-compute]virt-handler", decorators.SigCompute, func() {
@@ -94,7 +92,7 @@ var _ = Describe("[sig-compute]virt-handler", decorators.SigCompute, func() {
 		}
 
 		By("Running the VMI")
-		vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
+		vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), libvmi.WithAutoattachGraphicsDevice(true))
 		vmi = libvmops.RunVMIAndExpectLaunch(vmi, 30)
 
 		By("VMI has the guest agent connected condition")

--- a/tests/virtctl/vnc.go
+++ b/tests/virtctl/vnc.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -50,7 +51,7 @@ var _ = Describe(SIG("[sig-compute]VNC", decorators.SigCompute, decorators.WgArm
 
 	BeforeEach(func() {
 		var err error
-		vmi = libvmifact.NewGuestless()
+		vmi = libvmifact.NewGuestless(libvmi.WithAutoattachGraphicsDevice(true))
 		vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).
 			Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -310,7 +310,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					}
 				}
 				Expect(computeContainer).ToNot(BeNil(), "could not find the compute container")
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(416)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(399)))
 			})
 			It("[test_id:4624]should set a correct memory units", func() {
 				vmi := libvmifact.NewAlpine(

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -28,8 +28,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	v1 "kubevirt.io/api/core/v1"
-
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 )
@@ -41,7 +39,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 		Context("with headless", func() {
 
 			It("[test_id:709][posneg:positive]should connect to console", func() {
-				vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(withAutoattachGraphicsDevice(false)), 30)
+				vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(libvmi.WithAutoattachGraphicsDevice(false)), 30)
 
 				By("checking that console works")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -51,9 +49,3 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 	})
 
 })
-
-func withAutoattachGraphicsDevice(enable bool) libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = &enable
-	}
-}

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1428,7 +1428,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		})
 
 		It("[test_id:3083][test_id:3084]should be able to connect to serial console and VNC", func() {
-			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewCirros(), 90)
+			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewCirros(libvmi.WithAutoattachGraphicsDevice(true)), 90)
 
 			By("Pausing the VMI")
 			err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -44,6 +44,7 @@ import (
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/subresources"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -56,7 +57,7 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		BeforeEach(func() {
 			var err error
-			vmi = libvmifact.NewGuestless()
+			vmi = libvmifact.NewGuestless(libvmi.WithAutoattachGraphicsDevice(true))
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			vmi = libwait.WaitForSuccessfulVMIStart(vmi)


### PR DESCRIPTION
### What this PR does
Before this PR:
Every VM started by e2e tests has a graphics card, which costs a lot to emulate and drive, when the vast majority of tests don't need graphics.

After this PR:
No graphics by default.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

