### PR TITLE
fixed lint issues in pkg/virtctl/create/instancetype

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -18,6 +18,7 @@ pkg/network/vmispec
 pkg/storage/pod/annotations
 pkg/virtctl/clientconfig
 pkg/virtctl/credentials
+pkg/virtctl/create/instancetype
 tests/console
 tests/decorators
 tests/infrastructure

--- a/pkg/virtctl/create/instancetype/instancetype.go
+++ b/pkg/virtctl/create/instancetype/instancetype.go
@@ -46,6 +46,8 @@ const (
 
 	nameErr       = "name must be specified"
 	deviceNameErr = "deviceName must be specified"
+
+	randomNameSuffixLength = 5
 )
 
 type createInstancetype struct {
@@ -59,16 +61,6 @@ type createInstancetype struct {
 	namespaced      bool
 }
 
-type gpu struct {
-	Name       string `param:"name"`
-	DeviceName string `param:"devicename"`
-}
-
-type hostDevice struct {
-	Name       string `param:"name"`
-	DeviceName string `param:"devicename"`
-}
-
 func NewCommand() *cobra.Command {
 	c := createInstancetype{}
 	cmd := &cobra.Command{
@@ -80,10 +72,14 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&c.name, NameFlag, c.name, "Specify the name of the Instancetype.")
 	cmd.Flags().Uint32Var(&c.cpu, CPUFlag, c.cpu, "Specify the count of CPUs of the Instancetype.")
 	cmd.Flags().StringVar(&c.memory, MemoryFlag, c.memory, "Specify the amount of memory of the Instancetype.")
-	cmd.Flags().StringVar(&c.ioThreadsPolicy, IOThreadsPolicyFlag, c.ioThreadsPolicy, "Specify IOThreadsPolicy to be used. Only valid values are \"auto\" and \"shared\".")
-	cmd.Flags().BoolVar(&c.namespaced, NamespacedFlag, false, "Specify if VirtualMachineInstancetype should be created. By default VirtualMachineClusterInstancetype is created.")
-	cmd.Flags().StringArrayVar(&c.gpus, GPUFlag, c.gpus, "Specify the list of vGPUs to passthrough. Can be provided multiple times.")
-	cmd.Flags().StringArrayVar(&c.hostDevices, HostDeviceFlag, c.hostDevices, "Specify list of HostDevices to passthrough. Can be provided multiple times.")
+	cmd.Flags().StringVar(&c.ioThreadsPolicy, IOThreadsPolicyFlag, c.ioThreadsPolicy,
+		"Specify IOThreadsPolicy to be used. Only valid values are \"auto\" and \"shared\".")
+	cmd.Flags().BoolVar(&c.namespaced, NamespacedFlag, false,
+		"Specify if VirtualMachineInstancetype should be created. By default VirtualMachineClusterInstancetype is created.")
+	cmd.Flags().StringArrayVar(&c.gpus, GPUFlag, c.gpus,
+		"Specify the list of vGPUs to passthrough. Can be provided multiple times.")
+	cmd.Flags().StringArrayVar(&c.hostDevices, HostDeviceFlag, c.hostDevices,
+		"Specify list of HostDevices to passthrough. Can be provided multiple times.")
 
 	if err := cmd.MarkFlagRequired(CPUFlag); err != nil {
 		panic(err)
@@ -110,9 +106,9 @@ func (c *createInstancetype) setDefaults(cmd *cobra.Command) error {
 	}
 
 	if c.namespaced {
-		c.name = "instancetype-" + rand.String(5)
+		c.name = "instancetype-" + rand.String(randomNameSuffixLength)
 	} else {
-		c.name = "clusterinstancetype-" + rand.String(5)
+		c.name = "clusterinstancetype-" + rand.String(randomNameSuffixLength)
 	}
 
 	return nil
@@ -126,44 +122,44 @@ func (c *createInstancetype) optFns() map[string]func(*instancetypev1beta1.Virtu
 	}
 }
 
-func (c *createInstancetype) withGPUs(instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec) error {
-	for _, param := range c.gpus {
-		obj := gpu{}
-		if err := params.Map(GPUFlag, param, &obj); err != nil {
+func (c *createInstancetype) processDeviceParams(flagName string, deviceParams []string,
+	addToSpec func(name, deviceName string),
+) error {
+	for _, param := range deviceParams {
+		obj := struct {
+			Name       string `param:"name"`
+			DeviceName string `param:"devicename"`
+		}{}
+
+		if err := params.Map(flagName, param, &obj); err != nil {
 			return err
 		}
 
 		if obj.Name == "" {
-			return params.FlagErr(GPUFlag, nameErr)
+			return params.FlagErr(flagName, nameErr)
 		}
 		if obj.DeviceName == "" {
-			return params.FlagErr(GPUFlag, deviceNameErr)
+			return params.FlagErr(flagName, deviceNameErr)
 		}
 
-		instancetypeSpec.GPUs = append(instancetypeSpec.GPUs, v1.GPU{Name: obj.Name, DeviceName: obj.DeviceName})
+		addToSpec(obj.Name, obj.DeviceName)
 	}
 
 	return nil
 }
 
+func (c *createInstancetype) withGPUs(instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec) error {
+	return c.processDeviceParams(GPUFlag, c.gpus, func(name, deviceName string) {
+		instancetypeSpec.GPUs = append(instancetypeSpec.GPUs,
+			v1.GPU{Name: name, DeviceName: deviceName})
+	})
+}
+
 func (c *createInstancetype) withHostDevices(instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec) error {
-	for _, param := range c.hostDevices {
-		obj := hostDevice{}
-		if err := params.Map(HostDeviceFlag, param, &obj); err != nil {
-			return err
-		}
-
-		if obj.Name == "" {
-			return params.FlagErr(HostDeviceFlag, nameErr)
-		}
-		if obj.DeviceName == "" {
-			return params.FlagErr(HostDeviceFlag, deviceNameErr)
-		}
-
-		instancetypeSpec.HostDevices = append(instancetypeSpec.HostDevices, v1.HostDevice{Name: obj.Name, DeviceName: obj.DeviceName})
-	}
-
-	return nil
+	return c.processDeviceParams(HostDeviceFlag, c.hostDevices, func(name, deviceName string) {
+		instancetypeSpec.HostDevices = append(instancetypeSpec.HostDevices,
+			v1.HostDevice{Name: name, DeviceName: deviceName})
+	})
 }
 
 func (c *createInstancetype) withIOThreadsPolicy(instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec) error {
@@ -278,11 +274,12 @@ func (c *createInstancetype) run(cmd *cobra.Command, _ []string) error {
 	}
 
 	var out []byte
-	var err error
+
 	if c.namespaced {
 		instancetype := c.newInstancetype()
 
-		if err = c.applyFlags(cmd, &instancetype.Spec); err != nil {
+		err := c.applyFlags(cmd, &instancetype.Spec)
+		if err != nil {
 			return err
 		}
 
@@ -293,7 +290,8 @@ func (c *createInstancetype) run(cmd *cobra.Command, _ []string) error {
 	} else {
 		clusterInstancetype := c.newClusterInstancetype()
 
-		if err = c.applyFlags(cmd, &clusterInstancetype.Spec); err != nil {
+		err := c.applyFlags(cmd, &clusterInstancetype.Spec)
+		if err != nil {
 			return err
 		}
 

--- a/pkg/virtctl/create/instancetype/instancetype_test.go
+++ b/pkg/virtctl/create/instancetype/instancetype_test.go
@@ -66,9 +66,12 @@ var _ = Describe("create instancetype", func() {
 			_, err := runCmd(args...)
 			Expect(err).To(MatchError(ContainSubstring(errMsg)))
 		},
-			Entry("VirtualMachineInstancetype invalid cpu string value", "two", "256Mi", `parsing "two": invalid syntax`, setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineInstancetype invalid cpu negative value", "-2", "256Mi", `parsing "-2": invalid syntax`, setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineInstancetype invalid memory value", "2", "256My", "quantities must match the regular expression", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype invalid cpu string value",
+				"two", "256Mi", `parsing "two": invalid syntax`, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype invalid cpu negative value",
+				"-2", "256Mi", `parsing "-2": invalid syntax`, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype invalid memory value",
+				"2", "256My", "quantities must match the regular expression", setFlag(NamespacedFlag, "true")),
 			Entry("VirtualMachineClusterInstancetype invalid cpu string value", "two", "256Mi", `parsing "two": invalid syntax`),
 			Entry("VirtualMachineClusterInstancetype invalid cpu negative value", "-2", "256Mi", `parsing "-2": invalid syntax`),
 			Entry("VirtualMachineClusterInstancetype invalid memory value", "2", "256My", "quantities must match the regular expression"),
@@ -82,16 +85,41 @@ var _ = Describe("create instancetype", func() {
 			_, err := runCmd(args...)
 			Expect(err).To(MatchError(ContainSubstring(errMsg)))
 		},
-			Entry("VirtualMachineInstancetype gpu missing name", nameErr, setFlag(GPUFlag, "devicename:nvidia"), setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineInstancetype gpu missing deviceName", deviceNameErr, setFlag(GPUFlag, "name:gpu1"), setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineInstancetype hostdevice missing name", nameErr, setFlag(HostDeviceFlag, "devicename:intel"), setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineInstancetype hostdevice missing deviceName", deviceNameErr, setFlag(HostDeviceFlag, "name:device1"), setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineInstancetype invalid IOThreadsPolicy", ioThreadErr, setFlag(IOThreadsPolicyFlag, "invalid-policy"), setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineClusterInstancetype gpu missing name", nameErr, setFlag(GPUFlag, "devicename:nvidia")),
-			Entry("VirtualMachineClusterInstancetype gpu missing deviceName", deviceNameErr, setFlag(GPUFlag, "name:gpu1")),
-			Entry("VirtualMachineClusterInstancetype hostdevice missing name", nameErr, setFlag(HostDeviceFlag, "devicename:intel")),
-			Entry("VirtualMachineClusterInstancetype hostdevice missing deviceName", deviceNameErr, setFlag(HostDeviceFlag, "name:device1")),
-			Entry("VirtualMachineClusterInstancetype invalid IOThreadsPolicy", ioThreadErr, setFlag(IOThreadsPolicyFlag, "invalid-policy")),
+			Entry("VirtualMachineInstancetype gpu missing name",
+				nameErr,
+				setFlag(GPUFlag, "devicename:nvidia"),
+				setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype gpu missing deviceName",
+				deviceNameErr,
+				setFlag(GPUFlag, "name:gpu1"),
+				setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype hostdevice missing name",
+				nameErr,
+				setFlag(HostDeviceFlag, "devicename:intel"),
+				setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype hostdevice missing deviceName",
+				deviceNameErr,
+				setFlag(HostDeviceFlag, "name:device1"),
+				setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype invalid IOThreadsPolicy",
+				ioThreadErr,
+				setFlag(IOThreadsPolicyFlag, "invalid-policy"),
+				setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstancetype gpu missing name",
+				nameErr,
+				setFlag(GPUFlag, "devicename:nvidia")),
+			Entry("VirtualMachineClusterInstancetype gpu missing deviceName",
+				deviceNameErr,
+				setFlag(GPUFlag, "name:gpu1")),
+			Entry("VirtualMachineClusterInstancetype hostdevice missing name",
+				nameErr,
+				setFlag(HostDeviceFlag, "devicename:intel")),
+			Entry("VirtualMachineClusterInstancetype hostdevice missing deviceName",
+				deviceNameErr,
+				setFlag(HostDeviceFlag, "name:device1")),
+			Entry("VirtualMachineClusterInstancetype invalid IOThreadsPolicy",
+				ioThreadErr,
+				setFlag(IOThreadsPolicyFlag, "invalid-policy")),
 		)
 	})
 
@@ -140,44 +168,35 @@ var _ = Describe("create instancetype", func() {
 			Entry("VirtualMachinePreference", true),
 			Entry("VirtualMachineClusterPreference", false),
 		)
+		testDeviceConfig := func(flagName, deviceParam string, validateFunc func(spec *instancetypev1beta1.VirtualMachineInstancetypeSpec)) {
+			DescribeTable(fmt.Sprintf("with defined %s", flagName), func(extraArgs ...string) {
+				args := append([]string{
+					setFlag(CPUFlag, "1"),
+					setFlag(MemoryFlag, "128Mi"),
+					setFlag(flagName, deviceParam),
+				}, extraArgs...)
+				out, err := runCmd(args...)
+				Expect(err).ToNot(HaveOccurred())
 
-		DescribeTable("with defined gpus", func(extraArgs ...string) {
-			args := append([]string{
-				setFlag(CPUFlag, "1"),
-				setFlag(MemoryFlag, "128Mi"),
-				setFlag(GPUFlag, "name:gpu1,devicename:nvidia"),
-			}, extraArgs...)
-			out, err := runCmd(args...)
-			Expect(err).ToNot(HaveOccurred())
-
-			spec := getInstancetypeSpec(out)
+				spec := getInstancetypeSpec(out)
+				validateFunc(spec)
+				Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
+			},
+				Entry("VirtualMachineInstancetype", setFlag(NamespacedFlag, "true")),
+				Entry("VirtualMachineClusterInstancetype"),
+			)
+		}
+		testDeviceConfig(GPUFlag, "name:gpu1,devicename:nvidia", func(spec *instancetypev1beta1.VirtualMachineInstancetypeSpec) {
 			Expect(spec.GPUs).To(HaveLen(1))
 			Expect(spec.GPUs[0].Name).To(Equal("gpu1"))
 			Expect(spec.GPUs[0].DeviceName).To(Equal("nvidia"))
-			Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
-		},
-			Entry("VirtualMachineInstancetype", setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineClusterInstancetype"),
-		)
+		})
 
-		DescribeTable("with defined hostDevices", func(extraArgs ...string) {
-			args := append([]string{
-				setFlag(CPUFlag, "1"),
-				setFlag(MemoryFlag, "128Mi"),
-				setFlag(HostDeviceFlag, "name:device1,devicename:intel"),
-			}, extraArgs...)
-			out, err := runCmd(args...)
-			Expect(err).ToNot(HaveOccurred())
-
-			spec := getInstancetypeSpec(out)
+		testDeviceConfig(HostDeviceFlag, "name:device1,devicename:intel", func(spec *instancetypev1beta1.VirtualMachineInstancetypeSpec) {
 			Expect(spec.HostDevices).To(HaveLen(1))
 			Expect(spec.HostDevices[0].Name).To(Equal("device1"))
 			Expect(spec.HostDevices[0].DeviceName).To(Equal("intel"))
-			Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
-		},
-			Entry("VirtualMachineInstancetype", setFlag(NamespacedFlag, "true")),
-			Entry("VirtualMachineClusterInstancetype"),
-		)
+		})
 
 		DescribeTable("with valid IOThreadsPolicy", func(policy v1.IOThreadsPolicy, extraArgs ...string) {
 			args := append([]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:    we had lint issues in `pkg/virtctl/create/instancetype`

After this PR: 
fixed following lint issues
- Magic Numbers:
Added a` randomNameSuffixLength `constant with a value of 5
Used this constant instead of the magic number 5 in the `rand.String calls`
- Line Length Issues:
Split long flag definitions into multiple lines to stay under the 140 character limit
Also fixed long lines in the test file by breaking multi-parameter Entry calls over multiple lines
- Duplicate Code:
Refactored duplicated code in `withGPUs` and `withHostDevices` functions by creating a generic `processDevices `helper function
Refactored duplicate test code into a shared `testDeviceConfig `helper function that parameterizes the device testing
- Sloppy Reassign:
Fixed reassignment issues by using` := `instead of` =` when redefining the `err `variable in the run function
 in 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes
- https://github.com/kubevirt/kubevirt/issues/14195

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

