### PR TITLE
fixed  linting issues in pkg/virtctl/create/clone

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -3,6 +3,7 @@ pkg/instancetype
 pkg/libvmi
 pkg/network/admitter
 pkg/network/controllers
+pkg/virtctl/create/clone
 pkg/network/deviceinfo
 pkg/network/domainspec
 pkg/network/downwardapi

--- a/pkg/virtctl/create/clone/clone_test.go
+++ b/pkg/virtctl/create/clone/clone_test.go
@@ -36,9 +36,10 @@ import (
 const (
 	create = "create"
 
-	vmKind, vmApiGroup             = "VirtualMachine", "kubevirt.io"
-	snapshotKind, snapshotApiGroup = "VirtualMachineSnapshot", "snapshot.kubevirt.io"
+	vmKind, vmAPIGroup             = "VirtualMachine", "kubevirt.io"
+	snapshotKind, snapshotAPIGroup = "VirtualMachineSnapshot", "snapshot.kubevirt.io"
 )
+
 const (
 	labelFilters = iota
 	annotationsFilters
@@ -50,7 +51,6 @@ const (
 
 var _ = Describe("create clone", func() {
 	Context("required arguments", func() {
-
 		It("source name must be specified", func() {
 			_, err := newCommand()
 			Expect(err).To(HaveOccurred())
@@ -64,8 +64,10 @@ var _ = Describe("create clone", func() {
 	})
 
 	Context("source and target", func() {
-
-		DescribeTable("supported types", func(sourceType, expectedSourceKind, expectedSourceApiGroup, targetType, expectedTargetKind, expectedTargetApiGroup string) {
+		DescribeTable("supported types", func(
+			sourceType, expectedSourceKind, expectedSourceAPIGroup,
+			targetType, expectedTargetKind, expectedTargetAPIGroup string,
+		) {
 			const sourceName, targetName = "source-name", "target-name"
 
 			flags := addFlag(nil, virtctlclone.SourceNameFlag, sourceName)
@@ -79,23 +81,23 @@ var _ = Describe("create clone", func() {
 			Expect(cloneObj.Spec.Source.Name).To(Equal(sourceName))
 			Expect(cloneObj.Spec.Source.Kind).To(Equal(expectedSourceKind))
 			Expect(cloneObj.Spec.Source.APIGroup).ToNot(BeNil())
-			Expect(*cloneObj.Spec.Source.APIGroup).To(Equal(expectedSourceApiGroup))
+			Expect(*cloneObj.Spec.Source.APIGroup).To(Equal(expectedSourceAPIGroup))
 
 			Expect(cloneObj.Spec.Target.Name).To(Equal(targetName))
 			Expect(cloneObj.Spec.Target.Kind).To(Equal(expectedTargetKind))
 			Expect(cloneObj.Spec.Target.APIGroup).ToNot(BeNil())
-			Expect(*cloneObj.Spec.Target.APIGroup).To(Equal(expectedTargetApiGroup))
+			Expect(*cloneObj.Spec.Target.APIGroup).To(Equal(expectedTargetAPIGroup))
 		},
-			Entry("vm source, vm target", "vm", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VM source, vm target", "VM", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VirtualMachine source, vm target", "VirtualMachine", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("virtualmachine, vm target", "virtualmachine", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("vm source, VirtualMachine target", "vm", vmKind, vmApiGroup, "VirtualMachine", vmKind, vmApiGroup),
+			Entry("vm source, vm target", "vm", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VM source, vm target", "VM", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VirtualMachine source, vm target", "VirtualMachine", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("virtualmachine, vm target", "virtualmachine", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("vm source, VirtualMachine target", "vm", vmKind, vmAPIGroup, "VirtualMachine", vmKind, vmAPIGroup),
 
-			Entry("snapshot source, vm target", "snapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VirtualMachineSnapshot source, vm target", "VirtualMachineSnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("vmsnapshot source, vm target", "vmsnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VMSnapshot source, vm target", "VMSnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("snapshot source, vm target", "snapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VirtualMachineSnapshot source, vm target", "VirtualMachineSnapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("vmsnapshot source, vm target", "vmsnapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VMSnapshot source, vm target", "VMSnapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
 		)
 
 		It("snapshot is not supported as a target type", func() {
@@ -127,11 +129,9 @@ var _ = Describe("create clone", func() {
 			_, err := newCommand()
 			Expect(err).To(HaveOccurred())
 		})
-
 	})
 
 	Context("label and annotation filters", func() {
-
 		DescribeTable("with", func(filterType int) {
 			flags := getSourceNameFlags()
 
@@ -180,7 +180,6 @@ var _ = Describe("create clone", func() {
 				Expect(cloneObj.Spec.Template.LabelFilters).To(HaveLen(expectedLen))
 				Expect(cloneObj.Spec.Template.AnnotationFilters).To(HaveLen(expectedLen))
 			}
-
 		},
 			Entry("label filters", labelFilters),
 			Entry("annotation filters", annotationsFilters),
@@ -253,7 +252,6 @@ var _ = Describe("create clone", func() {
 
 		Expect(cloneObj.Namespace).To(Equal(namespace))
 	})
-
 })
 
 func addFlag(s []string, flag, value string) []string {
@@ -262,9 +260,9 @@ func addFlag(s []string, flag, value string) []string {
 
 func newCommand(createCloneFlags ...string) (*clone.VirtualMachineClone, error) {
 	baseArgs := []string{create, virtctlclone.Clone}
-	args := append(baseArgs, createCloneFlags...)
+	baseArgs = append(baseArgs, createCloneFlags...)
 
-	bytes, err := testing.NewRepeatableVirtctlCommandWithOut(args...)()
+	bytes, err := testing.NewRepeatableVirtctlCommandWithOut(baseArgs...)()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: we had lint issues in` pkg/virtctl/create/clone`

After this PR: made following changes 
- Changed string constants to named constants
Added `virtualMachineKind` and `virtualMachineSnapshot` constants for reused strings
- Fixed import name shadowing
Renamed the imported package `clone` to `cloneapi` to avoid shadowing
Changed variable name from` clone `to `vmClone` to avoid shadowing the imported package
- Fixed append assign issue
In `clone_test.go`, modified `args := append(baseArgs, createCloneFlags...)` to use `baseArgs = append(baseArgs, createCloneFlags...) `to assign back to the same slice
- Fixed long lines 
Split long lines into multiple lines or reformatted them
- Fixed magic numbers
Added constants for magic numbers
`cloneRandomSuffixLength = 5` for random string generation
`expectedSplitParamLen = 2` for parameter validation
- Fixed stylecheck issues
Renamed `vmApiGroup` to` vmAPIGroup` and `snapshotApiGroup` to `snapshotAPIGroup` in the test file

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes 
- https://github.com/kubevirt/kubevirt/issues/14194

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

