### PR TITLE
release.sh: relabel the contents of the volumes with a private SELinu…

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -37,9 +37,9 @@ kubevirtci/release-tool:latest \
 \"$@\""
 
 ${KUBEVIRT_CRI} run -it --rm \
-    -v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private \
-    -v ${GPG_PASSPHRASE_FILE}:/home/releaser/gpg-passphrase \
-    -v ${GITHUB_API_TOKEN_FILE}:/home/releaser/github-api-token \
+    -v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private:Z \
+    -v ${GPG_PASSPHRASE_FILE}:/home/releaser/gpg-passphrase:Z \
+    -v ${GITHUB_API_TOKEN_FILE}:/home/releaser/github-api-token:Z \
     quay.io/kubevirtci/release-tool:latest \
     --org=kubevirt \
     --repo=kubevirt \


### PR DESCRIPTION
### What this PR does
The release script doesn't properly map the selinux labels on private volumes
This change allows podman to relabel the contents of the volumes with a private SELinux context


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

