### PR TITLE
Add kubevirt_node_deprecated_machine_types metric

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -452,7 +452,7 @@ func (app *virtHandlerApp) Run() {
 		factory.KubeVirt().HasSynced,
 	)
 
-	if err := metrics.SetupMetrics(app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight, vmiSourceInformer); err != nil {
+	if err := metrics.SetupMetrics(app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight, vmiSourceInformer, machines); err != nil {
 		panic(err)
 	}
 

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -311,13 +311,15 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
+	machines := getMachines(capabilities)
+
 	nodeLabellerrecorder := broadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: "node-labeller", Host: app.HostOverride})
 	nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig,
 		app.virtCli.CoreV1().Nodes(),
 		app.HostOverride,
 		nodeLabellerrecorder,
 		capabilities.Host.CPU.Counter,
-		capabilities.Guests,
+		machines,
 	)
 	if err != nil {
 		panic(err)
@@ -683,6 +685,14 @@ func (app *virtHandlerApp) setupTLS(factory controller.KubeInformerFactory) erro
 	app.clientTLSConfig = kvtls.SetupTLSForVirtHandlerClients(app.caManager, app.clientcertmanager, app.externallyManaged)
 
 	return nil
+}
+
+func getMachines(capabilities libvirtxml.Caps) []libvirtxml.CapsGuestMachine {
+	var machines []libvirtxml.CapsGuestMachine
+	for _, guest := range capabilities.Guests {
+		machines = append(machines, guest.Arch.Machines...)
+	}
+	return machines
 }
 
 func main() {

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -18,6 +18,9 @@ Version information. Type: Gauge.
 ### kubevirt_memory_delta_from_requested_bytes
 The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator. Type: Gauge.
 
+### kubevirt_node_deprecated_machine_types
+List of deprecated machine types based on the capabilities of individual nodes, as detected by virt-handler. Type: Gauge.
+
 ### kubevirt_nodes_with_kvm
 The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. Type: Gauge.
 

--- a/pkg/monitoring/metrics/virt-handler/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "machine_type.go",
         "metrics.go",
         "version_metrics.go",
     ],
@@ -16,11 +17,22 @@ go_library(
         "//staging/src/kubevirt.io/client-go/version:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["virt_handler_suite_test.go"],
-    deps = ["//staging/src/kubevirt.io/client-go/testutils:go_default_library"],
+    srcs = [
+        "machine_type_test.go",
+        "virt_handler_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
 )

--- a/pkg/monitoring/metrics/virt-handler/machine_type.go
+++ b/pkg/monitoring/metrics/virt-handler/machine_type.go
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virt_handler
+
+import (
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"libvirt.org/go/libvirtxml"
+)
+
+var (
+	machineTypeMetrics = []operatormetrics.Metric{
+		deprecatedMachineTypeMetric,
+	}
+
+	deprecatedMachineTypeMetric = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_node_deprecated_machine_types",
+			Help: "List of deprecated machine types based on the capabilities of individual nodes, as detected by virt-handler.",
+		},
+		[]string{"machine_type", "node"},
+	)
+)
+
+func ReportDeprecatedMachineTypes(machines []libvirtxml.CapsGuestMachine, nodeName string) {
+	for _, machine := range machines {
+		if machine.Deprecated == "yes" {
+			deprecatedMachineTypeMetric.WithLabelValues(machine.Name, nodeName).Set(1)
+		}
+	}
+}

--- a/pkg/monitoring/metrics/virt-handler/machine_type_test.go
+++ b/pkg/monitoring/metrics/virt-handler/machine_type_test.go
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virt_handler
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"libvirt.org/go/libvirtxml"
+)
+
+var _ = Describe("deprecated machine types metric", func() {
+	Context("ReportDeprecatedMachineTypes", func() {
+		BeforeEach(func() {
+			operatormetrics.UnregisterMetrics(machineTypeMetrics)
+			Expect(operatormetrics.RegisterMetrics(machineTypeMetrics)).To(Succeed())
+		})
+
+		It("should initialize the metric correctly", func() {
+			machineTypes := []libvirtxml.CapsGuestMachine{
+				{Name: "machine1", Deprecated: "false"},
+				{Name: "machine2", Deprecated: "true"},
+			}
+
+			ReportDeprecatedMachineTypes(machineTypes, "test-node")
+
+			Expect(machineTypeMetrics).ToNot(BeEmpty())
+			Expect(deprecatedMachineTypeMetric).ToNot(BeNil(), "deprecatedMachineTypeMetric should be initialized")
+
+			for _, machine := range machineTypes {
+				labels := map[string]string{
+					"machine_type": machine.Name,
+					"node":         "test-node",
+				}
+				_, err := deprecatedMachineTypeMetric.GetMetricWith(labels)
+				Expect(err).ToNot(HaveOccurred(), "should initialize metric with labels %v", labels)
+			}
+		})
+	})
+})

--- a/pkg/monitoring/metrics/virt-handler/metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/metrics.go
@@ -21,6 +21,7 @@ package virt_handler
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 	"k8s.io/client-go/tools/cache"
+	"libvirt.org/go/libvirtxml"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/workqueue"
@@ -28,7 +29,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/migrationdomainstats"
 )
 
-func SetupMetrics(virtShareDir, nodeName string, MaxRequestsInFlight int, vmiInformer cache.SharedIndexInformer) error {
+func SetupMetrics(virtShareDir, nodeName string, MaxRequestsInFlight int, vmiInformer cache.SharedIndexInformer, machines []libvirtxml.CapsGuestMachine) error {
 	if err := workqueue.SetupMetrics(); err != nil {
 		return err
 	}
@@ -37,10 +38,11 @@ func SetupMetrics(virtShareDir, nodeName string, MaxRequestsInFlight int, vmiInf
 		return err
 	}
 
-	if err := operatormetrics.RegisterMetrics(versionMetrics); err != nil {
+	if err := operatormetrics.RegisterMetrics(versionMetrics, machineTypeMetrics); err != nil {
 		return err
 	}
 	SetVersionInfo()
+	ReportDeprecatedMachineTypes(machines, nodeName)
 
 	domainstats.SetupDomainStatsCollector(virtShareDir, nodeName, MaxRequestsInFlight, vmiInformer)
 

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -75,18 +75,18 @@ type NodeLabeller struct {
 	volumePath              string
 	domCapabilitiesFileName string
 	cpuCounter              *libvirtxml.CapsHostCPUCounter
-	guestCaps               []libvirtxml.CapsGuest
+	supportedMachines       []libvirtxml.CapsGuestMachine
 	hostCPUModel            hostCPUModel
 	SEV                     SEVConfiguration
 	SecureExecution         SecureExecutionConfiguration
 	arch                    archLabeller
 }
 
-func NewNodeLabeller(clusterConfig *virtconfig.ClusterConfig, nodeClient k8scli.NodeInterface, host string, recorder record.EventRecorder, cpuCounter *libvirtxml.CapsHostCPUCounter, guestCaps []libvirtxml.CapsGuest) (*NodeLabeller, error) {
-	return newNodeLabeller(clusterConfig, nodeClient, host, NodeLabellerVolumePath, recorder, cpuCounter, guestCaps)
+func NewNodeLabeller(clusterConfig *virtconfig.ClusterConfig, nodeClient k8scli.NodeInterface, host string, recorder record.EventRecorder, cpuCounter *libvirtxml.CapsHostCPUCounter, supportedMachines []libvirtxml.CapsGuestMachine) (*NodeLabeller, error) {
+	return newNodeLabeller(clusterConfig, nodeClient, host, NodeLabellerVolumePath, recorder, cpuCounter, supportedMachines)
 
 }
-func newNodeLabeller(clusterConfig *virtconfig.ClusterConfig, nodeClient k8scli.NodeInterface, host, volumePath string, recorder record.EventRecorder, cpuCounter *libvirtxml.CapsHostCPUCounter, guestCaps []libvirtxml.CapsGuest) (*NodeLabeller, error) {
+func newNodeLabeller(clusterConfig *virtconfig.ClusterConfig, nodeClient k8scli.NodeInterface, host, volumePath string, recorder record.EventRecorder, cpuCounter *libvirtxml.CapsHostCPUCounter, supportedMachines []libvirtxml.CapsGuestMachine) (*NodeLabeller, error) {
 	n := &NodeLabeller{
 		recorder:      recorder,
 		nodeClient:    nodeClient,
@@ -100,7 +100,7 @@ func newNodeLabeller(clusterConfig *virtconfig.ClusterConfig, nodeClient k8scli.
 		volumePath:              volumePath,
 		domCapabilitiesFileName: "virsh_domcapabilities.xml",
 		cpuCounter:              cpuCounter,
-		guestCaps:               guestCaps,
+		supportedMachines:       supportedMachines,
 		hostCPUModel:            hostCPUModel{requiredFeatures: make(map[string]bool)},
 		arch:                    newArchLabeller(runtime.GOARCH),
 	}
@@ -249,7 +249,7 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
 		}
 	}
 
-	for _, machine := range n.getSupportedMachines() {
+	for _, machine := range n.supportedMachines {
 		labelKey := kubevirtv1.SupportedMachineTypeLabel + machine.Name
 		newLabels[labelKey] = "true"
 	}
@@ -354,12 +354,4 @@ func (n *NodeLabeller) alertIfHostModelIsObsolete(originalNode *v1.Node, hostMod
 
 func (n *NodeLabeller) hasTSCCounter() bool {
 	return n.cpuCounter != nil && n.cpuCounter.Name == "tsc"
-}
-
-func (n *NodeLabeller) getSupportedMachines() []libvirtxml.CapsGuestMachine {
-	var supportedMachines []libvirtxml.CapsGuestMachine
-	for _, guest := range n.guestCaps {
-		supportedMachines = append(supportedMachines, guest.Arch.Machines...)
-	}
-	return supportedMachines
 }

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Node-labeller ", func() {
 	})
 
 	DescribeTable("should add machine type labels", func(machines []libvirtxml.CapsGuestMachine, arch string) {
-		guestsCaps[0].Arch.Machines = machines
+		supportedMachines = machines
 
 		initNodeLabeller(&v1.KubeVirt{})
 		nlController.arch = newArchLabeller(arch)

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Node-labeller ", func() {
 	var nlController *NodeLabeller
 	var kubeClient *fake.Clientset
 	var cpuCounter *libvirtxml.CapsHostCPUCounter
-	var guestsCaps []libvirtxml.CapsGuest
+	var supportedMachines []libvirtxml.CapsGuestMachine
 
 	initNodeLabeller := func(kubevirt *v1.KubeVirt) {
 		config, _, _ := testutils.NewFakeClusterConfigUsingKV(kubevirt)
@@ -56,7 +56,7 @@ var _ = Describe("Node-labeller ", func() {
 		recorder.IncludeObject = true
 
 		var err error
-		nlController, err = newNodeLabeller(config, kubeClient.CoreV1().Nodes(), nodeName, "testdata", recorder, cpuCounter, guestsCaps)
+		nlController, err = newNodeLabeller(config, kubeClient.CoreV1().Nodes(), nodeName, "testdata", recorder, cpuCounter, supportedMachines)
 		Expect(err).ToNot(HaveOccurred())
 	}
 
@@ -67,16 +67,7 @@ var _ = Describe("Node-labeller ", func() {
 			Scaling:   "no",
 		}
 
-		guestsCaps = []libvirtxml.CapsGuest{
-			{
-				OSType: "test",
-				Arch: libvirtxml.CapsGuestArch{
-					Machines: []libvirtxml.CapsGuestMachine{
-						{Name: "testmachine"},
-					},
-				},
-			},
-		}
+		supportedMachines = []libvirtxml.CapsGuestMachine{{Name: "testmachine"}}
 
 		node := newNode(nodeName)
 		kubeClient = fake.NewSimpleClientset(node)

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -419,6 +419,20 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		Entry("[test_id:6227] by using IPv6", k8sv1.IPv6Protocol),
 	)
 
+	It("should expose kubevirt_node_deprecated_machine_types metric", func() {
+		ip := libnet.GetIP(handlerMetricIPs, k8sv1.IPv4Protocol)
+
+		By("Scraping the Prometheus endpoint for kubevirt_node_deprecated_machine_types metric")
+		metrics := collectMetrics(ip, "kubevirt_node_deprecated_machine_types")
+		Expect(metrics).ToNot(BeEmpty())
+
+		By("Checking that each entry has a machine_type label")
+		keys := libinfra.GetKeysFromMetrics(metrics)
+		for _, key := range keys {
+			Expect(key).To(ContainSubstring(`machine_type="`), fmt.Sprintf("Expected machine_type label in metric: %s", key))
+		}
+	})
+
 	DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
 		libnet.SkipWhenClusterNotSupportIPFamily(family)
 

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -73,6 +73,9 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			// needs a snapshot - ignoring since already tested in - VM Monitoring, VM snapshot metrics
 			"kubevirt_vmsnapshot_succeeded_timestamp_seconds": true,
 
+			// needs a machines variable - ignoring since already tested in - tests/infrastructure/prometheus
+			"kubevirt_node_deprecated_machine_types": true,
+
 			// migration metrics
 			// needs a migration - ignoring since already tested in - VM Monitoring, VM migration metrics
 			"kubevirt_vmi_migration_phase_transition_time_from_creation_seconds": true,
@@ -110,7 +113,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			err = virtcontroller.RegisterLeaderMetrics()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = virthandler.SetupMetrics("", "", 0, nil)
+			err = virthandler.SetupMetrics("", "", 0, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, metric := range operatormetrics.ListMetrics() {

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -61,7 +61,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := virthandler.SetupMetrics("", "", 0, nil); err != nil {
+	if err := virthandler.SetupMetrics("", "", 0, nil, nil); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
### What this PR does

This PR introduces two changes:

- Refactors the node-labeller controller to accept `[]libvirtxml.CapGuestMachine` as an argument instead of `[]libvirtxml.CapGuest`.

- Adds a new dedicated metric to expose the list of deprecated machine types per each node in the KubeVirt cluster.

Before this PR:
KubeVirt did not have a dedicated metric to expose information about the deprecated machine types per each node in the cluster.

After this PR:
A dedicated metric is now available, listing all deprecated machine types per node that can be used for alerting purposes.

## Query Screenshot:
![image](https://github.com/user-attachments/assets/df700c78-9061-4e2c-ab5f-7b8fed70e07e)
Fixes #

### Why we need it and why it was done in this way
This lays the groundwork for future alerting features. It will help detect when virtual machines are provisioned using outdated or deprecated machine types that require upgrades.

### Release note
```release-note
None
```

