### PR TITLE
e2e: write file in tmpfs for reset test

### DIFF
--- a/tests/compute/subresources/reset.go
+++ b/tests/compute/subresources/reset.go
@@ -50,7 +50,7 @@ var _ = Describe(compute.SIG("Reset subresource", func() {
 
 			By("Create a file that is not expected to survive the reset request")
 			err := console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "touch non-persistent-file\n"},
+				&expect.BSnd{S: "touch /tmp/non-persistent-file\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: console.EchoLastReturnValue},
 				&expect.BExp{R: console.ShellSuccess},
@@ -62,7 +62,7 @@ var _ = Describe(compute.SIG("Reset subresource", func() {
 
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 			err = console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "ls non-persistent-file\n"},
+				&expect.BSnd{S: "ls /tmp/non-persistent-file\n"},
 				&expect.BExp{R: `non-persistent-file: No such file or director`},
 			}, 20)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the non persistent file is written in
the regular fs.
Actually it should be done in tmpfs, since it
is actually volatile.
Since reset does not involve pod recreation, it
could be possible that, depending on how k8s
manage the storage, that the file is still there
after the reset.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This flakiness was observed recently: https://search.ci.kubevirt.io/?search=Reset+subresource&maxAge=168h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

