### PR TITLE
Net l2bridge force bridge mac

### DIFF
--- a/pkg/network/driver/nmstate/BUILD.bazel
+++ b/pkg/network/driver/nmstate/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/pointer:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/pkg/network/driver/nmstate/spec.go
+++ b/pkg/network/driver/nmstate/spec.go
@@ -47,6 +47,11 @@ func (n NMState) Apply(spec *Spec) error {
 				}
 			}
 		} else {
+			if !linkExists {
+				if link, err = n.createInterface(iface); err != nil {
+					return err
+				}
+			}
 			if iface.CopyMacFrom != "" {
 				if iface.MacAddress != "" {
 					return fmt.Errorf("specifying both MAC address and copy-mac-from fields is not supported [%s]", iface.Name)
@@ -56,11 +61,6 @@ func (n NMState) Apply(spec *Spec) error {
 					return fmt.Errorf("unable to find mac source link [%s]: %v", iface.Name, err)
 				}
 				iface.MacAddress = macSourceLink.Attrs().HardwareAddr.String()
-			}
-			if !linkExists {
-				if link, err = n.createInterface(iface); err != nil {
-					return err
-				}
 			}
 
 			if linkType := normalizeLinkTypeName(link); iface.TypeName != "" && linkType != iface.TypeName {
@@ -138,7 +138,6 @@ func (n NMState) createInterface(iface Interface) (vishnetlink.Link, error) {
 	if iface.TypeName == TypeTap {
 		return n.createTap(iface, link)
 	}
-
 	if err := n.adapter.LinkAdd(link); err != nil {
 		return nil, err
 	}

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -482,13 +482,14 @@ func (n NetPod) managedTapSpec(podIfaceName string, vmiIfaceIndex int, ifaceStat
 	if !exist {
 		podStatusIface = ifaceStatusByName[podIfaceName]
 	}
-
+	bridgeInterFaceName := link.GenerateBridgeName(podIfaceName)
 	bridgeIface := nmstate.Interface{
-		Name:     link.GenerateBridgeName(podIfaceName),
-		TypeName: nmstate.TypeBridge,
-		State:    nmstate.IfaceStateUp,
-		Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
-		Metadata: &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
+		Name:        bridgeInterFaceName,
+		TypeName:    nmstate.TypeBridge,
+		State:       nmstate.IfaceStateUp,
+		CopyMacFrom: bridgeInterFaceName, // prevent bridge mac from changing
+		Ethtool:     nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
+		Metadata:    &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
 	}
 
 	podIface := nmstate.Interface{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

