### PR TITLE
e2e reporter: stop complaining about and marshalling diskless VMs

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -457,9 +457,8 @@ func (r *KubernetesReporter) logVMICommands(virtCli kubecli.KubevirtClient, vmiN
 	}
 
 	for _, vmi := range runningVMIs {
-		vmiType, err := getVmiType(vmi)
-		if err != nil {
-			printError("skipping vmi %s/%s: failed to get vmi type: %v", vmi.Namespace, vmi.Name, err)
+		vmiType := getVmiType(vmi)
+		if vmiType == "" {
 			continue
 		}
 
@@ -481,9 +480,8 @@ func (r *KubernetesReporter) logCloudInit(virtCli kubecli.KubevirtClient, vmiNam
 	}
 
 	for _, vmi := range runningVMIs {
-		vmiType, err := getVmiType(vmi)
-		if err != nil {
-			printError("skipping vmi %s/%s: failed to get vmi type: %v", vmi.Namespace, vmi.Name, err)
+		vmiType := getVmiType(vmi)
+		if vmiType == "" {
 			continue
 		}
 
@@ -989,14 +987,9 @@ func getRunningVMIs(virtCli kubecli.KubevirtClient, namespace []string) []v12.Vi
 				continue
 			}
 
-			vmiType, err := getVmiType(vmi)
-			if err != nil {
-				printError("skipping vmi %s/%s: failed to get vmi type: %v", vmi.Namespace, vmi.Name, err)
-				continue
-			}
+			vmiType := getVmiType(vmi)
 
-			if err := prepareVmiConsole(vmi, vmiType); err != nil {
-				printError("skipping vmi %s/%s: failed to login: %v", vmi.Namespace, vmi.Name, err)
+			if vmiType == "" || prepareVmiConsole(vmi, vmiType) != nil {
 				continue
 			}
 			runningVMIs = append(runningVMIs, vmi)
@@ -1187,7 +1180,7 @@ func writeStringToFile(filePath string, data string) error {
 	return err
 }
 
-func getVmiType(vmi v12.VirtualMachineInstance) (string, error) {
+func getVmiType(vmi v12.VirtualMachineInstance) string {
 	for _, volume := range vmi.Spec.Volumes {
 		if volume.VolumeSource.ContainerDisk == nil {
 			continue
@@ -1195,19 +1188,15 @@ func getVmiType(vmi v12.VirtualMachineInstance) (string, error) {
 
 		image := volume.VolumeSource.ContainerDisk.Image
 		if strings.Contains(image, "fedora") {
-			return "fedora", nil
+			return "fedora"
 		} else if strings.Contains(image, "cirros") {
-			return "cirros", nil
+			return "cirros"
 		} else if strings.Contains(image, "alpine") {
-			return "alpine", nil
+			return "alpine"
 		}
 	}
 
-	if vmiJson, err := json.Marshal(vmi); err == nil {
-		return "", fmt.Errorf("unknown type, vmi %s", vmiJson)
-	} else {
-		return "", fmt.Errorf("%w: unknown type, vmi %s", err, vmi.ObjectMeta.Name)
-	}
+	return ""
 }
 
 func prepareVmiConsole(vmi v12.VirtualMachineInstance, vmiType string) error {


### PR DESCRIPTION
### What this PR does
Before this PR:
- Local e2e runs are full of `skipping vmi [...]` messages that sometimes include entire VMI specs.
- Whenever a VMI is not fedora/alpine/cirros, it gets marshalled to json 2 to 3 times at the end of each test.

After this PR:
Silence

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This is mostly cosmetic, the time saved is negligible.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
