### PR TITLE
Removed //nolint:dupl from pkg/instancetype/preference/webhooks/admit…

### DIFF
--- a/pkg/instancetype/preference/webhooks/admitter_test.go
+++ b/pkg/instancetype/preference/webhooks/admitter_test.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package webhooks_test
 
 import (
@@ -21,14 +20,185 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
+type preferenceTestHelper interface {
+	createObject(preferredCPUTopology *instancetypev1beta1.PreferredCPUTopology, spreadAcross *instancetypev1beta1.SpreadAcross, ratio *uint32, socketToCoreRatio uint32) interface{}
+	createObjectForWarning(deprecatedTopology instancetypev1beta1.PreferredCPUTopology) interface{}
+	createAdmissionReview(obj interface{}, version string) *admissionv1.AdmissionReview
+	getAdmitter() interface{}
+	getSpecPath() *k8sfield.Path
+}
+
+type virtualMachinePreferenceHelper struct {
+	admitter *webhooks.PreferenceAdmitter
+}
+
+func (h *virtualMachinePreferenceHelper) createObject(preferredCPUTopology *instancetypev1beta1.PreferredCPUTopology, spreadAcross *instancetypev1beta1.SpreadAcross, ratio *uint32, socketToCoreRatio uint32) interface{} {
+	obj := &instancetypev1beta1.VirtualMachinePreference{
+		Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+			PreferSpreadSocketToCoreRatio: socketToCoreRatio,
+			CPU: &instancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: preferredCPUTopology,
+				SpreadOptions: &instancetypev1beta1.SpreadOptions{
+					Across: spreadAcross,
+					Ratio:  ratio,
+				},
+			},
+		},
+	}
+	return obj
+}
+
+func (h *virtualMachinePreferenceHelper) createObjectForWarning(deprecatedTopology instancetypev1beta1.PreferredCPUTopology) interface{} {
+	return &instancetypev1beta1.VirtualMachinePreference{
+		Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+			CPU: &instancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: pointer.P(deprecatedTopology),
+			},
+		},
+	}
+}
+
+func (h *virtualMachinePreferenceHelper) createAdmissionReview(obj interface{}, version string) *admissionv1.AdmissionReview {
+	return createPreferenceAdmissionReview(obj.(*instancetypev1beta1.VirtualMachinePreference), version)
+}
+
+func (h *virtualMachinePreferenceHelper) getAdmitter() interface{} {
+	return h.admitter
+}
+
+func (h *virtualMachinePreferenceHelper) getSpecPath() *k8sfield.Path {
+	return k8sfield.NewPath("spec")
+}
+
+type virtualMachineClusterPreferenceHelper struct {
+	admitter *webhooks.ClusterPreferenceAdmitter
+}
+
+func (h *virtualMachineClusterPreferenceHelper) createObject(preferredCPUTopology *instancetypev1beta1.PreferredCPUTopology, spreadAcross *instancetypev1beta1.SpreadAcross, ratio *uint32, socketToCoreRatio uint32) interface{} {
+	obj := &instancetypev1beta1.VirtualMachineClusterPreference{
+		Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+			PreferSpreadSocketToCoreRatio: socketToCoreRatio,
+			CPU: &instancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: preferredCPUTopology,
+				SpreadOptions: &instancetypev1beta1.SpreadOptions{
+					Across: spreadAcross,
+					Ratio:  ratio,
+				},
+			},
+		},
+	}
+	return obj
+}
+
+func (h *virtualMachineClusterPreferenceHelper) createObjectForWarning(deprecatedTopology instancetypev1beta1.PreferredCPUTopology) interface{} {
+	return &instancetypev1beta1.VirtualMachineClusterPreference{
+		Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+			CPU: &instancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: pointer.P(deprecatedTopology),
+			},
+		},
+	}
+}
+
+func (h *virtualMachineClusterPreferenceHelper) createAdmissionReview(obj interface{}, version string) *admissionv1.AdmissionReview {
+	return createClusterPreferenceAdmissionReview(obj.(*instancetypev1beta1.VirtualMachineClusterPreference), version)
+}
+
+func (h *virtualMachineClusterPreferenceHelper) getAdmitter() interface{} {
+	return h.admitter
+}
+
+func (h *virtualMachineClusterPreferenceHelper) getSpecPath() *k8sfield.Path {
+	return k8sfield.NewPath("spec")
+}
+
+func runUnsupportedSpreadOptionsTest(helper preferenceTestHelper, preferredCPUTopology instancetypev1beta1.PreferredCPUTopology) {
+	var unsupportedAcrossValue instancetypev1beta1.SpreadAcross = "foobar"
+	obj := helper.createObject(&preferredCPUTopology, pointer.P(unsupportedAcrossValue), nil, 3)
+	ar := helper.createAdmissionReview(obj, instancetypev1beta1.SchemeGroupVersion.Version)
+
+	var response *admissionv1.AdmissionResponse
+	switch admitter := helper.getAdmitter().(type) {
+	case *webhooks.PreferenceAdmitter:
+		response = admitter.Admit(context.Background(), ar)
+	case *webhooks.ClusterPreferenceAdmitter:
+		response = admitter.Admit(context.Background(), ar)
+	}
+
+	Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
+	Expect(response.Result.Details.Causes).To(HaveLen(1))
+	Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+	Expect(response.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("across %s is not supported", unsupportedAcrossValue)))
+	Expect(response.Result.Details.Causes[0].Field).To(Equal(helper.getSpecPath().Child("cpu", "spreadOptions", "across").String()))
+}
+
+func runSpreadingVCPUsTest(helper preferenceTestHelper, testCase string, preferredTopology instancetypev1beta1.PreferredCPUTopology, useRatio bool) {
+	var socketToCoreRatio uint32 = 3
+	var obj interface{}
+
+	if useRatio {
+		obj = helper.createObject(
+			pointer.P(preferredTopology),
+			pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
+			pointer.P(uint32(3)),
+			0,
+		)
+	} else {
+		obj = helper.createObject(
+			pointer.P(preferredTopology),
+			pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
+			nil,
+			socketToCoreRatio,
+		)
+	}
+
+	ar := helper.createAdmissionReview(obj, instancetypev1beta1.SchemeGroupVersion.Version)
+
+	var response *admissionv1.AdmissionResponse
+	switch admitter := helper.getAdmitter().(type) {
+	case *webhooks.PreferenceAdmitter:
+		response = admitter.Admit(context.Background(), ar)
+	case *webhooks.ClusterPreferenceAdmitter:
+		response = admitter.Admit(context.Background(), ar)
+	}
+
+	Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
+	Expect(response.Result.Details.Causes).To(HaveLen(1))
+	Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+	Expect(response.Result.Details.Causes[0].Message).To(Equal(
+		"only a ratio of 2 (1 core 2 threads) is allowed when spreading vCPUs over cores and threads"))
+	Expect(response.Result.Details.Causes[0].Field).To(Equal(helper.getSpecPath().Child("cpu", "spreadOptions", "ratio").String()))
+}
+
+func runWarningTest(helper preferenceTestHelper, deprecatedTopology, expectedAlternativeTopology instancetypev1beta1.PreferredCPUTopology) {
+	obj := helper.createObjectForWarning(deprecatedTopology)
+	ar := helper.createAdmissionReview(obj, instancetypev1beta1.SchemeGroupVersion.Version)
+
+	var response *admissionv1.AdmissionResponse
+	switch admitter := helper.getAdmitter().(type) {
+	case *webhooks.PreferenceAdmitter:
+		response = admitter.Admit(context.Background(), ar)
+	case *webhooks.ClusterPreferenceAdmitter:
+		response = admitter.Admit(context.Background(), ar)
+	}
+
+	Expect(response.Allowed).To(BeTrue())
+	Expect(response.Warnings).To(HaveLen(1))
+	Expect(response.Warnings[0]).To(ContainSubstring(
+		fmt.Sprintf("PreferredCPUTopology %s is deprecated for removal in a future release, please use %s instead",
+			deprecatedTopology, expectedAlternativeTopology)))
+}
+
 var _ = Describe("Validating Preference Admitter", func() {
 	var (
 		admitter      *webhooks.PreferenceAdmitter
 		preferenceObj *instancetypev1beta1.VirtualMachinePreference
+		helper        preferenceTestHelper
 	)
 
 	BeforeEach(func() {
 		admitter = &webhooks.PreferenceAdmitter{}
+		helper = &virtualMachinePreferenceHelper{admitter: admitter}
 
 		preferenceObj = &instancetypev1beta1.VirtualMachinePreference{
 			ObjectMeta: metav1.ObjectMeta{
@@ -57,286 +227,85 @@ var _ = Describe("Validating Preference Admitter", func() {
 		Expect(response.Result.Details.Causes[0].Field).To(Equal(k8sfield.NewPath("spec", "cpu", "preferredCPUTopology").String()))
 	})
 
-	DescribeTable("should reject unsupported SpreadOptions Across value", func(preferredCPUTopology instancetypev1beta1.PreferredCPUTopology) {
-		var unsupportedAcrossValue instancetypev1beta1.SpreadAcross = "foobar"
-		preferenceObj = &instancetypev1beta1.VirtualMachinePreference{
-			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-				PreferSpreadSocketToCoreRatio: uint32(3),
-				CPU: &instancetypev1beta1.CPUPreferences{
-					PreferredCPUTopology: &preferredCPUTopology,
-					SpreadOptions: &instancetypev1beta1.SpreadOptions{
-						Across: pointer.P(unsupportedAcrossValue),
-					},
-				},
-			},
-		}
-		ar := createPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(context.Background(), ar)
-
-		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
-		Expect(response.Result.Details.Causes).To(HaveLen(1))
-		Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-		Expect(response.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("across %s is not supported", unsupportedAcrossValue)))
-		Expect(response.Result.Details.Causes[0].Field).To(Equal(k8sfield.NewPath("spec", "cpu", "spreadOptions", "across").String()))
-	},
-		Entry("with spread", instancetypev1beta1.Spread),
-		Entry("with preferSpread", instancetypev1beta1.DeprecatedPreferSpread),
+	DescribeTable("should reject unsupported SpreadOptions Across value",
+		runUnsupportedSpreadOptionsTest,
+		Entry("with spread", helper, instancetypev1beta1.Spread),
+		Entry("with preferSpread", helper, instancetypev1beta1.DeprecatedPreferSpread),
 	)
 
-	DescribeTable("should reject when spreading vCPUs across CoresThreads with a ratio higher than 2 set through",
-		func(preferenceObj instancetypev1beta1.VirtualMachinePreference) {
-			ar := createPreferenceAdmissionReview(&preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-			response := admitter.Admit(context.Background(), ar)
-			Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
-			Expect(response.Result.Details.Causes).To(HaveLen(1))
-			Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(response.Result.Details.Causes[0].Message).To(Equal(
-				"only a ratio of 2 (1 core 2 threads) is allowed when spreading vCPUs over cores and threads"))
-			Expect(response.Result.Details.Causes[0].Field).To(Equal(k8sfield.NewPath("spec", "cpu", "spreadOptions", "ratio").String()))
+	DescribeTable("should reject when spreading vCPUs across CoresThreads with a ratio higher than 2",
+		func(testCase string, preferredTopology instancetypev1beta1.PreferredCPUTopology, useRatio bool) {
+			runSpreadingVCPUsTest(helper, testCase, preferredTopology, useRatio)
 		},
-		Entry("PreferSpreadSocketToCoreRatio with spread",
-			instancetypev1beta1.VirtualMachinePreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferSpreadSocketToCoreRatio: uint32(3),
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.Spread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-						},
-					},
-				},
-			},
-		),
-		Entry("PreferSpreadSocketToCoreRatio with preferSpread",
-			instancetypev1beta1.VirtualMachinePreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferSpreadSocketToCoreRatio: uint32(3),
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.DeprecatedPreferSpread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-						},
-					},
-				},
-			},
-		),
-		Entry("SpreadOptions with spread",
-			instancetypev1beta1.VirtualMachinePreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.Spread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-							Ratio:  pointer.P(uint32(3)),
-						},
-					},
-				},
-			},
-		),
-		Entry("SpreadOptions with preferSpread",
-			instancetypev1beta1.VirtualMachinePreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.DeprecatedPreferSpread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-							Ratio:  pointer.P(uint32(3)),
-						},
-					},
-				},
-			},
-		),
+		Entry("PreferSpreadSocketToCoreRatio with spread", "case1", instancetypev1beta1.Spread, false),
+		Entry("PreferSpreadSocketToCoreRatio with preferSpread", "case2", instancetypev1beta1.DeprecatedPreferSpread, false),
+		Entry("SpreadOptions with spread", "case3", instancetypev1beta1.Spread, true),
+		Entry("SpreadOptions with preferSpread", "case4", instancetypev1beta1.DeprecatedPreferSpread, true),
 	)
 
-	DescribeTable("should raise warning for", func(deprecatedTopology, expectedAlternativeTopology instancetypev1beta1.PreferredCPUTopology) {
-		preferenceObj := &instancetypev1beta1.VirtualMachinePreference{
-			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-				CPU: &instancetypev1beta1.CPUPreferences{
-					PreferredCPUTopology: pointer.P(deprecatedTopology),
-				},
-			},
-		}
-		ar := createPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(context.Background(), ar)
-		Expect(response.Allowed).To(BeTrue())
-		Expect(response.Warnings).To(HaveLen(1))
-		Expect(response.Warnings[0]).To(ContainSubstring(
-			fmt.Sprintf("PreferredCPUTopology %s is deprecated for removal in a future release, please use %s instead",
-				deprecatedTopology, expectedAlternativeTopology)))
-	},
+	DescribeTable("should raise warning for",
+		runWarningTest,
 		Entry("DeprecatedPreferSockets and provide Sockets as an alternative",
-			instancetypev1beta1.DeprecatedPreferSockets,
-			instancetypev1beta1.Sockets,
+			helper, instancetypev1beta1.DeprecatedPreferSockets, instancetypev1beta1.Sockets,
 		),
 		Entry("DeprecatedPreferCores and provide Cores as an alternative",
-			instancetypev1beta1.DeprecatedPreferCores,
-			instancetypev1beta1.Cores,
+			helper, instancetypev1beta1.DeprecatedPreferCores, instancetypev1beta1.Cores,
 		),
 		Entry("DeprecatedPreferThreads and provide Threads as an alternative",
-			instancetypev1beta1.DeprecatedPreferThreads,
-			instancetypev1beta1.Threads,
+			helper, instancetypev1beta1.DeprecatedPreferThreads, instancetypev1beta1.Threads,
 		),
 		Entry("DeprecatedPreferSpread and provide Spread as an alternative",
-			instancetypev1beta1.DeprecatedPreferSpread,
-			instancetypev1beta1.Spread,
+			helper, instancetypev1beta1.DeprecatedPreferSpread, instancetypev1beta1.Spread,
 		),
 		Entry("DeprecatedPreferAny and provide Any as an alternative",
-			instancetypev1beta1.DeprecatedPreferAny,
-			instancetypev1beta1.Any,
+			helper, instancetypev1beta1.DeprecatedPreferAny, instancetypev1beta1.Any,
 		),
 	)
 })
 
 var _ = Describe("Validating ClusterPreference Admitter", func() {
 	var (
-		admitter             *webhooks.ClusterPreferenceAdmitter
-		clusterPreferenceObj *instancetypev1beta1.VirtualMachineClusterPreference
+		admitter *webhooks.ClusterPreferenceAdmitter
+		helper   preferenceTestHelper
 	)
 
 	BeforeEach(func() {
 		admitter = &webhooks.ClusterPreferenceAdmitter{}
-
-		clusterPreferenceObj = &instancetypev1beta1.VirtualMachineClusterPreference{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "test-namespace",
-			},
-		}
+		helper = &virtualMachineClusterPreferenceHelper{admitter: admitter}
 	})
 
 	DescribeTable("should reject unsupported SpreadOptions Across value",
-		func(preferredCPUTopology instancetypev1beta1.PreferredCPUTopology) {
-			var unsupportedAcrossValue instancetypev1beta1.SpreadAcross = "foobar"
-			clusterPreferenceObj = &instancetypev1beta1.VirtualMachineClusterPreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferSpreadSocketToCoreRatio: uint32(3),
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: &preferredCPUTopology,
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(unsupportedAcrossValue),
-						},
-					},
-				},
-			}
-			ar := createClusterPreferenceAdmissionReview(clusterPreferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-			response := admitter.Admit(context.Background(), ar)
-
-			Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
-			Expect(response.Result.Details.Causes).To(HaveLen(1))
-			Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(response.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("across %s is not supported", unsupportedAcrossValue)))
-			Expect(response.Result.Details.Causes[0].Field).To(Equal(k8sfield.NewPath("spec", "cpu", "spreadOptions", "across").String()))
-		},
-		Entry("with spread", instancetypev1beta1.Spread),
-		Entry("with preferSpread", instancetypev1beta1.DeprecatedPreferSpread),
+		runUnsupportedSpreadOptionsTest,
+		Entry("with spread", helper, instancetypev1beta1.Spread),
+		Entry("with preferSpread", helper, instancetypev1beta1.DeprecatedPreferSpread),
 	)
 
-	DescribeTable("should reject when spreading vCPUs across CoresThreads with a ratio higher than 2 set through",
-		func(clusterPreferenceObj instancetypev1beta1.VirtualMachineClusterPreference) {
-			ar := createClusterPreferenceAdmissionReview(&clusterPreferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-			response := admitter.Admit(context.Background(), ar)
-			Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
-			Expect(response.Result.Details.Causes).To(HaveLen(1))
-			Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(response.Result.Details.Causes[0].Message).To(Equal(
-				"only a ratio of 2 (1 core 2 threads) is allowed when spreading vCPUs over cores and threads"))
-			Expect(response.Result.Details.Causes[0].Field).To(Equal(k8sfield.NewPath("spec", "cpu", "spreadOptions", "ratio").String()))
+	DescribeTable("should reject when spreading vCPUs across CoresThreads with a ratio higher than 2",
+		func(testCase string, preferredTopology instancetypev1beta1.PreferredCPUTopology, useRatio bool) {
+			runSpreadingVCPUsTest(helper, testCase, preferredTopology, useRatio)
 		},
-		Entry("PreferSpreadSocketToCoreRatio with spread",
-			instancetypev1beta1.VirtualMachineClusterPreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferSpreadSocketToCoreRatio: uint32(3),
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.Spread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-						},
-					},
-				},
-			},
-		),
-		Entry("PreferSpreadSocketToCoreRatio with preferSpread",
-			instancetypev1beta1.VirtualMachineClusterPreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferSpreadSocketToCoreRatio: uint32(3),
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.DeprecatedPreferSpread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-						},
-					},
-				},
-			},
-		),
-		Entry("SpreadOptions with spread",
-			instancetypev1beta1.VirtualMachineClusterPreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.Spread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-							Ratio:  pointer.P(uint32(3)),
-						},
-					},
-				},
-			},
-		),
-		Entry("SpreadOptions with preferSpread",
-			instancetypev1beta1.VirtualMachineClusterPreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(instancetypev1beta1.DeprecatedPreferSpread),
-						SpreadOptions: &instancetypev1beta1.SpreadOptions{
-							Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
-							Ratio:  pointer.P(uint32(3)),
-						},
-					},
-				},
-			},
-		),
+		Entry("PreferSpreadSocketToCoreRatio with spread", "case1", instancetypev1beta1.Spread, false),
+		Entry("PreferSpreadSocketToCoreRatio with preferSpread", "case2", instancetypev1beta1.DeprecatedPreferSpread, false),
+		Entry("SpreadOptions with spread", "case3", instancetypev1beta1.Spread, true),
+		Entry("SpreadOptions with preferSpread", "case4", instancetypev1beta1.DeprecatedPreferSpread, true),
 	)
 
 	DescribeTable("should raise warning for",
-		func(deprecatedTopology, expectedAlternativeTopology instancetypev1beta1.PreferredCPUTopology) {
-			preferenceObj := &instancetypev1beta1.VirtualMachineClusterPreference{
-				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-					CPU: &instancetypev1beta1.CPUPreferences{
-						PreferredCPUTopology: pointer.P(deprecatedTopology),
-					},
-				},
-			}
-			ar := createClusterPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-			response := admitter.Admit(context.Background(), ar)
-			Expect(response.Allowed).To(BeTrue())
-			Expect(response.Warnings).To(HaveLen(1))
-			Expect(response.Warnings[0]).To(
-				ContainSubstring(
-					fmt.Sprintf("PreferredCPUTopology %s is deprecated for removal in a future release, please use %s instead",
-						deprecatedTopology,
-						expectedAlternativeTopology,
-					),
-				),
-			)
-		},
+		runWarningTest,
 		Entry("DeprecatedPreferSockets and provide Sockets as an alternative",
-			instancetypev1beta1.DeprecatedPreferSockets,
-			instancetypev1beta1.Sockets,
+			helper, instancetypev1beta1.DeprecatedPreferSockets, instancetypev1beta1.Sockets,
 		),
 		Entry("DeprecatedPreferCores and provide Cores as an alternative",
-			instancetypev1beta1.DeprecatedPreferCores,
-			instancetypev1beta1.Cores,
+			helper, instancetypev1beta1.DeprecatedPreferCores, instancetypev1beta1.Cores,
 		),
 		Entry("DeprecatedPreferThreads and provide Threads as an alternative",
-			instancetypev1beta1.DeprecatedPreferThreads,
-			instancetypev1beta1.Threads,
+			helper, instancetypev1beta1.DeprecatedPreferThreads, instancetypev1beta1.Threads,
 		),
 		Entry("DeprecatedPreferSpread and provide Spread as an alternative",
-			instancetypev1beta1.DeprecatedPreferSpread,
-			instancetypev1beta1.Spread,
+			helper, instancetypev1beta1.DeprecatedPreferSpread, instancetypev1beta1.Spread,
 		),
 		Entry("DeprecatedPreferAny and provide Any as an alternative",
-			instancetypev1beta1.DeprecatedPreferAny,
-			instancetypev1beta1.Any,
+			helper, instancetypev1beta1.DeprecatedPreferAny, instancetypev1beta1.Any,
 		),
 	)
 })


### PR DESCRIPTION
…ter_test.go

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
linter is flagging duplicate test cases. Specifically, it's detecting that lines 59-186 are very similar to lines 206-340
After this PR:
add a similar logic in helper function
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/14179

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

