### PR TITLE
net, e2e: Prepare for Fedora version upgrade

### DIFF
--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -381,7 +381,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 			Expect(libnet.PingFromVMConsole(anotherVMI, migrateVmiAfterMigIP)).To(Succeed())
 		},
 			Entry("[IPv4]", k8sv1.IPv4Protocol),
-			Entry("[IPv6]", k8sv1.IPv6Protocol),
+			Entry("[IPv6]", k8sv1.IPv6Protocol, decorators.Quarantine),
 		)
 	})
 }))

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -627,24 +627,37 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					linuxBridgeInterfaceWithCustomMac := linuxBridgeInterfaceWithMACSpoofCheck
 					libvmi.InterfaceWithMac(&linuxBridgeInterfaceWithCustomMac, initialMacAddressStr)
 
+					networkData, err := cloudinit.NewNetworkData(
+						cloudinit.WithEthernet(linuxBridgeInterfaceWithCustomMac.Name,
+							cloudinit.WithAddresses(vmUnderTestIPAddress+bridgeSubnetMask),
+							cloudinit.WithMatchingMAC(linuxBridgeInterfaceWithCustomMac.MacAddress),
+						),
+					)
+					Expect(err).NotTo(HaveOccurred())
+
 					vmiUnderTest := libvmifact.NewFedora(
 						libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 						libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-						libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
-							cloudinit.CreateNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask),
-						)),
-						libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
+						libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+						libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+					)
 					vmiUnderTest, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiUnderTest)).Create(context.Background(), vmiUnderTest, metav1.CreateOptions{})
 					ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 					By("Creating a target VM with Linux bridge CNI network interface and default MAC address.")
+					targetNetworkData, err := cloudinit.NewNetworkData(
+						cloudinit.WithEthernet("eth0",
+							cloudinit.WithAddresses(targetVMIPAddress+bridgeSubnetMask),
+						),
+					)
+					Expect(err).NotTo(HaveOccurred())
+
 					targetVmi := libvmifact.NewFedora(
 						libvmi.WithInterface(linuxBridgeInterfaceWithMACSpoofCheck),
 						libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-						libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
-							cloudinit.CreateNetworkDataWithStaticIPsByIface("eth0", targetVMIPAddress+bridgeSubnetMask),
-						)),
-						libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
+						libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(targetNetworkData)),
+						libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+					)
 					targetVmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(targetVmi)).Create(context.Background(), targetVmi, metav1.CreateOptions{})
 					ExpectWithOffset(1, err).ToNot(HaveOccurred())
 

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -443,16 +443,22 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 			BeforeEach(func() {
 				By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
+				networkData, err := cloudinit.NewNetworkData(
+					cloudinit.WithEthernet("eth1",
+						cloudinit.WithAddresses(ptpSubnetIP2+ptpSubnetMask),
+					),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
 				vmiTwo := libvmifact.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
-						cloudinit.CreateNetworkDataWithStaticIPsByIface("eth1", ptpSubnetIP2+ptpSubnetMask),
-					)),
-					libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmiTwo, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiTwo)).Create(context.Background(), vmiTwo, metav1.CreateOptions{})
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+					libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+				)
+				vmiTwo, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiTwo)).Create(context.Background(), vmiTwo, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToFedora)
 			})
@@ -461,16 +467,25 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
 				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
 				linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress
+
+				networkData, err := cloudinit.NewNetworkData(
+					cloudinit.WithEthernet("eth1",
+						cloudinit.WithAddresses(ptpSubnetIP1+ptpSubnetMask),
+						cloudinit.WithMatchingMAC(linuxBridgeInterfaceWithCustomMac.MacAddress),
+					),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
 				vmiOne := libvmifact.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
-						cloudinit.CreateNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask),
-					)),
-					libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmiOne, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiOne)).Create(context.Background(), vmiOne, metav1.CreateOptions{})
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+					libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+				)
+
+				vmiOne, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiOne)).Create(context.Background(), vmiOne, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				vmiOne = libwait.WaitUntilVMIReady(vmiOne, console.LoginToFedora)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the network e2e tests are using Fedora 35 which had reached EOL a long time ago.
Prepare the network e2e tests for the upgrade to Fedora 39.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
- https://github.com/kubevirt/kubevirt/pull/13322
- https://github.com/kubevirt/kubevirt/pull/13863

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

