### PR TITLE
VMRestore: Keep VM RunStrategy as before the restore

### DIFF
--- a/pkg/storage/snapshot/BUILD.bazel
+++ b/pkg/storage/snapshot/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/externalsnapshotter/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testing:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -31,6 +32,7 @@ import (
 	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
 	"kubevirt.io/client-go/kubecli"
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
+	kvtesting "kubevirt.io/client-go/testing"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
@@ -162,6 +164,12 @@ var _ = Describe("Restore controller", func() {
 		return vm
 	}
 
+	createRestoreInProgressVM := func() *kubevirtv1.VirtualMachine {
+		vm := createVirtualMachine(testNamespace, vmName)
+		vm.Status.RestoreInProgress = &vmRestoreName
+		return vm
+	}
+
 	createVMI := func(vm *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachineInstance {
 		return &kubevirtv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
@@ -231,8 +239,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var vmInterface *kubecli.MockVirtualMachineInterface
-
 		var vmRestoreSource *framework.FakeControllerSource
 		var vmRestoreInformer cache.SharedIndexInformer
 
@@ -299,7 +305,6 @@ var _ = Describe("Restore controller", func() {
 			stop = make(chan struct{})
 			ctrl = gomock.NewController(GinkgoT())
 			virtClient = kubecli.NewMockKubevirtClient(ctrl)
-			vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
 
 			vmRestoreInformer, vmRestoreSource = testutils.NewFakeInformerWithIndexersFor(&snapshotv1.VirtualMachineRestore{}, virtcontroller.GetVirtualMachineRestoreInformerIndexers())
 			vmSnapshotInformer, vmSnapshotSource = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
@@ -383,14 +388,6 @@ var _ = Describe("Restore controller", func() {
 			mockVMRestoreQueue.ExpectAdds(1)
 			vmSource.Add(vm)
 			mockVMRestoreQueue.Wait()
-		}
-
-		expectUpdateVMRestoreInProgress := func(vm *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine {
-			vmStatusUpdate := vm.DeepCopy()
-			vmStatusUpdate.ResourceVersion = "1"
-			vmStatusUpdate.Status.RestoreInProgress = &vmRestoreName
-			vmInterface.EXPECT().UpdateStatus(context.Background(), vmStatusUpdate, metav1.UpdateOptions{}).Return(vmStatusUpdate, nil).Times(1)
-			return vmStatusUpdate
 		}
 
 		Context("with initialized snapshot and content", func() {
@@ -535,7 +532,7 @@ var _ = Describe("Restore controller", func() {
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
-			It("should update restore, add finalizer and owner", func() {
+			It("should update restore with finalizer and owner and update vm that restore is in progress", func() {
 				r := createRestoreWithOwner()
 				finalizers := r.Finalizers
 				r.Finalizers = nil
@@ -552,7 +549,6 @@ var _ = Describe("Restore controller", func() {
 				rc.ResourceVersion = "1"
 				rc.Finalizers = finalizers
 				rc.OwnerReferences = ownerRefs
-				updateCalls := expectVMRestoreUpdate(kubevirtClient, rc)
 
 				rc2 := rc.DeepCopy()
 				rc2.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -563,21 +559,26 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 				addInitialVolumeRestores(rc2)
-				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
 
 				vm := createModifiedVM()
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
-
+				vmStatusUpdate := vm.DeepCopy()
+				vmStatusUpdate.ResourceVersion = "1"
+				vmStatusUpdate.Status.RestoreInProgress = &vmRestoreName
 				addVirtualMachineRestore(r)
+
+				updateCalls := expectVMRestoreUpdate(kubevirtClient, rc)
+				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
+				updateVMStatusCalls := expectVMUpdateStatus(kubevirtClient, vmStatusUpdate)
 				controller.processVMRestoreWorkItem()
 				Expect(*updateCalls).To(Equal(1))
 				Expect(*updateStatusCalls).To(Equal(1))
+				Expect(*updateVMStatusCalls).To(Equal(1))
 			})
 
 			It("should update restore status with condition and VolumeRestores", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -589,7 +590,6 @@ var _ = Describe("Restore controller", func() {
 				}
 				addInitialVolumeRestores(rc)
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -606,7 +606,7 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 				addVolumeRestores(r)
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -621,7 +621,6 @@ var _ = Describe("Restore controller", func() {
 				vmSource.Add(vm)
 				addVirtualMachineRestore(r)
 
-				expectUpdateVMRestoreInProgress(vm)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				controller.processVMRestoreWorkItem()
 				Expect(*updateStatusCalls).To(Equal(1))
@@ -629,7 +628,7 @@ var _ = Describe("Restore controller", func() {
 
 			It("should create restore PVCs", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
@@ -642,7 +641,6 @@ var _ = Describe("Restore controller", func() {
 				pvcSize := resource.MustParse("2Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
 				fakeVolumeSnapshotProvider.Add(vs)
-				expectUpdateVMRestoreInProgress(vm)
 				calls := expectPVCCreates(k8sClient, r, pvcSize)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -665,7 +663,7 @@ var _ = Describe("Restore controller", func() {
 					VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk2",
 				})
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				// create extra pvc
 				pvcs := createPVCsForVM(vm)
 				pvcs = append(pvcs, corev1.PersistentVolumeClaim{
@@ -719,7 +717,6 @@ var _ = Describe("Restore controller", func() {
 				vmSource.Add(vm)
 				addVirtualMachineRestore(r)
 
-				expectUpdateVMRestoreInProgress(vm)
 				calls := expectPVCCreates(k8sClient, r, pvcSize)
 				controller.processVMRestoreWorkItem()
 				Expect(*calls).To(Equal(2))
@@ -727,7 +724,7 @@ var _ = Describe("Restore controller", func() {
 
 			It("should create restore PVC with volume snapshot size if bigger then PVC size", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
@@ -740,7 +737,6 @@ var _ = Describe("Restore controller", func() {
 				q := resource.MustParse("3Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
 				fakeVolumeSnapshotProvider.Add(vs)
-				expectUpdateVMRestoreInProgress(vm)
 				calls := expectPVCCreates(k8sClient, r, q)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -749,7 +745,7 @@ var _ = Describe("Restore controller", func() {
 
 			It("should create restore PVC with pvc size if restore size is smaller", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
@@ -762,7 +758,6 @@ var _ = Describe("Restore controller", func() {
 				q := resource.MustParse("1Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
 				fakeVolumeSnapshotProvider.Add(vs)
-				expectUpdateVMRestoreInProgress(vm)
 				pvcSize := resource.MustParse("2Gi")
 				calls := expectPVCCreates(k8sClient, r, pvcSize)
 				addVirtualMachineRestore(r)
@@ -781,14 +776,13 @@ var _ = Describe("Restore controller", func() {
 				}
 				addVolumeRestores(r)
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				vmSource.Add(vm)
 				vmRestoreSource.Add(r)
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Status.Phase = corev1.ClaimPending
 					addPVC(&pvc)
 				}
-				expectUpdateVMRestoreInProgress(vm)
 				controller.processVMRestoreWorkItem()
 			})
 
@@ -818,7 +812,7 @@ var _ = Describe("Restore controller", func() {
 				vm.Status.RestoreInProgress = &vmRestoreName
 				vmSource.Add(vm)
 				uvm := vm.DeepCopy()
-				uvm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+				uvm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 				uvm.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
 				uvm.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
 				for _, pvc := range getRestorePVCs(r) {
@@ -859,9 +853,8 @@ var _ = Describe("Restore controller", func() {
 					ur.Status.Restores[i].DataVolumeName = &ur.Status.Restores[i].PersistentVolumeClaimName
 				}
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
 				vmRestoreSource.Add(r)
 				pvcUpdateCalls := expectPVCUpdates(k8sClient, ur)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, ur)
@@ -976,9 +969,8 @@ var _ = Describe("Restore controller", func() {
 				}
 				vmRestoreSource.Add(r)
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				vm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
-				vm.Status.RestoreInProgress = &vmRestoreName
 
 				for _, n := range r.Status.DeletedDataVolumes {
 					dv := &cdiv1.DataVolume{
@@ -1000,7 +992,6 @@ var _ = Describe("Restore controller", func() {
 				updatedVM := vm.DeepCopy()
 				updatedVM.ResourceVersion = "1"
 				updatedVM.Status.RestoreInProgress = nil
-				vmInterface.EXPECT().UpdateStatus(context.Background(), updatedVM, metav1.UpdateOptions{}).Return(updatedVM, nil).Times(1)
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
@@ -1011,6 +1002,7 @@ var _ = Describe("Restore controller", func() {
 					newReadyCondition(corev1.ConditionTrue, "Operation complete"),
 				}
 
+				updateVMStatusCalls := expectVMUpdateStatus(kubevirtClient, updatedVM)
 				dvDeleteCalls := expectDataVolumeDeletes(cdiClient, r.Status.DeletedDataVolumes)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, ur)
 
@@ -1019,6 +1011,7 @@ var _ = Describe("Restore controller", func() {
 				l, err := cdiClient.CdiV1beta1().DataVolumes("").List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(l.Items).To(BeEmpty())
+				Expect(*updateVMStatusCalls).To(Equal(1))
 				Expect(*updateStatusCalls).To(Equal(1))
 				Expect(*dvDeleteCalls).To(Equal(len(r.Status.DeletedDataVolumes)))
 			})
@@ -1044,7 +1037,7 @@ var _ = Describe("Restore controller", func() {
 						Namespace: testNamespace,
 						UID:       vmUID,
 						Annotations: map[string]string{
-							"restore.kubevirt.io/lastRestoreUID": "restore-uid",
+							lastRestoreAnnotation: "restore-uid",
 						},
 					},
 				}
@@ -1086,7 +1079,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createModifiedVM()
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+				vm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
 				vmRestoreSource.Add(r)
 				addVM(vm)
@@ -1117,7 +1110,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createModifiedVM()
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+				vm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
 				vmRestoreSource.Add(r)
 				addVM(vm)
@@ -1142,15 +1135,13 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 
-				vm := createModifiedVM()
-				vm.Status.RestoreInProgress = &vmRestoreName
+				vm := createRestoreInProgressVM()
 
 				vmRestoreSource.Add(r)
 				addVM(vm)
 
 				vmUpdated := vm.DeepCopy()
 				vmUpdated.Status.RestoreInProgress = nil
-				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdated, metav1.UpdateOptions{}).Return(vmUpdated, nil).Times(1)
 
 				updatedVMRestore := r.DeepCopy()
 				updatedVMRestore.Status.Conditions = []snapshotv1.Condition{
@@ -1159,8 +1150,10 @@ var _ = Describe("Restore controller", func() {
 				}
 				updatedVMRestore.ResourceVersion = "1"
 
+				updateVMStatusCalls := expectVMUpdateStatus(kubevirtClient, vmUpdated)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, updatedVMRestore)
 				controller.processVMRestoreWorkItem()
+				Expect(*updateVMStatusCalls).To(Equal(1))
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
@@ -1197,8 +1190,7 @@ var _ = Describe("Restore controller", func() {
 				BeforeEach(func() {
 					r = createRestoreWithOwner()
 					addVolumeRestores(r)
-					vm = createModifiedVM()
-					vm.Status.RestoreInProgress = &vmRestoreName
+					vm = createRestoreInProgressVM()
 					targetVM, _ = controller.getTarget(r)
 					targetVM.UpdateTarget(vm)
 				})
@@ -1237,23 +1229,20 @@ var _ = Describe("Restore controller", func() {
 					pvcSource.Add(&pvc)
 					return calls
 				}
-				expectUpdateRestoredVM := func() {
-					updatedVM := createSnapshotVM()
-					updatedVM.Status.RestoreInProgress = &vmRestoreName
-					updatedVM.ResourceVersion = "1"
-					updatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-					updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
-					updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
-					vmInterface.EXPECT().Update(context.Background(), updatedVM, metav1.UpdateOptions{}).Return(updatedVM, nil).Times(1)
-				}
 
 				DescribeTable("should", func(dvExists bool, phase cdiv1.DataVolumePhase, expecteUpdateVM bool) {
 					dvCreateCalls := addRestoreVolumes(dvExists, phase)
 
 					vmRestoreSource.Add(r)
 					addVM(vm)
-					if expecteUpdateVM == false {
-						expectUpdateRestoredVM()
+					updateVMCalls := pointer.P(0)
+					if expecteUpdateVM {
+						updatedVM := vm.DeepCopy()
+						updatedVM.ResourceVersion = "1"
+						updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+						updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
+						updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
+						updateVMCalls = expectVMUpdate(kubevirtClient, updatedVM)
 					}
 					res, err := targetVM.Reconcile()
 					Expect(err).ShouldNot(HaveOccurred())
@@ -1261,11 +1250,14 @@ var _ = Describe("Restore controller", func() {
 					if dvCreateCalls != nil {
 						Expect(*dvCreateCalls).To(Equal(1))
 					}
+					if expecteUpdateVM {
+						Expect(*updateVMCalls).To(Equal(1))
+					}
 				},
-					Entry("update VM spec when dv phase succeeded", true, cdiv1.Succeeded, false),
-					Entry("update VM spec when dv phase WFFC", true, cdiv1.WaitForFirstConsumer, false),
-					Entry("wait for dvs when dv phase pending", true, cdiv1.Pending, true),
-					Entry("create dvs when dv doesnt exists", false, cdiv1.PhaseUnset, true),
+					Entry("update VM spec when dv phase succeeded", true, cdiv1.Succeeded, true),
+					Entry("update VM spec when dv phase WFFC", true, cdiv1.WaitForFirstConsumer, true),
+					Entry("wait for dvs when dv phase pending", true, cdiv1.Pending, false),
+					Entry("create dvs when dv doesnt exists", false, cdiv1.PhaseUnset, false),
 				)
 			})
 
@@ -1278,7 +1270,7 @@ var _ = Describe("Restore controller", func() {
 					vmSnapshotContentSource.Modify(sc)
 					By("Creating new VM")
 					newVM := createVirtualMachine(testNamespace, newVMName)
-					newVM.UID = ""
+					newVM.UID = newVMUID
 
 					By("Creating VM restore")
 					vmRestore := createRestoreWithOwner()
@@ -1302,7 +1294,7 @@ var _ = Describe("Restore controller", func() {
 					newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = *vmRestore.Status.Restores[0].DataVolumeName
 					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
-					vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil).Times(1)
+					createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 
 					By("Making sure right VMRestore update occurs")
 					updatedVMRestore := vmRestore.DeepCopy()
@@ -1316,6 +1308,7 @@ var _ = Describe("Restore controller", func() {
 
 					By("Running the controller")
 					controller.processVMRestoreWorkItem()
+					Expect(*createVMCalls).To(Equal(1))
 					Expect(*pvcUpdateCalls).To(Equal(1))
 					Expect(*updateStatusCalls).To(Equal(1))
 				})
@@ -1325,7 +1318,7 @@ var _ = Describe("Restore controller", func() {
 					newVM := createVirtualMachine(testNamespace, newVMName)
 					newVM.Status.RestoreInProgress = &vmRestoreName
 					newVM.UID = newVMUID
-					newVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 					vmSource.Add(newVM)
 
 					By("Creating VM restore")
@@ -1421,37 +1414,39 @@ var _ = Describe("Restore controller", func() {
 						r.Spec.Patches = []string{changeNamePatch}
 
 						newVM := createVirtualMachine(testNamespace, newVmName)
-						newVM.UID = ""
+						newVM.UID = newVMUID
 						newVM.Spec.DataVolumeTemplates[0].Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
-						vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil).Times(1)
+						createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 
 						targetVM, err := controller.getTarget(r)
 						Expect(err).ShouldNot(HaveOccurred())
 						success, err := targetVM.Reconcile()
 						Expect(success).To(BeTrue())
 						Expect(err).ShouldNot(HaveOccurred())
+						Expect(*createVMCalls).To(Equal(1))
 					})
 
 					It("with changed name and MAC address", func() {
 						r.Spec.Patches = []string{changeNamePatch, changeMacAddressPatch}
 
 						newVM := createVirtualMachine(testNamespace, newVmName)
-						newVM.UID = ""
+						newVM.UID = newVMUID
 						newVM.Spec.DataVolumeTemplates[0].Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 						newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = newMacAddress
 
-						vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil).Times(1)
+						createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 
 						targetVM, err := controller.getTarget(r)
 						Expect(err).ShouldNot(HaveOccurred())
 						success, err := targetVM.Reconcile()
 						Expect(success).To(BeTrue())
 						Expect(err).ShouldNot(HaveOccurred())
+						Expect(*createVMCalls).To(Equal(1))
 					})
 
 				})
@@ -1551,12 +1546,14 @@ var _ = Describe("Restore controller", func() {
 					}
 					vmSource.Add(vm)
 					vmiSource.Add(vmi)
-					vmInterface.EXPECT().Stop(context.Background(), vm.Name, &kubevirtv1.StopOptions{}).Return(nil).Times(1)
+					stopCalled := expectVMStop(kubevirtClient)
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
+
 					controller.processVMRestoreWorkItem()
 					testutils.ExpectEvent(recorder, "RestoreTargetNotReady")
 					Expect(*updateStatusCalls).To(Equal(1))
+					Expect(*stopCalled).To(Equal(1))
 				})
 
 				It("default - GracePeriodAndFail - should fail when grace period passed", func() {
@@ -1611,9 +1608,8 @@ var _ = Describe("Restore controller", func() {
 					addInitialVolumeRestores(rc)
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 
-					vm := createModifiedVM()
+					vm := createRestoreInProgressVM()
 					vmSource.Add(vm)
-					expectUpdateVMRestoreInProgress(vm)
 
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
@@ -1667,7 +1663,7 @@ var _ = Describe("Restore controller", func() {
 
 		It("should create restore PVCs with populated dataSourceRef and dataSource", func() {
 			// Mock the restore environment from scratch, so we use source PVCs with dataSourceRef
-			vm := createSnapshotVM()
+			vm := createRestoreInProgressVM()
 			pvcs := createPVCsForVMWithDataSourceRef(vm)
 			s := createSnapshot()
 			sc := createVirtualMachineSnapshotContent(s, vm, pvcs)
@@ -1677,13 +1673,13 @@ var _ = Describe("Restore controller", func() {
 				CreationTime: timeFunc(),
 				ReadyToUse:   pointer.P(true),
 			}
+			vmSource.Add(vm)
 			vmSnapshotSource.Add(s)
 			vmSnapshotContentSource.Add(sc)
 			storageClassSource.Add(storageClass)
 
 			// Actual test
 			r := createRestoreWithOwner()
-			vm = createModifiedVM()
 			r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 				Complete: pointer.P(false),
 				Conditions: []snapshotv1.Condition{
@@ -1691,12 +1687,10 @@ var _ = Describe("Restore controller", func() {
 					newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
 				},
 			}
-			vmSource.Add(vm)
 			addVolumeRestores(r)
 			pvcSize := resource.MustParse("2Gi")
 			vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
 			fakeVolumeSnapshotProvider.Add(vs)
-			expectUpdateVMRestoreInProgress(vm)
 			calls := expectPVCCreateWithDataSourceRef(k8sClient, r, pvcSize)
 			addVirtualMachineRestore(r)
 			controller.processVMRestoreWorkItem()
@@ -1719,29 +1713,6 @@ var _ = Describe("Restore controller", func() {
 
 			const vmCreationFailureMessage = "something failed during VirtualMachine creation"
 
-			expectCreateVM := func(vm *kubevirtv1.VirtualMachine) {
-				newVMUID := vm.UID
-				vm.UID = ""
-				vm.ResourceVersion = ""
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-				vmInterface.EXPECT().
-					Create(context.Background(), vm, metav1.CreateOptions{}).
-					Do(func(ctx context.Context, newVM *kubevirtv1.VirtualMachine, options metav1.CreateOptions) {
-						vm.UID = newVMUID
-					}).Return(vm, nil).Times(1)
-			}
-
-			expectUpdateVMRestored := func(vm *kubevirtv1.VirtualMachine) {
-				expectedUpdatedVM := vm.DeepCopy()
-				expectedUpdatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-				vmInterface.EXPECT().
-					Update(context.Background(), expectedUpdatedVM, metav1.UpdateOptions{}).
-					Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
-						updatedVM := obj.(*kubevirtv1.VirtualMachine)
-						Expect(*updatedVM).To(Equal(*expectedUpdatedVM))
-					}).Return(expectedUpdatedVM, nil).Times(1)
-			}
-
 			expectUpdateVMRestoreUpdatingTargetSpec := func(vmRestore *snapshotv1.VirtualMachineRestore, resourceVersion string) *int {
 				expectedUpdatedRestore := vmRestore.DeepCopy()
 				expectedUpdatedRestore.ResourceVersion = resourceVersion
@@ -1762,18 +1733,6 @@ var _ = Describe("Restore controller", func() {
 				return expectVMRestoreUpdateStatus(kubevirtClient, expectedUpdatedRestore)
 			}
 
-			expectCreateVMFailure := func(vm *kubevirtv1.VirtualMachine) {
-				newVMUID := vm.UID
-				vm.UID = ""
-				vm.ResourceVersion = ""
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-				vmInterface.EXPECT().
-					Create(context.Background(), vm, metav1.CreateOptions{}).
-					Do(func(ctx context.Context, newVM *kubevirtv1.VirtualMachine, options metav1.CreateOptions) {
-						vm.UID = newVMUID
-					}).Return(vm, fmt.Errorf(vmCreationFailureMessage))
-			}
-
 			getInstancetypeOriginalCR := func() *appsv1.ControllerRevision { return instancetypeOriginalCR }
 			getPreferenceOriginalCR := func() *appsv1.ControllerRevision { return preferenceOriginalCR }
 			nilInstancetypeMatcher := func() *kubevirtv1.InstancetypeMatcher { return nil }
@@ -1782,7 +1741,7 @@ var _ = Describe("Restore controller", func() {
 			BeforeEach(func() {
 				virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
 
-				originalVM = createSnapshotVM()
+				originalVM = createRestoreInProgressVM()
 				originalVM.Spec.DataVolumeTemplates = []kubevirtv1.DataVolumeTemplateSpec{}
 				restore = createRestoreWithOwner()
 
@@ -1809,7 +1768,6 @@ var _ = Describe("Restore controller", func() {
 				preferenceOriginalCR, err = instancetype.CreateControllerRevision(originalVM, preferenceObj)
 				Expect(err).ToNot(HaveOccurred())
 				crSource.Add(preferenceOriginalCR)
-
 				preferenceSnapshotCR = createInstancetypeVirtualMachineSnapshotCR(originalVM, vmSnapshot, preferenceObj)
 				crSource.Add(preferenceSnapshotCR)
 			})
@@ -1824,13 +1782,15 @@ var _ = Describe("Restore controller", func() {
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Preference = getSnapshotPreferenceMatcher()
 					vmSnapshotContentSource.Add(vmSnapshotContent)
 
-					updatedVM := expectUpdateVMRestoreInProgress(originalVM)
-					expectUpdateVMRestored(updatedVM)
+					updatedVM := originalVM.DeepCopy()
+					updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+					updateVMCalls := expectVMUpdate(kubevirtClient, updatedVM)
 					calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "1")
 
 					addVirtualMachineRestore(restore)
 					controller.processVMRestoreWorkItem()
 					Expect(*calls).To(Equal(1))
+					Expect(*updateVMCalls).To(Equal(1))
 				},
 				Entry("and referenced instancetype",
 					func() *kubevirtv1.InstancetypeMatcher {
@@ -1878,7 +1838,9 @@ var _ = Describe("Restore controller", func() {
 					// Ensure we restore into a new VM
 					newVM := originalVM.DeepCopy()
 					newVM.Name = "newvm"
-					newVM.UID = "newvm-uid"
+					newVM.UID = ""
+					newVM.ResourceVersion = ""
+					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 					restore.Spec.Target.Name = newVM.Name
 
 					originalCR := getExpectedCR()
@@ -1893,6 +1855,7 @@ var _ = Describe("Restore controller", func() {
 
 					expectedUpdatedCR := expectedCreatedCR.DeepCopy()
 					expectedUpdatedCR.ResourceVersion = "5"
+					newVM.UID = newVMUID
 					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, kubevirtv1.VirtualMachineGroupVersionKind)}
 					crUpdates := expectControllerRevisionUpdate(k8sClient, expectedUpdatedCR)
 
@@ -1902,7 +1865,7 @@ var _ = Describe("Restore controller", func() {
 					if newVM.Spec.Preference != nil {
 						newVM.Spec.Preference.RevisionName = expectedCreatedCR.Name
 					}
-					expectCreateVM(newVM)
+					createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 					calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "1")
 
 					addVirtualMachineRestore(restore)
@@ -1910,6 +1873,7 @@ var _ = Describe("Restore controller", func() {
 					Expect(*calls).To(Equal(1))
 					Expect(*crCreates).To(Equal(1))
 					Expect(*crUpdates).To(Equal(1))
+					Expect(*createVMCalls).To(Equal(1))
 				},
 				Entry("and referenced instancetype",
 					func() *kubevirtv1.InstancetypeMatcher {
@@ -1955,8 +1919,10 @@ var _ = Describe("Restore controller", func() {
 
 					// Ensure we restore into a new VM
 					newVM := originalVM.DeepCopy()
+					newVM.UID = newVMUID
+					newVM.ResourceVersion = ""
 					newVM.Name = "newvm"
-					newVM.UID = "newvm-uid"
+					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 					restore.Spec.Target.Name = newVM.Name
 
 					originalCR := getExpectedCR()
@@ -1981,15 +1947,16 @@ var _ = Describe("Restore controller", func() {
 						newVM.Spec.Preference.RevisionName = expectedCreatedCR.Name
 					}
 
-					expectCreateVMFailure(newVM)
+					createVMFailureCalls := expectVMCreateFailure(kubevirtClient, vmCreationFailureMessage)
 					failCalls := expectUpdateVMRestoreFailure(restore, "1", vmCreationFailureMessage)
 
 					addVirtualMachineRestore(restore)
 					controller.processVMRestoreWorkItem()
+					Expect(*createVMFailureCalls).To(Equal(1))
 
 					// We have already created the ControllerRevision but that shouldn't stop the reconcile from progressing
 					alreadyExistsCalls := expectCreateControllerRevisionAlreadyExists(k8sClient, expectedCreatedCR)
-					expectCreateVM(newVM)
+					createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 					calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "2")
 
 					addVirtualMachineRestore(restore)
@@ -1999,6 +1966,7 @@ var _ = Describe("Restore controller", func() {
 					Expect(*crCreates).To(Equal(1))
 					Expect(*alreadyExistsCalls).To(Equal(1))
 					Expect(*crUpdates).To(Equal(1))
+					Expect(*createVMCalls).To(Equal(1))
 				},
 				Entry("and referenced instancetype",
 					func() *kubevirtv1.InstancetypeMatcher {
@@ -2061,8 +2029,9 @@ var _ = Describe("Restore controller", func() {
 				crDeletes := expectControllerRevisionDelete(k8sClient, instancetypeOriginalCR.Name)
 				crCreates := expectControllerRevisionCreate(k8sClient, instancetypeOriginalCRCopy)
 
-				updatedVM := expectUpdateVMRestoreInProgress(originalVM)
-				expectUpdateVMRestored(updatedVM)
+				updatedVM := originalVM.DeepCopy()
+				updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+				updateVMCalls := expectVMUpdate(kubevirtClient, updatedVM)
 				calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "1")
 
 				addVirtualMachineRestore(restore)
@@ -2070,10 +2039,46 @@ var _ = Describe("Restore controller", func() {
 				Expect(*calls).To(Equal(1))
 				Expect(*crCreates).To(Equal(1))
 				Expect(*crDeletes).To(Equal(1))
+				Expect(*updateVMCalls).To(Equal(1))
 			})
 		})
 	})
 })
+
+func expectVMCreateFailure(client *kubevirtfake.Clientset, failureMsg string) *int {
+	calls := 0
+	client.Fake.PrependReactor("create", "virtualmachines", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		create, ok := action.(testing.CreateAction)
+		Expect(ok).To(BeTrue())
+
+		_, ok = create.GetObject().(*kubevirtv1.VirtualMachine)
+		Expect(ok).To(BeTrue())
+
+		calls++
+
+		return true, nil, fmt.Errorf(failureMsg)
+	})
+	return &calls
+}
+
+func expectVMCreate(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachine, newVMUID types.UID) *int {
+	calls := 0
+	client.Fake.PrependReactor("create", "virtualmachines", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		create, ok := action.(testing.CreateAction)
+		Expect(ok).To(BeTrue())
+
+		createObj, ok := create.GetObject().(*kubevirtv1.VirtualMachine)
+		Expect(ok).To(BeTrue())
+
+		calls++
+		createObj.UID = newVMUID
+		Expect(createObj.ObjectMeta).To(Equal(vm.ObjectMeta))
+		Expect(createObj.Spec).To(Equal(vm.Spec))
+
+		return true, createObj, nil
+	})
+	return &calls
+}
 
 func expectVMUpdate(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachine) *int {
 	calls := 0
@@ -2090,6 +2095,37 @@ func expectVMUpdate(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachin
 		return true, update.GetObject(), nil
 	})
 	return &calls
+}
+
+func expectVMUpdateStatus(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachine) *int {
+	calls := 0
+	client.Fake.PrependReactor("update", "virtualmachines", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		update, ok := action.(testing.UpdateAction)
+		Expect(ok).To(BeTrue())
+		if update.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+
+		updateObj := update.GetObject().(*kubevirtv1.VirtualMachine)
+		Expect(vm.Status).To(Equal(updateObj.Status))
+
+		calls++
+
+		return true, update.GetObject(), nil
+	})
+	return &calls
+}
+
+func expectVMStop(client *kubevirtfake.Clientset) *int {
+	stopCalled := 0
+	client.Fake.PrependReactor("put", "virtualmachines/stop", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		_, ok := action.(kvtesting.PutAction[*kubevirtv1.StopOptions])
+		Expect(ok).To(BeTrue())
+
+		stopCalled++
+		return true, nil, nil
+	})
+	return &stopCalled
 }
 
 func expectPVCCreates(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMachineRestore, expectedSize resource.Quantity) *int {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -320,18 +320,19 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			var err error
 			var snapshot *snapshotv1.VirtualMachineSnapshot
 
-			runStrategyHalted := v1.RunStrategyHalted
-
 			AfterEach(func() {
 				deleteSnapshot(snapshot)
 			})
 
 			It("should successfully restore", func() {
-				vm.Spec.RunStrategy = &runStrategyHalted
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyRerunOnFailure)
 				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
 				snapshot = createSnapshot(vm)
 
+				vm = libvmops.StopVirtualMachine(vm)
+				Expect(vm.Spec.RunStrategy).To(HaveValue(Equal(v1.RunStrategyRerunOnFailure)))
 				restore := createRestoreDef(vm.Name, snapshot.Name)
 
 				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
@@ -340,6 +341,9 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				restore = waitRestoreComplete(restore, vm.Name, &vm.UID)
 				Expect(restore.Status.Restores).To(BeEmpty())
 				Expect(restore.Status.DeletedDataVolumes).To(BeEmpty())
+				restoredVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(restoredVM.Spec.RunStrategy).To(Equal(pointer.P(v1.RunStrategyRerunOnFailure)))
 			})
 		})
 


### PR DESCRIPTION
When restoring a VM to its previous state, the runstrategy should remain unchanged and not automatically update to "Halted." Since the target VM being restored is the same as the original, it means that the user has already stopped the VM before initiating the restore. As a result, not altering the runstrategy ensures that the VM doesn't start during the restore.

This change also addresses a potential bug where, when a snapshot was taken, the VM could have either the Running field or the Runstrategy field. Without this update, this discrepancy could lead to errors when updating the VM, as both Running and Runstrategy might be applied simultaneously.

For new VMs, the runstrategy should be explicitly set to "Halted" to prevent the VM from starting automatically during the restore process.

Additionally, unit tests have been added to verify this behavior, which was previously untested. A check has also been implemented to ensure that the runstrategy for new VMs is always set to "Halted." Finally, a real expectation of the update has been added to ensure that the update is actually performed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-54440

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMRestore: Keep VM RunStrategy as before the restore
```

