### PR TITLE
Don't expose as VMI status the implicit qemu domain pause at the end of live migration

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1167,11 +1167,7 @@ func (c *VirtualMachineController) updatePausedConditions(vmi *v1.VirtualMachine
 	// Update paused condition in case VMI was paused / unpaused
 	if domain != nil && domain.Status.Status == api.Paused {
 		if !condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
-			reason := domain.Status.Reason
-			if c.isVMIPausedDuringMigration(vmi) {
-				reason = api.ReasonPausedMigration
-			}
-			calculatePausedCondition(vmi, reason)
+			c.calculatePausedCondition(vmi, domain.Status.Reason)
 		}
 	} else if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
 		log.Log.Object(vmi).V(3).Info("Removing paused condition")
@@ -1464,11 +1460,15 @@ func (c *VirtualMachineController) recordPhaseChangeEvent(vmi *v1.VirtualMachine
 	}
 }
 
-func calculatePausedCondition(vmi *v1.VirtualMachineInstance, reason api.StateChangeReason) {
+func (c *VirtualMachineController) calculatePausedCondition(vmi *v1.VirtualMachineInstance, reason api.StateChangeReason) {
 	now := metav1.NewTime(time.Now())
 	switch reason {
 	case api.ReasonPausedMigration:
-		log.Log.Object(vmi).V(3).Info("Adding paused condition")
+		if !isVMIPausedDuringMigration(vmi) || !c.isMigrationSource(vmi) {
+			log.Log.Object(vmi).V(3).Infof("Domain is paused after migration by qemu, no condition needed")
+			return
+		}
+		log.Log.Object(vmi).V(3).Info("Adding paused by migration monitor condition")
 		vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
 			Type:               v1.VirtualMachineInstancePaused,
 			Status:             k8sv1.ConditionTrue,
@@ -2524,7 +2524,7 @@ func (c *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 	return
 }
 
-func (c *VirtualMachineController) isVMIPausedDuringMigration(vmi *v1.VirtualMachineInstance) bool {
+func isVMIPausedDuringMigration(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Status.MigrationState != nil &&
 		vmi.Status.MigrationState.Mode == v1.MigrationPaused &&
 		!vmi.Status.MigrationState.Completed

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -241,9 +241,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 	AfterEach(func() {
 		close(stop)
 		wg.Wait()
-
+		var events []string
 		// Ensure that we add checks for expected events to every test
-		Expect(recorder.Events).To(BeEmpty())
+		for len(recorder.Events) > 0 {
+			events = append(events, <-recorder.Events)
+		}
+		Expect(events).To(BeEmpty(), "unexpected events: %+v", events)
 	})
 
 	addDomain := func(domain *api.Domain) {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -292,6 +292,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 		dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds = gracePeriod
 	}
 
+	vmiWithResourceVersion := func(resourceVersion string) libvmi.Option {
+		return func(vmi *v1.VirtualMachineInstance) {
+			vmi.ObjectMeta.ResourceVersion = resourceVersion
+		}
+	}
+
+	vmiWithUID := func(uid types.UID) libvmi.Option {
+		return func(vmi *v1.VirtualMachineInstance) {
+			vmi.UID = uid
+		}
+	}
+
 	Context("VirtualMachineInstance controller gets informed about a Domain change through the Domain controller", func() {
 		BeforeEach(func() {
 			diskutils.MockDefaultOwnershipManager()
@@ -918,57 +930,69 @@ var _ = Describe("VirtualMachineInstance", func() {
 			))
 		})
 
-		It("should add and remove paused condition", func() {
-			vmi := api2.NewMinimalVMI("testvmi")
-			vmi.UID = vmiTestUUID
-			vmi.ObjectMeta.ResourceVersion = "1"
-			vmi.Status.Phase = v1.Running
-			vmi = addActivePods(vmi, podTestUUID, host)
+		type domainIsPausedTest struct {
+			domainStateChangeReason api.StateChangeReason
+			vmiMigrationState       v1.VirtualMachineInstanceMigrationState
+			expectPausedCondition   bool
+			expectEvents            bool
+		}
+		DescribeTable("when domain is paused", func(td domainIsPausedTest) {
+			vmi := libvmi.New(
+				libvmi.WithNamespace(k8sv1.NamespaceDefault),
+				vmiWithResourceVersion("1"),
+				vmiWithUID(vmiTestUUID),
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithPhase(v1.Running),
+					libvmistatus.WithMigrationState(td.vmiMigrationState),
+					libvmistatus.WithActivePod(podTestUUID, host),
+				)),
+			)
 
-			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain := api.NewMinimalDomainWithUUID(vmi.Name, vmiTestUUID)
 
 			By("pausing domain")
 			domain.Status.Status = api.Paused
-			domain.Status.Reason = api.ReasonPausedUser
+			domain.Status.Reason = td.domainStateChangeReason
 
 			addVMI(vmi)
 			addDomain(domain)
 			createVMI(vmi)
 
-			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
-			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
-			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().MigrateVirtualMachine(gomock.Any(), gomock.Any()).AnyTimes()
+			client.EXPECT().SyncVirtualMachine(gomock.Any(), gomock.Any()).AnyTimes()
+			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil).AnyTimes()
+			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil).AnyTimes()
 
 			sanityExecute()
 
 			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.Conditions).To(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
+
+			if !td.expectPausedCondition {
+				Expect(updatedVMI.Status.Conditions).ToNot(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(v1.VirtualMachineInstancePaused),
+						"Status": Equal(k8sv1.ConditionTrue)},
+					)),
+				)
+				return
+			}
+
+			Expect(updatedVMI.Status.Conditions).To(ContainElements(
 				MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(v1.VirtualMachineInstancePaused),
 					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-			))
+				)),
+			)
+			expectEvent(VMIMigrating, td.expectEvents)
 
 			By("unpausing domain")
 			domain = domain.DeepCopy()
 			domain.Status.Status = api.Running
-			domain.Status.Reason = ""
+			domain.Status.Reason = td.domainStateChangeReason
 
 			addVMI(updatedVMI.DeepCopy())
 			addDomain(domain)
-
-			client.EXPECT().SyncVirtualMachine(updatedVMI, gomock.Any())
-			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
-			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
 
 			Expect(controller.domainStore.List()).To(ConsistOf(domain))
 			// TODO split this test
@@ -979,17 +1003,36 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			updatedVMI, err = virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.Conditions).To(ConsistOf(
+			Expect(updatedVMI.Status.Conditions).NotTo(ContainElements(
 				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
+					"Type":   Equal(v1.VirtualMachineInstancePaused),
 					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
-					"Status": Equal(k8sv1.ConditionTrue)},
-				),
-			))
-		})
+				)))
+			expectEvent(VMIMigrating, td.expectEvents)
+		},
+			Entry("by user should add and remove paused condition", domainIsPausedTest{
+				domainStateChangeReason: api.ReasonPausedUser,
+				expectPausedCondition:   true,
+			}),
+			Entry("by migration monitor should add and remove paused condition", domainIsPausedTest{
+				domainStateChangeReason: api.ReasonPausedMigration,
+				vmiMigrationState: v1.VirtualMachineInstanceMigrationState{
+					Mode:                           v1.MigrationPaused,
+					Completed:                      false,
+					TargetNode:                     "othernode",
+					TargetNodeAddress:              "127.0.0.1:12345",
+					SourceNode:                     host,
+					MigrationUID:                   "123",
+					TargetDirectMigrationNodePorts: map[string]int{"49152": 12132},
+				},
+				expectPausedCondition: true,
+				expectEvents:          true,
+			}),
+			Entry("by qemu during migration should skip paused condition", domainIsPausedTest{
+				domainStateChangeReason: api.ReasonPausedMigration,
+				expectPausedCondition:   false,
+			}),
+		)
 
 		It("should move VirtualMachineInstance from Scheduled to Failed if watchdog file is missing", func() {
 			cmdclient.MarkSocketUnresponsive(sockFile)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
At the end of live migration usually qemu do a super short domain pause to ensure that final bytes are copied, this is part of normal live migration flow and should not be exposed or affect statuses around but after merging [AllowWorkloadDisruption PR](https://github.com/kubevirt/kubevirt/pull/11833) that is exposes as a VMI statatus making VMI not ready for long time during live migration and breaking ingress tcp connections.

After this PR:
This change make sure that the status is modified only if the allow disruption at workload during live migration mechanism kicks in.

Fixed https://issues.redhat.com/browse/CNV-58354

### Why we need it and why it was done in this way
The following tradeoffs were made:
Kubevirt live migration should work the same on normal workflow

The following alternatives were considered:
N/A

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Don't expose as VMI status the implicit qemu domain pause at the end of live migration
```

