### PR TITLE
tests: Fail if command is not found

### DIFF
--- a/hack/ci/entrypoint.sh
+++ b/hack/ci/entrypoint.sh
@@ -105,7 +105,7 @@ function run_tests() {
     OC_PATH=$(get_path_or_empty_string_for_cmd oc)
     KUBECTL_PATH=$(get_path_or_empty_string_for_cmd kubectl)
 
-    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -oc-path=${OC_PATH} -kubectl-path=${KUBECTL_PATH} -gocli-path=$(pwd)/kubevirtci/cluster-up/cli.sh -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slow-spec-threshold=60s ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false
+    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -oc-path=${OC_PATH} -kubectl-path=${KUBECTL_PATH} -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slow-spec-threshold=60s ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false
 }
 
 export PATH="$BIN_DIR:$PATH"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -60,7 +60,7 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -timeout=${KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT} -r "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
+    _out/tests/ginkgo -timeout=${KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT} -r "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
 }
 
 additional_test_args=""

--- a/hack/kwok-perftests.sh
+++ b/hack/kwok-perftests.sh
@@ -60,7 +60,7 @@ echo 'ARTIFACTS ' "${ARTIFACTS}"
 echo 'TESTS_OUT_DIR ' "${TESTS_OUT_DIR}"
 
 function perftest() {
-    _out/tests/ginkgo -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- ${extra_args} -kubeconfig="${kubeconfig}" -container-tag="${docker_tag}" -container-tag-alt="${docker_tag_alt}" -container-prefix="${perftest_docker_prefix}" -image-prefix-alt="${image_prefix_alt}" -oc-path="${oc}" -kubectl-path="${kubectl}" -gocli-path="${gocli}" -installed-namespace="${namespace}" -previous-release-tag="${PREVIOUS_RELEASE_TAG}" -previous-release-registry="${previous_release_registry}" -deploy-testing-infra="${deploy_testing_infra}" -config="${KUBEVIRT_DIR}"/tests/default-config.json -deploy-fake-kwok-nodes=true --artifacts="${ARTIFACTS}"
+    _out/tests/ginkgo -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- ${extra_args} -kubeconfig="${kubeconfig}" -container-tag="${docker_tag}" -container-tag-alt="${docker_tag_alt}" -container-prefix="${perftest_docker_prefix}" -image-prefix-alt="${image_prefix_alt}" -oc-path="${oc}" -kubectl-path="${kubectl}" -installed-namespace="${namespace}" -previous-release-tag="${PREVIOUS_RELEASE_TAG}" -previous-release-registry="${previous_release_registry}" -deploy-testing-infra="${deploy_testing_infra}" -config="${KUBEVIRT_DIR}"/tests/default-config.json -deploy-fake-kwok-nodes=true --artifacts="${ARTIFACTS}"
 }
 
 function perfaudit() {

--- a/hack/perftests.sh
+++ b/hack/perftests.sh
@@ -58,7 +58,7 @@ echo 'ARTIFACTS ' ${ARTIFACTS}
 echo 'TESTS_OUT_DIR ' ${TESTS_OUT_DIR}
 
 function perftest() {
-    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
+    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
 }
 
 function perfaudit() {

--- a/hack/realtime-perftests.sh
+++ b/hack/realtime-perftests.sh
@@ -52,7 +52,7 @@ echo 'ARTIFACTS ' ${ARTIFACTS}
 echo 'TESTS_OUT_DIR ' ${TESTS_OUT_DIR}
 
 function perftest() {
-    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
+    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
 }
 
 if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -26,7 +26,6 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -161,7 +160,6 @@ func (r rights) list() (e []rightsEntry) {
 
 var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access", decorators.SigCompute, decorators.WgS390x, decorators.WgArm64, func() {
 
-	var k8sClient string
 	var authClient *authClientV1.AuthorizationV1Client
 
 	doSarRequest := func(group string, resource string, subresource string, namespace string, role string, verb string, expected, clusterWide bool) {
@@ -207,8 +205,6 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	}
 
 	BeforeEach(func() {
-		k8sClient = clientcmd.GetK8sCmdClient()
-		clientcmd.SkipIfNoCmd(k8sClient)
 		virtClient := kubevirt.Client()
 		var err error
 		authClient, err = authClientV1.NewForConfig(virtClient.Config())

--- a/tests/clientcmd/command.go
+++ b/tests/clientcmd/command.go
@@ -36,13 +36,6 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-const (
-	commandPipeFailed    = "command pipe failed"
-	commandPipeFailedFmt = "command pipe failed: %v"
-
-	serverName = "--server"
-)
-
 func GetK8sCmdClient() string {
 	// use oc if it exists, otherwise use kubectl
 	if flags.KubeVirtOcPath != "" {
@@ -52,7 +45,7 @@ func GetK8sCmdClient() string {
 	return "kubectl"
 }
 
-func SkipIfNoCmd(cmdName string) {
+func FailIfNoCmd(cmdName string) {
 	var cmdPath string
 	switch strings.ToLower(cmdName) {
 	case "oc":
@@ -61,11 +54,9 @@ func SkipIfNoCmd(cmdName string) {
 		cmdPath = flags.KubeVirtKubectlPath
 	case "virtctl":
 		cmdPath = flags.KubeVirtVirtctlPath
-	case "gocli":
-		cmdPath = flags.KubeVirtGoCliPath
 	}
 	if cmdPath == "" {
-		ginkgo.Skip(fmt.Sprintf("Skip test that requires %s binary", cmdName))
+		ginkgo.Fail(fmt.Sprintf("Test requires %s binary", cmdName))
 	}
 }
 
@@ -117,8 +108,6 @@ func CreateCommandWithNS(namespace string, cmdName string, args ...string) (stri
 		cmdPath = flags.KubeVirtKubectlPath
 	case "virtctl":
 		cmdPath = flags.KubeVirtVirtctlPath
-	case "gocli":
-		cmdPath = flags.KubeVirtGoCliPath
 	}
 
 	if cmdPath == "" {
@@ -136,7 +125,7 @@ func CreateCommandWithNS(namespace string, cmdName string, args ...string) (stri
 
 	master := flag.Lookup("master").Value
 	if master != nil && master.String() != "" {
-		args = append(args, serverName, master.String())
+		args = append(args, "--server", master.String())
 	}
 	if namespace != "" {
 		args = append([]string{"-n", namespace}, args...)

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -37,7 +37,6 @@ var KubeVirtKubectlPath = ""
 var KubeVirtOcPath = ""
 var KubeVirtVirtctlPath = ""
 var KubeVirtExampleGuestAgentPath = ""
-var KubeVirtGoCliPath = ""
 var KubeVirtInstallNamespace string
 var PrometheusNamespace string
 var PreviousReleaseTag = ""
@@ -77,7 +76,6 @@ func init() {
 	flag.StringVar(&KubeVirtOcPath, "oc-path", "", "Set path to oc binary")
 	flag.StringVar(&KubeVirtVirtctlPath, "virtctl-path", "", "Set path to virtctl binary")
 	flag.StringVar(&KubeVirtExampleGuestAgentPath, "example-guest-agent-path", "", "Set path to the example-guest-agent binary which is used for vsock testing")
-	flag.StringVar(&KubeVirtGoCliPath, "gocli-path", "", "Set path to gocli binary")
 	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "", "Set the namespace KubeVirt is installed in")
 	flag.StringVar(&PrometheusNamespace, "prometheus-installed-namespace", "monitoring", "Set the namespace Prometheus is installed in")
 	flag.BoolVar(&DeployFakeKWOKNodesFlag, "deploy-fake-kwok-nodes", false, "Deploy fake KWOK nodes to test performance.")

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -32,9 +32,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		err               error
 	)
 	BeforeEach(func() {
-
 		k8sClient = clientcmd.GetK8sCmdClient()
-		clientcmd.SkipIfNoCmd(k8sClient)
+		clientcmd.FailIfNoCmd(k8sClient)
 	})
 
 	DescribeTable("[test_id:3812]explain vm/vmi", func(resource string) {

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -461,7 +461,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	It("[test_id:4121]should create and verify kubectl/oc output for vm replicaset", func() {
 		k8sClient := clientcmd.GetK8sCmdClient()
-		clientcmd.SkipIfNoCmd(k8sClient)
+		clientcmd.FailIfNoCmd(k8sClient)
 
 		newRS := newReplicaSet()
 		doScale(newRS.ObjectMeta.Name, 2)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -974,7 +974,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		BeforeEach(func() {
 			k8sClient = clientcmd.GetK8sCmdClient()
-			clientcmd.SkipIfNoCmd(k8sClient)
+			clientcmd.FailIfNoCmd(k8sClient)
 			workDir = GinkgoT().TempDir()
 
 			// By default "." does not match newline: "Phase" and "Running" only match if on same line.

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -43,7 +43,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libdomain"
@@ -165,7 +164,6 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 
 			It("[test_id:3158]should update domain XML with SM BIOS properties", func() {
 				By("Reading domain XML using virsh")
-				clientcmd.SkipIfNoCmd("kubectl")
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				libwait.WaitForSuccessfulVMIStart(vmi)
 				domainXml, err := libdomain.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)


### PR DESCRIPTION
Tests now fail instead of silently skipping tests when a command is not found. It is achieved by converting clientcmd.SkipIfNoCmd to clientcmd.FailIfNoCmd. This also removes clientcmd.SkipIfNoCmd from places where it had no effect anyway.

Additionally, traces of the no longer used gocli command are removed and some smaller cleanups are applied.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Tests now fail instead of silently skipping tests when a command is not
found. It is achieved by converting clientcmd.SkipIfNoCmd to
clientcmd.FailIfNoCmd. This also removes clientcmd.SkipIfNoCmd from places
where it had no effect anyway.

Additionally, traces of the no longer used gocli command are removed and
some smaller cleanups are applied.

Before this PR:

Tests are silently skipped if a command is not found.

After this PR:

Tests fail if a command is not found.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

