### PR TITLE
fix variable shadowing in test, fix setupMemoryHotplug() and fix test case setup

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -144,24 +144,26 @@ func setupCPUHotplug(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMac
 }
 
 func setupMemoryHotplug(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance) {
-	if vmi.Spec.Domain.Memory.MaxGuest != nil {
-		return
-	}
 
 	var maxGuest *resource.Quantity
-	switch {
-	case clusterConfig.GetMaximumGuestMemory() != nil:
-		maxGuest = clusterConfig.GetMaximumGuestMemory()
-	case vmi.Spec.Domain.Memory.Guest != nil:
-		maxGuest = resource.NewQuantity(vmi.Spec.Domain.Memory.Guest.Value()*int64(clusterConfig.GetMaxHotplugRatio()), resource.BinarySI)
+
+	if vmi.Spec.Domain.Memory.MaxGuest == nil {
+		switch {
+		case clusterConfig.GetMaximumGuestMemory() != nil:
+			maxGuest = clusterConfig.GetMaximumGuestMemory()
+		case vmi.Spec.Domain.Memory.Guest != nil:
+			maxGuest = resource.NewQuantity(vmi.Spec.Domain.Memory.Guest.Value()*int64(clusterConfig.GetMaxHotplugRatio()), resource.BinarySI)
+		}
+	} else {
+		maxGuest = vmi.Spec.Domain.Memory.MaxGuest
 	}
 
 	if err := memory.ValidateLiveUpdateMemory(&vmi.Spec, maxGuest); err != nil {
 		// memory hotplug is not compatible with this VM configuration
 		log.Log.V(2).Object(vmi).Infof("memory-hotplug disabled: %s", err)
+		vmi.Spec.Domain.Memory.MaxGuest = nil
 		return
 	}
-
 	vmi.Spec.Domain.Memory.MaxGuest = maxGuest
 }
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -1421,7 +1421,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			})
 
 			DescribeTable("should leave MaxGuest empty when memory hotplug is incompatible", func(vmiSetup func(*v1.VirtualMachineInstanceSpec)) {
-				vmi := api.NewMinimalVMI("testvm")
+				vmi = api.NewMinimalVMI("testvm")
 				vmi.Spec.Domain.Memory = &v1.Memory{Guest: pointer.P(resource.MustParse("128Mi"))}
 				vmiSetup(&vmi.Spec)
 
@@ -1458,7 +1458,8 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 					vmiSpec.Domain.Memory.Guest = nil
 				}),
 				Entry("guest memory is greater than maxGuest", func(vmiSpec *v1.VirtualMachineInstanceSpec) {
-					moreThanMax := vmiSpec.Domain.Memory.Guest.DeepCopy()
+					vmiSpec.Domain.Memory.MaxGuest = pointer.P(resource.MustParse("4Gi"))
+					moreThanMax := vmiSpec.Domain.Memory.MaxGuest.DeepCopy()
 					moreThanMax.Mul(8)
 
 					vmiSpec.Domain.Memory.Guest = &moreThanMax


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: 

- Shadowed global variable allowed test cases that should fail to pass. 
- `setupMemoryHotplug()` in `pkg/defaults/defaults.go` skipped live update memory validation if `vmi.Spec.Domain.Memory.MaxGuest` was already set, leading to `vmi.Spec.Domain.Memory.MaxGuest` being set in cases where it should be nil.
- The test entry `guest memory is greater than maxGuest` is not set up properly; it tests for `guest` > `maxGuest` but never sets `maxGuest`, meaning `maxGuest` is defaulted to 4x `guest`

After this PR: 

- Fixed shadowed variable declaration
- Fixed `setupMemoryHotplug()` to correctly validate live update memory even if `vmi.Spec.Domain.Memory.MaxGuest` is already set.
- Correctly setup `guest memory is greater than maxGuest` testcase

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/14291

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
I thought about splitting each fix into a different PR, however they are all interdependent (submitting only one fix would cause PR checks to fail

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... --> https://github.com/kubevirt/kubevirt/pull/14156#issuecomment-2732124557

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

