### PR TITLE
Removed //nolint:dupl from pkg/instancetype/webhooks/vm/mutator.go

### DIFF
--- a/pkg/instancetype/webhooks/vm/mutator.go
+++ b/pkg/instancetype/webhooks/vm/mutator.go
@@ -140,88 +140,56 @@ func validateMatcherUpdate(oldMatcher, newMatcher virtv1.Matcher) error {
 	return nil
 }
 
-func validateInstancetypeMatcher(vm *virtv1.VirtualMachine) []metav1.StatusCause {
-	if vm.Spec.Instancetype == nil {
+// validateMatcher is a generic function to validate both instancetype and preference matchers
+func validateMatcher(matcherType string, matcher virtv1.Matcher) []metav1.StatusCause {
+	if matcher == nil {
 		return nil
 	}
 
+	fieldPath := k8sfield.NewPath("spec", matcherType)
 	var causes []metav1.StatusCause
-	if vm.Spec.Instancetype.Name == "" && vm.Spec.Instancetype.InferFromVolume == "" {
+	if matcher.GetName() == "" && matcher.GetInferFromVolume() == "" {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueNotFound,
-			Message: "Either Name or InferFromVolume should be provided within the InstancetypeMatcher",
-			Field:   k8sfield.NewPath("spec", "instancetype").String(),
+			Message: fmt.Sprintf("Either Name or InferFromVolume should be provided within the %s matcher", matcherType),
+			Field:   fieldPath.String(),
 		})
 	}
-	if vm.Spec.Instancetype.InferFromVolume != "" {
-		if vm.Spec.Instancetype.Name != "" {
+	if matcher.GetInferFromVolume() != "" {
+		if matcher.GetName() != "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueNotFound,
-				Message: "Name should not be provided when InferFromVolume is used within the InstancetypeMatcher",
-				Field:   k8sfield.NewPath("spec", "instancetype", "name").String(),
-			})
-		}
-		if vm.Spec.Instancetype.Kind != "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueNotFound,
-				Message: "Kind should not be provided when InferFromVolume is used within the InstancetypeMatcher",
-				Field:   k8sfield.NewPath("spec", "instancetype", "kind").String(),
+				Message: fmt.Sprintf("Name should not be provided when InferFromVolume is used within the %s matcher", matcherType),
+				Field:   fieldPath.Child("name").String(),
 			})
 		}
 	}
-	if vm.Spec.Instancetype.InferFromVolumeFailurePolicy != nil {
-		failurePolicy := *vm.Spec.Instancetype.InferFromVolumeFailurePolicy
+	if matcher.GetKind() != "" {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotFound,
+			Message: fmt.Sprintf("Kind should not be provided when InferFromVolume is used within the %s matcher", matcherType),
+			Field:   fieldPath.Child("kind").String(),
+		})
+	}
+	if matcher.GetInferFromVolumeFailurePolicy() != nil {
+		failurePolicy := *matcher.GetInferFromVolumeFailurePolicy()
 		if failurePolicy != virtv1.IgnoreInferFromVolumeFailure && failurePolicy != virtv1.RejectInferFromVolumeFailure {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: fmt.Sprintf("Invalid value '%s' for InferFromVolumeFailurePolicy", failurePolicy),
-				Field:   k8sfield.NewPath("spec", "instancetype", "inferFromVolumeFailurePolicy").String(),
+				Field:   fieldPath.Child("inferFromVolumeFailurePolicy").String(),
 			})
 		}
 	}
 	return causes
 }
 
-func validatePreferenceMatcher(vm *virtv1.VirtualMachine) []metav1.StatusCause {
-	if vm.Spec.Preference == nil {
-		return nil
-	}
+func validateInstancetypeMatcher(vm *virtv1.VirtualMachine) []metav1.StatusCause {
+	return validateMatcher("instancetype", vm.Spec.Instancetype)
+}
 
-	var causes []metav1.StatusCause
-	if vm.Spec.Preference.Name == "" && vm.Spec.Preference.InferFromVolume == "" {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueNotFound,
-			Message: "Either Name or InferFromVolume should be provided within the PreferenceMatcher",
-			Field:   k8sfield.NewPath("spec", "preference").String(),
-		})
-	}
-	if vm.Spec.Preference.InferFromVolume != "" {
-		if vm.Spec.Preference.Name != "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueNotFound,
-				Message: "Name should not be provided when InferFromVolume is used within the PreferenceMatcher",
-				Field:   k8sfield.NewPath("spec", "preference", "name").String(),
-			})
-		}
-		if vm.Spec.Preference.Kind != "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueNotFound,
-				Message: "Kind should not be provided when InferFromVolume is used within the PreferenceMatcher",
-				Field:   k8sfield.NewPath("spec", "preference", "kind").String(),
-			})
-		}
-	}
-	if vm.Spec.Preference.InferFromVolumeFailurePolicy != nil {
-		failurePolicy := *vm.Spec.Preference.InferFromVolumeFailurePolicy
-		if failurePolicy != virtv1.IgnoreInferFromVolumeFailure && failurePolicy != virtv1.RejectInferFromVolumeFailure {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Invalid value '%s' for InferFromVolumeFailurePolicy", failurePolicy),
-				Field:   k8sfield.NewPath("spec", "preference", "inferFromVolumeFailurePolicy").String(),
-			})
-		}
-	}
-	return causes
+func validatePreferenceMatcher(vm *virtv1.VirtualMachine) []metav1.StatusCause {
+	return validateMatcher("preference", vm.Spec.Preference)
 }
 
 func (m *mutator) inferMatchers(vm *virtv1.VirtualMachine) *admissionv1.AdmissionResponse {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does


Before this PR:
pkg/instancetype/webhooks/vm/mutator.go:142: 142-182 lines are duplicate of pkg/instancetype/webhooks/vm/mutator.go:184-224 (dupl)

After this PR:
solve the issue written a helper function

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/14245

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

