### PR TITLE
fix(reset): check boot time instead file

### DIFF
--- a/tests/compute/subresources/BUILD.bazel
+++ b/tests/compute/subresources/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//tests/libvmifact:go_default_library",
         "//tests/libvmops:go_default_library",
         "//tests/testsuite:go_default_library",
-        "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/tests/compute/subresources/reset.go
+++ b/tests/compute/subresources/reset.go
@@ -21,8 +21,8 @@ package subresources
 
 import (
 	"context"
+	"time"
 
-	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -48,24 +48,20 @@ var _ = Describe(compute.SIG("Reset subresource", func() {
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-			By("Create a file that is not expected to survive the reset request")
-			err := console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "touch /tmp/non-persistent-file\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: console.EchoLastReturnValue},
-				&expect.BExp{R: console.ShellSuccess},
-			}, 120)
+			By("Store boot time pre and post reset")
+			cmd := "cat /proc/stat | grep btime"
+			bTimePreReset, err := console.RunCommandAndStoreOutput(vmi, cmd, time.Second*30)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Reset(context.Background(), vmi.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-			err = console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "ls /tmp/non-persistent-file\n"},
-				&expect.BExp{R: `non-persistent-file: No such file or director`},
-			}, 20)
+			bTimePostReset, err := console.RunCommandAndStoreOutput(vmi, cmd, time.Second*30)
 			Expect(err).ToNot(HaveOccurred())
+
+			By("Check the pre and post reset boot times are different")
+			Expect(bTimePreReset).ToNot(Equal(bTimePostReset))
 
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, to check that the reset was performed,
we write a file in the `/tmp` folder and expect
that it is not there anymore after the reset.
Actually, the `/tmp` folder is not part of the
tmpfs, and hence some flakiness was observed.

The test can be improved by checking the boot time pre and post reset, and asserting that the two
are different.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

- mount `/tmp` in as `/tmpfs`
- write a file into `/dev` (it is part of the tmpfs)

Thanks to @jean-edouard and @iholder101 for the alternatives.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

