### PR TITLE
Reset subresource test: check that boot time string is not empty

### DIFF
--- a/tests/compute/subresources/reset.go
+++ b/tests/compute/subresources/reset.go
@@ -60,7 +60,9 @@ var _ = Describe(compute.SIG("Reset subresource", func() {
 			bTimePostReset, err := console.RunCommandAndStoreOutput(vmi, cmd, time.Second*30)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Check the pre and post reset boot times are different")
+			By("Check the pre and post reset boot times are different and non-empty")
+			Expect(bTimePreReset).ToNot(BeEmpty())
+			Expect(bTimePostReset).ToNot(BeEmpty())
 			Expect(bTimePreReset).ToNot(Equal(bTimePostReset))
 
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})


### PR DESCRIPTION
### What this PR does
A super duper tiny follow-up to https://github.com/kubevirt/kubevirt/pull/14313.
Checks that the boot time string is not empty, so the test won't pass as a false positive. see https://github.com/kubevirt/kubevirt/pull/14313#discussion_r2009129561.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

