### PR TITLE
fix the disk-images provider for s390x.

### DIFF
--- a/images/disks-images-provider/BUILD.bazel
+++ b/images/disks-images-provider/BUILD.bazel
@@ -8,11 +8,13 @@ genrule(
     name = "alpine-img",
     srcs = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": ["@alpine_image_aarch64//file"],
+        "@io_bazel_rules_go//go/platform:linux_s390x": ["@alpine_image_s390x//file"],
         "//conditions:default": ["@alpine_image//file"],
     }),
     outs = ["images/alpine/disk.img"],
     cmd = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": "mkdir -p images/alpine && cat $(location @alpine_image_aarch64//file) > $@",
+        "@io_bazel_rules_go//go/platform:linux_s390x": "mkdir -p images/alpine && cat $(location @alpine_image_s390x//file) > $@",
         "//conditions:default": "mkdir -p images/alpine && cat $(location @alpine_image//file) > $@",
     }),
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The disks-images-provider is pointing to wrong alpine.iso(x86). Because of this one of the virtctl image upload test(test_id:4621) is failing.

After this PR:
The disk-images-provider is now pointed to s390x alpine.iso. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     fix: disks-images-provider is pointing to wrong alpine image for s390x.

```

