### PR TITLE
Handle lowercase instancetypes/preference keys in VM monitoring

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	k6tv1 "kubevirt.io/api/core/v1"
+	instancetypeapi "kubevirt.io/api/instancetype"
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/controller"
@@ -248,7 +249,7 @@ func getVMInstancetype(vm *k6tv1.VirtualMachine) string {
 		return none
 	}
 
-	if instancetype.Kind == "VirtualMachineInstancetype" {
+	if strings.EqualFold(instancetype.Kind, instancetypeapi.SingularResourceName) {
 		key := types.NamespacedName{
 			Namespace: vm.Namespace,
 			Name:      instancetype.Name,
@@ -257,7 +258,7 @@ func getVMInstancetype(vm *k6tv1.VirtualMachine) string {
 		return fetchResourceName(key.String(), stores.Instancetype)
 	}
 
-	if instancetype.Kind == "VirtualMachineClusterInstancetype" {
+	if strings.EqualFold(instancetype.Kind, instancetypeapi.ClusterSingularResourceName) {
 		return fetchResourceName(instancetype.Name, stores.ClusterInstancetype)
 	}
 
@@ -271,7 +272,7 @@ func getVMPreference(vm *k6tv1.VirtualMachine) string {
 		return none
 	}
 
-	if preference.Kind == "VirtualMachinePreference" {
+	if strings.EqualFold(preference.Kind, instancetypeapi.SingularPreferenceResourceName) {
 		key := types.NamespacedName{
 			Namespace: vm.Namespace,
 			Name:      preference.Name,
@@ -280,7 +281,7 @@ func getVMPreference(vm *k6tv1.VirtualMachine) string {
 		return fetchResourceName(key.String(), stores.Preference)
 	}
 
-	if preference.Kind == "VirtualMachineClusterPreference" {
+	if strings.EqualFold(preference.Kind, instancetypeapi.ClusterSingularPreferenceResourceName) {
 		return fetchResourceName(preference.Name, stores.ClusterPreference)
 	}
 

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -211,6 +211,10 @@ var _ = Describe("VM Stats Collector", func() {
 			Entry("with no cluster instance type expect <none>", "VirtualMachineClusterInstancetype", "", "<none>"),
 			Entry("with managed cluster instance type expect its name", "VirtualMachineClusterInstancetype", "ci-managed", "ci-managed"),
 			Entry("with custom cluster instance type expect <other>", "VirtualMachineClusterInstancetype", "ci-unmanaged", "<other>"),
+			Entry("with an instance type which no longer exists expect <other>", "VirtualMachineInstancetype", "i-gone", "<other>"),
+			Entry("with a cluster instance type which no longer exists expect <other>", "VirtualMachineClusterInstancetype", "ci-gone", "<other>"),
+			Entry("with lowercase instance type expect the same behavior", "virtualmachineinstancetype", "i-managed", "i-managed"),
+			Entry("with lowercase cluster instance type expect the same behavior", "virtualmachineclusterinstancetype", "ci-managed", "ci-managed"),
 		)
 
 		DescribeTable("should show preference value correctly", func(preferenceAnnotationKey string, preferenceName string, expected string) {
@@ -242,6 +246,10 @@ var _ = Describe("VM Stats Collector", func() {
 			Entry("with no cluster preference expect <none>", "VirtualMachineClusterPreference", "", "<none>"),
 			Entry("with managed cluster preference expect its name", "VirtualMachineClusterPreference", "cp-managed", "cp-managed"),
 			Entry("with custom cluster preference expect <other>", "VirtualMachineClusterPreference", "cp-unmanaged", "<other>"),
+			Entry("with an preference which no longer exists expect <other>", "VirtualMachinePreference", "p-gone", "<other>"),
+			Entry("with a cluster preference which no longer exists expect <other>", "VirtualMachineClusterPreference", "cp-gone", "<other>"),
+			Entry("with lowercase preference expect the same behavior", "virtualmachinepreference", "p-managed", "p-managed"),
+			Entry("with lowercase cluster preference expect the same behavior", "virtualmachineclusterpreference", "cp-managed", "cp-managed"),
 		)
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

instancetypes/preference kind keys in VM definitions can appear as lowercase only, being ignored in the VM monitoring processs.

After this PR:

instancetypes/preference kind keys are handled correctly in any casing style

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: `https://issues.redhat.com/browse/CNV-54195`

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle lowercase instancetypes/preference keys in VM monitoring
```

