### PR TITLE
net, admitter: Remove SLIRP validation

### DIFF
--- a/pkg/network/admitter/admit_suite_test.go
+++ b/pkg/network/admitter/admit_suite_test.go
@@ -30,15 +30,10 @@ func TestAdmitter(t *testing.T) {
 }
 
 type stubClusterConfigChecker struct {
-	slirpEnabled                 bool
 	bridgeBindingOnPodNetEnabled bool
 	macvtapFeatureGateEnabled    bool
 	passtFeatureGateEnabled      bool
 	bindingPluginFGEnabled       bool
-}
-
-func (s stubClusterConfigChecker) IsSlirpInterfaceEnabled() bool {
-	return s.slirpEnabled
 }
 
 func (s stubClusterConfigChecker) IsBridgeInterfaceOnPodNetworkEnabled() bool {

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -26,7 +26,6 @@ import (
 )
 
 type clusterConfigChecker interface {
-	IsSlirpInterfaceEnabled() bool
 	IsBridgeInterfaceOnPodNetworkEnabled() bool
 	MacvtapEnabled() bool
 	PasstEnabled() bool
@@ -54,7 +53,6 @@ func (v Validator) Validate() []metav1.StatusCause {
 	causes = append(causes, validateMultusNetworkSource(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceStateValue(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceBinding(v.field, v.vmiSpec, v.configChecker)...)
-	causes = append(causes, validateSlirpBinding(v.field, v.vmiSpec, v.configChecker)...)
 	causes = append(causes, validateNetworkNameUnique(v.field, v.vmiSpec)...)
 	causes = append(causes, validateNetworksAssignedToInterfaces(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceNameUnique(v.field, v.vmiSpec)...)

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -48,19 +48,6 @@ var _ = Describe("test configuration", func() {
 
 	trueValue := true
 	falseValue := false
-	DescribeTable(" when permitSlirpInterface", func(value *bool, result bool) {
-		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-			NetworkConfiguration: &v1.NetworkConfiguration{
-				DeprecatedPermitSlirpInterface: value,
-			},
-		})
-
-		Expect(clusterConfig.IsSlirpInterfaceEnabled()).To(Equal(result))
-	},
-		Entry("is true, IsSlirpInterfaceEnabled should return true", &trueValue, true),
-		Entry("is false, IsSlirpInterfaceEnabled should return false", &falseValue, false),
-		Entry("when unset, IsSlirpInterfaceEnabled should return false", nil, false),
-	)
 
 	DescribeTable(" when permitBridgeInterfaceOnPodNetwork", func(value *bool, result bool) {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -212,10 +212,6 @@ func (c *ClusterConfig) GetDefaultArchitecture() string {
 	return c.GetConfig().ArchitectureConfiguration.DefaultArchitecture
 }
 
-func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {
-	return *c.GetConfig().NetworkConfiguration.DeprecatedPermitSlirpInterface
-}
-
 func (c *ClusterConfig) GetSMBIOS() *v1.SMBiosConfiguration {
 	return c.GetConfig().SMBIOSConfig
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
SLIRP was discontinued in v1.3 [1].
The net validator blocks creating VMs with SLIRP binding [2].

There is no need to keep the old validation logic that runs every time a VMI is created and/or updated.

[1] https://github.com/kubevirt/kubevirt/pull/11701
[2] https://github.com/kubevirt/kubevirt/blob/09fbbcf888b1fee3c509e6b6e87144c83e44d8c8/pkg/network/admitter/validator.go#L67

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

