### PR TITLE
defaults: Limit MaxSockets based on maximum of vcpus

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -139,7 +139,16 @@ func setupCPUHotplug(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMac
 	}
 
 	if vmi.Spec.Domain.CPU.MaxSockets == 0 {
+		// Each machine type will have different maximum for vcpus,
+		// lets choose 512 as upper bound
+		const maxVCPUs = 512
+
 		vmi.Spec.Domain.CPU.MaxSockets = vmi.Spec.Domain.CPU.Sockets * clusterConfig.GetMaxHotplugRatio()
+		totalVCPUs := vmi.Spec.Domain.CPU.MaxSockets * vmi.Spec.Domain.CPU.Cores * vmi.Spec.Domain.CPU.Threads
+		if totalVCPUs > maxVCPUs {
+			adjustedSockets := maxVCPUs / (vmi.Spec.Domain.CPU.Cores * vmi.Spec.Domain.CPU.Threads)
+			vmi.Spec.Domain.CPU.MaxSockets = max(adjustedSockets, vmi.Spec.Domain.CPU.Sockets)
+		}
 	}
 }
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -1313,6 +1313,17 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
 				Expect(spec.Domain.CPU.MaxSockets).To(Equal(uint32(8)))
 			})
+
+			It("to calculate max sockets to be 4x times the configured sockets with upper bound 512 when no max sockets defined", func() {
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Sockets: 32,
+					Cores:   2,
+					Threads: 3,
+				}
+				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
+				Expect(spec.Domain.CPU.MaxSockets).To(Equal(uint32(85)))
+			})
+
 			It("to calculate max sockets to be 4x times the default sockets when default CPU topology used", func() {
 				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
 				Expect(spec.Domain.CPU.MaxSockets).To(Equal(uint32(4)))


### PR DESCRIPTION
### What this PR does
Each machine type allows different number of vcpus, therefore let's have upper bound that is reasonable.

It's a follow-up to #14105 

Fixes #

### Release note
```release-note
Bug fix: MaxSockets is limited so maximum of vcpus doesn't go over 512.
```

