### PR TITLE
Refactor: Use libvmi.New in tests

### DIFF
--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -41,7 +41,6 @@ go_test(
         ":go_default_library",
         "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -26,22 +26,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/network/admitter"
 )
 
 var _ = Describe("Validating network binding combinations", func() {
 	It("network interface has both binding plugin and interface binding method", func() {
-		vm := api.NewMinimalVMI("testvm")
-		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "foo",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-			Binding:                &v1.PluginBinding{Name: "boo"},
-		}}
-		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+		vm := libvmi.New(
+			libvmi.WithInterface(v1.Interface{
+				Name:                   "foo",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+				Binding:                &v1.PluginBinding{Name: "boo"},
+			}),
+			libvmi.WithNetwork(&v1.Network{
+				Name:          "foo",
+				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+			}),
+		)
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true, bindingPluginFGEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
@@ -53,24 +56,32 @@ var _ = Describe("Validating network binding combinations", func() {
 	})
 
 	It("network interface has only plugin binding", func() {
-		vm := api.NewMinimalVMI("testvm")
-		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:    "foo",
-			Binding: &v1.PluginBinding{Name: "boo"},
-		}}
-		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+		vm := libvmi.New(
+			libvmi.WithInterface(v1.Interface{
+				Name:    "foo",
+				Binding: &v1.PluginBinding{Name: "boo"},
+			}),
+			libvmi.WithNetwork(&v1.Network{
+				Name:          "foo",
+				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+			}),
+		)
 		clusterConfig := stubClusterConfigChecker{bindingPluginFGEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(BeEmpty())
 	})
 
 	It("network interface has only binding method", func() {
-		vm := api.NewMinimalVMI("testvm")
-		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "foo",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-		}}
-		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+		vm := libvmi.New(
+			libvmi.WithNetwork(&v1.Network{
+				Name:          "foo",
+				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+			}),
+			libvmi.WithInterface(v1.Interface{
+				Name:                   "foo",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+			}),
+		)
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(BeEmpty())
@@ -79,18 +90,19 @@ var _ = Describe("Validating network binding combinations", func() {
 
 var _ = Describe("Validating core binding", func() {
 	It("should reject a masquerade interface on a network different than pod", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-			Ports:                  []v1.Port{{Name: "test"}},
-		}}
-		spec.Networks = []v1.Network{{
-			Name:          "default",
-			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
-		}}
+		vmi := libvmi.New(
+			libvmi.WithInterface(v1.Interface{
+				Name:                   "default",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+				Ports:                  []v1.Port{{Name: "test"}},
+			}),
+			libvmi.WithNetwork(&v1.Network{
+				Name:          "default",
+				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
+			}),
+		)
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -101,17 +113,16 @@ var _ = Describe("Validating core binding", func() {
 	})
 
 	It("should reject a masquerade interface with a specified reserved MAC address", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-			MacAddress:             "02:00:00:00:00:00",
-		}}
-		spec.Networks = []v1.Network{
-			{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-		}
+		vmi := libvmi.New(
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithInterface(v1.Interface{
+				Name:                   "default",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+				MacAddress:             "02:00:00:00:00:00",
+			}),
+		)
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -122,11 +133,12 @@ var _ = Describe("Validating core binding", func() {
 	})
 
 	It("should reject a bridge interface on a pod network when it is not permitted", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+		vmi := libvmi.New(
+			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{

--- a/pkg/network/domainspec/BUILD.bazel
+++ b/pkg/network/domainspec/BUILD.bazel
@@ -30,10 +30,10 @@ go_test(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/network/driver:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/network/domainspec/domainspec_suite_test.go
+++ b/pkg/network/domainspec/domainspec_suite_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	v1 "kubevirt.io/api/core/v1"
-	api2 "kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/testutils"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -14,17 +14,13 @@ func TestDomainSpec(t *testing.T) {
 	testutils.KubeVirtTestSuiteSetup(t)
 }
 
-func newVMI(namespace, name string) *v1.VirtualMachineInstance {
-	vmi := api2.NewMinimalVMIWithNS(namespace, name)
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	return vmi
-}
-
 func newVMIMasqueradeInterface(namespace, vmiName string) *v1.VirtualMachineInstance {
-	vmi := newVMI(namespace, vmiName)
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-	return vmi
+	return libvmi.New(
+		libvmi.WithNamespace(namespace),
+		libvmi.WithName(vmiName),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
+	)
 }
 
 func NewDomainInterface(name string) *api.Domain {

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -61,7 +61,6 @@ go_test(
         "//pkg/os/fs:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 	"testing"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	kfs "kubevirt.io/kubevirt/pkg/os/fs"
 
 	v1 "kubevirt.io/api/core/v1"
-	api2 "kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/testutils"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -20,9 +20,12 @@ func TestNetwork(t *testing.T) {
 }
 
 func newVMIBridgeInterface(namespace string, name string) *v1.VirtualMachineInstance {
-	vmi := api2.NewMinimalVMIWithNS(namespace, name)
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+	vmi := libvmi.New(
+		libvmi.WithNamespace(namespace),
+		libvmi.WithName(name),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+	)
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
 }

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -24,7 +24,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
-	api2 "kubevirt.io/client-go/api"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -51,17 +52,23 @@ var _ = Describe("VMNetworkConfigurator", func() {
 
 		Context("when calling []podNIC factory functions", func() {
 			It("should not process SR-IOV networks", func() {
-				vmi := api2.NewMinimalVMIWithNS("testnamespace", "testVmName")
 				const networkName = "sriov"
-				vmi.Spec.Networks = []v1.Network{{
-					Name: networkName,
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "sriov-nad"},
-					},
-				}}
-				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-					Name: networkName, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
-				}}
+				vmi := libvmi.New(
+					libvmi.WithNamespace("testnamespace"),
+					libvmi.WithName("testVmName"),
+					libvmi.WithNetwork(&v1.Network{
+						Name: networkName,
+						NetworkSource: v1.NetworkSource{
+							Multus: &v1.MultusNetwork{NetworkName: "sriov-nad"},
+						},
+					}),
+					libvmi.WithInterface(v1.Interface{
+						Name: networkName,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							SRIOV: &v1.InterfaceSRIOV{},
+						},
+					}),
+				)
 
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, nil)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**  
Network package tests used `api.NewMinimalVMI`/`api.NewMinimalVMIWithNS` for VMI creation.  

**After this PR:**  
Tests use `libvmi.New()` builder pattern for explicit and consistent VMI configuration.

### Why we need it and why it was done in this way  

- Promotes standardized test setup using `libvmi` builder pattern  
- Improves readability by explicitly defining networks/interfaces  


**Parent issue:** #12059  
Fixes #14152

### Special notes for your reviewer

Kindly review this PR and let me know if there are any concerns or areas that need improvement.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

