### PR TITLE
e2e,compute-migration: Reduce the number of parallel tests run in compute-migrations test lane

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -73,6 +73,7 @@ elif [[ $TARGET =~ sig-compute-realtime ]]; then
   export KUBEVIRT_REALTIME_SCHEDULER=true
 elif [[ $TARGET =~ sig-compute-migrations ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations/}
+  export KUBEVIRT_E2E_PARALLEL_NODES=3
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_NUM_SECONDARY_NICS=1
   export KUBEVIRT_DEPLOY_NFS_CSI=true

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -74,6 +74,7 @@ elif [[ $TARGET =~ sig-compute-realtime ]]; then
 elif [[ $TARGET =~ sig-compute-migrations ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations/}
   export KUBEVIRT_E2E_PARALLEL_NODES=3
+  export KUBEVIRT_NUM_NODES=3
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_NUM_SECONDARY_NICS=1
   export KUBEVIRT_DEPLOY_NFS_CSI=true


### PR DESCRIPTION
### What this PR does

The sig-compute-migrations has been experiencing clustered failures of tests intermittently[1]. These failures look to be due to nfs server timeouts.

Reducing the number of parallel tests running at once seems to avoid these nfs server timeouts. Tested through a number of rehearsal runs in project-infra[2]

This PR also moves the KUBEVIRT_NUM_NODES from the prow job config in project-infra to automation/test.sh - Keeping the lane configuration in one place makes it easier for people to understand what
each test lane is running and how it is configured.

[1] https://github.com/kubevirt/kubevirt/issues/12932
[2] https://github.com/kubevirt/project-infra/pull/4048

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

