### PR TITLE
unsafe and directsync cache modes added

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -2095,7 +2095,7 @@ func validateSerialNumLength(field *k8sfield.Path, idx int, disk v1.Disk) []meta
 
 func validateCacheMode(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
 	var causes []metav1.StatusCause
-	if disk.Cache != "" && disk.Cache != v1.CacheNone && disk.Cache != v1.CacheWriteThrough && disk.Cache != v1.CacheWriteBack {
+	if disk.Cache != "" && disk.Cache != v1.CacheNone && disk.Cache != v1.CacheWriteThrough && disk.Cache != v1.CacheWriteBack && disk.Cache != v1.CacheDirectSync && disk.Cache != v1.CacheUnsafe {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s has invalid value %s", field.Index(idx).Child("cache").String(), disk.Cache),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2224,6 +2224,8 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Entry("none", v1.CacheNone),
 			Entry("writethrough", v1.CacheWriteThrough),
 			Entry("writeback", v1.CacheWriteBack),
+			Entry("directsync", v1.CacheDirectSync),
+			Entry("unsafe", v1.CacheUnsafe),
 		)
 
 		DescribeTable("should reject disk with invalid errorPolicy", func(policy string) {

--- a/pkg/virtctl/vm/add_volume.go
+++ b/pkg/virtctl/vm/add_volume.go
@@ -160,7 +160,9 @@ func addVolume(vmiName, volumeName, namespace string, virtClient kubecli.Kubevir
 		// Verify if cache mode is valid
 		if hotplugRequest.Disk.Cache != v1.CacheNone &&
 			hotplugRequest.Disk.Cache != v1.CacheWriteThrough &&
-			hotplugRequest.Disk.Cache != v1.CacheWriteBack {
+			hotplugRequest.Disk.Cache != v1.CacheWriteBack &&
+			hotplugRequest.Disk.Cache != v1.CacheUnsafe &&
+			hotplugRequest.Disk.Cache != v1.CacheDirectSync {
 			return fmt.Errorf("error adding volume, invalid cache value %s", cache)
 		}
 	}

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -205,6 +205,8 @@ var _ = Describe("Add volume command", func() {
 				Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
 				Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
 				Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
+				Entry("cache unsafe", "--cache=unsafe", verifyDiskSerial(volumeName), verifyCache(v1.CacheUnsafe)),
+				Entry("cache directsync", "--cache=directsync", verifyDiskSerial(volumeName), verifyCache(v1.CacheDirectSync)),
 			)
 
 			DescribeTable("should call VM endpoint with persist and", func(arg string, verifyFns ...verifyFn) {
@@ -221,6 +223,8 @@ var _ = Describe("Add volume command", func() {
 				Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
 				Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
 				Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
+				Entry("cache unsafe", "--cache=unsafe", verifyDiskSerial(volumeName), verifyCache(v1.CacheUnsafe)),
+				Entry("cache directsync", "--cache=directsync", verifyDiskSerial(volumeName), verifyCache(v1.CacheDirectSync)),
 			)
 
 			It("should fail immediately on non concurrent error", func() {
@@ -281,6 +285,8 @@ var _ = Describe("Add volume command", func() {
 				Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
 				Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
 				Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
+				Entry("cache unsafe", "--cache=unsafe", verifyDiskSerial(volumeName), verifyCache(v1.CacheUnsafe)),
+				Entry("cache directsync", "--cache=directsync", verifyDiskSerial(volumeName), verifyCache(v1.CacheDirectSync)),
 			)
 
 			DescribeTable("should call VM endpoint with persist and", func(arg string, verifyFns ...verifyFn) {
@@ -297,6 +303,8 @@ var _ = Describe("Add volume command", func() {
 				Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
 				Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
 				Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
+				Entry("cache unsafe", "--cache=unsafe", verifyDiskSerial(volumeName), verifyCache(v1.CacheUnsafe)),
+				Entry("cache directsync", "--cache=directsync", verifyDiskSerial(volumeName), verifyCache(v1.CacheDirectSync)),
 			)
 		})
 	})

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1861,6 +1861,10 @@ const (
 	CacheWriteThrough DriverCache = "writethrough"
 	// CacheWriteBack - I/O from the guest is cached on the host.
 	CacheWriteBack DriverCache = "writeback"
+	// CacheUnsafe - I/O from the guest is cached on the host and may not be written to the physical medium.
+	CacheUnsafe DriverCache = "unsafe"
+	// CacheDirectSync - I/O from the guest is cached on the host and is written to the physical medium synchronously.
+	CacheDirectSync DriverCache = "directsync"
 
 	// IOThreads - User mode based threads with a shared lock that perform I/O tasks. Can impact performance but offers
 	// more predictable behaviour. This method is also takes fewer CPU cycles to submit I/O requests.

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -126,7 +126,9 @@ var _ = Describe(SIG("Hotplug", func() {
 		}
 		if cache == v1.CacheNone ||
 			cache == v1.CacheWriteThrough ||
-			cache == v1.CacheWriteBack {
+			cache == v1.CacheWriteBack ||
+			cache == v1.CacheUnsafe ||
+			cache == v1.CacheDirectSync {
 			opts.Disk.Cache = cache
 		}
 		return opts

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1988,6 +1988,10 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
 			// ephemeral-disk2
 			vmi.Spec.Domain.Devices.Disks[1].Cache = v1.CacheWriteThrough
+			// ephemeral-disk3
+			vmi.Spec.Domain.Devices.Disks[3].Cache = v1.CacheDirectSync
+			// ephemeral-disk4
+			vmi.Spec.Domain.Devices.Disks[4].Cache = v1.CacheUnsafe
 			// ephemeral-disk5
 			vmi.Spec.Domain.Devices.Disks[2].Cache = v1.CacheWriteBack
 
@@ -2002,6 +2006,8 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			cacheNone := string(v1.CacheNone)
 			cacheWritethrough := string(v1.CacheWriteThrough)
 			cacheWriteback := string(v1.CacheWriteBack)
+			cacheDirectsync := string(v1.CacheDirectSync)
+			cacheUnsafe := string(v1.CacheUnsafe)
 
 			By("checking if requested cache 'none' has been set")
 			Expect(disks[0].Alias.GetName()).To(Equal("ephemeral-disk1"))
@@ -2014,6 +2020,14 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			By("checking if requested cache 'writeback' has been set")
 			Expect(disks[2].Alias.GetName()).To(Equal("ephemeral-disk5"))
 			Expect(disks[2].Driver.Cache).To(Equal(cacheWriteback))
+
+			By("checking if requested cache 'directsync' has been set")
+			Expect(disks[3].Alias.GetName()).To(Equal("ephemeral-disk3"))
+			Expect(disks[3].Driver.Cache).To(Equal(cacheDirectsync))
+
+			By("checking if requested cache 'unsafe' has been set")
+			Expect(disks[4].Alias.GetName()).To(Equal("ephemeral-disk4"))
+			Expect(disks[4].Driver.Cache).To(Equal(cacheUnsafe))
 
 			By("checking if default cache 'none' has been set to ephemeral disk")
 			Expect(disks[3].Alias.GetName()).To(Equal("ephemeral-disk3"))


### PR DESCRIPTION
Before this PR:
KubeVirt currently supports a few cache modes for disks (CacheNone, CacheWriteback & CacheWriteThrough), however libvirt supports more:
writeback
writethrough
none
unsafe
directsync

After this PR:
we would be able to add all these cache modes

Fixes [7906](https://github.com/harvester/harvester/issues/7906)

### Why we need it and why it was done in this way
The following tradeoffs were made:
The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
#14265
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for unsafe directsync disk cache modes
```

