### PR TITLE
fix(check flakes): improve regex escaping

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -39,6 +39,8 @@ export IMAGE_PREFIX=''
 export IMAGE_PREFIX_ALT=''
 source hack/config-default.sh
 
+CANNIER_IMAGE="${CANNIER_IMAGE-quay.io/kubevirtci/cannier:v20250328-a1ef64e}"
+
 export TIMESTAMP=${TIMESTAMP:-1}
 
 function usage() {
@@ -52,6 +54,7 @@ usage: [NUM_TESTS=x] \
     hint: set NEW_TESTS to explicitly name the json file containing test names to run
 
     options:
+        CANNIER_IMAGE       the container image to use to execute cannier command
         NUM_TESTS           how many times the test lane is run, default is 5
         NEW_TESTS           the json file containing the (textual) names of the
                             tests to run, according to what is shown in the
@@ -99,7 +102,7 @@ function new_tests() {
     podman run --rm \
         -v "${KUBEVIRT_ROOT}:/kubevirt/" \
         -v "${tmp_dir}:/tmp" \
-        quay.io/kubevirtci/cannier:v20250227-c93cf50 \
+        "${CANNIER_IMAGE}" \
         extract changed-tests ${target_commit_range} \
         -p /kubevirt \
         -t /kubevirt/tests/ \
@@ -255,10 +258,12 @@ if [[ -n ${NEW_TESTS} ]]; then
     readarray -t test_names <<<"$(jq -r '.[]' "${NEW_TESTS}")"
     for test_name in "${test_names[@]}"; do
         echo "test name: ${test_name}"
-        # escape square brackets, hopefully that is the only thing needed
-        escaped=$(echo "${test_name}" | sed -E 's/([][])/\\\1/g')
+        # escape steps:
+        # 1) whitespaces - this avoids skipping tests
+        # 2) square brackets - which make the regex bail and
+        escaped=$(echo "${test_name// /\\s}" | sed -E 's/([][])/\\\1/g')
         echo "test name escaped: ${escaped}"
-        ginkgo_params+=" -focus='${escaped}'"
+        ginkgo_params+=" -focus=${escaped}"
     done
 fi
 

--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -260,7 +260,7 @@ if [[ -n ${NEW_TESTS} ]]; then
         echo "test name: ${test_name}"
         # escape steps:
         # 1) whitespaces - this avoids skipping tests
-        # 2) square brackets - which make the regex bail and
+        # 2) square brackets - which make the regex bail
         escaped=$(echo "${test_name// /\\s}" | sed -E 's/([][])/\\\1/g')
         echo "test name escaped: ${escaped}"
         ginkgo_params+=" -focus=${escaped}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Calling functest with `-focus=` containing whitespace doesn't work.

After this PR:
Added a step where we replace the whitespace in the escaping.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @brianmcarey @akalenyu

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

