### PR TITLE
[WIP] avoid loopback nfs - take 2

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -79,8 +79,9 @@ elif [[ $TARGET =~ sig-compute-realtime ]]; then
   export KUBEVIRT_REALTIME_SCHEDULER=true
 elif [[ $TARGET =~ sig-compute-migrations ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations/}
-  export KUBEVIRT_E2E_PARALLEL_NODES=3
-  export KUBEVIRT_NUM_NODES=3
+  export KUBEVIRT_E2E_PARALLEL_NODES=4
+  # extra cordoned node for NFS to avoid loopback (mounting a share on same server)
+  export KUBEVIRT_NUM_NODES=$((3 + 1))
   export KUBEVIRT_STORAGE="rook-ceph-default"
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_NUM_SECONDARY_NICS=1
@@ -549,6 +550,112 @@ spec:
 EOF
 fi
 
+if [[ "${KUBEVIRT_DEPLOY_NFS_CSI}" == "true" ]]; then
+  # reschedule pod/recreate volume so everything ends up on worker
+  kubectl delete deploy -n nfs-csi -l=app=nfs-server
+  kubectl delete pvc -n nfs-csi nfs-data
+  kubectl create -f - <<EOF
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-data
+  namespace: nfs-csi
+spec:
+  storageClassName: local
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-server
+  namespace: nfs-csi
+  labels:
+    app: "nfs-server"
+    cdi.kubevirt.io/testing: ""
+spec:
+  selector:
+    matchLabels:
+      app: nfs-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nfs-server
+        cdi.kubevirt.io/testing: ""
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      containers:
+      - image: quay.io/kubevirtci/gists-nfs-server:2.6.4
+        imagePullPolicy: IfNotPresent
+        name: nfs-server
+        env:
+        - name: NFS_DIR
+          value: /data/nfs
+        - name: NFS_OPTION
+          value: fsid=0,rw,sync,insecure,no_root_squash,no_subtree_check,nohide
+        securityContext:
+          privileged: true
+        ports:
+          - name: tcp-2049
+            containerPort: 2049
+            protocol: TCP
+          - name: udp-111
+            containerPort: 111
+            protocol: UDP
+        volumeMounts:
+        - mountPath: "/data/nfs"
+          name: nfsdata
+        command: ["sh", "-c"]
+        args:
+          - |
+            chmod 777 /data/nfs;
+            mkdir /data/nfs/disk1;
+            chmod 777 /data/nfs/disk1;
+            mkdir /data/nfs/disk2;
+            chmod 777 /data/nfs/disk2;
+            mkdir /data/nfs/disk3;
+            chmod 777 /data/nfs/disk3;
+            mkdir /data/nfs/disk4;
+            chmod 777 /data/nfs/disk4;
+            mkdir /data/nfs/disk5;
+            chmod 777 /data/nfs/disk5;
+            mkdir /data/nfs/disk6;
+            chmod 777 /data/nfs/disk6;
+            mkdir /data/nfs/disk7;
+            chmod 777 /data/nfs/disk7;
+            mkdir /data/nfs/disk8;
+            chmod 777 /data/nfs/disk8;
+            mkdir /data/nfs/disk9;
+            chmod 777 /data/nfs/disk9;
+            mkdir /data/nfs/disk10;
+            chmod 777 /data/nfs/disk10;
+            mkdir /data/nfs/extraDisk1;
+            chmod 777 /data/nfs/extraDisk1;
+            mkdir /data/nfs/extraDisk2;
+            chmod 777 /data/nfs/extraDisk2;
+            /bin/nfsd.sh
+      volumes:
+      - name: nfsdata
+        persistentVolumeClaim:
+          claimName: nfs-data
+EOF
+  kubectl wait deployment nfs-server \
+    --namespace="nfs-csi" \
+    --for=condition='Available' \
+    --timeout='2m'
+  # W/A - extra cordoned node for NFS to avoid loopback (mounting a share on same server)
+  node=$(kubectl get pod -n nfs-csi -l=app=nfs-server -ojsonpath="{ $.items[0].spec.nodeName }")
+  kubectl cordon ${node}
+  kubectl label node ${node} test.kubevirt.io/excludenode=true
+  # Ensure NFS CSI controller also ends up on different node than NFS server
+  kubectl delete pod -n nfs-csi -l=app=csi-nfs-controller
+fi
 
 # Run functional tests
 FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER="--label-filter=(!flake-check)&&(${label_filter})" make functest

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -2111,6 +2111,10 @@ func prepareNodeSelectorForHostCpuModel(node *k8sv1.Node, pod *k8sv1.Pod, source
 }
 
 func isNodeSuitableForHostModelMigration(node *k8sv1.Node, requiredNodeLabels map[string]string) bool {
+	if node.Spec.Unschedulable {
+		return false
+	}
+
 	for key, value := range requiredNodeLabels {
 		nodeValue, ok := node.Labels[key]
 

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -300,7 +300,7 @@ func GetNodesWithKVM() []*k8sv1.Node {
 // GetAllSchedulableNodes returns list of Nodes which are "KubeVirt" schedulable.
 func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *k8sv1.NodeList {
 	nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{
-		LabelSelector: v1.NodeSchedulable + "=" + "true",
+		LabelSelector: fmt.Sprintf("%s=%s,%s!=%s", v1.NodeSchedulable, "true", "test.kubevirt.io/excludenode", "true"),
 	})
 	Expect(err).ToNot(HaveOccurred(), "Should list compute nodeList")
 	return nodeList
@@ -397,7 +397,7 @@ func GetControlPlaneNodes(virtCli kubecli.KubevirtClient) *k8sv1.NodeList {
 func GetWorkerNodesWithCPUManagerEnabled(virtClient kubecli.KubevirtClient) []k8sv1.Node {
 	ginkgo.By("getting the list of worker nodes that have cpumanager enabled")
 	nodeList, err := virtClient.CoreV1().Nodes().List(context.TODO(), k8smetav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=,%s=%s", workerLabel, "cpumanager", "true"),
+		LabelSelector: fmt.Sprintf("%s=,%s=%s,%s!=%s", workerLabel, "cpumanager", "true", "test.kubevirt.io/excludenode", "true"),
 	})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(nodeList).ToNot(BeNil())

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1045,13 +1045,13 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}
 			})
 
-			It("[test_id:2653][QUARANTINE] should be migrated successfully, using guest agent on VM with default migration configuration", decorators.Quarantine, func() {
+			It("[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration", func() {
 				By("Creating the DV")
 				createDV(testsuite.NamespacePrivileged)
 				VMIMigrationWithGuestAgent(virtClient, dv.Name, fedoraVMSize, nil)
 			})
 
-			It("[test_id:6975][QUARANTINE] should have guest agent functional after migration", decorators.Quarantine, func() {
+			It("[test_id:6975] should have guest agent functional after migration", func() {
 				By("Creating the DV")
 				createDV(testsuite.GetTestNamespace(nil))
 				By("Creating the VMI")
@@ -1168,7 +1168,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 						libvmi.WithNetwork(v1.DefaultPodNetwork()))
 				}, console.LoginToAlpine),
 
-				Entry("[test_id:8610][QUARANTINE] with DataVolume", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("[test_id:8610] with DataVolume", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the DataVolume
 					return libvmi.New(
@@ -1183,7 +1183,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					return prepareVMIWithAllVolumeSources(testsuite.NamespacePrivileged, false)
 				}, console.LoginToFedora),
 
-				Entry("[test_id:8612][QUARANTINE] with PVC", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("[test_id:8612] with PVC", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the Underlying PVC
 					return libvmi.New(
@@ -1254,7 +1254,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 						libvmi.WithNetwork(v1.DefaultPodNetwork()))
 				}, console.LoginToAlpine),
 
-				Entry("[QUARANTINE] with DataVolume", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("with DataVolume", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the DataVolume
 					return libvmi.New(
@@ -1269,7 +1269,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					return prepareVMIWithAllVolumeSources(testsuite.NamespacePrivileged, false)
 				}, console.LoginToFedora),
 
-				Entry("[QUARANTINE] with PVC", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("with PVC", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the underlying PVC
 					return libvmi.New(
@@ -2799,7 +2799,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			}, 200)).To(Succeed())
 		})
 
-		It("[QUARANTINE] should migrate with a shared DV", decorators.Quarantine, func() {
+		It("should migrate with a shared DV", func() {
 			sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
 
 			if !foundSC {

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -100,7 +100,7 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:5004][QUARANTINE] should be migrated successfully, using guest agent on VM with post-copy", decorators.Quarantine, func() {
+		It("[test_id:5004] should be migrated successfully, using guest agent on VM with post-copy", func() {
 			VMIMigrationWithGuestAgent(virtClient, dv.Name, "1Gi", migrationPolicy)
 		})
 

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -190,10 +190,10 @@ var _ = Describe("[sig-compute]VM state", func() {
 			err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(context.Background(), vm.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		},
-			Entry("[test_id:10818][QUARANTINE] TPM across migration and restart", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "migrate", "restart"),
-			Entry("[test_id:10819][QUARANTINE]TPM across restart and migration", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "restart", "migrate"),
-			Entry("[test_id:10820][QUARANTINE]EFI across migration and restart", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, !tpm, efi, rwx, "migrate", "restart"),
-			Entry("[test_id:10821][QUARANTINE] TPM+EFI across migration and restart", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, tpm, efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10818]TPM across migration and restart", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10819]TPM across restart and migration", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "restart", "migrate"),
+			Entry("[test_id:10820]EFI across migration and restart", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, !tpm, efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10821]TPM+EFI across migration and restart", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, tpm, efi, rwx, "migrate", "restart"),
 			// The entries below are clones of the entries above, but made for cluster that *do not* support RWX FS.
 			// They can't be flake-checked since the flake-checker cluster does support RWX FS.
 			Entry("TPM across migration and restart", decorators.SigCompute, decorators.RequiresRWOFsVMStateStorageClass, decorators.NoFlakeCheck, tpm, !efi, rwo, "migrate", "restart"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Testing a theory; Loopback NFS (mounting a share on the same server) is not supported and can cause deadlocks https://www.suse.com/support/kb/doc/?id=000018709

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

