### PR TITLE
[code-cleanup]: refactor `IsMigrating` function from `pkg/util/migrations`

### DIFF
--- a/pkg/util/migrations/BUILD.bazel
+++ b/pkg/util/migrations/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -2,10 +2,8 @@ package migrations
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/log"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
@@ -55,30 +53,6 @@ func FilterRunningMigrations(migrations []*v1.VirtualMachineInstanceMigration) [
 		}
 	}
 	return runningMigrations
-}
-
-// IsMigrating returns true if a given VMI is still migrating and false otherwise.
-func IsMigrating(vmi *v1.VirtualMachineInstance) bool {
-	if vmi == nil {
-		log.Log.V(4).Infof("checking if VMI is migrating, but it is empty")
-		return false
-	}
-
-	now := v12.Now()
-
-	running := false
-	if vmi.Status.MigrationState != nil {
-		start := vmi.Status.MigrationState.StartTimestamp
-		stop := vmi.Status.MigrationState.EndTimestamp
-		if start != nil && (now.After(start.Time) || now.Equal(start)) {
-			running = true
-		}
-
-		if stop != nil && (now.After(stop.Time) || now.Equal(stop)) {
-			running = false
-		}
-	}
-	return running
 }
 
 func MigrationFailed(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -43,7 +43,6 @@ import (
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-api"
 	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	storageAdmitters "kubevirt.io/kubevirt/pkg/storage/admitters"
-	migrationutil "kubevirt.io/kubevirt/pkg/util/migrations"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -430,7 +429,7 @@ func (admitter *VMsAdmitter) validateVolumeRequests(ctx context.Context, vm *v1.
 			return causes, nil
 		}
 
-		if migrationutil.IsMigrating(vmi) {
+		if vmi.IsMigrating() {
 			return []metav1.StatusCause{{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
 				Message: fmt.Sprintf("Cannot handle volume requests while VMI migration is in progress"),

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -359,7 +359,7 @@ func (c *EvacuationController) execute(key string) error {
 func getMarkedForEvictionVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
 	var evictionCandidates []*virtv1.VirtualMachineInstance
 	for _, vmi := range vmis {
-		if vmi.IsMarkedForEviction() && !hasMigratedOnEviction(vmi) && !migrationutils.IsMigrating(vmi) {
+		if vmi.IsMarkedForEviction() && !hasMigratedOnEviction(vmi) && !vmi.IsMigrating() {
 			evictionCandidates = append(evictionCandidates, vmi)
 		}
 	}

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
-        "//pkg/util/migrations:go_default_library",
         "//pkg/util/trace:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/watch/common:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -68,7 +68,6 @@ import (
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
-	"kubevirt.io/kubevirt/pkg/util/migrations"
 	traceUtils "kubevirt.io/kubevirt/pkg/util/trace"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	volumemig "kubevirt.io/kubevirt/pkg/virt-controller/watch/volume-migration"
@@ -600,7 +599,7 @@ func (c *Controller) handleCPUChangeRequest(vm *virtv1.VirtualMachine, vmi *virt
 		return fmt.Errorf("another CPU hotplug is in progress")
 	}
 
-	if migrations.IsMigrating(vmi) {
+	if vmi.IsMigrating() {
 		return fmt.Errorf("CPU hotplug is not allowed while VMI is migrating")
 	}
 
@@ -719,7 +718,7 @@ func (c *Controller) handleTolerationsChangeRequest(vm *virtv1.VirtualMachine, v
 		return nil
 	}
 
-	if migrations.IsMigrating(vmi) {
+	if vmi.IsMigrating() {
 		return fmt.Errorf("tolerations should not be changed during VMI migration")
 	}
 
@@ -744,7 +743,7 @@ func (c *Controller) handleAffinityChangeRequest(vm *virtv1.VirtualMachine, vmi 
 	hasNodeSelectorChanged := !equality.Semantic.DeepEqual(vmCopyWithInstancetype.Spec.Template.Spec.NodeSelector, vmi.Spec.NodeSelector)
 	hasNodeAffinityChanged := !equality.Semantic.DeepEqual(vmCopyWithInstancetype.Spec.Template.Spec.Affinity, vmi.Spec.Affinity)
 
-	if migrations.IsMigrating(vmi) && (hasNodeSelectorChanged || hasNodeAffinityChanged) {
+	if vmi.IsMigrating() && (hasNodeSelectorChanged || hasNodeAffinityChanged) {
 		return fmt.Errorf("Node affinity should not be changed during VMI migration")
 	}
 
@@ -2557,7 +2556,7 @@ func (c *Controller) isVirtualMachineStatusTerminating(vm *virtv1.VirtualMachine
 
 // isVirtualMachineStatusMigrating determines whether the VM status field should be set to "Migrating".
 func (c *Controller) isVirtualMachineStatusMigrating(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
-	return vmi != nil && migrations.IsMigrating(vmi)
+	return vmi != nil && vmi.IsMigrating()
 }
 
 // isVirtualMachineStatusUnschedulable determines whether the VM status field should be set to "FailedUnschedulable".
@@ -3189,7 +3188,7 @@ func (c *Controller) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi *
 		return fmt.Errorf("another memory hotplug is in progress")
 	}
 
-	if migrations.IsMigrating(vmi) {
+	if vmi.IsMigrating() {
 		return fmt.Errorf("memory hotplug is not allowed while VMI is migrating")
 	}
 

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -218,7 +218,7 @@ func (c *WorkloadUpdateController) updateVmi(_, obj interface{}) {
 	}
 
 	if !(isHotplugInProgress(vmi) || isVolumesUpdateInProgress(vmi)) ||
-		migrationutils.IsMigrating(vmi) {
+		vmi.IsMigrating() {
 		return
 	}
 
@@ -328,7 +328,7 @@ func isVolumesUpdateInProgress(vmi *virtv1.VirtualMachineInstance) bool {
 }
 
 func (c *WorkloadUpdateController) doesRequireMigration(vmi *virtv1.VirtualMachineInstance) bool {
-	if vmi.IsFinal() || migrationutils.IsMigrating(vmi) {
+	if vmi.IsFinal() || vmi.IsMigrating() {
 		return false
 	}
 	if metav1.HasAnnotation(vmi.ObjectMeta, v1.WorkloadUpdateMigrationAbortionAnnotation) {
@@ -406,7 +406,7 @@ func (c *WorkloadUpdateController) getUpdateData(kv *virtv1.KubeVirt) *updateDat
 		// while a migrating workload can still be counted towards
 		// the outDatedVMIs list, we don't want to add it to any
 		// of the lists that results in actions being performed on them
-		if migrationutils.IsMigrating(vmi) {
+		if vmi.IsMigrating() {
 			continue
 		} else if exists := lookup[vmi.Namespace+"/"+vmi.Name]; exists {
 			continue

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -749,7 +749,7 @@ func (c *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		c.finalizeMigration(vmiCopy)
 	}
 
-	if !migrations.IsMigrating(vmi) {
+	if !vmi.IsMigrating() {
 		destSrcPortsMap := c.migrationProxy.GetTargetListenerPorts(string(vmi.UID))
 		if len(destSrcPortsMap) == 0 {
 			msg := "target migration listener is not up for this vmi"
@@ -2735,7 +2735,7 @@ func (c *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 		// Re-enqueue to trigger handler final cleanup
 		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second)
 		return nil
-	} else if migrations.IsMigrating(vmi) {
+	} else if vmi.IsMigrating() {
 		// If the migration has already started,
 		// then there's nothing left to prepare on the target side
 		return nil

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -468,6 +468,24 @@ func (v *VirtualMachineInstance) IsMigratable() bool {
 	return false
 }
 
+func (v *VirtualMachineInstance) IsMigrating() bool {
+	now := metav1.Now()
+
+	migrating := false
+	if v.Status.MigrationState != nil {
+		start := v.Status.MigrationState.StartTimestamp
+		stop := v.Status.MigrationState.EndTimestamp
+		if start != nil && (now.After(start.Time) || now.Equal(start)) {
+			migrating = true
+		}
+
+		if stop != nil && (now.After(stop.Time) || now.Equal(stop)) {
+			migrating = false
+		}
+	}
+	return migrating
+}
+
 func (v *VirtualMachineInstance) IsBlockMigration() bool {
 	return v.Status.MigrationMethod == BlockMigration ||
 		len(v.Status.MigratedVolumes) > 0


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

Following the code cleanup practice, the motivation is to reduce to content of `pkg/util`, and eventually get rid of it.

### What this PR does
Before this PR:
Although related to the VMI state, the function `IsMigrating` lives in `pkg/util/migrations` 

After this PR:
Moving `IsMigrating` to the VMI API, converting it to a method function of VMI struct.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

