### PR TITLE
[release-1.2] vmsnapshot: when checking if a VM is running, ignore runStrategy

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -1051,15 +1051,6 @@ func (ctrl *VMSnapshotController) checkVMIRunning(vm *kubevirtv1.VirtualMachine)
 	return exists, err
 }
 
-func checkVMRunning(vm *kubevirtv1.VirtualMachine) (bool, error) {
-	rs, err := vm.RunStrategy()
-	if err != nil {
-		return false, err
-	}
-
-	return rs == kubevirtv1.RunStrategyAlways || rs == kubevirtv1.RunStrategyRerunOnFailure, nil
-}
-
 func updateSnapshotCondition(ss *snapshotv1.VirtualMachineSnapshot, c snapshotv1.Condition) {
 	ss.Status.Conditions = updateCondition(ss.Status.Conditions, c, false)
 }

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -765,7 +765,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				controller.processVMSnapshotWorkItem()
 			})
 
-			It("should (partial) lock source if running", func() {
+			It("should (partial) lock source if running but no VMI", func() {
 				vmSnapshot := createVMSnapshotInProgress()
 				vm := createVM()
 				vm.Spec.Running = &t
@@ -782,17 +782,13 @@ var _ = Describe("Snapshot controlleer", func() {
 					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
 					newReadyCondition(corev1.ConditionFalse, "Not ready"),
 				}
-				updatedSnapshot.Status.Indications = []snapshotv1.Indication{
-					snapshotv1.VMSnapshotOnlineSnapshotIndication,
-					snapshotv1.VMSnapshotNoGuestAgentIndication,
-				}
 				expectVMSnapshotUpdate(vmSnapshotClient, updatedSnapshot)
 
 				addVirtualMachineSnapshot(vmSnapshot)
 				controller.processVMSnapshotWorkItem()
 			})
 
-			It("should (finish) lock source if running", func() {
+			It("should (finish) lock source if running but no VMI", func() {
 				vmSnapshot := createVMSnapshotInProgress()
 				vm := createVM()
 				vm.Spec.Running = &t
@@ -809,10 +805,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
 					newReadyCondition(corev1.ConditionFalse, "Not ready"),
-				}
-				updatedSnapshot.Status.Indications = []snapshotv1.Indication{
-					snapshotv1.VMSnapshotOnlineSnapshotIndication,
-					snapshotv1.VMSnapshotNoGuestAgentIndication,
 				}
 				expectVMSnapshotUpdate(vmSnapshotClient, updatedSnapshot)
 
@@ -909,6 +901,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vm := createVM()
 				vm.Spec.Running = &t
 				vmSource.Add(vm)
+				vmiSource.Add(createVMI(vm))
 				pods := createPodsUsingPVCs(vm)
 				podSource.Add(&pods[0])
 

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -286,17 +286,12 @@ func (s *vmSnapshotSource) Spec() (snapshotv1.SourceSpec, error) {
 }
 
 func (s *vmSnapshotSource) Online() (bool, error) {
-	vmRunning, err := checkVMRunning(s.vm)
-	if err != nil {
-		return false, err
-	}
-
 	exists, err := s.controller.checkVMIRunning(s.vm)
 	if err != nil {
 		return false, err
 	}
 
-	return (vmRunning || exists), nil
+	return exists, nil
 }
 
 func (s *vmSnapshotSource) GuestAgent() (bool, error) {

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -246,8 +246,17 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			Expect(snapshot.Status.SourceUID).ToNot(BeNil())
 			Expect(*snapshot.Status.SourceUID).To(Equal(vm.UID))
 
+			running := true
+			_, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				running = false
+			}
+
 			contentName := *snapshot.Status.VirtualMachineSnapshotContentName
-			if vm.Spec.Running != nil && *vm.Spec.Running {
+			if running {
 				expectedIndications := []snapshotv1.Indication{snapshotv1.VMSnapshotOnlineSnapshotIndication, snapshotv1.VMSnapshotNoGuestAgentIndication}
 				Expect(snapshot.Status.Indications).To(Equal(expectedIndications))
 				checkOnlineSnapshotExpectedContentSource(vm, contentName, false)
@@ -268,10 +277,18 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		})
 
 		It("[test_id:4610]create a snapshot when VM is running should succeed", func() {
-			patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
+			patch := []byte("[{ \"op\": \"remove\", \"path\": \"/spec/running\"}, { \"op\": \"add\", \"path\": \"/spec/runStrategy\", \"value\": \"Always\"}]")
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*vm.Spec.Running).Should(BeTrue())
+			Expect(vm.Spec.RunStrategy).To(HaveValue(Equal(v1.RunStrategyAlways)))
+			Eventually(func() bool {
+				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return false
+				}
+				Expect(err).ToNot(HaveOccurred())
+				return vmi.Status.Phase == v1.Running
+			}, 360*time.Second, time.Second).Should(BeTrue())
 
 			createAndVerifyVMSnapshot(vm)
 		})


### PR DESCRIPTION
This is a manual backport of PR https://github.com/kubevirt/kubevirt/pull/12582
/cc @mhenriks 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
Fixes: https://github.com/kubevirt/kubevirt/issues/12515
Jira-ticket: https://issues.redhat.com/browse/CNV-54971

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vmsnapshot: when checking if a VM is running, ignore runStrategy
```

