### PR TITLE
converter/arch/amd64: Use Virtio over Bochs for EFI VMs

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
@@ -39,7 +39,7 @@ func (converterAMD64) AddGraphicsDevice(_ *v1.VirtualMachineInstance, domain *ap
 		domain.Spec.Devices.Video = []api.Video{
 			{
 				Model: api.VideoModel{
-					Type:  "bochs",
+					Type:  v1.VirtIO,
 					Heads: pointer.P(graphicsDeviceDefaultHeads),
 				},
 			},


### PR DESCRIPTION
Switch the default video device from Bochs to Virtio for EFI-based VMs. Virtio provides better performance, higher resolutions, and improved compatibility with modern guest operating systems.

This change ensures a smoother experience, especially for graphical workloads in EFI environments.

### What this PR does
Before this PR:

After this PR:

Fixes #

### Release note
```release-note
none
```

