### PR TITLE
tests, network: Reuse of VMs between the passt e2e tests

### DIFF
--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -57,7 +57,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 
 	var err error
 
-	BeforeEach(func() {
+	BeforeEach(OncePerOrdered, func() {
 		const passtBindingName = "passt"
 
 		passtComputeMemoryOverheadWhenAllPortsAreForwarded := resource.MustParse("500Mi")
@@ -77,7 +77,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	BeforeEach(func() {
+	BeforeEach(OncePerOrdered, func() {
 		netAttachDef := libnet.NewPasstNetAttachDef(passtNetAttDefName)
 		_, err := libnet.CreateNetAttachDef(context.Background(), testsuite.GetTestNamespace(nil), netAttachDef)
 		Expect(err).NotTo(HaveOccurred())
@@ -109,13 +109,13 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		Expect(console.RunCommand(vmi, cmd, time.Second*5)).To(Succeed())
 	})
 
-	Context("TCP without port specification", func() {
+	Context("TCP without port specification", Ordered, decorators.OncePerOrderedCleanup, func() {
 		var clientVMI *v1.VirtualMachineInstance
 		var serverVMI *v1.VirtualMachineInstance
 
 		const highTCPPort = 8080
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			clientVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -146,13 +146,13 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		)
 	})
 
-	Context("TCP with port specification", func() {
+	Context("TCP with port specification", Ordered, decorators.OncePerOrderedCleanup, func() {
 		var clientVMI *v1.VirtualMachineInstance
 		var serverVMI *v1.VirtualMachineInstance
 
 		const highTCPPort = 8080
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			clientVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -192,13 +192,13 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		)
 	})
 
-	Context("TCP with low port specification", func() {
+	Context("TCP with low port specification", Ordered, decorators.OncePerOrderedCleanup, func() {
 		var clientVMI *v1.VirtualMachineInstance
 		var serverVMI *v1.VirtualMachineInstance
 
 		const lowTCPPort = 80
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			clientVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -238,14 +238,14 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		)
 	})
 
-	Context("UDP", func() {
+	Context("UDP", Ordered, decorators.OncePerOrderedCleanup, func() {
 		var clientVMI *v1.VirtualMachineInstance
 		var serverVMI *v1.VirtualMachineInstance
 
 		const udpPortForIPv4 = 1700
 		const udpPortForIPv6 = 1701
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			var ports = []v1.Port{
 				{Port: udpPortForIPv4, Protocol: "UDP"},
 				{Port: udpPortForIPv6, Protocol: "UDP"},
@@ -291,10 +291,10 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		)
 	})
 
-	Context("egress connectivity", func() {
+	Context("egress connectivity", Ordered, decorators.OncePerOrderedCleanup, func() {
 		var vmi *v1.VirtualMachineInstance
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			vmi = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -336,11 +336,11 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		})
 	})
 
-	Context("migration", func() {
+	Context("migration", Ordered, decorators.OncePerOrderedCleanup, func() {
 		var migrateVMI *v1.VirtualMachineInstance
 		var anotherVMI *v1.VirtualMachineInstance
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			By("Starting a VMI")
 			migrateVMI = startPasstVMI()
 


### PR DESCRIPTION
### What this PR does

Reuse the VMs when executing both IP families

Utilize the `BeforeAll` fixture in ordered contexts and mark common
fixtures (plugin registration and NAD creation) with `OncePerOrdered` so
these will run only once for the ordered tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer
This change demonstrates the resource reuse between tests.
It depends on two PRs: The [passt e2e tests refactoring](https://github.com/kubevirt/kubevirt/pull/14390) and  the [controlled cleanup](https://github.com/kubevirt/kubevirt/pull/13786).

The relevant commits for review in this context are the last two.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

