### PR TITLE
Add supplementalPool to the description of the ioThreadsPolicy possible values

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13561,7 +13561,7 @@
       "$ref": "#/definitions/v1.DiskIOThreads"
      },
      "ioThreadsPolicy": {
-      "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads. One of: shared, auto",
+      "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads. One of: shared, auto, supplementalPool",
       "type": "string"
      },
      "launchSecurity": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6843,7 +6843,7 @@ var CRDsValidation map[string]string = map[string]string{
                       description: |-
                         Controls whether or not disks will share IOThreads.
                         Omitting IOThreadsPolicy disables use of IOThreads.
-                        One of: shared, auto
+                        One of: shared, auto, supplementalPool
                       type: string
                     launchSecurity:
                       description: Launch Security setting of the vmi.
@@ -12128,7 +12128,7 @@ var CRDsValidation map[string]string = map[string]string{
               description: |-
                 Controls whether or not disks will share IOThreads.
                 Omitting IOThreadsPolicy disables use of IOThreads.
-                One of: shared, auto
+                One of: shared, auto, supplementalPool
               type: string
             launchSecurity:
               description: Launch Security setting of the vmi.
@@ -15348,7 +15348,7 @@ var CRDsValidation map[string]string = map[string]string{
               description: |-
                 Controls whether or not disks will share IOThreads.
                 Omitting IOThreadsPolicy disables use of IOThreads.
-                One of: shared, auto
+                One of: shared, auto, supplementalPool
               type: string
             launchSecurity:
               description: Launch Security setting of the vmi.
@@ -17778,7 +17778,7 @@ var CRDsValidation map[string]string = map[string]string{
                       description: |-
                         Controls whether or not disks will share IOThreads.
                         Omitting IOThreadsPolicy disables use of IOThreads.
-                        One of: shared, auto
+                        One of: shared, auto, supplementalPool
                       type: string
                     launchSecurity:
                       description: Launch Security setting of the vmi.
@@ -22288,7 +22288,7 @@ var CRDsValidation map[string]string = map[string]string{
                               description: |-
                                 Controls whether or not disks will share IOThreads.
                                 Omitting IOThreadsPolicy disables use of IOThreads.
-                                One of: shared, auto
+                                One of: shared, auto, supplementalPool
                               type: string
                             launchSecurity:
                               description: Launch Security setting of the vmi.
@@ -27490,7 +27490,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   description: |-
                                     Controls whether or not disks will share IOThreads.
                                     Omitting IOThreadsPolicy disables use of IOThreads.
-                                    One of: shared, auto
+                                    One of: shared, auto, supplementalPool
                                   type: string
                                 launchSecurity:
                                   description: Launch Security setting of the vmi.

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -201,7 +201,7 @@ type DomainSpec struct {
 	Devices Devices `json:"devices"`
 	// Controls whether or not disks will share IOThreads.
 	// Omitting IOThreadsPolicy disables use of IOThreads.
-	// One of: shared, auto
+	// One of: shared, auto, supplementalPool
 	// +optional
 	IOThreadsPolicy *IOThreadsPolicy `json:"ioThreadsPolicy,omitempty"`
 	// IOThreads specifies the IOThreads options.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -92,7 +92,7 @@ func (DomainSpec) SwaggerDoc() map[string]string {
 		"clock":           "Clock sets the clock and timers of the vmi.\n+optional",
 		"features":        "Features like acpi, apic, hyperv, smm.\n+optional",
 		"devices":         "Devices allows adding disks, network interfaces, and others",
-		"ioThreadsPolicy": "Controls whether or not disks will share IOThreads.\nOmitting IOThreadsPolicy disables use of IOThreads.\nOne of: shared, auto\n+optional",
+		"ioThreadsPolicy": "Controls whether or not disks will share IOThreads.\nOmitting IOThreadsPolicy disables use of IOThreads.\nOne of: shared, auto, supplementalPool\n+optional",
 		"ioThreads":       "IOThreads specifies the IOThreads options.\n+optional",
 		"chassis":         "Chassis specifies the chassis info passed to the domain.\n+optional",
 		"launchSecurity":  "Launch Security setting of the vmi.\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19486,7 +19486,7 @@ func schema_kubevirtio_api_core_v1_DomainSpec(ref common.ReferenceCallback) comm
 					},
 					"ioThreadsPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads. One of: shared, auto",
+							Description: "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads. One of: shared, auto, supplementalPool",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Follow up for the PR that introduces the actual functionality: https://github.com/kubevirt/kubevirt/pull/13110

Before this PR:

```
$ oc explain vm.spec.template.spec.domain.ioThreadsPolicy
...
DESCRIPTION:
    ...
    One of: shared, auto
```

After this PR:

```
$ oc explain vm.spec.template.spec.domain.ioThreadsPolicy
...
DESCRIPTION:
    ...
    One of: shared, auto, supplementalPool
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
supplementalPool added to the description of the ioThreadsPolicy possible values
```

