### PR TITLE
nfs-csi: switch to external nfs server

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -140,6 +140,7 @@ export WINDOWS_NFS_DIR=${WINDOWS_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/
 export WINDOWS_LOCK_PATH=${WINDOWS_LOCK_PATH:-/var/lib/stdci/shared/download_windows_image.lock}
 export WINDOWS_SYSPREP_NFS_DIR=${WINDOWS_SYSPREP_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/windows2012_syspreped}
 export WINDOWS_SYSPREP_LOCK_PATH=${WINDOWS_SYSPREP_LOCK_PATH:-/var/lib/stdci/shared/download_windows_syspreped_image.lock}
+export KUBEVIRT_NFS_DIR=${KUBEVIRT_NFS_DIR:-/var/lib/containers/nfs-data}
 
 wait_for_download_lock() {
   local max_lock_attempts=60

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -87,6 +87,26 @@ if [[ "$KUBEVIRT_DEPLOY_CDI" != "false" ]] && [[ ${ARCHITECTURE} != *aarch64 ]];
     _ensure_cdi_deployment
 fi
 
+if [[ "${KUBEVIRT_DEPLOY_NFS_CSI}" == "true" ]]; then
+    # Hack to change the nfs-csi storage class outside of kubevirtci/gocli
+    _kubectl delete sc nfs-csi
+    _kubectl create -f - <<EOF
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-csi
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: nfs
+  share: /
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+mountOptions:
+  - nfsvers=4.1
+EOF
+fi
+
 # Deploy kubevirt operator
 _kubectl apply -f ${MANIFESTS_OUT_DIR}/release/kubevirt-operator.yaml
 

--- a/kubevirtci/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/kubevirtci/cluster-up/cluster/ephemeral-provider-common.sh
@@ -152,7 +152,11 @@ function _add_common_params() {
     fi
 
     if [ $KUBEVIRT_DEPLOY_NFS_CSI == "true" ]; then
-        params=" --enable-nfs-csi $params"
+        if [ -z $KUBEVIRT_NFS_DIR ]; then
+            >&2 echo "NFS requested but no NFS directory specified (KUBEVIRT_NFS_DIR)"
+            exit 1
+        fi
+        params=" --enable-nfs-csi --nfs-data $KUBEVIRT_NFS_DIR $params"
     fi
 
     # alternate (new) way to specify storage providers

--- a/kubevirtci/cluster-up/cluster/k8s-provider-common.sh
+++ b/kubevirtci/cluster-up/cluster/k8s-provider-common.sh
@@ -39,6 +39,19 @@ function wait_for_kwok_ready() {
     fi
 }
 
+function configure_nfs() {
+    if [[ "$KUBEVIRT_DEPLOY_NFS_CSI" == "true" ]] && [[ -n "$KUBEVIRT_NFS_DIR" ]]; then
+        ${_cri_bin} run --privileged --rm -v /:/hostroot \
+            --entrypoint /bin/sh ${_cli_container} \
+            -c "mkdir -p /hostroot/${KUBEVIRT_NFS_DIR} && chmod 777 /hostroot/${KUBEVIRT_NFS_DIR}"
+
+        ${_cri_bin} run --privileged --rm -v $KUBEVIRT_NFS_DIR:/nfsdir \
+            --entrypoint /bin/sh ${_cli_container} \
+            -c 'for disk in disk1 disk2 disk3 disk4 disk5 disk6 disk7 disk8 disk9 disk10 extraDisk1 extraDisk2; do \
+            mkdir -p /nfsdir/${disk} && chmod 777 /nfsdir/${disk}; done'
+    fi
+}
+
 function up() {
     params=$(_add_common_params)
     if echo "$params" | grep -q ERROR; then
@@ -83,6 +96,8 @@ function up() {
     # [1] https://github.com/kubevirt/kubevirtci/issues/906
     # [2] https://github.com/k8snetworkplumbingwg/multus-cni/issues/982
     copy_istio_cni_conf_files
+
+    configure_nfs
 }
 
 # The scp command for docker and podman is different, in order to avoid segmentation fault

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1045,13 +1045,13 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}
 			})
 
-			It("[test_id:2653][QUARANTINE] should be migrated successfully, using guest agent on VM with default migration configuration", decorators.Quarantine, func() {
+			It("[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration", func() {
 				By("Creating the DV")
 				createDV(testsuite.NamespacePrivileged)
 				VMIMigrationWithGuestAgent(virtClient, dv.Name, fedoraVMSize, nil)
 			})
 
-			It("[test_id:6975][QUARANTINE] should have guest agent functional after migration", decorators.Quarantine, func() {
+			It("[test_id:6975] should have guest agent functional after migration", func() {
 				By("Creating the DV")
 				createDV(testsuite.GetTestNamespace(nil))
 				By("Creating the VMI")
@@ -1168,7 +1168,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 						libvmi.WithNetwork(v1.DefaultPodNetwork()))
 				}, console.LoginToAlpine),
 
-				Entry("[test_id:8610][QUARANTINE] with DataVolume", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("[test_id:8610] with DataVolume", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the DataVolume
 					return libvmi.New(
@@ -1183,7 +1183,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					return prepareVMIWithAllVolumeSources(testsuite.NamespacePrivileged, false)
 				}, console.LoginToFedora),
 
-				Entry("[test_id:8612][QUARANTINE] with PVC", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("[test_id:8612] with PVC", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the Underlying PVC
 					return libvmi.New(
@@ -1254,7 +1254,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 						libvmi.WithNetwork(v1.DefaultPodNetwork()))
 				}, console.LoginToAlpine),
 
-				Entry("[QUARANTINE] with DataVolume", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("with DataVolume", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the DataVolume
 					return libvmi.New(
@@ -1269,7 +1269,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					return prepareVMIWithAllVolumeSources(testsuite.NamespacePrivileged, false)
 				}, console.LoginToFedora),
 
-				Entry("[QUARANTINE] with PVC", decorators.Quarantine, func() *v1.VirtualMachineInstance {
+				Entry("with PVC", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the underlying PVC
 					return libvmi.New(
@@ -2799,7 +2799,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			}, 200)).To(Succeed())
 		})
 
-		It("[QUARANTINE] should migrate with a shared DV", decorators.Quarantine, func() {
+		It("should migrate with a shared DV", func() {
 			sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
 
 			if !foundSC {

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -100,7 +100,7 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:5004][QUARANTINE] should be migrated successfully, using guest agent on VM with post-copy", decorators.Quarantine, func() {
+		It("[test_id:5004] should be migrated successfully, using guest agent on VM with post-copy", func() {
 			VMIMigrationWithGuestAgent(virtClient, dv.Name, "1Gi", migrationPolicy)
 		})
 

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -190,10 +190,10 @@ var _ = Describe("[sig-compute]VM state", func() {
 			err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(context.Background(), vm.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		},
-			Entry("[test_id:10818][QUARANTINE] TPM across migration and restart", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "migrate", "restart"),
-			Entry("[test_id:10819][QUARANTINE]TPM across restart and migration", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "restart", "migrate"),
-			Entry("[test_id:10820][QUARANTINE]EFI across migration and restart", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, !tpm, efi, rwx, "migrate", "restart"),
-			Entry("[test_id:10821][QUARANTINE] TPM+EFI across migration and restart", decorators.SigComputeMigrations, decorators.Quarantine, decorators.RequiresRWXFsVMStateStorageClass, tpm, efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10818]TPM across migration and restart", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10819]TPM across restart and migration", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, tpm, !efi, rwx, "restart", "migrate"),
+			Entry("[test_id:10820]EFI across migration and restart", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, !tpm, efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10821]TPM+EFI across migration and restart", decorators.SigComputeMigrations, decorators.RequiresRWXFsVMStateStorageClass, tpm, efi, rwx, "migrate", "restart"),
 			// The entries below are clones of the entries above, but made for cluster that *do not* support RWX FS.
 			// They can't be flake-checked since the flake-checker cluster does support RWX FS.
 			Entry("TPM across migration and restart", decorators.SigCompute, decorators.RequiresRWOFsVMStateStorageClass, decorators.NoFlakeCheck, tpm, !efi, rwo, "migrate", "restart"),


### PR DESCRIPTION
### What this PR does
Before this PR:
We use an nfs-server pod inside the test cluster

After this PR:
The test cluster connects to an external NFS server, provided by kubevirtci

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- This PR contains changes that belong to kubevirtci, but were made here for now for ease of testing.
- We still deploy nfs-server, its removal will be part of the kubevirtci PR.
- Running CRI commands in a loop in cluster-up is slow, we should combine them into a script or something.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

