### PR TITLE
Sig-Network Cirros to alpine image changes for s390x architecture

### DIFF
--- a/tests/network/bindingplugin_slirp.go
+++ b/tests/network/bindingplugin_slirp.go
@@ -61,7 +61,7 @@ var _ = Describe(SIG("Slirp", decorators.Networking, decorators.NetCustomBinding
 	})
 
 	It("VMI with SLIRP interface, custom mac and port is configured correctly", func() {
-		vmi := libvmifact.NewCirros(
+		vmi := libvmifact.NewAlpine(
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithInterface(v1.Interface{
 				Name:       v1.DefaultPodNetwork().Name,
@@ -78,7 +78,7 @@ var _ = Describe(SIG("Slirp", decorators.Networking, decorators.NetCustomBinding
 			libwait.WithTimeout(180),
 		)
 
-		generateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
+		generateHelloWorldServer(vmi, 80, "tcp", console.LoginToAlpine, true)
 
 		By("have containerPort in the pod manifest")
 		vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -72,8 +72,8 @@ var _ = Describe(SIG("Port-forward", func() {
 				Skip(skipIPv6Message)
 			}
 
-			vmi := createCirrosVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
-			vmnetserver.StartHTTPServerWithSourceIP(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
+			vmi := createAlpineVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
+			vmnetserver.StartHTTPServerWithSourceIP(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToAlpine)
 
 			localPort = 1500 + GinkgoParallelProcess()
 			vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -163,15 +163,15 @@ func killPortForwardCommand(portForwardCmd *exec.Cmd) error {
 	return err
 }
 
-func createCirrosVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClient, ports []v1.Port) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewCirros(
+func createAlpineVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClient, ports []v1.Port) *v1.VirtualMachineInstance {
+	vmi := libvmifact.NewAlpine(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 	)
 
 	vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 	return vmi
 }

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -68,7 +68,7 @@ var _ = Describe(SIG("Services", func() {
 		BeforeEach(func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
 
-			inboundVMI = libvmifact.NewCirros(
+			inboundVMI = libvmifact.NewAlpine(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
@@ -79,8 +79,8 @@ var _ = Describe(SIG("Services", func() {
 			inboundVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), inboundVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
-			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToCirros)
+			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
+			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToAlpine)
 		})
 
 		Context("with a service matching the vmi exposed", func() {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -203,14 +203,14 @@ var istioTests = func(vmType VmType) {
 			BeforeEach(func() {
 				skipTestByVMType(vmType)
 
-				bastionVMI = libvmifact.NewCirros(
+				bastionVMI = libvmifact.NewAlpine(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
 				)
 
 				bastionVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), bastionVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				bastionVMI = libwait.WaitUntilVMIReady(bastionVMI, console.LoginToCirros)
+				bastionVMI = libwait.WaitUntilVMIReady(bastionVMI, console.LoginToAlpine)
 			})
 			Context("With VMI having explicit ports specified", func() {
 				BeforeEach(func() {

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -93,7 +93,7 @@ var _ = Describe(SIG("[crit:high][vendor:cnv-qe@redhat.com][level:component]", d
 				}, 50, 5).Should(Equal(k8sv1.PodSucceeded))
 
 				By("starting another VMI on the same node, to verify kubelet is running again")
-				newVMI := libvmifact.NewCirros()
+				newVMI := libvmifact.NewAlpine()
 				newVMI.Spec.NodeSelector = map[string]string{k8sv1.LabelHostname: nodeName}
 				Eventually(func() error {
 					newVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(newVMI)).Create(context.Background(), newVMI, metav1.CreateOptions{})
@@ -111,7 +111,7 @@ var _ = Describe(SIG("[crit:high][vendor:cnv-qe@redhat.com][level:component]", d
 
 			It("VMIs with Bridge Networking should work with Duplicate Address Detection (DAD)", decorators.Networking, func() {
 				libnet.SkipWhenClusterNotSupportIpv4()
-				bridgeVMI := libvmifact.NewCirros(
+				bridgeVMI := libvmifact.NewAlpine(
 					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
@@ -121,7 +121,7 @@ var _ = Describe(SIG("[crit:high][vendor:cnv-qe@redhat.com][level:component]", d
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting the VirtualMachineInstance start")
-				bridgeVMI = libwait.WaitUntilVMIReady(bridgeVMI, console.LoginToCirros)
+				bridgeVMI = libwait.WaitUntilVMIReady(bridgeVMI, console.LoginToAlpine)
 				verifyDummyNicForBridgeNetwork(bridgeVMI)
 
 				vmIP := libnet.GetVmiPrimaryIPByFamily(bridgeVMI, k8sv1.IPv4Protocol)


### PR DESCRIPTION
### **What this PR does**
Before this PR:
SIG-Network tests using Cirros are not supported on s390x arch, as Cirros OS isn't supported on s390x arch.

After this PR:
Enabled all those tests for s390x, by replacing Cirros with Alpine

Fixes #

### **Why we need it and why it was done in this way**
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place:

### **Special notes for your reviewer**
### **Checklist**
This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

 

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ]  PR: The PR description is expressive enough and will help future contributors
- [ ]  Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ]  Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ]  Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ]  Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ]  Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ]  Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered