### PR TITLE
move the logic of validating the clone's source away from webhooks

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -23,13 +23,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
-
-	"kubevirt.io/kubevirt/pkg/network/link"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	clonebase "kubevirt.io/api/clone"
 	clone "kubevirt.io/api/clone/v1beta1"
@@ -37,6 +33,7 @@ import (
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	clonecontroller "kubevirt.io/kubevirt/pkg/virt-controller/watch/clone"
 )
 
 const (
@@ -79,32 +76,32 @@ func (admitter *VirtualMachineCloneAdmitter) Admit(ctx context.Context, ar *admi
 
 	var causes []metav1.StatusCause
 
-	if newCauses := validateFilters(vmClone.Spec.AnnotationFilters, "spec.annotations"); newCauses != nil {
+	if newCauses := clonecontroller.ValidateFilters(vmClone.Spec.AnnotationFilters, "spec.annotations"); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
-	if newCauses := validateFilters(vmClone.Spec.LabelFilters, "spec.labels"); newCauses != nil {
+	if newCauses := clonecontroller.ValidateFilters(vmClone.Spec.LabelFilters, "spec.labels"); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
-	if newCauses := validateFilters(vmClone.Spec.Template.AnnotationFilters, "spec.template.annotations"); newCauses != nil {
+	if newCauses := clonecontroller.ValidateFilters(vmClone.Spec.Template.AnnotationFilters, "spec.template.annotations"); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
-	if newCauses := validateFilters(vmClone.Spec.Template.LabelFilters, "spec.template.labels"); newCauses != nil {
-		causes = append(causes, newCauses...)
-	}
-
-	if newCauses := validateSourceAndTargetKind(vmClone); newCauses != nil {
+	if newCauses := clonecontroller.ValidateFilters(vmClone.Spec.Template.LabelFilters, "spec.template.labels"); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
 
-	if newCauses := validateSource(ctx, admitter.Client, vmClone); newCauses != nil {
+	if newCauses := clonecontroller.ValidateSourceAndTargetKind(vmClone); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
 
-	if newCauses := validateTarget(vmClone); newCauses != nil {
+	if newCauses := clonecontroller.ValidateSource(ctx, admitter.Client, vmClone); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
 
-	if newCauses := validateNewMacAddresses(vmClone); newCauses != nil {
+	if newCauses := clonecontroller.ValidateTarget(vmClone); newCauses != nil {
+		causes = append(causes, newCauses...)
+	}
+
+	if newCauses := clonecontroller.ValidateNewMacAddresses(vmClone); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
 
@@ -116,157 +113,4 @@ func (admitter *VirtualMachineCloneAdmitter) Admit(ctx context.Context, ar *admi
 		Allowed: true,
 	}
 	return &reviewResponse
-}
-
-func validateFilters(filters []string, fieldName string) (causes []metav1.StatusCause) {
-	if filters == nil {
-		return nil
-	}
-
-	addCause := func(message string) {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: message,
-			Field:   fieldName,
-		})
-	}
-	const negationChar = "!"
-	const wildcardChar = "*"
-
-	for _, filter := range filters {
-		if len(filter) == 1 {
-			if filter == negationChar {
-				addCause("a negation character is not a valid filter")
-			}
-			continue
-		}
-
-		const errPattern = "%s filter %s is invalid: cannot contain a %s character (%s); FilterRules: %s"
-
-		if filterWithoutFirstChar := filter[1:]; strings.Contains(filterWithoutFirstChar, negationChar) {
-			addCause(fmt.Sprintf(errPattern, fieldName, filter, "negation", negationChar, "NegationChar can be only used at the beginning of the filter"))
-		}
-
-		if filterWithoutLastChar := filter[:len(filter)-1]; strings.Contains(filterWithoutLastChar, wildcardChar) {
-			addCause(fmt.Sprintf(errPattern, fieldName, filter, "wildcard", wildcardChar, "WildcardChar can be only at the end of the filter"))
-		}
-	}
-
-	return causes
-}
-
-func validateSourceAndTargetKind(vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
-	var causes []metav1.StatusCause = nil
-	sourceField := k8sfield.NewPath("spec")
-
-	supportedSourceTypes := []string{virtualMachineKind, virtualMachineSnapshotKind}
-	supportedTargetTypes := []string{virtualMachineKind}
-
-	if !doesSliceContainStr(supportedSourceTypes, vmClone.Spec.Source.Kind) {
-		causes = []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Source kind is not supported",
-			Field:   sourceField.Child("Source").Child("Kind").String(),
-		}}
-	}
-
-	if vmClone.Spec.Target != nil && !doesSliceContainStr(supportedTargetTypes, vmClone.Spec.Target.Kind) {
-		if causes == nil {
-			causes = []metav1.StatusCause{}
-		}
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Target kind is not supported",
-			Field:   sourceField.Child("Target").Child("Kind").String(),
-		})
-	}
-
-	return causes
-}
-
-func validateSource(ctx context.Context, client kubecli.KubevirtClient, vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
-	var causes []metav1.StatusCause = nil
-	sourceField := k8sfield.NewPath("spec")
-	source := vmClone.Spec.Source
-
-	if source == nil {
-		causes = []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Source cannot be nil",
-			Field:   sourceField.Child("Source").String(),
-		}}
-		return causes
-	}
-	if source.APIGroup == nil || *source.APIGroup == "" {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Source's APIGroup cannot be empty",
-			Field:   sourceField.Child("Source").Child("APIGroup").String(),
-		})
-	}
-	if source.Kind == "" {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Source's Kind cannot be empty",
-			Field:   sourceField.Child("Source").String(),
-		})
-	}
-	if source.Name == "" {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Source's name cannot be empty",
-			Field:   sourceField.Child("Source").Child("Name").String(),
-		})
-	}
-	return causes
-}
-
-func validateTarget(vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
-	var causes []metav1.StatusCause
-
-	source := vmClone.Spec.Source
-	target := vmClone.Spec.Target
-
-	if source != nil &&
-		target != nil &&
-		source.Kind == virtualMachineKind &&
-		target.Kind == virtualMachineKind &&
-		target.Name == source.Name {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Target name cannot be equal to source name when both are VirtualMachines",
-			Field:   k8sfield.NewPath("spec").Child("target").Child("name").String(),
-		})
-	}
-
-	return causes
-}
-
-func validateNewMacAddresses(vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
-	var causes []metav1.StatusCause
-
-	for ifaceName, ifaceMac := range vmClone.Spec.NewMacAddresses {
-		if ifaceMac != "" {
-			if err := link.ValidateMacAddress(ifaceMac); err != nil {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("interface %s has malformed MAC address (%s).", ifaceName, ifaceMac),
-					Field:   k8sfield.NewPath("spec").Child("newMacAddresses").Child(ifaceName).String(),
-				})
-			}
-		}
-	}
-
-	return causes
-}
-
-func doesSliceContainStr(slice []string, str string) (isFound bool) {
-	for _, curSliceStr := range slice {
-		if curSliceStr == str {
-			isFound = true
-			break
-		}
-	}
-
-	return isFound
 }

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -1,8 +1,10 @@
 package clone
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	k8scorev1 "k8s.io/api/core/v1"
@@ -21,6 +23,11 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/storage/snapshot"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	"kubevirt.io/kubevirt/pkg/network/link"
 )
 
 type Event string
@@ -42,6 +49,8 @@ const (
 	SourceDoesNotExist              Event = "SourceDoesNotExist"
 	SourceWithBackendStorageInvalid Event = "SourceVMWithBackendStorageInvalid"
 	VMVolumeSnapshotsInvalid        Event = "VMVolumeSnapshotsInvalid"
+	virtualMachineKind                    = "VirtualMachine"
+	virtualMachineSnapshotKind            = "VirtualMachineSnapshot"
 )
 
 var (
@@ -411,4 +420,157 @@ func (ctrl *VMCloneController) Execute() bool {
 func (ctrl *VMCloneController) runWorker() {
 	for ctrl.Execute() {
 	}
+}
+
+func ValidateSourceAndTargetKind(vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
+	var causes []metav1.StatusCause = nil
+	sourceField := k8sfield.NewPath("spec")
+
+	supportedSourceTypes := []string{virtualMachineKind, virtualMachineSnapshotKind}
+	supportedTargetTypes := []string{virtualMachineKind}
+
+	if !doesSliceContainStr(supportedSourceTypes, vmClone.Spec.Source.Kind) {
+		causes = []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Source kind is not supported",
+			Field:   sourceField.Child("Source").Child("Kind").String(),
+		}}
+	}
+
+	if vmClone.Spec.Target != nil && !doesSliceContainStr(supportedTargetTypes, vmClone.Spec.Target.Kind) {
+		if causes == nil {
+			causes = []metav1.StatusCause{}
+		}
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Target kind is not supported",
+			Field:   sourceField.Child("Target").Child("Kind").String(),
+		})
+	}
+
+	return causes
+}
+
+func ValidateSource(ctx context.Context, client kubecli.KubevirtClient, vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
+	var causes []metav1.StatusCause = nil
+	sourceField := k8sfield.NewPath("spec")
+	source := vmClone.Spec.Source
+
+	if source == nil {
+		causes = []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Source cannot be nil",
+			Field:   sourceField.Child("Source").String(),
+		}}
+		return causes
+	}
+	if source.APIGroup == nil || *source.APIGroup == "" {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Source's APIGroup cannot be empty",
+			Field:   sourceField.Child("Source").Child("APIGroup").String(),
+		})
+	}
+	if source.Kind == "" {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Source's Kind cannot be empty",
+			Field:   sourceField.Child("Source").String(),
+		})
+	}
+	if source.Name == "" {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Source's name cannot be empty",
+			Field:   sourceField.Child("Source").Child("Name").String(),
+		})
+	}
+	return causes
+}
+
+func ValidateTarget(vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+
+	source := vmClone.Spec.Source
+	target := vmClone.Spec.Target
+
+	if source != nil &&
+		target != nil &&
+		source.Kind == virtualMachineKind &&
+		target.Kind == virtualMachineKind &&
+		target.Name == source.Name {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Target name cannot be equal to source name when both are VirtualMachines",
+			Field:   k8sfield.NewPath("spec").Child("target").Child("name").String(),
+		})
+	}
+
+	return causes
+}
+
+func ValidateNewMacAddresses(vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+
+	for ifaceName, ifaceMac := range vmClone.Spec.NewMacAddresses {
+		if ifaceMac != "" {
+			if err := link.ValidateMacAddress(ifaceMac); err != nil {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("interface %s has malformed MAC address (%s).", ifaceName, ifaceMac),
+					Field:   k8sfield.NewPath("spec").Child("newMacAddresses").Child(ifaceName).String(),
+				})
+			}
+		}
+	}
+
+	return causes
+}
+
+func ValidateFilters(filters []string, fieldName string) (causes []metav1.StatusCause) {
+	if filters == nil {
+		return nil
+	}
+
+	addCause := func(message string) {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: message,
+			Field:   fieldName,
+		})
+	}
+	const negationChar = "!"
+	const wildcardChar = "*"
+
+	for _, filter := range filters {
+		if len(filter) == 1 {
+			if filter == negationChar {
+				addCause("a negation character is not a valid filter")
+			}
+			continue
+		}
+
+		const errPattern = "%s filter %s is invalid: cannot contain a %s character (%s); FilterRules: %s"
+
+		if filterWithoutFirstChar := filter[1:]; strings.Contains(filterWithoutFirstChar, negationChar) {
+			addCause(fmt.Sprintf(errPattern, fieldName, filter, "negation", negationChar, "NegationChar can be only used at the beginning of the filter"))
+		}
+
+		if filterWithoutLastChar := filter[:len(filter)-1]; strings.Contains(filterWithoutLastChar, wildcardChar) {
+			addCause(fmt.Sprintf(errPattern, fieldName, filter, "wildcard", wildcardChar, "WildcardChar can be only at the end of the filter"))
+		}
+	}
+
+	return causes
+}
+
+func doesSliceContainStr(slice []string, str string) (isFound bool) {
+	for _, curSliceStr := range slice {
+		if curSliceStr == str {
+			isFound = true
+			break
+		}
+	}
+
+	return isFound
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Currently, webhooks for clone make API calls to fetch the clone's source (e.g. Snapshot, VM) in order to perform validations upon it, such if it exists.

To avoid races and enhance the eventual consistency paradigm, move this logic away to the clone controller instead.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/12798

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

