### PR TITLE
Fix kubevirt_vmi_migration_failed to not include VMIMs in 'unset'

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -216,6 +216,9 @@ Number of current running migrations. Type: Gauge.
 ### kubevirt_vmi_migrations_in_scheduling_phase
 Number of current scheduling migrations. Type: Gauge.
 
+### kubevirt_vmi_migrations_in_unset_phase
+Number of current unset migrations. These are pending items the virt-controller hasn’t processed yet from the queue. Type: Gauge.
+
 ### kubevirt_vmi_network_receive_bytes_total
 Total network traffic received in bytes. Type: Counter.
 

--- a/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
@@ -29,6 +29,7 @@ var (
 		Metrics: []operatormetrics.Metric{
 			pendingMigrations,
 			schedulingMigrations,
+			unsetMigration,
 			runningMigrations,
 			succeededMigration,
 			failedMigration,
@@ -47,6 +48,13 @@ var (
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_migrations_in_scheduling_phase",
 			Help: "Number of current scheduling migrations.",
+		},
+	)
+
+	unsetMigration = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_migrations_in_unset_phase",
+			Help: "Number of current unset migrations. These are pending items the virt-controller hasn’t processed yet from the queue.",
 		},
 	)
 
@@ -89,6 +97,7 @@ func reportMigrationStats(vmims []*k6tv1.VirtualMachineInstanceMigration) []oper
 
 	pendingCount := 0
 	schedulingCount := 0
+	unsetCount := 0
 	runningCount := 0
 
 	for _, vmim := range vmims {
@@ -97,6 +106,8 @@ func reportMigrationStats(vmims []*k6tv1.VirtualMachineInstanceMigration) []oper
 			pendingCount++
 		case k6tv1.MigrationScheduling:
 			schedulingCount++
+		case k6tv1.MigrationPhaseUnset:
+			unsetCount++
 		case k6tv1.MigrationRunning, k6tv1.MigrationScheduled, k6tv1.MigrationPreparingTarget, k6tv1.MigrationTargetReady:
 			runningCount++
 		case k6tv1.MigrationSucceeded:
@@ -109,6 +120,7 @@ func reportMigrationStats(vmims []*k6tv1.VirtualMachineInstanceMigration) []oper
 	return append(cr,
 		operatormetrics.CollectorResult{Metric: pendingMigrations, Value: float64(pendingCount)},
 		operatormetrics.CollectorResult{Metric: schedulingMigrations, Value: float64(schedulingCount)},
+		operatormetrics.CollectorResult{Metric: unsetMigration, Value: float64(unsetCount)},
 		operatormetrics.CollectorResult{Metric: runningMigrations, Value: float64(runningCount)},
 	)
 }

--- a/pkg/monitoring/metrics/virt-controller/migrationstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/migrationstats_collector_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Migration Stats Collector", func() {
 		Entry("Running migration", k6tv1.MigrationRunning, runningMigrations),
 		Entry("Scheduling migration", k6tv1.MigrationScheduling, schedulingMigrations),
 		Entry("Succeeded migration", k6tv1.MigrationSucceeded, succeededMigration),
+		Entry("Undefined migration", k6tv1.MigrationPhaseUnset, unsetMigration),
 	)
 
 	It("should set succeeded and pending to 1 and others to 0 with 1 successful and 1 pending", func() {

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -78,6 +78,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_migration_phase_transition_time_from_creation_seconds": true,
 			"kubevirt_vmi_migrations_in_pending_phase":                           true,
 			"kubevirt_vmi_migrations_in_scheduling_phase":                        true,
+			"kubevirt_vmi_migrations_in_unset_phase":                             true,
 			"kubevirt_vmi_migrations_in_running_phase":                           true,
 			"kubevirt_vmi_migration_succeeded":                                   true,
 			"kubevirt_vmi_migration_failed":                                      true,

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -190,6 +190,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", Serial, decorators.SigMonitori
 
 			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_pending_phase", 0)
 			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_scheduling_phase", 0)
+			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_unset_phase", 0)
 			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_running_phase", 0)
 
 			labels := map[string]string{
@@ -224,6 +225,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", Serial, decorators.SigMonitori
 			Eventually(matcher.ThisMigration(migration)).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed), "migration creation should fail")
 
 			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_scheduling_phase", 0)
+			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_unset_phase", 0)
 			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_migration_failed", 1, labels, 1)
 
 			By("Deleting the VMI")


### PR DESCRIPTION
VMIM's in unset simply means the virt-controller has not interacted with the VMIM object yet, but is expected to as it works through the incoming queue. This pr adds a separated metric for unset state instead of including it in kubevirt_vmi_migration_failed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
kubevirt_vmi_migration_failed included migrations in unset state.

After this PR:
migrations in unset state are reported in new metric named kubevirt_vmi_migrations_in_unset_phase instead of including it in kubevirt_vmi_migration_failed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
jira-ticket: https://issues.redhat.com/browse/CNV-56912


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added kubevirt_vmi_migrations_in_unset_phase, instead of including it in kubevirt_vmi_migration_failed.
```

