### PR TITLE
[release-1.5] volume-migration: fix several bugs: volume mode evaluation, hotplug paths and cgroup allow list generation

### DIFF
--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/safepath:go_default_library",
+        "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/cgroup/constants:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
@@ -26,6 +27,7 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/devices:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -138,13 +138,13 @@ func newManagerFromPid(pid int, deviceRules []*devices.Rule) (manager Manager, e
 	return manager, err
 }
 
-func NewManagerFromVM(vmi *v1.VirtualMachineInstance) (Manager, error) {
+func NewManagerFromVM(vmi *v1.VirtualMachineInstance, host string) (Manager, error) {
 	isolationRes, err := detectVMIsolation(vmi, "")
 	if err != nil {
 		return nil, err
 	}
 
-	vmiDeviceRules, err := generateDeviceRulesForVMI(vmi, isolationRes)
+	vmiDeviceRules, err := generateDeviceRulesForVMI(vmi, isolationRes, host)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -211,7 +211,7 @@ func NewController(
 		migrationProxy:                   migrationProxy,
 		podIsolationDetector:             podIsolationDetector,
 		containerDiskMounter:             container_disk.NewMounter(podIsolationDetector, containerDiskState, clusterConfig),
-		hotplugVolumeMounter:             hotplug_volume.NewVolumeMounter(hotplugState, kubeletPodsDir),
+		hotplugVolumeMounter:             hotplug_volume.NewVolumeMounter(hotplugState, kubeletPodsDir, host),
 		clusterConfig:                    clusterConfig,
 		virtLauncherFSRunDirPattern:      "/proc/%d/root/var/run",
 		capabilities:                     capabilities,

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -155,8 +155,8 @@ const (
 	memoryHotplugFailedReason = "Memory Hotplug Failed"
 )
 
-var getCgroupManager = func(vmi *v1.VirtualMachineInstance) (cgroup.Manager, error) {
-	return cgroup.NewManagerFromVM(vmi)
+var getCgroupManager = func(vmi *v1.VirtualMachineInstance, host string) (cgroup.Manager, error) {
+	return cgroup.NewManagerFromVM(vmi, host)
 }
 
 func NewController(
@@ -2178,7 +2178,7 @@ func (c *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstan
 
 	// UnmountAll does the cleanup on the "best effort" basis: it is
 	// safe to pass a nil cgroupManager.
-	cgroupManager, _ := getCgroupManager(vmi)
+	cgroupManager, _ := getCgroupManager(vmi, c.host)
 	if err := c.hotplugVolumeMounter.UnmountAll(vmi, cgroupManager); err != nil {
 		return err
 	}
@@ -2806,7 +2806,7 @@ func (c *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 
 	// Mount hotplug disks
 	if attachmentPodUID := vmi.Status.MigrationState.TargetAttachmentPodUID; attachmentPodUID != types.UID("") {
-		cgroupManager, err := getCgroupManager(vmi)
+		cgroupManager, err := getCgroupManager(vmi, c.host)
 		if err != nil {
 			return err
 		}
@@ -3005,7 +3005,7 @@ func (c *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		return err
 	}
 
-	cgroupManager, err := getCgroupManager(vmi)
+	cgroupManager, err := getCgroupManager(vmi, c.host)
 	if err != nil {
 		return err
 	}
@@ -3479,7 +3479,7 @@ func (c *VirtualMachineController) claimDeviceOwnership(virtLauncherRootMount *s
 }
 
 func (c *VirtualMachineController) reportDedicatedCPUSetForMigratingVMI(vmi *v1.VirtualMachineInstance) error {
-	cgroupManager, err := getCgroupManager(vmi)
+	cgroupManager, err := getCgroupManager(vmi, c.host)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -115,7 +115,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 	const migratableNetworkBindingPlugin = "mig_plug"
 	const host = "master"
 
-	getCgroupManager = func(_ *v1.VirtualMachineInstance) (cgroup.Manager, error) {
+	getCgroupManager = func(_ *v1.VirtualMachineInstance, _ string) (cgroup.Manager, error) {
 		return mockCgroupManager, nil
 	}
 

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/host-disk:go_default_library",
+        "//pkg/hotplug-disk:go_default_library",
         "//pkg/ignition:go_default_library",
         "//pkg/liveupdate/memory:go_default_library",
         "//pkg/network/cache:go_default_library",
@@ -77,6 +78,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "live-migration-source_test.go",
         "manager_test.go",
         "nichotplug_test.go",
         "virtwrap_suite_test.go",
@@ -116,6 +118,7 @@ go_test(
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -50,6 +50,8 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 
+	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/sriov"
@@ -889,6 +891,13 @@ func configureLocalDiskToMigrate(dom *libvirtxml.Domain, vmi *v1.VirtualMachineI
 	migDisks := classifyVolumesForMigration(vmi)
 	fsSrcBlockDstVols := getFsSrcBlockDstVols(vmi)
 	blockSrcFsDstVols := getBlockSrcFsDstVols(vmi)
+	hotplugVols := make(map[string]bool)
+
+	for _, v := range vmi.Spec.Volumes {
+		if storagetypes.IsHotplugVolume(&v) {
+			hotplugVols[v.Name] = true
+		}
+	}
 
 	for i, d := range dom.Devices.Disks {
 		if d.Alias == nil {
@@ -915,18 +924,30 @@ func configureLocalDiskToMigrate(dom *libvirtxml.Domain, vmi *v1.VirtualMachineI
 					},
 				}}
 		}
+		var path string
+		_, hotplugVol := hotplugVols[name]
 		// Adjust the XML configuration when it migrates from a filesystem source to a block destination or vice versa
 		if _, ok := fsSrcBlockDstVols[name]; ok {
 			log.Log.V(2).Infof("Replace filesystem source with block destination for volume %s", name)
+			if hotplugVol {
+				path = hotplugdisk.GetVolumeMountDir(name)
+			} else {
+				path = filepath.Join(string(filepath.Separator), "dev", name)
+			}
 			dom.Devices.Disks[i].Source.Block = &libvirtxml.DomainDiskSourceBlock{
-				Dev: filepath.Join(string(filepath.Separator), "dev", name),
+				Dev: path,
 			}
 			dom.Devices.Disks[i].Source.File = nil
 		}
 		if _, ok := blockSrcFsDstVols[name]; ok {
 			log.Log.V(2).Infof("Replace block source with destination for volume %s", name)
+			if hotplugVol {
+				path = hotplugdisk.GetVolumeMountDir(name) + ".img"
+			} else {
+				path = filepath.Join(hostdisk.GetMountedHostDiskDir(name), "disk.img")
+			}
 			dom.Devices.Disks[i].Source.File = &libvirtxml.DomainDiskSourceFile{
-				File: filepath.Join(hostdisk.GetMountedHostDiskDir(name), "disk.img"),
+				File: path,
 			}
 			dom.Devices.Disks[i].Source.Block = nil
 		}

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -1,0 +1,34 @@
+package virtwrap
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
+)
+
+var _ = Describe("Live Migration for the source", func() {
+	Context("classifyVolumesForMigration", func() {
+		It("should classify shared volumes to migrated when they are part of the migrated volumes set", func() {
+			const vol = "vol"
+			vmi := libvmi.New(
+				libvmi.WithHostDiskAndCapacity(vol, "/disk.img", v1.HostDiskExistsOrCreate, "1G"), libvmistatus.WithStatus(
+					libvmistatus.New(
+						libvmistatus.WithMigratedVolume(v1.StorageMigratedVolumeInfo{
+							VolumeName: vol,
+						}),
+					),
+				))
+			Expect(classifyVolumesForMigration(vmi)).To(PointTo(Equal(
+				migrationDisks{
+					shared:         map[string]bool{},
+					generated:      map[string]bool{},
+					localToMigrate: map[string]bool{vol: true},
+				})))
+		})
+	})
+})

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -752,9 +752,6 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 	Describe("Hotplug volumes", func() {
 		var fgDisabled bool
 		BeforeEach(func() {
-			var err error
-			virtClient, err = kubecli.GetKubevirtClient()
-			Expect(err).ToNot(HaveOccurred())
 			fgDisabled = !checks.HasFeature(featuregate.HotplugVolumesGate)
 			if fgDisabled {
 				config.EnableFeatureGate(featuregate.HotplugVolumesGate)
@@ -1039,6 +1036,7 @@ func waitForMigrationToSucceed(virtClient kubecli.KubevirtClient, vmiName, ns st
 			return false
 		}
 
+		Expect(vmi.Status.MigrationState.Failed).To(BeFalse())
 		return true
 	}, 120*time.Second, time.Second).Should(BeTrue())
 }

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -55,6 +55,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -91,6 +92,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 		Expect(err).ToNot(HaveOccurred())
 		return dv
 	}
+
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 		originalKv := libkubevirt.GetCurrentKv(virtClient)
@@ -168,6 +170,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			}, 120*time.Second, time.Second).Should(BeTrue())
 		}
 		waitVMIToHaveVolumeChangeCond := func(vmiName, ns string) {
+
 			Eventually(func() bool {
 				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vmiName,
 					metav1.GetOptions{})
@@ -192,6 +195,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			Expect(err).ToNot(HaveOccurred())
 			return dv
 		}
+
 		createVMWithDV := func(dv *cdiv1.DataVolume, volName string) *virtv1.VirtualMachine {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(ns),
@@ -212,7 +216,6 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 
 			return vm
 		}
-
 		updateVMWithPVC := func(vm *virtv1.VirtualMachine, volName, claim string) {
 			// Replace dst pvc
 			i := slices.IndexFunc(vm.Spec.Template.Spec.Volumes, func(volume virtv1.Volume) bool {
@@ -749,7 +752,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 		})
 	})
 
-	Describe("Hotplug volumes", func() {
+	Context("Hotplug volumes", func() {
 		var fgDisabled bool
 		BeforeEach(func() {
 			fgDisabled = !checks.HasFeature(featuregate.HotplugVolumesGate)
@@ -851,65 +854,214 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			Entry("with an ephemeral volume", false),
 		)
 
-		It("should be able to migrate an hotplugged volume", func() {
-			const volName = "vol0"
-			ns := testsuite.GetTestNamespace(nil)
-			dv := createBlankDV(virtClient, ns, "2G")
-			vmi := libvmifact.NewCirros(
-				libvmi.WithNamespace(ns),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
-			)
-			vm := libvmi.NewVirtualMachine(vmi,
-				libvmi.WithRunStrategy(virtv1.RunStrategyAlways),
-			)
-			vm, err := virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
-			libwait.WaitForSuccessfulVMIStart(vmi)
-
-			volumeSource := &v1.HotplugVolumeSource{
-				DataVolume: &v1.DataVolumeSource{
-					Name: dv.Name,
-				},
-			}
-
-			// Add the volume
-			addOpts := &v1.AddVolumeOptions{
-				Name: volName,
-				Disk: &v1.Disk{
-					DiskDevice: v1.DiskDevice{
-						Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
+		Context("should be able to volume migrate a VM", func() {
+			addVolume := func(vmName, ns, volName, dvName string) {
+				volumeSource := &v1.HotplugVolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: dvName,
 					},
-					//					Serial: volName,
-				},
-				VolumeSource: volumeSource,
-			}
-			Expect(virtClient.VirtualMachine(ns).AddVolume(context.Background(), vm.Name, addOpts)).ToNot(HaveOccurred())
-			waitForHotplugVol(vm.Name, vm.Namespace, volName)
-
-			dvDst := createBlankDV(virtClient, vm.Namespace, "2Gi")
-			By("Update volumes")
-			var index int
-			Eventually(func() int {
-				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for i, v := range vm.Spec.Template.Spec.Volumes {
-					if v.Name == volName {
-						index = i
-						return i
-					}
 				}
-				return -1
-			}).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).Should(BeNumerically(">", -1))
-			p, err := patch.New(
-				patch.WithReplace(fmt.Sprintf("/spec/template/spec/volumes/%d/dataVolume/name", index), dvDst.Name),
-				patch.WithReplace("/spec/updateVolumesStrategy", virtv1.UpdateVolumesStrategyMigration),
-			).GeneratePayload()
-			Expect(err).ToNot(HaveOccurred())
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, p, metav1.PatchOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			waitForMigrationToSucceed(virtClient, vm.Name, vm.Namespace)
+				// Add the volume
+				addOpts := &v1.AddVolumeOptions{
+					Name: volName,
+					Disk: &v1.Disk{
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
+						},
+					},
+					VolumeSource: volumeSource,
+				}
+				Expect(virtClient.VirtualMachine(ns).AddVolume(context.Background(), vmName, addOpts)).ToNot(HaveOccurred())
+				waitForHotplugVol(vmName, ns, volName)
+			}
+			getIndexVol := func(vmName, ns, volName string) int {
+				var index int
+				// Loop if the hotplug volume has been added with the imperative API it might be still not present on the VM
+				Eventually(func() int {
+					vm, err := virtClient.VirtualMachine(ns).Get(context.Background(), vmName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for i, v := range vm.Spec.Template.Spec.Volumes {
+						if v.Name == volName {
+							index = i
+							return i
+						}
+					}
+					return -1
+				}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(BeNumerically(">", -1))
+				return index
+			}
+
+			createFileOnHotpluggedVol := func(vmi *v1.VirtualMachineInstance, volName string) {
+				var device string
+				Eventually(func() string {
+					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, v := range vmi.Status.VolumeStatus {
+						if v.HotplugVolume == nil {
+							continue
+						}
+						if v.Name == volName {
+							device = v.Target
+							return v.Target
+						}
+					}
+					return ""
+				}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).ShouldNot(BeEmpty())
+
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+				Expect(console.RunCommand(vmi, "sudo mkfs.ext3 /dev/sda", 30*time.Second)).To(Succeed())
+				Expect(console.RunCommand(vmi, "mkdir test", 30*time.Second)).To(Succeed())
+				Expect(console.RunCommand(vmi, fmt.Sprintf("sudo mount -t ext3 /dev/%s /home/cirros/test", device), 30*time.Second)).To(Succeed())
+				Expect(console.RunCommand(vmi, "sudo chmod 777 /home/cirros/test", 30*time.Second)).To(Succeed())
+				Expect(console.RunCommand(vmi, "sudo chown cirros:cirros /home/cirros/test", 30*time.Second)).To(Succeed())
+				Expect(console.RunCommand(vmi, "printf 'test' &> /home/cirros/test/test", 30*time.Second)).To(Succeed())
+			}
+			checkFileOnHotpluggedVol := func(vmi *v1.VirtualMachineInstance) {
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+				Expect(console.RunCommand(vmi, "cat /home/cirros/test/test |grep test", 60*time.Second)).To(Succeed())
+			}
+
+			It("with a containerdisk and a hotplugged volume", func() {
+				const volName = "vol0"
+				ns := testsuite.GetTestNamespace(nil)
+				dv := createBlankDV(virtClient, ns, "2G")
+				vmi := libvmifact.NewCirros(
+					libvmi.WithNamespace(ns),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+				)
+				vm := libvmi.NewVirtualMachine(vmi,
+					libvmi.WithRunStrategy(virtv1.RunStrategyAlways),
+				)
+				vm, err := virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
+				libwait.WaitForSuccessfulVMIStart(vmi)
+
+				addVolume(vm.Name, vm.Namespace, volName, dv.Name)
+				createFileOnHotpluggedVol(vmi, volName)
+
+				dvDst := createBlankDV(virtClient, vm.Namespace, "2Gi")
+				By("Update volumes")
+				index := getIndexVol(vm.Name, vm.Namespace, volName)
+				p, err := patch.New(
+					patch.WithReplace(fmt.Sprintf("/spec/template/spec/volumes/%d/dataVolume/name", index), dvDst.Name),
+					patch.WithReplace("/spec/updateVolumesStrategy", virtv1.UpdateVolumesStrategyMigration),
+				).GeneratePayload()
+				Expect(err).ToNot(HaveOccurred())
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, p, metav1.PatchOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				waitForMigrationToSucceed(virtClient, vm.Name, vm.Namespace)
+				checkFileOnHotpluggedVol(vmi)
+			})
+
+			DescribeTable("with a datavolume and an hotplugged datavolume migrating", func(srcBlock, dstBlock bool) {
+				ns := testsuite.GetTestNamespace(nil)
+				rootVolName := "root"
+				hpVolName := "hp"
+				var sc string
+				var exist bool
+				var volumeMode k8sv1.PersistentVolumeMode
+				if srcBlock {
+					sc, exist = libstorage.GetRWOBlockStorageClass()
+					volumeMode = k8sv1.PersistentVolumeBlock
+				} else {
+					sc, exist = libstorage.GetRWOFileSystemStorageClass()
+					volumeMode = k8sv1.PersistentVolumeFilesystem
+				}
+				Expect(exist).To(BeTrue())
+				rootDV := libdv.NewDataVolume(
+					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
+					libdv.WithStorage(libdv.StorageWithStorageClass(sc),
+						libdv.StorageWithVolumeSize("1Gi"),
+						libdv.StorageWithVolumeMode(volumeMode),
+						libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
+					),
+				)
+				vmi := libvmi.New(
+					libvmi.WithNamespace(ns),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+					libvmi.WithResourceMemory("128Mi"),
+					libvmi.WithDataVolume(rootVolName, rootDV.Name),
+					libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()),
+				)
+				vm := libvmi.NewVirtualMachine(vmi,
+					libvmi.WithRunStrategy(virtv1.RunStrategyAlways),
+					libvmi.WithDataVolumeTemplate(rootDV),
+				)
+				vm, err := virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
+				libwait.WaitForSuccessfulVMIStart(vmi)
+
+				hpDV := libdv.NewDataVolume(
+					libdv.WithBlankImageSource(),
+					libdv.WithStorage(libdv.StorageWithStorageClass(sc),
+						libdv.StorageWithVolumeSize("1G"),
+						libdv.StorageWithVolumeMode(volumeMode),
+						libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
+					),
+				)
+				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+					hpDV, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVolume(vm.Name, vm.Namespace, hpVolName, hpDV.Name)
+				createFileOnHotpluggedVol(vmi, hpVolName)
+
+				indexRoot := getIndexVol(vm.Name, vm.Namespace, rootVolName)
+				indexHp := getIndexVol(vm.Name, vm.Namespace, hpVolName)
+
+				if dstBlock {
+					sc, exist = libstorage.GetRWOBlockStorageClass()
+					volumeMode = k8sv1.PersistentVolumeBlock
+					Expect(exist).To(BeTrue())
+				} else {
+					sc = testSc
+					volumeMode = k8sv1.PersistentVolumeFilesystem
+				}
+				dvRootDst := libdv.NewDataVolume(
+					libdv.WithBlankImageSource(),
+					libdv.WithStorage(libdv.StorageWithStorageClass(sc),
+						libdv.StorageWithVolumeSize("2Gi"),
+						libdv.StorageWithVolumeMode(volumeMode),
+						libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
+					),
+				)
+				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+					dvRootDst, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				dvHpDst := libdv.NewDataVolume(
+					libdv.WithBlankImageSource(),
+					libdv.WithStorage(libdv.StorageWithStorageClass(sc),
+						libdv.StorageWithVolumeSize("2Gi"),
+						libdv.StorageWithVolumeMode(volumeMode),
+						libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
+					),
+				)
+				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+					dvHpDst, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				p, err := patch.New(
+					patch.WithReplace("/spec/dataVolumeTemplates", []virtv1.DataVolumeTemplateSpec{}),
+					patch.WithReplace(fmt.Sprintf("/spec/template/spec/volumes/%d/dataVolume/name", indexRoot), dvRootDst.Name),
+					patch.WithReplace(fmt.Sprintf("/spec/template/spec/volumes/%d/dataVolume/name", indexHp), dvHpDst.Name),
+					patch.WithReplace("/spec/updateVolumesStrategy", virtv1.UpdateVolumesStrategyMigration),
+				).GeneratePayload()
+				Expect(err).ToNot(HaveOccurred())
+
+				By(fmt.Sprintf("Update root DV %s with %s and hotplug dv %s with %s", rootDV.Name, dvRootDst.Name, hpDV.Name, dvHpDst.Name))
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, p, metav1.PatchOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				waitForMigrationToSucceed(virtClient, vm.Name, vm.Namespace)
+				checkFileOnHotpluggedVol(vmi)
+			},
+				Entry("from filesystem to filesystem", false, false),
+				Entry("from filesystem to block", false, true),
+				Entry("from block to filesystem", true, false),
+				Entry("from block to block", true, true),
+			)
 		})
 	})
 


### PR DESCRIPTION
Manual backport: https://github.com/kubevirt/kubevirt/pull/13931

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

