### PR TITLE
nit: consistent `KubeVirt Authors` capitalization

### DIFF
--- a/pkg/liveupdate/memory/memory_test.go
+++ b/pkg/liveupdate/memory/memory_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright The Kubevirt Authors
+ * Copyright The KubeVirt Authors
  *
  */
 

--- a/pkg/monitoring/metrics/testing/metric_matcher.go
+++ b/pkg/monitoring/metrics/testing/metric_matcher.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright The Kubevirt Authors
+ * Copyright The KubeVirt Authors
  *
  */
 

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright The Kubevirt Authors
+ * Copyright The KubeVirt Authors
  *
  */
 


### PR DESCRIPTION
It's a nit, to make it harder for people to introduce wrong capitalization by copying these three exceptional files.

/kind cleanup

```release-note
NONE
```

