### PR TITLE
refactor: use libvirt api to set user password

### DIFF
--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -285,16 +285,12 @@ func (l *AccessCredentialManager) agentSetFilePermissions(domName string, filePa
 }
 
 func (l *AccessCredentialManager) agentSetUserPassword(domName string, user string, password string) error {
-
-	base64Str := base64.StdEncoding.EncodeToString([]byte(password))
-
-	cmdSetPassword := fmt.Sprintf(`{"execute":"guest-set-user-password", "arguments": {"username":"%s", "password": "%s", "crypted": false }}`, user, base64Str)
-
-	_, err := l.virConn.QemuAgentCommand(cmdSetPassword, domName)
+	domain, err := l.virConn.LookupDomainByName(domName)
 	if err != nil {
-		return err
+		return fmt.Errorf("domain lookup failed: %w", err)
 	}
-	return nil
+	defer domain.Free()
+	return domain.SetUserPassword(user, password, 0)
 }
 
 func (l *AccessCredentialManager) pingAgent(domName string) error {

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -555,6 +555,16 @@ func (_mr *_MockVirDomainRecorder) SetTime(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTime", arg0, arg1, arg2)
 }
 
+func (_m *MockVirDomain) SetUserPassword(user string, password string, flags libvirt.DomainSetUserPasswordFlags) error {
+	ret := _m.ctrl.Call(_m, "SetUserPassword", user, password, flags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirDomainRecorder) SetUserPassword(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUserPassword", arg0, arg1, arg2)
+}
+
 func (_m *MockVirDomain) AuthorizedSSHKeysSet(user string, keys []string, flags libvirt.DomainAuthorizedSSHKeysFlags) error {
 	ret := _m.ctrl.Call(_m, "AuthorizedSSHKeysSet", user, keys, flags)
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -528,6 +528,7 @@ type VirDomain interface {
 	GetGuestInfo(types libvirt.DomainGuestInfoTypes, flags uint32) (*libvirt.DomainGuestInfo, error)
 	GetDiskErrors(flags uint32) ([]libvirt.DomainDiskError, error)
 	SetTime(secs int64, nsecs uint, flags libvirt.DomainSetTimeFlags) error
+	SetUserPassword(user string, password string, flags libvirt.DomainSetUserPasswordFlags) error
 	AuthorizedSSHKeysSet(user string, keys []string, flags libvirt.DomainAuthorizedSSHKeysFlags) error
 	AbortJob() error
 	Free() error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Use libvirt API to set user password
instead of using QEMU agent command
directly.

This improves abstraction and aligns with
recommended usage patterns in libvirt-based
workflows.

Libvirt still uses the same guest agent command
internally. Password encoding is no longer
necessary, simplifying the implementation.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```