### PR TITLE
e2e, net, istio: Revert skip of passt

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -201,7 +201,6 @@ var istioTests = func(vmType VmType) {
 			}
 
 			BeforeEach(func() {
-				skipTestByVMType(vmType)
 
 				bastionVMI = libvmifact.NewCirros(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -255,7 +254,6 @@ var istioTests = func(vmType VmType) {
 
 			Context("With VMI having explicit ports specified", func() {
 				BeforeEach(func() {
-					skipTestByVMType(vmType)
 					vmiPorts = explicitPorts
 				})
 				DescribeTable("request to VMI should reach HTTP server", func(targetPort int) {
@@ -289,7 +287,6 @@ var istioTests = func(vmType VmType) {
 				})
 				Context("With VMI having explicit ports specified", func() {
 					BeforeEach(func() {
-						skipTestByVMType(vmType)
 						vmiPorts = explicitPorts
 					})
 					DescribeTable("client outside mesh should NOT reach VMI HTTP server", func(targetPort int) {
@@ -390,7 +387,6 @@ var istioTests = func(vmType VmType) {
 
 			Context("VMI with explicit ports", func() {
 				BeforeEach(func() {
-					skipTestByVMType(vmType)
 					vmiPorts = explicitPorts
 				})
 				It("Should be able to reach http server outside of mesh", func() {
@@ -425,7 +421,6 @@ var istioTests = func(vmType VmType) {
 
 				Context("VMI with explicit ports", func() {
 					BeforeEach(func() {
-						skipTestByVMType(vmType)
 						vmiPorts = explicitPorts
 					})
 					It("Should not be able to reach http service outside of mesh", func() {
@@ -447,12 +442,6 @@ var istioTests = func(vmType VmType) {
 			})
 		})
 	})
-}
-
-func skipTestByVMType(vmType VmType) {
-	if vmType == Passt {
-		Skip("this test is quarantine due to https://github.com/kubevirt/kubevirt/issues/13927")
-	}
 }
 
 var istioTestsWithMasqueradeBinding = func() {


### PR DESCRIPTION
PR https://github.com/kubevirt/kubevirt/pull/13924 introduced skips of tests that ran`Istio`+`passt` together. This was necessary due to a bug in recent versions of Istio [1].

The bug has been fixed in Istio 1.24.4 and since bumping [2] kubevirtci, the skips are now safe to revert.

[[1]](https://github.com/kubevirt/kubevirt/issues/13927) [[2]](https://github.com/kubevirt/kubevirtci/pull/1411)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

https://github.com/kubevirt/kubevirt/pull/13924
https://github.com/kubevirt/kubevirt/issues/13927
https://github.com/kubevirt/kubevirtci/pull/1411
### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

