### PR TITLE
Restore tests: Rearrange tpm-related commands to avoid transient failures in Fedora 39

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -834,32 +834,23 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 
 					if tpm {
 						batch = append(batch, []expect.Batcher{
-							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_createprimary -C o -c %s.ctx\n", "/dev/tpm0")},
-							&expect.BExp{R: console.PromptExpression},
-							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_createprimary -C o -c %s.ctx && %s", "/dev/tpm0", console.EchoLastReturnValue)},
 							&expect.BExp{R: console.RetValue("0")},
 
-							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvdefine -C o -s %d 1\n", len(string(vm.UID))+1)},
-							&expect.BExp{R: console.PromptExpression},
-							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvdefine -C o -s %d 1 && %s", len(string(vm.UID))+1, console.EchoLastReturnValue)},
 							&expect.BExp{R: console.RetValue("0")},
 
-							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvwrite -C o -i /test/data/message 1\n")},
-							&expect.BExp{R: console.PromptExpression},
-							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvwrite -C o -i /test/data/message 1 && %s", console.EchoLastReturnValue)},
 							&expect.BExp{R: console.RetValue("0")},
 
 							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvread -s %d -C o 1\n", len(string(vm.UID)))},
 							&expect.BExp{R: string(vm.UID)},
-							&expect.BSnd{S: console.EchoLastReturnValue},
-							&expect.BExp{R: console.RetValue("0")},
 							&expect.BSnd{S: syncName},
 							&expect.BExp{R: console.PromptExpression},
 							&expect.BSnd{S: syncName},
 							&expect.BExp{R: console.PromptExpression},
 						}...)
 					}
-
 					Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 				}
 			}
@@ -910,11 +901,9 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 						batch = append(batch, []expect.Batcher{
 							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvread -s %d -C o 1\n", len(string(vm.UID)))},
 							&expect.BExp{R: string(vm.UID)},
-							&expect.BSnd{S: console.EchoLastReturnValue},
-							&expect.BExp{R: console.RetValue("0")},
-							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvwrite -C o -i /test/data/message 1\n")},
+							&expect.BSnd{S: syncName},
 							&expect.BExp{R: console.PromptExpression},
-							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvwrite -C o -i /test/data/message 1 && %s", console.EchoLastReturnValue)},
 							&expect.BExp{R: console.RetValue("0")},
 							&expect.BSnd{S: syncName},
 							&expect.BExp{R: console.PromptExpression},
@@ -966,8 +955,6 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 						batch = append(batch, []expect.Batcher{
 							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvread -s %d -C o 1\n", len(string(vm.UID)))},
 							&expect.BExp{R: string(vm.UID)},
-							&expect.BSnd{S: console.EchoLastReturnValue},
-							&expect.BExp{R: console.RetValue("0")},
 							&expect.BSnd{S: syncName},
 							&expect.BExp{R: console.PromptExpression},
 							&expect.BSnd{S: syncName},


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

There's been an effort  to upgrade the fedora-with-test-tooling VM image used for e2e testing in kubevirt from the really old fedora 35 to the less old fedora 39. However, two tests have been consistently failing when checking the return value of `echo $?` after running tpm2-related commands:

- [sig-storage] VirtualMachineRestore Tests [storage-req] With a more complicated VM Should restore a vm with backend storage with online snapshot
- [sig-storage] VirtualMachineRestore Tests [storage-req] With a more complicated VM Should restore a vm with backend storage with offline snapshot expand_more

There seem to be some timing or buffering differences in Fedora 39 that are causing the error when expecting the return value. These failures are fixed when including the `echo $?` in the same `expect` as the tpm2 command, so this PR rearranges these commands to avoid the issue.

/cc @brianmcarey 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

