### PR TITLE
restore tests: add missing carriage return to tpm2_nvread output

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -64,6 +64,9 @@ const (
 	stoppingVM                = "Stopping VM"
 	creatingSnapshot          = "creating snapshot"
 
+	// tpm2_nvread output doesn't always end with a carriage return. This command adds it while preserving the return code
+	tpmNVReadFormat = "sudo tpm2_nvread -s %d -C o 1 ; ret=$? ; echo ; (exit $ret)\n"
+
 	macAddressCloningPatchPattern   = `{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "%s"}`
 	firmwareUUIDCloningPatchPattern = `{"op": "replace", "path": "/spec/template/spec/domain/firmware/uuid", "value": "%s"}`
 
@@ -849,7 +852,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 							&expect.BSnd{S: console.EchoLastReturnValue},
 							&expect.BExp{R: console.RetValue("0")},
 
-							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvread -s %d -C o 1\n", len(string(vm.UID)))},
+							&expect.BSnd{S: fmt.Sprintf(tpmNVReadFormat, len(string(vm.UID)))},
 							&expect.BExp{R: string(vm.UID)},
 							&expect.BSnd{S: console.EchoLastReturnValue},
 							&expect.BExp{R: console.RetValue("0")},
@@ -908,7 +911,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 
 					if tpm {
 						batch = append(batch, []expect.Batcher{
-							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvread -s %d -C o 1\n", len(string(vm.UID)))},
+							&expect.BSnd{S: fmt.Sprintf(tpmNVReadFormat, len(string(vm.UID)))},
 							&expect.BExp{R: string(vm.UID)},
 							&expect.BSnd{S: console.EchoLastReturnValue},
 							&expect.BExp{R: console.RetValue("0")},
@@ -964,7 +967,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 
 					if tpm {
 						batch = append(batch, []expect.Batcher{
-							&expect.BSnd{S: fmt.Sprintf("sudo tpm2_nvread -s %d -C o 1\n", len(string(vm.UID)))},
+							&expect.BSnd{S: fmt.Sprintf(tpmNVReadFormat, len(string(vm.UID)))},
 							&expect.BExp{R: string(vm.UID)},
 							&expect.BSnd{S: console.EchoLastReturnValue},
 							&expect.BExp{R: console.RetValue("0")},


### PR DESCRIPTION
### What this PR does
Before this PR:
`tpm2_nvread` may not add a carriage return at the end of its output, throwing off `console.SafeExpectBatch()`

After this PR:
Carriage return added

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```