### PR TITLE
drop deprecated & unused SkipIfS390X

### DIFF
--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -56,13 +56,6 @@ func SkipIfPrometheusRuleIsNotEnabled(virtClient kubecli.KubevirtClient) {
 	}
 }
 
-// Deprecated: SkipIfS390X should be converted to check & fail
-func SkipIfS390X(arch string, message string) {
-	if IsS390X(arch) {
-		ginkgo.Skip("Skip test on s390x: " + message)
-	}
-}
-
 // Deprecated: SkipIfRunningOnKindInfra should be converted to check & fail
 func SkipIfRunningOnKindInfra(message string) {
 	if IsRunningOnKindInfra() {


### PR DESCRIPTION
Good riddance. Programmatic skips are a bad idea, as the person running the test suit cannot be sure which tests are executed without reviewing them all.

/kind cleanup

```release-note
NONE
```

