### PR TITLE
fix(network): Apply preferences to interfaces during hotplug

### DIFF
--- a/pkg/instancetype/controller/network/BUILD.bazel
+++ b/pkg/instancetype/controller/network/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "mock.go",
+        "network.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/pkg/instancetype/controller/network",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/instancetype/preference/apply:go_default_library",
+        "//pkg/instancetype/preference/find:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "network_suite_test.go",
+        "network_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/pkg/instancetype/controller/network/mock.go
+++ b/pkg/instancetype/controller/network/mock.go
@@ -1,0 +1,24 @@
+package network
+
+import (
+	virtv1 "kubevirt.io/api/core/v1"
+)
+
+type mockController struct {
+	applyFunc func(vm *virtv1.VirtualMachine, spec *virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachineInstanceSpec
+}
+
+func NewMockController() *mockController {
+	return &mockController{
+		applyFunc: func(_ *virtv1.VirtualMachine, spec *virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachineInstanceSpec {
+			return spec.DeepCopy()
+		},
+	}
+}
+
+func (m *mockController) ApplyInterfacePreferencesToVMI(
+	vm *virtv1.VirtualMachine,
+	spec *virtv1.VirtualMachineInstanceSpec,
+) *virtv1.VirtualMachineInstanceSpec {
+	return m.applyFunc(vm, spec)
+}

--- a/pkg/instancetype/controller/network/network.go
+++ b/pkg/instancetype/controller/network/network.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/api/instancetype/v1beta1"
+	"kubevirt.io/client-go/kubecli"
+
+	preferenceapply "kubevirt.io/kubevirt/pkg/instancetype/preference/apply"
+	preferencefind "kubevirt.io/kubevirt/pkg/instancetype/preference/find"
+)
+
+type finder interface {
+	FindPreference(*virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error)
+}
+
+type applier interface {
+	Apply(*v1beta1.VirtualMachinePreferenceSpec, *virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachineInstanceSpec
+}
+
+type netController struct {
+	finder
+	applier
+}
+
+func New(preferenceStore, clusterPreferenceStore, revisionStore cache.Store, virtClient kubecli.KubevirtClient) *netController {
+	return &netController{
+		finder:  preferencefind.NewSpecFinder(preferenceStore, clusterPreferenceStore, revisionStore, virtClient),
+		applier: &preferenceapply.InterfaceApplier{},
+	}
+}
+
+func (n *netController) ApplyInterfacePreferencesToVMI(
+	vm *virtv1.VirtualMachine,
+	spec *virtv1.VirtualMachineInstanceSpec,
+) *virtv1.VirtualMachineInstanceSpec {
+	preferenceSpec, err := n.FindPreference(vm)
+	// Allow the calling controller to be eventually consistent here by swallowing the err to find the preference
+	if preferenceSpec == nil || err != nil {
+		return spec
+	}
+	return n.Apply(preferenceSpec, spec)
+}

--- a/pkg/instancetype/controller/network/network_suite_test.go
+++ b/pkg/instancetype/controller/network/network_suite_test.go
@@ -1,0 +1,13 @@
+package network_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Network Suite")
+}

--- a/pkg/instancetype/controller/network/network_test.go
+++ b/pkg/instancetype/controller/network/network_test.go
@@ -1,0 +1,108 @@
+package network_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/golang/mock/gomock"
+	"kubevirt.io/client-go/kubecli"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/api/instancetype/v1beta1"
+	"kubevirt.io/client-go/kubevirt/fake"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/controller/network"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+)
+
+var _ = Describe("network controller instance type and preference handler", func() {
+	const (
+		preferenceName = "preference"
+	)
+
+	type netHandler interface {
+		ApplyInterfacePreferencesToVMI(*virtv1.VirtualMachine, *virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachineInstanceSpec
+	}
+
+	var (
+		virtClient *kubecli.MockKubevirtClient
+		controller netHandler
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+
+		virtClient.EXPECT().VirtualMachinePreference(k8sv1.NamespaceDefault).Return(
+			fake.NewSimpleClientset().InstancetypeV1beta1().VirtualMachinePreferences(metav1.NamespaceDefault)).AnyTimes()
+
+		virtClient.EXPECT().VirtualMachineClusterPreference().Return(
+			fake.NewSimpleClientset().InstancetypeV1beta1().VirtualMachineClusterPreferences()).AnyTimes()
+
+		spec := v1beta1.VirtualMachinePreferenceSpec{
+			Devices: &v1beta1.DevicePreferences{
+				PreferredInterfaceModel: virtv1.VirtIO,
+			},
+		}
+
+		preference := &v1beta1.VirtualMachinePreference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      preferenceName,
+				Namespace: k8sv1.NamespaceDefault,
+			},
+			Spec: spec,
+		}
+
+		_, err := virtClient.VirtualMachinePreference(k8sv1.NamespaceDefault).Create(context.Background(), preference, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		clusterPreference := &v1beta1.VirtualMachineClusterPreference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: preferenceName,
+			},
+			Spec: spec,
+		}
+		_, err = virtClient.VirtualMachineClusterPreference().Create(context.Background(), clusterPreference, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		// We only care about asserting the specific logic within the handler so just pass a valid client without any stores for these tests
+		controller = network.New(nil, nil, nil, virtClient)
+	})
+
+	DescribeTable("should apply interface preferences to provided spec", func(vmPreferenceOption func(*virtv1.VirtualMachine)) {
+		vm := libvmi.NewVirtualMachine(
+			libvmi.New(
+				libvmi.WithNamespace(k8sv1.NamespaceDefault),
+				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+				libvmi.WithInterface(*virtv1.DefaultBridgeNetworkInterface()),
+			),
+			vmPreferenceOption,
+		)
+		// Ensure a model isn't set by DefaultBridgeNetworkInterface above
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].Model).To(BeEmpty())
+
+		spec := controller.ApplyInterfacePreferencesToVMI(vm, &vm.Spec.Template.Spec)
+		Expect(spec.Domain.Devices.Interfaces[0].Model).To(Equal(virtv1.VirtIO))
+	},
+		Entry("using namespaced preference", libvmi.WithPreference(preferenceName)),
+		Entry("using cluster preference", libvmi.WithClusterPreference(preferenceName)),
+	)
+
+	It("should return original spec when unable to find preference", func() {
+		vm := libvmi.NewVirtualMachine(
+			libvmi.New(
+				libvmi.WithNamespace(k8sv1.NamespaceDefault),
+				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+				libvmi.WithInterface(*virtv1.DefaultBridgeNetworkInterface()),
+			),
+			libvmi.WithPreference("unknown"),
+		)
+		spec := controller.ApplyInterfacePreferencesToVMI(vm, &vm.Spec.Template.Spec)
+		Expect(*spec).To(Equal(vm.Spec.Template.Spec))
+	})
+})

--- a/pkg/instancetype/preference/apply/vmi.go
+++ b/pkg/instancetype/preference/apply/vmi.go
@@ -50,3 +50,14 @@ func (a *vmiApplier) Apply(
 	applyTerminationGracePeriodSeconds(preferenceSpec, vmiSpec)
 	applyPreferenceAnnotations(preferenceSpec.Annotations, vmiMetadata)
 }
+
+type InterfaceApplier struct{}
+
+func (i *InterfaceApplier) Apply(
+	preferenceSpec *v1beta1.VirtualMachinePreferenceSpec,
+	spec *virtv1.VirtualMachineInstanceSpec,
+) *virtv1.VirtualMachineInstanceSpec {
+	specCopy := spec.DeepCopy()
+	applyInterfacePreferences(preferenceSpec, specCopy)
+	return specCopy
+}

--- a/pkg/network/controllers/BUILD.bazel
+++ b/pkg/network/controllers/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/instancetype/controller/network:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",
         "//pkg/network/multus:go_default_library",

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
         "//pkg/hooks:go_default_library",
+        "//pkg/instancetype/controller/network:go_default_library",
         "//pkg/instancetype/controller/vm:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -80,6 +80,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
 
+	instancetypenetcontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/network"
 	instancetypecontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/vm"
 	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
@@ -750,6 +751,12 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.clusterConfig,
 		netcontrollers.NewVMController(
 			vca.clientSet.GeneratedKubeVirtClient(),
+			instancetypenetcontroller.New(
+				vca.preferenceInformer.GetStore(),
+				vca.clusterPreferenceInformer.GetStore(),
+				vca.controllerRevisionInformer.GetStore(),
+				vca.clientSet,
+			),
 		),
 		instancetypecontroller.New(
 			vca.instancetypeInformer.GetStore(),

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -242,23 +242,28 @@ type instancetypeHandler interface {
 	ApplyDevicePreferences(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error
 }
 
+type instancetypeNetHandler interface {
+	ApplyInterfacePreferencesToVMI(*virtv1.VirtualMachine, *virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachineInstanceSpec
+}
+
 type Controller struct {
-	clientset              kubecli.KubevirtClient
-	Queue                  workqueue.TypedRateLimitingInterface[string]
-	vmiIndexer             cache.Indexer
-	vmIndexer              cache.Indexer
-	dataVolumeStore        cache.Store
-	dataSourceStore        cache.Store
-	namespaceStore         cache.Store
-	pvcStore               cache.Store
-	crIndexer              cache.Indexer
-	instancetypeController instancetypeHandler
-	recorder               record.EventRecorder
-	expectations           *controller.UIDTrackingControllerExpectations
-	dataVolumeExpectations *controller.UIDTrackingControllerExpectations
-	cloneAuthFunc          CloneAuthFunc
-	clusterConfig          *virtconfig.ClusterConfig
-	hasSynced              func() bool
+	clientset                 kubecli.KubevirtClient
+	Queue                     workqueue.TypedRateLimitingInterface[string]
+	vmiIndexer                cache.Indexer
+	vmIndexer                 cache.Indexer
+	dataVolumeStore           cache.Store
+	dataSourceStore           cache.Store
+	namespaceStore            cache.Store
+	pvcStore                  cache.Store
+	crIndexer                 cache.Indexer
+	instancetypeController    instancetypeHandler
+	instancetypeNetController instancetypeNetHandler
+	recorder                  record.EventRecorder
+	expectations              *controller.UIDTrackingControllerExpectations
+	dataVolumeExpectations    *controller.UIDTrackingControllerExpectations
+	cloneAuthFunc             CloneAuthFunc
+	clusterConfig             *virtconfig.ClusterConfig
+	hasSynced                 func() bool
 
 	netSynchronizer synchronizer
 }


### PR DESCRIPTION
### What this PR does

A simple handler implementation is provided by the instancetype package for this task. This implementation ignores any errors encountered during the lookup of a given preference to ensure we don't block the overall interface hotplug process.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

