### PR TITLE
[release-1.4] VMRestore: Keep VM RunStrategy as before the restore

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -739,20 +739,28 @@ func (t *vmRestoreTarget) generateRestoredVMSpec(snapshotVM *snapshotv1.VirtualM
 			Spec:   *snapshotVM.Spec.DeepCopy(),
 			Status: kubevirtv1.VirtualMachineStatus{},
 		}
-
+		if newVM.Spec.Running != nil {
+			newVM.Spec.Running = pointer.P(false)
+		} else {
+			newVM.Spec.RunStrategy = pointer.P(kubevirtv1.RunStrategyHalted)
+		}
 	} else {
 		newVM = t.vm.DeepCopy()
 		newVM.Spec = *snapshotVM.Spec.DeepCopy()
+		if t.vm.Spec.Running != nil {
+			newVM.Spec.Running = pointer.P(false)
+			newVM.Spec.RunStrategy = nil
+		} else {
+			runStrategy, err := t.vm.RunStrategy()
+			if err != nil {
+				return nil, err
+			}
+			// make sure an existing VM keeps the same run strategy as before the restore
+			newVM.Spec.RunStrategy = pointer.P(runStrategy)
+			newVM.Spec.Running = nil
+		}
 	}
 
-	// update Running state in case snapshot was on online VM
-	if newVM.Spec.RunStrategy != nil {
-		runStrategyHalted := kubevirtv1.RunStrategyHalted
-		newVM.Spec.RunStrategy = &runStrategyHalted
-	} else if newVM.Spec.Running != nil {
-		running := false
-		newVM.Spec.Running = &running
-	}
 	newVM.Spec.DataVolumeTemplates = newTemplates
 	newVM.Spec.Template.Spec.Volumes = newVolumes
 	setLastRestoreAnnotation(t.vmRestore, newVM)

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -45,6 +46,8 @@ var _ = Describe("Restore controller", func() {
 		uid            = "uid"
 		vmName         = "testvm"
 		vmSnapshotName = "snapshot"
+		newVMUID       = "new-vm-UID"
+		newVMName      = "new-vm-name"
 	)
 
 	var (
@@ -154,6 +157,12 @@ var _ = Describe("Restore controller", func() {
 		return vm
 	}
 
+	createRestoreInProgressVM := func() *kubevirtv1.VirtualMachine {
+		vm := createVirtualMachine(testNamespace, vmName)
+		vm.Status.RestoreInProgress = &vmRestoreName
+		return vm
+	}
+
 	createVMI := func(vm *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachineInstance {
 		return &kubevirtv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
@@ -223,8 +232,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var vmInterface *kubecli.MockVirtualMachineInterface
-
 		var vmRestoreSource *framework.FakeControllerSource
 		var vmRestoreInformer cache.SharedIndexInformer
 
@@ -291,7 +298,6 @@ var _ = Describe("Restore controller", func() {
 			stop = make(chan struct{})
 			ctrl = gomock.NewController(GinkgoT())
 			virtClient = kubecli.NewMockKubevirtClient(ctrl)
-			vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
 
 			vmRestoreInformer, vmRestoreSource = testutils.NewFakeInformerWithIndexersFor(&snapshotv1.VirtualMachineRestore{}, virtcontroller.GetVirtualMachineRestoreInformerIndexers())
 			vmSnapshotInformer, vmSnapshotSource = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
@@ -377,14 +383,6 @@ var _ = Describe("Restore controller", func() {
 			mockVMRestoreQueue.Wait()
 		}
 
-		expectUpdateVMRestoreInProgress := func(vm *kubevirtv1.VirtualMachine) *kubevirtv1.VirtualMachine {
-			vmStatusUpdate := vm.DeepCopy()
-			vmStatusUpdate.ResourceVersion = "1"
-			vmStatusUpdate.Status.RestoreInProgress = &vmRestoreName
-			vmInterface.EXPECT().UpdateStatus(context.Background(), vmStatusUpdate, metav1.UpdateOptions{}).Return(vmStatusUpdate, nil).Times(1)
-			return vmStatusUpdate
-		}
-
 		Context("with initialized snapshot and content", func() {
 
 			var (
@@ -412,7 +410,7 @@ var _ = Describe("Restore controller", func() {
 
 			It("should error if snapshot does not exist", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -424,7 +422,6 @@ var _ = Describe("Restore controller", func() {
 				}
 				vmSnapshotSource.Delete(createSnapshot())
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -454,7 +451,7 @@ var _ = Describe("Restore controller", func() {
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
-			It("should update restore, add finalizer and owner", func() {
+			It("should update restore with finalizer and owner and update vm that restore is in progress", func() {
 				r := createRestoreWithOwner()
 				finalizers := r.Finalizers
 				r.Finalizers = nil
@@ -471,7 +468,6 @@ var _ = Describe("Restore controller", func() {
 				rc.ResourceVersion = "1"
 				rc.Finalizers = finalizers
 				rc.OwnerReferences = ownerRefs
-				updateCalls := expectVMRestoreUpdate(kubevirtClient, rc)
 
 				rc2 := rc.DeepCopy()
 				rc2.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -482,21 +478,26 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 				addInitialVolumeRestores(rc2)
-				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
 
 				vm := createModifiedVM()
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
-
+				vmStatusUpdate := vm.DeepCopy()
+				vmStatusUpdate.ResourceVersion = "1"
+				vmStatusUpdate.Status.RestoreInProgress = &vmRestoreName
 				addVirtualMachineRestore(r)
+
+				updateCalls := expectVMRestoreUpdate(kubevirtClient, rc)
+				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
+				updateVMStatusCalls := expectVMUpdateStatus(kubevirtClient, vmStatusUpdate)
 				controller.processVMRestoreWorkItem()
 				Expect(*updateCalls).To(Equal(1))
 				Expect(*updateStatusCalls).To(Equal(1))
+				Expect(*updateVMStatusCalls).To(Equal(1))
 			})
 
 			It("should update restore status with condition and VolumeRestores", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -508,7 +509,6 @@ var _ = Describe("Restore controller", func() {
 				}
 				addInitialVolumeRestores(rc)
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -525,7 +525,7 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 				addVolumeRestores(r)
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -540,7 +540,6 @@ var _ = Describe("Restore controller", func() {
 				vmSource.Add(vm)
 				addVirtualMachineRestore(r)
 
-				expectUpdateVMRestoreInProgress(vm)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				controller.processVMRestoreWorkItem()
 				Expect(*updateStatusCalls).To(Equal(1))
@@ -548,7 +547,7 @@ var _ = Describe("Restore controller", func() {
 
 			It("should create restore PVCs", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
@@ -561,7 +560,6 @@ var _ = Describe("Restore controller", func() {
 				pvcSize := resource.MustParse("2Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
 				fakeVolumeSnapshotProvider.Add(vs)
-				expectUpdateVMRestoreInProgress(vm)
 				calls := expectPVCCreates(k8sClient, r, pvcSize)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -584,7 +582,7 @@ var _ = Describe("Restore controller", func() {
 					VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk2",
 				})
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				// create extra pvc
 				pvcs := createPVCsForVM(vm)
 				pvcs = append(pvcs, corev1.PersistentVolumeClaim{
@@ -638,7 +636,6 @@ var _ = Describe("Restore controller", func() {
 				vmSource.Add(vm)
 				addVirtualMachineRestore(r)
 
-				expectUpdateVMRestoreInProgress(vm)
 				calls := expectPVCCreates(k8sClient, r, pvcSize)
 				controller.processVMRestoreWorkItem()
 				Expect(*calls).To(Equal(2))
@@ -646,7 +643,7 @@ var _ = Describe("Restore controller", func() {
 
 			It("should create restore PVC with volume snapshot size if bigger then PVC size", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
@@ -659,7 +656,6 @@ var _ = Describe("Restore controller", func() {
 				q := resource.MustParse("3Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
 				fakeVolumeSnapshotProvider.Add(vs)
-				expectUpdateVMRestoreInProgress(vm)
 				calls := expectPVCCreates(k8sClient, r, q)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -668,7 +664,7 @@ var _ = Describe("Restore controller", func() {
 
 			It("should create restore PVC with pvc size if restore size is smaller", func() {
 				r := createRestoreWithOwner()
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
@@ -681,7 +677,6 @@ var _ = Describe("Restore controller", func() {
 				q := resource.MustParse("1Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
 				fakeVolumeSnapshotProvider.Add(vs)
-				expectUpdateVMRestoreInProgress(vm)
 				pvcSize := resource.MustParse("2Gi")
 				calls := expectPVCCreates(k8sClient, r, pvcSize)
 				addVirtualMachineRestore(r)
@@ -700,16 +695,13 @@ var _ = Describe("Restore controller", func() {
 				}
 				addVolumeRestores(r)
 
-				vm := createModifiedVM()
-				vmi := createVMI(vm)
+				vm := createRestoreInProgressVM()
 				vmSource.Add(vm)
-				vmiSource.Add(vmi)
 				vmRestoreSource.Add(r)
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Status.Phase = corev1.ClaimPending
 					addPVC(&pvc)
 				}
-				expectUpdateVMRestoreInProgress(vm)
 				controller.processVMRestoreWorkItem()
 			})
 
@@ -730,12 +722,11 @@ var _ = Describe("Restore controller", func() {
 					newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
 				}
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				vmi := createVMI(vm)
 				vmSource.Add(vm)
 				vmiSource.Add(vmi)
 				vmRestoreSource.Add(r)
-				expectUpdateVMRestoreInProgress(vm)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, ur)
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Status.Phase = corev1.ClaimBound
@@ -771,7 +762,7 @@ var _ = Describe("Restore controller", func() {
 				vm.Status.RestoreInProgress = &vmRestoreName
 				vmSource.Add(vm)
 				uvm := vm.DeepCopy()
-				uvm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+				uvm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 				uvm.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
 				uvm.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
 				for _, pvc := range getRestorePVCs(r) {
@@ -812,9 +803,8 @@ var _ = Describe("Restore controller", func() {
 					ur.Status.Restores[i].DataVolumeName = &ur.Status.Restores[i].PersistentVolumeClaimName
 				}
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
 				vmRestoreSource.Add(r)
 				pvcUpdateCalls := expectPVCUpdates(k8sClient, ur)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, ur)
@@ -929,9 +919,8 @@ var _ = Describe("Restore controller", func() {
 				}
 				vmRestoreSource.Add(r)
 
-				vm := createModifiedVM()
+				vm := createRestoreInProgressVM()
 				vm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
-				vm.Status.RestoreInProgress = &vmRestoreName
 
 				for _, n := range r.Status.DeletedDataVolumes {
 					dv := &cdiv1.DataVolume{
@@ -953,7 +942,6 @@ var _ = Describe("Restore controller", func() {
 				updatedVM := vm.DeepCopy()
 				updatedVM.ResourceVersion = "1"
 				updatedVM.Status.RestoreInProgress = nil
-				vmInterface.EXPECT().UpdateStatus(context.Background(), updatedVM, metav1.UpdateOptions{}).Return(updatedVM, nil).Times(1)
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
@@ -964,6 +952,7 @@ var _ = Describe("Restore controller", func() {
 					newReadyCondition(corev1.ConditionTrue, "Operation complete"),
 				}
 
+				updateVMStatusCalls := expectVMUpdateStatus(kubevirtClient, updatedVM)
 				dvDeleteCalls := expectDataVolumeDeletes(cdiClient, r.Status.DeletedDataVolumes)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, ur)
 
@@ -972,6 +961,7 @@ var _ = Describe("Restore controller", func() {
 				l, err := cdiClient.CdiV1beta1().DataVolumes("").List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(l.Items).To(BeEmpty())
+				Expect(*updateVMStatusCalls).To(Equal(1))
 				Expect(*updateStatusCalls).To(Equal(1))
 				Expect(*dvDeleteCalls).To(Equal(len(r.Status.DeletedDataVolumes)))
 			})
@@ -997,7 +987,7 @@ var _ = Describe("Restore controller", func() {
 						Namespace: testNamespace,
 						UID:       vmUID,
 						Annotations: map[string]string{
-							"restore.kubevirt.io/lastRestoreUID": "restore-uid",
+							lastRestoreAnnotation: "restore-uid",
 						},
 					},
 				}
@@ -1039,7 +1029,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createModifiedVM()
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+				vm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
 				vmRestoreSource.Add(r)
 				addVM(vm)
@@ -1070,7 +1060,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createModifiedVM()
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+				vm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
 				vmRestoreSource.Add(r)
 				addVM(vm)
@@ -1095,15 +1085,13 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 
-				vm := createModifiedVM()
-				vm.Status.RestoreInProgress = &vmRestoreName
+				vm := createRestoreInProgressVM()
 
 				vmRestoreSource.Add(r)
 				addVM(vm)
 
 				vmUpdated := vm.DeepCopy()
 				vmUpdated.Status.RestoreInProgress = nil
-				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdated, metav1.UpdateOptions{}).Return(vmUpdated, nil).Times(1)
 
 				updatedVMRestore := r.DeepCopy()
 				updatedVMRestore.Status.Conditions = []snapshotv1.Condition{
@@ -1112,8 +1100,10 @@ var _ = Describe("Restore controller", func() {
 				}
 				updatedVMRestore.ResourceVersion = "1"
 
+				updateVMStatusCalls := expectVMUpdateStatus(kubevirtClient, vmUpdated)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, updatedVMRestore)
 				controller.processVMRestoreWorkItem()
+				Expect(*updateVMStatusCalls).To(Equal(1))
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
@@ -1150,8 +1140,7 @@ var _ = Describe("Restore controller", func() {
 				BeforeEach(func() {
 					r = createRestoreWithOwner()
 					addVolumeRestores(r)
-					vm = createModifiedVM()
-					vm.Status.RestoreInProgress = &vmRestoreName
+					vm = createRestoreInProgressVM()
 					targetVM, _ = controller.getTarget(r)
 					targetVM.UpdateTarget(vm)
 				})
@@ -1190,23 +1179,20 @@ var _ = Describe("Restore controller", func() {
 					pvcSource.Add(&pvc)
 					return calls
 				}
-				expectUpdateRestoredVM := func() {
-					updatedVM := createSnapshotVM()
-					updatedVM.Status.RestoreInProgress = &vmRestoreName
-					updatedVM.ResourceVersion = "1"
-					updatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-					updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
-					updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
-					vmInterface.EXPECT().Update(context.Background(), updatedVM, metav1.UpdateOptions{}).Return(updatedVM, nil).Times(1)
-				}
 
 				DescribeTable("should", func(dvExists bool, phase cdiv1.DataVolumePhase, expecteUpdateVM bool) {
 					dvCreateCalls := addRestoreVolumes(dvExists, phase)
 
 					vmRestoreSource.Add(r)
 					addVM(vm)
-					if expecteUpdateVM == false {
-						expectUpdateRestoredVM()
+					updateVMCalls := pointer.P(0)
+					if expecteUpdateVM {
+						updatedVM := vm.DeepCopy()
+						updatedVM.ResourceVersion = "1"
+						updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+						updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
+						updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
+						updateVMCalls = expectVMUpdate(kubevirtClient, updatedVM)
 					}
 					res, err := targetVM.Reconcile()
 					Expect(err).ShouldNot(HaveOccurred())
@@ -1214,11 +1200,14 @@ var _ = Describe("Restore controller", func() {
 					if dvCreateCalls != nil {
 						Expect(*dvCreateCalls).To(Equal(1))
 					}
+					if expecteUpdateVM {
+						Expect(*updateVMCalls).To(Equal(1))
+					}
 				},
-					Entry("update VM spec when dv phase succeeded", true, cdiv1.Succeeded, false),
-					Entry("update VM spec when dv phase WFFC", true, cdiv1.WaitForFirstConsumer, false),
-					Entry("wait for dvs when dv phase pending", true, cdiv1.Pending, true),
-					Entry("create dvs when dv doesnt exists", false, cdiv1.PhaseUnset, true),
+					Entry("update VM spec when dv phase succeeded", true, cdiv1.Succeeded, true),
+					Entry("update VM spec when dv phase WFFC", true, cdiv1.WaitForFirstConsumer, true),
+					Entry("wait for dvs when dv phase pending", true, cdiv1.Pending, false),
+					Entry("create dvs when dv doesnt exists", false, cdiv1.PhaseUnset, false),
 				)
 			})
 
@@ -1230,8 +1219,8 @@ var _ = Describe("Restore controller", func() {
 					sc.Spec.Source.VirtualMachine.Spec.RunStrategy = pointer.P(kubevirtv1.RunStrategyAlways)
 					vmSnapshotContentSource.Modify(sc)
 					By("Creating new VM")
-					newVM := createVirtualMachine(testNamespace, "new-test-vm")
-					newVM.UID = ""
+					newVM := createVirtualMachine(testNamespace, newVMName)
+					newVM.UID = newVMUID
 
 					By("Creating VM restore")
 					vmRestore := createRestoreWithOwner()
@@ -1255,7 +1244,7 @@ var _ = Describe("Restore controller", func() {
 					newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = *vmRestore.Status.Restores[0].DataVolumeName
 					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
-					vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil).Times(1)
+					createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 
 					By("Making sure right VMRestore update occurs")
 					updatedVMRestore := vmRestore.DeepCopy()
@@ -1269,6 +1258,7 @@ var _ = Describe("Restore controller", func() {
 
 					By("Running the controller")
 					controller.processVMRestoreWorkItem()
+					Expect(*createVMCalls).To(Equal(1))
 					Expect(*pvcUpdateCalls).To(Equal(1))
 					Expect(*updateStatusCalls).To(Equal(1))
 				})
@@ -1277,7 +1267,8 @@ var _ = Describe("Restore controller", func() {
 					By("Creating new VM")
 					newVM := createVirtualMachine(testNamespace, "new-test-vm")
 					newVM.Status.RestoreInProgress = &vmRestoreName
-					newVM.UID = ""
+					newVM.UID = newVMUID
+					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 					vmSource.Add(newVM)
 
 					By("Creating VM restore")
@@ -1373,37 +1364,39 @@ var _ = Describe("Restore controller", func() {
 						r.Spec.Patches = []string{changeNamePatch}
 
 						newVM := createVirtualMachine(testNamespace, newVmName)
-						newVM.UID = ""
+						newVM.UID = newVMUID
 						newVM.Spec.DataVolumeTemplates[0].Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
-						vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil).Times(1)
+						createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 
 						targetVM, err := controller.getTarget(r)
 						Expect(err).ShouldNot(HaveOccurred())
 						success, err := targetVM.Reconcile()
 						Expect(success).To(BeTrue())
 						Expect(err).ShouldNot(HaveOccurred())
+						Expect(*createVMCalls).To(Equal(1))
 					})
 
 					It("with changed name and MAC address", func() {
 						r.Spec.Patches = []string{changeNamePatch, changeMacAddressPatch}
 
 						newVM := createVirtualMachine(testNamespace, newVmName)
-						newVM.UID = ""
+						newVM.UID = newVMUID
 						newVM.Spec.DataVolumeTemplates[0].Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
 						newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 						newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = newMacAddress
 
-						vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil).Times(1)
+						createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 
 						targetVM, err := controller.getTarget(r)
 						Expect(err).ShouldNot(HaveOccurred())
 						success, err := targetVM.Reconcile()
 						Expect(success).To(BeTrue())
 						Expect(err).ShouldNot(HaveOccurred())
+						Expect(*createVMCalls).To(Equal(1))
 					})
 
 				})
@@ -1463,7 +1456,7 @@ var _ = Describe("Restore controller", func() {
 
 		It("should create restore PVCs with populated dataSourceRef and dataSource", func() {
 			// Mock the restore environment from scratch, so we use source PVCs with dataSourceRef
-			vm := createSnapshotVM()
+			vm := createRestoreInProgressVM()
 			pvcs := createPVCsForVMWithDataSourceRef(vm)
 			s := createSnapshot()
 			sc := createVirtualMachineSnapshotContent(s, vm, pvcs)
@@ -1473,13 +1466,13 @@ var _ = Describe("Restore controller", func() {
 				CreationTime: timeFunc(),
 				ReadyToUse:   pointer.P(true),
 			}
+			vmSource.Add(vm)
 			vmSnapshotSource.Add(s)
 			vmSnapshotContentSource.Add(sc)
 			storageClassSource.Add(storageClass)
 
 			// Actual test
 			r := createRestoreWithOwner()
-			vm = createModifiedVM()
 			r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 				Complete: pointer.P(false),
 				Conditions: []snapshotv1.Condition{
@@ -1487,12 +1480,10 @@ var _ = Describe("Restore controller", func() {
 					newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
 				},
 			}
-			vmSource.Add(vm)
 			addVolumeRestores(r)
 			pvcSize := resource.MustParse("2Gi")
 			vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
 			fakeVolumeSnapshotProvider.Add(vs)
-			expectUpdateVMRestoreInProgress(vm)
 			calls := expectPVCCreateWithDataSourceRef(k8sClient, r, pvcSize)
 			addVirtualMachineRestore(r)
 			controller.processVMRestoreWorkItem()
@@ -1515,29 +1506,6 @@ var _ = Describe("Restore controller", func() {
 
 			const vmCreationFailureMessage = "something failed during VirtualMachine creation"
 
-			expectCreateVM := func(vm *kubevirtv1.VirtualMachine) {
-				newVMUID := vm.UID
-				vm.UID = ""
-				vm.ResourceVersion = ""
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-				vmInterface.EXPECT().
-					Create(context.Background(), vm, metav1.CreateOptions{}).
-					Do(func(ctx context.Context, newVM *kubevirtv1.VirtualMachine, options metav1.CreateOptions) {
-						vm.UID = newVMUID
-					}).Return(vm, nil).Times(1)
-			}
-
-			expectUpdateVMRestored := func(vm *kubevirtv1.VirtualMachine) {
-				expectedUpdatedVM := vm.DeepCopy()
-				expectedUpdatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-				vmInterface.EXPECT().
-					Update(context.Background(), expectedUpdatedVM, metav1.UpdateOptions{}).
-					Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
-						updatedVM := obj.(*kubevirtv1.VirtualMachine)
-						Expect(*updatedVM).To(Equal(*expectedUpdatedVM))
-					}).Return(expectedUpdatedVM, nil).Times(1)
-			}
-
 			expectUpdateVMRestoreUpdatingTargetSpec := func(vmRestore *snapshotv1.VirtualMachineRestore, resourceVersion string) *int {
 				expectedUpdatedRestore := vmRestore.DeepCopy()
 				expectedUpdatedRestore.ResourceVersion = resourceVersion
@@ -1558,18 +1526,6 @@ var _ = Describe("Restore controller", func() {
 				return expectVMRestoreUpdateStatus(kubevirtClient, expectedUpdatedRestore)
 			}
 
-			expectCreateVMFailure := func(vm *kubevirtv1.VirtualMachine) {
-				newVMUID := vm.UID
-				vm.UID = ""
-				vm.ResourceVersion = ""
-				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-				vmInterface.EXPECT().
-					Create(context.Background(), vm, metav1.CreateOptions{}).
-					Do(func(ctx context.Context, newVM *kubevirtv1.VirtualMachine, options metav1.CreateOptions) {
-						vm.UID = newVMUID
-					}).Return(vm, fmt.Errorf(vmCreationFailureMessage))
-			}
-
 			getInstancetypeOriginalCR := func() *appsv1.ControllerRevision { return instancetypeOriginalCR }
 			getPreferenceOriginalCR := func() *appsv1.ControllerRevision { return preferenceOriginalCR }
 			nilInstancetypeMatcher := func() *kubevirtv1.InstancetypeMatcher { return nil }
@@ -1578,7 +1534,7 @@ var _ = Describe("Restore controller", func() {
 			BeforeEach(func() {
 				virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
 
-				originalVM = createSnapshotVM()
+				originalVM = createRestoreInProgressVM()
 				originalVM.Spec.DataVolumeTemplates = []kubevirtv1.DataVolumeTemplateSpec{}
 				restore = createRestoreWithOwner()
 
@@ -1605,7 +1561,6 @@ var _ = Describe("Restore controller", func() {
 				preferenceOriginalCR, err = instancetype.CreateControllerRevision(originalVM, preferenceObj)
 				Expect(err).ToNot(HaveOccurred())
 				crSource.Add(preferenceOriginalCR)
-
 				preferenceSnapshotCR = createInstancetypeVirtualMachineSnapshotCR(originalVM, vmSnapshot, preferenceObj)
 				crSource.Add(preferenceSnapshotCR)
 			})
@@ -1620,13 +1575,15 @@ var _ = Describe("Restore controller", func() {
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Preference = getSnapshotPreferenceMatcher()
 					vmSnapshotContentSource.Add(vmSnapshotContent)
 
-					updatedVM := expectUpdateVMRestoreInProgress(originalVM)
-					expectUpdateVMRestored(updatedVM)
+					updatedVM := originalVM.DeepCopy()
+					updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+					updateVMCalls := expectVMUpdate(kubevirtClient, updatedVM)
 					calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "1")
 
 					addVirtualMachineRestore(restore)
 					controller.processVMRestoreWorkItem()
 					Expect(*calls).To(Equal(1))
+					Expect(*updateVMCalls).To(Equal(1))
 				},
 				Entry("and referenced instancetype",
 					func() *kubevirtv1.InstancetypeMatcher {
@@ -1674,7 +1631,9 @@ var _ = Describe("Restore controller", func() {
 					// Ensure we restore into a new VM
 					newVM := originalVM.DeepCopy()
 					newVM.Name = "newvm"
-					newVM.UID = "newvm-uid"
+					newVM.UID = ""
+					newVM.ResourceVersion = ""
+					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 					restore.Spec.Target.Name = newVM.Name
 
 					originalCR := getExpectedCR()
@@ -1689,6 +1648,7 @@ var _ = Describe("Restore controller", func() {
 
 					expectedUpdatedCR := expectedCreatedCR.DeepCopy()
 					expectedUpdatedCR.ResourceVersion = "5"
+					newVM.UID = newVMUID
 					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, kubevirtv1.VirtualMachineGroupVersionKind)}
 					crUpdates := expectControllerRevisionUpdate(k8sClient, expectedUpdatedCR)
 
@@ -1698,7 +1658,7 @@ var _ = Describe("Restore controller", func() {
 					if newVM.Spec.Preference != nil {
 						newVM.Spec.Preference.RevisionName = expectedCreatedCR.Name
 					}
-					expectCreateVM(newVM)
+					createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 					calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "1")
 
 					addVirtualMachineRestore(restore)
@@ -1706,6 +1666,7 @@ var _ = Describe("Restore controller", func() {
 					Expect(*calls).To(Equal(1))
 					Expect(*crCreates).To(Equal(1))
 					Expect(*crUpdates).To(Equal(1))
+					Expect(*createVMCalls).To(Equal(1))
 				},
 				Entry("and referenced instancetype",
 					func() *kubevirtv1.InstancetypeMatcher {
@@ -1751,8 +1712,10 @@ var _ = Describe("Restore controller", func() {
 
 					// Ensure we restore into a new VM
 					newVM := originalVM.DeepCopy()
+					newVM.UID = newVMUID
+					newVM.ResourceVersion = ""
 					newVM.Name = "newvm"
-					newVM.UID = "newvm-uid"
+					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 					restore.Spec.Target.Name = newVM.Name
 
 					originalCR := getExpectedCR()
@@ -1777,15 +1740,16 @@ var _ = Describe("Restore controller", func() {
 						newVM.Spec.Preference.RevisionName = expectedCreatedCR.Name
 					}
 
-					expectCreateVMFailure(newVM)
+					createVMFailureCalls := expectVMCreateFailure(kubevirtClient, vmCreationFailureMessage)
 					failCalls := expectUpdateVMRestoreFailure(restore, "1", vmCreationFailureMessage)
 
 					addVirtualMachineRestore(restore)
 					controller.processVMRestoreWorkItem()
+					Expect(*createVMFailureCalls).To(Equal(1))
 
 					// We have already created the ControllerRevision but that shouldn't stop the reconcile from progressing
 					alreadyExistsCalls := expectCreateControllerRevisionAlreadyExists(k8sClient, expectedCreatedCR)
-					expectCreateVM(newVM)
+					createVMCalls := expectVMCreate(kubevirtClient, newVM, newVMUID)
 					calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "2")
 
 					addVirtualMachineRestore(restore)
@@ -1795,6 +1759,7 @@ var _ = Describe("Restore controller", func() {
 					Expect(*crCreates).To(Equal(1))
 					Expect(*alreadyExistsCalls).To(Equal(1))
 					Expect(*crUpdates).To(Equal(1))
+					Expect(*createVMCalls).To(Equal(1))
 				},
 				Entry("and referenced instancetype",
 					func() *kubevirtv1.InstancetypeMatcher {
@@ -1857,8 +1822,9 @@ var _ = Describe("Restore controller", func() {
 				crDeletes := expectControllerRevisionDelete(k8sClient, instancetypeOriginalCR.Name)
 				crCreates := expectControllerRevisionCreate(k8sClient, instancetypeOriginalCRCopy)
 
-				updatedVM := expectUpdateVMRestoreInProgress(originalVM)
-				expectUpdateVMRestored(updatedVM)
+				updatedVM := originalVM.DeepCopy()
+				updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+				updateVMCalls := expectVMUpdate(kubevirtClient, updatedVM)
 				calls := expectUpdateVMRestoreUpdatingTargetSpec(restore, "1")
 
 				addVirtualMachineRestore(restore)
@@ -1866,10 +1832,46 @@ var _ = Describe("Restore controller", func() {
 				Expect(*calls).To(Equal(1))
 				Expect(*crCreates).To(Equal(1))
 				Expect(*crDeletes).To(Equal(1))
+				Expect(*updateVMCalls).To(Equal(1))
 			})
 		})
 	})
 })
+
+func expectVMCreateFailure(client *kubevirtfake.Clientset, failureMsg string) *int {
+	calls := 0
+	client.Fake.PrependReactor("create", "virtualmachines", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		create, ok := action.(testing.CreateAction)
+		Expect(ok).To(BeTrue())
+
+		_, ok = create.GetObject().(*kubevirtv1.VirtualMachine)
+		Expect(ok).To(BeTrue())
+
+		calls++
+
+		return true, nil, fmt.Errorf(failureMsg)
+	})
+	return &calls
+}
+
+func expectVMCreate(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachine, newVMUID types.UID) *int {
+	calls := 0
+	client.Fake.PrependReactor("create", "virtualmachines", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		create, ok := action.(testing.CreateAction)
+		Expect(ok).To(BeTrue())
+
+		createObj, ok := create.GetObject().(*kubevirtv1.VirtualMachine)
+		Expect(ok).To(BeTrue())
+
+		calls++
+		createObj.UID = newVMUID
+		Expect(createObj.ObjectMeta).To(Equal(vm.ObjectMeta))
+		Expect(createObj.Spec).To(Equal(vm.Spec))
+
+		return true, createObj, nil
+	})
+	return &calls
+}
 
 func expectVMUpdate(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachine) *int {
 	calls := 0
@@ -1882,6 +1884,25 @@ func expectVMUpdate(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachin
 		calls++
 		Expect(vm.ObjectMeta).To(Equal(updateObj.ObjectMeta))
 		Expect(vm.Spec).To(Equal(updateObj.Spec))
+
+		return true, update.GetObject(), nil
+	})
+	return &calls
+}
+
+func expectVMUpdateStatus(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachine) *int {
+	calls := 0
+	client.Fake.PrependReactor("update", "virtualmachines", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		update, ok := action.(testing.UpdateAction)
+		Expect(ok).To(BeTrue())
+		if update.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+
+		updateObj := update.GetObject().(*kubevirtv1.VirtualMachine)
+		Expect(vm.Status).To(Equal(updateObj.Status))
+
+		calls++
 
 		return true, update.GetObject(), nil
 	})

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -331,10 +331,10 @@ var _ = Describe("Restore controller", func() {
 			controller.vmRestoreQueue = mockVMRestoreQueue
 
 			// Set up mock client
-			virtClient.EXPECT().VirtualMachine(testNamespace).Return(vmInterface).AnyTimes()
-
 			kubevirtClient = kubevirtfake.NewSimpleClientset()
 
+			virtClient.EXPECT().VirtualMachine(testNamespace).
+				Return(kubevirtClient.KubevirtV1().VirtualMachines(testNamespace)).AnyTimes()
 			virtClient.EXPECT().VirtualMachineRestore(testNamespace).
 				Return(kubevirtClient.SnapshotV1beta1().VirtualMachineRestores(testNamespace)).AnyTimes()
 			virtClient.EXPECT().VirtualMachineSnapshot(testNamespace).
@@ -349,10 +349,6 @@ var _ = Describe("Restore controller", func() {
 			virtClient.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
 
 			k8sClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-				Expect(action).To(BeNil())
-				return true, nil, nil
-			})
-			kubevirtClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				Expect(action).To(BeNil())
 				return true, nil, nil
 			})
@@ -747,6 +743,52 @@ var _ = Describe("Restore controller", func() {
 				}
 				controller.processVMRestoreWorkItem()
 				Expect(*updateStatusCalls).To(Equal(1))
+			})
+
+			It("should keep existing VM runstrategy as before the restore", func() {
+				// Update snapshoted VM to have running instead of runstrategy
+				// to show the resulted VM has the expected run stratgey as before
+				// the restore and doesnt have both running and runstrategy
+				sc.Spec.Source.VirtualMachine.Spec.RunStrategy = nil
+				sc.Spec.Source.VirtualMachine.Spec.Running = pointer.P(true)
+				vmSnapshotContentSource.Modify(sc)
+
+				r := createRestoreWithOwner()
+				addVolumeRestores(r)
+				r.Status.DeletedDataVolumes = getDeletedDataVolumes(createModifiedVM())
+				for i := range r.Status.Restores {
+					r.Status.Restores[i].DataVolumeName = &r.Status.Restores[i].PersistentVolumeClaimName
+				}
+				ur := r.DeepCopy()
+				ur.ResourceVersion = "1"
+				ur.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionTrue, "Updating target spec"),
+					newReadyCondition(corev1.ConditionFalse, "Waiting for target update"),
+				}
+
+				vm := createSnapshotVM()
+				vm.Spec.RunStrategy = pointer.P(kubevirtv1.RunStrategyManual)
+				vm.Status.RestoreInProgress = &vmRestoreName
+				vmSource.Add(vm)
+				uvm := vm.DeepCopy()
+				uvm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+				uvm.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
+				uvm.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
+				for _, pvc := range getRestorePVCs(r) {
+					pvc.Status.Phase = corev1.ClaimBound
+					addPVC(&pvc)
+				}
+				addVirtualMachineRestore(r)
+
+				// Expect vm runstrategy to not change
+				updateVMCalls := expectVMUpdate(kubevirtClient, uvm)
+				pvcUpdateCalls := expectPVCUpdates(k8sClient, ur)
+				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, ur)
+
+				controller.processVMRestoreWorkItem()
+				Expect(*pvcUpdateCalls).To(Equal(1))
+				Expect(*updateStatusCalls).To(Equal(1))
+				Expect(*updateVMCalls).To(Equal(1))
 			})
 
 			It("should update PVCs and restores to have datavolumename", func() {
@@ -1183,6 +1225,10 @@ var _ = Describe("Restore controller", func() {
 			Context("target VM is different than source VM", func() {
 
 				It("should be able to restore to a new VM", func() {
+					// Update snapshoted VM to have runstrategy Always
+					// and see the resulted new VM has Halted
+					sc.Spec.Source.VirtualMachine.Spec.RunStrategy = pointer.P(kubevirtv1.RunStrategyAlways)
+					vmSnapshotContentSource.Modify(sc)
 					By("Creating new VM")
 					newVM := createVirtualMachine(testNamespace, "new-test-vm")
 					newVM.UID = ""
@@ -1204,6 +1250,7 @@ var _ = Describe("Restore controller", func() {
 					pvcUpdateCalls := expectPVCUpdates(k8sClient, vmRestore)
 
 					By("Making sure right VM update occurs")
+					newVM.Spec.RunStrategy = pointer.P(kubevirtv1.RunStrategyHalted)
 					newVM.Spec.DataVolumeTemplates[0].Name = *vmRestore.Status.Restores[0].DataVolumeName
 					newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = *vmRestore.Status.Restores[0].DataVolumeName
 					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
@@ -1823,6 +1870,23 @@ var _ = Describe("Restore controller", func() {
 		})
 	})
 })
+
+func expectVMUpdate(client *kubevirtfake.Clientset, vm *kubevirtv1.VirtualMachine) *int {
+	calls := 0
+	client.Fake.PrependReactor("update", "virtualmachines", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		update, ok := action.(testing.UpdateAction)
+		Expect(ok).To(BeTrue())
+
+		updateObj := update.GetObject().(*kubevirtv1.VirtualMachine)
+
+		calls++
+		Expect(vm.ObjectMeta).To(Equal(updateObj.ObjectMeta))
+		Expect(vm.Spec).To(Equal(updateObj.Spec))
+
+		return true, update.GetObject(), nil
+	})
+	return &calls
+}
 
 func expectPVCCreates(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMachineRestore, expectedSize resource.Quantity) *int {
 	calls := 0


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/14281

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMRestore: Keep VM RunStrategy as before the restore
```

