### PR TITLE
make, lint: Limit use of OncePerOrderedCleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ format:
 fmt: format
 
 lint:
+	hack/dockerized "hack/lint-test-cleanup-label.sh"
 	hack/dockerized "hack/golangci-lint.sh"
 	hack/dockerized "monitoringlinter ./pkg/..."
 

--- a/hack/lint-test-cleanup-label.sh
+++ b/hack/lint-test-cleanup-label.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+#
+
+EXCLUDE_PATTERN="./decorators/decorators.go|\
+./tests_suite_test.go|\
+./tests/virtctl|\
+./tests/network"
+
+if grep -rl 'OncePerOrderedCleanup' ./tests --include=*.go |
+    grep -Evq "$EXCLUDE_PATTERN"; then
+    echo "The use of OncePerOrderedCleanup label is currently limited to SIG-Network and virtctl tests only"
+    exit 1
+fi


### PR DESCRIPTION
The `OncePerOrderedCleanup` label was introduced in
https://github.com/kubevirt/kubevirt/pull/13786 as a pilot for SIG-Network and `virtctl`.
Its purpose is to enable sharing of VMs between multiple tests thus reducing test duration and resource usage. Since the feature is temporarily only allowed in the above areas, this commit adds a linter that will fail the lint process, should a file located elsewhere uses the label.
If additional files/areas would like to participate in the pilot, please add required file or directory to the `EXCLUDE_PATTERN` variable.
This entire commit is expected to be reverted once the whole project is on board.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

