### PR TITLE
schema: Fix typo

### DIFF
--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -361,7 +361,7 @@ type NUMAGuestMappingPassthrough struct {
 type NUMA struct {
 	// GuestMappingPassthrough will create an efficient guest topology based on host CPUs exclusively assigned to a pod.
 	// The created topology ensures that memory and CPUs on the virtual numa nodes never cross boundaries of host numa nodes.
-	// +opitonal
+	// +optional
 	GuestMappingPassthrough *NUMAGuestMappingPassthrough `json:"guestMappingPassthrough,omitempty"`
 }
 
@@ -722,7 +722,7 @@ type SEV struct {
 	// Note: due to security reasons it is not allowed to enable guest debugging. Therefore NoDebug flag is not exposed to users and is always true.
 	Policy *SEVPolicy `json:"policy,omitempty"`
 	// If specified, run the attestation process for a vmi.
-	// +opitonal
+	// +optional
 	Attestation *SEVAttestation `json:"attestation,omitempty"`
 	// Base64 encoded session blob.
 	Session string `json:"session,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -186,7 +186,7 @@ func (NUMAGuestMappingPassthrough) SwaggerDoc() map[string]string {
 
 func (NUMA) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"guestMappingPassthrough": "GuestMappingPassthrough will create an efficient guest topology based on host CPUs exclusively assigned to a pod.\nThe created topology ensures that memory and CPUs on the virtual numa nodes never cross boundaries of host numa nodes.\n+opitonal",
+		"guestMappingPassthrough": "GuestMappingPassthrough will create an efficient guest topology based on host CPUs exclusively assigned to a pod.\nThe created topology ensures that memory and CPUs on the virtual numa nodes never cross boundaries of host numa nodes.\n+optional",
 	}
 }
 
@@ -394,7 +394,7 @@ func (LaunchSecurity) SwaggerDoc() map[string]string {
 func (SEV) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"policy":      "Guest policy flags as defined in AMD SEV API specification.\nNote: due to security reasons it is not allowed to enable guest debugging. Therefore NoDebug flag is not exposed to users and is always true.",
-		"attestation": "If specified, run the attestation process for a vmi.\n+opitonal",
+		"attestation": "If specified, run the attestation process for a vmi.\n+optional",
 		"session":     "Base64 encoded session blob.",
 		"dhCert":      "Base64 encoded guest owner's Diffie-Hellman key.",
 	}


### PR DESCRIPTION
### What this PR does

Fix a typo in the API schema.

### Release note

```release-note
NONE
```