### PR TITLE
tests: CPU hotplug: give time for domxml to update

### DIFF
--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -319,6 +319,7 @@ func (c *VirtLauncherClient) genericSendVMICmd(cmdName string,
 	err = handleError(err, cmdName, response)
 	return err
 }
+
 func IsUnimplemented(err error) bool {
 	if grpcStatus, ok := status.FromError(err); ok {
 		if grpcStatus.Code() == codes.Unimplemented {

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -293,12 +293,11 @@ var _ = Describe("[sig-compute]CPU Hotplug", decorators.SigCompute, decorators.S
 			))
 
 			By("Ensuring the libvirt domain has 4 enabled cores")
-			Eventually(func() error {
+			Eventually(func() cpuCount {
 				domSpec, err = libdomain.GetRunningVMIDomainSpec(vmi)
-				return err
-			}).WithTimeout(20 * time.Second).WithPolling(time.Second).Should(Succeed())
-
-			Expect(countDomCPUs(domSpec)).To(Equal(cpuCount{
+				Expect(err).NotTo(HaveOccurred())
+				return countDomCPUs(domSpec)
+			}).WithTimeout(20 * time.Second).WithPolling(time.Second).Should(Equal(cpuCount{
 				enabled:  4,
 				disabled: 2,
 			}))


### PR DESCRIPTION
### What this PR does
Before this PR:
Right after a CPU hotplug, we check the domain XML and on rare occasions it appears to still contain the pre-hotplug values, causing flakiness.
Since the hotplug appears to be successful in failed tests, I assume libvirt just needs a couple seconds to reflect the change in the domain XML.

After this PR:
Move the expectation into a 20-second Eventually loop to give it time to update.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

