### PR TITLE
virt-handler: emit VMI event on non-fatal hotplug failure 

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -288,16 +288,12 @@ func (m *volumeMounter) mountHotplugVolume(
 		if m.isBlockVolume(&vmi.Status, volumeName) {
 			logger.V(4).Infof("Mounting block volume: %s", volumeName)
 			if err := m.mountBlockHotplugVolume(vmi, volumeName, sourceUID, record, cgroupManager); err != nil {
-				if !errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("failed to mount block hotplug volume %s: %v", volumeName, err)
-				}
+				return fmt.Errorf("failed to mount block hotplug volume %s: %w", volumeName, err)
 			}
 		} else {
 			logger.V(4).Infof("Mounting file system volume: %s", volumeName)
 			if err := m.mountFileSystemHotplugVolume(vmi, volumeName, sourceUID, record, mountDirectory); err != nil {
-				if !errors.Is(err, os.ErrNotExist) {
-					return fmt.Errorf("failed to mount filesystem hotplug volume %s: %v", volumeName, err)
-				}
+				return fmt.Errorf("failed to mount filesystem hotplug volume %s: %w", volumeName, err)
 			}
 		}
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3008,7 +3008,10 @@ func (c *VirtualMachineController) handleRunningVMI(vmi *v1.VirtualMachineInstan
 	}
 
 	if err := c.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
-		return err
+		if !goerror.Is(err, os.ErrNotExist) {
+			return err
+		}
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, "HotplugFailed", err.Error())
 	}
 
 	if err := c.getMemoryDump(vmi); err != nil {
@@ -3055,7 +3058,10 @@ func (c *VirtualMachineController) handleStartingVMI(
 	}
 
 	if err := c.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
-		return false, err
+		if !goerror.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, "HotplugFailed", err.Error())
 	}
 
 	isolationRes, err := c.podIsolationDetector.Detect(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

In certain scenarios, volume hotplugging can fail due to a non-fatal error. For example, in filesystem PVCs, the PVC may be unpopulated resulting in an os.ErrNotExist when attempting to mount it.

Previously, such errors didn't get logged, resulting in a deadlock for the AttachedToNode interim state despite having no message to indicate it. 

**After this PR:**

The aforementioned errors now get emitted as an `HotplugFailed` event on the VMI instead.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes:
- https://issues.redhat.com/browse/CNV-56714

### Why we need it and why it was done in this way

**The following alternatives were considered:**

Several alternatives have been considered:
- It's possible to error out on `ErrNotExist` but that would result in a `SyncError` which indicates a fatal error not being the case in this scenario.
- It's possible to log the failure at the lower mount level but that would: 1. spam the virt-handler logs (fixable by gating behind a higher verbosity), 2. not rectify the situation as the issue remains unclear except for when examining the virt-handler logs.

### Special notes for your reviewer
Polling for the disk.img in the case of unpopulated filesystem PVCs was considered unnecessary, as it only serves to potentially slow down event emission- and those events are being aggregated regardless.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

