### PR TITLE
Fix KubeVirt installation failure on Rancher RKE2 clusters

### DIFF
--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -185,6 +185,11 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 							Operator: corev1.TolerationOpExists,
 							Effect:   corev1.TaintEffectNoSchedule,
 						},
+						{
+							Key:      "node-role.kubernetes.io/etcd",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoExecute,
+						},
 					},
 				},
 			}


### PR DESCRIPTION
### What this PR does
Before this PR: KubeVirt installation on Rancher RKE2 clusters gets stuck in pending state due to scheduling problems with etcd nodes.

After this PR: KubeVirt installs successfully on Rancher RKE2 clusters by applying the kustomize patch that addresses node affinity/selector requirements.

Fixes #14429

### Why we need it and why it was done in this way
The patch implements the necessary changes to make KubeVirt compatible with RKE2 cluster configuration, specifically addressing the etcd role handling that was causing the installation to fail.

### Release note
```release-note
Fixed KubeVirt installation on Rancher RKE2 clusters that was failing due to node scheduling issues.
```