### PR TITLE
Replace use of [Conformance] with the Conformance decorator

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -5,7 +5,7 @@ defining Kubevirt core functionalities. The goal of the suite is to make sure th
 
 ## How are Conformance tests selected
 
-By default tests with a `[Conformance]` tag (and from release 0.59 also decorator) will be executed and tests with a
+By default tests with a `conformance` decorator will be executed and tests with a
 `[Disruptive]` tag will be skipped. These tests will not destroy or modify
 anything outside of the explicitly created test namespaces by the binary.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ Additional suggestions:
 
  * The `[Disruptive]` tag is recognized by the test suite but is not yet
    mandatory. Feel free to set it on destructive tests.
- * Conformance tests need to be marked with a `[Conformance]` tag.
+ * Conformance tests need to be marked with a `decorators.Conformance` label.
  * We try to mark tests that require advanced/special storage capabilities with `[storage-req]`,  
    So they are easy to skip when lanes with new storage solutions are introduced.  
    At the point of writing this we use `rook-ceph-block` which certainly qualifies for running them.

--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -40,7 +40,7 @@ func execute() error {
 	} else if value, exists := os.LookupEnv("E2E_FOCUS"); exists {
 		args = append(args, "--ginkgo.focus", value)
 	} else {
-		args = append(args, "--ginkgo.focus", "\\[Conformance\\]")
+		args = append(args, "--ginkgo.label-filter", "(conformance)")
 	}
 
 	if value, exists := os.LookupEnv("CONTAINER_PREFIX"); exists {

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -63,7 +63,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting and stopping the same VirtualMachine", func() {
 		Context("with ephemeral registry disk", func() {
-			It("[test_id:1463][Conformance] should success multiple times", decorators.Conformance, func() {
+			It("[test_id:1463] should success multiple times", decorators.Conformance, func() {
 				By("Creating the VirtualMachine")
 				vm := libvmi.NewVirtualMachine(libvmifact.NewCirros())
 				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.TODO(), vm, metav1.CreateOptions{})

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -24,6 +24,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -117,7 +118,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 					assertIPsNotEmptyForVMI(clientVMI)
 				})
 
-				It("[Conformance][test_id:1513] should succeed pinging between two VMI/s in the same namespace", func() {
+				It("[test_id:1513] should succeed pinging between two VMI/s in the same namespace", decorators.Conformance, func() {
 					assertPingSucceed(clientVMI, serverVMI)
 				})
 			})
@@ -132,7 +133,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 					assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 				})
 
-				It("[Conformance][test_id:1514] should fail pinging between two VMI/s each on different namespaces", func() {
+				It("[test_id:1514] should fail pinging between two VMI/s each on different namespaces", decorators.Conformance, func() {
 					assertPingFail(clientVMIAlternativeNamespace, serverVMI)
 				})
 			})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -35,6 +35,7 @@ import (
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -149,7 +150,7 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 					)
 				})
 
-				It("[Conformance] should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
+				It("should report PodIP as its own on interface status", decorators.Conformance, func() { AssertReportedIP(vmi) })
 			})
 		})
 	})

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/job"
@@ -157,7 +158,7 @@ var _ = Describe(SIG("Services", func() {
 		})
 
 		Context("with a service matching the vmi exposed", func() {
-			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
+			DescribeTable("should be able to reach the vmi based on labels specified on the vmi", decorators.Conformance, func(ipFamily k8sv1.IPFamily) {
 				var service *k8sv1.Service
 				serviceName := "myservice"
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -439,7 +439,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			}
 		}
 
-		Context("[Conformance][test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", func() {
+		Context("[test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", decorators.Conformance, func() {
 			// This CIDR tests backwards compatibility of the "vmNetworkCIDR" field.
 			// The leading zero is intentional.
 			// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
@@ -593,7 +593,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				return pod, nil
 			}
 
-			DescribeTable("[Conformance] preserves connectivity - IPv4", func(ports []v1.Port) {
+			DescribeTable("preserves connectivity - IPv4", decorators.Conformance, func(ports []v1.Port) {
 				libnet.SkipWhenClusterNotSupportIpv4()
 
 				var err error
@@ -632,7 +632,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Entry("with explicit ports used by live migration", portsUsedByLiveMigration()),
 			)
 
-			It("[Conformance] should preserve connectivity - IPv6", func() {
+			It("should preserve connectivity - IPv6", decorators.Conformance, func() {
 				libnet.SkipWhenClusterNotSupportIpv6()
 
 				var err error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Some tests used the Conformance decorator while others used the [Conformance] tag. The `conformance.go` test suite used in our Sonobuoy image was only matching by the tag, while other users of the test suite only matched by the decorator.

After this PR:

The tag is finally removed and the conformance.go suite defaults to use it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The is a risk that some unknown users of [Conformance] still exist. This PR tries to adjust all the known callers.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

With this change, the Sonobuoy test suite finally runs all the conformance tests. This brings the number of tests from 18 to 100. If anybody would like to keep testing only network conformance tests through Sonobuoy, they can select `(conformance && sig-network)`.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network conformance tests are now marked using the `Conformance` decorator. Use `--ginkgo.label-filter '(sig-network && conformance)` to select them.
```

