### PR TITLE
Disable free-page-reporting for s390x

### DIFF
--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -170,6 +170,7 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 	nodeSelectorsDefault, _ := parseNodeSelectors(DefaultNodeSelectors)
 	defaultNetworkInterface := DefaultNetworkInterface
 	defaultMemBalloonStatsPeriod := DefaultMemBalloonStatsPeriod
+	var defaultFreePageReportingDisabled *v1.DisableFreePageReporting
 	SmbiosDefaultConfig := &v1.SMBiosConfiguration{
 		Family:       SmbiosConfigDefaultFamily,
 		Manufacturer: SmbiosConfigDefaultManufacturer,
@@ -180,6 +181,10 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 		MemoryLimit: resource.NewScaledQuantity(DefaultDiskVerificationMemoryLimitMBytes, resource.Mega),
 	}
 	defaultEvictionStrategy := v1.EvictionStrategyNone
+
+	if cpuArch == "s390x" {
+		defaultFreePageReportingDisabled = &v1.DisableFreePageReporting{}
+	}
 
 	return &v1.KubeVirtConfiguration{
 		ImagePullPolicy: DefaultImagePullPolicy,
@@ -238,6 +243,9 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 				QPS:   DefaultVirtHandlerQPS,
 				Burst: DefaultVirtHandlerBurst,
 			}}},
+		},
+		VirtualMachineOptions: &v1.VirtualMachineOptions{
+			DisableFreePageReporting: defaultFreePageReportingDisabled,
 		},
 		WebhookConfiguration: &v1.ReloadableComponentConfiguration{
 			RestClient: &v1.RESTClientConfiguration{RateLimiter: &v1.RateLimiter{TokenBucketRateLimiter: &v1.TokenBucketRateLimiter{

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -26,6 +26,7 @@ package virtconfig
 import (
 	"strings"
 
+	"runtime"
 	"kubevirt.io/client-go/log"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -427,7 +428,14 @@ func (c *ClusterConfig) GetVMStateStorageClass() string {
 }
 
 func (c *ClusterConfig) IsFreePageReportingDisabled() bool {
-	return c.GetConfig().VirtualMachineOptions != nil && c.GetConfig().VirtualMachineOptions.DisableFreePageReporting != nil
+	cfg := c.GetConfig()
+	if cfg.VirtualMachineOptions == nil {
+		return runtime.GOARCH == "s390x"
+	}
+	if cfg.VirtualMachineOptions.DisableFreePageReporting == nil {
+		return runtime.GOARCH == "s390x"
+	}
+	return true
 }
 
 func (c *ClusterConfig) IsSerialConsoleLogDisabled() bool {


### PR DESCRIPTION
### What this PR does
Before this PR:
Free-page reporting functionality of memory ballooning is broken for s390x VMs (kernel issue), printing stacktraces on the VM console.

After this PR:
The Broken free-page reporting is disabled by setting disableFreePageReporting toggle for s390x-based kubevirt installations.

Fixes #14516

### Why we need it and why it was done in this way
The following tradeoffs were made:
There is a flag in kubevirt config called [disableFreePageReporting](https://github.com/kubevirt/kubevirt/blob/main/manifests/generated/kv-resource.yaml#L964), by default this is set to false, which means it is enabled for all VMs. As this is broken for s390x linux kernel, we wanted to disable it for now for s390x kubevirt installations.

The following alternatives were considered:

Links to places where the discussion took place: Fix made in latest kernel https://git.kernel.org/pub/scm/linux/kernel/git/s390/linux.git/commit/?h=fixes&id=2ccd42b959aaf490333dbd3b9b102eaf295c036a when we reported this kernel(RHEL) team.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
disableFreePageReporting default is to true for s390x based VMs as it is broken
```

