### PR TITLE
virt-handler/device-manager: Do not expose global handler variable

### DIFF
--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -55,7 +55,7 @@ type DeviceHandler interface {
 
 type DeviceUtilsHandler struct{}
 
-var Handler DeviceHandler
+var handler DeviceHandler = &DeviceUtilsHandler{}
 
 // getDeviceIOMMUGroup gets devices iommu_group
 // e.g. /sys/bus/pci/devices/0000\:65\:00.0/iommu_group -> ../../../../../kernel/iommu_groups/45
@@ -194,12 +194,6 @@ func (h *DeviceUtilsHandler) ReadMDEVAvailableInstances(mdevType string, parentI
 	}
 
 	return i, nil
-}
-
-func initHandler() {
-	if Handler == nil {
-		Handler = &DeviceUtilsHandler{}
-	}
 }
 
 func waitForGRPCServer(socketPath string, timeout time.Duration) error {

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -256,7 +256,6 @@ func removeSelectorSpaces(selectorName string) string {
 	typeNameStr := strings.Replace(string(selectorName), " ", "_", -1)
 	typeNameStr = strings.TrimSpace(typeNameStr)
 	return typeNameStr
-
 }
 
 func (c *DeviceController) splitPermittedDevices(devices []Device) (map[string]Device, map[string]struct{}) {

--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Device Controller", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockPCI = NewMockDeviceHandler(ctrl)
 		mockPCI.EXPECT().GetDevicePCIID(gomock.Any(), gomock.Any()).Return("1234:5678", nil).AnyTimes()
-		Handler = mockPCI
+		handler = mockPCI
 
 		fakeConfigMap, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 			PermittedHostDevices: &v1.PermittedHostDevices{
@@ -109,6 +109,7 @@ var _ = Describe("Device Controller", func() {
 		defer os.RemoveAll(workDir)
 		// Ensure the deviceController is stopped after each test to avoid leaking resources
 		stop <- struct{}{}
+		handler = &DeviceUtilsHandler{}
 	})
 
 	Context("Basic Tests", func() {

--- a/pkg/virt-handler/device-manager/mediated_device.go
+++ b/pkg/virt-handler/device-manager/mediated_device.go
@@ -108,8 +108,6 @@ func NewMediatedDevicePlugin(mdevs []*MDEV, resourceName string) *MediatedDevice
 	serverSock := SocketPath(mdevTypeName)
 	iommuToMDEVMap := make(map[string]string)
 
-	initHandler()
-
 	devs := constructDPIdevicesFromMdev(mdevs, iommuToMDEVMap)
 
 	dpi := &MediatedDevicePlugin{
@@ -200,8 +198,6 @@ func (dpi *MediatedDevicePlugin) Allocate(_ context.Context, r *pluginapi.Alloca
 }
 
 func discoverPermittedHostMediatedDevices(supportedMdevsMap map[string]string) map[string][]*MDEV {
-	initHandler()
-
 	mdevsMap := make(map[string][]*MDEV)
 	files, err := os.ReadDir(mdevBasePath)
 	for _, info := range files {
@@ -219,15 +215,15 @@ func discoverPermittedHostMediatedDevices(supportedMdevsMap map[string]string) m
 				typeName: mdevTypeName,
 				UUID:     info.Name(),
 			}
-			parentPCIAddr, err := Handler.GetMdevParentPCIAddr(info.Name())
+			parentPCIAddr, err := handler.GetMdevParentPCIAddr(info.Name())
 			if err != nil {
 				log.DefaultLogger().Reason(err).Errorf("failed parent PCI address for mdev: %s", info.Name())
 				continue
 			}
 			mdev.parentPciAddress = parentPCIAddr
 
-			mdev.numaNode = Handler.GetDeviceNumaNode(pciBasePath, parentPCIAddr)
-			iommuGroup, err := Handler.GetDeviceIOMMUGroup(mdevBasePath, info.Name())
+			mdev.numaNode = handler.GetDeviceNumaNode(pciBasePath, parentPCIAddr)
+			iommuGroup, err := handler.GetDeviceIOMMUGroup(mdevBasePath, info.Name())
 			if err != nil {
 				log.DefaultLogger().Reason(err).Errorf("failed to get iommu group of mdev: %s", info.Name())
 				continue

--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Mediated Device", func() {
 			By("mocking PCI and MDEV functions to simulate an mdev an its parent PCI device")
 			ctrl = gomock.NewController(GinkgoT())
 			mockPCI = NewMockDeviceHandler(ctrl)
-			Handler = mockPCI
+			handler = mockPCI
 			// Force pre-defined returned values and ensure the function only get called exacly once each on 0000:00:00.0
 			mockPCI.EXPECT().GetMdevParentPCIAddr(fakeMdevUUID).Return(fakeAddress, nil).Times(1)
 			mockPCI.EXPECT().GetDeviceIOMMUGroup(mdevBasePath, fakeMdevUUID).Return(fakeIommuGroup, nil).Times(1)

--- a/pkg/virt-handler/device-manager/mediated_devices_types.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types.go
@@ -41,7 +41,6 @@ type MDEVTypesManager struct {
 }
 
 func NewMDEVTypesManager() *MDEVTypesManager {
-	initHandler()
 	return &MDEVTypesManager{
 		availableMdevTypesMap: make(map[string][]string),
 	}
@@ -228,14 +227,14 @@ func (m *MDEVTypesManager) configureDesiredMDEVTypes() {
 }
 
 func createMdevTypes(mdevType string, parentID string) error {
-	instances, err := Handler.ReadMDEVAvailableInstances(mdevType, parentID)
+	instances, err := handler.ReadMDEVAvailableInstances(mdevType, parentID)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create mdevs of type %s, failed to obtain number of instances", mdevType)
 		return err
 	}
 	// create mdevs for all available instances
 	for i := 0; i < instances; i++ {
-		err := Handler.CreateMDEVType(mdevType, parentID)
+		err := handler.CreateMDEVType(mdevType, parentID)
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to create mdevs of type %s", mdevType)
 			return err
@@ -281,7 +280,7 @@ func removeUndesiredMDEVs(desiredTypesMap map[string]struct{}) {
 	}
 	for _, file := range files {
 		if shouldRemoveMDEV(file.Name(), desiredTypesMap) {
-			err = Handler.RemoveMDEVType(file.Name())
+			err = handler.RemoveMDEVType(file.Name())
 			log.Log.Reason(err).Warningf("failed to remove mdev type: %s", file.Name())
 		}
 	}

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clientTest = fake.NewSimpleClientset()
 		mockMDEV = NewMockDeviceHandler(ctrl)
-		Handler = mockMDEV
+		handler = mockMDEV
 		configuredMdevTypesOnCards = make(map[string]map[string]struct{})
 
 		mockMDEV.EXPECT().CreateMDEVType(gomock.Any(), gomock.Any()).DoAndReturn(func(mdevType string, parentID string) error {

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -48,7 +48,7 @@ var _ = Describe("PCI Device", func() {
 		By("mocking PCI functions to simulate a vfio-pci device at " + fakeAddress)
 		ctrl = gomock.NewController(GinkgoT())
 		mockPCI = NewMockDeviceHandler(ctrl)
-		Handler = mockPCI
+		handler = mockPCI
 		// Force pre-defined returned values and ensure the function only get called exacly once each on 0000:00:00.0
 		mockPCI.EXPECT().GetDeviceIOMMUGroup(pciBasePath, fakeAddress).Return(fakeIommuGroup, nil).Times(1)
 		mockPCI.EXPECT().GetDeviceDriver(pciBasePath, fakeAddress).Return(fakeDriver, nil).Times(1)


### PR DESCRIPTION
The Handler variable is only used internally and should not be exposed outside the package.
Additionally, it only needs to be initialized once, so the initHandler function is not needed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
device-manager unit-test would flake when run with race detection on (most pronounced on s390x)

After this PR:
device-manager unit-test no longer has a race condition

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #14508

### Why we need it and why it was done in this way
The following tradeoffs were made:
This PR does not solve the actual parallel execution of `BeforeEach` and `DeviceController.updatePermittedHostDevicePlugins`, which should not happen.

The following alternatives were considered:
I first tried to make the stop channel blocking, however this did not solve the issue.
Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

