### PR TITLE
node-labeller: enable node-labeller for ARM64 clusters

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -314,11 +314,9 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	if nodeLabellerController.ShouldLabelNodes() {
-		hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
+	hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
 
-		go nodeLabellerController.Run(10, stop)
-	}
+	go nodeLabellerController.Run(10, stop)
 
 	migrationIpAddress := app.PodIpAddress
 	migrationIpAddress, err = virthandler.FindMigrationIP(migrationIpAddress)

--- a/pkg/virt-handler/node-labeller/amd64.go
+++ b/pkg/virt-handler/node-labeller/amd64.go
@@ -26,15 +26,15 @@ type archLabellerAMD64 struct {
 	defaultArchLabeller
 }
 
-func (archLabellerAMD64) shouldLabelNodes() bool {
-	return true
-}
-
 func (archLabellerAMD64) hasHostSupportedFeatures() bool {
 	return true
 }
 
 func (archLabellerAMD64) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerAMD64) supportsNamedModels() bool {
 	return true
 }
 

--- a/pkg/virt-handler/node-labeller/arch_labeller.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller.go
@@ -35,11 +35,11 @@ const (
 var _ = archLabeller(&defaultArchLabeller{})
 
 type archLabeller interface {
-	shouldLabelNodes() bool
 	defaultVendor() string
 	requirePolicy(policy string) bool
 	hasHostSupportedFeatures() bool
 	supportsHostModel() bool
+	supportsNamedModels() bool
 	arch() string
 }
 
@@ -58,10 +58,6 @@ func newArchLabeller(arch string) archLabeller {
 
 type defaultArchLabeller struct{}
 
-func (defaultArchLabeller) shouldLabelNodes() bool {
-	return false
-}
-
 func (defaultArchLabeller) defaultVendor() string {
 	return ""
 }
@@ -75,6 +71,10 @@ func (defaultArchLabeller) hasHostSupportedFeatures() bool {
 }
 
 func (defaultArchLabeller) supportsHostModel() bool {
+	return false
+}
+
+func (defaultArchLabeller) supportsNamedModels() bool {
 	return false
 }
 

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -180,11 +180,6 @@ func (n *NodeLabeller) loadAll() error {
 }
 
 func (n *NodeLabeller) run() error {
-	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
-	cpuModels := n.getSupportedCpuModels(obsoleteCPUsx86)
-	cpuFeatures := n.getSupportedCpuFeatures()
-	hostCPUModel := n.GetHostCpuModel()
-
 	originalNode, err := n.nodeClient.Get(context.Background(), n.host, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -194,7 +189,7 @@ func (n *NodeLabeller) run() error {
 
 	if !skipNodeLabelling(node) {
 		//prepare new labels
-		newLabels := n.prepareLabels(node, cpuModels, cpuFeatures, hostCPUModel, obsoleteCPUsx86)
+		newLabels := n.prepareLabels(node)
 		//remove old labeller labels
 		n.removeLabellerLabels(node)
 		//add new labels
@@ -235,27 +230,27 @@ func (n *NodeLabeller) loadHypervFeatures() {
 
 // prepareLabels converts cpu models, features, hyperv features to map[string]string format
 // e.g. "cpu-feature.node.kubevirt.io/Penryn": "true"
-func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatures cpuFeatures, hostCpuModel hostCPUModel, obsoleteCPUsx86 map[string]bool) map[string]string {
+func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
+	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
+	hostCpuModel := n.GetHostCpuModel()
 	newLabels := make(map[string]string)
-	for key := range cpuFeatures {
-		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
+
+	if n.arch.hasHostSupportedFeatures() {
+		for key := range n.getSupportedCpuFeatures() {
+			newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
+		}
 	}
 
-	for _, value := range cpuModels {
-		newLabels[kubevirtv1.CPUModelLabel+value] = "true"
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+	if n.arch.supportsNamedModels() {
+		for _, value := range n.getSupportedCpuModels(obsoleteCPUsx86) {
+			newLabels[kubevirtv1.CPUModelLabel+value] = "true"
+			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+		}
 	}
 
-	// Add labels for supported machine types
-	machines := n.getSupportedMachines()
-
-	for _, machine := range machines {
+	for _, machine := range n.getSupportedMachines() {
 		labelKey := kubevirtv1.SupportedMachineTypeLabel + machine.Name
 		newLabels[labelKey] = "true"
-	}
-
-	if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
 	}
 
 	for _, key := range n.hypervFeatures.items {
@@ -267,19 +262,24 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatu
 		newLabels[kubevirtv1.CPUTimerLabel+"tsc-scalable"] = fmt.Sprintf("%t", n.cpuCounter.Scaling == "yes")
 	}
 
-	for feature := range hostCpuModel.requiredFeatures {
-		newLabels[kubevirtv1.HostModelRequiredFeaturesLabel+feature] = "true"
-	}
-	if _, obsolete := obsoleteCPUsx86[hostCpuModel.Name]; obsolete {
-		newLabels[kubevirtv1.NodeHostModelIsObsoleteLabel] = "true"
-		err := n.alertIfHostModelIsObsolete(node, hostCpuModel.Name, obsoleteCPUsx86)
-		if err != nil {
-			n.logger.Reason(err).Error(err.Error())
+	if n.arch.supportsHostModel() {
+		if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
+			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
+		} else {
+			newLabels[kubevirtv1.NodeHostModelIsObsoleteLabel] = "true"
+			err := n.alertIfHostModelIsObsolete(node, hostCpuModel.Name, obsoleteCPUsx86)
+			if err != nil {
+				n.logger.Reason(err).Error(err.Error())
+			}
 		}
-	}
 
-	newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
-	newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
+		for feature := range hostCpuModel.requiredFeatures {
+			newLabels[kubevirtv1.HostModelRequiredFeaturesLabel+feature] = "true"
+		}
+
+		newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
+		newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
+	}
 
 	capable, err := isNodeRealtimeCapable()
 	if err != nil {

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -359,7 +359,3 @@ func (n *NodeLabeller) getSupportedMachines() []libvirtxml.CapsGuestMachine {
 	}
 	return supportedMachines
 }
-
-func (n *NodeLabeller) ShouldLabelNodes() bool {
-	return n.arch.shouldLabelNodes()
-}

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -288,6 +288,33 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
+
+	DescribeTable("should add machine type labels", func(machines []libvirtxml.CapsGuestMachine, arch string) {
+		guestsCaps[0].Arch.Machines = machines
+
+		initNodeLabeller(&v1.KubeVirt{})
+		nlController.arch = newArchLabeller(arch)
+		mockQueue := testutils.NewMockWorkQueue(nlController.queue)
+		nlController.queue = mockQueue
+
+		mockQueue.ExpectAdds(1)
+		nlController.queue.Add(nodeName)
+		mockQueue.Wait()
+
+		res := nlController.execute()
+		Expect(res).To(BeTrue(), "labeller should complete successfully")
+
+		node := retrieveNode(kubeClient)
+
+		for _, machine := range machines {
+			expectedLabelKey := v1.SupportedMachineTypeLabel + machine.Name
+			Expect(node.Labels).To(HaveKey(expectedLabelKey), "expected machine type label %s to be present", expectedLabelKey)
+		}
+	},
+		Entry("for amd64", []libvirtxml.CapsGuestMachine{{Name: "q35"}, {Name: "q35-rhel9.6.0"}}, amd64),
+		Entry("for arm64", []libvirtxml.CapsGuestMachine{{Name: "virt"}, {Name: "virt-rhel9.6.0"}}, arm64),
+	)
+
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -288,16 +288,6 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
-
-	DescribeTable("should only label arches that support it", func(arch string, shouldLabel bool) {
-		nlController.arch = newArchLabeller(arch)
-		Expect(nlController.ShouldLabelNodes()).To(Equal(shouldLabel))
-	},
-		Entry(amd64, amd64, true),
-		Entry(arm64, arm64, false),
-		Entry(s390x, s390x, true),
-		Entry("unknown", "unknown", false),
-	)
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/s390x.go
+++ b/pkg/virt-handler/node-labeller/s390x.go
@@ -26,10 +26,6 @@ var _ = archLabeller(&archLabellerS390X{})
 
 type archLabellerS390X struct{}
 
-func (archLabellerS390X) shouldLabelNodes() bool {
-	return true
-}
-
 func (archLabellerS390X) defaultVendor() string {
 	// On s390x the xml does not include a CPU Vendor, however there is only one company selling them anyway.
 	return "IBM"
@@ -45,6 +41,10 @@ func (archLabellerS390X) hasHostSupportedFeatures() bool {
 }
 
 func (archLabellerS390X) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerS390X) supportsNamedModels() bool {
 	return true
 }
 


### PR DESCRIPTION
This change enables the `node-labeller` routine for ARM64-based clusters in KubeVirt by updating the `archLabellerARM64` structure to drop `shouldLabelNodes()` since it returns true for all arches.
Previously, the `node-labeller` was disabled for ARM64 clusters due to incomplete support for labels like CPU features and models, which are supported on other architectures such as `amd64` and `s390x` - ref https://issues.redhat.com/browse/RHEL-88219.

For this PR, we’ve chosen to enable only machine-type labels for ARM64, as these are critical for virtual machine (VM) scheduling and represent the minimum functionality required from the `node-labeller`.

Note that machine-type labels were not required on arm64 clusters previously because VM scheduling on ARM64 did not depend on them. This changed after #13690 was merged, introducing functionality that relies on machine-type labels for proper VM scheduling.

Machine types are retrieved from the libvirt capabilities.xml, which is reliably available on ARM64 nodes. These values can be safely processed by the node-labeller without introducing risk or other issues.

Other labels supported by `node-labeller` on `amd64` and `s390x` (listed down) are intentionally ignored for ARM64 to minimize risk and focus on essential functionality. Support for additional labels may be added in future PRs.

Currently, the only supported label on ARM64 is:

- SupportedMachineTypeLabel

The following labels are not supported for ARM64 in this PR:
- CPUFeatureLabel
- CPUModelLabel
- CPUModelVendorLabel
- SupportedHostModelMigrationCPU
- CPUTimerLabel
- HypervLabel
- RealtimeLabel
- SEVLabel
- SEVESLabel
- HostModelCPULabel
- HostModelRequiredFeaturesLabel
- NodeHostModelIsObsoleteLabel

Fixes #

### Release note
```release-note
Enable node-labeller for ARM64 clusters, supporting machine-type labels.
```
