### PR TITLE
cmd, sidecars, passt: Enable vhost-user

### DIFF
--- a/cmd/sidecars/network-passt-binding/domain/configurator_test.go
+++ b/cmd/sidecars/network-passt-binding/domain/configurator_test.go
@@ -40,6 +40,8 @@ func (nl defaultNetLinkStub) LinkByName(name string) (vishnetlink.Link, error) {
 
 type netLinkStub struct{}
 
+const ifaceTypeVhostUser = "vhostuser"
+
 func (nl netLinkStub) LinkByName(name string) (vishnetlink.Link, error) {
 	return &vishnetlink.Veth{LinkAttrs: vishnetlink.LinkAttrs{Name: name}}, nil
 }
@@ -98,7 +100,7 @@ var _ = Describe("pod network configurator", func() {
 				&vmschema.Interface{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}},
 				&domainschema.Interface{
 					Alias:       domainschema.NewUserDefinedAlias("default"),
-					Type:        "user",
+					Type:        ifaceTypeVhostUser,
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -110,7 +112,7 @@ var _ = Describe("pod network configurator", func() {
 					PciAddress: "0000:02:02.0"},
 				&domainschema.Interface{
 					Alias:       domainschema.NewUserDefinedAlias("default"),
-					Type:        "user",
+					Type:        ifaceTypeVhostUser,
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -123,7 +125,7 @@ var _ = Describe("pod network configurator", func() {
 					MacAddress: "02:02:02:02:02:02"},
 				&domainschema.Interface{
 					Alias:       domainschema.NewUserDefinedAlias("default"),
-					Type:        "user",
+					Type:        ifaceTypeVhostUser,
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -136,7 +138,7 @@ var _ = Describe("pod network configurator", func() {
 					ACPIIndex: 2},
 				&domainschema.Interface{
 					Alias:       domainschema.NewUserDefinedAlias("default"),
-					Type:        "user",
+					Type:        ifaceTypeVhostUser,
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -150,7 +152,7 @@ var _ = Describe("pod network configurator", func() {
 				},
 				&domainschema.Interface{
 					Alias:       domainschema.NewUserDefinedAlias("default"),
-					Type:        "user",
+					Type:        ifaceTypeVhostUser,
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -163,7 +165,7 @@ var _ = Describe("pod network configurator", func() {
 				},
 				&domainschema.Interface{
 					Alias:   domainschema.NewUserDefinedAlias("default"),
-					Type:    "user",
+					Type:    ifaceTypeVhostUser,
 					Source:  domainschema.InterfaceSource{Device: "eth0"},
 					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
@@ -183,7 +185,7 @@ var _ = Describe("pod network configurator", func() {
 				},
 				&domainschema.Interface{
 					Alias:   domainschema.NewUserDefinedAlias("default"),
-					Type:    "user",
+					Type:    ifaceTypeVhostUser,
 					Source:  domainschema.InterfaceSource{Device: "eth0"},
 					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
@@ -203,7 +205,7 @@ var _ = Describe("pod network configurator", func() {
 				},
 				&domainschema.Interface{
 					Alias:   domainschema.NewUserDefinedAlias("default"),
-					Type:    "user",
+					Type:    ifaceTypeVhostUser,
 					Source:  domainschema.InterfaceSource{Device: "eth0"},
 					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
@@ -241,7 +243,7 @@ var _ = Describe("pod network configurator", func() {
 				&domain.NetworkConfiguratorOptions{UseVirtioTransitional: true},
 				&domainschema.Interface{
 					Alias:       domainschema.NewUserDefinedAlias("default"),
-					Type:        "user",
+					Type:        ifaceTypeVhostUser,
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -252,7 +254,7 @@ var _ = Describe("pod network configurator", func() {
 				&domain.NetworkConfiguratorOptions{IstioProxyInjectionEnabled: true},
 				&domainschema.Interface{
 					Alias:   domainschema.NewUserDefinedAlias("default"),
-					Type:    "user",
+					Type:    ifaceTypeVhostUser,
 					Source:  domainschema.InterfaceSource{Device: "eth0"},
 					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
@@ -280,7 +282,7 @@ var _ = Describe("pod network configurator", func() {
 
 			expectedDomainIface := &domainschema.Interface{
 				Alias:       domainschema.NewUserDefinedAlias("default"),
-				Type:        "user",
+				Type:        ifaceTypeVhostUser,
 				Source:      domainschema.InterfaceSource{Device: "eth0"},
 				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -306,7 +308,7 @@ var _ = Describe("pod network configurator", func() {
 
 			expectedDomainIface := &domainschema.Interface{
 				Alias:       domainschema.NewUserDefinedAlias("default"),
-				Type:        "user",
+				Type:        ifaceTypeVhostUser,
 				Source:      domainschema.InterfaceSource{Device: "eth0"},
 				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -330,7 +332,7 @@ var _ = Describe("pod network configurator", func() {
 
 			expectedDomainIface := &domainschema.Interface{
 				Alias:       domainschema.NewUserDefinedAlias("default"),
-				Type:        "user",
+				Type:        ifaceTypeVhostUser,
 				Source:      domainschema.InterfaceSource{Device: "ovn-udn1"},
 				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
@@ -347,6 +349,52 @@ var _ = Describe("pod network configurator", func() {
 
 			Expect(testMutator.Mutate(mutatedDomSpec)).To(Equal(mutatedDomSpec))
 		})
+	})
+	Context("should define memoryBacking for vhost-user", func() {
+		var testMutator *domain.PasstNetworkConfigurator
+		BeforeEach(func() {
+			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}}
 
+			var err error
+			testMutator, err = domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{}, &netLinkStub{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should set shared memfd when clean domain", func() {
+			expectedMemoryBacking := &domainschema.MemoryBacking{
+				Access: &domainschema.MemoryBackingAccess{
+					Mode: "shared",
+				},
+				Source: &domainschema.MemoryBackingSource{
+					Type: "memfd",
+				},
+			}
+			mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mutatedDomSpec.MemoryBacking).To(Equal(expectedMemoryBacking))
+		})
+
+		It("should fail when private memory is predefined", func() {
+			domainWithPrivateMem := &domainschema.DomainSpec{
+				MemoryBacking: &domainschema.MemoryBacking{
+					Access: &domainschema.MemoryBackingAccess{Mode: "private"},
+				},
+			}
+			_, err := testMutator.Mutate(domainWithPrivateMem)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should use other configs of backing memory as long as they are shared", func() {
+			domainWithOtherSharedMem := &domainschema.DomainSpec{
+				MemoryBacking: &domainschema.MemoryBacking{
+					Access: &domainschema.MemoryBackingAccess{Mode: "shared"},
+					Source: &domainschema.MemoryBackingSource{Type: "file"},
+				},
+			}
+			mutatedDomSpec, err := testMutator.Mutate(domainWithOtherSharedMem)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mutatedDomSpec.MemoryBacking).To(Equal(domainWithOtherSharedMem.MemoryBacking))
+		})
 	})
 })

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -458,7 +458,7 @@ var istioTestsWithPasstBinding = func() {
 		err := config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
 			SidecarImage:                passtSidecarImage,
 			NetworkAttachmentDefinition: passtNetAttDefName,
-			Migration:                   &v1.InterfaceBindingMigration{Method: v1.LinkRefresh},
+			Migration:                   &v1.InterfaceBindingMigration{},
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
As of `passt` release [2025_02_17.a1e48a0](https://passt.top/passt/tag/?h=2025_02_17.a1e48a0) vhost-user protocol has been implemented. It offers improved network throughput and is also a prerequisite for advanced passt functionality to be implemented in the future. Namely, seamless TCP live migration.
Libvirt added support in version 10.10.0-7.
This commit modifies the DomainXML interface format to start `passt` in vhostuser mode.
In addition, as vhost-user data plane operates in shared memory, `MemoryBacking` of mode `shared` is added.
Unless pre-configured otherwise `<source type='memfd'>` is configured for shared memory. If a different source type is already defined, keep using it. 

Note that this version of net binding plugin cannot be used with older versions of `passt`, since those did not support `vhost-user`.
On the other hand `passt` is backward compatible and can work with older versions of this network plugin.
 
The following documentation is relevant for configuring `libvirt` with `passt` and `vhost-user` [[1]](https://libvirt.org/formatdomain.html#userspace-connection-using-passt), [[2]](https://libvirt.org/formatdomain.html#vhost-user-connection-with-passt-backend), [[3]](https://libvirt.org/formatdomain.html#vhost-user-connection), [[4]](https://libvirt.org/formatdomain.html#memory-backing), [[5]](https://libvirt.org/kbase/virtiofs.html#other-options-for-vhost-user-memory-setup).


### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/enhancements/pull/20
### Special notes for your reviewer

See what sourcery-ai [wrote](https://github.com/kubevirt/kubevirt/pull/14539#issuecomment-2818507258). It summarized the PR much better than I did. 
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable vhost-user mode for passt network binding plugin
```

