### PR TITLE
Fix v1.Disk cache mode values in the description.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13428,7 +13428,7 @@
       "format": "int32"
      },
      "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
+      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
       "type": "string"
      },
      "cdrom": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13428,7 +13428,7 @@
       "format": "int32"
      },
      "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
+      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none: Guest I/O not cached on the host, but may be kept in a disk cache. writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees. writeback: Guest I/O cached on the host. Defaults to none if the storage supports O_DIRECT, otherwise writethrough.",
       "type": "string"
      },
      "cdrom": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13428,7 +13428,7 @@
       "format": "int32"
      },
      "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.",
+      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
       "type": "string"
      },
      "cdrom": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6046,7 +6046,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: CacheNone, CacheWriteThrough.
+                                  Supported values are: none, writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -8275,7 +8275,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: CacheNone, CacheWriteThrough.
+                          Supported values are: none, writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -11351,7 +11351,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: CacheNone, CacheWriteThrough.
+                          Supported values are: none, writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -14580,7 +14580,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: CacheNone, CacheWriteThrough.
+                          Supported values are: none, writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -17009,7 +17009,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: CacheNone, CacheWriteThrough.
+                                  Supported values are: none, writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -21508,7 +21508,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       cache:
                                         description: |-
                                           Cache specifies which kvm disk cache mode should be used.
-                                          Supported values are: CacheNone, CacheWriteThrough.
+                                          Supported values are: none, writethrough.
                                         type: string
                                       cdrom:
                                         description: Attach a volume as a cdrom to
@@ -26711,7 +26711,7 @@ var CRDsValidation map[string]string = map[string]string{
                                           cache:
                                             description: |-
                                               Cache specifies which kvm disk cache mode should be used.
-                                              Supported values are: CacheNone, CacheWriteThrough.
+                                              Supported values are: none, writethrough.
                                             type: string
                                           cdrom:
                                             description: Attach a volume as a cdrom
@@ -29007,7 +29007,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   cache:
                                     description: |-
                                       Cache specifies which kvm disk cache mode should be used.
-                                      Supported values are: CacheNone, CacheWriteThrough.
+                                      Supported values are: none, writethrough.
                                     type: string
                                   cdrom:
                                     description: Attach a volume as a cdrom to the

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6046,7 +6046,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough.
+                                  Supported values are: none, writethrough, writeback.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -8275,7 +8275,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough.
+                          Supported values are: none, writethrough, writeback.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -11351,7 +11351,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough.
+                          Supported values are: none, writethrough, writeback.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -14580,7 +14580,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough.
+                          Supported values are: none, writethrough, writeback.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -17009,7 +17009,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough.
+                                  Supported values are: none, writethrough, writeback.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -21508,7 +21508,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       cache:
                                         description: |-
                                           Cache specifies which kvm disk cache mode should be used.
-                                          Supported values are: none, writethrough.
+                                          Supported values are: none, writethrough, writeback.
                                         type: string
                                       cdrom:
                                         description: Attach a volume as a cdrom to
@@ -26711,7 +26711,7 @@ var CRDsValidation map[string]string = map[string]string{
                                           cache:
                                             description: |-
                                               Cache specifies which kvm disk cache mode should be used.
-                                              Supported values are: none, writethrough.
+                                              Supported values are: none, writethrough, writeback.
                                             type: string
                                           cdrom:
                                             description: Attach a volume as a cdrom
@@ -29007,7 +29007,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   cache:
                                     description: |-
                                       Cache specifies which kvm disk cache mode should be used.
-                                      Supported values are: none, writethrough.
+                                      Supported values are: none, writethrough, writeback.
                                     type: string
                                   cdrom:
                                     description: Attach a volume as a cdrom to the

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6046,7 +6046,11 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough, writeback.
+                                  Supported values are:
+                                  none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                  writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                  writeback: Guest I/O cached on the host.
+                                  Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -8275,7 +8279,11 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough, writeback.
+                          Supported values are:
+                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                          writeback: Guest I/O cached on the host.
+                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -11351,7 +11359,11 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough, writeback.
+                          Supported values are:
+                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                          writeback: Guest I/O cached on the host.
+                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -14580,7 +14592,11 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough, writeback.
+                          Supported values are:
+                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                          writeback: Guest I/O cached on the host.
+                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -17009,7 +17025,11 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough, writeback.
+                                  Supported values are:
+                                  none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                  writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                  writeback: Guest I/O cached on the host.
+                                  Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -21508,7 +21528,11 @@ var CRDsValidation map[string]string = map[string]string{
                                       cache:
                                         description: |-
                                           Cache specifies which kvm disk cache mode should be used.
-                                          Supported values are: none, writethrough, writeback.
+                                          Supported values are:
+                                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                          writeback: Guest I/O cached on the host.
+                                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                         type: string
                                       cdrom:
                                         description: Attach a volume as a cdrom to
@@ -26711,7 +26735,11 @@ var CRDsValidation map[string]string = map[string]string{
                                           cache:
                                             description: |-
                                               Cache specifies which kvm disk cache mode should be used.
-                                              Supported values are: none, writethrough, writeback.
+                                              Supported values are:
+                                              none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                              writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                              writeback: Guest I/O cached on the host.
+                                              Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                             type: string
                                           cdrom:
                                             description: Attach a volume as a cdrom
@@ -29007,7 +29035,11 @@ var CRDsValidation map[string]string = map[string]string{
                                   cache:
                                     description: |-
                                       Cache specifies which kvm disk cache mode should be used.
-                                      Supported values are: none, writethrough, writeback.
+                                      Supported values are:
+                                      none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                      writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                      writeback: Guest I/O cached on the host.
+                                      Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                     type: string
                                   cdrom:
                                     description: Attach a volume as a cdrom to the

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -646,7 +646,11 @@ type Disk struct {
 	// +optional
 	DedicatedIOThread *bool `json:"dedicatedIOThread,omitempty"`
 	// Cache specifies which kvm disk cache mode should be used.
-	// Supported values are: none, writethrough, writeback.
+	// Supported values are:
+	// none: Guest I/O not cached on the host, but may be kept in a disk cache.
+	// writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+	// writeback: Guest I/O cached on the host.
+	// Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
 	// IO specifies which QEMU disk IO mode should be used.

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -646,7 +646,7 @@ type Disk struct {
 	// +optional
 	DedicatedIOThread *bool `json:"dedicatedIOThread,omitempty"`
 	// Cache specifies which kvm disk cache mode should be used.
-	// Supported values are: none, writethrough.
+	// Supported values are: none, writethrough, writeback.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
 	// IO specifies which QEMU disk IO mode should be used.

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -646,7 +646,7 @@ type Disk struct {
 	// +optional
 	DedicatedIOThread *bool `json:"dedicatedIOThread,omitempty"`
 	// Cache specifies which kvm disk cache mode should be used.
-	// Supported values are: CacheNone, CacheWriteThrough.
+	// Supported values are: none, writethrough.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
 	// IO specifies which QEMU disk IO mode should be used.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -347,7 +347,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"bootOrder":         "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
-		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough, writeback.\n+optional",
+		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are:\nnone: Guest I/O not cached on the host, but may be kept in a disk cache.\nwritethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.\nwriteback: Guest I/O cached on the host.\nDefaults to none if the storage supports O_DIRECT, otherwise writethrough.\n+optional",
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 		"blockSize":         "If specified, the virtual disk will be presented with the given block sizes.\n+optional",

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -347,7 +347,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"bootOrder":         "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
-		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: CacheNone, CacheWriteThrough.\n+optional",
+		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough.\n+optional",
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 		"blockSize":         "If specified, the virtual disk will be presented with the given block sizes.\n+optional",

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -347,7 +347,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"bootOrder":         "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
-		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough.\n+optional",
+		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough, writeback.\n+optional",
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 		"blockSize":         "If specified, the virtual disk will be presented with the given block sizes.\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19254,7 +19254,7 @@ func schema_kubevirtio_api_core_v1_Disk(ref common.ReferenceCallback) common.Ope
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none: Guest I/O not cached on the host, but may be kept in a disk cache. writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees. writeback: Guest I/O cached on the host. Defaults to none if the storage supports O_DIRECT, otherwise writethrough.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19254,7 +19254,7 @@ func schema_kubevirtio_api_core_v1_Disk(ref common.ReferenceCallback) common.Ope
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19254,7 +19254,7 @@ func schema_kubevirtio_api_core_v1_Disk(ref common.ReferenceCallback) common.Ope
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
The values in the disk cache mode description are internal enums, they cannot be used in the VM spec and fail validation.
This fix changes them to the allowed values the user can actually set in the spec.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

kubectl explain and OpenShift Console show unusable values for Disk cache modes. Those are internal enums and not usable.

```
oc explain vm.spec.template.spec.domain.devices.disks.cache
GROUP:      kubevirt.io
KIND:       VirtualMachine
VERSION:    v1


FIELD: cache <string>




DESCRIPTION:
    Cache specifies which kvm disk cache mode should be used.
    Supported values are: CacheNone, CacheWriteThrough.     <-------

```

After this PR:

kubectl explain and OpenShift Console show usable values for Disk cache modes.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-50877

### Release note
```
```
