### PR TITLE
tests/migration: fix unschedulable migration check flake

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2234,9 +2234,8 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 				Expect(scheduledCond.Status).To(BeEquivalentTo(k8sv1.ConditionFalse), "PodScheduled status should be False")
 				Expect(scheduledCond.Reason).To(BeEquivalentTo(k8sv1.PodReasonUnschedulable), "PodScheduled reason should be Unschedulable")
-				Expect(scheduledCond.Message).To(ContainSubstring("node(s) didn't match Pod's node affinity/selector."), "PodScheduled message mismatch")
+				Expect(scheduledCond.Message).To(ContainSubstring("node(s) didn't match Pod's node affinity/selector"), "PodScheduled message mismatch")
 			})
-
 		})
 	})
 


### PR DESCRIPTION
Original expected message example:
  0/2 nodes are available: 2 node(s) didn't match Pod's node affinity/selector`.` preemption: 0/2 nodes are available: 2 Preemption is not helpful for scheduling.

On OCP clusters we get:
  0/X nodes are available: Y node(s) didn't match Pod's node affinity/selector`,` Y node(s) had untolerated taint {node-role.kubernetes.io/master: }. preemption: 0/X nodes are available: X Preemption is not helpful for scheduling.

The trailing period in the expected substring causes the test to fail. Remove it to make the check pass on both environments.

Fixes #

### Release note
```release-note
none
```

