### PR TITLE
fix(preference): Ensure memory requirements are respected when no memory is specified

### DIFF
--- a/pkg/instancetype/preference/requirements/BUILD.bazel
+++ b/pkg/instancetype/preference/requirements/BUILD.bazel
@@ -12,8 +12,10 @@ go_library(
     deps = [
         "//pkg/instancetype/conflict:go_default_library",
         "//pkg/instancetype/preference/apply:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )
 

--- a/pkg/instancetype/preference/requirements/memory_test.go
+++ b/pkg/instancetype/preference/requirements/memory_test.go
@@ -104,5 +104,37 @@ var _ = Describe("Preferences - Requirement - Memory", func() {
 			conflict.Conflicts{conflict.New("spec", "template", "spec", "domain", "memory")},
 			fmt.Sprintf(requirements.InsufficientVMMemoryResourcesErrorFmt, "1Gi", "2Gi"),
 		),
+		Entry("by a VM without Memory - bug #14551",
+			nil,
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{
+					Memory: &v1beta1.MemoryPreferenceRequirement{
+						Guest: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{},
+			},
+			conflict.Conflicts{conflict.New("spec", "template", "spec", "domain", "memory")},
+			fmt.Sprintf(requirements.InsufficientVMMemoryResourcesErrorFmt, "0", "2Gi"),
+		),
+		Entry("by a VM with Memory but without a Guest value provided - bug #14551",
+			nil,
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{
+					Memory: &v1beta1.MemoryPreferenceRequirement{
+						Guest: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					Memory: &v1.Memory{},
+				},
+			},
+			conflict.Conflicts{conflict.New("spec", "template", "spec", "domain", "memory")},
+			fmt.Sprintf(requirements.InsufficientVMMemoryResourcesErrorFmt, "0", "2Gi"),
+		),
 	)
 })

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -1656,7 +1656,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				},
 				"insufficient CPU resources",
 			),
-			Entry("VirtualMachine meets Memory requirements",
+			Entry("VirtualMachine does not meet Memory requirements",
 				nil,
 				&instancetypev1beta1.VirtualMachinePreference{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1686,6 +1686,38 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 										Guest: &guestMemory1GB,
 									},
 								},
+							},
+						},
+					},
+				},
+				"insufficient Memory resources",
+			),
+			Entry("VirtualMachine does not meet Memory requirements or provide any guest visible memory - bug #14551",
+				nil,
+				&instancetypev1beta1.VirtualMachinePreference{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "preference-",
+					},
+					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+						Requirements: &instancetypev1beta1.PreferenceRequirements{
+							Memory: &instancetypev1beta1.MemoryPreferenceRequirement{
+								Guest: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+				&virtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "vm-",
+					},
+					Spec: virtv1.VirtualMachineSpec{
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
+						Preference: &virtv1.PreferenceMatcher{
+							Kind: "VirtualMachinePreference",
+						},
+						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: virtv1.VirtualMachineInstanceSpec{
+								Domain: virtv1.DomainSpec{},
 							},
 						},
 					},


### PR DESCRIPTION
/area instancetype
/cc @0xFelix 
/cc @geetikakay 

### What this PR does

As set out in bug #14551 the VM admission webhook could previously crash with a nil-pointer error while asserting that the VM meets the memory requirements of a referenced preference.

This change corrects this by rewriting the checkMemory function to always default to a `0Mi` resource quantity while also fully asserting that values from the VMI spec (spec.template.spec.domain.memory.guest) are non-nil before use.

Support for validating preference requirements against memory provided within the VM by resource requests and various other clean ups are left for a follow up changes to allow this fix to be backported.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #14551

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

