### PR TITLE
[release-1.0] e2e, hotplug: Fix flaky RemoveInterface test

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -176,6 +176,12 @@ load(
     "git_repository",
 )
 
+go_repository(
+    name = "org_golang_x_sys",
+    commit = "2964e1e4b1dbd55a8ac69a4c9e3004a8038515b6",
+    importpath = "golang.org/x/sys",
+)
+
 # Winrmcli dependencies
 go_repository(
     name = "com_github_masterzen_winrmcli",

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -411,6 +411,12 @@ var _ = SIGDescribe("nic-hotunplug", func() {
 			var err error
 			vm, err = kubevirt.Client().VirtualMachine(util.NamespaceTestDefault).Create(context.Background(), vm)
 			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() v1.VirtualMachinePrintableStatus {
+				virtualMachine, err := kubevirt.Client().VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return virtualMachine.Status.PrintableStatus
+			}, 10*time.Second, 1*time.Second).Should(Equal(v1.VirtualMachineStatusStopped))
 		})
 
 		It("cannot be subject to **hot** unplug, but will mutate the template.Spec on behalf of the user", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Depends on https://github.com/kubevirt/kubevirt/pull/14494 (first commit)

The test creates a stopped VM, and then runs `RemoveInterface`.
`RemoveInterface` patches `/status/interfaceRequests` (test + add verbs).

The problem is a stopped VM creation is blocking wrt k8s resource creation only, 
but the one that adds the status is the virt-controller asynchonosly.
Therefore this is raceful,  because the patch would fail if `/status` doesn't exist yet.

In other words, expected flow:
1. Test trigger creation of the stopped VM resource in etcd.
2. VM controller amends it and adds /status sub resource to it.
fields of status for example: conditions, printableStatus, volumeSnapshotStatuses.
3. Test triggers patch to remove an interface.
4. virt-api triggers the json patch, which consist of test + add,

Since [2] runs in parallel to the rest,
in case the patch [4] happens before VM controller [2] amends the object with status,
the patch would fail, because /status path doesn't exists yet,
which leads to the race.  

To fix it, wait for deterministic field to appear under status, which means status exists.

virt-api log:
```
{"component":"virt-api","kind":"VirtualMachine","level":"error","msg":"unable to patch vm status: the server rejected our request due to an error in our request","name":"testvmi-tpqlg","namespace":"kubevirt-test-default2","pos":"interfacehotplug.go:230","timestamp":"2025-04-21T16:49:46.592396Z","uid":"af292473-4693-408e-8e75-aa217997d1d9"}
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way

### Special notes for your reviewer
The reason it affects only release-1.0 is that only this release
has the combination of stopped VM + patching /status field,
all the other releases either use path under spec, for patching (1.1 -> 1.3) ,
or removed already the stopped VM patching test.
Tests with running VM aren't affected because they of course have both status and spec fields.

We also saw this error so far only on release-1.0, which makes sense due to the above.

Original error:
```
tests/network/hotplug.go:416
Expected success, but got an error:
    <*errors.StatusError | 0xc00310d5e0>: 
    the server rejected our request due to an error in our request
    {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "the server rejected our request due to an error in our request",
            Reason: "Invalid",
            Details: {Name: "", Group: "", Kind: "", UID: "", Causes: nil, RetryAfterSeconds: 0},
            Code: 422,
        },
    }
tests/network/hotplug.go:421
```
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

