### PR TITLE
Adding EKS IRSA support for kubevirt VMs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -218,6 +218,7 @@ build_other_images_aarch64_x86_64 = dicts.add(
         "$(container_prefix)/$(image_prefix)example-hook-sidecar:$(container_tag)": "//cmd/sidecars/smbios:example-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)example-disk-mutation-hook-sidecar:$(container_tag)": "//cmd/sidecars/disk-mutation:example-disk-mutation-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)example-cloudinit-hook-sidecar:$(container_tag)": "//cmd/sidecars/cloudinit:example-cloudinit-hook-sidecar-image",
+        "$(container_prefix)/$(image_prefix)eks-iamrsa-sidecar:$(container_tag)": "//cmd/sidecars/eks-irsa-support:eks-irsa-sidecar-image",
         "$(container_prefix)/$(image_prefix)network-slirp-binding:$(container_tag)": "//cmd/sidecars/network-slirp-binding:network-slirp-binding-image",
         "$(container_prefix)/$(image_prefix)network-passt-binding:$(container_tag)": "//cmd/sidecars/network-passt-binding:network-passt-binding-image",
         "$(container_prefix)/$(image_prefix)pr-helper:$(container_tag)": "//cmd/pr-helper:pr-helper",
@@ -407,6 +408,15 @@ container_push(
     image = "//cmd/sidecars/cloudinit:example-cloudinit-hook-sidecar-image",
     registry = "$(container_prefix)",
     repository = "$(image_prefix)example-cloudinit-hook-sidecar",
+    tag = "$(container_tag)",
+)
+
+container_push(
+    name = "push-eks-irsa-sidecar",
+    format = "Docker",
+    image = "//cmd/sidecars/eks-irsa-support:eks-irsa-sidecar-image",
+    registry = "$(container_prefix)",
+    repository = "$(image_prefix)eks-irsa-sidecar",
     tag = "$(container_tag)",
 )
 

--- a/cmd/sidecars/eks-irsa-support/BUILD.bazel
+++ b/cmd/sidecars/eks-irsa-support/BUILD.bazel
@@ -1,0 +1,46 @@
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["eks-irsa-support.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/eks-irsa-support",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/cloud-init:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "preCloudInitIso",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "onDefineDomain",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "eks-irsa-sidecar-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = "//cmd/sidecars:sidecar-shim-image",
+    directory = "/usr/bin/",
+    entrypoint = ["/sidecar-shim"],
+    files = [
+        ":onDefineDomain",
+        ":preCloudInitIso",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sidecars/eks-irsa-support/README.md
+++ b/cmd/sidecars/eks-irsa-support/README.md
@@ -1,0 +1,177 @@
+# EKS IRSA Support Sidecar
+
+This sidecar container provides support for AWS IAM Roles for Service Accounts (IRSA) in KubeVirt virtual machines running on Amazon EKS.
+
+## Overview
+
+The sidecar implements two hooks that work together to enable IRSA support in VMs:
+
+1. `preCloudInitIso` - Injects AWS credentials into the VM's cloud-init configuration
+2. `onDefineDomain` - Sets up a virtiofs device to mount the AWS token
+
+## Important: Required Webhook
+
+To make this sidecar work correctly, you must also deploy the [IRSA Mutation Webhook](https://github.com/kubevirt/irsa-mutation-webhook) in your cluster. The complete IRSA solution consists of two components:
+
+1. **IRSA Mutation Webhook** - Injects the virtio-fs container that shares the AWS IAM token from the host with the VM
+2. **EKS IRSA Support Sidecar** - Configures the VM to use the shared token
+
+The mutation webhook must be deployed on your cluster first to enable automatic injection of the virtio-fs container that shares the AWS IAM token with your VMs.
+
+## AWS IAM Token Volume
+
+This sidecar uses the `onDefineDomain` hook to add a virtiofs filesystem to the VM's domain XML that mounts the AWS IAM token. The token is automatically projected by the IRSA mutation webhook, which injects a container with a volume mounted as follows:
+
+```yaml
+volumes:
+- name: aws-iam-token
+  projected:
+    defaultMode: 420
+    sources:
+    - serviceAccountToken:
+        audience: sts.amazonaws.com
+        expirationSeconds: 86400
+        path: token
+```
+
+This projected volume contains the AWS IAM token needed for authentication with AWS services. The sidecar ensures this token is accessible within the VM through a virtiofs mount.
+
+The complete flow works as follows:
+1. IRSA creates the projected volume with the AWS token in the pod
+2. The mutation webhook injects a virtiofs container that makes this token accessible via a socket
+3. This sidecar adds the virtiofs filesystem to the VM domain XML
+4. The VM can then mount and use this token for AWS authentication
+
+## Features
+
+- Supports both Linux and Windows VMs
+- Automatically detects VM OS type
+- Injects AWS environment variables into the VM
+- Provides secure token access via virtiofs
+- Handles both cloud-init and domain XML modifications
+
+## Usage
+
+The sidecar is automatically invoked by KubeVirt when:
+- Creating a cloud-init ISO for a VM
+- Defining the domain XML for a VM
+
+### Prerequisites
+
+1. Deploy the [IRSA Mutation Webhook](https://github.com/kubevirt/irsa-mutation-webhook) to your cluster:
+   ```bash
+   git clone https://github.com/kubevirt/irsa-mutation-webhook.git
+   cd irsa-mutation-webhook
+   make deploy
+   ```
+
+### Enabling the Sidecar
+
+To enable the EKS IRSA support sidecar for a VM, add the following annotations to your VirtualMachine or VirtualMachineInstance:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  annotations:
+    hooks.kubevirt.io/hookSidecars: |
+      [
+        {
+          "args": ["--version", "v1alpha3"],
+          "image": "quay.io/kubevirt/eks-irsa-sidecar"
+        }
+      ]
+  name: example-vmi
+spec:
+  domain:
+    devices:
+      filesystems:
+        - name: serviceaccount-fs
+          virtiofs: {}
+      disks:
+        - disk:
+            bus: virtio
+          name: containerdisk
+    machine:
+      type: ""
+    resources:
+      requests:
+        memory: 1024M
+  volumes:
+    - name: containerdisk
+      containerDisk:
+        image: quay.io/containerdisks/fedora:latest
+    - cloudInitNoCloud:
+        userData: |-
+          #cloud-config
+          chpasswd:
+            expire: false
+          password: fedora
+          user: fedora
+          bootcmd:
+            # mount the ConfigMap
+            - "sudo mkdir -p /mnt/serviceaccount"
+            - "sudo mkdir -p /mnt/aws-iam-token"
+            - "sudo mount -t virtiofs serviceaccount-fs /mnt/serviceaccount"
+            - "sudo mount -t virtiofs aws-iam-token /mnt/aws-iam-token"
+      name: cloudinitdisk
+    - name: serviceaccount-fs
+      serviceAccount:
+        serviceAccountName: example-sa
+```
+
+### Environment Variables
+
+The sidecar automatically collects and injects all AWS-related environment variables (those starting with `AWS_`) from the host into the VM.
+
+### Linux VMs
+
+For Linux VMs, the sidecar:
+1. Adds AWS environment variables to `/etc/environment`
+2. Sets up a virtiofs mount for the AWS token at `/aws-iam-token`
+
+### Windows VMs
+
+For Windows VMs, the sidecar:
+1. Creates PowerShell scripts to set AWS environment variables
+2. Sets up a virtiofs mount for the AWS token
+
+## Requirements
+
+- KubeVirt running on Amazon EKS
+- IRSA configured for the cluster
+- Appropriate IAM roles and policies
+- [IRSA Mutation Webhook](https://github.com/kubevirt/irsa-mutation-webhook) installed in the cluster
+
+## Configuration
+
+No additional configuration is required. The sidecar automatically:
+- Detects the VM's operating system
+- Collects AWS environment variables
+- Configures the appropriate cloud-init or domain XML
+
+## Security
+
+- AWS credentials are injected securely via cloud-init
+- Token access is provided through a secure virtiofs mount
+- Environment variables are set at the system level
+
+## Troubleshooting
+
+Common issues and solutions:
+
+1. **Missing AWS credentials**
+   - Verify IRSA is properly configured
+   - Check IAM role permissions
+   - Ensure environment variables are present
+
+2. **Mount issues**
+   - Verify virtiofs is supported by the VM
+   - Check for proper permissions
+   - Ensure the token socket exists
+   - Confirm the IRSA Mutation Webhook is properly installed
+
+3. **Cloud-init failures**
+   - Check cloud-init logs in the VM
+   - Verify the cloud-init configuration
+   - Ensure proper OS detection

--- a/cmd/sidecars/eks-irsa-support/eks-irsa-support.go
+++ b/cmd/sidecars/eks-irsa-support/eks-irsa-support.go
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Inspired by cmd/example-hook-sidecar
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
+)
+
+func generateWindowsScript(envVars map[string]string) string {
+	var content strings.Builder
+	content.WriteString("[System.Environment]::SetEnvironmentVariable('PATH', $env:PATH, [System.EnvironmentVariableTarget]::Machine)\n")
+	for key, value := range envVars {
+		content.WriteString(fmt.Sprintf("[System.Environment]::SetEnvironmentVariable('%s', '%s', [System.EnvironmentVariableTarget]::Machine)\n", key, value))
+	}
+	return content.String()
+}
+
+func generateLinuxScript(envVars map[string]string) string {
+	var content strings.Builder
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"\"", "\\\"",
+		"`", "\\`",
+		"$", "\\$",
+		"\n", "\\n",
+	)
+
+	content.WriteString("#!/bin/sh\n")
+	content.WriteString("# AWS environment variables for IRSA\n\n")
+
+	for key, value := range envVars {
+		escapedValue := replacer.Replace(value)
+		content.WriteString(fmt.Sprintf("export %s=\"%s\"\n", key, escapedValue))
+	}
+	return content.String()
+}
+
+type CloudInitFile struct {
+	Path        string `yaml:"path"`
+	Permissions string `yaml:"permissions"`
+	Content     string `yaml:"content"`
+}
+
+type CloudInitConfig struct {
+	WriteFiles []CloudInitFile `yaml:"write_files,omitempty"`
+}
+
+func preCloudInitIso(log *log.Logger, vmiJSON, cloudInitDataJSON []byte) (string, error) {
+	log.Print("EKS IAM RSA hook's PreCloudInitIso callback method has been called")
+
+	vmi := v1.VirtualMachineInstance{}
+	err := json.Unmarshal(vmiJSON, &vmi)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal given VMI spec: %s %s", err, string(vmiJSON))
+	}
+
+	cloudInitData := cloudinit.CloudInitData{}
+	err = json.Unmarshal(cloudInitDataJSON, &cloudInitData)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal given CloudInitData: %s %s", err, string(cloudInitDataJSON))
+	}
+
+	awsEnvVars := make(map[string]string)
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "AWS_") {
+			key := env[:strings.Index(env, "=")]
+			value := env[strings.Index(env, "=")+1:]
+			awsEnvVars[key] = value
+		}
+	}
+
+	isWindows := false
+	if vmi.Spec.Domain.Firmware != nil && vmi.Spec.Domain.Firmware.Bootloader != nil {
+		if vmi.Spec.Domain.Firmware.Bootloader.EFI != nil {
+			isWindows = true
+		}
+	}
+
+	if isWindows {
+		if cloudInitData.UserData == "" {
+			cloudInitData.UserData = "#ps1_sysnative\n"
+		}
+		script := generateWindowsScript(awsEnvVars)
+		cloudInitData.UserData += fmt.Sprintf("\n%s\n", script)
+		log.Printf("Generated Windows PowerShell script for setting AWS environment variables")
+	} else {
+		if cloudInitData.UserData == "" {
+			cloudInitData.UserData = "#cloud-config\n"
+		}
+		envContent := generateLinuxScript(awsEnvVars)
+
+		config := CloudInitConfig{
+			WriteFiles: []CloudInitFile{
+				{
+					Path:        "/etc/profile.d/aws-env.sh",
+					Permissions: "0755",
+					Content:     envContent,
+				},
+			},
+		}
+
+		yamlData, err := yaml.Marshal(config)
+		if err != nil {
+			return "", fmt.Errorf("Failed to marshal cloud-init config: %v", err)
+		}
+
+		cloudInitData.UserData += "\n" + string(yamlData)
+		log.Printf("Generated Linux cloud-config for setting AWS environment variables in /etc/profile.d/aws-env.sh")
+	}
+
+	response, err := json.Marshal(cloudInitData)
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal CloudInitData: %s %+v", err, cloudInitData)
+	}
+
+	return string(response), nil
+}
+
+func onDefineDomain(log *log.Logger, vmiJSON, domainXML []byte) (string, error) {
+	log.Print("EKS IRSA support hook's OnDefineDomain callback method has been called")
+
+	vmi := v1.VirtualMachineInstance{}
+	err := json.Unmarshal(vmiJSON, &vmi)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal given VMI spec: %s %s", err, string(vmiJSON))
+	}
+
+	domainStr := string(domainXML)
+	if strings.Contains(domainStr, "aws-iam-token") {
+		log.Print("EKS token filesystem already exists in domain XML, skipping addition")
+		return domainStr, nil
+	}
+
+	fsXML := `
+    <filesystem type='mount' accessmode='passthrough'>
+      <driver type='virtiofs' queue='1024'/>
+      <source dir='' socket='/var/run/kubevirt/virtiofs-containers/aws-iam-token.sock'/>
+      <target dir='aws-iam-token'/>
+    </filesystem>`
+
+	devicesEnd := strings.Index(domainStr, "</devices>")
+	if devicesEnd == -1 {
+		return "", fmt.Errorf("Could not find </devices> tag in domain XML")
+	}
+
+	modifiedDomain := domainStr[:devicesEnd] + fsXML + domainStr[devicesEnd:]
+	return modifiedDomain, nil
+}
+
+func main() {
+	var vmiJSON, cloudInitDataJSON, domainXML string
+
+	pflag.StringVar(&vmiJSON, "vmi", "", "Current VMI, in JSON format")
+	pflag.StringVar(&cloudInitDataJSON, "cloud-init", "", "The CloudInitData, in JSON format")
+	pflag.StringVar(&domainXML, "domain", "", "The domain XML")
+	pflag.Parse()
+
+	logger := log.New(os.Stderr, "eks-irsa-support", log.Ldate)
+
+	if vmiJSON == "" {
+		logger.Printf("Bad input vmi=%d", len(vmiJSON))
+		os.Exit(1)
+	}
+
+	var result string
+	var err error
+
+	executable, err := os.Executable()
+	if err != nil {
+		logger.Printf("Failed to get executable name: %s", err)
+		os.Exit(1)
+	}
+	hookType := filepath.Base(executable)
+
+	switch hookType {
+	case "preCloudInitIso":
+		if cloudInitDataJSON == "" {
+			logger.Printf("Bad input cloud-init=%d", len(cloudInitDataJSON))
+			os.Exit(1)
+		}
+		result, err = preCloudInitIso(logger, []byte(vmiJSON), []byte(cloudInitDataJSON))
+	case "onDefineDomain":
+		if domainXML == "" {
+			logger.Printf("Bad input domain=%d", len(domainXML))
+			os.Exit(1)
+		}
+		result, err = onDefineDomain(logger, []byte(vmiJSON), []byte(domainXML))
+	default:
+		logger.Printf("Unknown hook type: %s", hookType)
+		os.Exit(1)
+	}
+
+	if err != nil {
+		logger.Printf("%s failed: %s", hookType, err)
+		panic(err)
+	}
+	fmt.Println(result)
+}

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	golang.org/x/time v0.7.0
 	golang.org/x/tools v0.28.0
 	google.golang.org/grpc v1.65.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.1
 	k8s.io/apiextensions-apiserver v0.32.1
 	k8s.io/apimachinery v0.32.1
@@ -153,7 +154,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
https://github.com/kubevirt/kubevirt/issues/13311

More info : https://groups.google.com/g/kubevirt-dev/c/gZCZQkcuKCU

We have also added irsa-mutation-webhook https://github.com/kubevirt/irsa-mutation-webhook

Here are the logs for the end to end testing performed using this ->
```
❯ k -n ns-beig logs virt-launcher-vmi-fedora-sa-m8vhc -c hook-sidecar-0
{"component":"shim-sidecar","level":"info","msg":"shim is now exposing its services on socket /var/run/kubevirt-hooks/shim-nvwh.sock","pos":"sidecar_shim.go:327","timestamp":"2025-05-13T10:48:26.904690Z"}
{"component":"shim-sidecar","level":"info","msg":"Info method has been called","pos":"sidecar_shim.go:65","timestamp":"2025-05-13T10:48:27.073305Z"}
{"component":"shim-sidecar","level":"info","msg":"PreCloudInitIso method has been called","pos":"sidecar_shim.go:123","timestamp":"2025-05-13T10:48:36.814158Z"}
{"component":"shim-sidecar","level":"info","msg":"Executing preCloudInitIso","pos":"sidecar_shim.go:198","timestamp":"2025-05-13T10:48:36.816459Z"}
{"component":"shim-sidecar","hook":"cloudInitData","level":"info","msg":"eks-iamrsa2025/05/13 EKS IAM RSA hook's PreCloudInitIso callback method has been called","pos":"sidecar_shim.go:236","timestamp":"2025-05-13T10:48:36.821030Z"}
{"component":"shim-sidecar","hook":"cloudInitData","level":"info","msg":"eks-iamrsa2025/05/13 Generated Linux cloud-config for setting AWS environment variables","pos":"sidecar_shim.go:236","timestamp":"2025-05-13T10:48:36.822823Z"}
{"component":"shim-sidecar","level":"info","msg":"OnDefineDomain method has been called","pos":"sidecar_shim.go:111","timestamp":"2025-05-13T10:48:36.850863Z"}
{"component":"shim-sidecar","level":"info","msg":"Executing onDefineDomain","pos":"sidecar_shim.go:222","timestamp":"2025-05-13T10:48:36.851162Z"}
{"component":"shim-sidecar","hook":"onDefineDomain","level":"info","msg":"eks-iamrsa2025/05/13 EKS IAM RSA hook's OnDefineDomain callback method has been called","pos":"sidecar_shim.go:236","timestamp":"2025-05-13T10:48:36.856492Z"}
{"component":"shim-sidecar","level":"info","msg":"OnDefineDomain method has been called","pos":"sidecar_shim.go:111","timestamp":"2025-05-13T10:48:37.300806Z"}
{"component":"shim-sidecar","level":"info","msg":"Executing onDefineDomain","pos":"sidecar_shim.go:222","timestamp":"2025-05-13T10:48:37.301132Z"}
{"component":"shim-sidecar","hook":"onDefineDomain","level":"info","msg":"eks-iamrsa2025/05/13 EKS IAM RSA hook's OnDefineDomain callback method has been called","pos":"sidecar_shim.go:236","timestamp":"2025-05-13T10:48:37.305903Z"}
{"component":"shim-sidecar","hook":"onDefineDomain","level":"info","msg":"eks-iamrsa2025/05/13 EKS token filesystem already exists in domain XML, skipping addition","pos":"sidecar_shim.go:236","timestamp":"2025-05-13T10:48:37.307902Z"}

❯ k -n ns-beig logs virt-launcher-vmi-fedora-sa-m8vhc -c virtiofs-aws-iam-token
[2025-05-13T10:48:36Z INFO  virtiofsd] Waiting for vhost-user socket connection...
[2025-05-13T10:48:37Z INFO  virtiofsd] Client connected, servicing requests

```

This sidecar modifying domain xml in similar way as of service account token added by kubevirt. Logs of the same ->
```
		<filesystem type="mount" accessMode="">
			<source dir="" socket="/var/run/kubevirt/virtiofs-containers/serviceaccount-fs.sock"></source>
			<target dir="serviceaccount-fs"></target>
			<driver type="virtiofs" queue="1024"></driver>
		</filesystem>
		<filesystem type="mount" accessMode="">
			<source dir="" socket="/var/run/kubevirt/virtiofs-containers/aws-iam-token.sock"></source>
			<target dir="aws-iam-token"></target>
			<driver type="virtiofs"></driver>
		</filesystem>
```
### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduces support for AWS IAM Roles for Service Accounts (IRSA) in KubeVirt virtual machines. This sidecar automatically injects AWS credentials into VMs and configures a virtio-fs mount for the AWS token, enabling KubeVirt workloads to securely access AWS services using the host pod's service account identity.
```

