### PR TITLE
Fix cpu counting for io threads count

### DIFF
--- a/pkg/libvmi/cpu.go
+++ b/pkg/libvmi/cpu.go
@@ -111,3 +111,12 @@ func WithLimitCPU(value string) Option {
 		vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse(value)
 	}
 }
+
+func WithIsolateEmulatorThread() Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.CPU == nil {
+			vmi.Spec.Domain.CPU = &v1.CPU{}
+		}
+		vmi.Spec.Domain.CPU.IsolateEmulatorThread = true
+	}
+}

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -380,3 +380,12 @@ func newHostDisk(name, path string, diskType v1.HostDiskType, capacity string, o
 
 	return v
 }
+
+func WithSupplementalPoolThreadCount(count uint32) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.IOThreads == nil {
+			vmi.Spec.Domain.IOThreads = &v1.DiskIOThreads{}
+		}
+		vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount = pointer.P(count)
+	}
+}

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -175,97 +175,65 @@ var _ = Describe("Resource pod spec renderer", func() {
 		})
 	})
 
-	Context("WithCPUPinning option", func() {
-		userCPURequest := resource.MustParse("200m")
-		userSpecifiedCPU := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
-
-		It("the user requested CPU configs are *not* overriden", func() {
-			vmi := libvmi.New(libvmi.WithCPUCount(5, 0, 0))
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
-		})
-
-		It("carries over the CPU limits as requests when no CPUs are requested", func() {
-			vmi := libvmi.New(libvmi.WithCPUCount(0, 0, 0))
-			rr = NewResourceRenderer(userSpecifiedCPU, nil, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
-		})
-
-		It("carries over the CPU requests as limits when no CPUs are requested", func() {
-			vmi := libvmi.New(libvmi.WithCPUCount(0, 0, 0))
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
-		})
-
-		It("carries over the requested memory as a *limit*", func() {
-			memoryRequest := resource.MustParse("128M")
-			userSpecifiedCPU := kubev1.ResourceList{
-				kubev1.ResourceCPU:    userCPURequest,
-				kubev1.ResourceMemory: memoryRequest,
-			}
-			vmi := libvmi.New(libvmi.WithCPUCount(5, 0, 0))
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, resource.MustParse("200m")))
-			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceMemory, memoryRequest))
-		})
-
-		When("an isolated emulator thread is requested", func() {
-			userSpecifiedCPURequest := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
-
-			DescribeTable("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits",
-				func(vmiAnnotations map[string]string, defineUserSpecifiedCPULimit bool, cores uint32, expectedCPUOverhead string) {
-					cpuIsolatedEmulatorThreadOverhead := resource.MustParse(expectedCPUOverhead)
-					var userSpecifiedCPULimit kubev1.ResourceList
-
-					if defineUserSpecifiedCPULimit {
-						userSpecifiedCPULimit = kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
-					}
-					vmi := libvmi.New(
-						libvmi.WithCPUCount(cores, 0, 0),
-						libvmi.WithIsolateEmulatorThread(),
-					)
-					rr = NewResourceRenderer(
-						userSpecifiedCPULimit,
-						userSpecifiedCPURequest,
-						WithCPUPinning(vmi, vmiAnnotations, 0),
-					)
-					Expect(rr.Limits()).To(HaveKeyWithValue(
-						kubev1.ResourceCPU,
-						*resource.NewQuantity(cpuIsolatedEmulatorThreadOverhead.Value()+int64(cores), resource.BinarySI),
-					))
-					Expect(rr.Requests()).To(HaveKeyWithValue(
-						kubev1.ResourceCPU,
-						addResources(userCPURequest, cpuIsolatedEmulatorThreadOverhead),
-					))
-				},
-				Entry("EmulatorThreadCompleteToEvenParity mode is disabled, only CPU requests set by the user", map[string]string{}, false, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is disabled, request and limits set by the user", map[string]string{}, true, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, only CPU requests set by the user, odd amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, false, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, only CPU requests set by the user, even amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, false, uint32(6), "2000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, request and limits set by the user, odd amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, true, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, request and limits set by the user, even amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, true, uint32(6), "2000m"),
-			)
-
-			It("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits and the IOThreads", func() {
-				cores := uint32(2)
-				iothreads := uint32(4)
-
+	When("an isolated emulator thread is requested", func() {
+		DescribeTable("sets limits and requests to vCPUs + iothreads + emulatorThreadCPUs when vCPUs != 0",
+			func(vcpus uint32, ioThreads uint32, userSpecifiedCPULimit, userSpecifiedCPURequest *resource.Quantity, annotations map[string]string, expectedCPUs int64) {
 				vmi := libvmi.New(
-					libvmi.WithCPUCount(cores, 0, 0),
-					libvmi.WithIsolateEmulatorThread(),
-					libvmi.WithDedicatedCPUPlacement(),
+					libvmi.WithCPUCount(vcpus, 0, 0),
 					libvmi.WithIOThreadsPolicy(v1.IOThreadsPolicySupplementalPool),
-					libvmi.WithSupplementalPoolThreadCount(iothreads),
+					libvmi.WithSupplementalPoolThreadCount(ioThreads),
+					libvmi.WithIsolateEmulatorThread(),
 				)
-				rr = NewResourceRenderer(
-					nil, nil,
-					WithCPUPinning(vmi, nil, 0),
+
+				vmLimits := kubev1.ResourceList{}
+				vmRequests := kubev1.ResourceList{}
+				if userSpecifiedCPULimit != nil && userSpecifiedCPURequest != nil {
+					vmLimits[kubev1.ResourceCPU] = *userSpecifiedCPULimit
+					vmRequests[kubev1.ResourceCPU] = *userSpecifiedCPURequest
+				}
+
+				rr := NewResourceRenderer(
+					vmLimits,
+					vmRequests,
+					WithCPUPinning(vmi, annotations, 0),
 				)
-				Expect(rr.Limits()).Should(HaveKeyWithValue(
-					kubev1.ResourceCPU,
-					*resource.NewQuantity(int64(cores)+int64(iothreads)+1, resource.BinarySI),
-				), "should have the limits")
-			})
+
+				expectedQuantity := resource.NewQuantity(expectedCPUs, resource.BinarySI)
+
+				Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceCPU, *expectedQuantity))
+				Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, *expectedQuantity))
+			},
+			Entry("vCPUs specified, IO threads present",
+				uint32(5), uint32(2), nil, nil, nil, int64(8)),
+			Entry("vCPUs specified, IO threads present, EmulatorThreadCompleteToEvenParity enabled, odd total",
+				uint32(5), uint32(2), nil, nil, map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, int64(8)),
+			Entry("vCPUs specified, IO threads present, EmulatorThreadCompleteToEvenParity enabled, even total",
+				uint32(6), uint32(2), nil, nil, map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, int64(10)),
+			Entry("No vCPUs, no IO threads, user-specified reqs/limits CPU",
+				uint32(0), uint32(0), resource.NewQuantity(3, resource.BinarySI), resource.NewQuantity(3, resource.BinarySI), nil, int64(4)),
+			Entry("No vCPUs, IO threads, user-specified reqs/limits CPU, EmulatorThreadCompleteToEvenParity enabled",
+				uint32(0), uint32(2), resource.NewQuantity(5, resource.BinarySI), resource.NewQuantity(5, resource.BinarySI), map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, int64(8)),
+		)
+
+		It("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits and the IOThreads", func() {
+			cores := uint32(2)
+			iothreads := uint32(4)
+
+			vmi := libvmi.New(
+				libvmi.WithCPUCount(cores, 0, 0),
+				libvmi.WithIsolateEmulatorThread(),
+				libvmi.WithDedicatedCPUPlacement(),
+				libvmi.WithIOThreadsPolicy(v1.IOThreadsPolicySupplementalPool),
+				libvmi.WithSupplementalPoolThreadCount(iothreads),
+			)
+			rr = NewResourceRenderer(
+				nil, nil,
+				WithCPUPinning(vmi, nil, 0),
+			)
+			Expect(rr.Limits()).Should(HaveKeyWithValue(
+				kubev1.ResourceCPU,
+				*resource.NewQuantity(int64(cores)+int64(iothreads)+1, resource.BinarySI),
+			), "should have the limits")
 		})
 	})
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1491,8 +1491,8 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 	return VMIResourcePredicates{
 		vmi: vmi,
 		resourceRules: []VMIResourceRule{
-			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi.Spec.Domain.CPU, vmi.Annotations, additionalCPUs)),
-			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi.Spec.Domain.CPU, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
+			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi, vmi.Annotations, additionalCPUs)),
+			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
 			NewVMIResourceRule(hasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(hasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),
 			NewVMIResourceRule(t.doesVMIRequireAutoMemoryLimits, WithAutoMemoryLimits(vmi.Namespace, t.namespaceStore)),
@@ -1503,7 +1503,6 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 			NewVMIResourceRule(util.IsHostDevVMI, WithHostDevices(vmi.Spec.Domain.Devices.HostDevices)),
 			NewVMIResourceRule(util.IsSEVVMI, WithSEV()),
 			NewVMIResourceRule(reservation.HasVMIPersistentReservation, WithPersistentReservation()),
-			NewVMIResourceRule(doesVMIRequireCPUForIOThreads, WithIOThreads(vmi.Spec.Domain.IOThreads)),
 		},
 	}
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4931,6 +4931,7 @@ var _ = Describe("Template", func() {
 					expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
 					expectedMemory.Add(GetMemoryOverhead(&vmi, defaultArch, config.GetConfig().AdditionalGuestMemoryOverheadRatio))
 					expectedMemory.Add(guestMemory)
+					Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(BeEquivalentTo(expectedMemory.Value()))
 					Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeEquivalentTo(expectedMemory.Value()))
 				},
 					Entry("if they are already set in the vmi", true, false),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The number of calculated cpus was wrong using the supplementalPoolThreadCount failing with:
```
Pod "virt-launcher-rhel9-tomato-canidae-79-ztl4l" is invalid: spec.containers[0].resources.requests: Invalid value: "8": must be less than or equal to cpu limit of 4
```

After this PR:
Number of CPUs is now correctly allocated

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-59494

### Special notes for your reviewer
The `WithoutDedicatedCPU` and `WithCPUPinning` need to be fixed. There was mixture between calculated and vm limits/resources.

We still probably need to fix the memory resource/limits as well. This will be done in a separate pr.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

