### PR TITLE
[release-1.0] Fix build functests dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -376,6 +376,13 @@ http_file(
 
 # some repos which are not part of go_rules anymore
 go_repository(
+    name = "org_golang_x_sys",
+    importpath = "golang.org/x/sys",
+    sum = "h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=",
+    version = "v0.12.0",
+)
+
+go_repository(
     name = "com_github_golang_glog",
     importpath = "github.com/golang/glog",
     sum = "h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=",

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -481,6 +481,9 @@ spec:
 EOF
 fi
 
+if [ "${KUBEVIRT_PSA:-false}" = "false" ]; then
+  add_to_label_filter '(!CustomSeccomp)' '&&'
+fi
 
 # Run functional tests
 FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER='--label-filter='${label_filter} make functest

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -66,6 +66,10 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
+    if [ "${KUBEVIRT_PSA:-false}" = "false" ]; then
+        KUBEVIRT_FUNC_TEST_SUITE_ARGS="-use-custom-seccomp-profile=false ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
+    fi
+
     _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
 }
 

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -38,6 +38,7 @@ var (
 	VMX                          = []interface{}{Label("VMX")}
 	Upgrade                      = []interface{}{Label("Upgrade")}
 	CustomSELinux                = []interface{}{Label("CustomSELinux")}
+	CustomSeccomp                = []interface{}{Label("CustomSeccomp")}
 	Istio                        = []interface{}{Label("Istio")}
 	InPlaceHotplugNICs           = []interface{}{Label("in-place-hotplug-NICs")}
 	MigrationBasedHotplugNICs    = []interface{}{Label("migration-based-hotplug-NICs")}

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -63,6 +63,8 @@ var MigrationNetworkNIC = "eth1"
 
 var DisableCustomSELinuxPolicy bool
 
+var UseCustomSeccompProfile bool
+
 func init() {
 	kubecli.Init()
 	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
@@ -98,6 +100,8 @@ func init() {
 	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
 	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
 	flag.BoolVar(&DisableCustomSELinuxPolicy, "disable-custom-selinux-policy", false, "disables the installation and use of the custom SELinux policy for virt-launcher")
+	flag.BoolVar(&UseCustomSeccompProfile, "use-custom-seccomp-profile", true, "enables the installation and use of the custom custom seccomp profile for virt-launcher")
+
 }
 
 func NormalizeFlags() {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2963,7 +2963,7 @@ spec:
 		})
 	})
 
-	Context("[Serial] Seccomp configuration", Serial, func() {
+	Context("[Serial] Seccomp configuration", Serial, decorators.CustomSeccomp, func() {
 
 		Context("Kubevirt profile", func() {
 			var nodeName string

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -83,13 +83,6 @@ func AdjustKubeVirtResource() {
 		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{}
 	}
 
-	kv.Spec.Configuration.SeccompConfiguration = &v1.SeccompConfiguration{
-		VirtualMachineInstanceProfile: &v1.VirtualMachineInstanceProfile{
-			CustomProfile: &v1.CustomProfile{
-				LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
-			},
-		},
-	}
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
 		virtconfig.CPUManager,
 		virtconfig.IgnitionGate,
@@ -105,7 +98,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.ExpandDisksGate,
 		virtconfig.WorkloadEncryptionSEV,
 		virtconfig.VMExportGate,
-		virtconfig.KubevirtSeccompProfile,
 		virtconfig.HotplugNetworkIfacesGate,
 		virtconfig.VMPersistentState,
 		virtconfig.VMLiveUpdateFeaturesGate,
@@ -114,6 +106,19 @@ func AdjustKubeVirtResource() {
 	if flags.DisableCustomSELinuxPolicy {
 		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
 			virtconfig.DisableCustomSELinuxPolicy,
+		)
+	}
+
+	if flags.UseCustomSeccompProfile {
+		kv.Spec.Configuration.SeccompConfiguration = &v1.SeccompConfiguration{
+			VirtualMachineInstanceProfile: &v1.VirtualMachineInstanceProfile{
+				CustomProfile: &v1.CustomProfile{
+					LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
+				},
+			},
+		}
+		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+			virtconfig.KubevirtSeccompProfile,
 		)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
google.golang.org/grpc v1.30 defined in WORKSPACE
has golang.org/x/sys:v0.0.0-20190215142949-d0b11bdaac8a as dependency, as defined in https://deps.dev/go/google.golang.org%2Fgrpc/v1.30.0/dependencies.

https://pkg.go.dev/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a this version disappeared.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

