### PR TITLE
[release-1.5] Fix repeated pod patching when VM has multiple SR-IOV NICs

### DIFF
--- a/pkg/network/downwardapi/networkinfo.go
+++ b/pkg/network/downwardapi/networkinfo.go
@@ -21,6 +21,8 @@ package downwardapi
 
 import (
 	"encoding/json"
+	"maps"
+	"slices"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -47,7 +49,11 @@ func CreateNetworkInfoAnnotationValue(networkDeviceInfoMap map[string]*networkv1
 
 func generateNetworkInfo(networkDeviceInfoMap map[string]*networkv1.DeviceInfo) NetworkInfo {
 	var downwardAPIInterfaces []Interface
-	for networkName, deviceInfo := range networkDeviceInfoMap {
+
+	// Sort keys of the map with to get deterministic order
+	sortedNetNames := slices.Sorted(maps.Keys(networkDeviceInfoMap))
+	for _, networkName := range sortedNetNames {
+		deviceInfo := networkDeviceInfoMap[networkName]
 		downwardAPIInterfaces = append(downwardAPIInterfaces, Interface{Network: networkName, DeviceInfo: deviceInfo})
 	}
 	networkInfo := NetworkInfo{Interfaces: downwardAPIInterfaces}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR is an automatic cherry-pick of https://github.com/kubevirt/kubevirt/pull/14477 and https://github.com/kubevirt/kubevirt/pull/14553.

Currently, when a VM has an SR-IOV NIC, the VMI controller adds the `kubevirt.io/network-info` annotation to the virt-launcher pod.
This annotation's value is a JSON array derived from the Multus network status annotation (`k8s.v1.cni.cncf.io/network-status`).

When there are multiple SR-IOV NICs, the order of the JSON array keeps changing - thus the VMI controller repeatedly patches the pod.

Create a JSON array ordered by lexicographical order so the VMI controller will not repeatedly patch the pod.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix repeated pod patching when VM has multiple SR-IOV NICs
```

