### PR TITLE
chore: add pkg/virtctl/adm to lint paths (no lint issues)

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -43,4 +43,3 @@ tests/numa
 tests/usb
 tests/virtctl
 pkg/virtctl/adm
-pkg/virtctl/adm

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -42,3 +42,5 @@ tests/libwait
 tests/numa
 tests/usb
 tests/virtctl
+pkg/virtctl/adm
+pkg/virtctl/adm


### PR DESCRIPTION
This PR adds `pkg/virtctl/adm` to the list of lint-checked directories. 
The directory currently passes `golangci-lint` with zero issues using the default lint settings.
Resolves: https://github.com/kubevirt/kubevirt/issues/14185


