### PR TITLE
chore(api): Fix typo within tpm.Enabled description

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16166,7 +16166,7 @@
     "type": "object",
     "properties": {
      "enabled": {
-      "description": "Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine Defaults to True",
+      "description": "Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine Defaults to True",
       "type": "boolean"
      },
      "persistent": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6457,7 +6457,7 @@ var CRDsValidation map[string]string = map[string]string{
                           properties:
                             enabled:
                               description: |-
-                                Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                                Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                                 Defaults to True
                               type: boolean
                             persistent:
@@ -9324,7 +9324,7 @@ var CRDsValidation map[string]string = map[string]string{
               properties:
                 enabled:
                   description: |-
-                    Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                    Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                     Defaults to True
                   type: boolean
                 persistent:
@@ -11757,7 +11757,7 @@ var CRDsValidation map[string]string = map[string]string{
                   properties:
                     enabled:
                       description: |-
-                        Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                        Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                         Defaults to True
                       type: boolean
                     persistent:
@@ -14987,7 +14987,7 @@ var CRDsValidation map[string]string = map[string]string{
                   properties:
                     enabled:
                       description: |-
-                        Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                        Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                         Defaults to True
                       type: boolean
                     persistent:
@@ -17421,7 +17421,7 @@ var CRDsValidation map[string]string = map[string]string{
                           properties:
                             enabled:
                               description: |-
-                                Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                                Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                                 Defaults to True
                               type: boolean
                             persistent:
@@ -21936,7 +21936,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   properties:
                                     enabled:
                                       description: |-
-                                        Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                                        Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                                         Defaults to True
                                       type: boolean
                                     persistent:
@@ -23859,7 +23859,7 @@ var CRDsValidation map[string]string = map[string]string{
               properties:
                 enabled:
                   description: |-
-                    Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                    Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                     Defaults to True
                   type: boolean
                 persistent:
@@ -27147,7 +27147,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       properties:
                                         enabled:
                                           description: |-
-                                            Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+                                            Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
                                             Defaults to True
                                           type: boolean
                                         persistent:

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -547,7 +547,7 @@ type SoundDevice struct {
 }
 
 type TPMDevice struct {
-	// Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
+	// Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine
 	// Defaults to True
 	Enabled *bool `json:"enabled,omitempty"`
 	// Persistent indicates the state of the TPM device should be kept accross reboots

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -288,7 +288,7 @@ func (SoundDevice) SwaggerDoc() map[string]string {
 
 func (TPMDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"enabled":    "Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine\nDefaults to True",
+		"enabled":    "Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine\nDefaults to True",
 		"persistent": "Persistent indicates the state of the TPM device should be kept accross reboots\nDefaults to false",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -24428,7 +24428,7 @@ func schema_kubevirtio_api_core_v1_TPMDevice(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enabled allows a user to explictly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine Defaults to True",
+							Description: "Enabled allows a user to explicitly disable the vTPM even when one is enabled by a preference referenced by the VirtualMachine Defaults to True",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
### What this PR does

$subject, fixes a simple typo of explictly and corrects it to explicitly in the description of the vTPM Enabled attribute. Identified by [sourcery-ai](https://github.com/apps/sourcery-ai) in the following backport PR:

https://github.com/kubevirt/kubevirt/pull/14581#discussion_r2057900068

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

