### PR TITLE
restore_test.go: Remove Invalid Unit Test for VM Name Patch

### DIFF
--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -316,7 +316,7 @@ type VirtualMachineRestoreSpec struct {
 	// If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be
 	// applied to the target manifest before it's created. Patches should fit the target's Kind.
 	//
-	// Example for a patch: {"op": "replace", "path": "/metadata/name", "value": "new-vm-name"}
+	// Example for a patch: {"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "00:00:5e:00:53:01"}
 	//
 	// +optional
 	// +listType=atomic

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
@@ -141,7 +141,7 @@ func (VirtualMachineRestoreSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":        "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource",
 		"target":  "initially only VirtualMachine type supported",
-		"patches": "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be\napplied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}\n\n+optional\n+listType=atomic",
+		"patches": "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be\napplied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/devices/interfaces/0/macAddress\", \"value\": \"00:00:5e:00:53:01\"}\n\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -32752,7 +32752,7 @@ func schema_kubevirtio_api_snapshot_v1alpha1_VirtualMachineRestoreSpec(ref commo
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be applied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}",
+							Description: "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be applied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/devices/interfaces/0/macAddress\", \"value\": \"00:00:5e:00:53:01\"}",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
### What this PR does

The `VMRestoreAdmitter` validates patches in `VirtualMachineRestore` and rejects those targeting fields outside of `/spec/`, `/metadata/labels/`, or `/metadata/annotations/`.
However, a [unit test](https://github.com/kubevirt/kubevirt/blob/a56c9c2b7d2e9fe4d1bfdb6d3b95ac516947267c/pkg/storage/snapshot/restore_test.go#L1413) in `restore_test.go` attempts to patch `/metadata/name`, which contradicts the validation logic and is invalid.
This PR removes the conflicting unit test to ensure tests align with the system's behavior.

Fixes #

### Release note
```release-note
none
```
