### PR TITLE
cleanup: virt-handler to handle unhandled errors

### DIFF
--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -78,7 +78,7 @@ func (h *HeartBeat) heartBeat(heartBeatInterval time.Duration, stopCh chan struc
 }
 
 func (h *HeartBeat) labelNodeUnschedulable() {
-	retry.OnError(retry.DefaultBackoff, func(err error) bool { return err != nil }, func() error {
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return err != nil }, func() error {
 		now, err := json.Marshal(metav1.Now())
 		if err != nil {
 			log.DefaultLogger().Reason(err).Errorf("Can't determine date")
@@ -98,6 +98,10 @@ func (h *HeartBeat) labelNodeUnschedulable() {
 		}
 		return nil
 	})
+
+	if err != nil {
+		log.Log.Warningf("Failed to set node %s unschedulable", h.host)
+	}
 }
 
 // waitForDevicePlugins gives the device plugins additional time to successfully connect to the kubelet.

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -746,7 +746,11 @@ func (c *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		log.Log.Object(vmi).Info("The target node received the running migrated domain")
 		now := metav1.Now()
 		vmiCopy.Status.MigrationState.TargetNodeDomainReadyTimestamp = &now
-		c.finalizeMigration(vmiCopy)
+
+		err := c.finalizeMigration(vmiCopy)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !migrations.IsMigrating(vmi) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2198,7 +2198,11 @@ func (c *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineIns
 		close(clientInfo.DomainPipeStopChan)
 	}
 
-	virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
+	err := virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return err
+	}
+
 	c.launcherClients.Delete(vmi.UID)
 	return nil
 }


### PR DESCRIPTION
### What this PR does
A small cleanup PR to handle some unhandled errors in virt-handler.

/kind cleanup

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

