### PR TITLE
[release-1.4] vol-mig: invalidate destination DVs with no csi storageclass

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1035,7 +1035,7 @@ func (c *Controller) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi *v
 			return nil
 		}
 		// Validate if the update volumes can be migrated
-		if err := volumemig.ValidateVolumes(vmi, vm); err != nil {
+		if err := volumemig.ValidateVolumes(vmi, vm, c.dataVolumeStore, c.pvcStore); err != nil {
 			log.Log.Object(vm).Errorf("cannot migrate the VM. Volumes are invalid: %v", err)
 			setRestartRequired(vm, err.Error())
 			return nil

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -100,6 +100,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachine{}, virtcontroller.GetVirtualMachineInformerIndexers())
 			pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 			namespaceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
+
 			ns1 := &k8sv1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ns1",

--- a/pkg/virt-controller/watch/volume-migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/volume-migration/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )
 
@@ -45,5 +46,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -71,6 +71,15 @@ func WithName(name string) dvOption {
 	}
 }
 
+func WithAnnotation(ann, val string) dvOption {
+	return func(dv *v1beta1.DataVolume) {
+		if dv.ObjectMeta.Annotations == nil {
+			dv.ObjectMeta.Annotations = make(map[string]string)
+		}
+		dv.ObjectMeta.Annotations[ann] = val
+	}
+}
+
 type pvcOption func(*corev1.PersistentVolumeClaimSpec)
 type storageOption func(*v1beta1.StorageSpec)
 

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/cleanup:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/framework/storage:go_default_library",

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	storagev1 "k8s.io/api/storage/v1"
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -55,6 +56,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/cleanup"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libdv"
@@ -71,6 +73,22 @@ import (
 
 var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 	var virtClient kubecli.KubevirtClient
+	var testSc string
+	getCSIStorageClass := libstorage.GetSnapshotStorageClass
+	createBlankDV := func(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.DataVolume {
+		dv := libdv.NewDataVolume(
+			libdv.WithBlankImageSource(),
+			libdv.WithStorage(libdv.StorageWithStorageClass(testSc),
+				libdv.StorageWithVolumeSize(size),
+				libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
+				libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
+			),
+		)
+		_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+			dv, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return dv
+	}
 	BeforeEach(func() {
 		checks.SkipIfMigrationIsNotPossible()
 		virtClient = kubevirt.Client()
@@ -88,6 +106,28 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			currentKv.ResourceVersion,
 			config.ExpectResourceVersionToBeLessEqualThanConfigVersion,
 			time.Minute)
+		scName, err := getCSIStorageClass(virtClient)
+		Expect(err).ToNot(HaveOccurred())
+		if scName == "" {
+			Fail("Fail test when a CSI storage class is not present")
+		}
+
+		sc, err := virtClient.StorageV1().StorageClasses().Get(context.Background(), scName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		wffcSc := sc.DeepCopy()
+		wffcSc.ObjectMeta = metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-wffc", scName),
+			Labels: map[string]string{
+				cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(nil)): "",
+			},
+		}
+		wffcSc.VolumeBindingMode = pointer.P(storagev1.VolumeBindingWaitForFirstConsumer)
+		sc, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), wffcSc, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		testSc = sc.Name
+	})
+	AfterEach(func() {
+		virtClient.StorageV1().StorageClasses().Delete(context.Background(), testSc, metav1.DeleteOptions{})
 	})
 
 	Describe("Update volumes with the migration updateVolumesStrategy", func() {
@@ -355,18 +395,8 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 				srcDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			sc, exist = libstorage.GetRWOFileSystemStorageClass()
-			Expect(exist).To(BeTrue())
-			destDV := libdv.NewDataVolume(
-				libdv.WithBlankImageSource(),
-				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
-					libdv.StorageWithVolumeSize(size),
-					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
-				),
-			)
-			_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
-				destDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
+			destDV := createBlankDV(virtClient, ns, size)
 			vm := createVMWithDV(srcDV, volName)
 			By("Update volumes")
 			updateVMWithDV(vm, volName, destDV.Name)
@@ -969,23 +999,6 @@ func createSmallImageForDestinationMigration(vm *virtv1.VirtualMachine, name, si
 	p, err := virtCli.CoreV1().Pods(vmi.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(matcher.ThisPod(p)).WithTimeout(120 * time.Second).WithPolling(time.Second).Should(matcher.HaveSucceeded())
-}
-
-func createBlankDV(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.DataVolume {
-	sc, exist := libstorage.GetRWOFileSystemStorageClass()
-	Expect(exist).To(BeTrue())
-	dv := libdv.NewDataVolume(
-		libdv.WithBlankImageSource(),
-		libdv.WithStorage(libdv.StorageWithStorageClass(sc),
-			libdv.StorageWithVolumeSize(size),
-			libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
-			libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
-		),
-	)
-	_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
-		dv, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	return dv
 }
 
 func waitMigrationToExist(virtClient kubecli.KubevirtClient, vmiName, ns string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/13717

For the branch 1.4, libdv is still under `tests`, therefore I defined a local function `newDataVolume` in order to create the DVs there.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refuse to volume migrate to legacy datavolumes using no-CSI storageclasses
```

