### PR TITLE
feature: add smt label to the node labeller

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -307,8 +307,7 @@ func (app *virtHandlerApp) Run() {
 		app.virtCli.CoreV1().Nodes(),
 		app.HostOverride,
 		nodeLabellerrecorder,
-		capabilities.Host.CPU.Counter,
-		capabilities.Guests,
+		&capabilities,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -23,6 +23,7 @@ type NodeSelectorRenderer struct {
 	realtimeEnabled  bool
 	sevEnabled       bool
 	sevESEnabled     bool
+	smtEnabled       bool
 }
 
 type NodeSelectorRendererOption func(renderer *NodeSelectorRenderer)
@@ -79,6 +80,9 @@ func (nsr *NodeSelectorRenderer) Render() map[string]string {
 	if nsr.sevESEnabled {
 		nsr.enableSelectorLabel(v1.SEVESLabel)
 	}
+	if nsr.smtEnabled {
+		nsr.enableSelectorLabel(v1.SMTCPULabel)
+	}
 
 	return nsr.podNodeSelectors
 }
@@ -104,6 +108,12 @@ func WithSEVSelector() NodeSelectorRendererOption {
 func WithSEVESSelector() NodeSelectorRendererOption {
 	return func(renderer *NodeSelectorRenderer) {
 		renderer.sevESEnabled = true
+	}
+}
+
+func WithSMTSelector() NodeSelectorRendererOption {
+	return func(renderer *NodeSelectorRenderer) {
+		renderer.smtEnabled = true
 	}
 }
 

--- a/pkg/virt-controller/services/nodeselectorrenderer_test.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer_test.go
@@ -141,6 +141,20 @@ var _ = Describe("Node Selector Renderer", func() {
 					}))
 			})
 		})
+
+		When("smt selector is present", func() {
+			BeforeEach(func() {
+				nsr = NewNodeSelectorRenderer(
+					emptySelectors(),
+					emptySelectors(),
+					"",
+					WithSMTSelector())
+			})
+
+			It("the VMI requires the smt node", func() {
+				Expect(nsr.Render()).To(HaveKey(v1.SMTCPULabel))
+			})
+		})
 	})
 })
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -711,6 +711,11 @@ func (t *templateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		opts = append(opts, WithSEVESSelector())
 	}
 
+	if vmi.IsSMTRequired() {
+		log.Log.V(4).Info("Add SMT node label selector")
+		opts = append(opts, WithSMTSelector())
+	}
+
 	return NewNodeSelectorRenderer(
 		vmi.Spec.NodeSelector,
 		t.clusterConfig.GetNodeSelectors(),

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -495,6 +495,11 @@ func (v *VirtualMachineInstance) IsCPUDedicated() bool {
 	return v.Spec.Domain.CPU != nil && v.Spec.Domain.CPU.DedicatedCPUPlacement
 }
 
+func (v *VirtualMachineInstance) IsSMTRequired() bool {
+	cpu := v.Spec.Domain.CPU
+	return cpu != nil && cpu.DedicatedCPUPlacement && cpu.Threads > 1
+}
+
 func (v *VirtualMachineInstance) IsBootloaderEFI() bool {
 	return v.Spec.Domain.Firmware != nil && v.Spec.Domain.Firmware.Bootloader != nil &&
 		v.Spec.Domain.Firmware.Bootloader.EFI != nil
@@ -992,6 +997,8 @@ const (
 	CPUModelVendorLabel = "cpu-vendor.node.kubevirt.io/"
 	// This label represents supported machine type on the node
 	SupportedMachineTypeLabel = "machine-type.node.kubevirt.io/"
+	// This label represents cpu supports smt
+	SMTCPULabel = "cpu.node.kubevirt.io/smt"
 
 	VirtIO = "virtio"
 


### PR DESCRIPTION
### What this PR does
Before this PR:
When VMI requests dedicatedCPUPlacement and cpu.threads > 1,
then the VM can be scheduled to a node, where the smt is not enabled.
This will affect the VMI performance.
After this PR:
Node-labeller will try to parse if CPU on the host has SMT enabled,
based on information from virh capabilities. If the SMT is enabled
on the host, then node labeller will try to add new label
cpu.node.kubevirt.io/smt which indicates that host has SMT enabled.

Add to the virt-launcher pod a node selector, which looks for a node, where smt is enabled.
The nodeSelector is added only when VMI had dedicatedCPUPlacement
enabled and number of threads > 1

Fixes https://github.com/kubevirt/kubevirt/issues/11749

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
feature: add smt label to the node labeller
```

