### PR TITLE
[DNM] PoC broken build for release-1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # KubeVirt
 
+### POC THAT VERIRIES RELEASE-1.1 BRANCH BUILD IS BROKEN
+
 <p align="center">
 <img src="https://github.com/kubevirt/community/blob/main/logo/KubeVirt_icon.png" width="100">
 </p>


### PR DESCRIPTION
PoC for broken build of release-1.1, will use CI pull-kubevirt-build in order to confirm.
This is an evidence that immediate actions should be taken regarding this branch