### PR TITLE
vm ctrl: Allow live changes to network fields

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -15,6 +15,7 @@ pkg/network/netmachinery
 pkg/network/netns
 pkg/network/pod/annotations
 pkg/network/vmispec
+pkg/network/vmliveupdate
 pkg/storage/pod/annotations
 pkg/virt-launcher/virtwrap/agent-poller
 pkg/virtctl/adm

--- a/pkg/network/vmliveupdate/BUILD.bazel
+++ b/pkg/network/vmliveupdate/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["restart.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/network/vmliveupdate",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/network/vmispec:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "restart_test.go",
+        "vmliveupdate_suite_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/pkg/network/vmliveupdate/restart.go
+++ b/pkg/network/vmliveupdate/restart.go
@@ -1,0 +1,115 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vmliveupdate
+
+import (
+	"reflect"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+)
+
+// IsRestartRequired - Checks if the changes in network related fields require a reset of the VM
+// in order for them to be applied
+func IsRestartRequired(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) bool {
+	desiredIfaces := vm.Spec.Template.Spec.Domain.Devices.Interfaces
+	currentIfaces := vmi.Spec.Domain.Devices.Interfaces
+
+	desiredNets := vm.Spec.Template.Spec.Networks
+	currentNets := vmi.Spec.Networks
+
+	return shouldIfacesChangeRequireRestart(desiredIfaces, currentIfaces) ||
+		shouldNetsChangeRequireRestart(desiredNets, currentNets)
+}
+
+func shouldIfacesChangeRequireRestart(desiredIfaces, currentIfaces []v1.Interface) bool {
+	desiredIfacesByName := vmispec.IndexInterfaceSpecByName(desiredIfaces)
+	currentIfacesByName := vmispec.IndexInterfaceSpecByName(currentIfaces)
+
+	return haveCurrentIfacesBeenRemoved(desiredIfacesByName, currentIfacesByName) ||
+		haveCurrentIfacesChanged(desiredIfacesByName, currentIfacesByName)
+}
+
+func shouldNetsChangeRequireRestart(desiredNets, currentNets []v1.Network) bool {
+	desiredNetsByName := vmispec.IndexNetworkSpecByName(desiredNets)
+	currentNetsByName := vmispec.IndexNetworkSpecByName(currentNets)
+
+	return haveCurrentNetsBeenRemoved(desiredNetsByName, currentNetsByName) ||
+		haveCurrentNetsChanged(desiredNetsByName, currentNetsByName)
+}
+
+// haveCurrentIfacesBeenRemoved checks if interfaces existing in the VMI spec were removed
+// from the VM spec without using the hotunplug flow.
+func haveCurrentIfacesBeenRemoved(desiredIfacesByName, currentIfacesByName map[string]v1.Interface) bool {
+	for currentIfaceName := range currentIfacesByName {
+		if _, desiredIfaceExists := desiredIfacesByName[currentIfaceName]; !desiredIfaceExists {
+			return true
+		}
+	}
+
+	return false
+}
+
+func haveCurrentIfacesChanged(desiredIfacesByName, currentIfacesByName map[string]v1.Interface) bool {
+	for currentIfaceName, currentIface := range currentIfacesByName {
+		desiredIface := desiredIfacesByName[currentIfaceName]
+
+		if !areNormalizedIfacesEqual(desiredIface, currentIface) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func areNormalizedIfacesEqual(iface1, iface2 v1.Interface) bool {
+	normalizedIface1 := iface1.DeepCopy()
+	normalizedIface1.State = ""
+
+	normalizedIface2 := iface2.DeepCopy()
+	normalizedIface2.State = ""
+
+	return reflect.DeepEqual(normalizedIface1, normalizedIface2)
+}
+
+// haveCurrentNetsBeenRemoved checks if networks existing in the VMI spec were removed
+// from the VM spec without using the hotunplug flow.
+func haveCurrentNetsBeenRemoved(desiredNetsByName, currentNetsByName map[string]v1.Network) bool {
+	for currentNetName := range currentNetsByName {
+		if _, desiredNetExists := desiredNetsByName[currentNetName]; !desiredNetExists {
+			return true
+		}
+	}
+
+	return false
+}
+
+func haveCurrentNetsChanged(desiredNetsByName, currentNetsByName map[string]v1.Network) bool {
+	for currentNetName, currentNet := range currentNetsByName {
+		desiredNet := desiredNetsByName[currentNetName]
+
+		if !reflect.DeepEqual(desiredNet, currentNet) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/network/vmliveupdate/restart_test.go
+++ b/pkg/network/vmliveupdate/restart_test.go
@@ -1,0 +1,210 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vmliveupdate_test
+
+import (
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/network/vmliveupdate"
+)
+
+var _ = Describe("IsRestartRequired", func() {
+	const (
+		secondaryNetName1 = "foo"
+		secondaryNADName1 = "foo-nad"
+
+		secondaryNetName2 = "bar"
+		secondaryNADName2 = "bar-nad"
+	)
+
+	DescribeTable("should not require restart when there is no change", func(vmi *v1.VirtualMachineInstance) {
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	},
+		Entry("Without interfaces and networks",
+			libvmi.New(libvmi.WithAutoAttachPodInterface(false)),
+		),
+		Entry("With interfaces and networks",
+			libvmi.New(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
+			),
+		),
+	)
+
+	It("should not require restart when networks are added", func() {
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces = append(
+			vm.Spec.Template.Spec.Domain.Devices.Interfaces,
+			libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1),
+		)
+
+		vm.Spec.Template.Spec.Networks = append(
+			vm.Spec.Template.Spec.Networks,
+			*libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1),
+		)
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	})
+
+	DescribeTable("should not require restart when interface state changes", func(current, desired v1.InterfaceState) {
+		iface := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)
+		iface.State = current
+
+		vmi := libvmi.New(
+			libvmi.WithInterface(iface),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].State = desired
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	},
+		Entry("From empty to empty", v1.InterfaceState(""), v1.InterfaceState("")),
+		Entry("From empty to absent", v1.InterfaceState(""), v1.InterfaceStateAbsent),
+		Entry("From empty to up", v1.InterfaceState(""), v1.InterfaceStateLinkUp),
+		Entry("From empty to down", v1.InterfaceState(""), v1.InterfaceStateLinkDown),
+		Entry("From up to empty", v1.InterfaceStateLinkUp, v1.InterfaceState("")),
+		Entry("From up to absent", v1.InterfaceStateLinkUp, v1.InterfaceStateAbsent),
+		Entry("From up to up", v1.InterfaceStateLinkUp, v1.InterfaceStateLinkUp),
+		Entry("From up to down", v1.InterfaceStateLinkUp, v1.InterfaceStateLinkDown),
+		Entry("From down to empty", v1.InterfaceStateLinkDown, v1.InterfaceState("")),
+		Entry("From down to absent", v1.InterfaceStateLinkDown, v1.InterfaceStateAbsent),
+		Entry("From down to up", v1.InterfaceStateLinkDown, v1.InterfaceStateLinkUp),
+		Entry("From down to down", v1.InterfaceStateLinkDown, v1.InterfaceStateLinkDown),
+	)
+
+	It("should not require restart when secondary NICs are hotplugged", func() {
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+
+		ifacesToHotplug := []v1.Interface{
+			libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1),
+			libvmi.InterfaceDeviceWithSRIOVBinding(secondaryNetName2),
+		}
+
+		netsToHotplug := []v1.Network{
+			*libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1),
+			*libvmi.MultusNetwork(secondaryNetName2, secondaryNADName2),
+		}
+
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces = append(
+			vm.Spec.Template.Spec.Domain.Devices.Interfaces,
+			ifacesToHotplug...,
+		)
+
+		vm.Spec.Template.Spec.Networks = append(vm.Spec.Template.Spec.Networks, netsToHotplug...)
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	})
+
+	It("should not require restart when interfaces or networks order is changed", func() {
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName2)),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName2, secondaryNADName2)),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+
+		slices.Reverse(vm.Spec.Template.Spec.Domain.Devices.Interfaces)
+		slices.Reverse(vm.Spec.Template.Spec.Networks)
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	})
+
+	It("should require restart when interface binding changes", func() {
+		iface := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)
+
+		vmi := libvmi.New(
+			libvmi.WithInterface(iface),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces[0] = libvmi.InterfaceDeviceWithMasqueradeBinding()
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
+	})
+
+	DescribeTable("should require restart when network source changes", func(current, desired v1.Network) {
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(&current),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+		vm.Spec.Template.Spec.Networks[0] = desired
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
+	},
+		Entry("From Pod to Multus", *v1.DefaultPodNetwork(), *libvmi.MultusNetwork("default", secondaryNADName1)),
+		Entry("From Multus to Pod", *libvmi.MultusNetwork("default", secondaryNADName1), *v1.DefaultPodNetwork()),
+	)
+
+	It("should require restart when NAD name changes", func() {
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+		vm.Spec.Template.Spec.Networks[0] = *libvmi.MultusNetwork(secondaryNetName1, secondaryNADName2)
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
+	})
+
+	It("Should require restart when interfaces and networks are removed", func() {
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces = vm.Spec.Template.Spec.Domain.Devices.Interfaces[:1]
+		vm.Spec.Template.Spec.Networks = vm.Spec.Template.Spec.Networks[:1]
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
+	})
+})

--- a/pkg/network/vmliveupdate/vmliveupdate_suite_test.go
+++ b/pkg/network/vmliveupdate/vmliveupdate_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vmliveupdate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVMLiveUpdate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VMLiveUpdate Suite")
+}

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/liveupdate/memory:go_default_library",
         "//pkg/network/admitter:go_default_library",
         "//pkg/network/vmispec:go_default_library",
+        "//pkg/network/vmliveupdate:go_default_library",
         "//pkg/storage/memorydump:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 
 	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
-	"kubevirt.io/kubevirt/pkg/network/vmispec"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/common"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 
@@ -1216,7 +1216,7 @@ func (c *Controller) startVMI(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine
 
 	autoAttachInputDevice(vmi)
 
-	err = vmispec.SetDefaultNetworkInterface(c.clusterConfig, &vmi.Spec)
+	err = netvmispec.SetDefaultNetworkInterface(c.clusterConfig, &vmi.Spec)
 	if err != nil {
 		return vm, err
 	}

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -36,6 +36,7 @@ import (
 
 	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
+	netvmliveupdate "kubevirt.io/kubevirt/pkg/network/vmliveupdate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/common"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 
@@ -2934,6 +2935,11 @@ func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMa
 			lastSeenVM.Spec.Template.Spec.Volumes = currentVM.Spec.Template.Spec.Volumes
 			lastSeenVM.Spec.Template.Spec.Domain.Devices.Disks = currentVM.Spec.Template.Spec.Domain.Devices.Disks
 		}
+	}
+
+	if !netvmliveupdate.IsRestartRequired(currentVM, vmi) {
+		lastSeenVM.Spec.Template.Spec.Domain.Devices.Interfaces = currentVM.Spec.Template.Spec.Domain.Devices.Interfaces
+		lastSeenVM.Spec.Template.Spec.Networks = currentVM.Spec.Template.Spec.Networks
 	}
 
 	if !equality.Semantic.DeepEqual(lastSeenVM.Spec.Template.Spec, currentVM.Spec.Template.Spec) {

--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -122,6 +122,11 @@ var _ = Describe(SIG("interface state up/down", func() {
 
 		Expect(patchToggleVMInterfacesStates(vm)).To(Succeed())
 
+		Consistently(matcher.ThisVM(vm)).
+			WithTimeout(15 * time.Second).
+			WithPolling(1 * time.Second).
+			Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+
 		expectedIfaceStatuses = []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: primaryLogicalNetName, LinkState: string(v1.InterfaceStateLinkDown)},
 			{Name: secondary2LogicalNetName, LinkState: string(v1.InterfaceStateLinkUp)},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the "RestartRequired" condition is added to the VirtualMachine object for every change made to network-related fields.
This is true for both `LiveUpdate` and `Staging` rollout strategies.

Users of the NIC hotplug / hotunplug and link state management features are required to restart their VMs in order for the "RestartRequired" condition to be removed.

Allow the following changes to network-related fields:
- Addition of interfaces and networks (hotplug).
- Changing the interface's state (hotunplug and link state management).

All other changes that are not explicitly mentioned - require restarting the VM in order for them to be applied.

The newly added logic does not depend on the rollout strategy, due to the following reasons:
 - NIC hotplug and hotunplug can be performed in-place.
 - Link state management is performed in-place.

Note: There is a webhook in-place that verifies that interfaces and networks match.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/enhancements/pull/8

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The "RestartRequired" condition is not set on VM objects for live-updatable network fields
```

