### PR TITLE
Tools: fix unit-test and ensure execution

### DIFF
--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -4,8 +4,7 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tests/framework/..."}
-
+WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tools/util/... //tools/cache/... //tests/framework/..."}
 rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 
 if [ "${CI}" == "true" ]; then

--- a/tools/util/marshaller_test.go
+++ b/tools/util/marshaller_test.go
@@ -29,11 +29,7 @@ import (
 
 func TestMarshallObject(t *testing.T) {
 	var imagePullSecret []v1.LocalObjectReference
-	handler, err := components.NewHandlerDaemonSet("{{.Namespace}}", "", "{{.DockerPrefix}}", "{{.DockerTag}}", "", "", "", "", "", "", "", "", v1.PullIfNotPresent, imagePullSecret, nil, "2", nil, false)
-	if err != nil {
-		t.Fatalf("error generating virt-handler deployment for marshall test %v", err)
-	}
-
+	handler := components.NewHandlerDaemonSet("{{.Namespace}}", "", "{{.DockerPrefix}}", "{{.DockerTag}}", "", "", "", "", "", "", "", "", "", "", v1.PullIfNotPresent, imagePullSecret, nil, "2", nil, false)
 	writer := strings.Builder{}
 
 	MarshallObject(handler, &writer)


### PR DESCRIPTION
### What this PR does

Before this PR:
- The `marshaller_test.go` test file failed to compile due to missing parameters in the `NewHandlerDaemonSet` function call.
- Tests under the `tools` directory were not included in the Bazel test runs.

After this PR:
- Fixed the compilation error in `marshaller_test.go` by providing all required arguments to `NewHandlerDaemonSet`.
- Updated the Bazel test script to include the `tools` directory, ensuring coverage of all testable components.

Fixes #12790

### Release note
```release-note
None
