### PR TITLE
[release-1.5] node-labeller: enable node-labeller for ARM64 clusters

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -311,8 +310,7 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	// Node labelling is only relevant on x86_64 and s390x arches.
-	if virtconfig.IsAMD64(runtime.GOARCH) || virtconfig.IsS390X(runtime.GOARCH) {
+	if nodeLabellerController.ShouldLabelNodes() {
 		hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
 
 		go nodeLabellerController.Run(10, stop)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -310,11 +310,9 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	if nodeLabellerController.ShouldLabelNodes() {
-		hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
+	hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
 
-		go nodeLabellerController.Run(10, stop)
-	}
+	go nodeLabellerController.Run(10, stop)
 
 	migrationIpAddress := app.PodIpAddress
 	migrationIpAddress, err = virthandler.FindMigrationIP(migrationIpAddress)

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -3,12 +3,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "amd64.go",
+        "arch_labeller.go",
+        "arm64.go",
         "cpu_plugin.go",
         "kvm-caps-info-plugin_amd64.go",
         "kvm-caps-info-plugin_arm64.go",
         "kvm-caps-info-plugin_s390x.go",
         "model.go",
         "node_labeller.go",
+        "s390x.go",
     ],
     cgo = True,
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller",
@@ -34,21 +38,23 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "arch_labeller_test.go",
         "cpu_plugin_test.go",
         "node_labeller_suite_test.go",
         "node_labeller_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = select({
+    deps = [
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "//pkg/testutils:go_default_library",
             "//pkg/virt-handler/node-labeller/util:go_default_library",
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",
             "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-            "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
-            "//vendor/github.com/onsi/gomega:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -63,8 +69,6 @@ go_test(
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",
             "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-            "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
-            "//vendor/github.com/onsi/gomega:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/virt-handler/node-labeller/amd64.go
+++ b/pkg/virt-handler/node-labeller/amd64.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&archLabellerAMD64{})
+
+type archLabellerAMD64 struct {
+	defaultArchLabeller
+}
+
+func (archLabellerAMD64) shouldLabelNodes() bool {
+	return true
+}
+
+func (archLabellerAMD64) hasHostSupportedFeatures() bool {
+	return true
+}
+
+func (archLabellerAMD64) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerAMD64) arch() string {
+	return amd64
+}

--- a/pkg/virt-handler/node-labeller/amd64.go
+++ b/pkg/virt-handler/node-labeller/amd64.go
@@ -26,15 +26,15 @@ type archLabellerAMD64 struct {
 	defaultArchLabeller
 }
 
-func (archLabellerAMD64) shouldLabelNodes() bool {
-	return true
-}
-
 func (archLabellerAMD64) hasHostSupportedFeatures() bool {
 	return true
 }
 
 func (archLabellerAMD64) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerAMD64) supportsNamedModels() bool {
 	return true
 }
 

--- a/pkg/virt-handler/node-labeller/arch_labeller.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller.go
@@ -35,11 +35,11 @@ const (
 var _ = archLabeller(&defaultArchLabeller{})
 
 type archLabeller interface {
-	shouldLabelNodes() bool
 	defaultVendor() string
 	requirePolicy(policy string) bool
 	hasHostSupportedFeatures() bool
 	supportsHostModel() bool
+	supportsNamedModels() bool
 	arch() string
 }
 
@@ -58,10 +58,6 @@ func newArchLabeller(arch string) archLabeller {
 
 type defaultArchLabeller struct{}
 
-func (defaultArchLabeller) shouldLabelNodes() bool {
-	return false
-}
-
 func (defaultArchLabeller) defaultVendor() string {
 	return ""
 }
@@ -75,6 +71,10 @@ func (defaultArchLabeller) hasHostSupportedFeatures() bool {
 }
 
 func (defaultArchLabeller) supportsHostModel() bool {
+	return false
+}
+
+func (defaultArchLabeller) supportsNamedModels() bool {
 	return false
 }
 

--- a/pkg/virt-handler/node-labeller/arch_labeller.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller.go
@@ -1,0 +1,83 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+import (
+	"runtime"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
+)
+
+const (
+	amd64 = "amd64"
+	arm64 = "arm64"
+	s390x = "s390x"
+)
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&defaultArchLabeller{})
+
+type archLabeller interface {
+	shouldLabelNodes() bool
+	defaultVendor() string
+	requirePolicy(policy string) bool
+	hasHostSupportedFeatures() bool
+	supportsHostModel() bool
+	arch() string
+}
+
+func newArchLabeller(arch string) archLabeller {
+	switch arch {
+	case amd64:
+		return archLabellerAMD64{}
+	case arm64:
+		return archLabellerARM64{}
+	case s390x:
+		return archLabellerS390X{}
+	default:
+		return defaultArchLabeller{}
+	}
+}
+
+type defaultArchLabeller struct{}
+
+func (defaultArchLabeller) shouldLabelNodes() bool {
+	return false
+}
+
+func (defaultArchLabeller) defaultVendor() string {
+	return ""
+}
+
+func (defaultArchLabeller) requirePolicy(policy string) bool {
+	return policy == util.RequirePolicy
+}
+
+func (defaultArchLabeller) hasHostSupportedFeatures() bool {
+	return false
+}
+
+func (defaultArchLabeller) supportsHostModel() bool {
+	return false
+}
+
+func (defaultArchLabeller) arch() string {
+	return runtime.GOARCH
+}

--- a/pkg/virt-handler/node-labeller/arch_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller_test.go
@@ -1,0 +1,42 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+import (
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Arch Node Labeller", func() {
+
+	DescribeTable("Should create a new archLabeller for the correct architecture", func(arch string, result archLabeller) {
+		ac := newArchLabeller(arch)
+
+		Expect(ac).To(Equal(result))
+		if arch == "unknown" {
+			arch = runtime.GOARCH
+		}
+		Expect(ac.arch()).To(Equal(arch))
+	},
+		Entry(amd64, amd64, archLabellerAMD64{}),
+		Entry(arm64, arm64, archLabellerARM64{}),
+		Entry(s390x, s390x, archLabellerS390X{}),
+		Entry("unknown", "unknown", defaultArchLabeller{}),
+	)
+})

--- a/pkg/virt-handler/node-labeller/arm64.go
+++ b/pkg/virt-handler/node-labeller/arm64.go
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&archLabellerARM64{})
+
+type archLabellerARM64 struct {
+	defaultArchLabeller
+}
+
+func (archLabellerARM64) arch() string {
+	return arm64
+}

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Node-labeller config", func() {
 			domCapabilitiesFileName: "virsh_domcapabilities.xml",
 			cpuCounter:              nil,
 			hostCPUModel:            hostCPUModel{requiredFeatures: make(map[string]bool, 0)},
-			arch:                    runtime.GOARCH,
+			arch:                    newArchLabeller(runtime.GOARCH),
 		}
 	})
 
@@ -99,7 +99,7 @@ var _ = Describe("Node-labeller config", func() {
 	})
 
 	It("Should return the cpu features on s390x even without policy='require' property", func() {
-		nlController.arch = "s390x"
+		nlController.arch = newArchLabeller(s390x)
 		nlController.volumePath = "testdata/s390x"
 
 		err := nlController.loadHostSupportedFeatures()
@@ -110,7 +110,7 @@ var _ = Describe("Node-labeller config", func() {
 		Expect(cpuFeatures).To(HaveLen(89), "number of features doesn't match")
 	})
 	It("Should return the cpu features on amd64 only with policy='require' property", func() {
-		nlController.arch = "amd64"
+		nlController.arch = newArchLabeller(amd64)
 		nlController.volumePath = "testdata/s390x"
 
 		err := nlController.loadHostSupportedFeatures()
@@ -122,7 +122,7 @@ var _ = Describe("Node-labeller config", func() {
 	})
 
 	It("Should default to IBM as CPU Vendor on s390x if none is given", func() {
-		nlController.arch = "s390x"
+		nlController.arch = newArchLabeller(s390x)
 		nlController.volumePath = "testdata/s390x"
 
 		err := nlController.loadDomCapabilities()

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -180,11 +180,6 @@ func (n *NodeLabeller) loadAll() error {
 }
 
 func (n *NodeLabeller) run() error {
-	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
-	cpuModels := n.getSupportedCpuModels(obsoleteCPUsx86)
-	cpuFeatures := n.getSupportedCpuFeatures()
-	hostCPUModel := n.GetHostCpuModel()
-
 	originalNode, err := n.nodeClient.Get(context.Background(), n.host, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -194,7 +189,7 @@ func (n *NodeLabeller) run() error {
 
 	if !skipNodeLabelling(node) {
 		//prepare new labels
-		newLabels := n.prepareLabels(node, cpuModels, cpuFeatures, hostCPUModel, obsoleteCPUsx86)
+		newLabels := n.prepareLabels(node)
 		//remove old labeller labels
 		n.removeLabellerLabels(node)
 		//add new labels
@@ -235,27 +230,27 @@ func (n *NodeLabeller) loadHypervFeatures() {
 
 // prepareLabels converts cpu models, features, hyperv features to map[string]string format
 // e.g. "cpu-feature.node.kubevirt.io/Penryn": "true"
-func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatures cpuFeatures, hostCpuModel hostCPUModel, obsoleteCPUsx86 map[string]bool) map[string]string {
+func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
+	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
+	hostCpuModel := n.GetHostCpuModel()
 	newLabels := make(map[string]string)
-	for key := range cpuFeatures {
-		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
+
+	if n.arch.hasHostSupportedFeatures() {
+		for key := range n.getSupportedCpuFeatures() {
+			newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
+		}
 	}
 
-	for _, value := range cpuModels {
-		newLabels[kubevirtv1.CPUModelLabel+value] = "true"
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+	if n.arch.supportsNamedModels() {
+		for _, value := range n.getSupportedCpuModels(obsoleteCPUsx86) {
+			newLabels[kubevirtv1.CPUModelLabel+value] = "true"
+			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+		}
 	}
 
-	// Add labels for supported machine types
-	machines := n.getSupportedMachines()
-
-	for _, machine := range machines {
+	for _, machine := range n.getSupportedMachines() {
 		labelKey := kubevirtv1.SupportedMachineTypeLabel + machine.Name
 		newLabels[labelKey] = "true"
-	}
-
-	if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
 	}
 
 	for _, key := range n.hypervFeatures.items {
@@ -267,19 +262,24 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatu
 		newLabels[kubevirtv1.CPUTimerLabel+"tsc-scalable"] = fmt.Sprintf("%t", n.cpuCounter.Scaling == "yes")
 	}
 
-	for feature := range hostCpuModel.requiredFeatures {
-		newLabels[kubevirtv1.HostModelRequiredFeaturesLabel+feature] = "true"
-	}
-	if _, obsolete := obsoleteCPUsx86[hostCpuModel.Name]; obsolete {
-		newLabels[kubevirtv1.NodeHostModelIsObsoleteLabel] = "true"
-		err := n.alertIfHostModelIsObsolete(node, hostCpuModel.Name, obsoleteCPUsx86)
-		if err != nil {
-			n.logger.Reason(err).Error(err.Error())
+	if n.arch.supportsHostModel() {
+		if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
+			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
+		} else {
+			newLabels[kubevirtv1.NodeHostModelIsObsoleteLabel] = "true"
+			err := n.alertIfHostModelIsObsolete(node, hostCpuModel.Name, obsoleteCPUsx86)
+			if err != nil {
+				n.logger.Reason(err).Error(err.Error())
+			}
 		}
-	}
 
-	newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
-	newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
+		for feature := range hostCpuModel.requiredFeatures {
+			newLabels[kubevirtv1.HostModelRequiredFeaturesLabel+feature] = "true"
+		}
+
+		newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
+		newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
+	}
 
 	capable, err := isNodeRealtimeCapable()
 	if err != nil {

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -359,7 +359,3 @@ func (n *NodeLabeller) getSupportedMachines() []libvirtxml.CapsGuestMachine {
 	}
 	return supportedMachines
 }
-
-func (n *NodeLabeller) ShouldLabelNodes() bool {
-	return n.arch.shouldLabelNodes()
-}

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -290,16 +290,6 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
-
-	DescribeTable("should only label arches that support it", func(arch string, shouldLabel bool) {
-		nlController.arch = newArchLabeller(arch)
-		Expect(nlController.ShouldLabelNodes()).To(Equal(shouldLabel))
-	},
-		Entry(amd64, amd64, true),
-		Entry(arm64, arm64, false),
-		Entry(s390x, s390x, true),
-		Entry("unknown", "unknown", false),
-	)
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -290,6 +290,33 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
+
+	DescribeTable("should add machine type labels", func(machines []libvirtxml.CapsGuestMachine, arch string) {
+		guestsCaps[0].Arch.Machines = machines
+
+		initNodeLabeller(&v1.KubeVirt{})
+		nlController.arch = newArchLabeller(arch)
+		mockQueue := testutils.NewMockWorkQueue(nlController.queue)
+		nlController.queue = mockQueue
+
+		mockQueue.ExpectAdds(1)
+		nlController.queue.Add(nodeName)
+		mockQueue.Wait()
+
+		res := nlController.execute()
+		Expect(res).To(BeTrue(), "labeller should complete successfully")
+
+		node := retrieveNode(kubeClient)
+
+		for _, machine := range machines {
+			expectedLabelKey := v1.SupportedMachineTypeLabel + machine.Name
+			Expect(node.Labels).To(HaveKey(expectedLabelKey), "expected machine type label %s to be present", expectedLabelKey)
+		}
+	},
+		Entry("for amd64", []libvirtxml.CapsGuestMachine{{Name: "q35"}, {Name: "q35-rhel9.6.0"}}, amd64),
+		Entry("for arm64", []libvirtxml.CapsGuestMachine{{Name: "virt"}, {Name: "virt-rhel9.6.0"}}, arm64),
+	)
+
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -290,6 +290,16 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
+
+	DescribeTable("should only label arches that support it", func(arch string, shouldLabel bool) {
+		nlController.arch = newArchLabeller(arch)
+		Expect(nlController.ShouldLabelNodes()).To(Equal(shouldLabel))
+	},
+		Entry(amd64, amd64, true),
+		Entry(arm64, arm64, false),
+		Entry(s390x, s390x, true),
+		Entry("unknown", "unknown", false),
+	)
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/s390x.go
+++ b/pkg/virt-handler/node-labeller/s390x.go
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package nodelabeller
+
+import "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
+
+// Ensure that there is a compile error should the struct not implement the archLabeller interface anymore.
+var _ = archLabeller(&archLabellerS390X{})
+
+type archLabellerS390X struct{}
+
+func (archLabellerS390X) shouldLabelNodes() bool {
+	return true
+}
+
+func (archLabellerS390X) defaultVendor() string {
+	// On s390x the xml does not include a CPU Vendor, however there is only one company selling them anyway.
+	return "IBM"
+}
+
+func (archLabellerS390X) requirePolicy(policy string) bool {
+	// On s390x, the policy is not set
+	return policy == util.RequirePolicy || policy == ""
+}
+
+func (archLabellerS390X) hasHostSupportedFeatures() bool {
+	return true
+}
+
+func (archLabellerS390X) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerS390X) arch() string {
+	return s390x
+}

--- a/pkg/virt-handler/node-labeller/s390x.go
+++ b/pkg/virt-handler/node-labeller/s390x.go
@@ -26,10 +26,6 @@ var _ = archLabeller(&archLabellerS390X{})
 
 type archLabellerS390X struct{}
 
-func (archLabellerS390X) shouldLabelNodes() bool {
-	return true
-}
-
 func (archLabellerS390X) defaultVendor() string {
 	// On s390x the xml does not include a CPU Vendor, however there is only one company selling them anyway.
 	return "IBM"
@@ -45,6 +41,10 @@ func (archLabellerS390X) hasHostSupportedFeatures() bool {
 }
 
 func (archLabellerS390X) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerS390X) supportsNamedModels() bool {
 	return true
 }
 


### PR DESCRIPTION
Manual backport of #14520

automatic cherry-pick failed because arch-labeller wasn't introduced yet for release-1.5
to overcome the conflicts i had to cherry pick [this](https://github.com/kubevirt/kubevirt/pull/13973/commits/2acda9cf945189f3afdf91c547b2b82a0efb2e37) commit as well

### Release note
```release-note
Enable node-labeller for ARM64 clusters, supporting machine-type labels.
```

