### PR TITLE
tests/virtctl: use a single VM for three tests

### DIFF
--- a/tests/virtctl/vnc.go
+++ b/tests/virtctl/vnc.go
@@ -46,10 +46,10 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("[sig-compute]VNC", decorators.SigCompute, decorators.WgArm64, func() {
+var _ = Describe(SIG("[sig-compute]VNC", decorators.SigCompute, decorators.WgArm64, Ordered, decorators.OncePerOrderedCleanup, func() {
 	var vmi *v1.VirtualMachineInstance
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		var err error
 		vmi = libvmifact.NewGuestless(libvmi.WithAutoattachGraphicsDevice(true))
 		vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).


### PR DESCRIPTION
There is no need to waste RAM, CPU and runtime to run three VMs just in order to test connection to them.

/kind cleanup

```release-note
NONE
```

