### PR TITLE
Watch VM resource for status change instead of polling in tests/vm_test.go

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -529,10 +529,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			By("Verifying that the status toggles between ErrImagePull and ImagePullBackOff")
 			expectedStates := []v1.VirtualMachinePrintableStatus{
-				// State transitions during 1st image pull attempt
-				v1.VirtualMachineStatusErrImagePull,
-				v1.VirtualMachineStatusImagePullBackOff,
-				// State transitions during 2nd image pull attempt
+				// State transitions a single image pull attempt
 				v1.VirtualMachineStatusErrImagePull,
 				v1.VirtualMachineStatusImagePullBackOff,
 			}

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -519,7 +519,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			),
 		)
 
-		It("[test_id:6869]should report an error status when image pull error occurs", decorators.Conformance, decorators.Quarantine, func() {
+		It("[test_id:6869][QUARANTINE]should report an error status when image pull error occurs", decorators.Conformance, decorators.Quarantine, func() {
 			vmi := libvmi.New(
 				libvmi.WithContainerDisk("disk0", "no-such-image"),
 				libvmi.WithResourceMemory("128Mi"),

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -533,8 +533,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				v1.VirtualMachineStatusErrImagePull,
 				v1.VirtualMachineStatusImagePullBackOff,
 			}
-
-			waitForVMStateTransition(vm, expectedStates, 600*time.Second)
+			// Timeout is set to 360 seconds to allow for 1 max backoff grace period (5 mins), and 2 image pull attempts.
+			waitForVMStateTransition(vm, expectedStates, 360*time.Second)
 		})
 
 		It("[test_id:7679]should report an error status when data volume error occurs", func() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -528,13 +528,13 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			vm := createRunningVM(virtClient, vmi)
 
 			By("Verifying that the status toggles between ErrImagePull and ImagePullBackOff")
-			maxImgPullRetries := 2 // max number of image pull (re)tries
-			expectedStates := []v1.VirtualMachinePrintableStatus{}
-			for range maxImgPullRetries {
-				// each image pull (re)try should take the VM
-				// from status ErrImagePull to ImagePullBackOff
-				expectedStates = append(expectedStates, v1.VirtualMachineStatusErrImagePull)
-				expectedStates = append(expectedStates, v1.VirtualMachineStatusImagePullBackOff)
+			expectedStates := []v1.VirtualMachinePrintableStatus{
+				// State transitions during 1st image pull attempt
+				v1.VirtualMachineStatusErrImagePull,
+				v1.VirtualMachineStatusImagePullBackOff,
+				// State transitions during 2nd image pull attempt
+				v1.VirtualMachineStatusErrImagePull,
+				v1.VirtualMachineStatusImagePullBackOff,
 			}
 
 			waitForVMStateTransition(virtClient, vm, expectedStates, 600*time.Second)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -530,13 +530,15 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			By("Verifying that the status toggles between ErrImagePull and ImagePullBackOff")
 			expectedStates := []v1.VirtualMachinePrintableStatus{
-				// State transitions a single image pull attempt
+				// State transitions two toggles of the VM state b/w ErrImagePull and ImagePullBackOff
+				v1.VirtualMachineStatusErrImagePull,
+				v1.VirtualMachineStatusImagePullBackOff,
 				v1.VirtualMachineStatusErrImagePull,
 				v1.VirtualMachineStatusImagePullBackOff,
 			}
-			// Timeout is set to 330 seconds to allow for
-			// 1 worst-case backoff grace period (5 mins), and 1 image pull attempt (30 secs).
-			waitForVMStateTransition(vm, expectedStates, 360*time.Second)
+			// Timeout is set to 660 seconds to allow for states to toggle twice, i.e.,
+			// 2 worst-case backoff grace periods (5 mins each), and 2 image pull attempts (30 secs each).
+			waitForVMStateTransition(vm, expectedStates, 660*time.Second)
 		})
 
 		It("[test_id:7679]should report an error status when data volume error occurs", func() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -537,7 +537,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				v1.VirtualMachineStatusImagePullBackOff,
 			}
 
-			waitForVMStateTransition(virtClient, vm, expectedStates, 600*time.Second)
+			waitForVMStateTransition(vm, expectedStates, 600*time.Second)
 		})
 
 		It("[test_id:7679]should report an error status when data volume error occurs", func() {
@@ -1273,8 +1273,9 @@ func createRunningVM(virtClient kubecli.KubevirtClient, template *v1.VirtualMach
 	return vm
 }
 
-func waitForVMStateTransition(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, expectedStates []v1.VirtualMachinePrintableStatus, timeoutDuration time.Duration) {
+func waitForVMStateTransition(vm *v1.VirtualMachine, expectedStates []v1.VirtualMachinePrintableStatus, timeoutDuration time.Duration) {
 	// Setting up a watch on the VM resource
+	virtClient := kubevirt.Client()
 	watch, err := virtClient.VirtualMachine(vm.Namespace).Watch(context.Background(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", vm.Name),
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: The test used the `Eventually` construct of Ginkgo to poll the VM status until it was in the desired state. However, the polling period of 1 second was missing the intermediate status of `ErrImagePull` (between two occurrences of the `ImagePullBackOff` status) in the second retry of image pull. This resulted in the `Eventually` assertion failure.

After this PR: The test relies on a Watch on the VM resource, so that no status updates are missed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #14566

### Why we need it and why it was done in this way
The following tradeoffs were made: At the

The following alternatives were considered: One alternative that was considered involved reducing the polling interval to detect VM status changes more quickly. However, this approach does not resolve the underlying race condition and would result in increased resource usage due to more frequent polling.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

