### PR TITLE
feat(clones): support arbitrary patches on vmclones

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19263,6 +19263,15 @@
       "description": "NewSMBiosSerial manually sets that target's SMbios serial. If this field is not specified, a new serial will be generated automatically.",
       "type": "string"
      },
+     "patches": {
+      "description": "Patches holds JSON patches to apply to target. Patches should fit the target's Kind. Example: '{\"op\": \"add\", \"path\": \"/spec/template/metadata/labels/example\", \"value\": \"new-label\"}'",
+      "type": "array",
+      "items": {
+       "type": "string",
+       "default": ""
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "source": {
       "description": "Source is the object that would be cloned. Currently supported source types are: VirtualMachine of kubevirt.io API group, VirtualMachineSnapshot of snapshot.kubevirt.io API group",
       "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"

--- a/pkg/apimachinery/patch/patch.go
+++ b/pkg/apimachinery/patch/patch.go
@@ -127,6 +127,21 @@ func (p *PatchSet) IsEmpty() bool {
 	return len(p.patches) < 1
 }
 
+func (p *PatchSet) ToSlice() ([]string, error) {
+	var result []string
+
+	for _, operation := range p.patches {
+		patch, err := operation.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, string(patch))
+	}
+
+	return result, nil
+}
+
 func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
 	if len(patches) == 0 {
 		return nil, fmt.Errorf("list of patches is empty")

--- a/pkg/apimachinery/patch/patch_test.go
+++ b/pkg/apimachinery/patch/patch_test.go
@@ -71,6 +71,25 @@ var _ = Describe("PatchSet", func() {
 		)))
 	})
 
+	It("should convert to a slice of strings", func() {
+		patch := patch.New(patch.WithRemove("/abcd"),
+			patch.WithAdd("/abcd", "test"),
+			patch.WithReplace("/abcd", "test"),
+			patch.WithTest("/abcd", "test"))
+
+		slice, err := patch.ToSlice()
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedSlice := []string{
+			`{"op":"remove","path":"/abcd"}`,
+			`{"op":"add","path":"/abcd","value":"test"}`,
+			`{"op":"replace","path":"/abcd","value":"test"}`,
+			`{"op":"test","path":"/abcd","value":"test"}`,
+		}
+
+		Expect(slice).To(Equal(expectedSlice))
+	})
+
 	It("should generate an empty set of patches", func() {
 		patches := patch.New()
 		Expect(patches.IsEmpty()).To(BeTrue())

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -108,6 +108,10 @@ func (admitter *VirtualMachineCloneAdmitter) Admit(ctx context.Context, ar *admi
 		causes = append(causes, newCauses...)
 	}
 
+	if newCauses := validatePatches(vmClone); newCauses != nil {
+		causes = append(causes, newCauses...)
+	}
+
 	if len(causes) > 0 {
 		return webhookutils.ToAdmissionResponse(causes)
 	}
@@ -254,6 +258,22 @@ func validateNewMacAddresses(vmClone *clone.VirtualMachineClone) []metav1.Status
 					Field:   k8sfield.NewPath("spec").Child("newMacAddresses").Child(ifaceName).String(),
 				})
 			}
+		}
+	}
+
+	return causes
+}
+
+func validatePatches(vmClone *clone.VirtualMachineClone) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+
+	for i, patch := range vmClone.Spec.Patches {
+		if !json.Valid([]byte(patch)) {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("patch is not valid JSON (%s)", patch),
+				Field:   k8sfield.NewPath("spec").Child("patches").Index(i).String(),
+			})
 		}
 	}
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,6 +44,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -419,10 +419,10 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 	Context("Custom patches", func() {
 		It("Should accept valid JSON patches", func() {
 			validPatch := patch.New(patch.WithReplace("/spec/template/spec/domain/devices/interfaces/0/macAddress", "DE-AD-00-FF-FF-FF"))
-			p, err := validPatch.GeneratePayload()
-			Expect(err).NotTo(HaveOccurred())
 
-			vmClone.Spec.Patches = []string{string(p)}
+			var err error
+			vmClone.Spec.Patches, err = validPatch.ToSlice()
+			Expect(err).NotTo(HaveOccurred())
 
 			admitter.admitAndExpect(vmClone, true)
 		})

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -1030,11 +1030,9 @@ var _ = Describe("Clone", func() {
 				patch.WithRemove("/spec/template/metadata/labels/label-to-remove"),
 			)
 
-			for _, operation := range patchSet.GetPatches() {
-				json, err := operation.MarshalJSON()
-				Expect(err).NotTo(HaveOccurred())
-				vmClone.Spec.Patches = append(vmClone.Spec.Patches, string(json))
-			}
+			var err error
+			vmClone.Spec.Patches, err = patchSet.ToSlice()
+			Expect(err).NotTo(HaveOccurred())
 
 			// Extra label we want to remove from the spec labels
 			sourceVM.Spec.Template.ObjectMeta.Labels = make(map[string]string)
@@ -1086,11 +1084,9 @@ var _ = Describe("Clone", func() {
 				patch.WithReplace("/spec/template/spec/domain/devices/interfaces/0/macAddress", "DE-AD-00-FF-FF-FF"),
 			)
 
-			for _, operation := range patchSet.GetPatches() {
-				json, err := operation.MarshalJSON()
-				Expect(err).NotTo(HaveOccurred())
-				vmClone.Spec.Patches = append(vmClone.Spec.Patches, string(json))
-			}
+			var err error
+			vmClone.Spec.Patches, err = patchSet.ToSlice()
+			Expect(err).NotTo(HaveOccurred())
 
 			addVM(sourceVM)
 			addClone(vmClone)

--- a/pkg/virt-controller/watch/clone/vm-target.go
+++ b/pkg/virt-controller/watch/clone/vm-target.go
@@ -48,6 +48,8 @@ func generatePatches(source *k6tv1.VirtualMachine, cloneSpec *clone.VirtualMachi
 		return nil, err
 	}
 
+	patches = append(patches, cloneSpec.Patches...)
+
 	log.Log.V(defaultVerbosityLevel).Object(source).Infof("patches generated for vm %s clone: %v", source.Name, patches)
 	return patches, nil
 }
@@ -61,6 +63,7 @@ func generateStringPatchOperations(set *patch.PatchSet) ([]string, error) {
 		}
 		patches = append(patches, string(payloadBytes))
 	}
+
 	return patches, nil
 }
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8671,6 +8671,14 @@ var CRDsValidation map[string]string = map[string]string{
             NewSMBiosSerial manually sets that target's SMbios serial. If this field is not specified, a new serial will
             be generated automatically.
           type: string
+        patches:
+          description: |-
+            Patches holds JSON patches to apply to target. Patches should fit the target's Kind.
+            Example: '{"op": "add", "path": "/spec/template/metadata/labels/example", "value": "new-label"}'
+          items:
+            type: string
+          type: array
+          x-kubernetes-list-type: atomic
         source:
           description: |-
             Source is the object that would be cloned. Currently supported source types are:

--- a/staging/src/kubevirt.io/api/clone/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/deepcopy_generated.go
@@ -141,6 +141,11 @@ func (in *VirtualMachineCloneSpec) DeepCopyInto(out *VirtualMachineCloneSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Patches != nil {
+		in, out := &in.Patches, &out.Patches
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/clone/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/types.go
@@ -88,6 +88,11 @@ type VirtualMachineCloneSpec struct {
 	// be generated automatically.
 	// +optional
 	NewSMBiosSerial *string `json:"newSMBiosSerial,omitempty"`
+	// Patches holds JSON patches to apply to target. Patches should fit the target's Kind.
+	// Example: '{"op": "add", "path": "/spec/template/metadata/labels/example", "value": "new-label"}'
+	// +optional
+	// +listType=atomic
+	Patches []string `json:"patches,omitempty"`
 }
 
 type VirtualMachineClonePhase string

--- a/staging/src/kubevirt.io/api/clone/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/types_swagger_generated.go
@@ -24,6 +24,7 @@ func (VirtualMachineCloneSpec) SwaggerDoc() map[string]string {
 		"template":          "For a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.\n+optional",
 		"newMacAddresses":   "NewMacAddresses manually sets that target interfaces' mac addresses. The key is the interface name and the\nvalue is the new mac address. If this field is not specified, a new MAC address will\nbe generated automatically, as for any interface that is not included in this map.\n+optional",
 		"newSMBiosSerial":   "NewSMBiosSerial manually sets that target's SMbios serial. If this field is not specified, a new serial will\nbe generated automatically.\n+optional",
+		"patches":           "Patches holds JSON patches to apply to target. Patches should fit the target's Kind.\nExample: '{\"op\": \"add\", \"path\": \"/spec/template/metadata/labels/example\", \"value\": \"new-label\"}'\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17373,6 +17373,26 @@ func schema_kubevirtio_api_clone_v1beta1_VirtualMachineCloneSpec(ref common.Refe
 							Format:      "",
 						},
 					},
+					"patches": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Patches holds JSON patches to apply to target. Patches should fit the target's Kind. Example: '{\"op\": \"add\", \"path\": \"/spec/template/metadata/labels/example\", \"value\": \"new-label\"}'",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"source"},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
VMs that have been cloned using VirtualMachineClones couldn't be modified beyond removing/adding labels/annotations. 

After this PR:
It is possible to clone VMs with arbitrary modifications (adding labels/annotations, modifying/adding/deleting values in the specs).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #14588

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for custom JSON patches in VirtualMachineClones.

A new property `patches` was added to the VirtualMachineClones CRD.
```

