### PR TITLE
tests: collect stderr from clientcmd.RunCommand()

### DIFF
--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -130,9 +130,9 @@ func TemporaryNodeDrain(nodeName string) {
 	// we can't really expect an error during node drain because vms with eviction strategy can be migrated by the
 	// time that we call it.
 	vmiSelector := v1.AppLabel + "=virt-launcher"
-	_, _, err := clientcmd.RunCommand("", "kubectl", "drain", nodeName, "--delete-emptydir-data", "--pod-selector", vmiSelector,
+	_, stderr, err := clientcmd.RunCommand("", "kubectl", "drain", nodeName, "--delete-emptydir-data", "--pod-selector", vmiSelector,
 		"--ignore-daemonsets=true", "--force", "--timeout=180s")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), stderr)
 }
 
 type mapType string

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -741,12 +741,12 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 			if updateOperator {
 				By("Deleting testing manifests")
-				_, _, err = clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "delete", "-f", flags.TestingManifestPath)
-				Expect(err).ToNot(HaveOccurred(), "failed to delete testing manifests")
+				_, stderr, err := clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "delete", "-f", flags.TestingManifestPath)
+				Expect(err).ToNot(HaveOccurred(), "failed to delete testing manifests: "+stderr)
 
 				By("Deleting virt-operator installation")
-				_, _, err = clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "delete", "-f", flags.OperatorManifestPath)
-				Expect(err).ToNot(HaveOccurred(), "failed to delete virt-operator installation")
+				_, stderr, err = clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "delete", "-f", flags.OperatorManifestPath)
+				Expect(err).ToNot(HaveOccurred(), "failed to delete virt-operator installation: "+stderr)
 
 				By("Installing previous release of virt-operator")
 				manifestURL := getUpstreamReleaseAssetURL(previousImageTag, "kubevirt-operator.yaml")
@@ -839,9 +839,8 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				installOperator(flags.OperatorManifestPath)
 
 				By("Re-installing testing manifests")
-				_, _, err = clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "apply", "-f", flags.TestingManifestPath)
-				Expect(err).ToNot(HaveOccurred(), "failed to re-install the testing manifests")
-
+				_, stderr, err := clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "apply", "-f", flags.TestingManifestPath)
+				Expect(err).ToNot(HaveOccurred(), "failed to re-install the testing manifests: "+stderr)
 			} else {
 				By("Updating KubeVirt object With current tag")
 				patches := patch.New(
@@ -946,8 +945,8 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 				By(fmt.Sprintf("Ensure vm %s can be restored from vmsnapshots", vmYaml.vmName))
 				for _, snapshot := range vmYaml.vmSnapshots {
-					_, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "create", "-f", snapshot.restoreYamlFile, "--cache-dir", newClientCacheDir)
-					Expect(err).ToNot(HaveOccurred())
+					_, stderr, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "create", "-f", snapshot.restoreYamlFile, "--cache-dir", newClientCacheDir)
+					Expect(err).ToNot(HaveOccurred(), stderr)
 					Eventually(func() bool {
 						r, err := virtClient.VirtualMachineRestore(testsuite.GetTestNamespace(nil)).Get(context.Background(), snapshot.restoreName, metav1.GetOptions{})
 						if err != nil {
@@ -958,8 +957,8 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				}
 
 				By(fmt.Sprintf("Deleting VM with %s api", vmYaml.apiVersion))
-				_, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "delete", "-f", vmYaml.yamlFile, "--cache-dir", newClientCacheDir)
-				Expect(err).ToNot(HaveOccurred())
+				_, stderr, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "delete", "-f", vmYaml.yamlFile, "--cache-dir", newClientCacheDir)
+				Expect(err).ToNot(HaveOccurred(), stderr)
 
 				By("Waiting for VM to be removed")
 				Eventually(func() error {
@@ -2638,8 +2637,8 @@ func parseImage(image string) (registry, imageName, version string) {
 
 func installOperator(manifestPath string) {
 	// namespace is already hardcoded within the manifests
-	_, _, err := clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "apply", "-f", manifestPath)
-	Expect(err).ToNot(HaveOccurred())
+	_, stderr, err := clientcmd.RunCommand(metav1.NamespaceNone, "kubectl", "apply", "-f", manifestPath)
+	Expect(err).ToNot(HaveOccurred(), stderr)
 
 	By("Waiting for KubeVirt CRD to be created")
 	ext, err := extclient.NewForConfig(kubevirt.Client().Config())


### PR DESCRIPTION
When clientcmd.RunCommand() fails, report its stderr. This may help debugging the failure.

/kind cleanup

```release-note
NONE
```

