### PR TITLE
[Bugfix] Memory hotplug is effectively broken - memory not exposed to guest

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1150,6 +1150,7 @@ func setupDomainMemory(vmi *v1.VirtualMachineInstance, domain *api.Domain) error
 	}
 
 	domain.Spec.Memory = currentMemory
+	domain.Spec.CurrentMemory = &currentMemory
 
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3163,6 +3163,10 @@ var _ = Describe("Converter", func() {
 				Expect(domain.Spec.Memory).ToNot(BeNil())
 				Expect(domain.Spec.Memory.Unit).To(Equal("b"))
 				Expect(domain.Spec.Memory.Value).To(Equal(uint64(guestMemory.Value())))
+
+				Expect(domain.Spec.CurrentMemory).ToNot(BeNil())
+				Expect(domain.Spec.CurrentMemory.Unit).To(Equal("b"))
+				Expect(domain.Spec.CurrentMemory.Value).To(Equal(uint64(guestMemory.Value())))
 			})
 		})
 	})

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -3,6 +3,7 @@ package hotplug
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,6 +19,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
@@ -395,6 +397,42 @@ var _ = Describe("[sig-compute]Memory Hotplug", decorators.SigCompute, decorator
 			libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)
 		})
 
+		It("should ensure the guest is exposed to the added memory", func() {
+			By("Creating a VM")
+			guest := resource.MustParse("1Gi")
+			newSockets := uint32(2)
+			vm, vmi := createHotplugVM(pointer.P(uint32(1)), newSockets)
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
+
+			originalGuestMemory := getGuestMemory(vmi)
+			Expect(originalGuestMemory.IsZero()).To(BeFalse(), "original guest memory is zero")
+
+			By("Hotplug Memory")
+			newGuestMemory := resource.MustParse("1042Mi")
+			patchData, err := patch.New(
+				patch.WithTest("/spec/template/spec/domain/memory/guest", guest.String()),
+				patch.WithReplace("/spec/template/spec/domain/memory/guest", newGuestMemory.String()),
+			).GeneratePayload()
+			Expect(err).NotTo(HaveOccurred())
+			_, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchData, k8smetav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking that Memory hotplug was successful")
+			Eventually(func() int64 {
+				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, k8smetav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return vmi.Status.Memory.GuestCurrent.Value()
+			}, 360*time.Second, time.Second).Should(BeNumerically(">", guest.Value()))
+
+			Eventually(func() error {
+				guestMemoryAfterHotplug := getGuestMemory(vmi)
+				if originalGuestMemory.Cmp(*guestMemoryAfterHotplug) != -1 {
+					return fmt.Errorf("guest memory after hotplug %s should be greater than original guest memory %s", guestMemoryAfterHotplug.String(), originalGuestMemory.String())
+				}
+				return nil
+			}).WithPolling(2 * time.Second).WithTimeout(30 * time.Second).Should(Succeed())
+		})
+
 	})
 })
 
@@ -413,4 +451,14 @@ func getVMIMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 		return false
 	}, 30*time.Second, time.Second).Should(BeTrue(), "A migration should be created")
 	return migration
+}
+
+// The VMI is assumed to be already logged-in.
+func getGuestMemory(vmi *v1.VirtualMachineInstance) *resource.Quantity {
+	res, err := console.RunCommandAndStoreOutput(vmi, "free -b | awk '/^Mem:/{print $2}'", time.Second*30)
+
+	guestBytes, err := strconv.Atoi(res)
+	Expect(err).ToNot(HaveOccurred())
+
+	return resource.NewQuantity(int64(guestBytes), resource.BinarySI)
 }


### PR DESCRIPTION
### What this PR does
After hotplug, the domain XML shows the following:
```xml
  <maxMemory unit='KiB'>2097152</maxMemory>
  <memory unit='KiB'>2097152</memory>
  <currentMemory unit='KiB'>1048576</currentMemory>
```

According to libvirt's [documentation](https://libvirt.org/formatdomain.html):
>currentMemory
>      The actual allocation of memory for the guest. This value can be less than the maximum allocation, to allow for ballooning up the guests memory on the fly. If this is omitted, it defaults to the same value as the memory element. The unit attribute behaves the same as for memory.

We actually set it here to the wrong place:
https://github.com/kubevirt/kubevirt/blob/904b5b49c339b1a3cbdc430c71da89d6353f4286/pkg/virt-launcher/virtwrap/converter/converter.go#L1152

What we want to do is:
```go
domain.Spec.CurrentMemory = &currentMemory
```

Fixes https://github.com/kubevirt/kubevirt/issues/14622

### Before this PR:
Memory hotplug is broken as the memory is not exposed to the guest.
For example, when executing `free` the memory in the guest remains untouched.

###  After this PR:
Memory hotplug is fixed.
A functional and a unit test is added.

### Special notes for the reviewer
Thanks a lot @orelmisan for reporting this!

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: memory hotplug to be exposed to the guest.
```

