### PR TITLE
Update examples to include newer fields [cpu, memory]

### DIFF
--- a/examples/vm-alpine-datavolume.yaml
+++ b/examples/vm-alpine-datavolume.yaml
@@ -28,11 +28,17 @@ spec:
         kubevirt.io/vm: vm-alpine-datavolume
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:
               bus: virtio
             name: datavolumedisk1
+        memory:
+          guest: 128Mi
         resources:
           requests:
             memory: 128Mi

--- a/examples/vm-alpine-multipvc.yaml
+++ b/examples/vm-alpine-multipvc.yaml
@@ -13,6 +13,10 @@ spec:
         kubevirt.io/vm: vm-alpine-multipvc
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:
@@ -21,6 +25,8 @@ spec:
           - disk:
               bus: virtio
             name: pvcdisk2
+        memory:
+          guest: 128Mi
         resources:
           requests:
             memory: 128Mi

--- a/examples/vm-cirros-clarge-virtio.yaml
+++ b/examples/vm-cirros-clarge-virtio.yaml
@@ -19,12 +19,18 @@ spec:
         kubevirt.io/vm: vm-cirros-clarge-virtio
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk: {}
             name: containerdisk
           - disk: {}
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-clarge-windows.yaml
+++ b/examples/vm-cirros-clarge-windows.yaml
@@ -19,12 +19,18 @@ spec:
         kubevirt.io/vm: vm-cirros-clarge-windows
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk: {}
             name: containerdisk
           - disk: {}
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-clarge.yaml
+++ b/examples/vm-cirros-clarge.yaml
@@ -16,6 +16,10 @@ spec:
         kubevirt.io/vm: vm-cirros-clarge
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk: {}
@@ -23,6 +27,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-cluster-csmall.yaml
+++ b/examples/vm-cirros-cluster-csmall.yaml
@@ -16,6 +16,10 @@ spec:
         kubevirt.io/vm: vm-cirros-cluster-csmall
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk: {}
@@ -23,6 +27,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-csmall.yaml
+++ b/examples/vm-cirros-csmall.yaml
@@ -16,6 +16,10 @@ spec:
         kubevirt.io/vm: vm-cirros-csmall
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk: {}
@@ -23,6 +27,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-sata.yaml
+++ b/examples/vm-cirros-sata.yaml
@@ -13,7 +13,13 @@ spec:
         kubevirt.io/vm: vm-cirros-sata
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices: {}
+        memory:
+          guest: 128Mi
         resources:
           requests:
             memory: 128Mi

--- a/examples/vm-cirros-with-sidecar-hook-configmap.yaml
+++ b/examples/vm-cirros-with-sidecar-hook-configmap.yaml
@@ -16,6 +16,10 @@ spec:
         kubevirt.io/vm: vm-cirros-with-sidecar-hook-configmap
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:
@@ -24,6 +28,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources:
           requests:
             memory: 128Mi

--- a/examples/vm-cirros.yaml
+++ b/examples/vm-cirros.yaml
@@ -13,6 +13,10 @@ spec:
         kubevirt.io/vm: vm-cirros
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:
@@ -21,6 +25,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources:
           requests:
             memory: 128Mi

--- a/examples/vm-pool-cirros.yaml
+++ b/examples/vm-pool-cirros.yaml
@@ -22,11 +22,17 @@ spec:
             kubevirt.io/vmpool: vm-pool-cirros
         spec:
           domain:
+            cpu:
+              cores: 1
+              sockets: 1
+              threads: 1
             devices:
               disks:
               - disk:
                   bus: virtio
                 name: containerdisk
+            memory:
+              guest: 128Mi
             resources:
               requests:
                 memory: 128Mi

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -13,6 +13,10 @@ spec:
         kubevirt.io/vm: vm-cirros
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:
@@ -21,6 +25,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources:
           requests:
             memory: 128Mi

--- a/examples/vm-windows-clarge-windows.yaml
+++ b/examples/vm-windows-clarge-windows.yaml
@@ -19,12 +19,18 @@ spec:
         kubevirt.io/vm: vm-windows-clarge-windows
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk: {}
             name: pvcdisk
         firmware:
           uuid: 5d307ca9-b3ef-428c-8861-06e72d69f223
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vmi-alpine-efi.yaml
+++ b/examples/vmi-alpine-efi.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-alpine-efi
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -16,6 +20,8 @@ spec:
       bootloader:
         efi:
           secureBoot: false
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1Gi

--- a/examples/vmi-arm.yaml
+++ b/examples/vmi-arm.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-arm
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -18,6 +22,8 @@ spec:
       - disk:
           bus: virtio
         name: emptydisk
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 256Mi

--- a/examples/vmi-ephemeral.yaml
+++ b/examples/vmi-ephemeral.yaml
@@ -7,11 +7,17 @@ metadata:
   name: vmi-ephemeral
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
           bus: virtio
         name: containerdisk
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 128Mi

--- a/examples/vmi-fedora-isolated.yaml
+++ b/examples/vmi-fedora-isolated.yaml
@@ -20,6 +20,8 @@ spec:
           bus: virtio
         name: cloudinitdisk
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-fedora.yaml
+++ b/examples/vmi-fedora.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-fedora
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -19,6 +23,8 @@ spec:
       - masquerade: {}
         name: default
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-gpu.yaml
+++ b/examples/vmi-gpu.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-gpu
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -19,6 +23,8 @@ spec:
       - deviceName: nvidia.com/GP102GL_Tesla_P40
         name: gpu1
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-host-disk.yaml
+++ b/examples/vmi-host-disk.yaml
@@ -7,11 +7,17 @@ metadata:
   name: vmi-host-disk
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
           bus: virtio
         name: host-disk
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 128Mi

--- a/examples/vmi-kernel-boot.yaml
+++ b/examples/vmi-kernel-boot.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-kernel-boot
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices: {}
     firmware:
       kernelBoot:
@@ -15,6 +19,8 @@ spec:
           initrdPath: /boot/initramfs-virt
           kernelPath: /boot/vmlinuz-virt
         kernelArgs: console=ttyS0
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1Gi

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-masquerade
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -23,6 +27,8 @@ spec:
           port: 80
           protocol: TCP
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-migratable.yaml
+++ b/examples/vmi-migratable.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-migratable
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -15,6 +19,8 @@ spec:
       interfaces:
       - masquerade: {}
         name: default
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 128Mi

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-multus-multiple-net
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -21,6 +25,8 @@ spec:
       - bridge: {}
         name: ptp
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-multus-ptp.yaml
+++ b/examples/vmi-multus-ptp.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-multus-ptp
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -19,6 +23,8 @@ spec:
       - bridge: {}
         name: ptp
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-nocloud.yaml
+++ b/examples/vmi-nocloud.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-nocloud
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -18,6 +22,8 @@ spec:
       - disk:
           bus: virtio
         name: emptydisk
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 128Mi

--- a/examples/vmi-pvc.yaml
+++ b/examples/vmi-pvc.yaml
@@ -7,11 +7,17 @@ metadata:
   name: vmi-pvc
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
           bus: virtio
         name: pvcdisk
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 128Mi

--- a/examples/vmi-replicaset-cirros.yaml
+++ b/examples/vmi-replicaset-cirros.yaml
@@ -14,11 +14,17 @@ spec:
         kubevirt.io/vmReplicaSet: vmi-replicaset-cirros
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:
               bus: virtio
             name: containerdisk
+        memory:
+          guest: 128Mi
         resources:
           requests:
             memory: 128Mi

--- a/examples/vmi-sata.yaml
+++ b/examples/vmi-sata.yaml
@@ -7,7 +7,13 @@ metadata:
   name: vmi-sata
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 128Mi

--- a/examples/vmi-secureboot.yaml
+++ b/examples/vmi-secureboot.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-secureboot
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -20,6 +24,8 @@ spec:
       bootloader:
         efi:
           secureBoot: true
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1Gi

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-sriov
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -21,6 +25,8 @@ spec:
       - name: sriov-net
         sriov: {}
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-usb.yaml
+++ b/examples/vmi-usb.yaml
@@ -7,6 +7,10 @@ metadata:
   name: vmi-usb
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -19,6 +23,8 @@ spec:
       - deviceName: kubevirt.io/storage
         name: node-usb-to-vmi-storage
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-with-sidecar-hook-configmap.yaml
+++ b/examples/vmi-with-sidecar-hook-configmap.yaml
@@ -10,6 +10,10 @@ metadata:
   name: vmi-with-sidecar-hook-configmap
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -19,6 +23,8 @@ spec:
           bus: virtio
         name: cloudinitdisk
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-with-sidecar-hook.yaml
+++ b/examples/vmi-with-sidecar-hook.yaml
@@ -11,6 +11,10 @@ metadata:
   name: vmi-with-sidecar-hook
 spec:
   domain:
+    cpu:
+      cores: 1
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -20,6 +24,8 @@ spec:
           bus: virtio
         name: cloudinitdisk
       rng: {}
+    memory:
+      guest: 128Mi
     resources:
       requests:
         memory: 1024M

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -147,14 +147,23 @@ var DockerPrefix = "registry:5000/kubevirt"
 var DockerTag = "devel"
 
 var gracePeriod = int64(0)
+var memory = resource.MustParse("128Mi")
 
 func getBaseVMISpec() *v1.VirtualMachineInstanceSpec {
 	return &v1.VirtualMachineInstanceSpec{
 		TerminationGracePeriodSeconds: &gracePeriod,
 		Domain: v1.DomainSpec{
+			CPU: &v1.CPU{
+				Cores:   1,
+				Threads: 1,
+				Sockets: 1,
+			},
+			Memory: &v1.Memory{
+				Guest: &memory,
+			},
 			Resources: v1.ResourceRequirements{
 				Requests: k8sv1.ResourceList{
-					k8sv1.ResourceMemory: resource.MustParse("128Mi"),
+					k8sv1.ResourceMemory: memory,
 				},
 			},
 		},


### PR DESCRIPTION
### What this PR does

This PR updates the VM generator to include explicit CPU and guest memory configurations in the generated KubeVirt VM YAML examples.

**Before this PR:**  
- The examples did not explicitly specify the domain's CPU topology (cores/sockets) or the guest memory configuration.

**After this PR:**  
- The examples now explicitly declare CPU cores, sockets, and guest memory.

Fixes #12285

### Release note
```release-note
none
```

