### PR TITLE
python-client: Patch version from git in generate.sh

### DIFF
--- a/hack/gen-client-python/generate.sh
+++ b/hack/gen-client-python/generate.sh
@@ -17,7 +17,8 @@ HARD_CODED_MODULES="${KUBEVIRT_DIR}/hack/gen-client-python/hard-coded-modules"
 if [ -n "${DOCKER_TAG:-}" ]; then
     CLIENT_PYTHON_VERSION="$DOCKER_TAG"
 else
-    CLIENT_PYTHON_VERSION="$(git describe || echo 'none')"
+    version=$(git describe || echo 'none')
+    CLIENT_PYTHON_VERSION="${version%-g$(git rev-parse --short HEAD)}"
 fi
 
 mkdir -p "${PYTHON_CLIENT_OUT_DIR}"


### PR DESCRIPTION
### What this PR does
Before this PR:
```python
CLIENT_PYTHON_VERSION="v1.5.0-beta.0-1213-gabc9cabc"
```
After this PR:
```python
CLIENT_PYTHON_VERSION="v1.5.0-beta.0-1213"
```
Fixes #
TL;DR
> For exemple version should be parsed has v1.5.0-beta.0-1202 to work with setuptools

https://github.com/kubevirt/client-python/issues/60
https://github.com/kubevirt/kubevirt/issues/14630

### Why we need it and why it was done in this way
The Python client can no longer be installed via:
```
pip install git+https://github.com/kubevirt/client-python.git
```

The following tradeoffs were made:
- I used bash extension over `sed` because script is executed with bash
