### PR TITLE
Backend storage: Label backend PVC to support CDI WebhookPvcRendering

### DIFF
--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -49,6 +49,10 @@ import (
 const (
 	PVCPrefix = "persistent-state-for"
 	PVCSize   = "10Mi"
+
+	// LabelApplyStorageProfile is a label used by the CDI mutating webhook
+	// to modify the PVC according to the storage profile.
+	LabelApplyStorageProfile = "cdi.kubevirt.io/applyStorageProfile"
 )
 
 func basePVC(vmi *corev1.VirtualMachineInstance) string {
@@ -499,6 +503,15 @@ func (bs *BackendStorage) createPVC(vmi *corev1.VirtualMachineInstance, labels m
 			*metav1.NewControllerRef(vmi, corev1.VirtualMachineInstanceGroupVersionKind),
 		}
 	}
+
+	// Adding this label to allow the PVC to be processed by the CDI WebhookPvcRendering mutating webhook,
+	// which must be enabled in the CDI CR via feature gate.
+	// This mutating webhook processes the PVC based on its associated StorageProfile.
+	// For example, a profile can define a minimum supported volume size via the annotation:
+	// cdi.kubevirt.io/minimumSupportedPvcSize: 4Gi
+	// This helps avoid issues with provisioners that reject the hardcoded 10Mi PVC size used here.
+	labels[LabelApplyStorageProfile] = "true"
+
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName:    basePVC(vmi) + "-",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR adds the `cdi.kubevirt.io/applyStorageProfile: "true"` label to PVCs created by the backend storage logic. This allows the PVCs to be mutated by CDI's `WebhookPvcRendering` feature if enabled via feature gate.

This is mainly to support applying a minimum supported PVC size via the storage profile annotation `cdi.kubevirt.io/minimumSupportedPvcSize`, which helps with provisioners that don't support small sizes like the default 10Mi used in KubeVirt.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://github.com/kubevirt/kubevirt/issues/13351

### Why we need it and why it was done in this way

We decided to go with the mutating webhook approach after a long conversation in https://github.com/kubevirt/kubevirt/pull/13800.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Label backend PVC to support CDI WebhookPvcRendering
```

