### PR TITLE
tests: drop flags.KubeVirtOcPath

### DIFF
--- a/hack/ci/entrypoint.sh
+++ b/hack/ci/entrypoint.sh
@@ -102,10 +102,9 @@ function run_tests() {
     # required to be set for test binary
     export ARTIFACTS=${ARTIFACT_DIR}
 
-    OC_PATH=$(get_path_or_empty_string_for_cmd oc)
     KUBECTL_PATH=$(get_path_or_empty_string_for_cmd kubectl)
 
-    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -oc-path=${OC_PATH} -kubectl-path=${KUBECTL_PATH} -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slow-spec-threshold=60s ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false
+    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -kubectl-path=${KUBECTL_PATH} -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slow-spec-threshold=60s ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false
 }
 
 export PATH="$BIN_DIR:$PATH"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -37,10 +37,6 @@ functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
 echo "Using $kubevirt_test_config as test configuration"
 
-if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then
-    oc=${kubectl}
-fi
-
 virtctl_path=$(pwd)/_out/cmd/virtctl/virtctl
 example_guest_agent_path=$(pwd)/_out/cmd/example-guest-agent/example-guest-agent
 
@@ -60,7 +56,7 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -timeout=${KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT} -r "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
+    _out/tests/ginkgo -timeout=${KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT} -r "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
 }
 
 additional_test_args=""

--- a/hack/kwok-perftests.sh
+++ b/hack/kwok-perftests.sh
@@ -33,10 +33,6 @@ previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_releas
 
 perftest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then
-    oc="${kubectl}"
-fi
-
 if [ -z "$kubeconfig" ]; then
     kubeconfig="$KUBECONFIG"
 fi
@@ -60,7 +56,7 @@ echo 'ARTIFACTS ' "${ARTIFACTS}"
 echo 'TESTS_OUT_DIR ' "${TESTS_OUT_DIR}"
 
 function perftest() {
-    _out/tests/ginkgo -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- ${extra_args} -kubeconfig="${kubeconfig}" -container-tag="${docker_tag}" -container-tag-alt="${docker_tag_alt}" -container-prefix="${perftest_docker_prefix}" -image-prefix-alt="${image_prefix_alt}" -oc-path="${oc}" -kubectl-path="${kubectl}" -installed-namespace="${namespace}" -previous-release-tag="${PREVIOUS_RELEASE_TAG}" -previous-release-registry="${previous_release_registry}" -deploy-testing-infra="${deploy_testing_infra}" -config="${KUBEVIRT_DIR}"/tests/default-config.json -deploy-fake-kwok-nodes=true --artifacts="${ARTIFACTS}"
+    _out/tests/ginkgo -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- ${extra_args} -kubeconfig="${kubeconfig}" -container-tag="${docker_tag}" -container-tag-alt="${docker_tag_alt}" -container-prefix="${perftest_docker_prefix}" -image-prefix-alt="${image_prefix_alt}" -kubectl-path="${kubectl}" -installed-namespace="${namespace}" -previous-release-tag="${PREVIOUS_RELEASE_TAG}" -previous-release-registry="${previous_release_registry}" -deploy-testing-infra="${deploy_testing_infra}" -config="${KUBEVIRT_DIR}"/tests/default-config.json -deploy-fake-kwok-nodes=true --artifacts="${ARTIFACTS}"
 }
 
 function perfaudit() {

--- a/hack/perftests.sh
+++ b/hack/perftests.sh
@@ -33,10 +33,6 @@ previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_releas
 
 perftest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then
-    oc=${kubectl}
-fi
-
 if [ -z "$kubeconfig" ]; then
     kubeconfig="$KUBECONFIG"
 fi
@@ -58,7 +54,7 @@ echo 'ARTIFACTS ' ${ARTIFACTS}
 echo 'TESTS_OUT_DIR ' ${TESTS_OUT_DIR}
 
 function perftest() {
-    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
+    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
 }
 
 function perfaudit() {

--- a/hack/realtime-perftests.sh
+++ b/hack/realtime-perftests.sh
@@ -32,10 +32,6 @@ previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_releas
 
 perftest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then
-    oc=${kubectl}
-fi
-
 if [ -z "$kubeconfig" ]; then
     kubeconfig="$KUBECONFIG"
 fi
@@ -52,7 +48,7 @@ echo 'ARTIFACTS ' ${ARTIFACTS}
 echo 'TESTS_OUT_DIR ' ${TESTS_OUT_DIR}
 
 function perftest() {
-    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
+    _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
 }
 
 if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then

--- a/tests/clientcmd/command.go
+++ b/tests/clientcmd/command.go
@@ -36,20 +36,9 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-func GetK8sCmdClient() string {
-	// use oc if it exists, otherwise use kubectl
-	if flags.KubeVirtOcPath != "" {
-		return "oc"
-	}
-
-	return "kubectl"
-}
-
 func FailIfNoCmd(cmdName string) {
 	var cmdPath string
 	switch strings.ToLower(cmdName) {
-	case "oc":
-		cmdPath = flags.KubeVirtOcPath
 	case "kubectl":
 		cmdPath = flags.KubeVirtKubectlPath
 	case "virtctl":
@@ -102,8 +91,6 @@ func CreateCommandWithNS(namespace string, cmdName string, args ...string) (stri
 
 	cmdName = strings.ToLower(cmdName)
 	switch cmdName {
-	case "oc":
-		cmdPath = flags.KubeVirtOcPath
 	case "kubectl":
 		cmdPath = flags.KubeVirtKubectlPath
 	case "virtctl":

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -34,7 +34,6 @@ var KubeVirtRepoPrefix = "quay.io/kubevirt"
 var ImagePrefixAlt = ""
 var ContainerizedDataImporterNamespace = "cdi"
 var KubeVirtKubectlPath = ""
-var KubeVirtOcPath = ""
 var KubeVirtVirtctlPath = ""
 var KubeVirtExampleGuestAgentPath = ""
 var KubeVirtInstallNamespace string
@@ -73,7 +72,6 @@ func init() {
 	flag.StringVar(&ImagePrefixAlt, "image-prefix-alt", "", "Optional prefix for virt-* image names for additional imagePrefix operator test")
 	flag.StringVar(&ContainerizedDataImporterNamespace, "cdi-namespace", "cdi", "Set the repository prefix for CDI components")
 	flag.StringVar(&KubeVirtKubectlPath, "kubectl-path", "", "Set path to kubectl binary")
-	flag.StringVar(&KubeVirtOcPath, "oc-path", "", "Set path to oc binary")
 	flag.StringVar(&KubeVirtVirtctlPath, "virtctl-path", "", "Set path to virtctl binary")
 	flag.StringVar(&KubeVirtExampleGuestAgentPath, "example-guest-agent-path", "", "Set path to the example-guest-agent binary which is used for vsock testing")
 	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "", "Set the namespace KubeVirt is installed in")

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -26,21 +26,20 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
-var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]kubectl integration", decorators.SigCompute, func() {
 	var (
-		k8sClient, result string
-		err               error
+		result string
+		err    error
 	)
 	BeforeEach(func() {
-		k8sClient = clientcmd.GetK8sCmdClient()
-		clientcmd.FailIfNoCmd(k8sClient)
+		clientcmd.FailIfNoCmd("kubectl")
 	})
 
 	DescribeTable("[test_id:3812]explain vm/vmi", func(resource string) {
-		output, stderr, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "explain", resource)
+		output, stderr, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "explain", resource)
 		// kubectl will not find resource for the first time this command is issued
 		if err != nil {
-			output, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "explain", resource)
+			output, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "explain", resource)
 		}
 		Expect(err).NotTo(HaveOccurred(), stderr)
 		Expect(output).To(ContainSubstring("apiVersion	<string>"))
@@ -61,9 +60,9 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 	)
 
 	It("[test_id:5182]vmipreset have validation", func() {
-		output, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "explain", "vmipreset")
+		output, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "explain", "vmipreset")
 		if err != nil {
-			output, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "explain", "vmipreset")
+			output, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "explain", "vmipreset")
 		}
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(ContainSubstring("apiVersion	<string>"))
@@ -76,9 +75,9 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 	})
 
 	It("[test_id:5183]vmirs have validation", func() {
-		output, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "explain", "vmirs")
+		output, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "explain", "vmirs")
 		if err != nil {
-			output, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "explain", "vmirs")
+			output, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "explain", "vmirs")
 		}
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(ContainSubstring("apiVersion	<string>"))
@@ -90,7 +89,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 	})
 
-	Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", func() {
+	Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]kubectl get vm/vmi tests", func() {
 		var (
 			virtCli kubecli.KubevirtClient
 			vm      *v1.VirtualMachine
@@ -113,10 +112,10 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		})
 
 		DescribeTable("should verify set of columns for", func(verb, resource string, expectedHeader []string) {
-			result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, verb, resource, vm.Name)
+			result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", verb, resource, vm.Name)
 			// due to issue of kubectl that sometimes doesn't show CRDs on the first try, retry the same command
 			if err != nil {
-				result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, verb, resource, vm.Name)
+				result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", verb, resource, vm.Name)
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeEmpty())
@@ -135,10 +134,10 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 
 		DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {
 
-			result, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, verb, resource, vm.Name, "-o", option)
+			result, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", verb, resource, vm.Name, "-o", option)
 			// due to issue of kubectl that sometimes doesn't show CRDs on the first try, retry the same command
 			if err != nil {
-				result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, verb, resource, vm.Name, "-o", option)
+				result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", verb, resource, vm.Name, "-o", option)
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeEmpty())
@@ -192,11 +191,10 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 
 				libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)
 
-				k8sClient := clientcmd.GetK8sCmdClient()
-				result, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "get", "vmim", migration.Name)
+				result, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "get", "vmim", migration.Name)
 				// due to issue of kubectl that sometimes doesn't show CRDs on the first try, retry the same command
 				if err != nil {
-					result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "get", "vmim", migration.Name)
+					result, _, err = clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "get", "vmim", migration.Name)
 				}
 
 				expectedHeader := []string{"NAME", "PHASE", "VMI"}
@@ -221,19 +219,18 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		})
 	})
 
-	Describe("oc/kubectl logs", func() {
+	Describe("kubectl logs", func() {
 		var (
 			vm *v1.VirtualMachineInstance
 		)
 
-		It("oc/kubectl logs <vmi-pod> return default container log", func() {
+		It("kubectl logs <vmi-pod> return default container log", func() {
 			vm = libvmifact.NewCirros()
 			vm = libvmops.RunVMIAndExpectLaunch(vm, 30)
 
-			k8sClient := clientcmd.GetK8sCmdClient()
 			pod, err := libpod.GetPodByVirtualMachineInstance(vm, vm.Namespace)
 			Expect(err).NotTo(HaveOccurred())
-			output, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "logs", pod.Name)
+			output, _, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "logs", pod.Name)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(output).To(ContainSubstring("component"))

--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -187,7 +187,7 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 		sourcePort := 4321 + rand.Intn(6000)
 		targetPort := 9090
 		Eventually(func() error {
-			_, cmd, err := clientcmd.CreateCommandWithNS(monitoringNs, clientcmd.GetK8sCmdClient(),
+			_, cmd, err := clientcmd.CreateCommandWithNS(monitoringNs, "kubectl",
 				"port-forward", "service/prometheus-k8s", fmt.Sprintf("%d:%d", sourcePort, targetPort))
 			if err != nil {
 				return err

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -130,16 +130,9 @@ func TemporaryNodeDrain(nodeName string) {
 	// we can't really expect an error during node drain because vms with eviction strategy can be migrated by the
 	// time that we call it.
 	vmiSelector := v1.AppLabel + "=virt-launcher"
-	k8sClient := clientcmd.GetK8sCmdClient()
-	if k8sClient == "oc" {
-		_, _, err := clientcmd.RunCommand("", k8sClient, "adm", "drain", nodeName, "--delete-emptydir-data", "--pod-selector", vmiSelector,
-			"--ignore-daemonsets=true", "--force", "--timeout=180s")
-		Expect(err).ToNot(HaveOccurred())
-	} else {
-		_, _, err := clientcmd.RunCommand("", k8sClient, "drain", nodeName, "--delete-emptydir-data", "--pod-selector", vmiSelector,
-			"--ignore-daemonsets=true", "--force", "--timeout=180s")
-		Expect(err).ToNot(HaveOccurred())
-	}
+	_, _, err := clientcmd.RunCommand("", "kubectl", "drain", nodeName, "--delete-emptydir-data", "--pod-selector", vmiSelector,
+		"--ignore-daemonsets=true", "--force", "--timeout=180s")
+	Expect(err).ToNot(HaveOccurred())
 }
 
 type mapType string

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -146,7 +146,7 @@ var _ = Describe(SIG("Port-forward", func() {
 }))
 
 func portForwardCommand(pod *k8sv1.Pod, sourcePort, targetPort int) (*exec.Cmd, error) {
-	_, cmd, err := clientcmd.CreateCommandWithNS(pod.Namespace, clientcmd.GetK8sCmdClient(), "port-forward", pod.Name, fmt.Sprintf("%d:%d", sourcePort, targetPort))
+	_, cmd, err := clientcmd.CreateCommandWithNS(pod.Namespace, "kubectl", "port-forward", pod.Name, fmt.Sprintf("%d:%d", sourcePort, targetPort))
 
 	return cmd, err
 }

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -460,13 +460,12 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	})
 
 	It("[test_id:4121]should create and verify kubectl/oc output for vm replicaset", func() {
-		k8sClient := clientcmd.GetK8sCmdClient()
-		clientcmd.FailIfNoCmd(k8sClient)
+		clientcmd.FailIfNoCmd("kubectl")
 
 		newRS := newReplicaSet()
 		doScale(newRS.ObjectMeta.Name, 2)
 
-		result, _, _ := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), k8sClient, "get", "virtualmachineinstancereplicaset")
+		result, _, _ := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "kubectl", "get", "virtualmachineinstancereplicaset")
 		Expect(result).ToNot(BeNil())
 		resultFields := strings.Fields(result)
 		expectedHeader := []string{"NAME", "DESIRED", "CURRENT", "READY", "AGE"}

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1123,7 +1123,7 @@ func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient,
 }
 
 func (r *KubernetesReporter) logClusterOverview() {
-	stdout, stderr, err := clientcmd.RunCommand("", clientcmd.GetK8sCmdClient(), "get", "all", "--all-namespaces", "-o", "wide")
+	stdout, stderr, err := clientcmd.RunCommand("", "kubectl", "get", "all", "--all-namespaces", "-o", "wide")
 	if err != nil {
 		printError("failed to fetch cluster overview: %v, %s", err, stderr)
 		return

--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -77,7 +77,7 @@ var _ = Describe(SIG("[sig-storage]ImageUpload", decorators.SigStorage, Serial, 
 		if config.Status.UploadProxyURL == nil {
 			By("Setting up port forwarding")
 			_, kubectlCmd, err = clientcmd.CreateCommandWithNS(
-				flags.ContainerizedDataImporterNamespace, clientcmd.GetK8sCmdClient(), "port-forward", "svc/cdi-uploadproxy", "18443:443",
+				flags.ContainerizedDataImporterNamespace, "kubectl", "port-forward", "svc/cdi-uploadproxy", "18443:443",
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kubectlCmd.Start()).To(Succeed())


### PR DESCRIPTION
As much as we love OpenShift, we don't need to test (or even use) its command line tool `oc` in KubeVirt.

Let us simplify our command line dealings by dropping it.

```release-note
NONE
```

