### PR TITLE
Bug fix: Don't default hotplug on ARM

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -117,7 +117,12 @@ func SetDefaultVirtualMachineInstance(clusterConfig *virtconfig.ClusterConfig, v
 	setDefaultCPUArch(clusterConfig, &vmi.Spec)
 	setGuestMemoryStatus(vmi)
 	setCurrentCPUTopologyStatus(vmi)
-	setupHotplug(clusterConfig, vmi)
+
+	// Hotplug needs to be enabled on ARM yet
+	if !IsARM64(&vmi.Spec) {
+		setupHotplug(clusterConfig, vmi)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### What this PR does
ARM is yet to test and enable hotplug on launcher side.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer
The cause of this issue is hotplug code that will be fixed as follow up.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ARM: CPU pinning don't panic now
```

