### PR TITLE
tests/vmi_configurations: fix SMBIOS check quoting in test_id:2751

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2849,11 +2849,11 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			By("Check values in dmidecode")
 			// Check on the VM, if expected values are there with dmidecode
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: fmt.Sprintf("[ $(sudo dmidecode -s system-family | tr -s ' ') = %s ] && echo 'pass'\n", smBIOS.Family)},
+				&expect.BSnd{S: fmt.Sprintf(`[ "$(sudo dmidecode -s system-family | tr -s ' ')" = "%s" ] && echo 'pass'`+"\n", smBIOS.Family)},
 				&expect.BExp{R: console.RetValue("pass")},
-				&expect.BSnd{S: fmt.Sprintf("[ $(sudo dmidecode -s system-product-name | tr -s ' ') = %s ] && echo 'pass'\n", smBIOS.Product)},
+				&expect.BSnd{S: fmt.Sprintf(`[ "$(sudo dmidecode -s system-product-name | tr -s ' ')" = "%s" ] && echo 'pass'`+"\n", smBIOS.Product)},
 				&expect.BExp{R: console.RetValue("pass")},
-				&expect.BSnd{S: fmt.Sprintf("[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = %s ] && echo 'pass'\n", smBIOS.Manufacturer)},
+				&expect.BSnd{S: fmt.Sprintf(`[ "$(sudo dmidecode -s system-manufacturer | tr -s ' ')" = "%s" ] && echo 'pass'`+"\n", smBIOS.Manufacturer)},
 				&expect.BExp{R: console.RetValue("pass")},
 			}, 1)).To(Succeed())
 		})


### PR DESCRIPTION
Without double quotes around `dmidecode` output, bash throws: `"bash: [: too many arguments"` when values contain spaces. 
Quoting ensures proper string comparison in expect checks.

Fixes #

### Release note
```release-note
none
```

