### PR TITLE
Update examples to include CPU and guest memory fields

### DIFF
--- a/examples/vm-alpine-datavolume.yaml
+++ b/examples/vm-alpine-datavolume.yaml
@@ -33,9 +33,9 @@ spec:
           - disk:
               bus: virtio
             name: datavolumedisk1
-        resources:
-          requests:
-            memory: 128Mi
+        memory:
+          guest: 128Mi
+        resources: {}
       terminationGracePeriodSeconds: 0
       volumes:
       - dataVolume:

--- a/examples/vm-alpine-multipvc.yaml
+++ b/examples/vm-alpine-multipvc.yaml
@@ -21,9 +21,9 @@ spec:
           - disk:
               bus: virtio
             name: pvcdisk2
-        resources:
-          requests:
-            memory: 128Mi
+        memory:
+          guest: 128Mi
+        resources: {}
       terminationGracePeriodSeconds: 0
       volumes:
       - name: pvcdisk1

--- a/examples/vm-cirros-clarge-virtio.yaml
+++ b/examples/vm-cirros-clarge-virtio.yaml
@@ -25,6 +25,8 @@ spec:
             name: containerdisk
           - disk: {}
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-clarge-windows.yaml
+++ b/examples/vm-cirros-clarge-windows.yaml
@@ -25,6 +25,8 @@ spec:
             name: containerdisk
           - disk: {}
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-clarge.yaml
+++ b/examples/vm-cirros-clarge.yaml
@@ -23,6 +23,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-cluster-csmall.yaml
+++ b/examples/vm-cirros-cluster-csmall.yaml
@@ -23,6 +23,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-csmall.yaml
+++ b/examples/vm-cirros-csmall.yaml
@@ -23,6 +23,8 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-cirros-sata.yaml
+++ b/examples/vm-cirros-sata.yaml
@@ -14,9 +14,9 @@ spec:
     spec:
       domain:
         devices: {}
-        resources:
-          requests:
-            memory: 128Mi
+        memory:
+          guest: 128Mi
+        resources: {}
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vm-cirros-with-sidecar-hook-configmap.yaml
+++ b/examples/vm-cirros-with-sidecar-hook-configmap.yaml
@@ -24,9 +24,9 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
-        resources:
-          requests:
-            memory: 128Mi
+        memory:
+          guest: 128Mi
+        resources: {}
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vm-cirros.yaml
+++ b/examples/vm-cirros.yaml
@@ -21,9 +21,9 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
-        resources:
-          requests:
-            memory: 128Mi
+        memory:
+          guest: 128Mi
+        resources: {}
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vm-pool-cirros.yaml
+++ b/examples/vm-pool-cirros.yaml
@@ -27,9 +27,9 @@ spec:
               - disk:
                   bus: virtio
                 name: containerdisk
-            resources:
-              requests:
-                memory: 128Mi
+            memory:
+              guest: 128Mi
+            resources: {}
           terminationGracePeriodSeconds: 0
           volumes:
           - containerDisk:

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -21,9 +21,9 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
-        resources:
-          requests:
-            memory: 128Mi
+        memory:
+          guest: 128Mi
+        resources: {}
       priorityClassName: non-preemtible
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vm-windows-clarge-windows.yaml
+++ b/examples/vm-windows-clarge-windows.yaml
@@ -25,6 +25,8 @@ spec:
             name: pvcdisk
         firmware:
           uuid: 5d307ca9-b3ef-428c-8861-06e72d69f223
+        memory:
+          guest: 128Mi
         resources: {}
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vmi-alpine-efi.yaml
+++ b/examples/vmi-alpine-efi.yaml
@@ -16,9 +16,9 @@ spec:
       bootloader:
         efi:
           secureBoot: false
-    resources:
-      requests:
-        memory: 1Gi
+    memory:
+      guest: 1Gi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-arm.yaml
+++ b/examples/vmi-arm.yaml
@@ -18,9 +18,9 @@ spec:
       - disk:
           bus: virtio
         name: emptydisk
-    resources:
-      requests:
-        memory: 256Mi
+    memory:
+      guest: 256Mi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-ephemeral.yaml
+++ b/examples/vmi-ephemeral.yaml
@@ -12,9 +12,9 @@ spec:
       - disk:
           bus: virtio
         name: containerdisk
-    resources:
-      requests:
-        memory: 128Mi
+    memory:
+      guest: 128Mi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-fedora-isolated.yaml
+++ b/examples/vmi-fedora-isolated.yaml
@@ -11,6 +11,8 @@ spec:
       cores: 1
       dedicatedCpuPlacement: true
       isolateEmulatorThread: true
+      sockets: 1
+      threads: 1
     devices:
       disks:
       - disk:
@@ -20,6 +22,8 @@ spec:
           bus: virtio
         name: cloudinitdisk
       rng: {}
+    memory:
+      guest: 1024M
     resources:
       requests:
         memory: 1024M

--- a/examples/vmi-fedora.yaml
+++ b/examples/vmi-fedora.yaml
@@ -19,9 +19,9 @@ spec:
       - masquerade: {}
         name: default
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-gpu.yaml
+++ b/examples/vmi-gpu.yaml
@@ -19,9 +19,9 @@ spec:
       - deviceName: nvidia.com/GP102GL_Tesla_P40
         name: gpu1
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-host-disk.yaml
+++ b/examples/vmi-host-disk.yaml
@@ -12,9 +12,9 @@ spec:
       - disk:
           bus: virtio
         name: host-disk
-    resources:
-      requests:
-        memory: 128Mi
+    memory:
+      guest: 128Mi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - hostDisk:

--- a/examples/vmi-kernel-boot.yaml
+++ b/examples/vmi-kernel-boot.yaml
@@ -15,7 +15,7 @@ spec:
           initrdPath: /boot/initramfs-virt
           kernelPath: /boot/vmlinuz-virt
         kernelArgs: console=ttyS0
-    resources:
-      requests:
-        memory: 1Gi
+    memory:
+      guest: 1Gi
+    resources: {}
   terminationGracePeriodSeconds: 0

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -23,9 +23,9 @@ spec:
           port: 80
           protocol: TCP
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   networks:
   - name: testmasquerade
     pod: {}

--- a/examples/vmi-migratable.yaml
+++ b/examples/vmi-migratable.yaml
@@ -15,9 +15,9 @@ spec:
       interfaces:
       - masquerade: {}
         name: default
-    resources:
-      requests:
-        memory: 128Mi
+    memory:
+      guest: 128Mi
+    resources: {}
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -21,9 +21,9 @@ spec:
       - bridge: {}
         name: ptp
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-multus-ptp.yaml
+++ b/examples/vmi-multus-ptp.yaml
@@ -19,9 +19,9 @@ spec:
       - bridge: {}
         name: ptp
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   networks:
   - multus:
       networkName: ptp-conf

--- a/examples/vmi-nocloud.yaml
+++ b/examples/vmi-nocloud.yaml
@@ -18,9 +18,9 @@ spec:
       - disk:
           bus: virtio
         name: emptydisk
-    resources:
-      requests:
-        memory: 128Mi
+    memory:
+      guest: 128Mi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-preset-small.yaml
+++ b/examples/vmi-preset-small.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   domain:
     devices: {}
-    resources:
-      requests:
-        memory: 128Mi
+    memory:
+      guest: 128Mi
+    resources: {}
   selector:
     matchLabels:
       kubevirt.io/vmPreset: vmi-preset-small

--- a/examples/vmi-pvc.yaml
+++ b/examples/vmi-pvc.yaml
@@ -12,9 +12,9 @@ spec:
       - disk:
           bus: virtio
         name: pvcdisk
-    resources:
-      requests:
-        memory: 128Mi
+    memory:
+      guest: 128Mi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - name: pvcdisk

--- a/examples/vmi-replicaset-cirros.yaml
+++ b/examples/vmi-replicaset-cirros.yaml
@@ -19,9 +19,9 @@ spec:
           - disk:
               bus: virtio
             name: containerdisk
-        resources:
-          requests:
-            memory: 128Mi
+        memory:
+          guest: 128Mi
+        resources: {}
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vmi-sata.yaml
+++ b/examples/vmi-sata.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   domain:
     devices: {}
-    resources:
-      requests:
-        memory: 128Mi
+    memory:
+      guest: 128Mi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-secureboot.yaml
+++ b/examples/vmi-secureboot.yaml
@@ -20,9 +20,9 @@ spec:
       bootloader:
         efi:
           secureBoot: true
-    resources:
-      requests:
-        memory: 1Gi
+    memory:
+      guest: 1Gi
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -21,9 +21,9 @@ spec:
       - name: sriov-net
         sriov: {}
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-usb.yaml
+++ b/examples/vmi-usb.yaml
@@ -19,9 +19,9 @@ spec:
       - deviceName: kubevirt.io/storage
         name: node-usb-to-vmi-storage
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-windows.yaml
+++ b/examples/vmi-windows.yaml
@@ -39,9 +39,9 @@ spec:
         efi:
           secureBoot: true
       uuid: 5d307ca9-b3ef-428c-8861-06e72d69f223
-    resources:
-      requests:
-        memory: 2Gi
+    memory:
+      guest: 2Gi
+    resources: {}
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-with-sidecar-hook-configmap.yaml
+++ b/examples/vmi-with-sidecar-hook-configmap.yaml
@@ -19,9 +19,9 @@ spec:
           bus: virtio
         name: cloudinitdisk
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-with-sidecar-hook.yaml
+++ b/examples/vmi-with-sidecar-hook.yaml
@@ -20,9 +20,9 @@ spec:
           bus: virtio
         name: cloudinitdisk
       rng: {}
-    resources:
-      requests:
-        memory: 1024M
+    memory:
+      guest: 1024M
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:


### PR DESCRIPTION
### What this PR does
This PR enhances the VM generator to explicitly include CPU topology and guest memory settings in the generated KubeVirt VM YAML examples.

Before this PR:
*  The examples lacked explicit definitions for CPU topology (cores, sockets) and guest memory.

After this PR:
* The vmi-fedora-isolated example now includes a complete CPU topology configuration (cores, sockets, threads).

* All other VM examples now define guest memory explicitly using the memory field instead of relying on resource requests.



Fixes  #12285 

### Release note
```
none
```

