### PR TITLE
[v1.6.0-alpha.0]: Fix test expected error in HCO smoke test

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -446,7 +446,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					Expect(scheduledCond.Status).To(BeEquivalentTo(k8sv1.ConditionFalse))
 					Expect(scheduledCond.Reason).To(BeEquivalentTo(k8sv1.PodReasonUnschedulable))
-					Expect(scheduledCond.Message).To(ContainSubstring("node(s) didn't match Pod's node affinity/selector."))
+					Expect(scheduledCond.Message).To(ContainSubstring("node(s) didn't match Pod's node affinity/selector"))
 				})
 			})
 		})


### PR DESCRIPTION
### What this PR does
**Before this PR**:
While [trying to adopt KubeVirt v1.6.0-alpha.0](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3502), HCO's smoke test [is failing](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/kubevirt_hyperconverged-cluster-operator/3502/pull-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-kv-smoke-azure/1919707675671662592) on the `should prevent scheduling of a pod for a VMI with an unsupported machine type` test.

The test expects scheduling condition message to have this sub string: `"node(s) didn't match Pod's node affinity/selector."`, while the message in HCO test environment is:
`"0/6 nodes are available: 3 node(s) didn't match Pod's node affinity/selector, 3 node(s) had untolerated taint {node-role.kubernetes.io/master: }. preemption: 0/6 nodes are available: 6 Preemption is not helpful for scheduling."`

The test failed because of the '.' at the end of the expected sub-string.

**After this PR**:
Fixing it by removing the dot, to match a case with a comma.

The test is expected to pass in the next version of KubeVirt.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

