### PR TITLE
tests: fix test for toggling PR feature gate

### DIFF
--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/storage/velero:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -9,6 +9,7 @@ import (
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/storage/reservation"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -344,25 +344,21 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 		It("should delete and recreate virt-handler", func() {
 			config.DisableFeatureGate(featuregate.PersistentReservation)
 
-			Eventually(func() bool {
+			Eventually(func() []k8sv1.Container {
 				ds, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.TODO(), "virt-handler", metav1.GetOptions{})
 				if err != nil {
-					return false
+					return nil
 				}
-				return len(ds.Spec.Template.Spec.Containers) == 1
-			}, time.Minute*5, time.Second*2).Should(BeTrue())
+				return ds.Spec.Template.Spec.Containers
+			}, time.Minute*5, time.Second*2).ShouldNot(
+				ContainElement((gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Name": Equal("pr-helper")},
+				))))
 
 			// Switching the PersistentReservation feature gate on/off
 			// causes redeployment of all KubeVirt components.
 			By("Ensuring all KubeVirt components are ready")
 			testsuite.EnsureKubevirtReady()
-
-			nodes := libnode.GetAllSchedulableNodes(virtClient)
-			for _, node := range nodes.Items {
-				output, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"ls", reservation.GetPrHelperSocketDir()})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(output).To(Or(BeEmpty(), ContainSubstring("multipathd.socket")))
-			}
 		})
 	})
 


### PR DESCRIPTION
The checking for the files inside the pr directory is wrong since the pr-helper.socket isn't cleaned-up when the pr-helper container is stopped, e.g if virt-handler pod is stopped or restarted.

Currently, the tests aren't failing because the multipathd.socket exists and makes the check true. However, in cases where the multipathd.socket doesn't exist the pr-helper.socket can still be there since the socket isn't clean-up.

For this reason, we simplify the this tests by checking that virt-handler pods are ready with a single container in it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The test is buggy and fails when the multipathd.socket doesn't exist on the host

After this PR:
Remove the buggy checks

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

