### PR TITLE
Backend storage: Update backend logic so it works with restored PVCs

### DIFF
--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -260,8 +260,8 @@ func (bs *BackendStorage) labelLegacyPVC(pvc *v1.PersistentVolumeClaim, name str
 
 func CurrentPVCName(vmi *corev1.VirtualMachineInstance) string {
 	for _, volume := range vmi.Status.VolumeStatus {
-		if strings.HasPrefix(volume.Name, basePVC(vmi)) {
-			return volume.Name
+		if strings.Contains(volume.Name, basePVC(vmi)) {
+			return volume.PersistentVolumeClaimInfo.ClaimName
 		}
 	}
 

--- a/pkg/storage/utils/volumes_test.go
+++ b/pkg/storage/utils/volumes_test.go
@@ -59,6 +59,9 @@ var _ = Describe("GetVolumes", func() {
 				VolumeStatus: []v1.VolumeStatus{
 					{
 						Name: backendVolume + name,
+						PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+							ClaimName: backendVolume,
+						},
 					},
 				},
 			},

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1794,7 +1794,7 @@ func (c *Controller) addPVC(obj interface{}) {
 		return
 	}
 
-	if !strings.HasPrefix(pvc.Name, backendstorage.PVCPrefix) {
+	if !strings.Contains(pvc.Name, backendstorage.PVCPrefix) {
 		return
 	}
 	migrationName, exists := pvc.Labels[virtv1.MigrationNameLabel]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR updates the `CurrentPVCName` function in the backend storage logic to improve the handling of PVCs with different naming conventions.

Instead of requiring the PVC name to start with a specific prefix, the function now checks for the expected substring anywhere in the name. This fixes issues with restored PVCs that used a different prefix in their name.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-60685

### Why we need it and why it was done in this way

Alternative solution to https://github.com/kubevirt/kubevirt/pull/14641. That solution sets a more generic and cleaner volume name, which I prefer, but carries a risk of introducing bugs after upgrade. This PR is simpler and safer, especially for VMs relying on the older behavior.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Update backend-storage logic so it works with PVCs with non-standard naming convention
```

