### PR TITLE
Add UnschedulableToleration for hot-plug

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -664,6 +664,36 @@ func hotplugContainerRequests(config *virtconfig.ClusterConfig) k8sv1.ResourceLi
 	}
 }
 
+func hotplugPodTolerations() []k8sv1.Toleration {
+	return []k8sv1.Toleration{
+		{
+			Key:      k8sv1.TaintNodeUnschedulable,
+			Operator: k8sv1.TolerationOpExists,
+			Effect:   k8sv1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      k8sv1.TaintNodeNetworkUnavailable,
+			Operator: k8sv1.TolerationOpExists,
+			Effect:   k8sv1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      k8sv1.TaintNodeDiskPressure,
+			Operator: k8sv1.TolerationOpExists,
+			Effect:   k8sv1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      k8sv1.TaintNodeMemoryPressure,
+			Operator: k8sv1.TolerationOpExists,
+			Effect:   k8sv1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      k8sv1.TaintNodePIDPressure,
+			Operator: k8sv1.TolerationOpExists,
+			Effect:   k8sv1.TaintEffectNoSchedule,
+		},
+	}
+}
+
 func vmExportContainerResourceRequirements(config *virtconfig.ClusterConfig) k8sv1.ResourceRequirements {
 	return k8sv1.ResourceRequirements{
 		Limits:   vmExportContainerLimits(config),

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -444,6 +444,40 @@ var _ = Describe("Resource pod spec renderer", func() {
 	)
 })
 
+var _ = Describe("Tolerations pod spec renderer", func() {
+	DescribeTable("Tolerations for hotplug pod", func(kvConfig v1.KubeVirtConfiguration, expectedTolerations []kubev1.Toleration) {
+		Expect(hotplugPodTolerations()).To(BeEquivalentTo(expectedTolerations))
+	},
+		Entry("empty tolerations, fallback to default", v1.KubeVirtConfiguration{}, []kubev1.Toleration{
+			{
+				Key:      kubev1.TaintNodeUnschedulable,
+				Operator: kubev1.TolerationOpExists,
+				Effect:   kubev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      kubev1.TaintNodeNetworkUnavailable,
+				Operator: kubev1.TolerationOpExists,
+				Effect:   kubev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      kubev1.TaintNodeDiskPressure,
+				Operator: kubev1.TolerationOpExists,
+				Effect:   kubev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      kubev1.TaintNodeMemoryPressure,
+				Operator: kubev1.TolerationOpExists,
+				Effect:   kubev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      kubev1.TaintNodePIDPressure,
+				Operator: kubev1.TolerationOpExists,
+				Effect:   kubev1.TaintEffectNoSchedule,
+			},
+		}),
+	)
+})
+
 var _ = Describe("GetMemoryOverhead calculation", func() {
 	// VirtLauncherMonitorOverhead + VirtLauncherOverhead + VirtlogdOverhead + VirtqemudOverhead + QemuOverhead + IothreadsOverhead
 	const staticOverheadString = "223Mi"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
On a cordoned host where VMs are still running, the hot-plug pod can not be recreated. This also causes some problems regarding LiveMigrations. If a host gets drained and the LiveMigrations to evict the VMs fail, the hot-plug Pods can never move back to the original host and reattach volumes to the old pod.

After this PR:
Hot-plug pods will tolerate the following Taints by adding tolerations

- node.kubernetes.io/memory-pressure
- node.kubernetes.io/disk-pressure
- node.kubernetes.io/pid-pressure
- node.kubernetes.io/network-unavailable
- node.kubernetes.io/unschedulable

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
Another option would be to add those tolerations with the help of Kyverno and using a MutatePolicy. But this would require Kyverno and I think this feature should be build in kubevirt so everyone can profit from it.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Slack: https://kubernetes.slack.com/archives/C8ED7RKFE/p1746537149771869

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add tolerations for unschedulable taints to hot-plug pods
```

