### PR TITLE
Fix misspellings in tests and nested lib* folders under tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -47,7 +47,7 @@ and you might want to skip them.
 For that some additional flags are needed to be passed.
 In addition, if you'd like to test outside connectivity
 using different addresses than the default
-(`8.8.8.8`, `2001:db8:1::1` and `google.com`), you can achive that with the 
+(`8.8.8.8`, `2001:db8:1::1` and `google.com`), you can achieve that with the 
 designated flags as well.
 
 For each method detailed below, there is note about the needed flags
@@ -102,7 +102,7 @@ make functest
 ```
 # Create directory for data / results / kubectl binary
 mkdir -p /tmp/kubevirt-tests-data
-# Make sure that eveybody can write there
+# Make sure that everybody can write there
 setfacl -m d:o:rwx /tmp/kubevirt-tests-data
 setfacl -m o:rwx /tmp/kubevirt-tests-data
 

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -157,7 +157,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				}
 			}
 
-			Expect(vm1Spec).To(Equal(vm2Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec not including mac adresses"))
+			Expect(vm1Spec).To(Equal(vm2Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec not including mac addresses"))
 		}
 
 		generateCloneFromVM := func() *clone.VirtualMachineClone {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -527,7 +527,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(podOutput1).To(Equal(expectedPrivateKey), "Expected pod output of private key to match genereated one.")
+				Expect(podOutput1).To(Equal(expectedPrivateKey), "Expected pod output of private key to match generated one.")
 
 				podOutput2, err := exec.ExecuteCommandOnPod(
 					vmiPod,
@@ -537,7 +537,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match genereated one.")
+				Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match generated one.")
 
 				By("Checking mounted secrets sshkeys image")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -99,9 +99,9 @@ func RunMigration(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachin
 func ConfirmMigrationDataIsStored(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance) {
 	By("Retrieving the VMI and the migration object")
 	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred(), "should have been able to retrive the VMI instance")
+	Expect(err).ToNot(HaveOccurred(), "should have been able to retrieve the VMI instance")
 	migration, migerr := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-	Expect(migerr).ToNot(HaveOccurred(), "should have been able to retrive the migration")
+	Expect(migerr).ToNot(HaveOccurred(), "should have been able to retrieve the migration")
 
 	By("Verifying the stored migration state")
 	Expect(migration.Status.MigrationState).ToNot(BeNil(), "should have been able to retrieve the migration `Status::MigrationState`")
@@ -116,7 +116,7 @@ func ConfirmMigrationDataIsStored(virtClient kubecli.KubevirtClient, migration *
 func ConfirmVMIPostMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, migration *v1.VirtualMachineInstanceMigration) *v1.VirtualMachineInstance {
 	By("Retrieving the VMI post migration")
 	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred(), "should have been able to retrive the VMI instance")
+	Expect(err).ToNot(HaveOccurred(), "should have been able to retrieve the VMI instance")
 
 	By("Verifying the VMI's migration state")
 	Expect(vmi.Status.MigrationState).ToNot(BeNil(), "should have been able to retrieve the VMIs `Status::MigrationState`")

--- a/tests/libnet/cloudinit/cloudinit.go
+++ b/tests/libnet/cloudinit/cloudinit.go
@@ -179,7 +179,7 @@ const (
 // CreateDefaultCloudInitNetworkData generates a default configuration
 // for the Cloud-Init Network Data, in version 2 format.
 // The default configuration sets dynamic IPv4 (DHCP) and static IPv6 addresses,
-// inclusing DNS settings of the cluster nameserver IP and search domains.
+// including DNS settings of the cluster nameserver IP and search domains.
 func CreateDefaultCloudInitNetworkData() string {
 	data, err := NewNetworkData(
 		WithEthernet("eth0",

--- a/tests/libnet/ping.go
+++ b/tests/libnet/ping.go
@@ -32,7 +32,7 @@ import (
 )
 
 // PingFromVMConsole performs a ping through the provided VMI console.
-// Optional arguments for the ping command may be provided, overwirting the default ones.
+// Optional arguments for the ping command may be provided, overwriting the default ones.
 // (default ping options: "-c 5, -w 10")
 // Note: The maximum overall command timeout is 20 seconds.
 func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...string) error {

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -462,7 +462,7 @@ func ExecuteCommandInVirtHandlerPod(nodeName string, args []string) (stdout stri
 	}
 	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtHandlerPod, components.VirtHandlerName, args)
 	if err != nil {
-		return stdout, fmt.Errorf("failed excuting command=%v, error=%v, stdout=%s, stderr=%s", args, err, stdout, stderr)
+		return stdout, fmt.Errorf("failed executing command=%v, error=%v, stdout=%s, stderr=%s", args, err, stdout, stderr)
 	}
 	return stdout, nil
 }

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -378,7 +378,7 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 
 		runBashCmdRw := func(cmd string) error {
 			// On kind, virt-handler seems to have /sys mounted as read-only.
-			// This uses a privileged pod with /sys explitly mounted in read/write mode.
+			// This uses a privileged pod with /sys explicitly mounted in read/write mode.
 			testPod := libpod.RenderPrivilegedPod("test-rw-sysfs", []string{"bash", "-x", "-c"}, []string{cmd})
 			testPod.Spec.Volumes = append(testPod.Spec.Volumes, k8sv1.Volume{
 				Name: "sys",

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -515,7 +515,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				return rs.Status.ReadyReplicas
 			}, 120*time.Second, 1*time.Second).Should(Equal(replicas))
 
-			By("Ensuring that VMI replicas are scheduled to seperate nodes")
+			By("Ensuring that VMI replicas are scheduled to separate nodes")
 			vmiSet, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s", vmLabelKey, vmLabelValue),
 			})

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -57,7 +57,7 @@ const (
 
 const (
 	// This xml will be the contents of the Autounattend.xml and Unattend.xml files, which are the answer files that Windows uses
-	// when booting from a sealed image at diffrent stages, in particulare to answer the questions at the OOBE stage.
+	// when booting from a sealed image at different stages, in particulare to answer the questions at the OOBE stage.
 	answerFileTemplate = `
     <?xml version="1.0" encoding="utf-8"?>
     <unattend xmlns="urn:schemas-microsoft-com:unattend">

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -181,7 +181,7 @@ func testCleanup() {
 // propagated if the current config in use does not match the original one.
 func resetToDefaultConfig() {
 	if !CurrentSpecReport().IsSerial {
-		// Tests which alter the global kubevirt config must be run serial, therefor, if we run in parallel
+		// Tests which alter the global kubevirt config must be run serial, therefore, if we run in parallel
 		// we can just skip the restore step.
 		return
 	}

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -75,7 +75,7 @@ var _ = Describe("[sig-compute]VM state", func() {
 		addDataToTPM := func(vmi *v1.VirtualMachineInstance) {
 			By("Storing a secret into the TPM")
 			// https://www.intel.com/content/www/us/en/developer/articles/code-sample/protecting-secret-data-and-keys-using-intel-platform-trust-technology.html
-			// Not sealing against a set of PCRs, out of scope here, but should work with a carefully selected set (at least PCR1 was seen changing accross reboots)
+			// Not sealing against a set of PCRs, out of scope here, but should work with a carefully selected set (at least PCR1 was seen changing across reboots)
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "tpm2_createprimary -Q --hierarchy=o --key-context=prim.ctx\n"},
 				&expect.BExp{R: console.PromptExpression},

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1007,7 +1007,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			maxExpectedFailCount := 3
 			Consistently(func() error {
 				// get the VM and verify the failure count is less than 4 over a minute,
-				// indicating that backoff is occuring
+				// indicating that backoff is occurring
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				if err != nil {
 					return err

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1381,7 +1381,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}
 				return false
 			}
-			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", decorators.Invtsc, decorators.TscFrequencies, func() {
+			It("[test_id:6843]should set a TSC frequency and have the CPU flag available in the guest", decorators.Invtsc, decorators.TscFrequencies, func() {
 				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(featureSupportedInAtLeastOneNode(nodes, "invtsc")).To(BeTrue(), "To run this test at least one node should support invtsc feature")
 				vmi := libvmifact.NewCirros()

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1137,7 +1137,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			It("[test_id:3204]the vmi with cpu.feature policy 'forbid' should not be scheduled on a node with that cpu feature label", func() {
 
 				// Add node affinity first to test later on that although there is node affinity to
-				// the specific node - the feature policy 'forbid' will deny shceduling on that node.
+				// the specific node - the feature policy 'forbid' will deny scheduling on that node.
 				vmi := libvmifact.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Cores: 1,

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -232,7 +232,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.P(true)
 		vmi = libvmops.RunVMIAndExpectLaunch(vmi, 60)
 
-		By("Connect to the guest on invalide port")
+		By("Connect to the guest on invalid port")
 		_, err = virtClient.VirtualMachineInstance(vmi.Namespace).VSOCK(vmi.Name, &v1.VSOCKOptions{TargetPort: uint32(0)})
 		Expect(err).To(HaveOccurred())
 	})


### PR DESCRIPTION
### What this PR does
Before this PR:
files directly under tests and and nested *lib folders had some misspelling words in them

After this PR:
The words are written correctly in the related files

### Why we need it and why it was done in this way
The following alternatives were considered:
Will open another PR to address the other files, this way it will be easier to review and monitor those changes.

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

