### PR TITLE
DNM: Try to run sriov test in loop

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -556,7 +556,10 @@ fi
 
 
 # Run functional tests
-FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER="--label-filter=(!flake-check)&&(${label_filter})" make functest
+for i in {1..30}; do
+  echo "iteration $i"
+  FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER="--label-filter=(!flake-check)&&(${label_filter})" make functest || break
+done
 
 # Run REST API coverage based on k8s audit log and openapi spec
 if [ -n "$RUN_REST_COVERAGE" ]; then

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -350,6 +350,7 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 			}
 		}
 		if interfaceStatus != nil {
+			log.Log.Infof("Updating interfaces status: %+v", interfaceStatus)
 			domain.Status.Interfaces = interfaceStatus
 		}
 		if osInfo != nil {

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -404,6 +404,8 @@ func (l *Launcher) HotplugHostDevices(_ context.Context, request *cmdv1.VMIReque
 		return response, nil
 	}
 
+	log.Log.Object(vmi).Info("DBG at HotplugHostDevices")
+
 	if err := l.domainManager.HotplugHostDevices(vmi); err != nil {
 		log.Log.Object(vmi).Errorf(err.Error())
 		response.Success = false

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -661,7 +661,7 @@ func (c *KubeVirtDeploymentConfig) GetNamespace() string {
 
 func (c *KubeVirtDeploymentConfig) GetVerbosity() string {
 	// not configurable yet
-	return "2"
+	return "3"
 }
 
 func (c *KubeVirtDeploymentConfig) GetProductComponent() string {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -281,7 +281,9 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 				Expect(libnet.CheckMacAddress(vmi, ifaceName, mac)).To(Succeed(), "SR-IOV VF is expected to exist in the guest")
 			})
 
-			It("[QUARANTINE]should be successful with a running VMI on the target", decorators.Quarantine, func() {
+			FIt("should be successful with a running VMI on the target", func() {
+				//for i := 0; i < 10; i++ {
+				//By(fmt.Sprintf("Starting migration iteration %d", i+1))
 				By("starting the migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 				migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
@@ -289,11 +291,14 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 
 				// It may take some time for the VMI interface status to be updated with the information reported by
 				// the guest-agent.
-				ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 2*time.Minute+10*time.Second)
+				ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 5*time.Minute)
 				Expect(err).NotTo(HaveOccurred())
 				updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(libnet.CheckMacAddress(updatedVMI, ifaceName, mac)).To(Succeed(), "SR-IOV VF is expected to exist in the guest after migration")
+				//By("Going to sleep")
+				//time.Sleep(30 * time.Minute)
+				//}
 			})
 		})
 	})

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -291,7 +291,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 
 				// It may take some time for the VMI interface status to be updated with the information reported by
 				// the guest-agent.
-				ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 5*time.Minute)
+				ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 2*time.Minute+10*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 				updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -58,6 +58,7 @@ const (
 	ipNeighShow                  = "ip neigh show"
 	bridgeJVlanShow              = "bridge -j vlan show"
 	bridgeFdb                    = "bridge fdb"
+	systemctlStatus              = "systemctl --failed --no-legend --no-pager --plain --full"
 	devVFio                      = "ls -lsh -Z -St /dev/vfio"
 	failedExecuteCmdFmt          = "failed to execute command %s on %s, stdout: %s, stderr: %s, error: %v"
 	failedExecuteCmdOnNodeFmt    = "failed to execute command %s on node %s, stdout: %s, error: %v"
@@ -1277,6 +1278,7 @@ func (r *KubernetesReporter) executeVMICommands(vmi v12.VirtualMachineInstance, 
 			{command: bridgeJVlanShow, fileNameSuffix: "brvlan"},
 			{command: bridgeFdb, fileNameSuffix: "brfdb"},
 			{command: "nmcli connection", fileNameSuffix: "nmcon"},
+			{command: systemctlStatus, fileNameSuffix: "systemctl_failed"},
 			{command: "nmcli device", fileNameSuffix: "nmdev"}}...)
 	} else if vmiType == "cirros" || vmiType == "alpine" {
 		cmds = append(cmds, []commands{

--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/run/run_command.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/run/run_command.go
@@ -184,7 +184,8 @@ OUTER_LOOP:
 		if suites.AnyHaveProgrammaticFocus() && strings.TrimSpace(os.Getenv("GINKGO_EDITOR_INTEGRATION")) == "" {
 			fmt.Printf("Test Suite Passed\n")
 			fmt.Printf("Detected Programmatic Focus - setting exit status to %d\n", types.GINKGO_FOCUS_EXIT_CODE)
-			command.Abort(command.AbortDetails{ExitCode: types.GINKGO_FOCUS_EXIT_CODE})
+			command.Abort(command.AbortDetails{})
+			//command.Abort(command.AbortDetails{ExitCode: types.GINKGO_FOCUS_EXIT_CODE})
 		} else {
 			fmt.Printf("Test Suite Passed\n")
 			command.Abort(command.AbortDetails{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

