### PR TITLE
Add TerminationMessagePolicy to all containers

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1376,6 +1376,7 @@ spec:
                     - ALL
                   seccompProfile:
                     type: RuntimeDefault
+                terminationMessagePolicy: FallbackToLogsOnError
                 volumeMounts:
                 - mountPath: /etc/virt-operator/certificates
                   name: kubevirt-operator-certs

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -53,19 +53,20 @@ func NewContainerSpecRenderer(containerName string, launcherImg string, imgPullP
 
 func (csr *ContainerSpecRenderer) Render(cmd []string) k8sv1.Container {
 	return k8sv1.Container{
-		Name:            csr.name,
-		Image:           csr.launcherImg,
-		ImagePullPolicy: csr.imgPullPolicy,
-		SecurityContext: securityContext(csr.userID, csr.isPrivileged, csr.capabilities),
-		Command:         cmd,
-		VolumeDevices:   csr.volumeDevices,
-		VolumeMounts:    csr.volumeMounts,
-		Resources:       csr.resources,
-		Ports:           csr.ports,
-		Env:             csr.envVars(),
-		LivenessProbe:   csr.liveninessProbe,
-		ReadinessProbe:  csr.readinessProbe,
-		Args:            csr.args,
+		Name:                     csr.name,
+		Image:                    csr.launcherImg,
+		ImagePullPolicy:          csr.imgPullPolicy,
+		SecurityContext:          securityContext(csr.userID, csr.isPrivileged, csr.capabilities),
+		Command:                  cmd,
+		VolumeDevices:            csr.volumeDevices,
+		VolumeMounts:             csr.volumeMounts,
+		Resources:                csr.resources,
+		Ports:                    csr.ports,
+		Env:                      csr.envVars(),
+		LivenessProbe:            csr.liveninessProbe,
+		ReadinessProbe:           csr.readinessProbe,
+		Args:                     csr.args,
+		TerminationMessagePolicy: k8sv1.TerminationMessageFallbackToLogsOnError,
 	}
 }
 

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -32,15 +32,8 @@ var _ = Describe("Container spec renderer", func() {
 		})
 
 		It("should have the unprivileged root user security context", func() {
-			Expect(specRenderer.Render(exampleCommand)).Should(
-				Equal(
-					k8sv1.Container{
-						Name:            containerName,
-						Image:           img,
-						Command:         exampleCommand,
-						ImagePullPolicy: pullPolicy,
-						SecurityContext: unprivilegedRootUserSecurityContext(),
-					}))
+			Expect(specRenderer.Render(exampleCommand).SecurityContext).Should(
+				Equal(unprivilegedRootUserSecurityContext()))
 		})
 	})
 

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -61,6 +61,7 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 			RunAsUser:  pointer.P(int64(util.RootUser)),
 			Privileged: pointer.P(true),
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 }
 
@@ -149,6 +150,7 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 					MountPath: nodeLabellerVolumePath,
 				},
 			},
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		},
 	}
 
@@ -173,6 +175,7 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 					corev1.ResourceMemory: resource.MustParse("20Mi"),
 				},
 			},
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		})
 	}
 

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -170,9 +170,10 @@ func newPodTemplateSpec(podName, imageName, repository, version, productName, pr
 			Tolerations:       criticalAddonsToleration(),
 			Containers: []corev1.Container{
 				{
-					Name:            podName,
-					Image:           image,
-					ImagePullPolicy: pullPolicy,
+					Name:                     podName,
+					Image:                    image,
+					ImagePullPolicy:          pullPolicy,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 		},
@@ -609,6 +610,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 								},
 								SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 							},
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},
 					},
 					SecurityContext: &corev1.PodSecurityContext{


### PR DESCRIPTION
### What this PR does
We use FallbackToLogsOnError in order to enhance
the status of the Pod. This can be helpful in case the node cannot be queried for logs anymore.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

