### PR TITLE
instancetype: Only return revision of currently referenced object

### DIFF
--- a/pkg/instancetype/find/spec_test.go
+++ b/pkg/instancetype/find/spec_test.go
@@ -36,6 +36,7 @@ import (
 var _ = Describe("Instance Type SpecFinder", func() {
 	const (
 		nonExistingResourceName = "non-existing-resource"
+		storedName              = "stored"
 	)
 
 	type instancetypeSpecFinder interface {
@@ -299,7 +300,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 		It("find returns only referenced object - bug #14595", func() {
 			// Make a slightly altered copy of the object already present in the client and store it in a CR
 			stored := clusterInstancetype.DeepCopy()
-			stored.ObjectMeta.Name = "stored"
+			stored.ObjectMeta.Name = storedName
 			stored.Spec.CPU.Guest = uint32(99)
 
 			controllerRevision, err := revision.CreateControllerRevision(vm, stored)
@@ -323,8 +324,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 
 			foundInstancetypeSpec, err := finder.Find(vm)
 			Expect(err).ToNot(HaveOccurred())
-			// FIXME(lyarwood): This is bug #14595, should return clusterInstancetype.Spec
-			Expect(foundInstancetypeSpec).To(HaveValue(Equal(stored.Spec)))
+			Expect(foundInstancetypeSpec).To(HaveValue(Equal(clusterInstancetype.Spec)))
 		})
 	})
 
@@ -514,7 +514,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 		It("find returns only referenced object - bug #14595", func() {
 			// Make a slightly altered copy of the object already present in the client and store it in a CR
 			stored := fakeInstancetype.DeepCopy()
-			stored.ObjectMeta.Name = "stored"
+			stored.ObjectMeta.Name = storedName
 			stored.Spec.CPU.Guest = uint32(99)
 
 			controllerRevision, err := revision.CreateControllerRevision(vm, stored)
@@ -538,8 +538,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 
 			foundInstancetypeSpec, err := finder.Find(vm)
 			Expect(err).ToNot(HaveOccurred())
-			// FIXME(lyarwood): This is bug #14595, should return fakeInstancetype.Spec
-			Expect(foundInstancetypeSpec).To(HaveValue(Equal(stored.Spec)))
+			Expect(foundInstancetypeSpec).To(HaveValue(Equal(fakeInstancetype.Spec)))
 		})
 	})
 })

--- a/pkg/instancetype/preference/find/BUILD.bazel
+++ b/pkg/instancetype/preference/find/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         ":go_default_library",
         "//pkg/instancetype/revision:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/pkg/instancetype/preference/find/spec_test.go
+++ b/pkg/instancetype/preference/find/spec_test.go
@@ -32,6 +32,7 @@ import (
 var _ = Describe("Preference SpecFinder", func() {
 	const (
 		nonExistingResourceName = "non-existing-resource"
+		storedName              = "stored"
 	)
 
 	type preferenceSpecFinder interface {
@@ -239,7 +240,7 @@ var _ = Describe("Preference SpecFinder", func() {
 		It("find returns only referenced object - bug #14595", func() {
 			// Make a slightly altered copy of the object already present in the client and store it in a CR
 			stored := clusterPreference.DeepCopy()
-			stored.ObjectMeta.Name = "stored"
+			stored.ObjectMeta.Name = storedName
 			stored.Spec.CPU.PreferredCPUTopology = pointer.P(v1beta1.Threads)
 
 			controllerRevision, err := revision.CreateControllerRevision(vm, stored)
@@ -263,8 +264,7 @@ var _ = Describe("Preference SpecFinder", func() {
 
 			foundPreferenceSpec, err := finder.FindPreference(vm)
 			Expect(err).ToNot(HaveOccurred())
-			// FIXME(lyarwood): This is bug #14595, should return clusterPreference.Spec
-			Expect(foundPreferenceSpec).To(HaveValue(Equal(stored.Spec)))
+			Expect(foundPreferenceSpec).To(HaveValue(Equal(clusterPreference.Spec)))
 		})
 	})
 
@@ -408,7 +408,7 @@ var _ = Describe("Preference SpecFinder", func() {
 		It("find returns only referenced object - bug #14595", func() {
 			// Make a slightly altered copy of the object already present in the client and store it in a CR
 			stored := preference.DeepCopy()
-			stored.ObjectMeta.Name = "stored"
+			stored.ObjectMeta.Name = storedName
 			stored.Spec.CPU.PreferredCPUTopology = pointer.P(v1beta1.Threads)
 
 			controllerRevision, err := revision.CreateControllerRevision(vm, stored)
@@ -432,8 +432,7 @@ var _ = Describe("Preference SpecFinder", func() {
 
 			foundPreferenceSpec, err := finder.FindPreference(vm)
 			Expect(err).ToNot(HaveOccurred())
-			// FIXME(lyarwood): This is bug #14595, should return preference.Spec
-			Expect(foundPreferenceSpec).To(HaveValue(Equal(stored.Spec)))
+			Expect(foundPreferenceSpec).To(HaveValue(Equal(preference.Spec)))
 		})
 	})
 })

--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libdomain:go_default_library",
+        "//tests/libinstancetype/builder:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmigration:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
We currently check that a given VirtualMachine meets any referenced
preference requirements within the admission webhook.

With the recent move of references to captured ControllerRevisions of
instance types and preferences into the status of the VirtualMachine we
no longer populate `spec.{instancetype,preference}.revisionName`. This
data is now held under
`status.{instancetypeRef,preferenceRef}.controllerRevisionRef` and is
maintained by the core VirtualMachine sync loop.

This causes an issue when checking any referenced preference
requirements within the admission webhook as these references will still
point to ControllerRevisions of different objects when switching between
instance types or preferences during a live update etc.

This change fixes this by ensuring the ControllerRevisions referenced by
the status of the VirtualMachine contain the instance type or preference
currently referenced from the spec of the VirtualMachine.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #14595

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Numerous follow ups are left for later PRs here to allow this bugfix to be backportable. These include:

* Moving preference resource requirement checks to the core VM sync loop
* Merging the seperate `revisionFinder` implementations for instance types and preferences into a single implementation like the `controllerRevisionFinder`
* Adding support to the instance type builder for `WithMemoryRequirement()`
* Removing duplication from `spec_test.go`
* Linting `tests/hotplug`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

