### PR TITLE
 PR 14599 commit cherry picked from main into release 1.5

### DIFF
--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -3,8 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "amd64.go",
         "arm64.go",
         "hyperv.go",
+        "s390x.go",
         "serviceaccounts.go",
         "utils.go",
     ],

--- a/pkg/virt-api/webhooks/amd64.go
+++ b/pkg/virt-api/webhooks/amd64.go
@@ -1,0 +1,50 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package webhooks
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+// ValidateVirtualMachineInstanceAmd64Setting is a validation function for validating-webhook on Amd64
+func ValidateVirtualMachineInstanceAmd64Setting(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	var statusCauses []metav1.StatusCause
+	validateWatchdogAmd64(field, spec, &statusCauses)
+	return statusCauses
+}
+
+func validateWatchdogAmd64(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, statusCauses *[]metav1.StatusCause) {
+	watchdog := spec.Domain.Devices.Watchdog
+	if watchdog == nil {
+		return
+	}
+
+	if !isOnlyI6300ESBWatchdog(watchdog) {
+		*statusCauses = append(*statusCauses, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: "amd64 only supports I6300ESB watchdog device",
+			Field:   field.Child("domain", "devices", "watchdog").String(),
+		})
+	}
+}
+
+func isOnlyI6300ESBWatchdog(watchdog *v1.Watchdog) bool {
+	return watchdog.WatchdogDevice.I6300ESB != nil && watchdog.WatchdogDevice.Diag288 == nil
+}

--- a/pkg/virt-api/webhooks/s390x.go
+++ b/pkg/virt-api/webhooks/s390x.go
@@ -1,0 +1,50 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package webhooks
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+// ValidateVirtualMachineInstanceS390xSetting is a validation function for validating-webhook on s390x
+func ValidateVirtualMachineInstanceS390XSetting(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	var statusCauses []metav1.StatusCause
+	validateWatchdogS390x(field, spec, &statusCauses)
+	return statusCauses
+}
+
+func validateWatchdogS390x(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, statusCauses *[]metav1.StatusCause) {
+	watchdog := spec.Domain.Devices.Watchdog
+	if watchdog == nil {
+		return
+	}
+
+	if !isOnlyDiag288Watchdog(watchdog) {
+		*statusCauses = append(*statusCauses, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: "s390x only supports Diag288 watchdog device",
+			Field:   field.Child("domain", "devices", "watchdog").String(),
+		})
+	}
+}
+
+func isOnlyDiag288Watchdog(watchdog *v1.Watchdog) bool {
+	return watchdog.WatchdogDevice.Diag288 != nil && watchdog.WatchdogDevice.I6300ESB == nil
+}


### PR DESCRIPTION
This PR cherry picks the commit of PR #14599 into release-1.5 branch

### What this PR does
Before this PR:
s390x watchdog not settable in release-1.5 

After this PR:
s390x watchdog settable in release-1.5

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place:  slack

### Special notes for your reviewer

sleck message of request:
Good afternoon
[2:19 PM](https://ibm-systems-z.slack.com/archives/D08JR8N3FV0/p1746814744728469)
Can you please backport this PR to release-1.5 - https://github.com/kubevirt/kubevirt/pull/14599
[2:20 PM](https://ibm-systems-z.slack.com/archives/D08JR8N3FV0/p1746814818221079)
It is merged to main. You can add assignee as me

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enabled watchdog validation on watchdog device models
```

