### PR TITLE
Fix misspellings in tests network, performance, instancetype, reporte…

### DIFF
--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -913,7 +913,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			),
 			Entry(", DataVolumeSourceRef and DataSource with labels",
 				func() []virtv1.DataVolumeTemplateSpec {
-					By("Createing a blank DV and PVC without labels")
+					By("Creating a blank DV and PVC without labels")
 					blankDV := libdv.NewDataVolume(
 						libdv.WithNamespace(namespace),
 						libdv.WithForceBindAnnotation(),

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -372,11 +372,11 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 
 			assertSourcePodContainersTerminate(labelSelector, fieldSelector, migrateVMI)
 
-			By("Verify the VMI new IP is propogated to the status")
+			By("Verify the VMI new IP is propagated to the status")
 			var migrateVmiAfterMigIP string
 			Eventually(func() string {
 				migrateVMI, err = kubevirt.Client().VirtualMachineInstance(migrateVMI.Namespace).Get(context.Background(), migrateVMI.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "should have been able to retrive the VMI instance")
+				Expect(err).ToNot(HaveOccurred(), "should have been able to retrieve the VMI instance")
 				migrateVmiAfterMigIP = libnet.GetVmiPrimaryIPByFamily(migrateVMI, ipFamily)
 				return migrateVmiAfterMigIP
 			}, 30*time.Second).ShouldNot(Equal(migrateVmiBeforeMigIP), "the VMI status should get a new IP after migration")

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -388,7 +388,7 @@ func checkHTTPPing(vmi *v1.VirtualMachineInstance, ip string, port int) error {
 }
 
 func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
-	ExpectWithOffset(1, vmi.Status.Interfaces[0].IPs).ToNot(BeEmpty(), "should contain a not empy list of ip addresses")
+	ExpectWithOffset(1, vmi.Status.Interfaces[0].IPs).ToNot(BeEmpty(), "should contain a not empty list of ip addresses")
 }
 
 func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {

--- a/tests/performance/density-kwok.go
+++ b/tests/performance/density-kwok.go
@@ -81,7 +81,7 @@ var _ = Describe(KWOK("Control Plane Performance Density Testing using kwok", fu
 
 	Describe("kwok density tests", func() {
 		Context("create a batch of fake VMIs", func() {
-			It("should sucessfully create all fake VMIs", func() {
+			It("should successfully create all fake VMIs", func() {
 				By(fmt.Sprintf("creating a batch of %d fake VMIs", vmCount))
 				createFakeVMIBatchWithKWOK(virtClient, vmCount)
 
@@ -97,7 +97,7 @@ var _ = Describe(KWOK("Control Plane Performance Density Testing using kwok", fu
 		})
 
 		Context("create a batch of fake VMs", func() {
-			It("should sucessfully create all fake VMs", func() {
+			It("should successfully create all fake VMs", func() {
 				By(fmt.Sprintf("creating a batch of %d fake VMs", vmCount))
 				createFakeBatchRunningVMWithKWOK(virtClient, vmCount)
 

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -87,7 +87,7 @@ var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 		vmBatchStartupLimit := 5 * time.Minute
 
 		Context(fmt.Sprintf("[small] create a batch of %d VMIs", vmCount), func() {
-			It("should sucessfully create all VMIS", func() {
+			It("should successfully create all VMIS", func() {
 				By("Creating a batch of VMIs")
 				createBatchVMIWithRateControl(virtClient, vmCount)
 
@@ -98,7 +98,7 @@ var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 		})
 
 		Context(fmt.Sprintf("[small] create a batch of %d running VMs", vmCount), func() {
-			It("should sucessfully create all VMS", func() {
+			It("should successfully create all VMS", func() {
 				By("Creating a batch of VMs")
 				createBatchRunningVMWithResourcesWithRateControl(virtClient, vmCount)
 
@@ -109,7 +109,7 @@ var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 		})
 
 		Context(fmt.Sprintf("[small] create a batch of %d running VMs using a single instancetype and preference", vmCount), func() {
-			It("should sucessfully create all VMS with instancetype and preference", func() {
+			It("should successfully create all VMS with instancetype and preference", func() {
 				By("Creating an instancetype and preference for the test")
 				instancetype := createInstancetype(virtClient)
 				preference := createPreference(virtClient)

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -37,7 +37,7 @@ var (
 )
 
 func init() {
-	flag.BoolVar(&RunPerfTests, "performance-test", false, "run performance tests. If false, all performance tests will be skiped.")
+	flag.BoolVar(&RunPerfTests, "performance-test", false, "run performance tests. If false, all performance tests will be skipped.")
 	if ptest, _ := strconv.ParseBool(os.Getenv("KUBEVIRT_E2E_PERF_TEST")); ptest {
 		RunPerfTests = true
 	}

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -552,7 +552,7 @@ func (r *KubernetesReporter) logVirtLauncherCommands(virtCli kubecli.KubevirtCli
 		}
 
 		if !isContainerReady(pod.Status.ContainerStatuses, computeContainer) {
-			printError("could not find healty compute container for pod %s", pod.ObjectMeta.Name)
+			printError("could not find healthy compute container for pod %s", pod.ObjectMeta.Name)
 			continue
 		}
 

--- a/tests/testsuite/serviceaccount.go
+++ b/tests/testsuite/serviceaccount.go
@@ -45,7 +45,7 @@ const (
 )
 
 // As our tests run in parallel we need to ensure each worker creates a
-// unique clusterRoleBinding to avoid cleaning up anothers prematurely
+// unique clusterRoleBinding to avoid cleaning up objects belonging to other tests prematurely
 func getClusterRoleBindingName(saName string) string {
 	return fmt.Sprintf("%s-%d", saName, GinkgoParallelProcess())
 }


### PR DESCRIPTION
### What this PR does
Before this PR:
files under tests [network, performance, instancetype, reporter, testsuite] had some misspelling words in them

After this PR:
The words are written correctly in the related files

### Special notes for your reviewer
Related PR:
 - https://github.com/kubevirt/kubevirt/pull/14662
 - https://github.com/kubevirt/kubevirt/pull/14731
 - https://github.com/kubevirt/kubevirt/pull/14750
 - https://github.com/kubevirt/kubevirt/pull/14751

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

