### PR TITLE
[release-1.4] VMI: Sort network interfaces to avoid patch flood

### DIFF
--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -808,8 +808,12 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 	cmpFunc := func(a, b virtv1.VirtualMachineInstanceNetworkInterface) int {
 		return strings.Compare(a.Name, b.Name)
 	}
-	newInterfaces := slices.SortedFunc(slices.Values(newVMI.Status.Interfaces), cmpFunc)
-	oldInterfaces := slices.SortedFunc(slices.Values(oldVMI.Status.Interfaces), cmpFunc)
+
+	newInterfaces := slices.Clone(newVMI.Status.Interfaces)
+	oldInterfaces := slices.Clone(oldVMI.Status.Interfaces)
+
+	slices.SortFunc(newInterfaces, cmpFunc)
+	slices.SortFunc(oldInterfaces, cmpFunc)
 
 	if !equality.Semantic.DeepEqual(newInterfaces, oldInterfaces) {
 		patchSet.AddOption(

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -783,6 +784,45 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 
 			expectPodAnnotations(pod, Not(HaveKeyWithValue(key1, value1)), Not(HaveKeyWithValue(key2, value2)))
+		})
+	})
+
+	Context("VMI patch", func() {
+		var (
+			oldVMI *virtv1.VirtualMachineInstance
+			newVMI *virtv1.VirtualMachineInstance
+		)
+		BeforeEach(func() {
+			oldVMI = newPendingVirtualMachine("oldvmi")
+			newVMI = newPendingVirtualMachine("newvmi")
+
+			oldVMI.Status.Interfaces = []virtv1.VirtualMachineInstanceNetworkInterface{
+				{Name: "stubNetStatusUpdate1"},
+				{Name: "stubNetStatusUpdate2"},
+			}
+		})
+		It("should create empty status network interfaces patch, regardless of interfaces order", func() {
+
+			// Reverse the order of interfaces in the new VMI
+			newVMI.Status.Interfaces = slices.Clone(oldVMI.Status.Interfaces)
+			slices.Reverse(newVMI.Status.Interfaces)
+
+			patch := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(patch).ToNot(BeNil(), "Patch should not be nil")
+			Expect(patch.IsEmpty()).To(BeTrue(), "Patch should be empty")
+		})
+		It("should create non empty status network interfaces patch", func() {
+
+			// Add a new interface to the new VMI
+			newVMI.Status.Interfaces = append(oldVMI.Status.Interfaces,
+				virtv1.VirtualMachineInstanceNetworkInterface{Name: "stubNetStatusUpdate3"},
+			)
+
+			patch := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(patch).ToNot(BeNil(), "Patch should not be nil")
+			Expect(patch.IsEmpty()).To(BeFalse(), "Patch should not be empty")
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual cherry-pick of PR https://github.com/kubevirt/kubevirt/pull/14613.
The change was adjusted to match the file structure of release-1.4.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

