### PR TITLE
Add "model" label to kubevirt_vm/i_vnic_info metrics

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -124,7 +124,7 @@ var (
 			Help: "Details of VirtualMachineInstance (VMI) vNIC interfaces, such as vNIC name, binding type, " +
 				"network name, and binding name for each vNIC of a running instance.",
 		},
-		[]string{"name", "namespace", "vnic_name", "binding_type", "network", "binding_name"},
+		[]string{"name", "namespace", "vnic_name", "binding_type", "network", "binding_name", "model"},
 	)
 )
 
@@ -445,6 +445,10 @@ func CollectVmisVnicInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.Co
 	networks := vmi.Spec.Networks
 
 	for _, iface := range interfaces {
+		model := "<none>"
+		if iface.Model != "" {
+			model = iface.Model
+		}
 		bindingType, bindingName := getBinding(iface)
 		networkName, matchFound := getNetworkName(iface.Name, networks)
 
@@ -461,6 +465,7 @@ func CollectVmisVnicInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.Co
 				bindingType,
 				networkName,
 				bindingName,
+				model,
 			},
 			Value: 1.0,
 		})

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -537,12 +537,14 @@ var _ = Describe("VMI Stats Collector", func() {
 									InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 										Bridge: &k6tv1.InterfaceBridge{},
 									},
+									Model: "virtio",
 								},
 								{
 									Name: "iface2",
 									InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 										Masquerade: &k6tv1.InterfaceMasquerade{},
 									},
+									Model: "e1000e",
 								},
 								{
 									Name: "iface3",
@@ -581,10 +583,10 @@ var _ = Describe("VMI Stats Collector", func() {
 			metrics := CollectVmisVnicInfo(vmi)
 			Expect(metrics).To(HaveLen(4))
 
-			Expect(metrics[0].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface1", "core", "pod networking", "bridge"}))
-			Expect(metrics[1].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface2", "core", "pod networking", "masquerade"}))
-			Expect(metrics[2].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface3", "core", "multus-net", "sriov"}))
-			Expect(metrics[3].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin"}))
+			Expect(metrics[0].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
+			Expect(metrics[1].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
+			Expect(metrics[2].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
+			Expect(metrics[3].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
 		})
 		It("should not collect kubevirt_vmi_vnic_info metric when interface name is not matching network name", func() {
 			vmi := &k6tv1.VirtualMachineInstance{

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -184,7 +184,7 @@ var (
 			Help: "Details of Virtual Machine (VM) vNIC interfaces, such as vNIC name, binding type, network name, " +
 				"and binding name for each vNIC defined in the VM's configuration.",
 		},
-		[]string{"name", "namespace", "vnic_name", "binding_type", "network", "binding_name"},
+		[]string{"name", "namespace", "vnic_name", "binding_type", "network", "binding_name", "model"},
 	)
 )
 
@@ -688,6 +688,10 @@ func CollectVmsVnicInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.Collector
 		networks := vm.Spec.Template.Spec.Networks
 
 		for _, iface := range interfaces {
+			model := "<none>"
+			if iface.Model != "" {
+				model = iface.Model
+			}
 			bindingType, bindingName := getBinding(iface)
 			networkName, matchFound := getNetworkName(iface.Name, networks)
 
@@ -704,6 +708,7 @@ func CollectVmsVnicInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.Collector
 					bindingType,
 					networkName,
 					bindingName,
+					model,
 				},
 				Value: 1.0,
 			})

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -700,12 +700,14 @@ var _ = Describe("VM Stats Collector", func() {
 											InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 												Bridge: &k6tv1.InterfaceBridge{},
 											},
+											Model: "virtio",
 										},
 										{
 											Name: "iface2",
 											InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 												Masquerade: &k6tv1.InterfaceMasquerade{},
 											},
+											Model: "e1000e",
 										},
 										{
 											Name: "iface3",
@@ -746,10 +748,10 @@ var _ = Describe("VM Stats Collector", func() {
 			metrics := CollectVmsVnicInfo([]*k6tv1.VirtualMachine{vm})
 			Expect(metrics).To(HaveLen(4), "Expected metrics for all vNICs")
 
-			Expect(metrics[0].Labels).To(Equal([]string{"test-vm", "test-ns", "iface1", "core", "pod networking", "bridge"}))
-			Expect(metrics[1].Labels).To(Equal([]string{"test-vm", "test-ns", "iface2", "core", "pod networking", "masquerade"}))
-			Expect(metrics[2].Labels).To(Equal([]string{"test-vm", "test-ns", "iface3", "core", "multus-net", "sriov"}))
-			Expect(metrics[3].Labels).To(Equal([]string{"test-vm", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin"}))
+			Expect(metrics[0].Labels).To(Equal([]string{"test-vm", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
+			Expect(metrics[1].Labels).To(Equal([]string{"test-vm", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
+			Expect(metrics[2].Labels).To(Equal([]string{"test-vm", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
+			Expect(metrics[3].Labels).To(Equal([]string{"test-vm", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
 		})
 		It("should not collect kubevirt_vm_vnic_info metric if no network defined", func() {
 			vm := &k6tv1.VirtualMachine{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add to the kubevirt_vm/i_vnic_info metrics,  the interface "model" (If exists) and which model it asks for. One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.

Before this PR:
kubevirt_vm/i_vnic_info metrics did not include "model" label
After this PR:
kubevirt_vm/i_vnic_info metrics includes "model" label
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
jira-ticket: https://issues.redhat.com/browse/CNV-57901

### Special notes for your reviewer
example output for the metrics:

![Screenshot From 2025-05-11 21-49-28](https://github.com/user-attachments/assets/38af10cb-c315-4431-8bfe-03d5d5b538db)


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

