### PR TITLE
Volume Expansion: Fix online expansion by requeuing VMIs on PVC size change

### DIFF
--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -62,7 +62,7 @@ func (c *Controller) addPVC(obj interface{}) {
 	}
 }
 
-// updatePVC handles updates to a PVC, enqueuing affected VMIs if capacity changes.
+// updatePVC handles updates to a PVC, enqueuing affected VMIs if capacity or requested size changes.
 func (c *Controller) updatePVC(old, cur interface{}) {
 	curPVC := cur.(*k8sv1.PersistentVolumeClaim)
 	oldPVC := old.(*k8sv1.PersistentVolumeClaim)
@@ -75,8 +75,9 @@ func (c *Controller) updatePVC(old, cur interface{}) {
 	if curPVC.DeletionTimestamp != nil {
 		return
 	}
-	if equality.Semantic.DeepEqual(curPVC.Status.Capacity, oldPVC.Status.Capacity) {
-		// We only do something when the capacity changes
+	if equality.Semantic.DeepEqual(curPVC.Status.Capacity, oldPVC.Status.Capacity) &&
+		equality.Semantic.DeepEqual(curPVC.Spec.Resources.Requests, oldPVC.Spec.Resources.Requests) {
+		// We only do something when the capacity or the requested size changes.
 		return
 	}
 	vmis, err := c.listVMIsMatchingDV(curPVC.Namespace, curPVC.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Online volume expansion can fail when the provisioner allocates a fixed large capacity (e.g. 50Gi), causing small increases in requested size to be ignored by our controller requeuing logic, which only accounts for `Capacity` increases.

This PR fixes the issue by requeuing the affected VMIs when their PVC's requested size changes, ensuring the expansion is applied.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-58023

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix online expansion by requeuing VMIs on PVC size change
```

