### PR TITLE
[release-1.4] Replace use of [Conformance] with the Conformance decorator

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -5,7 +5,7 @@ defining Kubevirt core functionalities. The goal of the suite is to make sure th
 
 ## How are Conformance tests selected
 
-By default tests with a `[Conformance]` tag (and from release 0.59 also decorator) will be executed and tests with a
+By default tests with a `conformance` decorator will be executed and tests with a
 `[Disruptive]` tag will be skipped. These tests will not destroy or modify
 anything outside of the explicitly created test namespaces by the binary.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ Additional suggestions:
 
  * The `[Disruptive]` tag is recognized by the test suite but is not yet
    mandatory. Feel free to set it on destructive tests.
- * Conformance tests need to be marked with a `[Conformance]` tag.
+ * Conformance tests need to be marked with a `decorators.Conformance` label.
  * We try to mark tests that require advanced/special storage capabilities with `[storage-req]`,  
    So they are easy to skip when lanes with new storage solutions are introduced.  
    At the point of writing this we use `rook-ceph-block` which certainly qualifies for running them.

--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -39,7 +39,7 @@ func execute() error {
 	if value, exists := os.LookupEnv("E2E_FOCUS"); exists {
 		args = append(args, "--ginkgo.focus", value)
 	} else {
-		args = append(args, "--ginkgo.focus", "\\[Conformance\\]")
+		args = append(args, "--ginkgo.label-filter", "(conformance)")
 	}
 	if value, exists := os.LookupEnv("CONTAINER_PREFIX"); exists {
 		args = append(args, "--container-prefix", value)

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -63,7 +63,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting and stopping the same VirtualMachine", func() {
 		Context("with ephemeral registry disk", func() {
-			It("[test_id:1463][Conformance] should success multiple times", decorators.Conformance, func() {
+			It("[test_id:1463] should success multiple times", decorators.Conformance, func() {
 				By("Creating the VirtualMachine")
 				vm := libvmi.NewVirtualMachine(libvmifact.NewCirros())
 				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.TODO(), vm, metav1.CreateOptions{})

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -24,6 +24,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -119,7 +120,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 					assertIPsNotEmptyForVMI(clientVMI)
 				})
 
-				It("[Conformance][test_id:1513] should succeed pinging between two VMI/s in the same namespace", func() {
+				It("[test_id:1513] should succeed pinging between two VMI/s in the same namespace", decorators.Conformance, func() {
 					assertPingSucceed(clientVMI, serverVMI)
 				})
 			})
@@ -134,7 +135,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 					assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 				})
 
-				It("[Conformance][test_id:1514] should fail pinging between two VMI/s each on different namespaces", func() {
+				It("[test_id:1514] should fail pinging between two VMI/s each on different namespaces", decorators.Conformance, func() {
 					assertPingFail(clientVMIAlternativeNamespace, serverVMI)
 				})
 			})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -35,6 +35,7 @@ import (
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -175,7 +176,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					)
 				})
 
-				It("[Conformance] should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
+				It("should report PodIP as its own on interface status", decorators.Conformance, func() { AssertReportedIP(vmi) })
 			})
 		})
 	})

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/job"
@@ -157,7 +158,7 @@ var _ = SIGDescribe("Services", func() {
 		})
 
 		Context("with a service matching the vmi exposed", func() {
-			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
+			DescribeTable("should be able to reach the vmi based on labels specified on the vmi", decorators.Conformance, func(ipFamily k8sv1.IPFamily) {
 				var service *k8sv1.Service
 				serviceName := "myservice"
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -490,7 +490,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			}
 		}
 
-		Context("[Conformance][test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", func() {
+		Context("[test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", decorators.Conformance, func() {
 			// This CIDR tests backwards compatibility of the "vmNetworkCIDR" field.
 			// The leading zero is intentional.
 			// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
@@ -649,7 +649,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				checks.SkipIfMigrationIsNotPossible()
 			})
 
-			DescribeTable("[Conformance] preserves connectivity - IPv4", func(ports []v1.Port) {
+			DescribeTable("preserves connectivity - IPv4", decorators.Conformance, func(ports []v1.Port) {
 				libnet.SkipWhenClusterNotSupportIpv4()
 
 				var err error
@@ -688,7 +688,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Entry("with explicit ports used by live migration", portsUsedByLiveMigration()),
 			)
 
-			It("[Conformance] should preserve connectivity - IPv6", func() {
+			It("should preserve connectivity - IPv6", decorators.Conformance, func() {
 				libnet.SkipWhenClusterNotSupportIpv6()
 
 				var err error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Cherry-pick of https://github.com/kubevirt/kubevirt/pull/14509

The preferred way of labeling conformance tests is now using the
decorator. 
Reflect that in the conformance test suite, e2e tests and the documentation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network conformance tests are now marked using the `Conformance` decorator. Use `--ginkgo.label-filter '(sig-network && conformance)` to select them.
```

