### PR TITLE
Allow CPU hotplug with net multi-queue

### DIFF
--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -139,3 +139,10 @@ func WithAutoAttachPodInterface(enabled bool) Option {
 		vmi.Spec.Domain.Devices.AutoattachPodInterface = &enabled
 	}
 }
+
+// WithNetworkInterfaceMultiQueue sets the networkInterfaceMultiQueue field.
+func WithNetworkInterfaceMultiQueue(enabled bool) Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &enabled
+	}
+}

--- a/pkg/network/setup/netpod/BUILD.bazel
+++ b/pkg/network/setup/netpod/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "//pkg/network/driver/nmstate:go_default_library",
         "//pkg/network/driver/procsys:go_default_library",
         "//pkg/network/errors:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/os/fs:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -70,7 +70,7 @@ type NetPod struct {
 	vmiUID           string
 	podPID           int
 	ownerID          int
-	queuesCap        int
+	queuesCapByIface map[string]int
 
 	nmstateAdapter    nmstateAdapter
 	masqueradeAdapter masqueradeAdapter
@@ -92,7 +92,6 @@ func NewNetPod(vmiNetworks []v1.Network, vmiIfaces []v1.Interface, vmiUID string
 		vmiUID:        vmiUID,
 		podPID:        podPID,
 		ownerID:       ownerID,
-		queuesCap:     queuesCapacity,
 		state:         state,
 
 		nmstateAdapter:    nmstate.New(),
@@ -106,6 +105,9 @@ func NewNetPod(vmiNetworks []v1.Network, vmiIfaces []v1.Interface, vmiUID string
 	for _, opt := range opts {
 		opt(&n)
 	}
+
+	n.queuesCapByIface = calcQueuesCapByIface(queuesCapacity, n.vmiSpecIfaces, n.vmiIfaceStatuses)
+
 	return n
 }
 
@@ -408,9 +410,11 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 }
 
 func (n NetPod) networkQueues(vmiIfaceIndex int) int {
-	if ifaceModel := n.vmiSpecIfaces[vmiIfaceIndex].Model; ifaceModel == "" || ifaceModel == v1.VirtIO {
-		return n.queuesCap
+	iface := n.vmiSpecIfaces[vmiIfaceIndex]
+	if ifaceModel := iface.Model; ifaceModel == "" || ifaceModel == v1.VirtIO {
+		return n.queuesCapByIface[iface.Name]
 	}
+
 	return 0
 }
 
@@ -562,6 +566,33 @@ func (n NetPod) lookupMasquradeBridge(desiredIfacesSpec []nmstate.Interface) *nm
 		return bridgeIfaceSpec
 	}
 	return nil
+}
+
+func calcQueuesCapByIface(desiredQueueCount int,
+	ifaces []v1.Interface,
+	ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface) map[string]int {
+
+	hasDomainInfoSource := func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
+		return vmispec.ContainsInfoSource(ifaceStatus.InfoSource, vmispec.InfoSourceDomain)
+	}
+
+	ifaceStatusesInDomainByName := vmispec.IndexInterfaceStatusByName(ifaceStatuses, hasDomainInfoSource)
+
+	queuesCapByIface := map[string]int{}
+	for _, iface := range ifaces {
+		if iface.SRIOV != nil {
+			continue
+		}
+
+		ifaceStatus, existsInDomain := ifaceStatusesInDomainByName[iface.Name]
+		if existsInDomain {
+			queuesCapByIface[iface.Name] = int(ifaceStatus.QueueCount)
+		} else {
+			queuesCapByIface[iface.Name] = desiredQueueCount
+		}
+	}
+
+	return queuesCapByIface
 }
 
 func ifaceStatusByName(interfaces []nmstate.Interface) map[string]nmstate.Interface {

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"sync"
 
 	vishnetlink "github.com/vishvananda/netlink"
@@ -43,6 +44,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/driver/procsys"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
 	"kubevirt.io/kubevirt/pkg/network/setup/netpod"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
 const (
@@ -1118,6 +1120,71 @@ var _ = Describe("netpod", func() {
 			PodIP:  primaryIPv4Address,
 			PodIPs: []string{primaryIPv4Address, primaryIPv6Address},
 		}))
+	})
+
+	It("should preserve network queue count if interface is already in the domain", func() {
+		const (
+			previousQueueCount = 1
+			currentQueueCount  = 2
+		)
+
+		vmiIface := v1.Interface{
+			Name:                   defaultPodNetworkName,
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+		}
+
+		vmiIfaceStatuses := []v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:             defaultPodNetworkName,
+				PodInterfaceName: "eth0",
+				QueueCount:       previousQueueCount,
+				InfoSource:       vmispec.InfoSourceDomain,
+			},
+		}
+
+		nmstatestub := nmstateStub{status: nmstate.Status{
+			Interfaces: []nmstate.Interface{{
+				Name:       "eth0",
+				Index:      0,
+				TypeName:   nmstate.TypeVETH,
+				State:      nmstate.IfaceStateUp,
+				MacAddress: "12:34:56:78:90:ab",
+				MTU:        1500,
+				IPv4: nmstate.IP{
+					Enabled: pointer.P(true),
+					Address: []nmstate.IPAddress{{
+						IP:        primaryIPv4Address,
+						PrefixLen: 30,
+					}},
+				},
+			}},
+			Routes: nmstate.Routes{Running: []nmstate.Route{
+				// Default Route
+				{
+					Destination:      "0.0.0.0/0",
+					NextHopInterface: "eth0",
+					NextHopAddress:   "10.0.0.1",
+					TableID:          0,
+				},
+			}},
+		}}
+
+		netPod := netpod.NewNetPod(
+			[]v1.Network{*v1.DefaultPodNetwork()},
+			[]v1.Interface{vmiIface},
+			vmiUID, 0, 0, currentQueueCount, state,
+			netpod.WithNMStateAdapter(&nmstatestub),
+			netpod.WithCacheCreator(&baseCacheCreator),
+			netpod.WithVMIIfaceStatuses(vmiIfaceStatuses),
+		)
+		Expect(netPod.Setup()).To(Succeed())
+
+		index := slices.IndexFunc(nmstatestub.spec.Interfaces, func(iface nmstate.Interface) bool {
+			return iface.Name == "tap0"
+		})
+		Expect(index).To(BeNumerically(">=", 0))
+
+		Expect(nmstatestub.spec.Interfaces[index].Tap.Queues).To(Equal(previousQueueCount))
 	})
 
 	DescribeTable("setup unhandled bindings", func(binding v1.InterfaceBindingMethod, expNmstateSpec nmstate.Spec) {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -618,12 +618,6 @@ func (c *Controller) handleCPUChangeRequest(vm *virtv1.VirtualMachine, vmi *virt
 		return nil
 	}
 
-	networkInterfaceMultiQueue := vmCopyWithInstancetype.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
-	if networkInterfaceMultiQueue != nil && *networkInterfaceMultiQueue {
-		setRestartRequired(vm, "Changes to CPU sockets require a restart when NetworkInterfaceMultiQueue is enabled")
-		return nil
-	}
-
 	if err := c.VMICPUsPatch(vmCopyWithInstancetype, vmi); err != nil {
 		log.Log.Object(vmi).Errorf("unable to patch vmi to add cpu topology status: %v", err)
 		return err

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -4786,31 +4786,6 @@ var _ = Describe("VirtualMachine", func() {
 					expectedCpuLim.Add(*resourcesDelta)
 					Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal(expectedCpuLim.String()))
 				})
-
-				It("should set a restartRequired condition if NetworkInterfaceMultiQueue is enabled", func() {
-					vm, _ := watchtesting.DefaultVirtualMachine(true)
-					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
-						Sockets: 2,
-					}
-					vm.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.P(true)
-
-					vmi := api.NewMinimalVMI(vm.Name)
-					vmi.Spec.Domain.CPU = &v1.CPU{
-						Sockets:    1,
-						MaxSockets: 4,
-					}
-
-					Expect(controller.handleCPUChangeRequest(vm, vmi)).To(Succeed())
-
-					vmCondManager := virtcontroller.NewVirtualMachineConditionManager()
-					cond := vmCondManager.GetCondition(vm, v1.VirtualMachineRestartRequired)
-					Expect(cond).To(Not(BeNil()))
-					Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Type":    Equal(v1.VirtualMachineRestartRequired),
-						"Message": ContainSubstring("when NetworkInterfaceMultiQueue is enabled"),
-						"Status":  Equal(k8sv1.ConditionTrue),
-					}))
-				})
 			})
 
 			Context("Memory", func() {

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -125,7 +125,10 @@ var _ = Describe("[sig-compute]CPU Hotplug", decorators.SigCompute, decorators.S
 				maxSockets uint32 = 2
 			)
 
-			vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+			vmi := libvmifact.NewAlpineWithTestTooling(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithNetworkInterfaceMultiQueue(true),
+			)
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
 			vmi.Spec.Domain.CPU = &v1.CPU{
 				Sockets:    1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, KubeVirt requires a restart of the VM in case CPU hotplug is requested with when NetworkInterfaceMultiQueue knob enabled.

Some background:
A tap device can be created with or without multi-queue support.
virt-handler creates tap devices with multi-queue support if the requested queue count is greater than one.

When the `NetworkInterfaceMultiQueue` knob is enabled, for interfaces using the `virtio` model, virt-handler can create the tap device with multi-queue support.

The number of queues is dependent on the vCPU topology:
sockets * cores * threads.

Note: This is not applicable for SR-IOV devices.

When creating a VM with one socket, one core and one thread and
the NetworkInterfaceMultiQueue knob is enabled, the tap devices are
not configured for multi-queue.

When a CPU hotplug is performed:
- The VMI vCPU topology is updated.
- KubeVirt automatically initiates a migration.
- On the target pod, the target virt-handler creates the tap devices
  with multi-queue, due to the increase in socket count.
- The domain is migrated without changes to the interfaces section
  from source to target.
- virtqemud on the target pod fails with the following error:

```
Live migration failed error encountered during MigrateToURI3 libvirt api
call: virError(Code=38, Domain=0, Message=''Unable to create multiple
fds for tap device tap0 (maybe existing device was created without
multi_queue flag): Invalid argument'')
```

Preserve the original tap configuration on the target pod when the VM is migrated.

On a CPU hotplug scenario, the queue count will not increase on existing interfaces.
In order to align the queue count of existing interfaces with the vCPU topology - a VM restart will be required.

Newly hotplugged NICs can enjoy the multi-queue support and the queue count which matches the new vCPU topology.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CPU hotplug with net multi-queue is now allowed
```

