### PR TITLE
VMSnapshot: fix QuiesceFailed indication not being updated

### DIFF
--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -1388,12 +1388,13 @@ var _ = Describe("Snapshot controlleer", func() {
 
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
-				errorMessage := "Failed freezing vm"
+				errorMessage := "Guest agent is not responding"
+				formatedErr := fmt.Sprintf("%s %s: %v", failedFreezeMsg, vm.Name, errorMessage)
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
 					ReadyToUse: pointer.P(false),
 					Error: &snapshotv1.Error{
 						Time:    timeFunc(),
-						Message: &errorMessage,
+						Message: &formatedErr,
 					},
 				}
 
@@ -1407,7 +1408,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
-			It("should set QuiesceFailed indication if failed freeze vm", func() {
+			It("should set QuiesceFailed indication if error in content says failed freeze vm", func() {
 				vm := createLockedVM()
 				vmSource.Add(vm)
 				vmi := createVMI(vm)
@@ -1419,8 +1420,9 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
 				vmiSource.Add(vmi)
 
-				errorMessage := "Failed freezing vm"
-				vmSnapshotContent := createErrorVMSnapshotContent(errorMessage)
+				errorMessage := "Guest agent is not responding"
+				formatedErr := fmt.Sprintf("%s %s: %v", failedFreezeMsg, vm.Name, errorMessage)
+				vmSnapshotContent := createErrorVMSnapshotContent(formatedErr)
 				vmSnapshotContentSource.Add(vmSnapshotContent)
 
 				vmSnapshot := createVMSnapshotInProgress()

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -440,8 +440,9 @@ func (s *vmSnapshotSource) Freeze() error {
 	err := s.controller.Client.VirtualMachineInstance(s.vm.Namespace).Freeze(context.Background(), s.vm.Name, getFailureDeadline(s.snapshot))
 	timeTrack(startTime, fmt.Sprintf("Freezing vmi %s", s.vm.Name))
 	if err != nil {
-		log.Log.Errorf("%s %s: %v", failedFreezeMsg, s.vm.Name, err.Error())
-		return err
+		formatedErr := fmt.Errorf("%s %s: %v", failedFreezeMsg, s.vm.Name, err.Error())
+		log.Log.Errorf(formatedErr.Error())
+		return formatedErr
 	}
 	s.state.frozen = true
 


### PR DESCRIPTION
The indication is updated when the error contains a pre-defined prefix. Needed to format the freeze error with this prefix for this indication to be shown.
The UT missed the check since the formated prefix was used as the error returned from the freeze mock.
Updated it to reflect the code.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

