### PR TITLE
Fix misspellings in tests/storage

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -909,7 +909,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 				))
 				Eventually(ThisPVCWith(testsuite.NamespaceTestAlternative, dataVolume.Name), 10*time.Second, 1*time.Second).Should(BeGone())
 
-				// We check if the VM is succesfully created
+				// We check if the VM is successfully created
 				By("Creating VM")
 				Eventually(func() error {
 					_, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -947,7 +947,7 @@ var _ = Describe(SIG("Export", func() {
 		Expect(*export.Status.TokenSecretRef).To(Equal(token.Name))
 	})
 
-	It("should be possibe to observe exportserver pod exiting", func() {
+	It("should be possible to observe exportserver pod exiting", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
 			Fail("Fail test when Filesystem storage is not present")

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -159,7 +159,7 @@ var _ = Describe(SIG("Hotplug", func() {
 
 		// Try at least 3 times, this is done because `AddVolume` is inherently racy in the way it's implemented
 		// as when it patches the VM Status it expects the field `volumeRequests` to be there (by using a test json patch op),
-		// but at the same time virt-controller trims this field when all requests have been satified.
+		// but at the same time virt-controller trims this field when all requests have been satisfied.
 		// To avoid hitting these we should explicitly try multiple times.
 		for i := 0; i < 3; i++ {
 			err = virtClient.VirtualMachine(namespace).AddVolume(context.Background(), name, volumeOptions)
@@ -448,7 +448,7 @@ var _ = Describe(SIG("Hotplug", func() {
 		return vm
 	}
 
-	verifyHotplugAttachedAndUseable := func(vmi *v1.VirtualMachineInstance, names []string) []string {
+	verifyHotplugAttachedAndUsable := func(vmi *v1.VirtualMachineInstance, names []string) []string {
 		targets := getTargetsFromVolumeStatus(vmi, names...)
 		for _, target := range targets {
 			verifyVolumeAccessible(vmi, target)
@@ -528,7 +528,7 @@ var _ = Describe(SIG("Hotplug", func() {
 		verifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
 		verifyVolumeStatus(vmi, v1.VolumeReady, "", "testvolume")
 		getVmiConsoleAndLogin(vmi)
-		targets := verifyHotplugAttachedAndUseable(vmi, []string{"testvolume"})
+		targets := verifyHotplugAttachedAndUsable(vmi, []string{"testvolume"})
 		verifySingleAttachmentPod(vmi)
 		By(removingVolumeFromVM)
 		removeVolumeFunc(vm.Name, vm.Namespace, "testvolume", false)
@@ -633,7 +633,7 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyVolumeAndDiskVMIAdded(virtClient, vmi, dv.Name)
 			verifyVolumeStatus(vmi, v1.VolumeReady, "", dv.Name)
 			getVmiConsoleAndLogin(vmi)
-			targets := verifyHotplugAttachedAndUseable(vmi, []string{dv.Name})
+			targets := verifyHotplugAttachedAndUsable(vmi, []string{dv.Name})
 			Expect(targets).To(HaveLen(1))
 		},
 			Entry("DataVolume", addDVVolumeVM),
@@ -660,7 +660,7 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyVolumeAndDiskVMIAdded(virtClient, vmi, dv.Name)
 			verifyVolumeStatus(vmi, v1.VolumeReady, "", dv.Name)
 			getVmiConsoleAndLogin(vmi)
-			targets := verifyHotplugAttachedAndUseable(vmi, []string{dv.Name})
+			targets := verifyHotplugAttachedAndUsable(vmi, []string{dv.Name})
 			Expect(targets).To(HaveLen(1))
 
 			By("Deleting virt-handler pod")
@@ -688,7 +688,7 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyVolumeAndDiskVMIAdded(virtClient, vmi, dv.Name)
 			verifyVolumeStatus(vmi, v1.VolumeReady, "", dv.Name)
 			getVmiConsoleAndLogin(vmi)
-			targets = verifyHotplugAttachedAndUseable(vmi, []string{dv.Name})
+			targets = verifyHotplugAttachedAndUsable(vmi, []string{dv.Name})
 			Expect(targets).To(HaveLen(1))
 
 			By("Verifying the block devices are still accessible")
@@ -760,7 +760,7 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyVolumeAndDiskVMIAdded(virtClient, vmi, dvNames...)
 			verifyVolumeStatus(vmi, v1.VolumeReady, "", dvNames...)
 			getVmiConsoleAndLogin(vmi)
-			verifyHotplugAttachedAndUseable(vmi, dvNames)
+			verifyHotplugAttachedAndUsable(vmi, dvNames)
 			verifySingleAttachmentPod(vmi)
 			for _, volumeName := range dvNames {
 				By("removing volume " + volumeName + " from VM")
@@ -870,7 +870,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				Expect(err).ToNot(HaveOccurred())
 				verifyVolumeAndDiskVMIAdded(virtClient, vmi, testVolumes...)
 				verifyVolumeStatus(vmi, v1.VolumeReady, "", testVolumes...)
-				targets := verifyHotplugAttachedAndUseable(vmi, testVolumes)
+				targets := verifyHotplugAttachedAndUsable(vmi, testVolumes)
 				verifySingleAttachmentPod(vmi)
 				for _, volumeName := range testVolumes {
 					By("removing volume " + volumeName + " from VM")
@@ -1042,7 +1042,7 @@ var _ = Describe(SIG("Hotplug", func() {
 
 				By("Verifying the volume is attached and usable")
 				getVmiConsoleAndLogin(vmi)
-				targets := verifyHotplugAttachedAndUseable(vmi, []string{"testvolume"})
+				targets := verifyHotplugAttachedAndUsable(vmi, []string{"testvolume"})
 				Expect(targets).To(HaveLen(1))
 
 				By("stopping VM")
@@ -1221,7 +1221,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				libwait.WaitForSuccessfulVMIStart(vmi,
 					libwait.WithTimeout(240),
 				)
-				By("Verifying the VMI is migrateable")
+				By("Verifying the VMI is migratable")
 				Eventually(matcher.ThisVMI(vmi), 90*time.Second, 1*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceIsMigratable))
 
 				By("Adding volume to running VMI")
@@ -1232,12 +1232,12 @@ var _ = Describe(SIG("Hotplug", func() {
 				verifyVolumeAndDiskVMIAdded(virtClient, vmi, volumeName)
 				verifyVolumeStatus(vmi, v1.VolumeReady, "", volumeName)
 
-				By("Verifying the VMI is still migrateable")
+				By("Verifying the VMI is still migratable")
 				Eventually(matcher.ThisVMI(vmi), 90*time.Second, 1*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceIsMigratable))
 
 				By("Verifying the volume is attached and usable")
 				getVmiConsoleAndLogin(vmi)
-				targets := verifyHotplugAttachedAndUseable(vmi, []string{volumeName})
+				targets := verifyHotplugAttachedAndUsable(vmi, []string{volumeName})
 				Expect(targets).To(HaveLen(1))
 
 				By("Starting the migration")
@@ -1451,8 +1451,8 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyVolumeStatus(vmi, v1.VolumeReady, "", checkVolumeName)
 			getVmiConsoleAndLogin(vmi)
 
-			By("verifying the volume is useable and creating some data on it")
-			verifyHotplugAttachedAndUseable(vmi, []string{checkVolumeName})
+			By("verifying the volume is usable and creating some data on it")
+			verifyHotplugAttachedAndUsable(vmi, []string{checkVolumeName})
 			targets := getTargetsFromVolumeStatus(vmi, checkVolumeName)
 			Expect(targets).ToNot(BeEmpty())
 			verifyWriteReadData(vmi, targets[0])
@@ -1972,7 +1972,7 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
 			verifyVolumeStatus(vmi, v1.VolumeReady, "", "testvolume")
 			getVmiConsoleAndLogin(vmi)
-			targets := verifyHotplugAttachedAndUseable(vmi, []string{"testvolume"})
+			targets := verifyHotplugAttachedAndUsable(vmi, []string{"testvolume"})
 			verifySingleAttachmentPod(vmi)
 			By(removingVolumeFromVM)
 			removeVolumeVM(vm.Name, vm.Namespace, "testvolume", false)

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -686,7 +686,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			}).WithTimeout(120 * time.Second).WithPolling(time.Second).Should(BeNil())
 		})
 
-		Context("should be able to recover from an interuppted volume migration", func() {
+		Context("should be able to recover from an interrupted volume migration", func() {
 			const volName = "volume0"
 
 			createMigpolicyWithLimitedBandwidth := func(vmi *virtv1.VirtualMachineInstance) {

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -38,7 +38,7 @@ import (
 
 // The SCSI persistent reservation tests require to run serially because of the
 // feature gate PersistentReservation. The enablement/disablement of this
-// feature gate redeploys virt-handler pod, and this might interfer with other
+// feature gate redeploys virt-handler pod, and this might interfere with other
 // tests.
 var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 	const randLen = 8
@@ -199,7 +199,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 		}
 	})
 
-	Context("Use LUN disk with presistent reservation", func() {
+	Context("Use LUN disk with persistent reservation", func() {
 		BeforeEach(func() {
 			var err error
 			naa = generateNaa()

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -434,7 +434,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 							ClientConfig: admissionregistrationv1.WebhookClientConfig{
 								Service: &admissionregistrationv1.ServiceReference{
 									Namespace: testsuite.GetTestNamespace(nil),
-									Name:      "nonexistant",
+									Name:      "nonexistent",
 									Path:      &whPath,
 								},
 							},
@@ -1230,7 +1230,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				libvmops.StartVirtualMachine(vm)
 			})
 
-			// This test is relevant to provisioner which round up the recieved size of
+			// This test is relevant to provisioner which round up the received size of
 			// the PVC. Currently we only test vmsnapshot tests which ceph which has this
 			// behavior. In case of running this test with other provisioner or if ceph
 			// will change this behavior it will fail.
@@ -1504,7 +1504,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 							ClientConfig: admissionregistrationv1.WebhookClientConfig{
 								Service: &admissionregistrationv1.ServiceReference{
 									Namespace: testsuite.GetTestNamespace(nil),
-									Name:      "nonexistant",
+									Name:      "nonexistent",
 									Path:      &whPath,
 								},
 							},

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1607,7 +1607,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 
 			DescribeTable("Bug #8435 - should create a snapshot successfully", decorators.StorageCritical, func(toRunSourceVM bool) {
 				if !toRunSourceVM {
-					By("Stoping the VM")
+					By("Stopping the VM")
 					vm = libvmops.StopVirtualMachine(vm)
 				}
 
@@ -1708,7 +1708,7 @@ func createDenyVolumeSnapshotCreateWebhook(virtClient kubecli.KubevirtClient, vm
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: testsuite.GetTestNamespace(nil),
-						Name:      "nonexistant",
+						Name:      "nonexistent",
 						Path:      &whPath,
 					},
 				},


### PR DESCRIPTION
### What this PR does
Before this PR:
files under tests storage had some misspelling words in them

After this PR:
The words are written correctly in the related files

### Special notes for your reviewer
Related PR:
Related PR:
 - https://github.com/kubevirt/kubevirt/pull/14662
 - https://github.com/kubevirt/kubevirt/pull/14688
 - https://github.com/kubevirt/kubevirt/pull/14750
 - https://github.com/kubevirt/kubevirt/pull/14751

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

