### PR TITLE
VMRestore+VM admission webhook: fix check of update VM during restore

### DIFF
--- a/pkg/storage/admitters/vm-storage-status.go
+++ b/pkg/storage/admitters/vm-storage-status.go
@@ -44,11 +44,12 @@ func (a *Admitter) validateRestoreStatus() []metav1.StatusCause {
 	}
 
 	if !equality.Semantic.DeepEqual(oldVM.Spec, a.vm.Spec) {
-		strategy, _ := a.vm.RunStrategy()
-		if strategy != v1.RunStrategyHalted {
+		oldStrategy, _ := oldVM.RunStrategy()
+		newStrategy, _ := a.vm.RunStrategy()
+		if newStrategy != oldStrategy {
 			return []metav1.StatusCause{{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
-				Message: fmt.Sprintf("Cannot start VM until restore %q completes", *a.vm.Status.RestoreInProgress),
+				Message: fmt.Sprintf("Cannot update VM runStrategy until restore %q completes", *a.vm.Status.RestoreInProgress),
 				Field:   k8sfield.NewPath("spec").String(),
 			}}
 		}

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -316,37 +316,6 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			})
 		})
 
-		Context("with run strategy and snapshot", func() {
-			var err error
-			var snapshot *snapshotv1.VirtualMachineSnapshot
-
-			AfterEach(func() {
-				deleteSnapshot(snapshot)
-			})
-
-			It("should successfully restore", func() {
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyRerunOnFailure)
-				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
-				snapshot = createSnapshot(vm)
-
-				vm = libvmops.StopVirtualMachine(vm)
-				Expect(vm.Spec.RunStrategy).To(HaveValue(Equal(v1.RunStrategyRerunOnFailure)))
-				restore := createRestoreDef(vm.Name, snapshot.Name)
-
-				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				restore = waitRestoreComplete(restore, vm.Name, &vm.UID)
-				Expect(restore.Status.Restores).To(BeEmpty())
-				Expect(restore.Status.DeletedDataVolumes).To(BeEmpty())
-				restoredVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(restoredVM.Spec.RunStrategy).To(Equal(pointer.P(v1.RunStrategyRerunOnFailure)))
-			})
-		})
-
 		Context("and good snapshot exists", func() {
 			var err error
 			var snapshot *snapshotv1.VirtualMachineSnapshot
@@ -1541,7 +1510,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				}, 180*time.Second, 3*time.Second).Should(BeTrue())
 
 				err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Cannot start VM until restore %q completes", restore.Name)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Cannot update VM runStrategy until restore %q completes", restore.Name)))
 
 				switch deleteFunc {
 				case "deleteWebhook":
@@ -1771,6 +1740,20 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Entry("[test_id:7425] to the same VM", false),
 				Entry("to a new VM", true),
 			)
+
+			It("with run strategy and snapshot should successfully restore", func() {
+				vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)
+				libvmi.WithRunStrategy(v1.RunStrategyRerunOnFailure)(vm)
+				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
+				vm = libvmops.StartVirtualMachine(vm)
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
+				Expect(vm.Spec.RunStrategy).To(HaveValue(Equal(v1.RunStrategyRerunOnFailure)))
+				doRestoreNoVMStart("", console.LoginToFedora, onlineSnapshot, false, vm.Name)
+				Expect(restore.Status.Restores).To(HaveLen(1))
+				restoredVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(restoredVM.Spec.RunStrategy).To(Equal(pointer.P(v1.RunStrategyRerunOnFailure)))
+			})
 
 			Context("with memory dump", func() {
 				var memoryDumpPVC *corev1.PersistentVolumeClaim


### PR DESCRIPTION
    A recent fix enabled restoring VMs with a RunStrategy other than Halted.
    However, when the VM has associated volumes being restored, the VM spec is
    updated as part of the process. This causes a failure in the vm restore
    because when updating the vm in the restore process the webhook detects
    a spec change and previously only allowed it if the RunStrategy remained Halted.
    Now that all RunStrategy values (except Always) are permitted, the restore
    process should only ensure that the RunStrategy itself hasn't been modified
    during the restore, rather than enforcing a specific value.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-59294

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

