### PR TITLE
DNM/WIP Use TypedObjectReference for VirtualMachineClone Source and Target

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19274,11 +19274,11 @@
      },
      "source": {
       "description": "Source is the object that would be cloned. Currently supported source types are: VirtualMachine of kubevirt.io API group, VirtualMachineSnapshot of snapshot.kubevirt.io API group",
-      "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.TypedObjectReference"
      },
      "target": {
       "description": "Target is the outcome of the cloning process. Currently supported source types are: - VirtualMachine of kubevirt.io API group - Empty (nil). If the target is not provided, the target type would default to VirtualMachine and a random name would be generated for the target. The target's name can be viewed by inspecting status \"TargetName\" field below.",
-      "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.TypedObjectReference"
      },
      "template": {
       "description": "For a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
@@ -106,7 +106,7 @@ func generateTargetName(sourceName string, targetSuffix string) string {
 	return fmt.Sprintf("clone-%s-%s", sourceName, targetSuffix)
 }
 
-func generateDefaultTarget(cloneSpec *clone.VirtualMachineCloneSpec, targetSuffix string) (target *k8sv1.TypedLocalObjectReference) {
+func generateDefaultTarget(cloneSpec *clone.VirtualMachineCloneSpec, targetSuffix string) (target *k8sv1.TypedObjectReference) {
 	const (
 		virtualMachineAPIGroup = "kubevirt.io"
 		virtualMachineKind     = "VirtualMachine"
@@ -114,7 +114,7 @@ func generateDefaultTarget(cloneSpec *clone.VirtualMachineCloneSpec, targetSuffi
 
 	source := cloneSpec.Source
 
-	target = &k8sv1.TypedLocalObjectReference{
+	target = &k8sv1.TypedObjectReference{
 		APIGroup: pointer.P(virtualMachineAPIGroup),
 		Kind:     virtualMachineKind,
 		Name:     generateTargetName(source.Name, targetSuffix),
@@ -123,7 +123,7 @@ func generateDefaultTarget(cloneSpec *clone.VirtualMachineCloneSpec, targetSuffi
 	return target
 }
 
-func hasTargetChanged(original, mutated *k8sv1.TypedLocalObjectReference) bool {
+func hasTargetChanged(original, mutated *k8sv1.TypedObjectReference) bool {
 	if original == nil {
 		return true
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Clone mutating webhook", func() {
 		mutator := mutators.NewCloneCreateMutatorWithTargetSuffix(expectedTargetSuffix)
 
 		expectedVirtualMachineCloneSpec := vmClone.Spec.DeepCopy()
-		expectedVirtualMachineCloneSpec.Target = &k8sv1.TypedLocalObjectReference{
+		expectedVirtualMachineCloneSpec.Target = &k8sv1.TypedObjectReference{
 			APIGroup: pointer.P(virtualMachineAPIGroup),
 			Kind:     virtualMachineKind,
 			Name:     fmt.Sprintf("clone-%s-%s", expectedVirtualMachineCloneSpec.Source.Name, expectedTargetSuffix),
@@ -124,7 +124,7 @@ const (
 
 func withVirtualMachineSource(virtualMachineName string) option {
 	return func(vmClone *clone.VirtualMachineClone) {
-		vmClone.Spec.Source = &k8sv1.TypedLocalObjectReference{
+		vmClone.Spec.Source = &k8sv1.TypedObjectReference{
 			APIGroup: pointer.P(virtualMachineAPIGroup),
 			Kind:     virtualMachineKind,
 			Name:     virtualMachineName,
@@ -134,7 +134,7 @@ func withVirtualMachineSource(virtualMachineName string) option {
 
 func withVirtualMachineSnapshotSource(virtualMachineSnapshotName string) option {
 	return func(vmClone *clone.VirtualMachineClone) {
-		vmClone.Spec.Source = &k8sv1.TypedLocalObjectReference{
+		vmClone.Spec.Source = &k8sv1.TypedObjectReference{
 			APIGroup: pointer.P(virtualMachineSnapshotAPIGroup),
 			Kind:     virtualMachineSnapshotKind,
 			Name:     virtualMachineSnapshotName,
@@ -144,7 +144,7 @@ func withVirtualMachineSnapshotSource(virtualMachineSnapshotName string) option 
 
 func withVirtualMachineTarget(virtualMachineName string) option {
 	return func(vmClone *clone.VirtualMachineClone) {
-		vmClone.Spec.Target = &k8sv1.TypedLocalObjectReference{
+		vmClone.Spec.Target = &k8sv1.TypedObjectReference{
 			APIGroup: pointer.P(virtualMachineAPIGroup),
 			Kind:     virtualMachineKind,
 			Name:     virtualMachineName,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -213,31 +213,31 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		admitter.admitAndExpect(vmClone, true)
 	})
 
-	DescribeTable("should reject clone with source that lacks information", func(getSource func() *k8sv1.TypedLocalObjectReference) {
+	DescribeTable("should reject clone with source that lacks information", func(getSource func() *k8sv1.TypedObjectReference) {
 		vmClone.Spec.Source = getSource()
 		admitter.admitAndExpect(vmClone, false)
 	},
-		Entry("Source without Name", func() *k8sv1.TypedLocalObjectReference {
+		Entry("Source without Name", func() *k8sv1.TypedObjectReference {
 			source := newValidObjReference()
 			source.Name = ""
 			return source
 		}),
-		Entry("Source without Kind", func() *k8sv1.TypedLocalObjectReference {
+		Entry("Source without Kind", func() *k8sv1.TypedObjectReference {
 			source := newValidObjReference()
 			source.Kind = ""
 			return source
 		}),
-		Entry("Source with nil APIGroup", func() *k8sv1.TypedLocalObjectReference {
+		Entry("Source with nil APIGroup", func() *k8sv1.TypedObjectReference {
 			source := newValidObjReference()
 			source.APIGroup = nil
 			return source
 		}),
-		Entry("Source with empty APIGroup", func() *k8sv1.TypedLocalObjectReference {
+		Entry("Source with empty APIGroup", func() *k8sv1.TypedObjectReference {
 			source := newValidObjReference()
 			source.APIGroup = pointer.P("")
 			return source
 		}),
-		Entry("Source with bad kind", func() *k8sv1.TypedLocalObjectReference {
+		Entry("Source with bad kind", func() *k8sv1.TypedObjectReference {
 			source := newValidObjReference()
 			source.Kind = "Foobar"
 			return source
@@ -472,8 +472,8 @@ func newValidClone() *clone.VirtualMachineClone {
 	return vmClone
 }
 
-func newValidObjReference() *k8sv1.TypedLocalObjectReference {
-	return &k8sv1.TypedLocalObjectReference{
+func newValidObjReference() *k8sv1.TypedObjectReference {
+	return &k8sv1.TypedObjectReference{
 		APIGroup: pointer.P(core.GroupName),
 		Kind:     virtualMachineKind,
 		Name:     "clone-source-vm",

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Clone", func() {
 		sourceVM = libvmi.NewVirtualMachine(sourceVMI)
 
 		vmClone = kubecli.NewMinimalCloneWithNS("testclone", metav1.NamespaceDefault)
-		cloneSourceRef := &k8sv1.TypedLocalObjectReference{
+		cloneSourceRef := &k8sv1.TypedObjectReference{
 			APIGroup: pointer.P(vmAPIGroup),
 			Kind:     "VirtualMachine",
 			Name:     sourceVM.Name,
@@ -1134,7 +1134,7 @@ var _ = Describe("Clone", func() {
 			}
 
 			It("should generate target vm name if it is not provided", func() {
-				vmClone.Spec.Target = &k8sv1.TypedLocalObjectReference{
+				vmClone.Spec.Target = &k8sv1.TypedObjectReference{
 					APIGroup: pointer.P(vmAPIGroup),
 					Kind:     "VirtualMachine",
 				}

--- a/pkg/virt-controller/watch/clone/util.go
+++ b/pkg/virt-controller/watch/clone/util.go
@@ -91,7 +91,7 @@ func generateSnapshot(vmClone *clone.VirtualMachineClone, sourceVM *v1.VirtualMa
 	}
 }
 
-func generateRestore(targetInfo *corev1.TypedLocalObjectReference, sourceVMName, namespace, cloneName, snapshotName string, cloneUID types.UID, patches []string) *snapshotv1.VirtualMachineRestore {
+func generateRestore(targetInfo *corev1.TypedObjectReference, sourceVMName, namespace, cloneName, snapshotName string, cloneUID types.UID, patches []string) *snapshotv1.VirtualMachineRestore {
 	targetInfo = targetInfo.DeepCopy()
 	if targetInfo.Name == "" {
 		targetInfo.Name = generateVMName(sourceVMName)
@@ -106,7 +106,11 @@ func generateRestore(targetInfo *corev1.TypedLocalObjectReference, sourceVMName,
 			},
 		},
 		Spec: snapshotv1.VirtualMachineRestoreSpec{
-			Target:                     *targetInfo,
+			Target: corev1.TypedLocalObjectReference{
+				APIGroup: targetInfo.APIGroup,
+				Name:     targetInfo.Name,
+				Kind:     targetInfo.Kind,
+			},
 			VirtualMachineSnapshotName: snapshotName,
 			Patches:                    patches,
 		},

--- a/pkg/virt-operator/resource/generate/components/crds_test.go
+++ b/pkg/virt-operator/resource/generate/components/crds_test.go
@@ -319,10 +319,10 @@ var _ = Describe("CRDs", func() {
 		Entry("for VirtualMachineClone", NewVirtualMachineCloneCrd,
 			clonev1beta1.VirtualMachineClone{
 				Spec: clonev1beta1.VirtualMachineCloneSpec{
-					Source: &k8sv1.TypedLocalObjectReference{
+					Source: &k8sv1.TypedObjectReference{
 						Name: "test-source",
 					},
-					Target: &k8sv1.TypedLocalObjectReference{
+					Target: &k8sv1.TypedObjectReference{
 						Name: "test-target",
 					},
 				},

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8697,11 +8697,16 @@ var CRDsValidation map[string]string = map[string]string{
             name:
               description: Name is the name of resource being referenced
               type: string
+            namespace:
+              description: |-
+                Namespace is the namespace of resource being referenced
+                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+              type: string
           required:
           - kind
           - name
           type: object
-          x-kubernetes-map-type: atomic
         target:
           description: |-
             Target is the outcome of the cloning process.
@@ -8724,11 +8729,16 @@ var CRDsValidation map[string]string = map[string]string{
             name:
               description: Name is the name of resource being referenced
               type: string
+            namespace:
+              description: |-
+                Namespace is the namespace of resource being referenced
+                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+              type: string
           required:
           - kind
           - name
           type: object
-          x-kubernetes-map-type: atomic
         template:
           description: For a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.
           properties:

--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -252,7 +252,7 @@ func (c *createClone) run(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, sourceOrTargetName string, isSource bool) (*v1.TypedLocalObjectReference, error) {
+func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, sourceOrTargetName string, isSource bool) (*v1.TypedObjectReference, error) {
 	var kind, apiGroup string
 
 	generateErr := func() error {
@@ -285,7 +285,7 @@ func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, source
 		return nil, generateErr()
 	}
 
-	return &v1.TypedLocalObjectReference{
+	return &v1.TypedObjectReference{
 		Name:     sourceOrTargetName,
 		Kind:     kind,
 		APIGroup: &apiGroup,

--- a/staging/src/kubevirt.io/api/clone/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/deepcopy_generated.go
@@ -112,12 +112,12 @@ func (in *VirtualMachineCloneSpec) DeepCopyInto(out *VirtualMachineCloneSpec) {
 	*out = *in
 	if in.Source != nil {
 		in, out := &in.Source, &out.Source
-		*out = new(v1.TypedLocalObjectReference)
+		*out = new(v1.TypedObjectReference)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Target != nil {
 		in, out := &in.Target, &out.Target
-		*out = new(v1.TypedLocalObjectReference)
+		*out = new(v1.TypedObjectReference)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.AnnotationFilters != nil {

--- a/staging/src/kubevirt.io/api/clone/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/types.go
@@ -54,7 +54,7 @@ type VirtualMachineCloneSpec struct {
 	// Source is the object that would be cloned. Currently supported source types are:
 	// VirtualMachine of kubevirt.io API group,
 	// VirtualMachineSnapshot of snapshot.kubevirt.io API group
-	Source *corev1.TypedLocalObjectReference `json:"source"`
+	Source *corev1.TypedObjectReference `json:"source"`
 
 	// Target is the outcome of the cloning process.
 	// Currently supported source types are:
@@ -64,7 +64,7 @@ type VirtualMachineCloneSpec struct {
 	// name would be generated for the target. The target's name can be viewed by
 	// inspecting status "TargetName" field below.
 	// +optional
-	Target *corev1.TypedLocalObjectReference `json:"target,omitempty"`
+	Target *corev1.TypedObjectReference `json:"target,omitempty"`
 
 	// Example use: "!some/key*".
 	// For a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17296,13 +17296,13 @@ func schema_kubevirtio_api_clone_v1beta1_VirtualMachineCloneSpec(ref common.Refe
 					"source": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Source is the object that would be cloned. Currently supported source types are: VirtualMachine of kubevirt.io API group, VirtualMachineSnapshot of snapshot.kubevirt.io API group",
-							Ref:         ref("k8s.io/api/core/v1.TypedLocalObjectReference"),
+							Ref:         ref("k8s.io/api/core/v1.TypedObjectReference"),
 						},
 					},
 					"target": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Target is the outcome of the cloning process. Currently supported source types are: - VirtualMachine of kubevirt.io API group - Empty (nil). If the target is not provided, the target type would default to VirtualMachine and a random name would be generated for the target. The target's name can be viewed by inspecting status \"TargetName\" field below.",
-							Ref:         ref("k8s.io/api/core/v1.TypedLocalObjectReference"),
+							Ref:         ref("k8s.io/api/core/v1.TypedObjectReference"),
 						},
 					},
 					"annotationFilters": {
@@ -17400,7 +17400,7 @@ func schema_kubevirtio_api_clone_v1beta1_VirtualMachineCloneSpec(ref common.Refe
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.TypedLocalObjectReference", "kubevirt.io/api/clone/v1beta1.VirtualMachineCloneTemplateFilters"},
+			"k8s.io/api/core/v1.TypedObjectReference", "kubevirt.io/api/clone/v1beta1.VirtualMachineCloneTemplateFilters"},
 	}
 }
 


### PR DESCRIPTION
/cc @iholder101
/cc @0xFelix 

Hey Itamar, I'm hacking around with the `clone.kubevirt.io` API and want to potentially extend it to support namespaced resources in the future. I'm assuming switching source and target to use `TypedObjectReference` instead of the current `TypedLocalObjectReference` will require a `v1beta2` version of the API but wanted to test it out and confirm with you before proceeding. Would appreciate your thoughts on this when you have time.

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

