### PR TITLE
virt-Freeze: skip freeze if domain is not in running state

### DIFF
--- a/cmd/virt-freezer/BUILD.bazel
+++ b/cmd/virt-freezer/BUILD.bazel
@@ -1,8 +1,8 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = ["virt-freezer.go"],
     importpath = "kubevirt.io/kubevirt/cmd/virt-freezer",
     visibility = ["//visibility:private"],
     deps = [
@@ -12,6 +12,24 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "virt-freezer_suite_test.go",
+        "virt-freezer_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/virt-handler/cmd-client:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/go.uber.org/mock/gomock:go_default_library",
     ],
 )
 

--- a/cmd/virt-freezer/main.go
+++ b/cmd/virt-freezer/main.go
@@ -51,7 +51,7 @@ func getGrpcClient() (cmdclient.LauncherClient, error) {
 	return client, err
 }
 
-func isVmRunning(client cmdclient.LauncherClient) bool {
+func shouldFreezeVirtualMachine(client cmdclient.LauncherClient) bool {
 	domain, exists, err := client.GetDomain()
 	if err != nil {
 		log.Log.Reason(err).Error("Failed to get domain")
@@ -108,9 +108,9 @@ func main() {
 
 	log.Log.Infof("Guest agent version is %s", info.GAVersion)
 
-	if !isVmRunning(client) {
-		log.Log.Error("Paused VM, unable to freeze/unfreeze")
-		os.Exit(1)
+	if !shouldFreezeVirtualMachine(client) {
+		log.Log.Info("VM domain not running, no need to freeze/unfreeze")
+		os.Exit(0)
 	}
 
 	if *freeze {

--- a/cmd/virt-freezer/virt-freezer_suite_test.go
+++ b/cmd/virt-freezer/virt-freezer_suite_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestComponents(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/cmd/virt-freezer/virt-freezer_test.go
+++ b/cmd/virt-freezer/virt-freezer_test.go
@@ -1,0 +1,149 @@
+// freezer_test.go
+package main
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
+	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+)
+
+var _ = Describe("Freezer", func() {
+	var (
+		client    *cmdclient.MockLauncherClient
+		config    *FreezerConfig
+		guestInfo *v1.VirtualMachineInstanceGuestAgentInfo
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		client = cmdclient.NewMockLauncherClient(ctrl)
+		config = &FreezerConfig{
+			Name:      "test-vmi",
+			Namespace: "default",
+		}
+		guestInfo = &v1.VirtualMachineInstanceGuestAgentInfo{
+			GAVersion: "1.0",
+		}
+	})
+
+	Describe("shouldFreezeVirtualMachine", func() {
+		It("should return true if domain exists and is running", func() {
+			client.EXPECT().GetDomain().Return(&api.Domain{
+				Status: api.DomainStatus{
+					Status: api.Running,
+				},
+			}, true, nil)
+
+			result, err := shouldFreezeVirtualMachine(client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false if domain exists and is not running", func() {
+			client.EXPECT().GetDomain().Return(&api.Domain{
+				Status: api.DomainStatus{
+					Status: api.Paused,
+				},
+			}, true, nil)
+
+			result, err := shouldFreezeVirtualMachine(client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false if domain does not exist", func() {
+			client.EXPECT().GetDomain().Return(nil, false, nil)
+
+			result, err := shouldFreezeVirtualMachine(client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return error if GetDomain fails", func() {
+			client.EXPECT().GetDomain().Return(nil, false, errors.New("Error getting domain"))
+
+			result, err := shouldFreezeVirtualMachine(client)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Context("Freeze", func() {
+		BeforeEach(func() {
+			config.Freeze = true
+		})
+		It("should return error if get guest agent fails", func() {
+			client.EXPECT().GetGuestInfo().Return(nil, errors.New("guest info error"))
+
+			err := run(config, client)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns nil and skip freeze if guest agent version is empty", func() {
+			client.EXPECT().GetGuestInfo().Return(&v1.VirtualMachineInstanceGuestAgentInfo{}, nil)
+
+			err := run(config, client)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns nil and skip freeze if vm domain not running", func() {
+			client.EXPECT().GetGuestInfo().Return(guestInfo, nil)
+			client.EXPECT().GetDomain().Return(&api.Domain{
+				Status: api.DomainStatus{
+					Status: api.Paused,
+				},
+			}, true, nil)
+
+			err := run(config, client)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed if Freeze VirtualMachine", func() {
+			client.EXPECT().GetGuestInfo().Return(guestInfo, nil)
+			client.EXPECT().GetDomain().Return(&api.Domain{Status: api.DomainStatus{Status: api.Running}}, true, nil)
+			client.EXPECT().FreezeVirtualMachine(gomock.Any(), gomock.Any()).Return(nil)
+
+			err := run(config, client)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if FreezeVirtualMachine fails", func() {
+			client.EXPECT().GetGuestInfo().Return(guestInfo, nil)
+			client.EXPECT().GetDomain().Return(&api.Domain{Status: api.DomainStatus{Status: api.Running}}, true, nil)
+			client.EXPECT().FreezeVirtualMachine(gomock.Any(), gomock.Any()).Return(errors.New("freeze failed"))
+
+			err := run(config, client)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("UnFreeze", func() {
+		BeforeEach(func() {
+			config.Unfreeze = true
+		})
+		It("should succeed if Unfreeze VirtualMachine", func() {
+			client.EXPECT().GetGuestInfo().Return(guestInfo, nil)
+			client.EXPECT().GetDomain().Return(&api.Domain{Status: api.DomainStatus{Status: api.Running}}, true, nil)
+			client.EXPECT().UnfreezeVirtualMachine(gomock.Any()).Return(nil)
+
+			err := run(config, client)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error if UnfreezeVirtualMachine fails", func() {
+			client.EXPECT().GetGuestInfo().Return(guestInfo, nil)
+			client.EXPECT().GetDomain().Return(&api.Domain{Status: api.DomainStatus{Status: api.Running}}, true, nil)
+			client.EXPECT().UnfreezeVirtualMachine(gomock.Any()).Return(errors.New("unfreeze failed"))
+
+			err := run(config, client)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",
-        "//pkg/storage/velero:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -3,12 +3,10 @@ package storage
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/events"
-	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/watcher"
 
@@ -31,9 +29,7 @@ import (
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/storage/velero"
 
-	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
@@ -300,18 +296,6 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				snapshotSourceMemory := contentSourceSpec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
 				Expect(snapshotSourceMemory).To(Equal(expectedMemory))
 				checkOnlineSnapshotExpectedContentSource(vm, contentName, true)
-			}
-
-			callVeleroHook := func(vmi *v1.VirtualMachineInstance, annoContainer, annoCommand string) (string, string, error) {
-				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(err).NotTo(HaveOccurred())
-				command := pod.Annotations[annoCommand]
-				command = strings.Trim(command, "[]")
-				commandSlice := []string{}
-				for _, c := range strings.Split(command, ",") {
-					commandSlice = append(commandSlice, strings.Trim(c, "\" "))
-				}
-				return exec.ExecuteCommandOnPodWithResults(pod, pod.Annotations[annoContainer], commandSlice)
 			}
 
 			ensureFreezeFedora := func(vmi *v1.VirtualMachineInstance) {
@@ -731,108 +715,6 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 					})),
 					"CreationTime": BeNil(),
 				})))
-			})
-
-			It("Calling Velero hooks should freeze/unfreeze VM", func() {
-				By("Creating VM")
-				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
-				vmi.Namespace = testsuite.GetTestNamespace(nil)
-				vm = libvmi.NewVirtualMachine(vmi)
-
-				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStart(vmi,
-					libwait.WithTimeout(300),
-				)
-				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-
-				By("Logging into Fedora")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-				By("Calling Velero pre-backup hook")
-				_, _, err := callVeleroHook(vmi, velero.PreBackupHookContainerAnnotation, velero.PreBackupHookCommandAnnotation)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Veryfing the VM was frozen")
-				journalctlCheck := "journalctl --file /var/log/journal/*/system.journal"
-				expectedFreezeOutput := "executing fsfreeze hook with arg 'freeze'"
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf(grepCmd, journalctlCheck, expectedFreezeOutput)},
-					&expect.BExp{R: fmt.Sprintf(qemuGa, expectedFreezeOutput)},
-					&expect.BSnd{S: console.EchoLastReturnValue},
-					&expect.BExp{R: console.RetValue("0")},
-				}, 30)).To(Succeed())
-				Eventually(func() string {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return vmi.Status.FSFreezeStatus
-				}, 180*time.Second, time.Second).Should(Equal("frozen"))
-
-				By("Calling Velero post-backup hook")
-				_, _, err = callVeleroHook(vmi, velero.PostBackupHookContainerAnnotation, velero.PostBackupHookCommandAnnotation)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Veryfing the VM was thawed")
-				expectedThawOutput := "executing fsfreeze hook with arg 'thaw'"
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf(grepCmd, journalctlCheck, expectedThawOutput)},
-					&expect.BExp{R: fmt.Sprintf(qemuGa, expectedThawOutput)},
-					&expect.BSnd{S: console.EchoLastReturnValue},
-					&expect.BExp{R: console.RetValue("0")},
-				}, 30)).To(Succeed())
-				Eventually(func() string {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return vmi.Status.FSFreezeStatus
-				}, 180*time.Second, time.Second).Should(BeEmpty())
-			})
-
-			It("[test_id:9647]Calling Velero hooks should not error if no guest agent", func() {
-				const noGuestAgentString = "No guest agent, exiting"
-				By("Creating VM")
-				var vmi *v1.VirtualMachineInstance
-				vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, snapshotStorageClass)
-				vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyHalted)
-
-				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStart(vmi,
-					libwait.WithTimeout(300),
-				)
-
-				By("Calling Velero pre-backup hook")
-				_, stderr, err := callVeleroHook(vmi, velero.PreBackupHookContainerAnnotation, velero.PreBackupHookCommandAnnotation)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr).Should(ContainSubstring(noGuestAgentString))
-
-				By("Calling Velero post-backup hook")
-				_, stderr, err = callVeleroHook(vmi, velero.PostBackupHookContainerAnnotation, velero.PostBackupHookCommandAnnotation)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr).Should(ContainSubstring(noGuestAgentString))
-			})
-
-			It("Calling Velero hooks should error if VM is Paused", func() {
-				By("Creating VM")
-				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
-				vmi.Namespace = testsuite.GetTestNamespace(nil)
-				vm = libvmi.NewVirtualMachine(vmi)
-
-				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStart(vmi,
-					libwait.WithTimeout(300),
-				)
-				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-
-				By("Logging into Fedora")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-				By("Pausing the VirtualMachineInstance")
-				err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
-
-				By("Calling Velero pre-backup hook")
-				_, stderr, err := callVeleroHook(vmi, velero.PreBackupHookContainerAnnotation, velero.PreBackupHookCommandAnnotation)
-				Expect(err).To(HaveOccurred())
-				Expect(stderr).Should(ContainSubstring("Paused VM"))
 			})
 
 			Context("with memory dump", func() {


### PR DESCRIPTION
### What this PR does
Before this PR:
When running the virt-freeze hook in velero backups if the vm is paused at the time of the backup, the hook returns an error, the backup partially fails and the vm is not in the backup.
Testing of the hook is done with e2e test.

After this PR:
When running the virt-freeze hook in velero backups if the vm is paused at the time of the backup, the hook prints that the vm domain is not running and skips the freeze, the backup continues with backing the vm.
E2E tests of the hook is removed, the hook is tested with UTs.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-61566

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-Freeze: skip freeze if domain is not in running state
```

