### PR TITLE
tests: add login into the VM after volume migration and some fixes/refactoring

### DIFF
--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -501,7 +501,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			sc, exist := libstorage.GetRWXBlockStorageClass()
 			Expect(exist).To(BeTrue())
 			srcDV := libdv.NewDataVolume(
-				libdv.WithBlankImageSource(),
+				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
 					libdv.StorageWithVolumeSize(size),
 					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeBlock),
@@ -521,6 +521,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				destDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			vm := createVMWithDV(srcDV, volName)
+
 			By("Update volumes")
 			updateVMWithDV(vm, volName, destDV.Name)
 			Eventually(func() bool {
@@ -543,7 +544,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			sc, exist := libstorage.GetRWOBlockStorageClass()
 			Expect(exist).To(BeTrue())
 			srcDV := libdv.NewDataVolume(
-				libdv.WithBlankImageSource(),
+				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
 					libdv.StorageWithVolumeSize(size),
 					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeBlock),

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -488,6 +488,12 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			libstorage.CreateFSPVC(destPVC, ns, "2Gi", nil)
 
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
+
+			By("Expecting the VirtualMachineInstance console")
+			vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
+				metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 		})
 
 		It("should migrate the source volume from a source and destination block RWX DVs", decorators.StorageCritical, decorators.RequiresRWXBlock, func() {
@@ -525,6 +531,11 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				return claim == destDV.Name
 			}, 120*time.Second, time.Second).Should(BeTrue())
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
+			By("Expecting the VirtualMachineInstance console")
+			vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
+				metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 		})
 
 		It("should migrate the source volume from a block source and filesystem destination DVs", decorators.RequiresBlockStorage, func() {
@@ -555,6 +566,12 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				return claim == destDV.Name
 			}, 120*time.Second, time.Second).Should(BeTrue())
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
+
+			By("Expecting the VirtualMachineInstance console")
+			vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
+				metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 		})
 
 		It("should migrate a PVC with a VM using a containerdisk", func() {
@@ -593,6 +610,8 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				return false
 			}, 120*time.Second, time.Second).Should(BeTrue())
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
+			By("Expecting the VirtualMachineInstance console")
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 		})
 
 		It("should cancel the migration by the reverting to the source volume", func() {


### PR DESCRIPTION
Login into the VM after volume migration ensure that the bootable disk hasn't been corrupted during the migration.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

