### PR TITLE
fix(quarantine): de-quarantine guestlog test

### DIFF
--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -86,7 +86,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 
 			var cirrosCheck = "http://cirros-cloud.net"
 
-			It("[QUARANTINE] it should fetch logs for a running VM with logs API", decorators.Quarantine, func() {
+			It("it should fetch logs for a running VM with logs API", func() {
 				vmi = libvmops.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Test [`guestlog... it should fetch logs for a running VM with logs API`](https://github.com/kubevirt/kubevirt/blob/696f97222bff2aa5c63a2f4cac791382f7cff91a/tests/guestlog/guestlog.go#L89) is in quarantine. According to [1] the test hasn't failed for more than a month.

After this PR:

Above mentioned test is de-quarantined.

[1]: https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.30-sig-compute&width=20

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

https://github.com/kubevirt/kubevirt/issues/14212#issuecomment-2879317664

/cc @fossedihelm 

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

