### PR TITLE
tests/vmi_configuration_test: drop a redundant e2e test

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -859,7 +859,7 @@ var _ = Describe("Converter", func() {
 			Expect(vmiToDomainXMLToDomainSpec(vmi, c).Type).To(Equal(domainType))
 		})
 
-		Context("when all addresses should be places at the root complex", func() {
+		Context("when all addresses should be placed at the root complex", func() {
 			It("should be converted to a libvirt Domain with vmi defaults set", func() {
 				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -55,7 +55,6 @@ import (
 	hw_utils "kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -113,29 +112,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-	})
-
-	Context("with all devices on the root PCI bus", func() {
-		It("[test_id:4623]should start run the guest as usual", func() {
-			vmi := libvmifact.NewCirros(
-				libvmi.WithAnnotation(v1.PlacePCIDevicesOnRootComplex, "true"),
-				libvmi.WithRng(),
-				libvmi.WithWatchdog(v1.WatchdogActionPoweroff, libnode.GetArch()),
-				libvmi.WithTablet("tablet", "virtio"),
-				libvmi.WithTablet("tablet1", "usb"),
-			)
-			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 60)
-			Expect(console.LoginToCirros(vmi)).To(Succeed())
-			domSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			rootPortController := []api.Controller{}
-			for _, c := range domSpec.Devices.Controllers {
-				if c.Model == "pcie-root-port" {
-					rootPortController = append(rootPortController, c)
-				}
-			}
-			Expect(rootPortController).To(BeEmpty(), "libvirt should not add additional buses to the root one")
-		})
 	})
 
 	Context("when requesting virtio-transitional models", func() {


### PR DESCRIPTION
The end-to-end test

    with all devices on the root PCI bus
    [test_id:4623]should start run the guest as usual

starts a VMI with kubevirt.io/placePCIDevicesOnRootComplex=true annotations and looks into libvirt to ensure that the domxml generated by kubevirt has only a single root pci controller.

This is already the unit test

    when all addresses should be placed at the root complex
    should be converted to a libvirt Domain with vmi defaults set

Starting VMIs is a slow and inherently fragile process. This commit drops the redundant test.

/kind cleanup

```release-note
NONE
```

