### PR TITLE
Fix misspellings in tests folders migration, operator

### DIFF
--- a/tests/migration/host_model.go
+++ b/tests/migration/host_model.go
@@ -176,10 +176,10 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				By("Starting the VirtualMachineInstance")
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
 
-				for indx, node := range nodes {
+				for index, node := range nodes {
 					patchedNode := libinfra.ExpectStoppingNodeLabellerToSucceed(node.Name, kubevirt.Client())
 					Expect(patchedNode).ToNot(BeNil())
-					nodes[indx] = *patchedNode
+					nodes[index] = *patchedNode
 				}
 			})
 

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -929,7 +929,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				migration1, err := virtClient.VirtualMachineInstanceMigration(migration1.Namespace).Create(context.Background(), migration1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// Successfully tested with 40, but requests start getting throttled above 10, which is better to avoid to prevent flakyness
+				// Successfully tested with 40, but requests start getting throttled above 10, which is better to avoid to prevent flakiness
 				By("Starting 10 more migrations expecting all to fail to create")
 				var wg sync.WaitGroup
 				for n := 0; n < 10; n++ {
@@ -1135,7 +1135,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				vmi := createVMI()
 
 				By("Starting the VirtualMachineInstance")
-				// Resizing takes too long and therefor a warning is thrown
+				// Resizing takes too long and therefore a warning is thrown
 				vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
@@ -1150,7 +1150,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 				migration = libmigration.RunMigrationAndExpectToComplete(virtClient, migration, 340)
 
-				By("Verifying Second Migration Succeeeds")
+				By("Verifying Second Migration Succeeds")
 				libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("Checking that the launcher is running as qemu")
@@ -1221,7 +1221,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				vmi.Namespace = testsuite.NamespacePrivileged
 
 				By("Starting the VirtualMachineInstance")
-				// Resizing takes too long and therefor a warning is thrown
+				// Resizing takes too long and therefore a warning is thrown
 				vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
@@ -1236,7 +1236,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 				migration = libmigration.RunMigrationAndExpectToComplete(virtClient, migration, 340)
 
-				By("Verifying Second Migration Succeeeds")
+				By("Verifying Second Migration Succeeds")
 				libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("Checking that the launcher is running as qemu")
@@ -1598,7 +1598,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				migration = libmigration.New(vmi.Name, vmi.Namespace)
 				migration = libmigration.RunMigrationAndExpectToComplete(virtClient, migration, 340)
 
-				By("Verifying Second Migration Succeeeds")
+				By("Verifying Second Migration Succeeds")
 				libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			})
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -384,7 +384,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Ports[0].Port).To(Equal(int32(123)))
 
-			By("Test that the port is revered to the original")
+			By("Test that the port is reverted to the original")
 			Eventually(func() int32 {
 				service, err := virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -513,7 +513,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				Expect(err).ToNot(HaveOccurred())
 				return vc.Annotations[v1.KubeVirtGenerationAnnotation]
 			}, 90*time.Second, 5*time.Second).Should(Equal(strconv.FormatInt(generation, 10)),
-				"Rsource generation numbers should be identical on both the Kubevirt CR and the virt-controller resource")
+				"Resource generation numbers should be identical on both the Kubevirt CR and the virt-controller resource")
 
 			By("Test that patch was applied to deployment")
 			vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
@@ -542,7 +542,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				Expect(err).ToNot(HaveOccurred())
 				return vc.Annotations[v1.KubeVirtGenerationAnnotation]
 			}, 90*time.Second, 5*time.Second).Should(Equal(strconv.FormatInt(generation, 10)),
-				"Rsource generation numbers should be identical on both the Kubevirt CR and the virt-controller resource")
+				"Resource generation numbers should be identical on both the Kubevirt CR and the virt-controller resource")
 
 			By("Test that patch was removed from deployment")
 			vc, err = virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
@@ -790,7 +790,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 			// Create VM on previous release using a specific API.
 			// NOTE: we are testing with yaml here and explicitly _NOT_ generating
-			// this vm using the latest api code. We want to guarrantee there are no
+			// this vm using the latest api code. We want to guarantee there are no
 			// surprises when it comes to backwards compatibility with previous
 			// virt apis.  As we progress our api from v1alpha3 -> v1 there
 			// needs to be a VM created for every api. This is how we will ensure
@@ -1595,7 +1595,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			Expect(patchKVInfra(originalKv, infra)).To(Succeed())
 
 			for _, deploymentName := range []string{"virt-controller", "virt-api"} {
-				errMsg := "NodeSelector should be propegated to the deployment eventually"
+				errMsg := "NodeSelector should be propagated to the deployment eventually"
 				Eventually(func() bool {
 					return nodeSelectorExistInDeployment(virtClient, deploymentName, fakeLabelKey, fakeLabelValue)
 				}, 60*time.Second, 1*time.Second).Should(BeTrue(), errMsg)
@@ -2418,7 +2418,7 @@ func detectLatestUpstreamOfficialTag() (string, error) {
 		return "", fmt.Errorf("no kubevirt releases found")
 	}
 
-	// decending order from most recent.
+	// descending order from most recent.
 	sort.Sort(sort.Reverse(semver.Versions(vs)))
 
 	// most recent tag
@@ -2547,7 +2547,7 @@ func allKvInfraPodsAreReady(kv *v1.KubeVirt) {
 			return err
 		}
 		if curKv.Status.TargetDeploymentID != curKv.Status.ObservedDeploymentID {
-			return fmt.Errorf("target and obeserved id don't match")
+			return fmt.Errorf("target and observed id don't match")
 		}
 
 		foundReadyAndOwnedPod := false


### PR DESCRIPTION
### What this PR does
Before this PR:
files under tests [migration, operator] had some misspelling words in them

After this PR:
The words are written correctly in the related files

### Special notes for your reviewer
Related PR:
 - https://github.com/kubevirt/kubevirt/pull/14662
 - https://github.com/kubevirt/kubevirt/pull/14688
 - https://github.com/kubevirt/kubevirt/pull/14731
 - https://github.com/kubevirt/kubevirt/pull/14750

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

