### PR TITLE
Add virtio-vga video driver to launcher_base_amd64 image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6650,6 +6650,14 @@ rpm(
 )
 
 rpm(
+    name = "qemu-kvm-device-display-virtio-vga-17__9.1.0-19.el9.x86_64",
+    sha256 = "aff5dd2d60bfc1f670430b627a46e6273fe4307eb3efa73152f2ddf3e2d999f3",
+    urls = [
+        "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/qemu-kvm-device-display-virtio-vga-9.1.0-19.el9.x86_64.rpm",
+    ],
+)
+
+rpm(
     name = "qemu-kvm-device-usb-host-17__9.1.0-19.el9.aarch64",
     sha256 = "e4ca3610d6ac9511c93e84f300d23a4b14c3190c4b40573f4c2aa56694fd6e71",
     urls = [

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -26,7 +26,7 @@ KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
 HOST_ARCHITECTURE="$(uname -m)"
 
 sandbox_root=${SANDBOX_DIR}/default/root
-sandbox_hash="7b6c1afd5a044d144c3b5c4b7aab4c2046956b23"
+sandbox_hash="314762f5ff21cbf3927e7ea3baeb92d8c4df2b6b"
 
 function kubevirt::bootstrap::regenerate() {
     (

--- a/hack/rpm-deps.sh
+++ b/hack/rpm-deps.sh
@@ -97,6 +97,7 @@ launcherbase_main="
 launcherbase_x86_64="
   edk2-ovmf-${EDK2_VERSION}
   qemu-kvm-device-display-virtio-gpu-${QEMU_VERSION}
+  qemu-kvm-device-display-virtio-vga-${QEMU_VERSION}
   qemu-kvm-device-display-virtio-gpu-pci-${QEMU_VERSION}
   qemu-kvm-device-usb-redirect-${QEMU_VERSION}
   seabios-${SEABIOS_VERSION}

--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -1186,6 +1186,7 @@ rpmtree(
         "@qemu-kvm-core-17__9.1.0-19.el9.x86_64//rpm",
         "@qemu-kvm-device-display-virtio-gpu-17__9.1.0-19.el9.x86_64//rpm",
         "@qemu-kvm-device-display-virtio-gpu-pci-17__9.1.0-19.el9.x86_64//rpm",
+        "@qemu-kvm-device-display-virtio-vga-17__9.1.0-19.el9.x86_64//rpm",
         "@qemu-kvm-device-usb-host-17__9.1.0-19.el9.x86_64//rpm",
         "@qemu-kvm-device-usb-redirect-17__9.1.0-19.el9.x86_64//rpm",
         "@readline-0__8.1-4.el9.x86_64//rpm",


### PR DESCRIPTION
### What this PR does
This PR enables support for the `virtio-vga` video device model in `QEMU` for `amd64` architectures. When the `virtio` video model is specified in the VM Domain via libvirt, the backend probes QEMU capabilities to determine which `virtio` video device is supported. If `virtio-vga` is available, it is now selected as the preferred device. Otherwise, we fall back to `virtio-gpu` or `virtio-gpu-pci` if `virtio-vga` is not supported.

This PR ensures that the required `QEMU` capabilities for `virtio-vga` are available and recognized on `amd64` systems, allowing the device to be used reliably when requested.

Before this PR:
- Even when specifying `virtio` as the video model, QEMU will fall back to `virtio-gpu` due to missing capability detection or support.

After this PR:
- `virtio` is now the default video device model on `amd64`, for both BIOS and EFI VMs, and `virtio-vga` will be used whenever supported by the underlying `QEMU`.

Fixes #

This is a Follow-up to this [Comment](https://github.com/kubevirt/enhancements/pull/36#issuecomment-2865591238)

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: 

### Special notes for your reviewer

- we should consider drop `BochsForEFIGuests` in the `ConverterContext` since virtio is now used by default?

### Release note
```release-note
none
```

