### PR TITLE
e2e,migration,sriov: Increase status update timeout

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -280,7 +280,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 
 				// It may take some time for the VMI interface status to be updated with the information reported by
 				// the guest-agent.
-				ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 2*time.Minute+10*time.Second)
+				ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 5*time.Minute)
 				Expect(err).NotTo(HaveOccurred())
 				updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Once migration finishes, virt-handler sends sriov reattach request to virt-launcher.
Sometimes the downwardAPI file (`/etc/podinfo/network-info`)
takes time to be created, hence the first reattach request fails.

By simulating errors on the virt-launcher and not letting
virt-launcher reattach finish, we can see that the next request
of reattach might arrive even up to 2m after the first one.

Since we wait in the test, after migration finished 2m10s, this is very marginal,
because beside the above non synchronic event,
also guest-agent that already started running, has a backoff
that already accumulated, (10 seconds initial, step 2x, up to 120s)
and the report of it is crucial (we need the guest interface name).

It can cause 2 problems:
1. The interface wasn't reattached yet, since it takes time for the 2nd reattach request
to be triggered.
2. Guest agent didn't update yet all the required info.

Both fail the test.

Follow-up PRs can address this either by
1. Investigating deeper why it happens, and fixing the synchronization between the 
virt-handler / virt-launcher pods wrt reattach command.
4. Move the reattach logic to virt-launcher SyncVMI,
which is synchronic and deterministic already.

Option [2] is better, it also makes the flow simpler, and reduces inter pod communication.

This PR extends the timeout, and removes the test from quarantine,
meanwhile to solve the flake.

Note: tried to run in loops with extended timeout, and the flow eventually successes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/14565

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
None
```

