### PR TITLE
e2e, SR-IOV: Rm env var assertions on virt-launcher

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -173,9 +173,6 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
 
-			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, sriovnet1, sriovResourceName)).To(Succeed())
-
 			Expect(checkDefaultInterfaceInPod(vmi)).To(Succeed())
 
 			By("checking virtual machine instance has two interfaces")
@@ -194,9 +191,6 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			vmi, err := createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
-
-			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, sriovnet1, sriovResourceName)).To(Succeed())
 
 			Expect(checkDefaultInterfaceInPod(vmi)).To(Succeed())
 
@@ -220,9 +214,6 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			vmi, err := createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
-
-			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, sriovnet1, sriovResourceName)).To(Succeed())
 
 			Expect(checkDefaultInterfaceInPod(vmi)).To(Succeed())
 
@@ -320,11 +311,6 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			vmi, err := createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
-
-			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variables are defined in pod")
-			for _, name := range sriovNetworks {
-				Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, name, sriovResourceName)).To(Succeed())
-			}
 
 			Expect(checkDefaultInterfaceInPod(vmi)).To(Succeed())
 
@@ -538,27 +524,6 @@ func getNodesWithAllocatedResource(resourceName string) []k8sv1.Node {
 	}
 
 	return filteredNodes
-}
-
-func validatePodKubevirtResourceNameByVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, networkName, sriovResourceName string) error {
-	pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-	Expect(err).NotTo(HaveOccurred())
-
-	out, err := exec.ExecuteCommandOnPod(
-		pod,
-		"compute",
-		[]string{"sh", "-c", fmt.Sprintf("echo $KUBEVIRT_RESOURCE_NAME_%s", networkName)},
-	)
-	if err != nil {
-		return err
-	}
-
-	out = strings.TrimSuffix(out, "\n")
-	if out != sriovResourceName {
-		return fmt.Errorf("env settings %s didnt match %s", out, sriovResourceName)
-	}
-
-	return nil
 }
 
 func defaultCloudInitNetworkData() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Following PR https://github.com/kubevirt/kubevirt/pull/8226, virt-launcher uses a mechanism based on downward API in order to infer the PCI addresses of SR-IOV devices.

There is currently a fallback on an older mechanism that uses environment variables from:
- VMI controller [1]
- SR-IOV device plugin

in order to infer the PCI addresses of SR-IOV devices.

In preparation for removing the older mechanism, remove the assertions asserting the existence of the environment variables inside virt-launcher's `compute` container, as they observe an implementation detail.

[1] https://github.com/kubevirt/kubevirt/blob/b020b9e114150b73d5ac716cfb70c9e7abbdfc7c/pkg/virt-controller/services/template.go#L454-L457

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

