### PR TITLE
Introduce FindSocket

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/collector/collector.go
+++ b/pkg/monitoring/metrics/virt-handler/collector/collector.go
@@ -129,7 +129,7 @@ func newvmiSocketMapFromVMIs(vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap 
 
 	ret := make(vmiSocketMap)
 	for _, vmi := range vmis {
-		socketPath, err := cmdclient.FindSocketOnHost(vmi)
+		socketPath, err := cmdclient.FindSocket(vmi)
 		if err != nil {
 			// nothing to scrape...
 			// this means there's no socket or the socket

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Virt remote commands", func() {
 
 	Context("client", func() {
 		It("socket from UID", func() {
-			sock, err := FindSocketOnHost(vmi)
+			sock, err := FindSocket(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sock).To(Equal(podSocketFile))
 
@@ -107,7 +107,7 @@ var _ = Describe("Virt remote commands", func() {
 		})
 
 		It("Detect unresponsive socket", func() {
-			sock, err := FindSocketOnHost(vmi)
+			sock, err := FindSocket(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(IsSocketUnresponsive(sock)).To(BeFalse())

--- a/pkg/virt-handler/dmetrics-manager/dmetrics-manager.go
+++ b/pkg/virt-handler/dmetrics-manager/dmetrics-manager.go
@@ -108,7 +108,7 @@ func (m *DownwardMetricsManager) StartServer(vmi *v1.VirtualMachineInstance, pid
 		return nil
 	}
 
-	launcherSocketPath, err := cmdclient.FindSocketOnHost(vmi)
+	launcherSocketPath, err := cmdclient.FindSocket(vmi)
 	if err != nil {
 		return fmt.Errorf("failed to get the launcher socket for VMI [%s], error: %v", vmi.GetName(), err)
 	}

--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -70,7 +70,7 @@ func NewSocketBasedIsolationDetector(socketDir string) PodIsolationDetector {
 
 func (s *socketBasedIsolationDetector) Detect(vm *v1.VirtualMachineInstance) (IsolationResult, error) {
 	// Look up the socket of the virt-launcher Pod which was created for that VM, and extract the PID from it
-	socket, err := cmdclient.FindSocketOnHost(vm)
+	socket, err := cmdclient.FindSocket(vm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-handler/rest/lifecycle.go
+++ b/pkg/virt-handler/rest/lifecycle.go
@@ -245,7 +245,7 @@ func (lh *LifecycleHandler) getVMILauncherClient(request *restful.Request, respo
 		return nil, nil, err
 	}
 
-	sockFile, err := cmdclient.FindSocketOnHost(vmi)
+	sockFile, err := cmdclient.FindSocket(vmi)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error(failedDetectCmdClient)
 		response.WriteError(http.StatusInternalServerError, err)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2228,7 +2228,7 @@ func (c *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualM
 			// use cached socket if we previously established a connection
 			socketFile = clientInfo.SocketFile
 		} else {
-			socketFile, err = cmdclient.FindSocketOnHost(vmi)
+			socketFile, err = cmdclient.FindSocket(vmi)
 			if err != nil {
 				// socket does not exist, but let's see if the pod is still there
 				if _, err = cmdclient.FindPodDirOnHost(vmi); err != nil {
@@ -2252,7 +2252,7 @@ func (c *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualM
 		}
 		c.launcherClients.Store(vmi.UID, clientInfo)
 		// attempt to find the socket if the established connection doesn't currently exist.
-		socketFile, err = cmdclient.FindSocketOnHost(vmi)
+		socketFile, err = cmdclient.FindSocket(vmi)
 		// no socket file, no VMI, so it's unresponsive
 		if err != nil {
 			// socket does not exist, but let's see if the pod is still there
@@ -2276,7 +2276,7 @@ func (c *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInsta
 		return clientInfo.Client, nil
 	}
 
-	socketFile, err := cmdclient.FindSocketOnHost(vmi)
+	socketFile, err := cmdclient.FindSocket(vmi)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What this PR does
Current FindSocketOnHost is actually ignoring a host all together and would try to find any Pod. FindSocketWithHost now takes host as argument "host" and filters base on it. A FindSocket now automatically provides the host based on "NODE_NAME" env variable.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

