### PR TITLE
Let the label_approved_veps github action to use a PAT

### DIFF
--- a/.github/workflows/label_approved_veps.yaml
+++ b/.github/workflows/label_approved_veps.yaml
@@ -1,8 +1,11 @@
 name: Label Approved VEP PRs
 on:
-  pull_request:
-    types: [opened, edited, synchronize]
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+  workflow_dispatch:
+
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -22,6 +25,6 @@ jobs:
 
       - name: Run VEP check script
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: python automation/label-approved-veps.py


### PR DESCRIPTION
### What this PR does

This will allow the label_approved_veps GitHub Action to use a dedicated token

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

