### PR TITLE
virt-handler: various cleanup

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -264,7 +264,7 @@ func (app *virtHandlerApp) Run() {
 		os.Exit(2)
 	}
 
-	podIsolationDetector := isolation.NewSocketBasedIsolationDetector(app.VirtShareDir)
+	podIsolationDetector := isolation.NewSocketBasedIsolationDetector()
 	app.clusterConfig, err = virtconfig.NewClusterConfig(factory.CRD(), factory.KubeVirt(), app.namespace)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -34,7 +34,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	virtutil "kubevirt.io/kubevirt/pkg/util"
 	cgroupconsts "kubevirt.io/kubevirt/pkg/virt-handler/cgroup/constants"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
@@ -179,7 +178,7 @@ func getCpuSetPath(manager Manager, cpusetFile string) (string, error) {
 // Socket is optional and makes the execution faster
 func detectVMIsolation(vm *v1.VirtualMachineInstance) (isolationRes isolation.IsolationResult, err error) {
 	const detectionErrFormat = "cannot detect vm \"%s\", err: %v"
-	detector := isolation.NewSocketBasedIsolationDetector(virtutil.VirtShareDir)
+	detector := isolation.NewSocketBasedIsolationDetector()
 
 	isolationRes, err = detector.Detect(vm)
 

--- a/pkg/virt-handler/cmd-client/BUILD.bazel
+++ b/pkg/virt-handler/cmd-client/BUILD.bazel
@@ -4,7 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = [
         "client.go",
+        "errors.go",
         "generated_mock_client.go",
+        "guest.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client",
     visibility = ["//visibility:public"],

--- a/pkg/virt-handler/cmd-client/errors.go
+++ b/pkg/virt-handler/cmd-client/errors.go
@@ -1,0 +1,89 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package cmdclient
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/rpc"
+	"os"
+	"syscall"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+)
+
+func IsUnimplemented(err error) bool {
+	if grpcStatus, ok := status.FromError(err); ok {
+		if grpcStatus.Code() == codes.Unimplemented {
+			return true
+		}
+	}
+	return false
+}
+
+func handleError(err error, cmdName string, response *cmdv1.Response) error {
+	if IsDisconnected(err) {
+		return err
+	} else if IsUnimplemented(err) {
+		return err
+	} else if err != nil {
+		msg := fmt.Sprintf("unknown error encountered sending command %s: %s", cmdName, err.Error())
+		return fmt.Errorf(msg)
+	} else if response != nil && !response.Success {
+		return fmt.Errorf("server error. command %s failed: %q", cmdName, response.Message)
+	}
+	return nil
+}
+
+func IsDisconnected(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if err == rpc.ErrShutdown || err == io.ErrUnexpectedEOF || err == io.EOF {
+		return true
+	}
+
+	if opErr, ok := err.(*net.OpError); ok {
+		if syscallErr, ok := opErr.Err.(*os.SyscallError); ok {
+			// catches "connection reset by peer"
+			if syscallErr.Err == syscall.ECONNRESET {
+				return true
+			}
+		}
+	}
+
+	if grpcStatus, ok := status.FromError(err); ok {
+
+		// see https://github.com/grpc/grpc-go/blob/master/codes/codes.go
+		switch grpcStatus.Code() {
+		case codes.Canceled:
+			// e.g. v1client connection closing
+			return true
+		}
+
+	}
+
+	return false
+}

--- a/pkg/virt-handler/cmd-client/guest.go
+++ b/pkg/virt-handler/cmd-client/guest.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package cmdclient
+
+import "path/filepath"
+
+func SocketOnGuest() string {
+	sockFile := StandardLauncherSocketFileName
+	return filepath.Join(SocketsDirectory(), sockFile)
+}
+
+func UninitializedSocketOnGuest() string {
+	sockFile := StandardInitLauncherSocketFileName
+	return filepath.Join(SocketsDirectory(), sockFile)
+}

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -375,7 +375,7 @@ func (m *mounter) ContainerDisksReady(vmi *v1.VirtualMachineInstance, notInitial
 		if volume.ContainerDisk != nil {
 			sock, err := m.socketPathGetter(vmi, i)
 			if err == nil {
-				_, err = m.podIsolationDetector.DetectForSocket(vmi, sock)
+				_, err = m.podIsolationDetector.DetectForSocket(sock)
 			}
 
 			if err != nil {
@@ -392,7 +392,7 @@ func (m *mounter) ContainerDisksReady(vmi *v1.VirtualMachineInstance, notInitial
 	if util.HasKernelBootContainerImage(vmi) {
 		sock, err := m.kernelBootSocketPathGetter(vmi)
 		if err == nil {
-			_, err = m.podIsolationDetector.DetectForSocket(vmi, sock)
+			_, err = m.podIsolationDetector.DetectForSocket(sock)
 		}
 		if err != nil {
 			log.DefaultLogger().Object(vmi).Reason(err).Info("kernelboot container not yet ready")
@@ -614,7 +614,7 @@ func (m *mounter) getContainerDiskPath(vmi *v1.VirtualMachineInstance, volume *v
 		return nil, ErrDiskContainerGone
 	}
 
-	res, err := m.podIsolationDetector.DetectForSocket(vmi, sock)
+	res, err := m.podIsolationDetector.DetectForSocket(sock)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect socket for containerDisk %v: %v", volume.Name, err)
 	}
@@ -633,7 +633,7 @@ func (m *mounter) getKernelArtifactPaths(vmi *v1.VirtualMachineInstance) (*kerne
 		return nil, ErrDiskContainerGone
 	}
 
-	res, err := m.podIsolationDetector.DetectForSocket(vmi, sock)
+	res, err := m.podIsolationDetector.DetectForSocket(sock)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect socket for kernelboot container: %v", err)
 	}

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -82,15 +82,15 @@ var _ = Describe("ContainerDisk", func() {
 	})
 
 	detectsSocket := func(detector *isolation.MockPodIsolationDetector) {
-		detector.EXPECT().DetectForSocket(vmi, "someting").Return(nil, nil)
+		detector.EXPECT().DetectForSocket("someting").Return(nil, nil)
 	}
 
 	noSocketDetected := func(detector *isolation.MockPodIsolationDetector) {
-		detector.EXPECT().DetectForSocket(vmi, "someting").Return(nil, fmt.Errorf("Not Found"))
+		detector.EXPECT().DetectForSocket("someting").Return(nil, fmt.Errorf("Not Found"))
 	}
 
 	detectForSocketNotCalled := func(detector *isolation.MockPodIsolationDetector) {
-		detector.EXPECT().DetectForSocket(gomock.Any(), gomock.Any()).Times(0)
+		detector.EXPECT().DetectForSocket(gomock.Any()).Times(0)
 	}
 
 	Context("checking if containerDisks are ready", func() {

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -113,8 +113,8 @@ var (
 		return isolation.IsBlockDevice(path)
 	}
 
-	isolationDetector = func(path string) isolation.PodIsolationDetector {
-		return isolation.NewSocketBasedIsolationDetector(path)
+	isolationDetector = func() isolation.PodIsolationDetector {
+		return isolation.NewSocketBasedIsolationDetector()
 	}
 
 	parentPathForMount = func(
@@ -553,7 +553,7 @@ func (m *volumeMounter) findVirtlauncherUID(vmi *v1.VirtualMachineInstance) (uid
 }
 
 func (m *volumeMounter) getSourcePodFilePath(sourceUID types.UID, vmi *v1.VirtualMachineInstance, volume string) (*safepath.Path, error) {
-	iso := isolationDetector("/path")
+	iso := isolationDetector()
 	isoRes, err := iso.DetectForSocket(socketPath(sourceUID))
 	if err != nil {
 		return nil, err

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -554,7 +554,7 @@ func (m *volumeMounter) findVirtlauncherUID(vmi *v1.VirtualMachineInstance) (uid
 
 func (m *volumeMounter) getSourcePodFilePath(sourceUID types.UID, vmi *v1.VirtualMachineInstance, volume string) (*safepath.Path, error) {
 	iso := isolationDetector("/path")
-	isoRes, err := iso.DetectForSocket(vmi, socketPath(sourceUID))
+	isoRes, err := iso.DetectForSocket(socketPath(sourceUID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -1031,7 +1031,7 @@ func (i *mockIsolationDetector) Detect(_ *v1.VirtualMachineInstance) (isolation.
 	return isolation.NewIsolationResult(i.pid, i.ppid), i.err
 }
 
-func (i *mockIsolationDetector) DetectForSocket(_ *v1.VirtualMachineInstance, _ string) (isolation.IsolationResult, error) {
+func (i *mockIsolationDetector) DetectForSocket(_ string) (isolation.IsolationResult, error) {
 	if i.pid != 9999 {
 		return isolation.NewIsolationResult(i.pid, i.ppid), nil
 	}

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -546,7 +546,7 @@ var _ = Describe("HotplugVolume", func() {
 			deviceBasePath = func(podUID types.UID, kubeletPodDir string) (*safepath.Path, error) {
 				return volumeDir, nil
 			}
-			isolationDetector = func(path string) isolation.PodIsolationDetector {
+			isolationDetector = func() isolation.PodIsolationDetector {
 				return &mockIsolationDetector{
 					pid: os.Getpid(),
 				}
@@ -590,7 +590,7 @@ var _ = Describe("HotplugVolume", func() {
 		It("getSourcePodFile should return error if iso detection returns error", func() {
 			_, err := newDir(tempDir, "ghfjk", "volumes")
 			Expect(err).ToNot(HaveOccurred())
-			isolationDetector = func(path string) isolation.PodIsolationDetector {
+			isolationDetector = func() isolation.PodIsolationDetector {
 				return &mockIsolationDetector{
 					pid: 9999,
 				}
@@ -740,7 +740,7 @@ var _ = Describe("HotplugVolume", func() {
 			statDevice = func(fileName *safepath.Path) (os.FileInfo, error) {
 				return fakeStat(true, 0777, 123456), nil
 			}
-			isolationDetector = func(path string) isolation.PodIsolationDetector {
+			isolationDetector = func() isolation.PodIsolationDetector {
 				return &mockIsolationDetector{
 					pid: os.Getpid(),
 				}

--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -58,15 +58,12 @@ type PodIsolationDetector interface {
 const isolationDialTimeout = 5
 
 type socketBasedIsolationDetector struct {
-	socketDir string
 }
 
 // NewSocketBasedIsolationDetector takes socketDir and creates a socket based IsolationDetector
 // It returns a PodIsolationDetector which detects pid, cgroups and namespaces of the socket owner.
-func NewSocketBasedIsolationDetector(socketDir string) PodIsolationDetector {
-	return &socketBasedIsolationDetector{
-		socketDir: socketDir,
-	}
+func NewSocketBasedIsolationDetector() PodIsolationDetector {
+	return &socketBasedIsolationDetector{}
 }
 
 func (s *socketBasedIsolationDetector) Detect(vm *v1.VirtualMachineInstance) (IsolationResult, error) {

--- a/pkg/virt-handler/isolation/detector_test.go
+++ b/pkg/virt-handler/isolation/detector_test.go
@@ -92,25 +92,25 @@ var _ = Describe("Isolation Detector", func() {
 		})
 
 		It("Should detect the PID of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector().Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Pid()).To(Equal(os.Getpid()))
 		})
 
 		It("Should detect the PID namespace of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector().Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.PIDNamespace()).To(Equal(fmt.Sprintf("/proc/%d/ns/pid", os.Getpid())))
 		})
 
 		It("Should detect the Parent PID of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector().Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.PPid()).To(Equal(os.Getppid()))
 		})
 
 		It("Should detect the Mount root of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector().Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			root, err := result.MountRoot()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/isolation/generated_mock_detector.go
+++ b/pkg/virt-handler/isolation/generated_mock_detector.go
@@ -70,16 +70,16 @@ func (mr *MockPodIsolationDetectorMockRecorder) Detect(vm any) *gomock.Call {
 }
 
 // DetectForSocket mocks base method.
-func (m *MockPodIsolationDetector) DetectForSocket(vm *v1.VirtualMachineInstance, socket string) (IsolationResult, error) {
+func (m *MockPodIsolationDetector) DetectForSocket(socket string) (IsolationResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DetectForSocket", vm, socket)
+	ret := m.ctrl.Call(m, "DetectForSocket", socket)
 	ret0, _ := ret[0].(IsolationResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DetectForSocket indicates an expected call of DetectForSocket.
-func (mr *MockPodIsolationDetectorMockRecorder) DetectForSocket(vm, socket any) *gomock.Call {
+func (mr *MockPodIsolationDetectorMockRecorder) DetectForSocket(socket any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectForSocket", reflect.TypeOf((*MockPodIsolationDetector)(nil).DetectForSocket), vm, socket)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectForSocket", reflect.TypeOf((*MockPodIsolationDetector)(nil).DetectForSocket), socket)
 }

--- a/pkg/virt-handler/selinux/BUILD.bazel
+++ b/pkg/virt-handler/selinux/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/safepath:go_default_library",
         "//pkg/unsafepath:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 
 	"kubevirt.io/kubevirt/pkg/safepath"
@@ -127,7 +126,7 @@ func RelabelFilesUnprivileged(continueOnError bool, files ...*safepath.Path) err
 }
 
 func GetVirtLauncherContext(vmi *v1.VirtualMachineInstance) (string, error) {
-	detector := isolation.NewSocketBasedIsolationDetector(util.VirtShareDir)
+	detector := isolation.NewSocketBasedIsolationDetector()
 	isolationRes, err := detector.Detect(vmi)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### What this PR does
1. Removes some clutter in pkg/virt-handler/cmd-client/client.go by refactoring out error logic and guest logic into own files. 
2. Drop a vmi argument for "DetectForSocket". The argument
is only needed for "contextual" logging. The error itself
will be logged appropriately.
3. Isolation detector: Remove unused field 
4. VM Controller: Remove virtPrivateDir , unused 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

