### PR TITLE
[release-1.4] backend-storage: ignore VMI PVCs that are being deleted

### DIFF
--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -66,6 +66,9 @@ func PVCForVMI(pvcStore cache.Store, vmi *corev1.VirtualMachineInstance) *v1.Per
 		if pvc.Namespace != vmi.Namespace {
 			continue
 		}
+		if pvc.DeletionTimestamp != nil {
+			continue
+		}
 		vmName, found := pvc.Labels[PVCPrefix]
 		if found && vmName == vmi.Name {
 			return pvc


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/13985/commits/4b9f1d5c56326a90bdf24c75597acaad1229bf0d

See commit message for more info

```release-note
Fixed a bug where multiple migrations of the same VM with persistent TPM/EFI enabled fail to complete
```
