### PR TITLE
virt-handler: fail VMIs that failed a post-copy migration

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3423,7 +3423,6 @@ func (c *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 			return v1.Failed, nil
 		}
 	} else {
-
 		switch domain.Status.Status {
 		case api.Shutoff, api.Crashed:
 			switch domain.Status.Reason {
@@ -3443,7 +3442,14 @@ func (c *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 				// if the domain migrated, we no longer know the phase.
 				return vmi.Status.Phase, nil
 			}
-		case api.Running, api.Paused, api.Blocked, api.PMSuspended:
+		case api.Paused:
+			switch domain.Status.Reason {
+			case api.ReasonPausedPostcopyFailed:
+				return v1.Failed, nil
+			default:
+				return v1.Running, nil
+			}
+		case api.Running, api.Blocked, api.PMSuspended:
 			return v1.Running, nil
 		}
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3657,6 +3657,43 @@ var _ = Describe("VirtualMachineInstance", func() {
 				ContainSubstring("syncing migration target failed")))
 		})
 	})
+
+	Context("on post-copy migration failure", func() {
+		It("should fail the VMI", func() {
+			By("Creating a migrating VMI with a domain in failed post-copy migration state")
+			vmi := libvmi.New(libvmi.WithUID(vmiTestUUID), libvmi.WithNamespace("default"), libvmi.WithName("testvmi"))
+			now := metav1.Time{Time: time.Unix(time.Now().UTC().Unix(), 0)}
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				TargetNode:                     "abc",
+				TargetNodeAddress:              "127.0.0.1:12345",
+				SourceNode:                     host,
+				MigrationUID:                   "123",
+				TargetNodeDomainDetected:       true,
+				TargetNodeDomainReadyTimestamp: &now,
+			}
+			vmi.Spec.Hostname = host
+			vmi.Status.Phase = v1.Running
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Paused
+			domain.Status.Reason = api.ReasonPausedPostcopyFailed
+			addDomain(domain)
+			addVMI(vmi)
+			createVMI(vmi)
+
+			By("Executing the controller")
+			client.EXPECT().Ping()
+			client.EXPECT().KillVirtualMachine(gomock.Any())
+			sanityExecute()
+			expectEvent("VirtualMachineInstance stopping", true)
+			expectEvent("VMI is irrecoverable due to failed post-copy migration", true)
+			expectEvent("The VirtualMachineInstance crashed", true)
+
+			By("Ensuring the VMI is now failed")
+			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedVMI.Status.Phase).To(Equal(v1.Failed))
+		})
+	})
 })
 
 var _ = Describe("DomainNotifyServerRestarts", func() {


### PR DESCRIPTION
### What this PR does
Before this PR:
VMIs that failed a post-copy migration may end up considered as having successfully completed (i.e. clean shutdown).
This is especially problematic for RestartOnFailure VMs, which may not restart after a failed post-copy migration.

After this PR:
VMIs that failed a post-copy migration are marked as failed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Failed post-copy migrations now always end in VMI failure
```
