### PR TITLE
Replace metric labels' none values with empty values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/krolaw/dhcp4 v0.0.0-20180925202202-7cead472c414
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
-	github.com/machadovilaca/operator-observability v0.0.22
+	github.com/machadovilaca/operator-observability v0.0.27
 	github.com/mdlayher/vsock v1.2.1
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed

--- a/go.sum
+++ b/go.sum
@@ -1907,8 +1907,8 @@ github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuz
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
-github.com/machadovilaca/operator-observability v0.0.22 h1:6+SdraJf91TmoPkZXJbjhxp99wMdYfBgk0WsV4fnfPo=
-github.com/machadovilaca/operator-observability v0.0.22/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
+github.com/machadovilaca/operator-observability v0.0.27 h1:TGzMkmiUC14x7/P6Ia2oJHbrwahp2lCTEMx4bRiMg5M=
+github.com/machadovilaca/operator-observability v0.0.27/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/go.work.sum
+++ b/go.work.sum
@@ -98,11 +98,11 @@ github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod
 github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c/go.mod h1:huN4d1phzjhlOsNIjFsw2SVRbwIHj3fJDMEU2SDPTmg=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/letsencrypt/boulder v0.0.0-20240418210053-89b07f4543e0/go.mod h1:srVwm2N3DC/tWqQ+igZXDrmKlNRN8X/dmJ1wEZrv760=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/machadovilaca/operator-observability v0.0.27 h1:TGzMkmiUC14x7/P6Ia2oJHbrwahp2lCTEMx4bRiMg5M=
+github.com/machadovilaca/operator-observability v0.0.27/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	none  = "<none>"
+	none  = "" // Empty values will be ignored by operator-observability and label will not be created
 	other = "<other>"
 
 	annotationPrefix        = "vm.kubevirt.io/"

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -279,10 +279,10 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(cr.Labels).To(HaveLen(17))
 			Expect(cr.Labels[7]).To(Equal(expected))
 		},
-			Entry("with no instance type expect <none>", k6tv1.InstancetypeAnnotation, "", "<none>"),
+			Entry("with no instance type expect empty string", k6tv1.InstancetypeAnnotation, "", ""),
 			Entry("with managed instance type expect its name", k6tv1.InstancetypeAnnotation, "i-managed", "i-managed"),
 			Entry("with custom instance type expect <other>", k6tv1.InstancetypeAnnotation, "i-unmanaged", "<other>"),
-			Entry("with no cluster instance type expect <none>", k6tv1.ClusterInstancetypeAnnotation, "", "<none>"),
+			Entry("with no cluster instance type expect empty string", k6tv1.ClusterInstancetypeAnnotation, "", ""),
 			Entry("with managed cluster instance type expect its name", k6tv1.ClusterInstancetypeAnnotation, "ci-managed", "ci-managed"),
 			Entry("with custom cluster instance type expect <other>", k6tv1.ClusterInstancetypeAnnotation, "ci-unmanaged", "<other>"),
 		)
@@ -316,10 +316,10 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(cr.Labels).To(HaveLen(17))
 			Expect(cr.Labels[8]).To(Equal(expected))
 		},
-			Entry("with no preference expect <none>", k6tv1.PreferenceAnnotation, "", "<none>"),
+			Entry("with no preference expect empty string", k6tv1.PreferenceAnnotation, "", ""),
 			Entry("with managed preference expect its name", k6tv1.PreferenceAnnotation, "p-managed", "p-managed"),
 			Entry("with custom preference expect <other>", k6tv1.PreferenceAnnotation, "p-unmanaged", "<other>"),
-			Entry("with no cluster preference expect <none>", k6tv1.ClusterPreferenceAnnotation, "", "<none>"),
+			Entry("with no cluster preference expect empty string", k6tv1.ClusterPreferenceAnnotation, "", ""),
 			Entry("with managed cluster preference expect its name", k6tv1.ClusterPreferenceAnnotation, "cp-managed", "cp-managed"),
 			Entry("with custom cluster preference expect <other>", k6tv1.ClusterPreferenceAnnotation, "cp-unmanaged", "<other>"),
 		)

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -635,7 +635,7 @@ func getDiskSizeValues(vm *k6tv1.VirtualMachine, pvc *k8sv1.PersistentVolumeClai
 		pvcSize = pvc.Spec.Resources.Requests.Storage()
 	}
 
-	volumeMode := "<none>"
+	volumeMode := ""
 	if pvc.Spec.VolumeMode != nil {
 		volumeMode = string(*pvc.Spec.VolumeMode)
 	}

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -205,10 +205,10 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr.Labels).To(HaveLen(10))
 			Expect(cr.GetLabelValue("instance_type")).To(Equal(expected))
 		},
-			Entry("with no instance type expect <none>", "VirtualMachineInstancetype", "", "<none>"),
+			Entry("with no instance type expect empty string", "VirtualMachineInstancetype", "", ""),
 			Entry("with managed instance type expect its name", "VirtualMachineInstancetype", "i-managed", "i-managed"),
 			Entry("with custom instance type expect <other>", "VirtualMachineInstancetype", "i-unmanaged", "<other>"),
-			Entry("with no cluster instance type expect <none>", "VirtualMachineClusterInstancetype", "", "<none>"),
+			Entry("with no cluster instance type expect empty string", "VirtualMachineClusterInstancetype", "", ""),
 			Entry("with managed cluster instance type expect its name", "VirtualMachineClusterInstancetype", "ci-managed", "ci-managed"),
 			Entry("with custom cluster instance type expect <other>", "VirtualMachineClusterInstancetype", "ci-unmanaged", "<other>"),
 			Entry("with an instance type which no longer exists expect <other>", "VirtualMachineInstancetype", "i-gone", "<other>"),
@@ -240,10 +240,10 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr.Labels).To(HaveLen(10))
 			Expect(cr.GetLabelValue("preference")).To(Equal(expected))
 		},
-			Entry("with no preference expect <none>", "VirtualMachinePreference", "", "<none>"),
+			Entry("with no preference expect empty string", "VirtualMachinePreference", "", ""),
 			Entry("with managed preference expect its name", "VirtualMachinePreference", "p-managed", "p-managed"),
 			Entry("with custom preference expect <other>", "VirtualMachinePreference", "p-unmanaged", "<other>"),
-			Entry("with no cluster preference expect <none>", "VirtualMachineClusterPreference", "", "<none>"),
+			Entry("with no cluster preference expect empty string", "VirtualMachineClusterPreference", "", ""),
 			Entry("with managed cluster preference expect its name", "VirtualMachineClusterPreference", "cp-managed", "cp-managed"),
 			Entry("with custom cluster preference expect <other>", "VirtualMachineClusterPreference", "cp-unmanaged", "<other>"),
 			Entry("with an preference which no longer exists expect <other>", "VirtualMachinePreference", "p-gone", "<other>"),
@@ -555,7 +555,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(results).ToNot(BeEmpty())
 			Expect(results[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
 			Expect(results[0].Value).To(Equal(float64(3 * 1024 * 1024 * 1024)))
-			Expect(results[0].Labels).To(Equal([]string{"test-vm-nil-mode", "default", "test-vm-pvc-nil-mode", "<none>", "rootdisk"}))
+			Expect(results[0].Labels).To(Equal([]string{"test-vm-nil-mode", "default", "test-vm-pvc-nil-mode", "", "rootdisk"}))
 		})
 
 		It("should prioritize DataVolume template size over PVC size", func() {

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
@@ -2,6 +2,7 @@ package operatormetrics
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,12 +42,12 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 	for _, cr := range collectedMetrics {
 		metric, ok := operatorRegistry.registeredCollectorMetrics[cr.Metric.GetOpts().Name]
 		if !ok {
-			fmt.Printf("metric %s not found in registry", cr.Metric.GetOpts().Name)
+			log.Printf("metric %s not found in registry", cr.Metric.GetOpts().Name)
 			continue
 		}
 
 		if err := collectValue(ch, metric, cr); err != nil {
-			fmt.Printf("error collecting metric %s: %v", cr.Metric.GetOpts().Name, err)
+			log.Printf("error collecting metric %s: %v", cr.Metric.GetOpts().Name, err)
 		}
 	}
 }
@@ -68,11 +69,17 @@ func collectValue(ch chan<- prometheus.Metric, metric Metric, cr CollectorResult
 	}
 
 	labels := map[string]string{}
+
 	for k, v := range cr.ConstLabels {
-		labels[k] = v
+		if v != "" {
+			labels[k] = v
+		}
 	}
+
 	for k, v := range metric.GetOpts().ConstLabels {
-		labels[k] = v
+		if v != "" {
+			labels[k] = v
+		}
 	}
 
 	desc := prometheus.NewDesc(

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
@@ -35,7 +35,8 @@ func (r *Registry) RegisterRecordingRules(recordingRules ...[]RecordingRule) err
 func (r *Registry) RegisterAlerts(alerts ...[]promv1.Rule) error {
 	for _, alertList := range alerts {
 		for _, alert := range alertList {
-			r.registeredAlerts[alert.Alert] = alert
+			key := alert.Alert + ":" + alert.Expr.String()
+			r.registeredAlerts[key] = alert
 		}
 	}
 
@@ -67,7 +68,10 @@ func (r *Registry) ListAlerts() []promv1.Rule {
 	}
 
 	slices.SortFunc(alerts, func(a, b promv1.Rule) int {
-		return cmp.Compare(a.Alert, b.Alert)
+		aKey := a.Alert + ":" + a.Expr.String()
+		bKey := b.Alert + ":" + b.Expr.String()
+
+		return cmp.Compare(aKey, bKey)
 	})
 
 	return alerts

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/testutil/BUILD.bazel
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/testutil/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "alert_custom_validations.go",
         "alert_validation.go",
+        "fetch_metrics.go",
         "linter.go",
         "problem.go",
         "recording_rule_validation.go",

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/testutil/fetch_metrics.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/testutil/fetch_metrics.go
@@ -1,0 +1,242 @@
+package testutil
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MetricResult represents a single metric.
+type MetricResult struct {
+	Name      string            `json:"name"`
+	Labels    map[string]string `json:"labels"`
+	Value     float64           `json:"value"`
+	Timestamp *time.Time        `json:"timestamp,omitempty"`
+}
+
+// MetricsFetcher defines the interface for fetching and loading metrics.
+type MetricsFetcher interface {
+	AddNameFilter(name string)
+	AddLabelFilter(labelsKeyValue ...string)
+	AddTimestampAfterFilter(ts time.Time)
+	AddTimestampBeforeFilter(ts time.Time)
+	Run() (map[string][]MetricResult, error)
+	LoadMetrics(payload string) (map[string][]MetricResult, error)
+}
+
+// DefaultMetricsGetter is the default implementation of MetricsFetcher.
+type DefaultMetricsGetter struct {
+	URL              string
+	metricNameFilter string
+	labelFilters     map[string]string
+	afterTimestamp   *time.Time
+	beforeTimestamp  *time.Time
+	metrics          map[string][]MetricResult
+}
+
+// NewMetricsFetcher creates a new MetricsFetcher instance.
+func NewMetricsFetcher(URL string) MetricsFetcher {
+	return &DefaultMetricsGetter{
+		URL:          URL,
+		labelFilters: make(map[string]string),
+		metrics:      make(map[string][]MetricResult),
+	}
+}
+
+func (dmg *DefaultMetricsGetter) AddNameFilter(name string) {
+	dmg.metricNameFilter = name
+}
+
+func (dmg *DefaultMetricsGetter) AddLabelFilter(labelsKeyValue ...string) {
+	for i := 0; i < len(labelsKeyValue); i += 2 {
+		if i+1 < len(labelsKeyValue) {
+			dmg.labelFilters[labelsKeyValue[i]] = labelsKeyValue[i+1]
+		}
+	}
+}
+
+func (dmg *DefaultMetricsGetter) AddTimestampAfterFilter(ts time.Time) {
+	dmg.afterTimestamp = &ts
+}
+
+func (dmg *DefaultMetricsGetter) AddTimestampBeforeFilter(ts time.Time) {
+	dmg.beforeTimestamp = &ts
+}
+
+// Run fetches metrics via HTTP, parses them, and applies filters.
+func (dmg *DefaultMetricsGetter) Run() (map[string][]MetricResult, error) {
+	resp, err := http.Get(dmg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query service endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status: %s", resp.Status)
+	}
+
+	dmg.metrics = make(map[string][]MetricResult)
+
+	if err := dmg.processReader(resp.Body); err != nil {
+		return nil, err
+	}
+
+	return dmg.metrics, nil
+}
+
+// LoadMetrics parses a provided metrics payload string and applies filters.
+func (dmg *DefaultMetricsGetter) LoadMetrics(payload string) (map[string][]MetricResult, error) {
+	dmg.metrics = make(map[string][]MetricResult)
+
+	reader := strings.NewReader(payload)
+	if err := dmg.processReader(reader); err != nil {
+		return nil, err
+	}
+
+	return dmg.metrics, nil
+}
+
+// processReader reads from the provided io.Reader line by line,
+// parses the metric lines, applies the filters, and stores the results.
+func (dmg *DefaultMetricsGetter) processReader(r io.Reader) error {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		mr, found, err := dmg.parseLine(line)
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+		if dmg.applyFilters(mr) {
+			dmg.metrics[mr.Name] = append(dmg.metrics[mr.Name], *mr)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+	return nil
+}
+
+// applyFilters checks whether the given MetricResult passes all filters.
+func (dmg *DefaultMetricsGetter) applyFilters(mr *MetricResult) bool {
+	if dmg.metricNameFilter != "" && !strings.HasPrefix(mr.Name, dmg.metricNameFilter) {
+		return false
+	}
+	for k, v := range dmg.labelFilters {
+		if mr.Labels[k] != v {
+			return false
+		}
+	}
+	if (dmg.afterTimestamp != nil || dmg.beforeTimestamp != nil) && mr.Timestamp == nil {
+		return false
+	}
+	if dmg.afterTimestamp != nil && mr.Timestamp.Before(*dmg.afterTimestamp) {
+		return false
+	}
+	if dmg.beforeTimestamp != nil && mr.Timestamp.After(*dmg.beforeTimestamp) {
+		return false
+	}
+	return true
+}
+
+// parseLine parses a single line of the metrics payload.
+func (dmg *DefaultMetricsGetter) parseLine(line string) (*MetricResult, bool, error) {
+	// Ignore comments and empty lines.
+	if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+		return nil, false, nil
+	}
+
+	// Use a custom splitter that respects quotes and curly braces.
+	metaPart, valuePart, err := splitMetricLine(line)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Parse the metric name and labels from metaPart.
+	name, labels := dmg.parseMetricNameAndLabels(metaPart)
+
+	// Now parse the value (and optional timestamp) from the valuePart.
+	parts := strings.Fields(valuePart)
+	if len(parts) < 1 {
+		err = fmt.Errorf("invalid metric line, no value: %s", line)
+		return nil, false, err
+	}
+
+	value, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse metric value: %w", err)
+	}
+
+	var timestamp *time.Time
+	if len(parts) >= 2 {
+		ts, err := strconv.ParseInt(parts[1], 10, 64)
+		if err == nil {
+			t := time.Unix(ts, 0)
+			timestamp = &t
+		}
+	}
+
+	mr := &MetricResult{
+		Name:      name,
+		Labels:    labels,
+		Value:     value,
+		Timestamp: timestamp,
+	}
+	return mr, true, nil
+}
+
+// splitMetricLine splits a metric line into its meta part (name and labels)
+// and its value part. It takes into account quoted strings and curly braces so that
+// spaces inside them are not treated as delimiters.
+func splitMetricLine(line string) (metaPart string, valuePart string, err error) {
+	inQuotes := false
+	inBraces := false
+	for i, r := range line {
+		switch r {
+		case '"':
+			inQuotes = !inQuotes
+		case '{':
+			if !inQuotes {
+				inBraces = true
+			}
+		case '}':
+			if !inQuotes {
+				inBraces = false
+			}
+		case ' ':
+			if !inQuotes && !inBraces {
+				metaPart = strings.TrimSpace(line[:i])
+				valuePart = strings.TrimSpace(line[i:])
+				return metaPart, valuePart, nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("invalid metric line, no value part found: %s", line)
+}
+
+// parseMetricNameAndLabels splits the metric name from its labels (if any).
+func (dmg *DefaultMetricsGetter) parseMetricNameAndLabels(input string) (string, map[string]string) {
+	labels := make(map[string]string)
+	nameEnd := strings.Index(input, "{")
+	if nameEnd == -1 {
+		return input, labels
+	}
+
+	name := input[:nameEnd]
+	labelStr := strings.Trim(input[nameEnd:], "{}")
+	labelPairs := strings.Split(labelStr, ",")
+	for _, pair := range labelPairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 2 {
+			labels[kv[0]] = strings.Trim(kv[1], "\"")
+		}
+	}
+	return name, labels
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -251,7 +251,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
 ## explicit; go 1.20
 github.com/kubevirt/monitoring/pkg/metrics/parser
-# github.com/machadovilaca/operator-observability v0.0.22
+# github.com/machadovilaca/operator-observability v0.0.27
 ## explicit; go 1.21
 github.com/machadovilaca/operator-observability/pkg/docs
 github.com/machadovilaca/operator-observability/pkg/operatormetrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

kubevirt_vmi_info and kubevirt_vm_info should not report <none> for missing labels. Like workload, flavor, instance_type, and preference.

This complicates the dashboards, since we don't want to show `<none>` value for labels that don't exist.

After this PR:

We only report labels if we have data for them

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-61830

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace metric labels' none values with empty values
```

