### PR TITLE
[release-1.5] Volume Expansion: Fix online expansion by requeuing VMIs on PVC size change

### DIFF
--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -1201,9 +1201,9 @@ func (c *Controller) updatePVC(old, cur interface{}) {
 	if curPVC.DeletionTimestamp != nil {
 		return
 	}
-
-	if equality.Semantic.DeepEqual(curPVC.Status.Capacity, oldPVC.Status.Capacity) {
-		// We only do something when the capacity changes
+	if equality.Semantic.DeepEqual(curPVC.Status.Capacity, oldPVC.Status.Capacity) &&
+		equality.Semantic.DeepEqual(curPVC.Spec.Resources.Requests, oldPVC.Spec.Resources.Requests) {
+		// We only do something when the capacity or the requested size changes.
 		return
 	}
 	vmis, err := c.listVMIsMatchingDV(curPVC.Namespace, curPVC.Name)

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -52,6 +52,8 @@ import (
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
 	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -3652,6 +3654,60 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			expectMatchingPodCreation(vmi)
 		})
 	})
+
+	Context("Event handling", func() {
+		indexVMI := func(vmi *virtv1.VirtualMachineInstance) {
+			Expect(controller.vmiIndexer.Add(vmi)).To(Succeed())
+			_, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		pvcWith := func(requestSize, capacity, rv string) *k8sv1.PersistentVolumeClaim {
+			pvc := newPvc("default", "testpvc")
+			pvc.Spec.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceStorage: resource.MustParse(requestSize),
+			}
+			pvc.Status.Capacity = k8sv1.ResourceList{
+				k8sv1.ResourceStorage: resource.MustParse(capacity),
+			}
+			pvc.ObjectMeta.ResourceVersion = rv
+			return pvc
+		}
+
+		DescribeTable("updatePVC", func(newReq, newCap, newRV string, expectEnqueue bool) {
+			vmi := libvmi.New(
+				libvmi.WithName("testvmi"),
+				libvmi.WithNamespace("default"),
+				libvmi.WithDataVolume("myvolume", "testpvc"),
+			)
+			indexVMI(vmi)
+
+			oldPVC := pvcWith("50Gi", "50Gi", "1")
+			newPVC := pvcWith(newReq, newCap, newRV)
+
+			addDataVolumePVC(oldPVC)
+			controller.updatePVC(oldPVC, newPVC)
+
+			if expectEnqueue {
+				Eventually(func() int {
+					return mockQueue.Len()
+				}, time.Second, 100*time.Millisecond).Should(Equal(1))
+
+				item, _ := mockQueue.Get()
+				Expect(item).To(Equal("default/testvmi"))
+			} else {
+				Consistently(func() int {
+					return mockQueue.Len()
+				}, time.Second, 100*time.Millisecond).Should(Equal(0))
+			}
+		},
+			Entry("should enqueue when requested size changes", "100Gi", "50Gi", "2", true),
+			Entry("should enqueue when capacity changes", "50Gi", "100Gi", "2", true),
+			Entry("should not enqueue when nothing changed", "50Gi", "50Gi", "2", false),
+			Entry("should not enqueue when resource version is the same", "10Gi", "50Gi", "1", false),
+		)
+	})
+
 })
 
 func newDv(namespace string, name string, phase cdiv1.DataVolumePhase) *cdiv1.DataVolume {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This is a manual backport of https://github.com/kubevirt/kubevirt/pull/14695. 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix online expansion by requeuing VMIs on PVC size change
```

