### PR TITLE
Label VEP tied PRs based on the KubeVirt project status

### DIFF
--- a/.github/workflows/label_approved_veps.yaml
+++ b/.github/workflows/label_approved_veps.yaml
@@ -27,4 +27,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_PROJECT_URL: "https://github.com/orgs/kubevirt/projects/15"
         run: python automation/label-approved-veps.py

--- a/automation/label-approved-veps.py
+++ b/automation/label-approved-veps.py
@@ -6,54 +6,87 @@ GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 KUBEVIRT_REPO = os.environ.get("GITHUB_REPOSITORY", "kubevirt/kubevirt")
 PR_NUMBER = os.environ["PR_NUMBER"]
 TARGET_PROJECT_URL = os.environ.get("TARGET_PROJECT_URL")
-HEADERS = {"Authorization": f"token {GITHUB_TOKEN}", "Accept": "application/vnd.github.v3+json"}
+HEADERS = {
+    "Authorization": f"token {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github.v3+json",
+}
 GRAPHQL_API_URL = "https://api.github.com/graphql"
 
 
 def get_pr_details():
-    #Fetch the kubevirt/kubevirt PR body
+    """Fetch the kubevirt/kubevirt PR body."""
     url = f"https://api.github.com/repos/{KUBEVIRT_REPO}/pulls/{PR_NUMBER}"
     response = requests.get(url, headers=HEADERS)
     response.raise_for_status()
     return response.json()["body"]
 
+
 def extract_enhancements_references(pr_body):
-    #Get the enhancements reference numbers from the PR.
-    pattern = r"(?:https://github.com/)?kubevirt/enhancements/(?:issues|pull)/(\d+)|(?:kubevirt/)?enhancements#(\d+)"
+    """Get the enhancements reference numbers from the PR."""
+    # Regex to find enhancement issue/pull numbers
+    pattern = (
+        r"(?:https://github.com/)?kubevirt/enhancements/(?:issues|pull)/(\d+)"
+        r"|(?:kubevirt/)?enhancements#(\d+)"
+    )
     matches = re.findall(pattern, pr_body)
 
-    # Extract the first non-empty group from each match and ensure they are issue numbers
-    ref_numbers = {group[0] or group[1] for group in matches if group[0] or group[1]}
+    # Extract the first non-empty group from each match
+    ref_numbers = {
+        group[0] or group[1] for group in matches if group[0] or group[1]
+    }
     return list(ref_numbers)
 
+
 def add_label_to_pr():
-    # Adds the 'approved-vep' label to the kubevirt PR. (when we will have that )
-    url = f"https://api.github.com/repos/{KUBEVIRT_REPO}/issues/{PR_NUMBER}/labels"
+    """Add the 'approved-vep' label to the kubevirt PR."""
+    url = (
+        f"https://api.github.com/repos/{KUBEVIRT_REPO}/issues/"
+        f"{PR_NUMBER}/labels"
+    )
     payload = {"labels": ["approved-vep"]}
     response = requests.post(url, headers=HEADERS, json=payload)
     response.raise_for_status()
 
+
 def parse_project_url(project_url):
-    # Extract the project number from the GitHub project URL.
-    # For example: https://github.com/orgs/kubevirt/projects/15
-    match = re.match(r"https://github.com/orgs/kubevirt/projects/(\d+)", project_url)
+    """
+    Extract the project number from the GitHub project URL.
+    For example: https://github.com/orgs/kubevirt/projects/15
+    """
+    match = re.match(
+                r"https://github.com/orgs/kubevirt/projects/(\d+)",
+                project_url)
     if match:
         return int(match.group(1))
-    raise ValueError(f"Invalid project URL format for kubevirt org: {project_url}. Expected format: https://github.com/orgs/kubevirt/projects/PROJECT_NUMBER")
+
+    msg_part1 = f"Invalid project URL format for kubevirt org: {project_url}."
+    msg_part2 = ("Expected format: https://github.com/orgs/kubevirt/"
+                 "projects/PROJECT_NUMBER")
+    raise ValueError(f"{msg_part1} {msg_part2}")
+
 
 def execute_graphql_query(query, variables):
-    # Executes a GraphQL query.
+    """Execute a GraphQL query."""
     try:
-        response = requests.post(GRAPHQL_API_URL, headers=HEADERS, json={"query": query, "variables": variables})
+        response = requests.post(
+            GRAPHQL_API_URL,
+            headers=HEADERS,
+            json={"query": query, "variables": variables},
+        )
         response.raise_for_status()
         return response.json()
     except requests.exceptions.RequestException as e:
-        raise RuntimeError(f"GraphQL request failed: {e}") from e
+        print(f"GraphQL request failed: {e}")
+        return None
+
 
 def get_tracked_enhancement_issues_from_project(project_number):
-    # Get VEP issue numbers from kubevirt/enhancements that are tracked in the target project
-    # and are approved. A "Tracked" issue means that it is approved for the release.
+    """
+    Get VEP issue numbers from kubevirt/enhancements that are tracked
+    in the target project and are approved.
 
+    A "Tracked" issue means that it is approved for the release.
+    """
     tracked_issues = {}
 
     query = """
@@ -101,18 +134,28 @@ def get_tracked_enhancement_issues_from_project(project_number):
     has_next_page = True
     current_cursor = None
 
-    print(f"Fetching items from project 'kubevirt/projects/{project_number}' to check for 'Status: Tracked'")
+    print(
+        f"Fetching items from project 'kubevirt/projects/{project_number}' "
+        "to check for 'Status: Tracked'"
+    )
     while has_next_page:
         variables["cursor"] = current_cursor
         result = execute_graphql_query(query, variables)
 
         if not result or "errors" in result:
-            print(f"GraphQL query errors: {result.get('errors') if result else 'No response'}")
+            error_payload = result.get('errors') if result else 'No response'
+            print(f"GraphQL query errors: {error_payload}")
             break
 
-        project_data = result.get("data", {}).get("organization", {}).get("projectV2", {})
+        data = result.get("data", {})
+        organization = data.get("organization", {})
+        project_data = organization.get("projectV2", {})
+
         if not project_data or not project_data.get("items"):
-            print(f"Warning: No items found for kubevirt project number {project_number}.")
+            print(
+                f"Warning: No items found for kubevirt project number "
+                f"{project_number}."
+            )
             break
 
         items_data = project_data.get("items", {})
@@ -121,23 +164,34 @@ def get_tracked_enhancement_issues_from_project(project_number):
         for item_node in nodes:
             content = item_node.get("content")
 
-            # Check if this is an Issue from the enhancements repo.
-            if not (content and content.get("__typename") == "Issue" and
-                    content.get("repository", {}).get("nameWithOwner") == "kubevirt/enhancements" and
-                    "number" in content):
+            if not content:
+                continue
+            if content.get("__typename") != "Issue":
+                continue
+            repo_info = content.get("repository", {})
+            if repo_info.get("nameWithOwner") != "kubevirt/enhancements":
+                continue
+            if "number" not in content:
                 continue
 
             issue_number = content["number"]
             is_tracked = False
-            for field_value_node in item_node.get("fieldValues", {}).get("nodes", []):
-                if field_value_node.get("__typename") == "ProjectV2ItemFieldSingleSelectValue":
+            field_values_data = item_node.get("fieldValues", {})
+            field_value_nodes = field_values_data.get("nodes", [])
+
+            for field_value_node in field_value_nodes:
+                expected_type = "ProjectV2ItemFieldSingleSelectValue"
+                if field_value_node.get("__typename") == expected_type:
                     field = field_value_node.get("field", {})
                     actual_field_name = field.get("field_definition_name")
-                    if actual_field_name == "Status" and field_value_node.get("selected_option_name") == "Tracked":
+                    is_status_field = actual_field_name == "Status"
+                    is_tracked_value = (
+                        field_value_node.get(
+                            "selected_option_name") == "Tracked"
+                    )
+                    if is_status_field and is_tracked_value:
                         is_tracked = True
                         break
-                            
-                            
 
             if is_tracked:
                 tracked_issues[issue_number] = True
@@ -148,30 +202,35 @@ def get_tracked_enhancement_issues_from_project(project_number):
 
     return tracked_issues
 
+
 def main():
+    """Main execution function."""
     try:
         project_number = parse_project_url(TARGET_PROJECT_URL)
     except ValueError as e:
-        print(f"Error parsing project URL '{TARGET_PROJECT_URL}': {e}")
+        print(f"Error parsing project URL '{TARGET_PROJECT_URL}':\n{e}")
         return
 
-    # Get PR body
     pr_body = get_pr_details()
     if not pr_body:
         print("No PR body found.")
         return
 
-    # Extract enhancements reference numbers
     ref_numbers_str = extract_enhancements_references(pr_body)
     if not ref_numbers_str:
         print("No enhancements references found.")
         return
 
     ref_numbers = {int(num_str) for num_str in ref_numbers_str}
-    print(f"Referenced KubeVirt Enhancement issue(s) in PR {KUBEVIRT_REPO}/pulls/{PR_NUMBER}: {ref_numbers}")
+    print(
+        f"Referenced KubeVirt Enhancement issue(s) in PR "
+        f"{KUBEVIRT_REPO}/pulls/{PR_NUMBER}: {ref_numbers}"
+    )
 
-    # Get the tracked VEP issue numbers from the enhancements repo
-    tracked_issues_in_project = get_tracked_enhancement_issues_from_project(project_number)
+    tracked_issues_in_project = get_tracked_enhancement_issues_from_project(
+        project_number
+    )
+
     first_matching_vep = None
     for vep_issue_num in ref_numbers:
         if vep_issue_num in tracked_issues_in_project:
@@ -179,12 +238,22 @@ def main():
             break
 
     if first_matching_vep is not None:
-        print(f"Match: KubeVirt Enhancement issue #{first_matching_vep} (referenced in this PR) is tracked in project {TARGET_PROJECT_URL}.")    
-        print(f"This PR ({KUBEVIRT_REPO}/pulls/{PR_NUMBER}) is related to a VEP tracked for the current release.")
+        print(
+            f"Match: KubeVirt Enhancement issue #{first_matching_vep} "
+            f"(referenced in this PR) is tracked in project "
+            f"{TARGET_PROJECT_URL}."
+        )
+        print(
+            f"This PR ({KUBEVIRT_REPO}/pulls/{PR_NUMBER}) is related to a VEP "
+            "tracked for the current release."
+        )
         add_label_to_pr()
     else:
-        print(f"This PR ({KUBEVIRT_REPO}/pulls/{PR_NUMBER}) is not related to any VEP issue currently tracked in project {TARGET_PROJECT_URL}.")
+        print(
+            f"This PR ({KUBEVIRT_REPO}/pulls/{PR_NUMBER}) is not related to "
+            f"any VEP issue currently tracked in project {TARGET_PROJECT_URL}."
+        )
+
 
 if __name__ == "__main__":
     main()
-

--- a/automation/label-approved-veps.py
+++ b/automation/label-approved-veps.py
@@ -5,7 +5,10 @@ import requests
 GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 KUBEVIRT_REPO = os.environ.get("GITHUB_REPOSITORY", "kubevirt/kubevirt")
 PR_NUMBER = os.environ["PR_NUMBER"]
+TARGET_PROJECT_URL = os.environ.get("TARGET_PROJECT_URL")
 HEADERS = {"Authorization": f"token {GITHUB_TOKEN}", "Accept": "application/vnd.github.v3+json"}
+GRAPHQL_API_URL = "https://api.github.com/graphql"
+
 
 def get_pr_details():
     #Fetch the kubevirt/kubevirt PR body
@@ -19,61 +22,9 @@ def extract_enhancements_references(pr_body):
     pattern = r"(?:https://github.com/)?kubevirt/enhancements/(?:issues|pull)/(\d+)|(?:kubevirt/)?enhancements#(\d+)"
     matches = re.findall(pattern, pr_body)
 
-    # Extract the first non-empty group from each match
-    ref_numbers = [group[0] or group[1] for group in matches]
-    # there can be duplicates
-    return list(set(ref_numbers))
-
-def find_related_merged_prs(issue_number):
-    #Find merged PRs in kubevirt/enhancements that reference a given issue.
-    
-    # Construct the search query for merged PRs referencing the issue
-    query = (
-        f'repo:kubevirt/enhancements is:pr is:merged '
-    )
-    base_url = "https://api.github.com/search/issues"
-    params = {"q": query, "per_page": 100}
-    
-    related_prs = []
-    page = 1
-    
-    while True:
-        try:
-            # Fetch the current page of results
-            response = requests.get(
-                f"{base_url}?q={params['q']}&per_page={params['per_page']}&page={page}",
-                headers=HEADERS
-            )
-            if response.status_code != 200:
-                print(f"API error: {response.status_code} - {response.text}")
-                break
-            
-            data = response.json()
-            items = data.get("items", [])
-            
-            # Extract PR numbers from the results
-            for item in items:
-                pr = item.get('pull_request', {})
-                # Check if PR is merged and references the issue in its body
-                # that's a bit of a mess since there can be multiple ways to reference 
-                body = item.get('body', '')
-                if (pr['merged_at'] and
-                    (f"#{issue_number}" in body or
-                     f"issues/{issue_number}" in body or
-                     f"https://github.com/kubevirt/enhancements/issues/{issue_number}" in body)):
-                    related_prs.append(item["number"])
-            
-            # If fewer than 100 items, we've reached the last page
-            if len(items) < 100:
-                break
-            
-            page += 1
-        
-        except Exception as e:
-            print(f"Request failed: {e}")
-            break
-    
-    return related_prs
+    # Extract the first non-empty group from each match and ensure they are issue numbers
+    ref_numbers = {group[0] or group[1] for group in matches if group[0] or group[1]}
+    return list(ref_numbers)
 
 def add_label_to_pr():
     # Adds the 'approved-vep' label to the kubevirt PR. (when we will have that )
@@ -81,6 +32,124 @@ def add_label_to_pr():
     payload = {"labels": ["approved-vep"]}
     response = requests.post(url, headers=HEADERS, json=payload)
     response.raise_for_status()
+
+def parse_project_url(project_url):
+    # Extract the project number from the GitHub project URL.
+    # For example: https://github.com/orgs/kubevirt/projects/15
+    match = re.match(r"https://github.com/orgs/kubevirt/projects/(\d+)", project_url)
+    if match:
+        return int(match.group(1))
+    raise ValueError(f"Invalid project URL format for kubevirt org: {project_url}. Expected format: https://github.com/orgs/kubevirt/projects/PROJECT_NUMBER")
+
+def execute_graphql_query(query, variables):
+    # Executes a GraphQL query.
+    try:
+        response = requests.post(GRAPHQL_API_URL, headers=HEADERS, json={"query": query, "variables": variables})
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"GraphQL request failed: {e}")
+        return None
+
+def get_tracked_enhancement_issues_from_project(project_number):
+    # Get VEP issue numbers from kubevirt/enhancements that are tracked in the target project
+    # and are approved. A "Tracked" issue means that it is approved for the release.
+
+    tracked_issues = {}
+
+    query = """
+    query($orgName: String!, $projectNumber: Int!, $cursor: String) {
+      organization(login: $orgName) {
+        projectV2(number: $projectNumber) {
+          items(first: 100, after: $cursor) {
+            nodes {
+              id
+              content {
+                __typename
+                ... on Issue {
+                  number
+                  repository {
+                    nameWithOwner
+                  }
+                }
+              }
+              fieldValues(first: 20) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    selected_option_name: name
+                    field {
+                      field_actual_typename: __typename
+                      ... on ProjectV2SingleSelectField {
+                          field_definition_id: id
+                          field_definition_name: name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    }
+    """
+    variables = {"orgName": "kubevirt", "projectNumber": project_number}
+    has_next_page = True
+    current_cursor = None
+
+    print(f"Fetching items from project 'kubevirt/projects/{project_number}' to check for 'Status: Tracked'")
+    while has_next_page:
+        variables["cursor"] = current_cursor
+        result = execute_graphql_query(query, variables)
+
+        if not result or "errors" in result:
+            print(f"GraphQL query errors: {result.get('errors') if result else 'No response'}")
+            break
+
+        project_data = result.get("data", {}).get("organization", {}).get("projectV2", {})
+        if not project_data or not project_data.get("items"):
+            print(f"Warning: No items found for kubevirt project number {project_number}.")
+            break
+        
+        items_data = project_data.get("items", {})
+        nodes = items_data.get("nodes", [])
+        
+        for item_node in nodes:
+            content = item_node.get("content")
+            
+            # Check if this is an Issue from the enhancements repo.
+            if not (content and content.get("__typename") == "Issue" and
+                    content.get("repository", {}).get("nameWithOwner") == "kubevirt/enhancements" and
+                    "number" in content):
+                continue
+
+            # Check the status
+            is_status_match = False
+            for field_value_node in item_node.get("fieldValues", {}).get("nodes", []):
+                if field_value_node.get("__typename") == "ProjectV2ItemFieldSingleSelectValue":
+                    field = field_value_node.get("field", {})
+                    if field.get("name") == "Status":
+                        if field_value_node.get("name") == "Tracked":
+                            is_status_match = True
+                            break
+            
+            if is_status_match:
+                tracked_issue_numbers.add(content["number"])
+                print(f"  Found kubevirt/enhancements issue #{content['number']} with Status Tracked.")
+            else:
+                print(f"  Found kubevirt/enhancements issue #{content['number']} but status was not Tracked.")
+
+
+        page_info = items_data.get("pageInfo", {})
+        has_next_page = page_info.get("hasNextPage", False)
+        current_cursor = page_info.get("endCursor") if has_next_page else None
+
+    return tracked_issue_numbers
 
 def main():
     # Get PR body


### PR DESCRIPTION
### What this PR does
This PR reworks the Github action that is responsible for labeling VEP approved PRs
The goal is to more accurately determine if a VEP is prioritized for the current release cycle.

Before this PR:
Previously, the script identified a PR as VEP approved if its description referenced a VEP issue in the kubevirt/enhancements repo.
It then checked if there was any merged PR in kubevirt/enhancements that mentioned this VEP issue.
With this logic we couldn't determine if the VEP was approved for the current release cycle.

After this PR:
In this PR, we are going to rely on a VEP issue status in the per-release VEP [tracker](https://github.com/orgs/kubevirt/projects/15)  using the GraphQL API.
It checks if any of the referenced VEP issues are present and have a `Tracked` status.

### Release note
```release-note
None
```

