### PR TITLE
Fix test: Use only schedulable nodes

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2196,8 +2196,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				Expect(machineType).ToNot(BeEmpty(), "VMI should have a valid machine type in its status")
 
 				By("Fetching all nodes in the cluster")
-				nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				nodeList := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodeList.Items).ToNot(BeEmpty())
 
 				By("Patching all nodes to remove the supported machine type label")


### PR DESCRIPTION
### What this PR does
The "with unsupported machine type should prevent migration scheduling" test was using all nodes and expecting those nodes to run node-labeller. This assumption is incorrect and GetAllSchedulableNodes should be used.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

