### PR TITLE
tests: Fix incorrect check in volume migration helper

### DIFF
--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -1300,11 +1300,7 @@ func waitMigrationToExist(virtClient kubecli.KubevirtClient, vmiName, ns string)
 				LabelSelector: ls.String(),
 			})
 		Expect(err).ToNot(HaveOccurred())
-		if len(migList.Items) < 0 {
-			return false
-		}
-		return true
-
+		return len(migList.Items) > 0
 	}, 120*time.Second, time.Second).Should(BeTrue())
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

The helper function `waitMigrationToExist` incorrectly checked if the migration list was empty using `len(migList.Items) < 0`, which is always false.

This Pull Request fixes this function so it correctly checks if the list is not empty.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

