### PR TITLE
virt-handler, net setup: Account for emulation

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -96,12 +96,12 @@ func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
 // NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
 // This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
 func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
-	return WantVirtioNetDevice(vmi) && !allowEmulation
+	return wantVirtioNetDevice(vmi) && !allowEmulation
 }
 
-// WantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
+// wantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
-func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
+func wantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		if iface.Model == "" || iface.Model == v1.VirtIO {
 			return true

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -93,6 +93,12 @@ func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
 	return IsSEVVMI(vmi) && vmi.Spec.Domain.LaunchSecurity.SEV.Attestation != nil
 }
 
+// NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
+// This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
+func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
+	return WantVirtioNetDevice(vmi) && !allowEmulation
+}
+
 // WantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
 func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -479,7 +479,7 @@ func getRequiredResources(vmi *v1.VirtualMachineInstance, allowEmulation bool) k
 	if util.NeedTunDevice(vmi) {
 		res[TunDevice] = resource.MustParse("1")
 	}
-	if needVirtioNetDevice(vmi, allowEmulation) {
+	if util.NeedVirtioNetDevice(vmi, allowEmulation) {
 		// Note that about network interface, allowEmulation does not make
 		// any difference on eventual Domain xml, but uniformly making
 		// /dev/vhost-net unavailable and libvirt implicitly fallback
@@ -741,10 +741,4 @@ func getMemoryLimitsRatio(namespace string, namespaceStore cache.Store) float64 
 	}
 
 	return limitRatioValue
-}
-
-// needVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
-// This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
-func needVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
-	return util.WantVirtioNetDevice(vmi) && !allowEmulation
 }

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -153,7 +153,7 @@ func (c *VirtualMachineController) prepareNetwork(vmi *v1.VirtualMachineInstance
 		return err
 	}
 
-	if virtutil.WantVirtioNetDevice(vmi) {
+	if virtutil.NeedVirtioNetDevice(vmi, c.clusterConfig.AllowEmulation()) {
 		if err := c.claimDeviceOwnership(rootMount, "vhost-net"); err != nil {
 			return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up vhost-net device, %s", err))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, when the cluster is configured with the `useEmulation` knob enabled, a VM using a virtio NIC fails to start due to the virt-handler attempting to claim ownership on the `/dev/vhost-net` device that doesn't exist. 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix network setup when emulation is enabled
```

