### PR TITLE
[virtctl] Properly pick up cobra onfigured streams in ssh command

### DIFF
--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -138,7 +138,7 @@ func (o *SSH) Run(cmd *cobra.Command, args []string) error {
 		return RunLocalClient(kind, namespace, name, &o.options, clientArgs)
 	}
 
-	return o.nativeSSH(kind, namespace, name, client)
+	return o.nativeSSH(kind, namespace, name, client, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 }
 
 func PrepareCommand(cmd *cobra.Command, fallbackNamespace string, opts *SSHOptions, args []string) (kind, namespace, name string, err error) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When using the ssh command in tests before, it did not properly pick up the stream redirections from cobra.Command.

#### After this PR:

Instead of directly using os.* streams, ask the ginkgo command for the configured stream.

This is more correct and helpful in e2e testing when using cobra.Commands.

```release-note
None
```

