### PR TITLE
device-manager: unit tests: add missing synchronization and error checks

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -70,6 +71,17 @@ var _ = Describe("Device Controller", func() {
 	var mockPCI *MockDeviceHandler
 	var ctrl *gomock.Controller
 	var clientTest *fake.Clientset
+	var wg *sync.WaitGroup
+
+	runDeviceController := func(deviceController *DeviceController) {
+		wg.Add(1)
+		go func() {
+			defer GinkgoRecover()
+			err := deviceController.Run(stop)
+			wg.Done()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+	}
 
 	BeforeEach(func() {
 		clientTest = fake.NewSimpleClientset()
@@ -103,12 +115,14 @@ var _ = Describe("Device Controller", func() {
 		maxDevices = 100
 		permissions = "rw"
 		stop = make(chan struct{}, 1)
+		wg = &sync.WaitGroup{}
 	})
 
 	AfterEach(func() {
 		defer os.RemoveAll(workDir)
 		// Ensure the deviceController is stopped after each test to avoid leaking resources
 		stop <- struct{}{}
+		wg.Wait()
 		handler = &DeviceUtilsHandler{}
 	})
 
@@ -122,7 +136,8 @@ var _ = Describe("Device Controller", func() {
 
 			fileObj, err := os.Create(devicePath)
 			Expect(err).ToNot(HaveOccurred())
-			fileObj.Close()
+			err = fileObj.Close()
+			Expect(err).ToNot(HaveOccurred())
 
 			res = deviceController.NodeHasDevice(devicePath)
 			Expect(res).To(BeTrue())
@@ -144,7 +159,8 @@ var _ = Describe("Device Controller", func() {
 			devicePath1 = path.Join(workDir, deviceName1)
 			devicePath2 = path.Join(workDir, deviceName2)
 			// only create the second device.
-			os.Create(devicePath2)
+			_, err = os.Create(devicePath2)
+			Expect(err).ToNot(HaveOccurred())
 
 			plugin1 = NewFakePlugin(deviceName1, devicePath1)
 			plugin2 = NewFakePlugin(deviceName2, devicePath2)
@@ -155,7 +171,8 @@ var _ = Describe("Device Controller", func() {
 			deviceController := NewDeviceController(host, maxDevices, permissions, initialDevices, fakeConfigMap, clientTest.CoreV1())
 			deviceController.backoff = []time.Duration{10 * time.Millisecond, 10 * time.Second}
 
-			go deviceController.Run(stop)
+			runDeviceController(deviceController)
+
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
 			}, 5*time.Second).Should(BeNumerically(">=", 1))
@@ -170,7 +187,8 @@ var _ = Describe("Device Controller", func() {
 			deviceController := NewDeviceController(host, maxDevices, permissions, initialDevices, fakeConfigMap, clientTest.CoreV1())
 			deviceController.backoff = []time.Duration{10 * time.Millisecond, 300 * time.Millisecond}
 
-			go deviceController.Run(stop)
+			runDeviceController(deviceController)
+
 			Consistently(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
 			}, 500*time.Millisecond).Should(BeNumerically("<", 3))
@@ -181,7 +199,7 @@ var _ = Describe("Device Controller", func() {
 			initialDevices := []Device{plugin1, plugin2}
 			deviceController := NewDeviceController(host, maxDevices, permissions, initialDevices, fakeConfigMap, clientTest.CoreV1())
 
-			go deviceController.Run(stop)
+			runDeviceController(deviceController)
 
 			Expect(deviceController.NodeHasDevice(devicePath1)).To(BeFalse())
 			Expect(deviceController.NodeHasDevice(devicePath2)).To(BeTrue())
@@ -204,7 +222,7 @@ var _ = Describe("Device Controller", func() {
 			deviceController.startDevice(deviceName1, plugin1)
 			deviceController.startDevice(deviceName2, plugin2)
 
-			go deviceController.Run(stop)
+			runDeviceController(deviceController)
 
 			Eventually(func() bool {
 				deviceController.startedPluginsMutex.Lock()
@@ -222,7 +240,7 @@ var _ = Describe("Device Controller", func() {
 			permanentPlugins := []Device{plugin1, plugin2}
 			deviceController := NewDeviceController(host, maxDevices, permissions, permanentPlugins, emptyConfigMap, clientTest.CoreV1())
 
-			go deviceController.Run(stop)
+			runDeviceController(deviceController)
 
 			Eventually(func() bool {
 				deviceController.startedPluginsMutex.Lock()


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Unit tests sometimes fail because of a data race in device-manager tests

#### After this PR:
No more race and added error checks

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
