### PR TITLE
pkg/util: Mv net devices requirement logic under SIG network

### DIFF
--- a/pkg/network/vmispec/BUILD.bazel
+++ b/pkg/network/vmispec/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "defaults.go",
+        "devices.go",
         "infosource.go",
         "interface.go",
         "network.go",

--- a/pkg/network/vmispec/devices.go
+++ b/pkg/network/vmispec/devices.go
@@ -24,7 +24,7 @@ import v1 "kubevirt.io/api/core/v1"
 // NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
 // This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
 func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
-	return HasVirtioIface(vmi) && !allowEmulation
+	return hasVirtioIface(vmi) && !allowEmulation
 }
 
 func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/network/vmispec/devices.go
+++ b/pkg/network/vmispec/devices.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vmispec
+
+import v1 "kubevirt.io/api/core/v1"
+
+// NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
+// This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
+func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
+	return HasVirtioIface(vmi) && !allowEmulation
+}
+
+func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {
+	return (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
+		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
+		(*vmi.Spec.Domain.Devices.AutoattachPodInterface)
+}

--- a/pkg/network/vmispec/devices.go
+++ b/pkg/network/vmispec/devices.go
@@ -21,13 +21,13 @@ package vmispec
 
 import v1 "kubevirt.io/api/core/v1"
 
-// NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
+// RequiresVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
 // This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
-func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
+func RequiresVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
 	return hasVirtioIface(vmi) && !allowEmulation
 }
 
-func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {
+func RequiresTunDevice(vmi *v1.VirtualMachineInstance) bool {
 	return (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
 		(*vmi.Spec.Domain.Devices.AutoattachPodInterface)

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -190,3 +190,14 @@ func HasBindingPluginDeviceInfo(iface v1.Interface, bindingPlugins map[string]v1
 	}
 	return false
 }
+
+// HasVirtioIface checks whether a VMI references at least one "virtio" network interface.
+// Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
+func HasVirtioIface(vmi *v1.VirtualMachineInstance) bool {
+	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+		if iface.Model == "" || iface.Model == v1.VirtIO {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -61,7 +61,7 @@ func VerifyVMIMigratable(vmi *v1.VirtualMachineInstance, bindingPlugins map[stri
 	}
 
 	_, allowPodBridgeNetworkLiveMigration := vmi.Annotations[v1.AllowPodBridgeNetworkLiveMigrationAnnotation]
-	if allowPodBridgeNetworkLiveMigration && IsPodNetworkWithBridgeBindingInterface(vmi.Spec.Networks, ifaces) {
+	if allowPodBridgeNetworkLiveMigration && isPodNetworkWithBridgeBindingInterface(vmi.Spec.Networks, ifaces) {
 		return nil
 	}
 	if IsPodNetworkWithMasqueradeBindingInterface(vmi.Spec.Networks, ifaces) ||
@@ -100,7 +100,7 @@ func IsPodNetworkWithMasqueradeBindingInterface(networks []v1.Network, ifaces []
 	return true
 }
 
-func IsPodNetworkWithBridgeBindingInterface(networks []v1.Network, ifaces []v1.Interface) bool {
+func isPodNetworkWithBridgeBindingInterface(networks []v1.Network, ifaces []v1.Interface) bool {
 	if podNetwork := LookupPodNetwork(networks); podNetwork != nil {
 		if podInterface := LookupInterfaceByName(ifaces, podNetwork.Name); podInterface != nil {
 			return podInterface.Bridge != nil
@@ -191,9 +191,9 @@ func HasBindingPluginDeviceInfo(iface v1.Interface, bindingPlugins map[string]v1
 	return false
 }
 
-// HasVirtioIface checks whether a VMI references at least one "virtio" network interface.
+// hasVirtioIface checks whether a VMI references at least one "virtio" network interface.
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
-func HasVirtioIface(vmi *v1.VirtualMachineInstance) bool {
+func hasVirtioIface(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		if iface.Model == "" || iface.Model == v1.VirtIO {
 			return true

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/util",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/scheme:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/scheme:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,6 +12,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	generatedscheme "kubevirt.io/client-go/kubevirt/scheme"
 	"kubevirt.io/client-go/log"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
 const (
@@ -90,18 +91,7 @@ func UseLaunchSecurity(vmi *v1.VirtualMachineInstance) bool {
 // NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
 // This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
 func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
-	return hasVirtioIface(vmi) && !allowEmulation
-}
-
-// hasVirtioIface checks whether a VMI references at least one "virtio" network interface.
-// Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
-func hasVirtioIface(vmi *v1.VirtualMachineInstance) bool {
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Model == "" || iface.Model == v1.VirtIO {
-			return true
-		}
-	}
-	return false
+	return netvmispec.HasVirtioIface(vmi) && !allowEmulation
 }
 
 func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -90,12 +90,12 @@ func UseLaunchSecurity(vmi *v1.VirtualMachineInstance) bool {
 // NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
 // This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
 func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
-	return wantVirtioNetDevice(vmi) && !allowEmulation
+	return hasVirtioIface(vmi) && !allowEmulation
 }
 
-// wantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
+// hasVirtioIface checks whether a VMI references at least one "virtio" network interface.
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
-func wantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
+func hasVirtioIface(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		if iface.Model == "" || iface.Model == v1.VirtIO {
 			return true

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,7 +12,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	generatedscheme "kubevirt.io/client-go/kubevirt/scheme"
 	"kubevirt.io/client-go/log"
-	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
 const (
@@ -86,18 +85,6 @@ func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
 
 func UseLaunchSecurity(vmi *v1.VirtualMachineInstance) bool {
 	return IsSEVVMI(vmi) || IsSecureExecutionVMI(vmi)
-}
-
-// NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
-// This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
-func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
-	return netvmispec.HasVirtioIface(vmi) && !allowEmulation
-}
-
-func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {
-	return (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
-		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
-		(*vmi.Spec.Domain.Devices.AutoattachPodInterface)
 }
 
 func IsAutoAttachVSOCK(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -547,10 +547,10 @@ func calcVCPUs(cpu *v1.CPU) int64 {
 
 func getRequiredResources(vmi *v1.VirtualMachineInstance, allowEmulation bool) k8sv1.ResourceList {
 	res := k8sv1.ResourceList{}
-	if netvmispec.NeedTunDevice(vmi) {
+	if netvmispec.RequiresTunDevice(vmi) {
 		res[TunDevice] = resource.MustParse("1")
 	}
-	if netvmispec.NeedVirtioNetDevice(vmi, allowEmulation) {
+	if netvmispec.RequiresVirtioNetDevice(vmi, allowEmulation) {
 		// Note that about network interface, allowEmulation does not make
 		// any difference on eventual Domain xml, but uniformly making
 		// /dev/vhost-net unavailable and libvirt implicitly fallback

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -14,6 +14,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/downwardmetrics"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/tpm"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
@@ -546,10 +547,10 @@ func calcVCPUs(cpu *v1.CPU) int64 {
 
 func getRequiredResources(vmi *v1.VirtualMachineInstance, allowEmulation bool) k8sv1.ResourceList {
 	res := k8sv1.ResourceList{}
-	if util.NeedTunDevice(vmi) {
+	if netvmispec.NeedTunDevice(vmi) {
 		res[TunDevice] = resource.MustParse("1")
 	}
-	if util.NeedVirtioNetDevice(vmi, allowEmulation) {
+	if netvmispec.NeedVirtioNetDevice(vmi, allowEmulation) {
 		// Note that about network interface, allowEmulation does not make
 		// any difference on eventual Domain xml, but uniformly making
 		// /dev/vhost-net unavailable and libvirt implicitly fallback

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -153,13 +153,13 @@ func (c *BaseController) prepareNetwork(vmi *v1.VirtualMachineInstance, res isol
 		return err
 	}
 
-	if netvmispec.NeedVirtioNetDevice(vmi, c.clusterConfig.AllowEmulation()) {
+	if netvmispec.RequiresVirtioNetDevice(vmi, c.clusterConfig.AllowEmulation()) {
 		if err := c.claimDeviceOwnership(rootMount, "vhost-net"); err != nil {
 			return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up vhost-net device, %s", err))
 		}
 	}
 
-	if netvmispec.NeedTunDevice(vmi) {
+	if netvmispec.RequiresTunDevice(vmi) {
 		if err := c.claimDeviceOwnership(rootMount, "/net/tun"); err != nil {
 			return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up tun device, %s", err))
 		}

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -13,9 +13,9 @@ import (
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/storage/types"
-	virtutil "kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
 
@@ -153,13 +153,13 @@ func (c *BaseController) prepareNetwork(vmi *v1.VirtualMachineInstance, res isol
 		return err
 	}
 
-	if virtutil.NeedVirtioNetDevice(vmi, c.clusterConfig.AllowEmulation()) {
+	if netvmispec.NeedVirtioNetDevice(vmi, c.clusterConfig.AllowEmulation()) {
 		if err := c.claimDeviceOwnership(rootMount, "vhost-net"); err != nil {
 			return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up vhost-net device, %s", err))
 		}
 	}
 
-	if virtutil.NeedTunDevice(vmi) {
+	if netvmispec.NeedTunDevice(vmi) {
 		if err := c.claimDeviceOwnership(rootMount, "/net/tun"); err != nil {
 			return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up tun device, %s", err))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, `NeedVirtioNetDevice` and `NeedTunDevice` are located under a general purpose `pkg/util`.
Move the above functions and their dependencies under SIG-network's ownership.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

