### PR TITLE
Introduce FindPodDir

### DIFF
--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -196,8 +196,14 @@ func SocketFilePathOnHost(podUID string) string {
 	return fmt.Sprintf("%s/%s", SocketDirectoryOnHost(podUID), StandardLauncherSocketFileName)
 }
 
+// Finds exactly one Pod dir on a host based on the NODE_NAME env. Returns error otherwise.
+func FindPodDir(vmi *v1.VirtualMachineInstance) (string, error) {
+	host, _ := os.LookupEnv("NODE_NAME")
+	return FindPodDirOnHost(vmi, host, SocketDirectoryOnHost)
+}
+
 // gets the cmd socket for a VMI
-func FindPodDirOnHost(vmi *v1.VirtualMachineInstance, socketDirFunc func(string) string) (string, error) {
+func FindPodDirOnHost(vmi *v1.VirtualMachineInstance, host string, socketDirFunc func(string) string) (string, error) {
 
 	var socketDirsForErrorReporting []string
 	// It is possible for multiple pods to be active on a single VMI
@@ -205,7 +211,10 @@ func FindPodDirOnHost(vmi *v1.VirtualMachineInstance, socketDirFunc func(string)
 	// this particular local node if it exists. A active pod not
 	// running on this node will not have a kubelet pods directory,
 	// so it will not be found.
-	for podUID := range vmi.Status.ActivePods {
+	for podUID, nodeName := range vmi.Status.ActivePods {
+		if host != "" && host != nodeName {
+			continue
+		}
 		socketPodDir := socketDirFunc(string(podUID))
 		socketDirsForErrorReporting = append(socketDirsForErrorReporting, socketPodDir)
 		exists, _ := diskutils.FileExists(socketPodDir)

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -131,15 +131,29 @@ var _ = Describe("Virt remote commands", func() {
 		})
 
 		It("socket dir from UID and file path provider func", func() {
-			path, err := FindPodDirOnHost(vmi, SocketFilePathOnHost)
+			path, err := FindPodDirOnHost(vmi, "", SocketFilePathOnHost)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(path).To(Equal(podSocketFile))
 		})
 
 		It("negative test socket dir not found", func() {
-			_, err := FindPodDirOnHost(vmi, func(string) string { return "no-such-dir" })
+			_, err := FindPodDirOnHost(vmi, "", func(string) string { return "no-such-dir" })
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no-such-dir"))
+		})
+
+		It("socket dir from UID and file path provider func, FindPodDir", func() {
+			path, err := FindPodDir(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			// TODO: FindPodDir should return clean path
+			Expect(filepath.Clean(path)).To(Equal(filepath.Dir(podSocketFile)))
+		})
+
+		It("negative test socket dir not found, FindPodDir", func() {
+			os.RemoveAll(filepath.Dir(podSocketFile))
+			_, err := FindPodDir(vmi)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No pod dir found for vmi 1234"))
 		})
 
 		Context("exec", func() {

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -131,9 +131,10 @@ var _ = Describe("Virt remote commands", func() {
 		})
 
 		It("socket dir from UID and file path provider func", func() {
-			path, err := FindPodDirOnHost(vmi, "", SocketFilePathOnHost)
+			path, err := FindPodDirOnHost(vmi, "", SocketDirectoryOnHost)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(path).To(Equal(podSocketFile))
+			// TODO: FindPodDirOnHost should return clean path
+			Expect(filepath.Clean(path)).To(Equal(filepath.Dir(podSocketFile)))
 		})
 
 		It("negative test socket dir not found", func() {

--- a/pkg/virt-handler/launcher-clients/launcher-clients.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients.go
@@ -165,7 +165,7 @@ func (l *launcherClientsManager) IsLauncherClientUnresponsive(vmi *v1.VirtualMac
 			socketFile, err = cmdclient.FindSocket(vmi)
 			if err != nil {
 				// socket does not exist, but let's see if the pod is still there
-				if _, err = cmdclient.FindPodDirOnHost(vmi, cmdclient.SocketDirectoryOnHost); err != nil {
+				if _, err = cmdclient.FindPodDir(vmi); err != nil {
 					// no pod meanst that waiting for it to initialize makes no sense
 					return true, true, nil
 				}
@@ -189,7 +189,7 @@ func (l *launcherClientsManager) IsLauncherClientUnresponsive(vmi *v1.VirtualMac
 		// no socket file, no VMI, so it's unresponsive
 		if err != nil {
 			// socket does not exist, but let's see if the pod is still there
-			if _, err = cmdclient.FindPodDirOnHost(vmi, cmdclient.SocketDirectoryOnHost); err != nil {
+			if _, err = cmdclient.FindPodDir(vmi); err != nil {
 				// no pod means that waiting for it to initialize makes no sense
 				return true, true, nil
 			}


### PR DESCRIPTION
### What this PR does
Current FindPodDirOnHost is actually ignoring a host all together and would try to find any Pod. FindPodDirOnHost now takes host as argument "host" and filters base on it. A FindPodDir now automatically provides the host based on "NODE_NAME" env variable.

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

