### PR TITLE
Fix the category for cluster scoped migrationpolicy crd

### DIFF
--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -845,9 +845,6 @@ func NewMigrationPolicyCrd() (*extv1.CustomResourceDefinition, error) {
 			Plural:   migrations.ResourceMigrationPolicies,
 			Singular: "migrationpolicy",
 			Kind:     migrationsv1.MigrationPolicyKind.Kind,
-			Categories: []string{
-				"all",
-			},
 		},
 	}
 	err := addFieldsToAllVersions(crd, &extv1.CustomResourceSubresources{


### PR DESCRIPTION
### What this PR does
Fixes category for clusterscoped migrationpolicy crd
The all category should typically be set only on namespaced resources, otherwise a kubectl get all will fail to list all resources in a given namespace if a user has only permissions to that single namespace.

Migration policies are cluster scoped, while all other resources with the all category are only namespaced
#### Before this PR:
Before this PR, migrationpolicy have category all which is not relevant for scope: cluster
oc get crd -o json | jq -rM '.items[] | [.metadata.name, .spec.names?.categories[]?] | @tsv' | grep -w all
dataimportcrons.cdi.kubevirt.io Namespaced      all
.....
migrationpolicies.migrations.kubevirt.io        Cluster all 

#### After this PR:
After this fix, we should not see migration policy when use 
oc get crd -o json | jq -rM '.items[] | [.metadata.name, .spec.scope, (.spec.names.categories // [""])[]] | @tsv' | grep -w all
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

