### PR TITLE
Move alicefr to become an emeritus approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,7 +10,6 @@ aliases:
     - enp0s3
     - xpivarc
     - vasiliy-ul
-    - alicefr
     - iholder101
   emeritus_approvers:
     - danielBelenky
@@ -25,6 +24,7 @@ aliases:
     - dhiller # 2024-03-15
     - AlonaKaplan
     - acardace
+    - alicefr # 2025-06-04
   code-reviewers:
     - vladikr
     - enp0s3
@@ -33,7 +33,6 @@ aliases:
     - EdDev
     - xpivarc
     - iholder101
-    - alicefr
     - 0xFelix
     - lyarwood
     - fossedihelm
@@ -86,7 +85,6 @@ aliases:
   #
   sig-storage-approvers:
     - mhenriks
-    - alicefr
     - akalenyu
     - ShellyKa13
   sig-storage-reviewers:
@@ -94,6 +92,8 @@ aliases:
     - akalenyu
     - ShellyKa13
     - alromeros
+  sig-storage-emeritus_approvers:
+    - alicefr
 
   #
   # SIG API


### PR DESCRIPTION
### What this PR does
Following https://github.com/kubevirt/community/pull/406, this PR moves @alicefr to become an emeritus approver.
This is mainly needed for the bot to avoid assigning her to new PRs.

@alicefr let me take this opportunity to thank you for all of your contributions!
Hope to still see your username pops up here every once in a while :)

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

