### PR TITLE
Bump to bazeldnf version xattr fixes and better new bazel verison compatibility

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 # See https://github.com/bazelbuild/bazel/issues/7899
 load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
-load("@bazeldnf//:def.bzl", "bazeldnf")
+load("@bazeldnf//bazeldnf:defs.bzl", "bazeldnf")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@com_github_ash2k_bazel_tools//goimports:def.bzl", "goimports")
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -186,18 +186,29 @@ http_file(
 
 http_archive(
     name = "bazeldnf",
-    sha256 = "fb24d80ad9edad0f7bd3000e8cffcfbba89cc07e495c47a7d3b1f803bd527a40",
+    sha256 = "286de512159f34ca3dcec01d0598eb7f502ab73c8f93e2ccb7a5a351c927cd84",
+    strip_prefix = "bazeldnf-e72ea52c428aff923ded3e95d6ddbe7c43835e10",
     urls = [
-        "https://github.com/rmohr/bazeldnf/releases/download/v0.5.9/bazeldnf-v0.5.9.tar.gz",
-        "https://storage.googleapis.com/builddeps/fb24d80ad9edad0f7bd3000e8cffcfbba89cc07e495c47a7d3b1f803bd527a40",
+        "https://github.com/rmohr/bazeldnf/archive/e72ea52c428aff923ded3e95d6ddbe7c43835e10.tar.gz",
     ],
 )
 
-load("@bazeldnf//:deps.bzl", "bazeldnf_dependencies", "rpm")
+load("@bazeldnf//bazeldnf:defs.bzl", "rpm")
+load(
+    "@bazeldnf//bazeldnf:repositories.bzl",
+    "bazeldnf_dependencies",
+    "bazeldnf_register_toolchains",
+)
 load(
     "@io_bazel_rules_go//go:deps.bzl",
     "go_register_toolchains",
     "go_rules_dependencies",
+)
+
+bazeldnf_dependencies()
+
+bazeldnf_register_toolchains(
+    name = "bazeldnf_prebuilt",
 )
 
 go_rules_dependencies()
@@ -234,8 +245,6 @@ go_repository(
 )
 
 gazelle_dependencies()
-
-bazeldnf_dependencies()
 
 # Winrmcli dependencies
 go_repository(

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazeldnf//:deps.bzl", "xattrs")
+load("@bazeldnf//bazeldnf:defs.bzl", "xattrs")
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -26,7 +26,7 @@ KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
 HOST_ARCHITECTURE="$(uname -m)"
 
 sandbox_root=${SANDBOX_DIR}/default/root
-sandbox_hash="7b6c1afd5a044d144c3b5c4b7aab4c2046956b23"
+sandbox_hash="61deaceec112417ee9ce4dda389e4e41e7daca23"
 
 function kubevirt::bootstrap::regenerate() {
     (

--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@bazeldnf//:def.bzl", "bazeldnf")
-load("@bazeldnf//:deps.bzl", "rpm", "rpmtree", "tar2files")
+load("@bazeldnf//bazeldnf:defs.bzl", "bazeldnf", "rpm", "rpmtree", "tar2files")
 
 bazeldnf(
     name = "sandbox_x86_64",


### PR DESCRIPTION

### What this PR does

The new version has a few fixes which are potentially hit on newer bazel versions due to plugin code changes and is also module ready in principle.

Most notably it brings in https://github.com/rmohr/bazeldnf/pull/135.


### References

- Fixes #
- Partially addresses #13111

### Release note

```release-note
NONE
```

