### PR TITLE
add nad metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -18,6 +18,9 @@ Version information. Type: Gauge.
 ### kubevirt_memory_delta_from_requested_bytes
 The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator. Type: Gauge.
 
+### kubevirt_network_attachment_definition_info
+Details about additional network interfaces attached to Virtual Machines Type: Gauge.
+
 ### kubevirt_nodes_with_kvm
 The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. Type: Gauge.
 

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -659,6 +659,7 @@ spec:
           - network-attachment-definitions
           verbs:
           - get
+          - list
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -661,6 +661,7 @@ rules:
   - network-attachment-definitions
   verbs:
   - get
+  - list
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/instancetype/preference/find:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/common/workqueue:go_default_library",
+        "//pkg/network/multus:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -38,6 +39,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -446,11 +446,11 @@ func CollectVmisVnicInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.Co
 
 	for _, iface := range interfaces {
 		model := "<none>"
-		if iface.Model != "" {
+		if iface.Model != "nil" {
 			model = iface.Model
 		}
 		bindingType, bindingName := getBinding(iface)
-		networkName, matchFound := getNetworkName(iface.Name, networks)
+		networkName, matchFound := getNetworkName(iface.Name, vmi.Namespace, networks)
 
 		if !matchFound {
 			continue

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -423,7 +423,10 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"network-attachment-definitions",
 				},
-				Verbs: []string{"get"},
+				Verbs: []string{
+					"get",
+					"list",
+				},
 			},
 			{
 				APIGroups: []string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add a metric that reports the Network Attachment Definitions and their properties.
The goal is to be able to identify what external network each VM is connected to.
#### Before this PR:
kubevirt_network_attachment_definition_info metric does not exists
#### After this PR:
kubevirt_network_attachment_definition_info metric exists
  
- Fixes #
Jira-ticket: https://issues.redhat.com/browse/CNV-56854

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added kubevirt_network_attachment_definition_info metric
```

