### PR TITLE
[NOT FOR MERGE] Test kubevirt using network policies

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -125,6 +125,8 @@ until _kubectl wait -n ${namespace} kv kubevirt --for condition=Available --time
     sleep 1m
 done
 
+_kubectl create -f ${MANIFESTS_OUT_DIR}/../../network-policies.yaml
+
 configure_prometheus
 
 echo "Done $0"

--- a/network-policies.yaml
+++ b/network-policies.yaml
@@ -60,4 +60,18 @@ spec:
     - ports:
         - protocol: TCP
           port: metrics
-
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-kubevirt-webhook-server
+spec:
+  podSelector:
+    matchLabels:
+      kubevirt.io: virt-api
+  policyTypes:
+    - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: virt-api

--- a/network-policies.yaml
+++ b/network-policies.yaml
@@ -75,3 +75,18 @@ spec:
   - ports:
     - protocol: TCP
       port: virt-api
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-virt-operator-webhook-server
+spec:
+  podSelector:
+    matchLabels:
+      kubevirt.io: virt-operator
+  policyTypes:
+    - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: webhooks

--- a/network-policies.yaml
+++ b/network-policies.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: kubevirt
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-api-server
+  namespace: kubevirt
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-to-dns
+  namespace: kubevirt
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        # allow talking to the kube-dns pods in kubevirt
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: TCP
+          port: dns-tcp
+        - protocol: UDP
+          port: dns
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-metrics
+  namespace: kubevirt
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: metrics
+


### PR DESCRIPTION
### What this PR does
This PR is **not intended to be merged**.

It rather tests Kubevirt working under network policies that allow only very basic communication (thanks @ormergi for helping me with those).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

