### PR TITLE
sync custom dynamic annotations and labels to virt-launcher pods

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -264,6 +264,8 @@ type VirtControllerApp struct {
 	restoreControllerThreads          int
 	snapshotControllerResyncPeriod    time.Duration
 	cloneControllerThreads            int
+	additionalLauncherAnnotationsSync []string
+	additionalLauncherLabelsSync      []string
 
 	caConfigMapName          string
 	promCertFilePath         string
@@ -705,6 +707,8 @@ func (vca *VirtControllerApp) initCommon() {
 			return netadmitter.ValidateCreation(field, vmiSpec, clusterCfg)
 		},
 		netmigration.NewEvaluator(),
+		vca.additionalLauncherAnnotationsSync,
+		vca.additionalLauncherLabelsSync,
 	)
 	if err != nil {
 		panic(err)
@@ -810,6 +814,8 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 			vca.clusterConfig,
 			recorder,
 		),
+		vca.additionalLauncherAnnotationsSync,
+		vca.additionalLauncherLabelsSync,
 	)
 	if err != nil {
 		panic(err)
@@ -1064,6 +1070,12 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.IntVar(&vca.cloneControllerThreads, "clone-controller-threads", defaultControllerThreads,
 		"Number of goroutines to run for clone controller")
+
+	flag.StringSliceVar(&vca.additionalLauncherAnnotationsSync, "additional-launcher-annotations-sync", []string{},
+		"Comma separated list of annotation keys which if present on the VM template and so VMI, will be sync to the virt-launcher pod. Note, it is unidirectional from VM.spec.template.metadata -> VMI and VMI -> virt-launcher pod")
+
+	flag.StringSliceVar(&vca.additionalLauncherLabelsSync, "additional-launcher-labels-sync", []string{},
+		"Comma separated list of labels keys which if present on the VM template and so VMI, will be sync to the virt-launcher pod. Note, it is unidirectional from VM.spec.template.metadata -> VMI and VMI -> virt-launcher pod")
 }
 
 func (vca *VirtControllerApp) setupLeaderElector() (err error) {

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -157,6 +157,8 @@ var _ = Describe("Application", func() {
 				return nil
 			},
 			stubMigrationEvaluator{},
+			[]string{},
+			[]string{},
 		)
 		app.rsController, _ = replicaset.NewController(vmiInformer, rsInformer, recorder, virtClient, uint(10))
 		app.vmController, _ = vm.NewController(vmiInformer,
@@ -173,6 +175,8 @@ var _ = Describe("Application", func() {
 			nil,
 			nil,
 			instancetypecontroller.NewControllerStub(),
+			[]string{},
+			[]string{},
 		)
 		app.migrationController, _ = migration.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -664,13 +664,18 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToPod(vmi *virtv1.VirtualMac
 		}
 	}
 
+	dynamicLabels := []string{virtv1.NodeNameLabel, virtv1.OutdatedLauncherImageLabel}
+	dynamicLabels = append(dynamicLabels, c.additionalLauncherLabelsSync...)
+	dynamicAnnotations := []string{descheduler.EvictPodAnnotationKeyAlpha, descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction}
+	dynamicAnnotations = append(dynamicAnnotations, c.additionalLauncherAnnotationsSync...)
+
 	syncMap(
-		[]string{virtv1.NodeNameLabel, virtv1.OutdatedLauncherImageLabel},
+		dynamicLabels,
 		vmi.Labels, newPodLabels, pod.ObjectMeta.Labels, "labels",
 	)
 
 	syncMap(
-		[]string{descheduler.EvictPodAnnotationKeyAlpha, descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction},
+		dynamicAnnotations,
 		vmi.Annotations, newPodAnnotations, pod.ObjectMeta.Annotations, "annotations",
 	)
 

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -70,6 +70,8 @@ func NewController(templateService templateService,
 	netStatusUpdater statusUpdater,
 	netSpecValidator specValidator,
 	netMigrationEvaluator migrationEvaluator,
+	additionalLauncherAnnotationsSync []string,
+	additionalLauncherLabelsSync []string,
 ) (*Controller, error) {
 
 	c := &Controller{
@@ -78,27 +80,29 @@ func NewController(templateService templateService,
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-vmi"},
 		),
-		vmiIndexer:              vmiInformer.GetIndexer(),
-		vmStore:                 vmInformer.GetStore(),
-		podIndexer:              podInformer.GetIndexer(),
-		pvcIndexer:              pvcInformer.GetIndexer(),
-		migrationIndexer:        migrationInformer.GetIndexer(),
-		recorder:                recorder,
-		clientset:               clientset,
-		podExpectations:         controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		vmiExpectations:         controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		pvcExpectations:         controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		dataVolumeIndexer:       dataVolumeInformer.GetIndexer(),
-		cdiStore:                cdiInformer.GetStore(),
-		cdiConfigStore:          cdiConfigInformer.GetStore(),
-		clusterConfig:           clusterConfig,
-		topologyHinter:          topologyHinter,
-		cidsMap:                 vsock.NewCIDsMap(),
-		backendStorage:          backendstorage.NewBackendStorage(clientset, clusterConfig, storageClassInformer.GetStore(), storageProfileInformer.GetStore(), pvcInformer.GetIndexer()),
-		netAnnotationsGenerator: netAnnotationsGenerator,
-		updateNetworkStatus:     netStatusUpdater,
-		validateNetworkSpec:     netSpecValidator,
-		netMigrationEvaluator:   netMigrationEvaluator,
+		vmiIndexer:                        vmiInformer.GetIndexer(),
+		vmStore:                           vmInformer.GetStore(),
+		podIndexer:                        podInformer.GetIndexer(),
+		pvcIndexer:                        pvcInformer.GetIndexer(),
+		migrationIndexer:                  migrationInformer.GetIndexer(),
+		recorder:                          recorder,
+		clientset:                         clientset,
+		podExpectations:                   controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		vmiExpectations:                   controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		pvcExpectations:                   controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		dataVolumeIndexer:                 dataVolumeInformer.GetIndexer(),
+		cdiStore:                          cdiInformer.GetStore(),
+		cdiConfigStore:                    cdiConfigInformer.GetStore(),
+		clusterConfig:                     clusterConfig,
+		topologyHinter:                    topologyHinter,
+		cidsMap:                           vsock.NewCIDsMap(),
+		backendStorage:                    backendstorage.NewBackendStorage(clientset, clusterConfig, storageClassInformer.GetStore(), storageProfileInformer.GetStore(), pvcInformer.GetIndexer()),
+		netAnnotationsGenerator:           netAnnotationsGenerator,
+		updateNetworkStatus:               netStatusUpdater,
+		validateNetworkSpec:               netSpecValidator,
+		netMigrationEvaluator:             netMigrationEvaluator,
+		additionalLauncherAnnotationsSync: additionalLauncherAnnotationsSync,
+		additionalLauncherLabelsSync:      additionalLauncherLabelsSync,
 	}
 
 	c.hasSynced = func() bool {
@@ -189,30 +193,32 @@ type migrationEvaluator interface {
 }
 
 type Controller struct {
-	templateService         templateService
-	clientset               kubecli.KubevirtClient
-	Queue                   workqueue.TypedRateLimitingInterface[string]
-	vmiIndexer              cache.Indexer
-	vmStore                 cache.Store
-	podIndexer              cache.Indexer
-	pvcIndexer              cache.Indexer
-	migrationIndexer        cache.Indexer
-	topologyHinter          topology.Hinter
-	recorder                record.EventRecorder
-	podExpectations         *controller.UIDTrackingControllerExpectations
-	vmiExpectations         *controller.UIDTrackingControllerExpectations
-	pvcExpectations         *controller.UIDTrackingControllerExpectations
-	dataVolumeIndexer       cache.Indexer
-	cdiStore                cache.Store
-	cdiConfigStore          cache.Store
-	clusterConfig           *virtconfig.ClusterConfig
-	cidsMap                 vsock.Allocator
-	backendStorage          *backendstorage.BackendStorage
-	hasSynced               func() bool
-	netAnnotationsGenerator annotationsGenerator
-	updateNetworkStatus     statusUpdater
-	validateNetworkSpec     specValidator
-	netMigrationEvaluator   migrationEvaluator
+	templateService                   templateService
+	clientset                         kubecli.KubevirtClient
+	Queue                             workqueue.TypedRateLimitingInterface[string]
+	vmiIndexer                        cache.Indexer
+	vmStore                           cache.Store
+	podIndexer                        cache.Indexer
+	pvcIndexer                        cache.Indexer
+	migrationIndexer                  cache.Indexer
+	topologyHinter                    topology.Hinter
+	recorder                          record.EventRecorder
+	podExpectations                   *controller.UIDTrackingControllerExpectations
+	vmiExpectations                   *controller.UIDTrackingControllerExpectations
+	pvcExpectations                   *controller.UIDTrackingControllerExpectations
+	dataVolumeIndexer                 cache.Indexer
+	cdiStore                          cache.Store
+	cdiConfigStore                    cache.Store
+	clusterConfig                     *virtconfig.ClusterConfig
+	cidsMap                           vsock.Allocator
+	backendStorage                    *backendstorage.BackendStorage
+	hasSynced                         func() bool
+	netAnnotationsGenerator           annotationsGenerator
+	updateNetworkStatus               statusUpdater
+	validateNetworkSpec               specValidator
+	netMigrationEvaluator             migrationEvaluator
+	additionalLauncherAnnotationsSync []string
+	additionalLauncherLabelsSync      []string
 }
 
 func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
With #14744 we gained the capability to sync a predefined list of annotations from
VM.spec.template.metadata to VMI and then to virt-launcher pods.
But the list of annotations to be synced was hardcoded.

#### After this PR:
This extend the mechanism used to sync selected annotations
from VM.spec.template.metadata to VMI and then to
virt-launcher pods to custom annotations and labels
defined as command flag for virt-controller.

### References
- Fixes: #13761
- Follows: #14744
- Replaces: #13762

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The list of annotations and labels synced from VM.spec.template.metadata to VMI and then to virt-launcher pods can be extended
```

