### PR TITLE
[release-1.3] Add kubevirt_vm_info metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -87,6 +87,9 @@ The total number of VMs created by namespace, since install. Type: Counter.
 ### kubevirt_vm_error_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to error status. Type: Counter.
 
+### kubevirt_vm_info
+Information about Virtual Machines. Type: Gauge.
+
 ### kubevirt_vm_migrating_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to migrating status. Type: Counter.
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/krolaw/dhcp4 v0.0.0-20180925202202-7cead472c414
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
-	github.com/machadovilaca/operator-observability v0.0.20
+	github.com/machadovilaca/operator-observability v0.0.22
 	github.com/mdlayher/vsock v1.2.1
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed

--- a/go.sum
+++ b/go.sum
@@ -1391,8 +1391,8 @@ github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuz
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
-github.com/machadovilaca/operator-observability v0.0.20 h1:I9CLKWcaJU9KtPREhUu4yn/CLAZUpxFqEUz/ZVenkAI=
-github.com/machadovilaca/operator-observability v0.0.20/go.mod h1:e4Z3VhOXb9InkmSh00JjqBBijE+iD+YMzynBpKB3+gE=
+github.com/machadovilaca/operator-observability v0.0.22 h1:6+SdraJf91TmoPkZXJbjhxp99wMdYfBgk0WsV4fnfPo=
+github.com/machadovilaca/operator-observability v0.0.22/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -128,7 +128,7 @@ func collectVMIInfo(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.Coll
 	var cr []operatormetrics.CollectorResult
 
 	for _, vmi := range vmis {
-		os, workload, flavor := getVMISystemInfo(vmi)
+		os, workload, flavor := getSystemInfoFromAnnotations(vmi.Annotations)
 		instanceType := getVMIInstancetype(vmi)
 		preference := getVMIPreference(vmi)
 		kernelRelease, machine, name, versionID := getGuestOSInfo(vmi)
@@ -151,20 +151,20 @@ func getVMIPhase(vmi *k6tv1.VirtualMachineInstance) string {
 	return strings.ToLower(string(vmi.Status.Phase))
 }
 
-func getVMISystemInfo(vmi *k6tv1.VirtualMachineInstance) (os, workload, flavor string) {
+func getSystemInfoFromAnnotations(annotations map[string]string) (os, workload, flavor string) {
 	os = none
 	workload = none
 	flavor = none
 
-	if val, ok := vmi.Annotations[annotationPrefix+"os"]; ok {
+	if val, ok := annotations[annotationPrefix+"os"]; ok {
 		os = val
 	}
 
-	if val, ok := vmi.Annotations[annotationPrefix+"workload"]; ok {
+	if val, ok := annotations[annotationPrefix+"workload"]; ok {
 		workload = val
 	}
 
-	if val, ok := vmi.Annotations[annotationPrefix+"flavor"]; ok {
+	if val, ok := annotations[annotationPrefix+"flavor"]; ok {
 		flavor = val
 	}
 

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -134,7 +134,7 @@ var _ = Describe("VMI Stats Collector", func() {
 				Expect(cr.Labels).To(HaveLen(13))
 
 				Expect(cr.Labels[3]).To(Equal(getVMIPhase(vmis[i])))
-				os, workload, flavor := getVMISystemInfo(vmis[i])
+				os, workload, flavor := getSystemInfoFromAnnotations(vmis[i].Annotations)
 				Expect(cr.Labels[4]).To(Equal(os))
 				Expect(cr.Labels[5]).To(Equal(workload))
 				Expect(cr.Labels[6]).To(Equal(flavor))

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/BUILD.bazel
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "collector.go",
+        "collector_result.go",
         "counter.go",
         "counter_vec.go",
         "gauge.go",

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
@@ -19,13 +19,6 @@ type Collector struct {
 	CollectCallback func() []CollectorResult
 }
 
-type CollectorResult struct {
-	Metric      Metric
-	Labels      []string
-	ConstLabels map[string]string
-	Value       float64
-}
-
 func (c Collector) hash() string {
 	var sb strings.Builder
 
@@ -38,7 +31,7 @@ func (c Collector) hash() string {
 
 func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	for _, cm := range c.Metrics {
-		cm.getCollector().Describe(ch)
+		cm.GetCollector().Describe(ch)
 	}
 }
 
@@ -93,7 +86,12 @@ func collectValue(ch chan<- prometheus.Metric, metric Metric, cr CollectorResult
 	if err != nil {
 		return err
 	}
-	ch <- cm
+
+	if cr.Timestamp.IsZero() {
+		ch <- cm
+	} else {
+		ch <- prometheus.NewMetricWithTimestamp(cr.Timestamp, cm)
+	}
 
 	return nil
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector_result.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector_result.go
@@ -1,0 +1,24 @@
+package operatormetrics
+
+import (
+	"errors"
+	"time"
+)
+
+type CollectorResult struct {
+	Metric      Metric
+	Labels      []string
+	ConstLabels map[string]string
+	Value       float64
+	Timestamp   time.Time
+}
+
+func (cr CollectorResult) GetLabelValue(key string) (string, error) {
+	for i, label := range cr.Metric.GetOpts().labels {
+		if label == key {
+			return cr.Labels[i], nil
+		}
+	}
+
+	return "", errors.New("label not found")
+}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter.go
@@ -31,6 +31,6 @@ func (c *Counter) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *Counter) getCollector() prometheus.Collector {
+func (c *Counter) GetCollector() prometheus.Collector {
 	return c.Counter
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter_vec.go
@@ -33,6 +33,6 @@ func (c *CounterVec) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *CounterVec) getCollector() prometheus.Collector {
+func (c *CounterVec) GetCollector() prometheus.Collector {
 	return c.CounterVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge.go
@@ -31,6 +31,6 @@ func (c *Gauge) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *Gauge) getCollector() prometheus.Collector {
+func (c *Gauge) GetCollector() prometheus.Collector {
 	return c.Gauge
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge_vec.go
@@ -33,6 +33,6 @@ func (c *GaugeVec) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *GaugeVec) getCollector() prometheus.Collector {
+func (c *GaugeVec) GetCollector() prometheus.Collector {
 	return c.GaugeVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram.go
@@ -46,6 +46,6 @@ func (c *Histogram) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *Histogram) getCollector() prometheus.Collector {
+func (c *Histogram) GetCollector() prometheus.Collector {
 	return c.Histogram
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram_vec.go
@@ -37,6 +37,6 @@ func (c *HistogramVec) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *HistogramVec) getCollector() prometheus.Collector {
+func (c *HistogramVec) GetCollector() prometheus.Collector {
 	return c.HistogramVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/metric.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/metric.go
@@ -15,8 +15,7 @@ type Metric interface {
 	GetOpts() MetricOpts
 	GetType() MetricType
 	GetBaseType() MetricType
-
-	getCollector() prometheus.Collector
+	GetCollector() prometheus.Collector
 }
 
 type MetricType string

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary.go
@@ -46,6 +46,6 @@ func (c *Summary) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *Summary) getCollector() prometheus.Collector {
+func (c *Summary) GetCollector() prometheus.Collector {
 	return c.Summary
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary_vec.go
@@ -37,6 +37,6 @@ func (c *SummaryVec) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *SummaryVec) getCollector() prometheus.Collector {
+func (c *SummaryVec) GetCollector() prometheus.Collector {
 	return c.SummaryVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/wrapper_registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/wrapper_registry.go
@@ -63,6 +63,21 @@ func RegisterCollector(collectors ...Collector) error {
 	return nil
 }
 
+// UnregisterMetrics unregisters the metrics from the Prometheus registry.
+func UnregisterMetrics(allMetrics ...[]Metric) error {
+	for _, metricList := range allMetrics {
+		for _, metric := range metricList {
+			if metricExists(metric) {
+				if err := unregisterMetric(metric); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // ListMetrics returns a list of all registered metrics.
 func ListMetrics() []Metric {
 	var result []Metric
@@ -107,7 +122,7 @@ func metricExists(metric Metric) bool {
 }
 
 func unregisterMetric(metric Metric) error {
-	if succeeded := Unregister(metric.getCollector()); succeeded {
+	if succeeded := Unregister(metric.GetCollector()); succeeded {
 		delete(operatorRegistry.registeredMetrics, metric.GetOpts().Name)
 		return nil
 	}
@@ -116,7 +131,7 @@ func unregisterMetric(metric Metric) error {
 }
 
 func registerMetric(metric Metric) error {
-	err := Register(metric.getCollector())
+	err := Register(metric.GetCollector())
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/BUILD.bazel
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "compatibility.go",
         "prometheusrules.go",
         "rbac.go",
         "recordingrule.go",

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/compatibility.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/compatibility.go
@@ -1,0 +1,37 @@
+package operatorrules
+
+import promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+// Deprecated: operatorRegistry is deprecated.
+var operatorRegistry = NewRegistry()
+
+// Deprecated: RegisterRecordingRules is deprecated.
+func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+	return operatorRegistry.RegisterRecordingRules(recordingRules...)
+}
+
+// Deprecated: RegisterAlerts is deprecated.
+func RegisterAlerts(alerts ...[]promv1.Rule) error {
+	return operatorRegistry.RegisterAlerts(alerts...)
+}
+
+// Deprecated: ListRecordingRules is deprecated.
+func ListRecordingRules() []RecordingRule {
+	return operatorRegistry.ListRecordingRules()
+}
+
+// Deprecated: ListAlerts is deprecated.
+func ListAlerts() []promv1.Rule {
+	return operatorRegistry.ListAlerts()
+}
+
+// Deprecated: CleanRegistry is deprecated.
+func CleanRegistry() error {
+	operatorRegistry = NewRegistry()
+	return nil
+}
+
+// Deprecated: BuildPrometheusRule is deprecated.
+func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	return operatorRegistry.BuildPrometheusRule(name, namespace, labels)
+}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
@@ -11,8 +11,8 @@ import (
 )
 
 // BuildPrometheusRule builds a PrometheusRule object from the registered recording rules and alerts.
-func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
-	spec, err := buildPrometheusRuleSpec()
+func (r *Registry) BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	spec, err := r.buildPrometheusRuleSpec()
 	if err != nil {
 		return nil, err
 	}
@@ -31,20 +31,20 @@ func BuildPrometheusRule(name, namespace string, labels map[string]string) (*pro
 	}, nil
 }
 
-func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
+func (r *Registry) buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	var groups []promv1.RuleGroup
 
-	if len(operatorRegistry.registeredRecordingRules) != 0 {
+	if len(r.registeredRecordingRules) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "recordingRules.rules",
-			Rules: buildRecordingRulesRules(),
+			Rules: r.buildRecordingRulesRules(),
 		})
 	}
 
-	if len(operatorRegistry.registeredAlerts) != 0 {
+	if len(r.registeredAlerts) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "alerts.rules",
-			Rules: ListAlerts(),
+			Rules: r.ListAlerts(),
 		})
 	}
 
@@ -55,10 +55,10 @@ func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	return &promv1.PrometheusRuleSpec{Groups: groups}, nil
 }
 
-func buildRecordingRulesRules() []promv1.Rule {
+func (r *Registry) buildRecordingRulesRules() []promv1.Rule {
 	var rules []promv1.Rule
 
-	for _, recordingRule := range operatorRegistry.registeredRecordingRules {
+	for _, recordingRule := range r.registeredRecordingRules {
 		rules = append(rules, promv1.Rule{
 			Record: recordingRule.MetricsOpts.Name,
 			Expr:   recordingRule.Expr,

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
@@ -7,26 +7,24 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
-var operatorRegistry = newRegistry()
-
-type operatorRegisterer struct {
+type Registry struct {
 	registeredRecordingRules map[string]RecordingRule
 	registeredAlerts         map[string]promv1.Rule
 }
 
-func newRegistry() operatorRegisterer {
-	return operatorRegisterer{
+func NewRegistry() *Registry {
+	return &Registry{
 		registeredRecordingRules: map[string]RecordingRule{},
 		registeredAlerts:         map[string]promv1.Rule{},
 	}
 }
 
 // RegisterRecordingRules registers the given recording rules.
-func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+func (r *Registry) RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 	for _, recordingRuleList := range recordingRules {
 		for _, recordingRule := range recordingRuleList {
 			key := recordingRule.MetricsOpts.Name + ":" + recordingRule.Expr.String()
-			operatorRegistry.registeredRecordingRules[key] = recordingRule
+			r.registeredRecordingRules[key] = recordingRule
 		}
 	}
 
@@ -34,10 +32,10 @@ func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 }
 
 // RegisterAlerts registers the given alerts.
-func RegisterAlerts(alerts ...[]promv1.Rule) error {
+func (r *Registry) RegisterAlerts(alerts ...[]promv1.Rule) error {
 	for _, alertList := range alerts {
 		for _, alert := range alertList {
-			operatorRegistry.registeredAlerts[alert.Alert] = alert
+			r.registeredAlerts[alert.Alert] = alert
 		}
 	}
 
@@ -45,9 +43,9 @@ func RegisterAlerts(alerts ...[]promv1.Rule) error {
 }
 
 // ListRecordingRules returns the registered recording rules.
-func ListRecordingRules() []RecordingRule {
+func (r *Registry) ListRecordingRules() []RecordingRule {
 	var rules []RecordingRule
-	for _, rule := range operatorRegistry.registeredRecordingRules {
+	for _, rule := range r.registeredRecordingRules {
 		rules = append(rules, rule)
 	}
 
@@ -62,9 +60,9 @@ func ListRecordingRules() []RecordingRule {
 }
 
 // ListAlerts returns the registered alerts.
-func ListAlerts() []promv1.Rule {
+func (r *Registry) ListAlerts() []promv1.Rule {
 	var alerts []promv1.Rule
-	for _, alert := range operatorRegistry.registeredAlerts {
+	for _, alert := range r.registeredAlerts {
 		alerts = append(alerts, alert)
 	}
 
@@ -73,10 +71,4 @@ func ListAlerts() []promv1.Rule {
 	})
 
 	return alerts
-}
-
-// CleanRegistry removes all registered rules and alerts.
-func CleanRegistry() error {
-	operatorRegistry = newRegistry()
-	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -243,7 +243,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
 ## explicit; go 1.20
 github.com/kubevirt/monitoring/pkg/metrics/parser
-# github.com/machadovilaca/operator-observability v0.0.20
+# github.com/machadovilaca/operator-observability v0.0.22
 ## explicit; go 1.21
 github.com/machadovilaca/operator-observability/pkg/docs
 github.com/machadovilaca/operator-observability/pkg/operatormetrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This pr is backport for https://github.com/kubevirt/kubevirt/pull/12718 
#### Before this PR:
The only info available was about VMIs. Since Virtual Machines may not have been started yet, we would have no metrics about them. Users may be interested in this information to predict cluster state and capacities.

#### After this PR:
kubevirt_vm_info adds information about VMs not started yet

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
Jira-ticket: https://issues.redhat.com/browse/CNV-62971

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vm_info metric
```

