### PR TITLE
Fix: e2e affinity

### DIFF
--- a/tests/hotplug/affinity.go
+++ b/tests/hotplug/affinity.go
@@ -139,10 +139,8 @@ var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.S
 			Eventually(func() bool {
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, k8smetav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				if vmi.Spec.NodeSelector == nil {
-					return false
-				}
-				return validateNodeSelector(vmNodeSelector, vmi.Spec.NodeSelector)
+
+				return vmi.Spec.NodeSelector == nil || validateNodeSelector(vmNodeSelector, vmi.Spec.NodeSelector)
 			}, 240*time.Second, time.Second).Should(BeTrue())
 
 		})


### PR DESCRIPTION
### What this PR does
Once we remove affinity it is expected to be nil.

```
package main

import (
	"encoding/json"
	"fmt"
)

type a struct {
	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
}

func main() {
	fmt.Println("Hello, 世界")
	st := a{}
	js := `{}`
	json.Unmarshal([]byte(js), &st)
	fmt.Println(st.NodeSelector == nil)
}

```



### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

