### PR TITLE
net, vm ctrl: Adjust VM's detached iface clearing logic

### DIFF
--- a/pkg/network/controllers/vm.go
+++ b/pkg/network/controllers/vm.go
@@ -92,13 +92,13 @@ func (v *VMController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstanc
 	}
 
 	vmiCopy := vmi.DeepCopy()
-	ifaces, networks = clearDetachedInterfaces(vmiCopy.Spec.Domain.Devices.Interfaces, vmiCopy.Spec.Networks, indexedStatusIfaces)
-	vmiCopy.Spec.Domain.Devices.Interfaces = ifaces
-	vmiCopy.Spec.Networks = networks
-
 	hasOrdinalIfaces := namescheme.HasOrdinalSecondaryIfaces(vmi.Spec.Networks, vmi.Status.Interfaces)
 	updatedVmiSpec := applyDynamicIfaceRequestOnVMI(vmCopy, vmiCopy, hasOrdinalIfaces)
 	vmiCopy.Spec = *updatedVmiSpec
+
+	ifaces, networks = clearDetachedInterfaces(vmiCopy.Spec.Domain.Devices.Interfaces, vmiCopy.Spec.Networks, indexedStatusIfaces)
+	vmiCopy.Spec.Domain.Devices.Interfaces = ifaces
+	vmiCopy.Spec.Networks = networks
 
 	if err := v.vmiInterfacesPatch(&vmiCopy.Spec, vmi); err != nil {
 		return vm, &syncError{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, VM's absent interfaces which are not present in the VMI.Status.Interfaces slice, are removed.

This is problematic in the following scenario:

1. The dynamic-networks-controller is not deployed.
2. A VM is running with an interface connected to pod network.
3. A secondary interface is hotplugged and the VM is not migrated.
4. The interface above is marked for hot-unplug by setting its state field to `absent`.

In this case, the interface and its matching network are removed from the VM spec, but are kept in the VMI spec.

This is because, the controller does not set the VMI's interface state as absent, as in this scenario the naming scheme is unknown and assumed to be ordinal, thus preventing hot-unplug.

Adjust the logic for clearing VM interfaces and their matching networks to remove only interfaces that meet the following criteria:
1. The interface state is absent.
2. The interface does not exist in the VMI spec.
3. The interface does not exist in the VMI status.

Following this change, in the scenario described above, the interface and its matching network will be retained both on the VM and VMI specs, until the VM will be migrated.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

