### PR TITLE
stabalize flaky vmi profile functest by increasing scheduled timeout 30->90 seconds

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2006,7 +2006,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				if psaRelatedErrorDetected && virtualMachineProfile == nil {
 					return
 				}
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(BeInPhase(v1.Scheduled))
+				Eventually(matcher.ThisVMI(vmi), 90*time.Second, time.Second).Should(BeInPhase(v1.Scheduled))
 
 				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What this PR does
Lately, the `pull-kubevirt-e2e-k8s-1.27-sig-operator-1.2` lane had shown to be [very flaky](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.27-sig-operator-1.2?buildId=). This was especially envisioned in [this PR](https://github.com/kubevirt/kubevirt/pull/14848), in which the lane had failed for multiple times before passing, all on the same failing test. An example for a failure can be found [here](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14910/pull-kubevirt-e2e-k8s-1.27-sig-operator-1.2/1932729862783504384).

After some investigation, it seems that by the time we expect the VMI to become scheduled, the virt-launcher pod was scheduled but the VMI wasn't updated yet. In https://github.com/kubevirt/kubevirt/pull/14910, I was testing the lane as-is and it failed, although it passed multiple times after the timeout was raised.

I'm not completely sure why we see this regression specifically for this lane, but 30 seconds is a pretty low timeout for a VMI being scheduled on our CI. I think it is best to fix it for the main branch and then backport.

#### Before this PR:

vmi profile functest is using a 30 second timeout for a VMI to become scheduled.

#### After this PR:

vmi profile functest is using a 90 second timeout for a VMI to become scheduled.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

