### PR TITLE
snapshot, source: include live-updated disks only if they are persistent

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -599,7 +599,11 @@ func (ctrl *VMSnapshotController) createContent(vmSnapshot *snapshotv1.VirtualMa
 	}
 
 	var volumeBackups []snapshotv1.VolumeBackup
-	pvcs, err := source.PersistentVolumeClaims()
+	sourceSpec, err := source.Spec()
+	if err != nil {
+		return err
+	}
+	pvcs, err := storageutils.PVCsFromObj(sourceSpec.VirtualMachine, ctrl.Client)
 	if err != nil {
 		return err
 	}
@@ -625,11 +629,6 @@ func (ctrl *VMSnapshotController) createContent(vmSnapshot *snapshotv1.VirtualMa
 		}
 
 		volumeBackups = append(volumeBackups, vb)
-	}
-
-	sourceSpec, err := source.Spec()
-	if err != nil {
-		return err
 	}
 	content := &snapshotv1.VirtualMachineSnapshotContent{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/storage/utils/BUILD.bazel
+++ b/pkg/storage/utils/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/storage/backend-storage:go_default_library",
+        "//pkg/storage/types:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/storage/utils/volumes.go
+++ b/pkg/storage/utils/volumes.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 )
 
 type VolumeOption int
@@ -50,8 +51,17 @@ const (
 
 var ErrNoBackendPVC = fmt.Errorf("no backend PVC when there should be one")
 
+// PVCsFromObj returns PVCs from the volumes of the passed object, empty if it's an unsupported object
+func PVCsFromObj(obj any, client kubecli.KubevirtClient) (map[string]string, error) {
+	volumes, err := GetVolumes(obj, client, WithAllVolumes)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return storagetypes.GetPVCsFromVolumes(volumes), nil
+}
+
 // GetVolumes returns all volumes of the passed object, empty if it's an unsupported object
-func GetVolumes(obj interface{}, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
+func GetVolumes(obj any, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
 	switch obj := obj.(type) {
 	case *v1.VirtualMachine:
 		return GetVirtualMachineVolumes(obj, client, opts...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Existing snapshot behavior for live-updated disks included additional disks that were added to the VM spec after it started without verifying whether they were present in the VMI as well. This results in unwanted behavior for online snapshots as additional volumes may be staged for the next VM rebbot but they'll be added to the snapshot anyway.

#### After this PR:
This PR asserts whether the VM and VMI have the same volumes (i.e., persistent live-update) and that the initial revision differs from current state to confirm live-update scenario.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

