### PR TITLE
VEP 41: Add virtctl objectgraph command

### DIFF
--- a/pkg/virt-api/rest/objectgraph.go
+++ b/pkg/virt-api/rest/objectgraph.go
@@ -312,7 +312,7 @@ func (og *ObjectGraph) addVolumeGraph(obj any, namespace string) ([]v1.ObjectGra
 		if !storageutils.IsErrNoBackendPVC(err) {
 			return nil, err
 		}
-		log.Log.Reason(err).Error("Failed to get backend volume, VM might still be provisioning. Proceeding with the remaining volumes.")
+		err = fmt.Errorf("failed to get backend volume (%w), VM might still be provisioning. Proceeding with the remaining volumes", err)
 	}
 
 	for _, volume := range volumes {

--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/virtctl/guestfs:go_default_library",
         "//pkg/virtctl/imageupload:go_default_library",
         "//pkg/virtctl/memorydump:go_default_library",
+        "//pkg/virtctl/objectgraph:go_default_library",
         "//pkg/virtctl/pause:go_default_library",
         "//pkg/virtctl/portforward:go_default_library",
         "//pkg/virtctl/reset:go_default_library",

--- a/pkg/virtctl/objectgraph/BUILD.bazel
+++ b/pkg/virtctl/objectgraph/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["objectgraph.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/objectgraph",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virtctl/clientconfig:go_default_library",
+        "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "objectgraph_suite_test.go",
+        "objectgraph_test.go",
+    ],
+    deps = [
+        "//pkg/pointer:go_default_library",
+        "//pkg/virtctl/testing:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/go.uber.org/mock/gomock:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/pkg/virtctl/objectgraph/BUILD.bazel
+++ b/pkg/virtctl/objectgraph/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/pkg/virtctl/objectgraph/OWNERS
+++ b/pkg/virtctl/objectgraph/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-storage-reviewers
+approvers:
+  - sig-storage-approvers
+labels:
+  - sig/storage

--- a/pkg/virtctl/objectgraph/objectgraph.go
+++ b/pkg/virtctl/objectgraph/objectgraph.go
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package objectgraph
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/clientconfig"
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+type command struct {
+	vmi            bool
+	shouldExclude  bool
+	labelSelectors map[string]string
+}
+
+func NewCommand() *cobra.Command {
+	c := command{}
+	cmd := &cobra.Command{
+		Use:     "objectgraph (VM|VMI)",
+		Short:   "Returns dependency graph related to a VM|VMI.",
+		Example: usageObjectGraph(),
+		Args:    cobra.ExactArgs(1),
+		RunE:    c.objectGraphRun,
+	}
+
+	cmd.Flags().BoolVar(&c.vmi, "vmi", false, "Returns the object graph from the VMI instead of the VM.")
+	cmd.Flags().BoolVar(&c.shouldExclude, "exclude-optional", false, "Exclude optional nodes from the object graph.")
+	cmd.Flags().StringToStringVar(&c.labelSelectors, "selector", map[string]string{}, "Label selectors to filter the object graph (multiple labels can be specified).")
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+
+	return cmd
+}
+
+// usageObjectGraph provides several valid usage examples of objectgraph
+func usageObjectGraph() string {
+	return `
+  # Get the object graph for a VirtualMachine named 'my-vm'
+  {{ProgramName}} objectgraph my-vm
+
+  # Get the object graph for a VirtualMachineInstance named 'my-vmi'
+  {{ProgramName}} objectgraph --vmi my-vmi
+
+  # Exclude optional nodes in the object graph for a VM
+  {{ProgramName}} objectgraph my-vm --exclude-optional
+
+  # Filter the object graph by label selector
+  {{ProgramName}} objectgraph my-vm --selector="kubevirt.io/dependency-type=storage,kubevirt.io/dependency-type=compute"
+`
+}
+
+func (c *command) objectGraphRun(cmd *cobra.Command, args []string) error {
+	vmName := args[0]
+
+	virtClient, namespace, _, err := clientconfig.ClientAndNamespaceFromContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	include := !c.shouldExclude
+	opts := &v1.ObjectGraphOptions{
+		IncludeOptionalNodes: &include,
+	}
+
+	if len(c.labelSelectors) > 0 {
+		opts.LabelSelector = &metav1.LabelSelector{
+			MatchLabels: c.labelSelectors,
+		}
+	}
+
+	var objectGraph v1.ObjectGraphNode
+	if c.vmi {
+		objectGraph, err = virtClient.VirtualMachineInstance(namespace).ObjectGraph(cmd.Context(), vmName, opts)
+		if err != nil {
+			return fmt.Errorf("error listing object graph of VirtualMachineInstance %s: %v", vmName, err)
+		}
+	} else {
+		objectGraph, err = virtClient.VirtualMachine(namespace).ObjectGraph(cmd.Context(), vmName, opts)
+		if err != nil {
+			return fmt.Errorf("error listing object graph of VirtualMachine %s: %v", vmName, err)
+		}
+	}
+
+	data, err := json.MarshalIndent(objectGraph, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal object graph: %v", err)
+	}
+
+	cmd.Println(string(data))
+	return nil
+}

--- a/pkg/virtctl/objectgraph/objectgraph_suite_test.go
+++ b/pkg/virtctl/objectgraph/objectgraph_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package objectgraph_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestObjectGraph(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/objectgraph/objectgraph_test.go
+++ b/pkg/virtctl/objectgraph/objectgraph_test.go
@@ -104,6 +104,35 @@ var _ = Describe("Object graph command", func() {
 			)
 			Expect(cmd()).To(Succeed())
 		})
+
+		It("should return object graph in YAML format", func() {
+			objectGraph := v1.ObjectGraphNode{}
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(true),
+			}
+
+			vmInterface.EXPECT().
+				ObjectGraph(gomock.Any(), vmName, opts).
+				Return(objectGraph, nil).
+				Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand, vmName, "--output", "yaml")
+			Expect(cmd()).To(Succeed())
+		})
+
+		It("should fail with unsupported output format", func() {
+			objectGraph := v1.ObjectGraphNode{}
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(true),
+			}
+			vmInterface.EXPECT().
+				ObjectGraph(gomock.Any(), vmName, opts).
+				Return(objectGraph, nil).
+				Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand, vmName, "--output", "unsupported")
+			Expect(cmd()).To(MatchError("unsupported output format: unsupported (must be 'json' or 'yaml')"))
+		})
 	})
 
 	Context("For VMI", func() {

--- a/pkg/virtctl/objectgraph/objectgraph_test.go
+++ b/pkg/virtctl/objectgraph/objectgraph_test.go
@@ -1,0 +1,155 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package objectgraph_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virtctl/testing"
+)
+
+var _ = Describe("Object graph command", func() {
+	const (
+		objectGraphCommand = "objectgraph"
+		vmName             = "testvm"
+	)
+
+	var (
+		vmInterface  *kubecli.MockVirtualMachineInterface
+		vmiInterface *kubecli.MockVirtualMachineInstanceInterface
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
+		kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
+		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
+		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(vmInterface).AnyTimes()
+		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(vmiInterface).AnyTimes()
+	})
+
+	Context("For VM", func() {
+		It("should fail with missing input parameters", func() {
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand)
+			Expect(cmd()).To(MatchError("accepts 1 arg(s), received 0"))
+		})
+
+		It("should fail with non-existing VM", func() {
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(true),
+			}
+
+			vmInterface.EXPECT().ObjectGraph(gomock.Any(), vmName, opts).Return(v1.ObjectGraphNode{}, fmt.Errorf("test-error")).Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand, vmName)
+			Expect(cmd()).To(MatchError("error listing object graph of VirtualMachine testvm: test-error"))
+		})
+
+		It("should return object graph from VM", func() {
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(true),
+			}
+			objectGraph := v1.ObjectGraphNode{}
+
+			vmInterface.EXPECT().ObjectGraph(gomock.Any(), vmName, opts).Return(objectGraph, nil).Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand, vmName)
+			Expect(cmd()).To(Succeed())
+		})
+
+		It("should apply label selectors and exclude optional flags", func() {
+			objectGraph := v1.ObjectGraphNode{}
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(false),
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubevirt.io/dependency-type": "storage",
+					},
+				},
+			}
+
+			vmInterface.EXPECT().ObjectGraph(gomock.Any(), vmName, opts).Return(objectGraph, nil).Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand,
+				vmName,
+				"--exclude-optional",
+				"--selector", "kubevirt.io/dependency-type=storage",
+			)
+			Expect(cmd()).To(Succeed())
+		})
+	})
+
+	Context("For VMI", func() {
+		It("should return object graph from VMI", func() {
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(true),
+			}
+			objectGraph := v1.ObjectGraphNode{}
+
+			vmiInterface.EXPECT().ObjectGraph(gomock.Any(), vmName, opts).Return(objectGraph, nil).Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand, vmName, "--vmi")
+			Expect(cmd()).To(Succeed())
+		})
+
+		It("should fail with non-existing VMI", func() {
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(true),
+			}
+
+			vmiInterface.EXPECT().ObjectGraph(gomock.Any(), vmName, opts).Return(v1.ObjectGraphNode{}, fmt.Errorf("test-error")).Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand, vmName, "--vmi")
+			Expect(cmd()).To(MatchError("error listing object graph of VirtualMachineInstance testvm: test-error"))
+		})
+
+		It("should apply label selectors and exclude optional flags for VMI", func() {
+			objectGraph := v1.ObjectGraphNode{}
+			opts := &v1.ObjectGraphOptions{
+				IncludeOptionalNodes: pointer.P(false),
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubevirt.io/dependency-type": "storage",
+					},
+				},
+			}
+
+			vmiInterface.EXPECT().ObjectGraph(gomock.Any(), vmName, opts).Return(objectGraph, nil).Times(1)
+
+			cmd := testing.NewRepeatableVirtctlCommand(objectGraphCommand,
+				vmName,
+				"--vmi",
+				"--exclude-optional",
+				"--selector", "kubevirt.io/dependency-type=storage",
+			)
+			Expect(cmd()).To(Succeed())
+		})
+	})
+})

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -26,6 +26,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/guestfs"
 	"kubevirt.io/kubevirt/pkg/virtctl/imageupload"
 	"kubevirt.io/kubevirt/pkg/virtctl/memorydump"
+	"kubevirt.io/kubevirt/pkg/virtctl/objectgraph"
 	"kubevirt.io/kubevirt/pkg/virtctl/pause"
 	"kubevirt.io/kubevirt/pkg/virtctl/portforward"
 	"kubevirt.io/kubevirt/pkg/virtctl/reset"
@@ -132,6 +133,7 @@ func NewVirtctlCommandFn() *cobra.Command {
 		create.NewCommand(),
 		credentials.NewCommand(),
 		adm.NewCommand(),
+		objectgraph.NewCommand(),
 		optionsCmd,
 	)
 

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachine_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachine_expansion.go
@@ -107,7 +107,7 @@ func (c *FakeVirtualMachines) PortForward(name string, port int, protocol string
 
 func (c *FakeVirtualMachines) ObjectGraph(ctx context.Context, name string, objectGraphOptions *v1.ObjectGraphOptions) (v1.ObjectGraphNode, error) {
 	obj, err := c.Fake.
-		Invokes(fake2.NewPutSubresourceAction(virtualmachinesResource, c.ns, "objectgraph", name, objectGraphOptions), nil)
+		Invokes(fake2.NewGetSubresourceAction(virtualmachinesResource, c.ns, "objectgraph", name, objectGraphOptions), nil)
 
 	return *obj.(*v1.ObjectGraphNode), err
 }

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
@@ -162,7 +162,7 @@ func (c *FakeVirtualMachineInstances) SEVInjectLaunchSecret(ctx context.Context,
 
 func (c *FakeVirtualMachineInstances) ObjectGraph(ctx context.Context, name string, objectGraphOptions *v1.ObjectGraphOptions) (v1.ObjectGraphNode, error) {
 	obj, err := c.Fake.
-		Invokes(fake2.NewPutSubresourceAction(virtualmachineinstancesResource, c.ns, "objectgraph", name, objectGraphOptions), nil)
+		Invokes(fake2.NewGetSubresourceAction(virtualmachineinstancesResource, c.ns, "objectgraph", name, objectGraphOptions), nil)
 
 	return *obj.(*v1.ObjectGraphNode), err
 }

--- a/staging/src/kubevirt.io/client-go/testing/actions.go
+++ b/staging/src/kubevirt.io/client-go/testing/actions.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/testing"
 )
 
+// PUT
+
 type PutAction[T any] interface {
 	testing.Action
 	GetName() string
@@ -87,6 +89,80 @@ func NewRootPutSubresourceAction[T any](resource schema.GroupVersionResource, su
 func NewPutSubresourceAction[T any](resource schema.GroupVersionResource, namespace, subresource, name string, options T) PutActionImpl[T] {
 	action := PutActionImpl[T]{}
 	action.Verb = "put"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Name = name
+	action.Options = options
+
+	return action
+}
+
+// GET
+
+type GetAction[T any] interface {
+	testing.Action
+	GetName() string
+	GetOptions() T
+}
+
+type GetActionImpl[T any] struct {
+	testing.ActionImpl
+	Name    string
+	Options T
+}
+
+func (a GetActionImpl[T]) GetName() string {
+	return a.Name
+}
+
+func (a GetActionImpl[T]) GetOptions() T {
+	return a.Options
+}
+
+func (a GetActionImpl[T]) DeepCopy() testing.Action {
+	return GetActionImpl[T]{
+		ActionImpl: a.ActionImpl.DeepCopy().(testing.ActionImpl),
+		Name:       a.Name,
+		Options:    a.Options,
+	}
+}
+
+func NewRootGetAction[T any](resource schema.GroupVersionResource, name string, options T) GetActionImpl[T] {
+	action := GetActionImpl[T]{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Name = name
+	action.Options = options
+
+	return action
+}
+
+func NewGetAction[T any](resource schema.GroupVersionResource, namespace, name string, options T) GetActionImpl[T] {
+	action := GetActionImpl[T]{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+	action.Options = options
+
+	return action
+}
+
+func NewRootGetSubresourceAction[T any](resource schema.GroupVersionResource, subresource, name string, options T) GetActionImpl[T] {
+	action := GetActionImpl[T]{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Name = name
+	action.Options = options
+
+	return action
+}
+
+func NewGetSubresourceAction[T any](resource schema.GroupVersionResource, namespace, subresource, name string, options T) GetActionImpl[T] {
+	action := GetActionImpl[T]{}
+	action.Verb = "get"
 	action.Resource = resource
 	action.Subresource = subresource
 	action.Namespace = namespace


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Follow-up for https://github.com/kubevirt/kubevirt/pull/14807.

This PR adds a simple virtctl command that prints the Object Graph of a VM or VMI.

```sh
# Get the object graph for a VirtualMachine named 'my-vm'
virtctl objectgraph my-vm

# Get the object graph for a VirtualMachineInstance named 'my-vmi'
virtctl objectgraph my-vmi --vmi

# Include optional nodes in the object graph for a VM
virtctl objectgraph my-vm --include-optional

# Filter the object graph by label selector
virtctl objectgraph my-vm --selector="kubevirt.io/dependency-type=storage,kubevirt.io/dependency-type=compute"
``` 

### References

**VEP 41:** https://github.com/kubevirt/enhancements/issues/41

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add virtctl objectgraph command
```

