### PR TITLE
objectgraph: Remove instance type and preference objects from graph

### DIFF
--- a/pkg/virt-api/rest/objectgraph.go
+++ b/pkg/virt-api/rest/objectgraph.go
@@ -22,7 +22,6 @@ package rest
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
@@ -76,19 +75,15 @@ func NewObjectGraph(client kubecli.KubevirtClient, opts *v1.ObjectGraphOptions) 
 // objectGraphMap represents the graph of objects that can be potentially related to a KubeVirt resource
 // This is not strictly needed, but helps to keep the list of objects that we are appending to the graph.
 var objectGraphMap = map[string]schema.GroupKind{
-	"virtualmachines":                    {Group: "kubevirt.io", Kind: "VirtualMachine"},
-	"virtualmachineinstances":            {Group: "kubevirt.io", Kind: "VirtualMachineInstance"},
-	"virtualmachineinstancetypes":        {Group: "instancetype.kubevirt.io", Kind: "VirtualMachineInstancetype"},
-	"virtualmachineclusterinstancetypes": {Group: "instancetype.kubevirt.io", Kind: "VirtualMachineClusterInstancetype"},
-	"virtualmachinepreferences":          {Group: "instancetype.kubevirt.io", Kind: "VirtualMachinePreference"},
-	"virtualmachineclusterpreferences":   {Group: "instancetype.kubevirt.io", Kind: "VirtualMachineClusterPreference"},
-	"datavolumes":                        {Group: "cdi.kubevirt.io", Kind: "DataVolume"},
-	"controllerrevisions":                {Group: "apps", Kind: "ControllerRevision"},
-	"configmaps":                         {Group: "", Kind: "ConfigMap"},
-	"persistentvolumeclaims":             {Group: "", Kind: "PersistentVolumeClaim"},
-	"serviceaccounts":                    {Group: "", Kind: "ServiceAccount"},
-	"secrets":                            {Group: "", Kind: "Secret"},
-	"pods":                               {Group: "", Kind: "Pod"},
+	"virtualmachines":         {Group: "kubevirt.io", Kind: "VirtualMachine"},
+	"virtualmachineinstances": {Group: "kubevirt.io", Kind: "VirtualMachineInstance"},
+	"datavolumes":             {Group: "cdi.kubevirt.io", Kind: "DataVolume"},
+	"controllerrevisions":     {Group: "apps", Kind: "ControllerRevision"},
+	"configmaps":              {Group: "", Kind: "ConfigMap"},
+	"persistentvolumeclaims":  {Group: "", Kind: "PersistentVolumeClaim"},
+	"serviceaccounts":         {Group: "", Kind: "ServiceAccount"},
+	"secrets":                 {Group: "", Kind: "Secret"},
+	"pods":                    {Group: "", Kind: "Pod"},
 }
 
 // getResourceDependencyType returns the dependency type for a given resource
@@ -98,8 +93,7 @@ func getResourceDependencyType(resource string) DependencyType {
 		return DependencyTypeStorage
 	case "pods", "virtualmachines", "virtualmachineinstances":
 		return DependencyTypeCompute
-	case "configmaps", "secrets", "virtualmachineinstancetypes", "virtualmachineclusterinstancetypes",
-		"virtualmachinepreferences", "virtualmachineclusterpreferences", "controllerrevisions":
+	case "configmaps", "secrets", "controllerrevisions":
 		return DependencyTypeConfig
 	case "serviceaccounts":
 		return DependencyTypeNetwork
@@ -418,12 +412,6 @@ func (og *ObjectGraph) getPreferenceNode(vm *v1.VirtualMachine) []v1.ObjectGraph
 
 func (og *ObjectGraph) getInstanceTypeMatcherResource(matcher v1.Matcher, statusRef *v1.InstancetypeStatusRef, namespace string) []v1.ObjectGraphNode {
 	var nodes []v1.ObjectGraphNode
-	switch resource := strings.ToLower(matcher.GetKind()) + "s"; resource {
-	case "virtualmachineclusterinstancetypes", "virtualmachineclusterpreferences":
-		nodes = append(nodes, *og.newGraphNode(matcher.GetName(), "", resource, nil, true))
-	case "virtualmachineinstancetypes", "virtualmachinepreferences":
-		nodes = append(nodes, *og.newGraphNode(matcher.GetName(), namespace, resource, nil, true))
-	}
 	if statusRef != nil && statusRef.ControllerRevisionRef != nil {
 		nodes = append(nodes, *og.newGraphNode(statusRef.ControllerRevisionRef.Name, namespace, "controllerrevisions", nil, false))
 	}

--- a/pkg/virt-api/rest/objectgraph_test.go
+++ b/pkg/virt-api/rest/objectgraph_test.go
@@ -458,22 +458,12 @@ var _ = Describe("Object Graph", func() {
 			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(graphNodes.Children).To(HaveLen(4))
+			Expect(graphNodes.Children).To(HaveLen(2))
 
 			childMap := make(map[string]v1.ObjectGraphNode)
 			for _, child := range graphNodes.Children {
 				childMap[child.ObjectReference.Name] = child
 			}
-
-			Expect(childMap).To(HaveKey("test-instancetype"))
-			instanceTypeNode := childMap["test-instancetype"]
-			Expect(instanceTypeNode.ObjectReference.Kind).To(Equal("VirtualMachineInstancetype"))
-			Expect(*instanceTypeNode.Optional).To(BeTrue())
-
-			Expect(childMap).To(HaveKey("test-preference"))
-			preferenceNode := childMap["test-preference"]
-			Expect(preferenceNode.ObjectReference.Kind).To(Equal("VirtualMachinePreference"))
-			Expect(*preferenceNode.Optional).To(BeTrue())
 
 			Expect(childMap).To(HaveKey("test-instancetype-revision"))
 			Expect(childMap["test-instancetype-revision"].ObjectReference.Kind).To(Equal("ControllerRevision"))
@@ -491,6 +481,17 @@ var _ = Describe("Object Graph", func() {
 				Kind: "VirtualMachineClusterPreference",
 			}
 
+			vm.Status.InstancetypeRef = &v1.InstancetypeStatusRef{
+				ControllerRevisionRef: &v1.ControllerRevisionRef{
+					Name: "test-instancetype-revision",
+				},
+			}
+			vm.Status.PreferenceRef = &v1.InstancetypeStatusRef{
+				ControllerRevisionRef: &v1.ControllerRevisionRef{
+					Name: "test-preference-revision",
+				},
+			}
+
 			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
@@ -500,15 +501,11 @@ var _ = Describe("Object Graph", func() {
 				childMap[child.ObjectReference.Name] = child
 			}
 
-			Expect(childMap).To(HaveKey("test-cluster-instancetype"))
-			instanceTypeNode := childMap["test-cluster-instancetype"]
-			Expect(instanceTypeNode.ObjectReference.Kind).To(Equal("VirtualMachineClusterInstancetype"))
-			Expect(*instanceTypeNode.ObjectReference.Namespace).To(Equal(""))
+			Expect(childMap).To(HaveKey("test-instancetype-revision"))
+			Expect(childMap["test-instancetype-revision"].ObjectReference.Kind).To(Equal("ControllerRevision"))
+			Expect(childMap).To(HaveKey("test-preference-revision"))
+			Expect(childMap["test-preference-revision"].ObjectReference.Kind).To(Equal("ControllerRevision"))
 
-			Expect(childMap).To(HaveKey("test-cluster-preference"))
-			preferenceNode := childMap["test-cluster-preference"]
-			Expect(preferenceNode.ObjectReference.Kind).To(Equal("VirtualMachineClusterPreference"))
-			Expect(*preferenceNode.ObjectReference.Namespace).To(Equal(""))
 		})
 
 		It("should handle VM with multiple access credentials", func() {


### PR DESCRIPTION
/area instancetype
/cc @alromeros

### What this PR does
The current implementation of instance types and preferences captures a point in time copy of any initially referenced object within ControllerRevisions when the VM is first sync'd.

This essentially breaks any dependency the VM has on the original objects allowing them to mutate or be removed entirely from the cluster without impacting the VM.

As we already include the instance type and preference ControllerRevisions in the object graph of a VM we can remove the instance type and preference objects entirely.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This has also recently been changed in the kubevirt-velero-plugin's original kvgraph implementation with https://github.com/kubevirt/kubevirt-velero-plugin/pull/360

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

