### PR TITLE
node-labeller: SEV and realtime labels should have a value

### DIFF
--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -287,15 +287,15 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
 		n.logger.Reason(err).Error("failed to identify if a node is capable of running realtime workloads")
 	}
 	if capable {
-		newLabels[kubevirtv1.RealtimeLabel] = ""
+		newLabels[kubevirtv1.RealtimeLabel] = "true"
 	}
 
 	if n.SEV.Supported == "yes" {
-		newLabels[kubevirtv1.SEVLabel] = ""
+		newLabels[kubevirtv1.SEVLabel] = "true"
 	}
 
 	if n.SEV.SupportedES == "yes" {
-		newLabels[kubevirtv1.SEVESLabel] = ""
+		newLabels[kubevirtv1.SEVESLabel] = "true"
 	}
 	if n.SecureExecution.Supported == "yes" {
 		newLabels[kubevirtv1.SecureExecutionLabel] = "true"


### PR DESCRIPTION
### What this PR does
This is a quick fix to restore the SEV and realtime functionality. 
Kubevirt expects these labels to have a value to schedule these VMs properly.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

