### PR TITLE
Beta: NodeRestriction

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -59,10 +59,11 @@ const (
 
 	// Owner: @xpivarc
 	// Alpha: v1.3.0
+	// Beta: v1.6.0
 	//
 	// NodeRestriction enables Kubelet's like NodeRestriction but for Kubevirt's virt-handler.
 	// This feature requires following Kubernetes feature gate "ServiceAccountTokenPodNodeInfo". The feature gate is available
-	// in Kubernetes 1.30 as Beta.
+	// in Kubernetes 1.30 as Beta and was graduated in 1.32.
 	NodeRestrictionGate = "NodeRestriction"
 
 	// Owner: @Barakmor1

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -117,6 +117,7 @@ func AdjustKubeVirtResource() {
 		featuregate.KubevirtSeccompProfile,
 		featuregate.ObjectGraph,
 		featuregate.DeclarativeHotplugVolumesGate,
+		featuregate.NodeRestrictionGate,
 	)
 
 	storageClass, exists := libstorage.GetVMStateStorageClass()


### PR DESCRIPTION
### What this PR does
The Kubernetes 1.32 graduated ServiceAccountTokenPodNodeInfo feature gate. Let's therefore push our NodeRestriction feature gate to Beta in order to graduate it in 1.7 release. The release will support Kubernetes versions that all will have ServiceAccountTokenPodNodeInfo GA.
At the same time we enable the feature gate in tests by default in order to have better feedback.

### Special notes for your reviewer
This feature doesn't have VEP afaik.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Beta: NodeRestriction
```

