### PR TITLE
controller: Remove excessive info logging regarding volume hotplug

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3334,7 +3334,7 @@ func (c *Controller) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi *
 
 func (c *Controller) handleDeclarativeVolumeHotplug(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
 	if c.clusterConfig.HotplugVolumesEnabled() || !c.clusterConfig.DeclarativeHotplugVolumesEnabled() {
-		log.Log.Object(vm).Info("Declarative hotplug volumes are not enabled, skipping")
+		log.Log.Object(vm).V(4).Info("Declarative hotplug volumes are not enabled, skipping")
 		return nil
 	}
 


### PR DESCRIPTION
/cc @mhenriks
/kind cleanup

### What this PR does

Noticed this in a local kubevirtci cluster, nothing important.

#### Before this PR:
```
$ virtctl create vm --volume-import type:registry,url:docker://quay.io/containerdisks/fedora:latest,name:fedora,size:10Gi --preference fedora --instancetype u1.medium --name example | kubectl apply -f -
[..]
$ kubectl logs -l kubevirt.io=virt-controller -n kubevirt | grep "Declarative hotplug"
selecting podman as container runtime
{"component":"virt-controller","kind":"","level":"info","msg":"Declarative hotplug volumes are not enabled, skipping","name":"example","namespace":"default","pos":"vm.go:3337","timestamp":"2025-06-20T11:58:37.986052Z","uid":"e2ba7f28-84cf-4bdb-9019-4113422141a0"}
{"component":"virt-controller","kind":"","level":"info","msg":"Declarative hotplug volumes are not enabled, skipping","name":"example","namespace":"default","pos":"vm.go:3337","timestamp":"2025-06-20T11:58:56.905097Z","uid":"e2ba7f28-84cf-4bdb-9019-4113422141a0"}
{"component":"virt-controller","kind":"","level":"info","msg":"Declarative hotplug volumes are not enabled, skipping","name":"example","namespace":"default","pos":"vm.go:3337","timestamp":"2025-06-20T11:58:56.912453Z","uid":"e2ba7f28-84cf-4bdb-9019-4113422141a0"}
{"component":"virt-controller","kind":"","level":"info","msg":"Declarative hotplug volumes are not enabled, skipping","name":"example","namespace":"default","pos":"vm.go:3337","timestamp":"2025-06-20T11:58:56.928429Z","uid":"e2ba7f28-84cf-4bdb-9019-4113422141a0"}
{"component":"virt-controller","kind":"","level":"info","msg":"Declarative hotplug volumes are not enabled, skipping","name":"example","namespace":"default","pos":"vm.go:3337","timestamp":"2025-06-20T11:58:56.934871Z","uid":"e2ba7f28-84cf-4bdb-9019-4113422141a0"}
{"component":"virt-controller","kind":"","level":"info","msg":"Declarative hotplug volumes are not enabled, skipping","name":"example","namespace":"default","pos":"vm.go:3337","timestamp":"2025-06-20T11:58:56.940677Z","uid":"e2ba7f28-84cf-4bdb-9019-4113422141a0"}
```

#### After this PR:

```
$ virtctl create vm --volume-import type:registry,url:docker://quay.io/containerdisks/fedora:latest,name:fedora,size:10Gi --preference fedora --instancetype u1.medium --name example | kubectl apply -f -
[..]
$ kubectl logs -l kubevirt.io=virt-controller -n kubevirt | grep "Declarative hotplug"
$
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

