### PR TITLE
VEP16:Add workaround to expose image digests for ImageVolume

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -501,6 +501,54 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			log.Log.Object(vmi).Infof("kernel boot container generated")
 			containers = append(containers, *kernelBootContainer)
 		}
+	} else {
+		r := k8sv1.ResourceRequirements{}
+		r.Requests = make(k8sv1.ResourceList)
+		r.Limits = make(k8sv1.ResourceList)
+		r.Requests[k8sv1.ResourceCPU] = resource.MustParse("1m")
+		r.Requests[k8sv1.ResourceMemory] = resource.MustParse("1M")
+		r.Limits[k8sv1.ResourceCPU] = resource.MustParse("1m")
+		r.Limits[k8sv1.ResourceMemory] = resource.MustParse("1M")
+		for _, volume := range vmi.Spec.Volumes {
+			if volume.ContainerDisk == nil {
+				continue
+			}
+			container := &k8sv1.Container{
+				Name:            fmt.Sprintf("volume%s", volume.Name),
+				Image:           volume.ContainerDisk.Image,
+				ImagePullPolicy: volume.ContainerDisk.ImagePullPolicy,
+				Command:         []string{"/bin/true"},
+				Resources:       r,
+				SecurityContext: &k8sv1.SecurityContext{
+					RunAsUser:                &userId,
+					RunAsNonRoot:             &nonRoot,
+					AllowPrivilegeEscalation: pointer.P(false),
+					Capabilities: &k8sv1.Capabilities{
+						Drop: []k8sv1.Capability{"ALL"},
+					},
+				},
+			}
+			containers = append(containers, *container)
+		}
+		if util.HasKernelBootContainerImage(vmi) {
+			kernelBootContainer := vmi.Spec.Domain.Firmware.KernelBoot.Container
+			container := &k8sv1.Container{
+				Name:            fmt.Sprintf("volume%s", containerdisk.KernelBootVolumeName),
+				Image:           kernelBootContainer.Image,
+				ImagePullPolicy: kernelBootContainer.ImagePullPolicy,
+				Command:         []string{"/bin/true"},
+				Resources:       r,
+				SecurityContext: &k8sv1.SecurityContext{
+					RunAsUser:                &userId,
+					RunAsNonRoot:             &nonRoot,
+					AllowPrivilegeEscalation: pointer.P(false),
+					Capabilities: &k8sv1.Capabilities{
+						Drop: []k8sv1.Capability{"ALL"},
+					},
+				},
+			}
+			containers = append(containers, *container)
+		}
 	}
 
 	virtiofsContainers := generateVirtioFSContainers(vmi, t.launcherImage, t.clusterConfig)


### PR DESCRIPTION
As described in the ImageVolume VEP
(https://github.com/kubevirt/enhancements/blob/main/veps/sig-compute/image-volume-proposal.md), we need the ImageVolume to report the image digest, similar to how imageID is exposed in containerStatus.

There is currently a KEP in Kubernetes to address this need (https://github.com/kubernetes/enhancements/pull/5375), but it depends on CRI-O support and may take time to GA.

To avoid delaying ImageVolume graduation in kubevirt, this commit adds a noop containers using the images from containerDisks and kernel boot.
To ensure that the image digest is fetched and
reported, enabling support during live migration.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
support live migration for ImageVolume with modified container disk images
```

