### PR TITLE
tests: quarantine flaky sig-storage tests

### DIFF
--- a/tests/storage/declarative-hotplug.go
+++ b/tests/storage/declarative-hotplug.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libstorage"
@@ -293,7 +294,7 @@ var _ = Describe(SIG("Declarative Hotplug", func() {
 	}
 
 	Context("Inject/Eject CD-ROM", func() {
-		It("Should inject, swap, and eject a CD-ROM", func() {
+		It("[QUARANTINE] Should inject, swap, and eject a CD-ROM", decorators.Quarantine, func() {
 			By("Creating a VM with an empty CD-ROM")
 			vm := createAndStartVMWithEmptyCDRom()
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1116,7 +1116,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				verifyVolumeStatus(vmi, v1.VolumeReady, "", testVolumes...)
 			})
 
-			It("should permanently add hotplug volume when added to VM, but still unpluggable after restart", func() {
+			It("[QUARANTINE] should permanently add hotplug volume when added to VM, but still unpluggable after restart", decorators.Quarantine, func() {
 				dvBlock := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeBlock)
 
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1876,7 +1876,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				restore = nil
 			})
 
-			It("should restore with volume restore policy InPlace and DV (not template) as disk", func() {
+			It("[QUARANTINE] should restore with volume restore policy InPlace and DV (not template) as disk", decorators.Quarantine, func() {
 				// VM with normal DV mounted to it
 				vm = createVMWithCloudInit(cd.ContainerDiskCirros, snapshotStorageClass)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
following some (great) dev cycles, we're encountering several flakes
that get in the way of PRs merging.

let's put those in quarantine for now track via issues.

### References
[stop start hotplug](https://search.ci.kubevirt.io/?search=but+still+unpluggable+after+restart&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)
[eject](https://search.ci.kubevirt.io/?search=Declarative+Hotplug+Inject%2FEject+CD-ROM+Should+inject%2C+swap%2C+and+eject+a+CD-ROM&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)
[with volume restore policy InPlace and DV (not template)](https://search.ci.kubevirt.io/?search=with+volume+restore+policy+InPlace+and+DV&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

