### PR TITLE
Add CPU Queue alerts

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -147,6 +147,9 @@ Guest system load average over 1 minute as reported by the guest agent. Load is 
 ### kubevirt_vmi_guest_load_5m
 Guest system load average over 5 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Type: Gauge.
 
+### kubevirt_vmi_guest_vcpu_queue
+Guest queue length. Type: Gauge.
+
 ### kubevirt_vmi_info
 Information about VirtualMachineInstances. Type: Gauge.
 
@@ -308,6 +311,9 @@ Total time spent on write operations. Type: Counter.
 
 ### kubevirt_vmi_storage_write_traffic_bytes_total
 Total number of written bytes. Type: Counter.
+
+### kubevirt_vmi_vcpu_count
+The number of the VMI vCPUs. Type: Gauge.
 
 ### kubevirt_vmi_vcpu_delay_seconds_total
 Amount of time spent by each vcpu waiting in the queue instead of running. Type: Counter.

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -814,3 +814,43 @@ tests:
       - eval_time: 13m
         alertname: KubeVirtDeprecatedAPIRequested
         exp_alerts: []
+
+
+  # VMI CPU Queue higher than 20
+  - interval: 1m
+    input_series:
+      # time:   0   1   2   3
+      - series: 'kubevirt_vmi_guest_load_1m{namespace="testns",name="vm1"}'
+        values: '0  12  25  5'
+      - series: 'kubevirt_vmi_vcpu_seconds_total{namespace="testns",name="vm1",id="0"}'
+        values: '0  0   0   0'
+      - series: 'kubevirt_vmi_vcpu_seconds_total{namespace="testns",name="vm1",id="1"}'
+        values: '0  0   0   0'   # values irrelevant. only series presence counts
+
+    alert_rule_test:
+      # at 1m: queue = 12 – 2 = 10  -> below 20
+      - eval_time: 1m
+        alertname: GuestVCPUQueueHighCritical
+        exp_alerts: []
+
+      # at 2m: queue = 25 – 2 = 23  -> alert fires
+      - eval_time: 2m
+        alertname: GuestVCPUQueueHighCritical
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachineInstance vm1 CPU queue length > 20"
+              summary: "Guest vCPU Queue within collection cycle > 20"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/GuestVCPUQueueHighCritical"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "testns"
+              name: "vm1"
+
+
+      # at3m: queue = 5 – 2 = 3 -> alert clears
+      - eval_time: 3m
+        alertname: GuestVCPUQueueHighCritical
+        exp_alerts: []

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -78,5 +78,29 @@ var (
 				operatorHealthImpactLabelKey: "none",
 			},
 		},
+		{
+			Alert: "GuestVCPUQueueHighWarning",
+			Expr:  intstr.FromString("kubevirt_vmi_guest_vcpu_queue > 10"),
+			Annotations: map[string]string{
+				"description": "VirtualMachineInstance {{ $labels.name }} CPU queue length > 10",
+				"summary":     "Guest vCPU Queue within collection cycle > 10",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "none",
+			},
+		},
+		{
+			Alert: "GuestVCPUQueueHighCritical",
+			Expr:  intstr.FromString("kubevirt_vmi_guest_vcpu_queue > 20"),
+			Annotations: map[string]string{
+				"description": "VirtualMachineInstance {{ $labels.name }} CPU queue length > 20",
+				"summary":     "Guest vCPU Queue within collection cycle > 20",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "none",
+			},
+		},
 	}
 )

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -41,4 +41,20 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 		MetricType: operatormetrics.GaugeType,
 		Expr:       intstr.FromString("kubevirt_vmi_memory_available_bytes-kubevirt_vmi_memory_usable_bytes"),
 	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_vcpu_count",
+			Help: "The number of the VMI vCPUs.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("count by (namespace, name, node) (kubevirt_vmi_vcpu_seconds_total)"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_guest_vcpu_queue",
+			Help: "Guest queue length.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("clamp_min(kubevirt_vmi_guest_load_1m - kubevirt_vmi_vcpu_count, 0)"),
+	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:
This PR adds recording rules and alerts related
to Guest CPU queue.

Signed-off-by: Shirly Radco <sradco@redhat.com>


#### Fixes:

jira-ticket: https://issues.redhat.com/browse/CNV-64318

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR adds the following alerts: GuestPeakVCPUQueueHighWarning, GuestPeakVCPUQueueHighCritical
```

