### PR TITLE
fix(vmrestore): volumerestorepolicy inplace flaky tests

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1875,7 +1875,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				restore = nil
 			})
 
-			It("[QUARANTINE] should restore with volume restore policy InPlace and DV (not template) as disk", decorators.Quarantine, func() {
+			It("should restore with volume restore policy InPlace and DV (not template) as disk", func() {
 				// VM with normal DV mounted to it
 				vm = createVMWithCloudInit(cd.ContainerDiskCirros, snapshotStorageClass)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR fixes flaky tests at https://github.com/kubevirt/kubevirt/issues/14982

#### Before this PR:

Flaky tests on VM restores with VolumeRestorePolicy InPlace

#### After this PR:

Hopefully no flaky test

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes https://github.com/kubevirt/kubevirt/issues/14982

-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

My analysis of the flaky test is a possible condition where the PVC deletion may error out, preventing the status of the VMRestore to be updated with the datavolume. But on the next resync cycle, the PVC got deleted because it was held by a finalizer (VM still up, Pod still up, anything that may slow down PVC deletion). We enter the bit of code where DataVolume is expected eventhough it was never set.

To fix this, we exit the reconciliation when setting the property, and we re-enter the reconciliation function on the next loop with a guarantee that the property is set.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- x ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

