### PR TITLE
allow external CA to be trusted by operator.

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -256,6 +256,15 @@ func (k *KubeVirtTestData) BeforeTest() {
 			return true, dummyValidatingAdmissionPolicy, nil
 		}
 
+		if action.GetVerb() == "create" && action.GetResource().Resource == "configmaps" {
+			dummyConfigMap := &k8sv1.ConfigMap{}
+			return true, dummyConfigMap, nil
+		}
+
+		if action.GetVerb() == "update" && action.GetResource().Resource == "configmaps" {
+			return true, nil, nil
+		}
+
 		if action.GetVerb() == "get" && action.GetResource().Resource == "serviceaccounts" {
 			return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "serviceaccounts"}, "whatever")
 		}
@@ -2433,8 +2442,9 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			// 1 because a temporary validation webhook is created to block new CRDs until api server is deployed
 			expectedTemporaryResources := 1
+			externalCAConfigMapCount := 1
 
-			Expect(kvTestData.totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources))
+			Expect(kvTestData.totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources + externalCAConfigMapCount))
 
 			Expect(kvTestData.controller.stores.ServiceAccountCache.List()).To(HaveLen(5))
 			Expect(kvTestData.controller.stores.ClusterRoleCache.List()).To(HaveLen(11))

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -2,7 +2,10 @@ package apply
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -306,6 +309,80 @@ func (r *Reconciler) createOrUpdateCertificateSecrets(queue workqueue.TypedRateL
 	return nil
 }
 
+func getValidCerts(certs []*x509.Certificate) []*tls.Certificate {
+	externalCAList := make([]*tls.Certificate, 0)
+	certMap := make(map[string]*x509.Certificate)
+	for _, cert := range certs {
+		hash := sha256.Sum256(cert.Raw)
+		hashString := hex.EncodeToString(hash[:])
+		if _, ok := certMap[hashString]; ok {
+			continue
+		}
+		tlsCert := &tls.Certificate{
+			Leaf: cert,
+		}
+		now := time.Now()
+		if now.After(cert.NotBefore) && now.Before(cert.NotAfter) {
+			// cert is still valid
+			log.Log.V(2).Infof("adding CA from external CA list because it is still valid %s, %s, now %s, not before %s, not after %s", cert.Issuer, cert.Subject, now.Format(time.RFC3339), cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+			externalCAList = append(externalCAList, tlsCert)
+			certMap[hashString] = cert
+		} else if now.Before(cert.NotBefore) {
+			log.Log.V(2).Infof("skipping CA from external CA because it is not yet valid %s, %s", cert.Issuer, cert.Subject)
+		} else if now.After(cert.NotAfter) {
+			log.Log.V(2).Infof("skipping CA from external CA because it is expired %s, %s", cert.Issuer, cert.Subject)
+		}
+	}
+	return externalCAList
+}
+
+func (r *Reconciler) getRemotePublicCas() []*tls.Certificate {
+	obj, exists, err := r.stores.ConfigMapCache.GetByKey(controller.NamespacedKey(r.kv.Namespace, components.ExternalKubeVirtCAConfigMapName))
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to get external CA configmap")
+		return nil
+	} else if !exists {
+		log.Log.V(3).Infof("external CA configmap does not exist, returning empty list")
+		return nil
+	}
+	externalCaConfigMap := obj.(*corev1.ConfigMap)
+	externalCAData := externalCaConfigMap.Data[components.CABundleKey]
+	if externalCAData == "" {
+		log.Log.V(3).Infof("external CA configmap is empty, returning empty list")
+		return nil
+	}
+	log.Log.V(4).Infof("external CA data: %s", externalCAData)
+	certs, err := cert.ParseCertsPEM([]byte(externalCAData))
+	if err != nil {
+		log.Log.Infof("failed to parse external CA certificates: %v", err)
+		return nil
+	}
+	return getValidCerts(certs)
+}
+
+func (r *Reconciler) cleanupExternalCACerts(configMap *corev1.ConfigMap) error {
+	if configMap == nil {
+		return nil
+	}
+	version, imageRegistry, id := getTargetVersionRegistryID(r.kv)
+	injectOperatorMetadata(r.kv, &configMap.ObjectMeta, version, imageRegistry, id, true)
+
+	configMap.Data = map[string]string{components.CABundleKey: ""}
+	_, exists, _ := r.stores.ConfigMapCache.Get(configMap)
+	if !exists {
+		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("unable to create configMap %+v: %v", configMap, err)
+		}
+	} else {
+		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to update configMap %+v: %v", configMap, err)
+		}
+	}
+	return nil
+}
+
 func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.TypedRateLimitingInterface[string]) error {
 	caDuration := GetCADuration(r.kv.Spec.CertificateRotationStrategy.SelfSigned)
 	caExportDuration := GetCADuration(r.kv.Spec.CertificateRotationStrategy.SelfSigned)
@@ -320,20 +397,33 @@ func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.Ty
 		return err
 	}
 
-	// create/update CA Certificate secret
+	// create/update export CA Certificate secret
 	caExportCert, err := r.createOrUpdateCACertificateSecret(queue, components.KubeVirtExportCASecretName, caExportDuration, caExportRenewBefore)
 	if err != nil {
 		return err
 	}
 
+	err = r.createExternalKubeVirtCAConfigMap(findRequiredCAConfigMap(components.ExternalKubeVirtCAConfigMapName, r.targetStrategy.ConfigMaps()))
+	if err != nil {
+		return err
+	}
+
+	log.Log.V(3).Info("reading external CA configmap")
+	externalCACerts := r.getRemotePublicCas()
+	log.Log.V(3).Infof("found %d external CA certificates", len(externalCACerts))
 	// create/update CA config map
-	caBundle, err := r.createOrUpdateKubeVirtCAConfigMap(queue, caCert, caRenewBefore, findRequiredCAConfigMap(components.KubeVirtCASecretName, r.targetStrategy.ConfigMaps()))
+	caBundle, err := r.createOrUpdateKubeVirtCAConfigMap(queue, caCert, externalCACerts, caRenewBefore, findRequiredCAConfigMap(components.KubeVirtCASecretName, r.targetStrategy.ConfigMaps()))
+	if err != nil {
+		return err
+	}
+
+	err = r.cleanupExternalCACerts(findRequiredCAConfigMap(components.ExternalKubeVirtCAConfigMapName, r.targetStrategy.ConfigMaps()))
 	if err != nil {
 		return err
 	}
 
 	// create/update export CA config map
-	_, err = r.createOrUpdateKubeVirtCAConfigMap(queue, caExportCert, caExportRenewBefore, findRequiredCAConfigMap(components.KubeVirtExportCASecretName, r.targetStrategy.ConfigMaps()))
+	_, err = r.createOrUpdateKubeVirtCAConfigMap(queue, caExportCert, nil, caExportRenewBefore, findRequiredCAConfigMap(components.KubeVirtExportCASecretName, r.targetStrategy.ConfigMaps()))
 	if err != nil {
 		return err
 	}
@@ -529,7 +619,17 @@ func findRequiredCAConfigMap(name string, configmaps []*corev1.ConfigMap) *corev
 	return nil
 }
 
-func shouldUpdateBundle(required, existing *corev1.ConfigMap, key string, queue workqueue.TypedRateLimitingInterface[string], caCert *tls.Certificate, overlapInterval *metav1.Duration) (bool, error) {
+func buildCertMap(certs []*x509.Certificate) map[string]*x509.Certificate {
+	certMap := make(map[string]*x509.Certificate)
+	for _, cert := range certs {
+		hash := sha256.Sum256(cert.Raw)
+		hashString := hex.EncodeToString(hash[:])
+		certMap[hashString] = cert
+	}
+	return certMap
+}
+
+func shouldUpdateBundle(required, existing *corev1.ConfigMap, key string, queue workqueue.TypedRateLimitingInterface[string], caCert *tls.Certificate, externalCACerts []*tls.Certificate, overlapInterval *metav1.Duration) (bool, error) {
 	bundle, certCount, err := components.MergeCABundle(caCert, []byte(existing.Data[components.CABundleKey]), overlapInterval.Duration)
 	if err != nil {
 		// the only error that can be returned form MergeCABundle is if the CA caBundle
@@ -542,16 +642,49 @@ func shouldUpdateBundle(required, existing *corev1.ConfigMap, key string, queue 
 		queue.AddAfter(key, overlapInterval.Duration)
 	}
 
-	updateBundle := false
-	required.Data = map[string]string{components.CABundleKey: string(bundle)}
-	if !equality.Semantic.DeepEqual(required.Data, existing.Data) {
-		updateBundle = true
+	bundleCerts, err := cert.ParseCertsPEM(bundle)
+	if err != nil {
+		return true, err
 	}
+	bundleCertMap := buildCertMap(bundleCerts)
 
-	return updateBundle, nil
+	bundleString := string(bundle)
+	for _, externalCACert := range externalCACerts {
+		pem := string(cert.EncodeCertPEM(externalCACert.Leaf))
+		hash := sha256.Sum256(externalCACert.Leaf.Raw)
+		hashString := hex.EncodeToString(hash[:])
+		if _, ok := bundleCertMap[hashString]; ok {
+			continue
+		}
+		bundleCertMap[hashString] = externalCACert.Leaf
+		bundleString += pem
+	}
+	required.Data = map[string]string{components.CABundleKey: bundleString}
+	return !equality.Semantic.DeepEqual(required.Data, existing.Data), nil
 }
 
-func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRateLimitingInterface[string], caCert *tls.Certificate, overlapInterval *metav1.Duration, configMap *corev1.ConfigMap) (caBundle []byte, err error) {
+func (r *Reconciler) createExternalKubeVirtCAConfigMap(configMap *corev1.ConfigMap) error {
+	if configMap == nil {
+		log.Log.V(2).Infof("cannot create external CA configmap because it is nil")
+		return nil
+	}
+	_, exists, _ := r.stores.ConfigMapCache.Get(configMap)
+	if !exists {
+		log.Log.V(4).Infof("checking external ca config map %v", configMap.Name)
+
+		version, imageRegistry, id := getTargetVersionRegistryID(r.kv)
+		injectOperatorMetadata(r.kv, &configMap.ObjectMeta, version, imageRegistry, id, true)
+
+		configMap.Data = map[string]string{components.CABundleKey: ""}
+		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("unable to create configMap %+v: %v", configMap, err)
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRateLimitingInterface[string], caCert *tls.Certificate, externalCACerts []*tls.Certificate, overlapInterval *metav1.Duration, configMap *corev1.ConfigMap) (caBundle []byte, err error) {
 	if configMap == nil {
 		return nil, nil
 	}
@@ -561,11 +694,14 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRate
 	version, imageRegistry, id := getTargetVersionRegistryID(r.kv)
 	injectOperatorMetadata(r.kv, &configMap.ObjectMeta, version, imageRegistry, id, true)
 
+	data := ""
 	obj, exists, _ := r.stores.ConfigMapCache.Get(configMap)
-
 	if !exists {
-		configMap.Data = map[string]string{components.CABundleKey: string(cert.EncodeCertPEM(caCert.Leaf))}
-
+		for _, externalCert := range externalCACerts {
+			data = data + string(cert.EncodeCertPEM(externalCert.Leaf))
+		}
+		data = data + string(cert.EncodeCertPEM(caCert.Leaf))
+		configMap.Data = map[string]string{components.CABundleKey: data}
 		r.expectations.ConfigMap.RaiseExpectations(r.kvKey, 1, 0)
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
 		if err != nil {
@@ -577,13 +713,13 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRate
 	}
 
 	existing := obj.(*corev1.ConfigMap)
-	updateBundle, err := shouldUpdateBundle(configMap, existing, r.kvKey, queue, caCert, overlapInterval)
+	updateBundle, err := shouldUpdateBundle(configMap, existing, r.kvKey, queue, caCert, externalCACerts, overlapInterval)
 	if err != nil {
 		if !updateBundle {
 			return nil, err
 		}
-
-		configMap.Data = map[string]string{components.CABundleKey: string(cert.EncodeCertPEM(caCert.Leaf))}
+		data = data + string(cert.EncodeCertPEM(caCert.Leaf))
+		configMap.Data = map[string]string{components.CABundleKey: data}
 		log.Log.Reason(err).V(2).Infof("There was an error validating the CA bundle stored in configmap %s. We are updating the bundle.", configMap.GetName())
 	}
 

--- a/pkg/virt-operator/resource/generate/components/secrets_test.go
+++ b/pkg/virt-operator/resource/generate/components/secrets_test.go
@@ -113,13 +113,13 @@ var _ = Describe("Certificate Management", func() {
 			now := time.Now()
 			current := newSelfSignedCert(now, now.Add(1*time.Hour))
 			given := []*tls.Certificate{}
-			for i := 1; i < 20; i++ {
+			for i := 1; i < 60; i++ {
 				given = append(given, newSelfSignedCert(now.Add(-1*time.Minute), now.Add(1*time.Hour)))
 			}
 			givenBundle := caCertsToBundle(given)
 			_, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(count).To(Equal(11))
+			Expect(count).To(Equal(51))
 		})
 
 		It("should immediately suggest a rotation if the cert is not signed by the provided CA", func() {

--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/apimachinery/wait:go_default_library",
+        "//pkg/certificates/triple:go_default_library",
+        "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In order to allow one to add an external trusted CA, we need a mechanism to allow this in KubeVirt. The idea is very similar to how you add additional external CAs to a browser. But instead of a trust store, there is a separate new config map called `external-kubevirt-ca`. You can add your PEM strings to this configmap and the KubeVirt operator will process the contents of the config map, and if the provided CAs are valid, will add them to the `kubevirt-ca` config map, which is used by the virt components to validate presented certificates are valid.

In particular this is useful for cross cluster live migration, where virt-handlers need to trust certificates signed by CAs that are not part of KubeVirt by default. This mechanism allows one to trust other CAs.

General flow:
1. Someone (user, orchester, etc) appends a PEM to the contents of the `ca-bundle` key in the `external-kubevirt-ca` config map.
2. The KubeVirt operator is monitoring this config map. If it notices a change it will process the contents. If a valid CA is presented (not expired, active), the CA will be copied to the kubevirt-ca config map.
3. The contents of the external-kubevirt-ca config map is cleared.

It is possible to clear the contents of the external-kubevirt-ca config map after each processing cycle because once the certificate is in kubevirt-ca, each additional cycle as long as it is valid it will remain there.

#### Before this PR:
It is impossible to trust additional CAs.

#### After this PR:
By adding the CA to the new configmap one can trust additional CAs.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/24

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
Have a specific CRD with extra validation constraints. It seemed to heavy for this relatively simple extra CAs configuration. This does not exclude adding a CRD in the future.

Links to places where the discussion took place:
https://groups.google.com/g/kubevirt-dev/c/nlEC9MXRPX0/m/rn8hIBmMBgAJ

 <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
Possible to trust additional CAs for verifying kubevirt infra structure components
```

