### PR TITLE
quarantine(migration): test_id:1783

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -544,7 +544,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			})
 
-			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", decorators.Conformance, func() {
+			It("[QUARANTINE][test_id:1783]should be successfully migrated multiple times with cloud-init disk", decorators.Quarantine, decorators.Conformance, func() {
 				vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
 
 				By("Starting the VirtualMachineInstance")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

Test `[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration Starting a VirtualMachineInstance  with a Alpine disk [test_id:1783]should be successfully migrated multiple times with cloud-init disk` [1] has an impact of more than 21% (example [3], flake-stats [4]).

[1]: https://github.com/kubevirt/kubevirt/blob/85b1535f6a5db6f4d5a1e746822979f8574433ef/tests/migration/migration.go#L547
[2]: https://search.ci.kubevirt.io/?search=test_id%3A1783&maxAge=72h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
[3]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14990/pull-kubevirt-e2e-k8s-1.32-sig-compute-migrations/1937438943729422336
[4]: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flake-stats-14days-2025-06-24.html#%5brfe_id%3a393%5d%5bcrit%3ahigh%5d%5bvendor%3acnv-qe%40redhat.com%5d%5blevel%3asystem%5d%5bsig-compute%5d%20VM%20Live%20Migration%20Starting%20a%20VirtualMachineInstance%20with%20a%20Alpine%20disk%20%5btest_id%3a1783%5dshould%20be%20successfully%20migrated%20multiple%20times%20with%20cloud-init%20disk

#### After this PR:

Test is quarantined according to the rules of quarantine.

/kind flake
/priority critical-urgent
/sig compute

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @fossedihelm @xpivarc 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

