### PR TITLE
webhooks: Drop v1beta1 AdmissionReview version support

### DIFF
--- a/pkg/virt-operator/resource/generate/components/webhooks.go
+++ b/pkg/virt-operator/resource/generate/components/webhooks.go
@@ -92,7 +92,7 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *admissi
 		Webhooks: []admissionregistrationv1.ValidatingWebhook{
 			{
 				Name:                    "kubevirt-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: operatorNamespace,
@@ -116,7 +116,7 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *admissi
 			},
 			{
 				Name:                    "kubevirt-update-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -140,7 +140,7 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *admissi
 			},
 			{
 				Name:                    "kubevirt-create-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -190,7 +190,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 		Webhooks: []admissionregistrationv1.MutatingWebhook{
 			{
 				Name:                    "virtualmachines-mutator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
@@ -215,7 +215,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 			},
 			{
 				Name:                    "virtualmachineinstances-mutator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
@@ -240,7 +240,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 			},
 			{
 				Name:                    "migrations-mutator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
@@ -264,7 +264,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 			},
 			{
 				Name:                    fmt.Sprintf("%s-mutator.kubevirt.io", clonebase.ResourceVMClonePlural),
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
@@ -331,7 +331,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 		Webhooks: []admissionregistrationv1.ValidatingWebhook{
 			{
 				Name:                    "virt-launcher-eviction-interceptor.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				// We don't want to block evictions in the cluster in a case where this webhook is down.
 				// The eviction of virt-launcher will still be protected by our pdb.
 				FailurePolicy:  &failurePolicy,
@@ -363,7 +363,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachineinstances-create-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -387,7 +387,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachineinstances-update-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -411,7 +411,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachine-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -436,7 +436,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachinereplicaset-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -461,7 +461,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachinepool-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -486,7 +486,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachinepreset-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -511,7 +511,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "migration-create-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -535,7 +535,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "migration-update-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -559,7 +559,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachinesnapshot-validator.snapshot.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -584,7 +584,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachinerestore-validator.snapshot.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
@@ -609,7 +609,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachineexport-validator.export.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -634,7 +634,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachineinstancetype-validator.instancetype.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -663,7 +663,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachineclusterinstancetype-validator.instancetype.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -692,7 +692,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachinepreference-validator.instancetype.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -721,7 +721,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "virtualmachineclusterpreference-validator.instancetype.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -750,7 +750,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "kubevirt-crd-status-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -779,7 +779,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "migration-policy-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
@@ -804,7 +804,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 			},
 			{
 				Name:                    "vm-clone-validator.kubevirt.io",
-				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,


### PR DESCRIPTION
### What this PR does

We have not had to support v1beta1 since k8s v1.17 [1] so drop the
version from AdmissionReviewVersions.

[1] https://github.com/kubernetes/kubernetes/blob/49945dbfab342a6d7dee7e83778bb1cc3886bdbe/CHANGELOG/CHANGELOG-1.17.md?plain=1#L1965

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

