### PR TITLE
WIP instancetype: Extract and cleanup mutation webhook

### DIFF
--- a/pkg/defaults/BUILD.bazel
+++ b/pkg/defaults/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/defaults/BUILD.bazel
+++ b/pkg/defaults/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -29,7 +29,6 @@ import (
 	"kubevirt.io/client-go/log"
 
 	apiinstancetype "kubevirt.io/api/instancetype"
-	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
@@ -37,15 +36,14 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-func SetVirtualMachineDefaults(vm *v1.VirtualMachine, clusterConfig *virtconfig.ClusterConfig, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec) {
+func SetVirtualMachineDefaults(vm *v1.VirtualMachine, clusterConfig *virtconfig.ClusterConfig) {
 	setDefaultInstancetypeKind(vm)
 	setDefaultPreferenceKind(vm)
 	setDefaultArchitecture(clusterConfig, &vm.Spec.Template.Spec)
-	setVMDefaultMachineType(vm, preferenceSpec, clusterConfig)
-	setPreferenceStorageClassName(vm, preferenceSpec)
+	setVMDefaultMachineType(vm, clusterConfig)
 }
 
-func setVMDefaultMachineType(vm *v1.VirtualMachine, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, clusterConfig *virtconfig.ClusterConfig) {
+func setVMDefaultMachineType(vm *v1.VirtualMachine, clusterConfig *virtconfig.ClusterConfig) {
 	// Nothing to do, let's the validating webhook fail later
 	if vm.Spec.Template == nil {
 		return
@@ -59,31 +57,8 @@ func setVMDefaultMachineType(vm *v1.VirtualMachine, preferenceSpec *instancetype
 		vm.Spec.Template.Spec.Domain.Machine = &v1.Machine{}
 	}
 
-	if preferenceSpec != nil && preferenceSpec.Machine != nil {
-		vm.Spec.Template.Spec.Domain.Machine.Type = preferenceSpec.Machine.PreferredMachineType
-	}
-
-	// Only use the cluster default if the user hasn't provided a machine type or referenced a preference with PreferredMachineType
 	if vm.Spec.Template.Spec.Domain.Machine.Type == "" {
 		vm.Spec.Template.Spec.Domain.Machine.Type = clusterConfig.GetMachineType(vm.Spec.Template.Spec.Architecture)
-	}
-}
-
-func setPreferenceStorageClassName(vm *v1.VirtualMachine, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec) {
-	// Nothing to do, let's the validating webhook fail later
-	if vm.Spec.Template == nil {
-		return
-	}
-
-	if preferenceSpec != nil && preferenceSpec.Volumes != nil && preferenceSpec.Volumes.PreferredStorageClassName != "" {
-		for _, dv := range vm.Spec.DataVolumeTemplates {
-			if dv.Spec.PVC != nil && dv.Spec.PVC.StorageClassName == nil {
-				dv.Spec.PVC.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
-			}
-			if dv.Spec.Storage != nil && dv.Spec.Storage.StorageClassName == nil {
-				dv.Spec.Storage.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
-			}
-		}
 	}
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -28,8 +28,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
-	apiinstancetype "kubevirt.io/api/instancetype"
-
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -37,8 +35,6 @@ import (
 )
 
 func SetVirtualMachineDefaults(vm *v1.VirtualMachine, clusterConfig *virtconfig.ClusterConfig) {
-	setDefaultInstancetypeKind(vm)
-	setDefaultPreferenceKind(vm)
 	setDefaultArchitecture(clusterConfig, &vm.Spec.Template.Spec)
 	setVMDefaultMachineType(vm, clusterConfig)
 }
@@ -59,26 +55,6 @@ func setVMDefaultMachineType(vm *v1.VirtualMachine, clusterConfig *virtconfig.Cl
 
 	if vm.Spec.Template.Spec.Domain.Machine.Type == "" {
 		vm.Spec.Template.Spec.Domain.Machine.Type = clusterConfig.GetMachineType(vm.Spec.Template.Spec.Architecture)
-	}
-}
-
-func setDefaultInstancetypeKind(vm *v1.VirtualMachine) {
-	if vm.Spec.Instancetype == nil {
-		return
-	}
-
-	if vm.Spec.Instancetype.Kind == "" {
-		vm.Spec.Instancetype.Kind = apiinstancetype.ClusterSingularResourceName
-	}
-}
-
-func setDefaultPreferenceKind(vm *v1.VirtualMachine) {
-	if vm.Spec.Preference == nil {
-		return
-	}
-
-	if vm.Spec.Preference.Kind == "" {
-		vm.Spec.Preference.Kind = apiinstancetype.ClusterSingularPreferenceResourceName
 	}
 }
 

--- a/pkg/instancetype/webhooks/vm/mutator.go
+++ b/pkg/instancetype/webhooks/vm/mutator.go
@@ -29,7 +29,7 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	virtv1 "kubevirt.io/api/core/v1"
-	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+	"kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
@@ -44,7 +44,7 @@ type inferHandler interface {
 }
 
 type findPreferenceSpecHandler interface {
-	FindPreference(vm *virtv1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error)
+	FindPreference(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error)
 }
 
 type mutator struct {
@@ -69,7 +69,45 @@ func (m *mutator) Mutate(vm, oldVM *virtv1.VirtualMachine, ar *admissionv1.Admis
 		return response
 	}
 
+	preferenceSpec, _ := m.FindPreference(vm)
+	mutateMachineType(vm, preferenceSpec)
+	mutateDataVolumeTemplates(vm, preferenceSpec)
+
 	return nil
+}
+
+// NOTE(lyarwood): We mutate the preferred machine type value into the VM early
+// ahead of existing default mutation code running in the main vm mutation
+// webhook.
+func mutateMachineType(vm *virtv1.VirtualMachine, preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) {
+	if vm.Spec.Template == nil {
+		return
+	}
+	if machine := vm.Spec.Template.Spec.Domain.Machine; machine != nil && machine.Type != "" {
+		return
+	}
+	if preferenceSpec != nil && preferenceSpec.Machine != nil {
+		if vm.Spec.Template.Spec.Domain.Machine == nil {
+			vm.Spec.Template.Spec.Domain.Machine = &virtv1.Machine{}
+		}
+		vm.Spec.Template.Spec.Domain.Machine.Type = preferenceSpec.Machine.PreferredMachineType
+	}
+}
+
+// NOTE(lyarwood): We have to mutate any preferred storage class value into the
+// DataVolumeTemplates within the VM as it's obviously too late to do this
+// during VMI creation with the rest of the preferred preference values
+func mutateDataVolumeTemplates(vm *virtv1.VirtualMachine, preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) {
+	if preferenceSpec != nil && preferenceSpec.Volumes != nil && preferenceSpec.Volumes.PreferredStorageClassName != "" {
+		for _, dv := range vm.Spec.DataVolumeTemplates {
+			if dv.Spec.PVC != nil && dv.Spec.PVC.StorageClassName == nil {
+				dv.Spec.PVC.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
+			}
+			if dv.Spec.Storage != nil && dv.Spec.Storage.StorageClassName == nil {
+				dv.Spec.Storage.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
+			}
+		}
+	}
 }
 
 func (m *mutator) validateMatchers(vm, oldVM *virtv1.VirtualMachine, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//staging/src/kubevirt.io/api/clone/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
-	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
@@ -42,7 +41,6 @@ import (
 
 type instancetypeVMsMutator interface {
 	Mutate(vm, oldVM *v1.VirtualMachine, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
-	FindPreference(vm *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error)
 }
 
 type VMsMutator struct {
@@ -93,8 +91,7 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	// Set VM defaults
 	log.Log.Object(vm).V(4).Info("Apply defaults")
 
-	preferenceSpec, _ := mutator.instancetypeMutator.FindPreference(vm)
-	defaults.SetVirtualMachineDefaults(vm, mutator.ClusterConfig, preferenceSpec)
+	defaults.SetVirtualMachineDefaults(vm, mutator.ClusterConfig)
 
 	patchBytes, err := patch.New(
 		patch.WithReplace("/spec", vm.Spec),

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -321,22 +321,6 @@ var _ = Describe("VirtualMachine Mutator", func() {
 
 	})
 
-	It("should default instancetype kind to ClusterSingularResourceName when not provided", func() {
-		vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-			Name: "foobar",
-		}
-		vmSpec, _ := getVMSpecMetaFromResponseCreate(rt.GOARCH)
-		Expect(vmSpec.Instancetype.Kind).To(Equal(apiinstancetype.ClusterSingularResourceName))
-	})
-
-	It("should default preference kind to ClusterSingularPreferenceResourceName when not provided", func() {
-		vm.Spec.Preference = &v1.PreferenceMatcher{
-			Name: "foobar",
-		}
-		vmSpec, _ := getVMSpecMetaFromResponseCreate(rt.GOARCH)
-		Expect(vmSpec.Preference.Kind).To(Equal(apiinstancetype.ClusterSingularPreferenceResourceName))
-	})
-
 	It("should use PreferredMachineType from ClusterSingularPreferenceResourceName when no preference kind is provided", func() {
 		preference := &instancetypev1beta1.VirtualMachineClusterPreference{
 			ObjectMeta: k8smetav1.ObjectMeta{


### PR DESCRIPTION
/hold

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

