### PR TITLE
Restore: include meaningful status message when target not ready

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -79,13 +79,20 @@ const (
 	restoreDataVolumeCreateErrorEvent = "RestoreDataVolumeCreateError"
 
 	defaultPvcRestorePrefix = "restore"
+
+	waitEventuallyMessage = "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"
+	stopTargetMessage     = "Automatically stopping restore target for restore operation"
+
+	vmiExistsEventMessage        = "Restore target VMI still exists, please stop the restore target to proceed with restore"
+	targetNotReadyFailureMessage = "Restore target VMI must be powered off before restore operation"
+
+	restoreFailedEvent           = "Operation failed"
+	errorRestoreToExistingTarget = "restore source and restore target are different but restore target already exists"
 )
 
 var (
-	restoreGracePeriodExceededError = fmt.Sprintf("Restore target failed to be ready within %s", snapshotv1.DefaultGracePeriod)
-	restoreTargetNotReady           = "Restore target not ready"
-	restoredFailed                  = "Operation failed"
-	errorRestoreToExistingTarget    = "restore source and restore target are different but restore target already exists"
+	restoreGracePeriodExceededError = fmt.Sprintf("Restore target failed to be ready within %s. Please power off the target VM before attempting restore", snapshotv1.DefaultGracePeriod)
+	waitGracePeriodMessage          = fmt.Sprintf("Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after %s", snapshotv1.DefaultGracePeriod)
 )
 
 type restoreTarget interface {
@@ -303,23 +310,35 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 }
 
 func (ctrl *VMRestoreController) doUpdateError(restore *snapshotv1.VirtualMachineRestore, err error) error {
-	ctrl.Recorder.Eventf(
-		restore,
-		corev1.EventTypeWarning,
-		restoreErrorEvent,
-		"VirtualMachineRestore encountered error %s",
-		err.Error(),
-	)
-
-	updated := restore.DeepCopy()
-
-	updateRestoreCondition(updated, newProgressingCondition(corev1.ConditionFalse, err.Error()))
-	updateRestoreCondition(updated, newReadyCondition(corev1.ConditionFalse, err.Error()))
-	if err2 := ctrl.doUpdateStatus(restore, updated); err2 != nil {
-		return err2
+	if updateErr := ctrl.doUpdateErrorWithFailure(restore, err.Error(), false); updateErr != nil {
+		return updateErr
 	}
 
 	return err
+}
+
+func (ctrl *VMRestoreController) doUpdateErrorWithFailure(restore *snapshotv1.VirtualMachineRestore, errMsg string, fail bool) error {
+	updated := restore.DeepCopy()
+
+	eventReason := restoreErrorEvent
+	eventMsg := fmt.Sprintf("VirtualMachineRestore encountered error %s", errMsg)
+
+	updateRestoreCondition(updated, newProgressingCondition(corev1.ConditionFalse, errMsg))
+	updateRestoreCondition(updated, newReadyCondition(corev1.ConditionFalse, errMsg))
+	if fail {
+		eventReason = restoreFailedEvent
+		eventMsg = fmt.Sprintf("VirtualMachineRestore failed %s", errMsg)
+		updateRestoreCondition(updated, newFailureCondition(corev1.ConditionTrue, errMsg))
+	}
+
+	ctrl.Recorder.Eventf(
+		restore,
+		corev1.EventTypeWarning,
+		eventReason,
+		eventMsg,
+	)
+
+	return ctrl.doUpdateStatus(restore, updated)
 }
 
 func (ctrl *VMRestoreController) doUpdateStatus(original, updated *snapshotv1.VirtualMachineRestore) error {
@@ -374,29 +393,44 @@ func (ctrl *VMRestoreController) handleVMRestoreTargetNotReady(vmRestore *snapsh
 		targetReadinessPolicy = *vmRestore.Spec.TargetReadinessPolicy
 	}
 
-	eventMsg := "Restore target VMI still exists"
-	ctrl.Recorder.Event(vmRestoreCpy, corev1.EventTypeNormal, restoreVMNotReadyEvent, eventMsg)
-	reason := "Waiting for target to be ready"
-	updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, reason))
-	updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, reason))
+	var reason, eventMsg string
 
 	switch targetReadinessPolicy {
 	case snapshotv1.VirtualMachineRestoreWaitEventually:
+		reason = waitEventuallyMessage
+		eventMsg = vmiExistsEventMessage
 	case snapshotv1.VirtualMachineRestoreStopTarget:
-		err := target.Stop()
-		if err != nil {
-			return ctrl.doUpdateError(vmRestore, err)
-		}
+		return ctrl.stopTarget(vmRestore, target)
 	case snapshotv1.VirtualMachineRestoreWaitGracePeriodAndFail:
 		if vmRestoreTargetReadyGracePeriodExceeded(vmRestore) {
-			updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, restoredFailed))
-			updateRestoreCondition(vmRestoreCpy, newFailureCondition(corev1.ConditionTrue, restoreGracePeriodExceededError))
-			updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, restoredFailed))
+			return ctrl.doUpdateErrorWithFailure(vmRestore, restoreGracePeriodExceededError, true)
 		}
+
+		reason = waitGracePeriodMessage
+		eventMsg = vmiExistsEventMessage
 	case snapshotv1.VirtualMachineRestoreFailImmediate:
-		updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, restoredFailed))
-		updateRestoreCondition(vmRestoreCpy, newFailureCondition(corev1.ConditionTrue, restoreTargetNotReady))
-		updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, restoredFailed))
+		return ctrl.doUpdateErrorWithFailure(vmRestore, targetNotReadyFailureMessage, true)
+	default:
+		return fmt.Errorf("unknown targetReadinessPolicy: %v", targetReadinessPolicy)
+	}
+
+	ctrl.Recorder.Event(vmRestoreCpy, corev1.EventTypeWarning, restoreVMNotReadyEvent, eventMsg)
+	updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, reason))
+	updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, reason))
+
+	return ctrl.doUpdateStatus(vmRestore, vmRestoreCpy)
+}
+
+func (ctrl *VMRestoreController) stopTarget(vmRestore *snapshotv1.VirtualMachineRestore, target restoreTarget) error {
+	vmRestoreCpy := vmRestore.DeepCopy()
+	ctrl.Recorder.Event(vmRestoreCpy, corev1.EventTypeWarning, restoreVMNotReadyEvent, stopTargetMessage)
+	updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, stopTargetMessage))
+	updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, stopTargetMessage))
+
+	// Stop the restore target
+	err := target.Stop()
+	if err != nil {
+		return ctrl.doUpdateError(vmRestoreCpy, err)
 	}
 
 	return ctrl.doUpdateStatus(vmRestore, vmRestoreCpy)

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -517,8 +517,8 @@ var _ = Describe("Restore controller", func() {
 				rc2.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
-						newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-						newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+						newProgressingCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
 					},
 				}
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
@@ -674,7 +674,7 @@ var _ = Describe("Restore controller", func() {
 					Spec: corev1.PersistentVolumeClaimSpec{
 						Resources: corev1.VolumeResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("2Gi"),
+								corev1.ResourceStorage: resource.MustParse("2Gi"),
 							},
 						},
 						VolumeName:       "volume2",
@@ -1806,8 +1806,8 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-							newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"),
+							newReadyCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1829,8 +1829,8 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-							newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Automatically stopping restore target for restore operation"),
+							newReadyCondition(corev1.ConditionFalse, "Automatically stopping restore target for restore operation"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1858,9 +1858,9 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Operation failed"),
-							newReadyCondition(corev1.ConditionFalse, "Operation failed"),
-							newFailureCondition(corev1.ConditionTrue, "Restore target failed to be ready within 5m0s"),
+							newProgressingCondition(corev1.ConditionFalse, "Restore target failed to be ready within 5m0s. Please power off the target VM before attempting restore"),
+							newReadyCondition(corev1.ConditionFalse, "Restore target failed to be ready within 5m0s. Please power off the target VM before attempting restore"),
+							newFailureCondition(corev1.ConditionTrue, "Restore target failed to be ready within 5m0s. Please power off the target VM before attempting restore"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1868,7 +1868,7 @@ var _ = Describe("Restore controller", func() {
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
-					testutils.ExpectEvent(recorder, "RestoreTargetNotReady")
+					testutils.ExpectEvent(recorder, "Operation failed")
 					Expect(*updateStatusCalls).To(Equal(1))
 				})
 
@@ -1877,8 +1877,8 @@ var _ = Describe("Restore controller", func() {
 					r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-							newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
+							newReadyCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
 						},
 					}
 					//change creation time such that it will make the default grace period pass
@@ -1915,9 +1915,9 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Operation failed"),
-							newReadyCondition(corev1.ConditionFalse, "Operation failed"),
-							newFailureCondition(corev1.ConditionTrue, "Restore target not ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newReadyCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newFailureCondition(corev1.ConditionTrue, "Restore target VMI must be powered off before restore operation"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1925,8 +1925,32 @@ var _ = Describe("Restore controller", func() {
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
-					testutils.ExpectEvent(recorder, "RestoreTargetNotReady")
+					testutils.ExpectEvent(recorder, "Operation failed")
 					Expect(*updateStatusCalls).To(Equal(1))
+				})
+
+				It("should not change from failure status even if VM becomes ready", func() {
+					r := createRestoreWithOwner()
+					r.Spec.TargetReadinessPolicy = pointer.P(snapshotv1.VirtualMachineRestoreFailImmediate)
+					// Set up restore with failure condition already present
+					r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+						Complete: pointer.P(false),
+						Conditions: []snapshotv1.Condition{
+							newProgressingCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newReadyCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newFailureCondition(corev1.ConditionTrue, "Restore target VMI must be powered off before restore operation"),
+						},
+					}
+					vm := createModifiedVM()
+					// Add VM without VMI (VM is ready), but restore already has failure condition
+					vmSource.Add(vm)
+
+					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, r)
+
+					addVirtualMachineRestore(r)
+					controller.processVMRestoreWorkItem()
+					// Verify no status update occurred since restore is already in terminal failure state
+					Expect(*updateStatusCalls).To(Equal(0))
 				})
 			})
 
@@ -1936,9 +1960,9 @@ var _ = Describe("Restore controller", func() {
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
-						newProgressingCondition(corev1.ConditionFalse, "Operation failed"),
-						newReadyCondition(corev1.ConditionFalse, "Operation failed"),
-						newFailureCondition(corev1.ConditionTrue, "Restore target not ready"),
+						newProgressingCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+						newReadyCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+						newFailureCondition(corev1.ConditionTrue, "Restore target VMI must be powered off before restore operation"),
 					},
 				}
 				vm := createModifiedVM()

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1024,7 +1024,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				if !stopVMBeforeRestore {
-					events.ExpectEvent(restore, corev1.EventTypeNormal, "RestoreTargetNotReady")
+					events.ExpectEvent(restore, corev1.EventTypeWarning, "RestoreTargetNotReady")
 					By(stoppingVM)
 					vm = libvmops.StopVirtualMachine(vm)
 				}
@@ -1173,7 +1173,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				events.ExpectEvent(restore, corev1.EventTypeNormal, "RestoreTargetNotReady")
+				events.ExpectEvent(restore, corev1.EventTypeWarning, "RestoreTargetNotReady")
 				By(stoppingVM)
 				vm = libvmops.StopVirtualMachine(vm)
 


### PR DESCRIPTION
Updated the condition messages to be clearer to what is expected when "target is not ready".
Added specific message according to different targetReadinessPolicy. Updated UT accordingly.

### What this PR does
#### Before this PR: 
status condition message and event was: "Waiting for target to be ready"

#### After this PR:
status condition message and event is more informative according to the targetReadinessPolicy

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
Jira-ticket: https://issues.redhat.com/browse/CNV-59687
- 
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

