### PR TITLE
Fix multifd compatibility with postcopy

### DIFF
--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -615,5 +615,9 @@ func configureParallelMigrationThreads(options *cmdclient.MigrationOptions, vm *
 		return
 	}
 
+	if options.AllowPostCopy {
+		return
+	}
+
 	options.ParallelMigrationThreads = pointer.P(parallelMultifdMigrationThreads)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
// UPGRADE PATH IS
1. daemonsets - ensures all compute nodes are updated to handle new features
2. wait for daemonsets to roll over
3. controllers - ensures control plane is ready for new features
4. wait for controllers to roll over
5. apiserver - toggles on new features.

After the virt-handler has been updated, it should be able to communicate with the older virt-launcher.
In https://github.com/kubevirt/kubevirt/pull/12705 a change of the ParallelMigrationThreads migrationOption has been introduced, which causes a wrong set of the libvirt migration options. In particular, previously the ParallelMigrationThreads migrationOption was set by the virt-handler, and the virt-launcher simply checks its presence or not, and adjusts the libvirt flags and params to enable the multifd.

With https://github.com/kubevirt/kubevirt/pull/12705 this paradigm changed, demanding the logic from the handler to the launcher; IOW, the handler sets the ParallelMigrationThreads, and the launcher decides whether set or not the libvirt flags and options to enable the multifd.

With same version of handler and launcher, everything is working well, but during upgrades, the launcher version is different from the handler one.

This is causing the migrations to fail due to:
`Postcopy is not yet compatible with multifd`

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

https://issues.redhat.com/browse/CNV-64362

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Fix postcopy multifd compatibility during upgrade
```

