### PR TITLE
IBM  s390x architecture configuration

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12811,6 +12811,9 @@
      },
      "ppc64le": {
       "$ref": "#/definitions/v1.ArchSpecificConfiguration"
+     },
+     "s390x": {
+      "$ref": "#/definitions/v1.ArchSpecificConfiguration"
      }
     }
    },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -181,6 +181,18 @@ spec:
                           ovmfPath:
                             type: string
                         type: object
+                      s390x:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
                     type: object
                   autoCPULimitNamespaceLabelSelector:
                     description: |-
@@ -3446,6 +3458,18 @@ spec:
                       defaultArchitecture:
                         type: string
                       ppc64le:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
+                      s390x:
                         properties:
                           emulatedMachines:
                             items:

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -181,6 +181,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 						Amd64:   &v1.ArchSpecificConfiguration{MachineType: amd64MachineType},
 						Arm64:   &v1.ArchSpecificConfiguration{MachineType: arm64MachineType},
 						Ppc64le: &v1.ArchSpecificConfiguration{MachineType: ppc64leMachineType},
+						S390x:   &v1.ArchSpecificConfiguration{MachineType: s390xMachineType},
 					},
 				},
 			},
@@ -193,7 +194,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		Entry("when override is for amd64 architecture", "amd64", machineTypeFromConfig, "", "", "", machineTypeFromConfig),
 		Entry("when override is for arm64 architecture", "arm64", "", machineTypeFromConfig, "", "", machineTypeFromConfig),
 		Entry("when override is for ppc64le architecture", "ppc64le", "", "", machineTypeFromConfig, "", machineTypeFromConfig),
-		Entry("when override is for s390x architecture, no override", "s390x", "", "", "", machineTypeFromConfig, "s390-ccw-virtio"),
+		Entry("when override is for s390x architecture", "s390x", "", "", "", machineTypeFromConfig, machineTypeFromConfig),
 	)
 
 	It("should not override default architecture with defaults on VM create", func() {
@@ -307,17 +308,15 @@ var _ = Describe("VirtualMachine Mutator", func() {
 						Amd64:   &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
 						Arm64:   &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
 						Ppc64le: &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
+						S390x:   &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
 					},
 				},
 			},
 		})
 
 		vmSpec, _ := getVMSpecMetaFromResponseCreate(rt.GOARCH)
-		if rt.GOARCH == "s390x" {
-			Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal("s390-ccw-virtio"))
-		} else {
-			Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal(machineTypeFromConfig))
-		}
+
+		Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal(machineTypeFromConfig))
 
 	})
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -241,6 +241,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 						Amd64:   &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
 						Arm64:   &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
 						Ppc64le: &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
+						S390x:   &v1.ArchSpecificConfiguration{MachineType: machineTypeFromConfig},
 					},
 				},
 			},
@@ -252,6 +253,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(*vmiSpec.Domain.Resources.Requests.Cpu()).To(Equal(cpuReq))
 	},
 		Entry("on amd64", "amd64", cpuModelFromConfig),
+		Entry("on s390x", "s390x", cpuModelFromConfig),
 		// Currently only Host-Passthrough is supported on Arm64, so you can only
 		// modify the CPU Model in a VMI yaml file, rather than in cluster config
 		Entry("on arm64", "arm64", v1.CPUModeHostPassthrough),

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -261,6 +261,11 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 				EmulatedMachines: strings.Split(DefaultPPC64LEEmulatedMachines, ","),
 				MachineType:      DefaultPPC64LEMachineType,
 			},
+			S390x: &v1.ArchSpecificConfiguration{
+				OVMFPath:         DefaultS390xOVMFPath,
+				EmulatedMachines: strings.Split(DefaultS390XEmulatedMachines, ","),
+				MachineType:      DefaultS390XMachineType,
+			},
 			DefaultArchitecture: runtime.GOARCH,
 		},
 		LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -133,6 +133,7 @@ var _ = Describe("test configuration", func() {
 						Amd64:   &v1.ArchSpecificConfiguration{MachineType: machineTypeAMD64},
 						Arm64:   &v1.ArchSpecificConfiguration{MachineType: machineTypeARM64},
 						Ppc64le: &v1.ArchSpecificConfiguration{MachineType: machineTypePPC64le},
+						S390x:   &v1.ArchSpecificConfiguration{MachineType: machineTypeS390X},
 					},
 				},
 			},
@@ -143,9 +144,9 @@ var _ = Describe("test configuration", func() {
 		Expect(clusterConfig.GetMachineType(cpuArch)).To(Equal(result))
 	},
 		Entry("when amd64 set, GetMachineType should return the value", "amd64", "pc-q35-3.0", "", "", "", "pc-q35-3.0"),
-		Entry("when arm64 set, GetMachineType should return the value", "arm64", "", "virt", "", "", "virt"),
-		Entry("when ppc64le set, GetMachineType should return the value", "ppc64le", "", "", "pseries", "", "pseries"),
-		Entry("when s390x set, GetMachineType should return the value", "s390x", "", "", "", "s390-ccw-virtio", "s390-ccw-virtio"),
+		Entry("when arm64 set, GetMachineType should return the value", "arm64", "", "virt-rhel", "", "", "virt-rhel"),
+		Entry("when ppc64le set, GetMachineType should return the value", "ppc64le", "", "", "pseries-rhel", "", "pseries-rhel"),
+		Entry("when s390x set, GetMachineType should return the value", "s390x", "", "", "", "s390-ccw-virtio-rhel", "s390-ccw-virtio-rhel"),
 		Entry("when amd64 unset, GetMachineType should return the default with amd64", "amd64", "", "", "", "", virtconfig.DefaultAMD64MachineType),
 		Entry("when arm64 unset, GetMachineType should return the default with arm64", "arm64", "", "", "", "", virtconfig.DefaultAARCH64MachineType),
 		Entry("when ppc64le unset, GetMachineType should return the default with ppc64le", "ppc64le", "", "", "", "", virtconfig.DefaultPPC64LEMachineType),
@@ -226,6 +227,7 @@ var _ = Describe("test configuration", func() {
 		})
 		Expect(clusterConfig.GetCPUAllocationRatio()).To(Equal(result))
 	},
+
 		Entry("when set, GetCPUAllocationRatio should return the value", 150, 150),
 		Entry("when unset, GetCPUAllocationRatio should return the default", 0, virtconfig.DefaultCPUAllocationRatio),
 		Entry("when negative, GetCPUAllocationRatio should return the default", -150, virtconfig.DefaultCPUAllocationRatio),
@@ -243,6 +245,7 @@ var _ = Describe("test configuration", func() {
 						Amd64:   &v1.ArchSpecificConfiguration{EmulatedMachines: emuMachinesAMD64},
 						Arm64:   &v1.ArchSpecificConfiguration{EmulatedMachines: emuMachinesARM64},
 						Ppc64le: &v1.ArchSpecificConfiguration{EmulatedMachines: emuMachinesAPC64le64},
+						S390x:   &v1.ArchSpecificConfiguration{EmulatedMachines: emuMachinesS390X},
 					},
 				},
 			},
@@ -254,9 +257,9 @@ var _ = Describe("test configuration", func() {
 		Expect(emulatedMachines).To(ConsistOf(result))
 	},
 		Entry("when amd64 set, GetEmulatedMachines should return the value", "amd64", []string{"q35", "i440*"}, nil, nil, nil, []string{"q35", "i440*"}),
-		Entry("when arm64 set, GetEmulatedMachines should return the value", "arm64", nil, []string{"virt*"}, nil, nil, []string{"virt*"}),
-		Entry("when ppc64le set, GetEmulatedMachines should return the value", "ppc64le", nil, nil, []string{"pseries*"}, nil, []string{"pseries*"}),
-		Entry("when s390x set, GetEmulatedMachines should return the value", "s390x", nil, nil, nil, []string{"s390-ccw-virtio*"}, []string{"s390-ccw-virtio*"}),
+		Entry("when arm64 set, GetEmulatedMachines should return the value", "arm64", nil, []string{"virt-test*"}, nil, nil, []string{"virt-test*"}),
+		Entry("when ppc64le set, GetEmulatedMachines should return the value", "ppc64le", nil, nil, []string{"pseries-test*"}, nil, []string{"pseries-test*"}),
+		Entry("when s390x set, GetEmulatedMachines should return the value", "s390x", nil, nil, nil, []string{"s390-ccw-virtio-test*"}, []string{"s390-ccw-virtio-test*"}),
 		Entry("when unset, GetEmulatedMachines should return the defaults with amd64", "amd64", nil, nil, nil, nil, strings.Split(virtconfig.DefaultAMD64EmulatedMachines, ",")),
 		Entry("when empty, GetEmulatedMachines should return the defaults with amd64", "amd64", []string{}, []string{}, []string{}, nil, strings.Split(virtconfig.DefaultAMD64EmulatedMachines, ",")),
 		Entry("when unset, GetEmulatedMachines should return the defaults with arm64", "arm64", nil, nil, nil, nil, strings.Split(virtconfig.DefaultAARCH64EmulatedMachines, ",")),
@@ -499,6 +502,7 @@ var _ = Describe("test configuration", func() {
 						Amd64:   &v1.ArchSpecificConfiguration{OVMFPath: ovmfPathKeyAMD64},
 						Arm64:   &v1.ArchSpecificConfiguration{OVMFPath: ovmfPathKeyARM64},
 						Ppc64le: &v1.ArchSpecificConfiguration{OVMFPath: ovmfPathKeyPPC64le64},
+						S390x:   &v1.ArchSpecificConfiguration{OVMFPath: ovmfPathKeyS390X},
 					},
 				},
 			},
@@ -514,11 +518,11 @@ var _ = Describe("test configuration", func() {
 		Entry("when amd64 set, GetOVMFPath should return the value", "amd64", "/usr/share/ovmf/x64", "", "", "", "/usr/share/ovmf/x64"),
 		Entry("when arm64 set, GetOVMFPath should return the value", "arm64", "", "/usr/share/AAVMF", "", "", "/usr/share/AAVMF"),
 		Entry("when ppc64le set, GetOVMFPath should return the value", "ppc64le", "", "", "/usr/share/ovmf/x64", "", "/usr/share/ovmf/x64"),
-		Entry("when s390x set, GetOVMFPath should return the value", "s390x", "", "", "", "", ""),
+		Entry("when s390x set, GetOVMFPath should return the value", "s390x", "", "", "", "/usr/share/ovmf/s390x", "/usr/share/ovmf/s390x"),
 		Entry("when unset, GetOVMFPath should return the default with amd64", "amd64", "", "", "", "", virtconfig.DefaultARCHOVMFPath),
 		Entry("when unset, GetOVMFPath should return the default with arm64", "arm64", "", "", "", "", virtconfig.DefaultAARCH64OVMFPath),
 		Entry("when unset, GetOVMFPath should return the default with ppc64le", "ppc64le", "", "", "", "", virtconfig.DefaultARCHOVMFPath),
-		Entry("when unset, GetOVMFPath should return an empty string with s390x", "s390x", "", "", "", "", ""),
+		Entry("when unset, GetOVMFPath should return the default with s390x", "s390x", "", "", "", "", virtconfig.DefaultS390xOVMFPath),
 	)
 
 	It("verifies that SetConfigModifiedCallback works as expected ", func() {

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -24,8 +24,6 @@ package virtconfig
 */
 
 import (
-	"strings"
-
 	"kubevirt.io/client-go/log"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -70,6 +68,7 @@ const (
 	SupportedGuestAgentVersions                     = "2.*,3.*,4.*,5.*"
 	DefaultARCHOVMFPath                             = "/usr/share/OVMF"
 	DefaultAARCH64OVMFPath                          = "/usr/share/AAVMF"
+	DefaultS390xOVMFPath                            = ""
 	DefaultMemBalloonStatsPeriod             uint32 = 10
 	DefaultCPUAllocationRatio                       = 10
 	DefaultDiskVerificationMemoryLimitBytes         = 2000 * 1024 * 1024
@@ -140,7 +139,7 @@ func (c *ClusterConfig) GetMachineType(arch string) string {
 	case "ppc64le":
 		return c.GetConfig().ArchitectureConfiguration.Ppc64le.MachineType
 	case "s390x":
-		return DefaultS390XMachineType
+		return c.GetConfig().ArchitectureConfiguration.S390x.MachineType
 	default:
 		return c.GetConfig().ArchitectureConfiguration.Amd64.MachineType
 	}
@@ -174,7 +173,7 @@ func (c *ClusterConfig) GetEmulatedMachines(arch string) []string {
 	case "ppc64le":
 		return c.GetConfig().ArchitectureConfiguration.Ppc64le.EmulatedMachines
 	case "s390x":
-		return strings.Split(DefaultS390XEmulatedMachines, ",")
+		return c.GetConfig().ArchitectureConfiguration.S390x.EmulatedMachines
 	default:
 		return c.GetConfig().ArchitectureConfiguration.Amd64.EmulatedMachines
 	}
@@ -236,7 +235,7 @@ func (c *ClusterConfig) GetOVMFPath(arch string) string {
 	case "ppc64le":
 		return c.GetConfig().ArchitectureConfiguration.Ppc64le.OVMFPath
 	case "s390x":
-		return ""
+		return c.GetConfig().ArchitectureConfiguration.S390x.OVMFPath
 	default:
 		return c.GetConfig().ArchitectureConfiguration.Amd64.OVMFPath
 	}

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -776,6 +776,18 @@ var CRDsValidation map[string]string = map[string]string{
                     ovmfPath:
                       type: string
                   type: object
+                s390x:
+                  properties:
+                    emulatedMachines:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    machineType:
+                      type: string
+                    ovmfPath:
+                      type: string
+                  type: object
               type: object
             autoCPULimitNamespaceLabelSelector:
               description: |-

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
@@ -190,6 +190,13 @@
           ],
           "machineType": "machineTypeValue"
         },
+        "s390x": {
+          "ovmfPath": "ovmfPathValue",
+          "emulatedMachines": [
+            "emulatedMachinesValue"
+          ],
+          "machineType": "machineTypeValue"
+        },
         "defaultArchitecture": "defaultArchitectureValue"
       },
       "evictionStrategy": "evictionStrategyValue",

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
@@ -69,6 +69,11 @@ spec:
         - emulatedMachinesValue
         machineType: machineTypeValue
         ovmfPath: ovmfPathValue
+      s390x:
+        emulatedMachines:
+        - emulatedMachinesValue
+        machineType: machineTypeValue
+        ovmfPath: ovmfPathValue
     autoCPULimitNamespaceLabelSelector:
       matchExpressions:
       - key: keyValue

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -137,6 +137,11 @@ func (in *ArchConfiguration) DeepCopyInto(out *ArchConfiguration) {
 		*out = new(ArchSpecificConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.S390x != nil {
+		in, out := &in.S390x, &out.S390x
+		*out = new(ArchSpecificConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2868,6 +2868,7 @@ type ArchConfiguration struct {
 	Amd64               *ArchSpecificConfiguration `json:"amd64,omitempty"`
 	Arm64               *ArchSpecificConfiguration `json:"arm64,omitempty"`
 	Ppc64le             *ArchSpecificConfiguration `json:"ppc64le,omitempty"`
+	S390x               *ArchSpecificConfiguration `json:"s390x,omitempty"`
 	DefaultArchitecture string                     `json:"defaultArchitecture,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17718,6 +17718,11 @@ func schema_kubevirtio_api_core_v1_ArchConfiguration(ref common.ReferenceCallbac
 							Ref: ref("kubevirt.io/api/core/v1.ArchSpecificConfiguration"),
 						},
 					},
+					"s390x": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("kubevirt.io/api/core/v1.ArchSpecificConfiguration"),
+						},
+					},
 					"defaultArchitecture": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1730,10 +1730,11 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 			config := kv.Spec.Configuration
 			config.MachineType = ""
-			config.ArchitectureConfiguration = &v1.ArchConfiguration{Amd64: &v1.ArchSpecificConfiguration{}, Arm64: &v1.ArchSpecificConfiguration{}, Ppc64le: &v1.ArchSpecificConfiguration{}}
+			config.ArchitectureConfiguration = &v1.ArchConfiguration{Amd64: &v1.ArchSpecificConfiguration{}, Arm64: &v1.ArchSpecificConfiguration{}, Ppc64le: &v1.ArchSpecificConfiguration{}, S390x: &v1.ArchSpecificConfiguration{}}
 			config.ArchitectureConfiguration.Amd64.EmulatedMachines = testEmulatedMachines
 			config.ArchitectureConfiguration.Arm64.EmulatedMachines = testEmulatedMachines
 			config.ArchitectureConfiguration.Ppc64le.EmulatedMachines = testEmulatedMachines
+			config.ArchitectureConfiguration.S390x.EmulatedMachines = testEmulatedMachines
 
 			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 		})
@@ -1783,13 +1784,15 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 			config := kv.Spec.Configuration
 
-			config.ArchitectureConfiguration = &v1.ArchConfiguration{Amd64: &v1.ArchSpecificConfiguration{}, Arm64: &v1.ArchSpecificConfiguration{}, Ppc64le: &v1.ArchSpecificConfiguration{}}
+			config.ArchitectureConfiguration = &v1.ArchConfiguration{Amd64: &v1.ArchSpecificConfiguration{}, Arm64: &v1.ArchSpecificConfiguration{}, Ppc64le: &v1.ArchSpecificConfiguration{}, S390x: &v1.ArchSpecificConfiguration{}}
 			config.ArchitectureConfiguration.Amd64.MachineType = "pc"
 			config.ArchitectureConfiguration.Arm64.MachineType = "pc"
 			config.ArchitectureConfiguration.Ppc64le.MachineType = "pc"
+			config.ArchitectureConfiguration.S390x.MachineType = "pc"
 			config.ArchitectureConfiguration.Amd64.EmulatedMachines = testEmulatedMachines
 			config.ArchitectureConfiguration.Arm64.EmulatedMachines = testEmulatedMachines
 			config.ArchitectureConfiguration.Ppc64le.EmulatedMachines = testEmulatedMachines
+			config.ArchitectureConfiguration.S390x.EmulatedMachines = testEmulatedMachines
 			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 
 			vmi := libvmifact.NewGuestless()


### PR DESCRIPTION
 github  Issue : https://github.com/kubevirt/kubevirt/issues/14953

**What this PR does**
**Before this PR:**
  KubeVirt configuration lacked support for the s390x architecture in the ArchitectureConfiguration struct. As a result, values     like MachineType, OVMFPath, and EmulatedMachines could not be set for s390x, and logic defaulted to hardcoded fallbacks.

**After this PR:**
Added s390x support in ArchConfiguration and ArchSpecificConfiguration

Integrated s390x with GetMachineType, GetEmulatedMachines, and GetOVMFPath

Updated tests to cover s390x scenarios for machine type, emulated machines, and CPU model behavior

Ensured consistency with existing amd64, arm64, and ppc64le configuration patterns


```release-note
Added support for architecture-specific configuration of `s390x` (IBM Z) in KubeVirt cluster config.
```

