### PR TITLE
host-disk: only chown files we created

### DIFF
--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -44,12 +44,27 @@ func MockDefaultOwnershipManager() {
 type nonOpManager struct {
 }
 
-func (no *nonOpManager) UnsafeSetFileOwnership(file string) error {
+func (no *nonOpManager) UnsafeSetFileOwnership(_ string) error {
 	return nil
 }
 
-func (no *nonOpManager) SetFileOwnership(file *safepath.Path) error {
+func (no *nonOpManager) SetFileOwnership(_ *safepath.Path) error {
 	return nil
+}
+
+func MockDefaultOwnershipManagerWithFailure() {
+	DefaultOwnershipManager = &failureManager{}
+}
+
+type failureManager struct {
+}
+
+func (no *failureManager) UnsafeSetFileOwnership(_ string) error {
+	panic("unexpected call to UnsafeSetFileOwnership")
+}
+
+func (no *failureManager) SetFileOwnership(_ *safepath.Path) error {
+	panic("unexpected call to SetFileOwnership")
 }
 
 type OwnershipManager struct {

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -226,7 +226,7 @@ func (hdc *DiskImgCreator) setlessPVCSpaceToleration(toleration int) {
 	hdc.lessPVCSpaceToleration = toleration
 }
 
-func (hdc DiskImgCreator) Create(vmi *v1.VirtualMachineInstance) error {
+func (hdc *DiskImgCreator) Create(vmi *v1.VirtualMachineInstance) error {
 	for _, volume := range vmi.Spec.Volumes {
 		if hostDisk := volume.VolumeSource.HostDisk; shouldMountHostDisk(hostDisk) {
 			if err := hdc.mountHostDiskAndSetOwnership(vmi, volume.Name, hostDisk); err != nil {
@@ -249,14 +249,14 @@ func (hdc *DiskImgCreator) mountHostDiskAndSetOwnership(vmi *v1.VirtualMachineIn
 		return err
 	}
 	if !fileExists {
-		if err := hdc.handleRequestedSizeAndCreateSparseRaw(vmi, diskDir, diskPath, hostDisk); err != nil {
+		if err = hdc.handleRequestedSizeAndCreateSparseRaw(vmi, diskDir, diskPath, hostDisk); err != nil {
 			return err
 		}
-	}
-	// Change file ownership to the qemu user.
-	if err := ephemeraldiskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(diskPath); err != nil {
-		log.Log.Reason(err).Errorf("Couldn't set Ownership on %s: %v", diskPath, err)
-		return err
+		// Change file ownership to the qemu user.
+		if err = ephemeraldiskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(diskPath); err != nil {
+			log.Log.Reason(err).Errorf("Couldn't set Ownership on %s: %v", diskPath, err)
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:
In DiskOrCreate mode, when the file exists, host-disk changes its owner.

#### After this PR:
host-disk only changes the owner of the files it creates.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HostDisk: KubeVirt no longer performs chown/chmod to compensate for storage that doesn't support fsGroup
```
