### PR TITLE
network, dns: Support adding IPv6 Nameservers

### DIFF
--- a/pkg/network/dhcp/serverv6/serverv6.go
+++ b/pkg/network/dhcp/serverv6/serverv6.go
@@ -40,7 +40,7 @@ type DHCPv6Handler struct {
 	modifiers []dhcpv6.Modifier
 }
 
-func SingleClientDHCPv6Server(clientIP net.IP, serverIfaceName string) error {
+func SingleClientDHCPv6Server(clientIP net.IP, serverIfaceName string, ipv6Nameservers [][]byte) error {
 	log.Log.Info("Starting SingleClientDHCPv6Server")
 
 	iface, err := net.InterfaceByName(serverIfaceName)
@@ -48,7 +48,7 @@ func SingleClientDHCPv6Server(clientIP net.IP, serverIfaceName string) error {
 		return fmt.Errorf("couldn't create DHCPv6 server, couldn't get the dhcp6 server interface: %v", err)
 	}
 
-	modifiers := prepareDHCPv6Modifiers(clientIP, iface.HardwareAddr)
+	modifiers := prepareDHCPv6Modifiers(clientIP, iface.HardwareAddr, ipv6Nameservers)
 
 	handler := &DHCPv6Handler{
 		clientIP:  clientIP,
@@ -121,9 +121,19 @@ func (h *DHCPv6Handler) buildResponse(msg dhcpv6.DHCPv6) (*dhcpv6.Message, error
 	return response, nil
 }
 
-func prepareDHCPv6Modifiers(clientIP net.IP, serverInterfaceMac net.HardwareAddr) []dhcpv6.Modifier {
+func prepareDHCPv6Modifiers(clientIP net.IP, serverInterfaceMac net.HardwareAddr, ipv6Nameservers [][]byte) []dhcpv6.Modifier {
 	optIAAddress := dhcpv6.OptIAAddress{IPv6Addr: clientIP, PreferredLifetime: infiniteLease, ValidLifetime: infiniteLease}
 	duid := &dhcpv6.DUIDLL{HWType: iana.HWTypeEthernet, LinkLayerAddr: serverInterfaceMac}
 
-	return []dhcpv6.Modifier{dhcpv6.WithIANA(optIAAddress), dhcpv6.WithServerID(duid)}
+	modifiers := []dhcpv6.Modifier{dhcpv6.WithIANA(optIAAddress), dhcpv6.WithServerID(duid)}
+
+	if len(ipv6Nameservers) > 0 {
+		var dnsServers []net.IP
+		for _, nameserver := range ipv6Nameservers {
+			dnsServers = append(dnsServers, net.IP(nameserver))
+		}
+		modifiers = append(modifiers, dhcpv6.WithDNS(dnsServers...))
+	}
+
+	return modifiers
 }

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -181,7 +181,7 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceNa
 				bridgeInterfaceName,
 				nic.AdvertisingIPAddr,
 				nic.Gateway,
-				nameservers,
+				nameservers.IPv4,
 				nic.Routes,
 				searchDomains,
 				nic.Mtu,

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -198,6 +198,7 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceNa
 			if err = DHCPv6Server(
 				nic.IPv6.IP,
 				bridgeInterfaceName,
+				nameservers.IPv6,
 			); err != nil {
 				log.Log.Reason(err).Error("failed to run DHCPv6 Server")
 				panic(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, parsing the Pod's nameservers is limited to IPv4 nameservers.
Fix it to support also IPv6 ones.
In order to populate the IPv6 ones to the VM, add IPv6 DHCP modifier, option 23,
which is used to advertise the IPV6 nameservers.

Note: Since Kubevirt doesn't support RA, SLAAC won't work out of the box,
and the VM won't get global IPv6, nor nameservers.
Hence `dhcp` method should be used (see examples in the PR comments).

### References
Fixes #15011

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Didn't add e2e, because we might not need e2e for it, and if we do
we can add it on the same test that  https://github.com/kubevirt/kubevirt/pull/14189 fixes,
once it is merged.
Because this mentioned PR purpose is also to use `method: dhcp` as required in this PR.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

