### PR TITLE
chore: upgrade libvirt.org/go/libvirt to v1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 	kubevirt.io/containerized-data-importer-api v1.60.3-0.20241105012228-50fbed985de9
 	kubevirt.io/qe-tools v0.1.8
-	libvirt.org/go/libvirt v1.10009.1
+	libvirt.org/go/libvirt v1.11002.0
 	libvirt.org/go/libvirtxml v1.11000.1
 	mvdan.cc/sh/v3 v3.8.0
 	sigs.k8s.io/controller-runtime v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -3424,8 +3424,8 @@ kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 kubevirt.io/qe-tools v0.1.8 h1:Ar7qicmzHdd+Ia+6rjHDg3D7GReIyq7QFXoC4F7TjhQ=
 kubevirt.io/qe-tools v0.1.8/go.mod h1:+Tr/WZGHIDQa/4pQgzM7+4J6YeVbUWAXESXtL2/zxqc=
-libvirt.org/go/libvirt v1.10009.1 h1:Z79EnxEVE190MeULGoq1GY0tb+O18FpYzUNYDHgkrN8=
-libvirt.org/go/libvirt v1.10009.1/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
+libvirt.org/go/libvirt v1.11002.0 h1:cb8KJG3D97pc/hxQ2n6P82hRX3rlgdzO7bih6W1AAQ8=
+libvirt.org/go/libvirt v1.11002.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
 libvirt.org/go/libvirtxml v1.11000.1 h1:xbqKCYJRr3QPamY0PKE/exAGgTCosH5s4vB6NPXGcFY=
 libvirt.org/go/libvirtxml v1.11000.1/go.mod h1:7Oq2BLDstLr/XtoQD8Fr3mfDNrzlI3utYKySXF2xkng=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=

--- a/vendor/libvirt.org/go/libvirt/.gitlab-ci.yml
+++ b/vendor/libvirt.org/go/libvirt/.gitlab-ci.yml
@@ -44,8 +44,8 @@ stages:
 
 include: '/ci/gitlab.yml'
 
-.api_coverage_job:
-  extents:
+api_coverage_job:
+  extends:
     - .gitlab_native_build_job
   stage: sanity_checks
   script:
@@ -97,6 +97,6 @@ go_1_16:
   image: golang:1.16
 
 # a quite new version
-go_1_20:
+go_1_24:
   <<: *go_build
-  image: golang:1.20
+  image: golang:1.24

--- a/vendor/libvirt.org/go/libvirt/connect.go
+++ b/vendor/libvirt.org/go/libvirt/connect.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"unsafe"
 )
@@ -137,32 +138,34 @@ const (
 type ConnectListAllNodeDeviceFlags uint
 
 const (
-	CONNECT_LIST_NODE_DEVICES_CAP_SYSTEM        = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SYSTEM)
-	CONNECT_LIST_NODE_DEVICES_CAP_PCI_DEV       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_PCI_DEV)
-	CONNECT_LIST_NODE_DEVICES_CAP_USB_DEV       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_USB_DEV)
-	CONNECT_LIST_NODE_DEVICES_CAP_USB_INTERFACE = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_USB_INTERFACE)
-	CONNECT_LIST_NODE_DEVICES_CAP_NET           = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_NET)
-	CONNECT_LIST_NODE_DEVICES_CAP_SCSI_HOST     = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI_HOST)
-	CONNECT_LIST_NODE_DEVICES_CAP_SCSI_TARGET   = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI_TARGET)
-	CONNECT_LIST_NODE_DEVICES_CAP_SCSI          = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI)
-	CONNECT_LIST_NODE_DEVICES_CAP_STORAGE       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_STORAGE)
-	CONNECT_LIST_NODE_DEVICES_CAP_FC_HOST       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_FC_HOST)
-	CONNECT_LIST_NODE_DEVICES_CAP_VPORTS        = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_VPORTS)
-	CONNECT_LIST_NODE_DEVICES_CAP_SCSI_GENERIC  = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI_GENERIC)
-	CONNECT_LIST_NODE_DEVICES_CAP_DRM           = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_DRM)
-	CONNECT_LIST_NODE_DEVICES_CAP_MDEV          = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_MDEV)
-	CONNECT_LIST_NODE_DEVICES_CAP_MDEV_TYPES    = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_MDEV_TYPES)
-	CONNECT_LIST_NODE_DEVICES_CAP_CCW_DEV       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_CCW_DEV)
-	CONNECT_LIST_NODE_DEVICES_CAP_CSS_DEV       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_CSS_DEV)
-	CONNECT_LIST_NODE_DEVICES_CAP_VDPA          = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_VDPA)
-	CONNECT_LIST_NODE_DEVICES_CAP_AP_CARD       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_AP_CARD)
-	CONNECT_LIST_NODE_DEVICES_CAP_AP_QUEUE      = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_AP_QUEUE)
-	CONNECT_LIST_NODE_DEVICES_CAP_AP_MATRIX     = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_AP_MATRIX)
-	CONNECT_LIST_NODE_DEVICES_CAP_VPD           = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_VPD)
-	CONNECT_LIST_NODE_DEVICES_INACTIVE          = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_INACTIVE)
-	CONNECT_LIST_NODE_DEVICES_ACTIVE            = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_ACTIVE)
-	CONNECT_LIST_NODE_DEVICES_PERSISTENT        = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_PERSISTENT)
-	CONNECT_LIST_NODE_DEVICES_TRANSIENT         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_TRANSIENT)
+	CONNECT_LIST_NODE_DEVICES_CAP_SYSTEM          = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SYSTEM)
+	CONNECT_LIST_NODE_DEVICES_CAP_PCI_DEV         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_PCI_DEV)
+	CONNECT_LIST_NODE_DEVICES_CAP_USB_DEV         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_USB_DEV)
+	CONNECT_LIST_NODE_DEVICES_CAP_USB_INTERFACE   = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_USB_INTERFACE)
+	CONNECT_LIST_NODE_DEVICES_CAP_NET             = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_NET)
+	CONNECT_LIST_NODE_DEVICES_CAP_SCSI_HOST       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI_HOST)
+	CONNECT_LIST_NODE_DEVICES_CAP_SCSI_TARGET     = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI_TARGET)
+	CONNECT_LIST_NODE_DEVICES_CAP_SCSI            = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI)
+	CONNECT_LIST_NODE_DEVICES_CAP_STORAGE         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_STORAGE)
+	CONNECT_LIST_NODE_DEVICES_CAP_FC_HOST         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_FC_HOST)
+	CONNECT_LIST_NODE_DEVICES_CAP_VPORTS          = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_VPORTS)
+	CONNECT_LIST_NODE_DEVICES_CAP_SCSI_GENERIC    = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_SCSI_GENERIC)
+	CONNECT_LIST_NODE_DEVICES_CAP_DRM             = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_DRM)
+	CONNECT_LIST_NODE_DEVICES_CAP_MDEV            = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_MDEV)
+	CONNECT_LIST_NODE_DEVICES_CAP_MDEV_TYPES      = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_MDEV_TYPES)
+	CONNECT_LIST_NODE_DEVICES_CAP_CCW_DEV         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_CCW_DEV)
+	CONNECT_LIST_NODE_DEVICES_CAP_CSS_DEV         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_CSS_DEV)
+	CONNECT_LIST_NODE_DEVICES_CAP_VDPA            = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_VDPA)
+	CONNECT_LIST_NODE_DEVICES_CAP_AP_CARD         = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_AP_CARD)
+	CONNECT_LIST_NODE_DEVICES_CAP_AP_QUEUE        = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_AP_QUEUE)
+	CONNECT_LIST_NODE_DEVICES_CAP_AP_MATRIX       = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_AP_MATRIX)
+	CONNECT_LIST_NODE_DEVICES_CAP_VPD             = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_VPD)
+	CONNECT_LIST_NODE_DEVICES_INACTIVE            = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_INACTIVE)
+	CONNECT_LIST_NODE_DEVICES_ACTIVE              = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_ACTIVE)
+	CONNECT_LIST_NODE_DEVICES_PERSISTENT          = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_PERSISTENT)
+	CONNECT_LIST_NODE_DEVICES_TRANSIENT           = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_TRANSIENT)
+	CONNECT_LIST_NODE_DEVICES_CAP_CCWGROUP_DEV    = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_CCWGROUP_DEV)
+	CONNECT_LIST_NODE_DEVICES_CAP_CCWGROUP_MEMBER = ConnectListAllNodeDeviceFlags(C.VIR_CONNECT_LIST_NODE_DEVICES_CAP_CCWGROUP_MEMBER)
 )
 
 type ConnectListAllSecretsFlags uint
@@ -258,6 +261,12 @@ const (
 	CRED_NOECHOPROMPT = ConnectCredentialType(C.VIR_CRED_NOECHOPROMPT)
 	CRED_REALM        = ConnectCredentialType(C.VIR_CRED_REALM)
 	CRED_EXTERNAL     = ConnectCredentialType(C.VIR_CRED_EXTERNAL)
+)
+
+type ConnectGetDomainCapabilitiesFlags uint32
+
+const (
+	DOMAIN_CAPABILITIES_DISABLE_DEPRECATED_FEATURES = ConnectGetDomainCapabilitiesFlags(C.VIR_CONNECT_GET_DOMAIN_CAPABILITIES_DISABLE_DEPRECATED_FEATURES)
 )
 
 type Connect struct {
@@ -2413,7 +2422,7 @@ func (c *Connect) GetCPUModelNames(arch string, flags uint32) ([]string, error) 
 }
 
 // See also https://libvirt.org/html/libvirt-libvirt-domain.html#virConnectGetDomainCapabilities
-func (c *Connect) GetDomainCapabilities(emulatorbin string, arch string, machine string, virttype string, flags uint32) (string, error) {
+func (c *Connect) GetDomainCapabilities(emulatorbin string, arch string, machine string, virttype string, flags ConnectGetDomainCapabilitiesFlags) (string, error) {
 	var cemulatorbin *C.char
 	if emulatorbin != "" {
 		cemulatorbin = C.CString(emulatorbin)
@@ -2544,39 +2553,128 @@ type DomainStatsState struct {
 
 func getDomainStatsStateFieldInfo(params *DomainStatsState) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		"state.state": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_STATE_STATE: typedParamsFieldInfo{
 			set: &params.StateSet,
 			i:   (*int)(unsafe.Pointer(&params.State)),
 		},
-		"state.reason": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_STATE_REASON: typedParamsFieldInfo{
 			set: &params.ReasonSet,
 			i:   &params.Reason,
 		},
 	}
 }
 
+type DomainStatsCPUCacheMonitorBank struct {
+	IDSet    bool
+	ID       uint
+	BytesSet bool
+	Bytes    uint64
+}
+
+func getDomainStatsCPUCacheMonitorBankFieldInfo(idx1, idx2 int, params *DomainStatsCPUCacheMonitorBank) map[string]typedParamsFieldInfo {
+	return map[string]typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_SUFFIX_ID, idx1, idx2): typedParamsFieldInfo{
+			set: &params.IDSet,
+			ui:  &params.ID,
+		},
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_SUFFIX_BYTES, idx1, idx2): typedParamsFieldInfo{
+			set: &params.BytesSet,
+			ul:  &params.Bytes,
+		},
+	}
+}
+
+type domainStatsCPUCacheMonitorLengths struct {
+	BankCountSet bool
+	BankCount    uint
+}
+
+func getDomainStatsCPUCacheMonitorLengthsFieldInfo(idx int, params *domainStatsCPUCacheMonitorLengths) map[string]typedParamsFieldInfo {
+	return map[string]typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_COUNT, idx): typedParamsFieldInfo{
+			set: &params.BankCountSet,
+			ui:  &params.BankCount,
+		},
+	}
+}
+
+type DomainStatsCPUCacheMonitor struct {
+	NameSet  bool
+	Name     string
+	VcpusSet bool
+	Vcpus    string
+	Banks    []DomainStatsCPUCacheMonitorBank
+}
+
+func getDomainStatsCPUCacheMonitorFieldInfo(idx int, params *DomainStatsCPUCacheMonitor) map[string]typedParamsFieldInfo {
+	return map[string]typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_NAME, idx): typedParamsFieldInfo{
+			set: &params.NameSet,
+			s:   &params.Name,
+		},
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_VCPUS, idx): typedParamsFieldInfo{
+			set: &params.VcpusSet,
+			s:   &params.Vcpus,
+		},
+	}
+}
+
+type domainStatsCPULengths struct {
+	CacheMonitorCountSet bool
+	CacheMonitorCount    uint
+}
+
+func getDomainStatsCPULengthsFieldInfo(params *domainStatsCPULengths) map[string]typedParamsFieldInfo {
+	return map[string]typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_COUNT: typedParamsFieldInfo{
+			set: &params.CacheMonitorCountSet,
+			ui:  &params.CacheMonitorCount,
+		},
+	}
+}
+
 type DomainStatsCPU struct {
-	TimeSet   bool
-	Time      uint64
-	UserSet   bool
-	User      uint64
-	SystemSet bool
-	System    uint64
+	TimeSet                bool
+	Time                   uint64
+	UserSet                bool
+	User                   uint64
+	SystemSet              bool
+	System                 uint64
+	HaltPollSuccessTimeSet bool
+	HaltPollSuccessTime    uint64
+	HaltPollFailTimeSet    bool
+	HaltPollFailTime       uint64
+	CacheMonitors          []DomainStatsCPUCacheMonitor
 }
 
 func getDomainStatsCPUFieldInfo(params *DomainStatsCPU) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		"cpu.time": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_CPU_TIME: typedParamsFieldInfo{
 			set: &params.TimeSet,
 			ul:  &params.Time,
 		},
-		"cpu.user": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_CPU_USER: typedParamsFieldInfo{
 			set: &params.UserSet,
 			ul:  &params.User,
 		},
-		"cpu.system": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_CPU_SYSTEM: typedParamsFieldInfo{
 			set: &params.SystemSet,
 			ul:  &params.System,
+		},
+		C.VIR_DOMAIN_STATS_CPU_HALTPOLL_SUCCESS_TIME: typedParamsFieldInfo{
+			set: &params.HaltPollSuccessTimeSet,
+			ul:  &params.HaltPollSuccessTime,
+		},
+		C.VIR_DOMAIN_STATS_CPU_HALTPOLL_FAIL_TIME: typedParamsFieldInfo{
+			set: &params.HaltPollFailTimeSet,
+			ul:  &params.HaltPollFailTime,
 		},
 	}
 }
@@ -2614,60 +2712,59 @@ type DomainStatsBalloon struct {
 
 func getDomainStatsBalloonFieldInfo(params *DomainStatsBalloon) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		"balloon.current": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_CURRENT: typedParamsFieldInfo{
 			set: &params.CurrentSet,
 			ul:  &params.Current,
 		},
-		"balloon.maximum": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_MAXIMUM: typedParamsFieldInfo{
 			set: &params.MaximumSet,
 			ul:  &params.Maximum,
 		},
-		"balloon.swap_in": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_SWAP_IN: typedParamsFieldInfo{
 			set: &params.SwapInSet,
 			ul:  &params.SwapIn,
 		},
-		"balloon.swap_out": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_SWAP_OUT: typedParamsFieldInfo{
 			set: &params.SwapOutSet,
 			ul:  &params.SwapOut,
 		},
-		"balloon.major_fault": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_MAJOR_FAULT: typedParamsFieldInfo{
 			set: &params.MajorFaultSet,
 			ul:  &params.MajorFault,
 		},
-		"balloon.minor_fault": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_MINOR_FAULT: typedParamsFieldInfo{
 			set: &params.MinorFaultSet,
 			ul:  &params.MinorFault,
 		},
-		"balloon.unused": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_UNUSED: typedParamsFieldInfo{
 			set: &params.UnusedSet,
 			ul:  &params.Unused,
 		},
-		"balloon.available": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_AVAILABLE: typedParamsFieldInfo{
 			set: &params.AvailableSet,
 			ul:  &params.Available,
 		},
-		"balloon.rss": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_RSS: typedParamsFieldInfo{
 			set: &params.RssSet,
 			ul:  &params.Rss,
 		},
-		"balloon.usable": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_USABLE: typedParamsFieldInfo{
 			set: &params.UsableSet,
 			ul:  &params.Usable,
 		},
-		// note: last-update not last_update, verified in libvirt source
-		"balloon.last-update": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_LAST_UPDATE: typedParamsFieldInfo{
 			set: &params.LastUpdateSet,
 			ul:  &params.LastUpdate,
 		},
-		"balloon.disk_caches": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_DISK_CACHES: typedParamsFieldInfo{
 			set: &params.DiskCachesSet,
 			ul:  &params.DiskCaches,
 		},
-		"balloon.hugetlb_pgalloc": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_HUGETLB_PGALLOC: typedParamsFieldInfo{
 			set: &params.HugetlbPgAllocSet,
 			ul:  &params.HugetlbPgAlloc,
 		},
-		"balloon.hugetlb_pgfail": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BALLOON_HUGETLB_PGFAIL: typedParamsFieldInfo{
 			set: &params.HugetlbPgFailSet,
 			ul:  &params.HugetlbPgFail,
 		},
@@ -2685,27 +2782,33 @@ type DomainStatsVcpu struct {
 	Halted    bool
 	DelaySet  bool
 	Delay     uint64
+	Custom    []TypedParamValue
 }
 
 func getDomainStatsVcpuFieldInfo(idx int, params *DomainStatsVcpu) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		fmt.Sprintf("vcpu.%d.state", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_VCPU_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_VCPU_SUFFIX_STATE, idx): typedParamsFieldInfo{
 			set: &params.StateSet,
 			i:   (*int)(unsafe.Pointer(&params.State)),
 		},
-		fmt.Sprintf("vcpu.%d.time", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_VCPU_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_VCPU_SUFFIX_TIME, idx): typedParamsFieldInfo{
 			set: &params.TimeSet,
 			ul:  &params.Time,
 		},
-		fmt.Sprintf("vcpu.%d.wait", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_VCPU_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_VCPU_SUFFIX_WAIT, idx): typedParamsFieldInfo{
 			set: &params.WaitSet,
 			ul:  &params.Wait,
 		},
-		fmt.Sprintf("vcpu.%d.halted", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_VCPU_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_VCPU_SUFFIX_HALTED, idx): typedParamsFieldInfo{
 			set: &params.HaltedSet,
 			b:   &params.Halted,
 		},
-		fmt.Sprintf("vcpu.%d.delay", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_VCPU_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_VCPU_SUFFIX_DELAY, idx): typedParamsFieldInfo{
 			set: &params.DelaySet,
 			ul:  &params.Delay,
 		},
@@ -2735,39 +2838,48 @@ type DomainStatsNet struct {
 
 func getDomainStatsNetFieldInfo(idx int, params *DomainStatsNet) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		fmt.Sprintf("net.%d.name", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_NAME, idx): typedParamsFieldInfo{
 			set: &params.NameSet,
 			s:   &params.Name,
 		},
-		fmt.Sprintf("net.%d.rx.bytes", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_RX_BYTES, idx): typedParamsFieldInfo{
 			set: &params.RxBytesSet,
 			ul:  &params.RxBytes,
 		},
-		fmt.Sprintf("net.%d.rx.pkts", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_RX_PKTS, idx): typedParamsFieldInfo{
 			set: &params.RxPktsSet,
 			ul:  &params.RxPkts,
 		},
-		fmt.Sprintf("net.%d.rx.errs", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_RX_ERRS, idx): typedParamsFieldInfo{
 			set: &params.RxErrsSet,
 			ul:  &params.RxErrs,
 		},
-		fmt.Sprintf("net.%d.rx.drop", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_RX_DROP, idx): typedParamsFieldInfo{
 			set: &params.RxDropSet,
 			ul:  &params.RxDrop,
 		},
-		fmt.Sprintf("net.%d.tx.bytes", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_TX_BYTES, idx): typedParamsFieldInfo{
 			set: &params.TxBytesSet,
 			ul:  &params.TxBytes,
 		},
-		fmt.Sprintf("net.%d.tx.pkts", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_TX_PKTS, idx): typedParamsFieldInfo{
 			set: &params.TxPktsSet,
 			ul:  &params.TxPkts,
 		},
-		fmt.Sprintf("net.%d.tx.errs", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_TX_ERRS, idx): typedParamsFieldInfo{
 			set: &params.TxErrsSet,
 			ul:  &params.TxErrs,
 		},
-		fmt.Sprintf("net.%d.tx.drop", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_NET_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_NET_SUFFIX_TX_DROP, idx): typedParamsFieldInfo{
 			set: &params.TxDropSet,
 			ul:  &params.TxDrop,
 		},
@@ -2805,69 +2917,91 @@ type DomainStatsBlock struct {
 	Capacity        uint64
 	PhysicalSet     bool
 	Physical        uint64
+	ThresholdSet    bool
+	Threshold       uint64
 }
 
 func getDomainStatsBlockFieldInfo(idx int, params *DomainStatsBlock) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		fmt.Sprintf("block.%d.name", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_NAME, idx): typedParamsFieldInfo{
 			set: &params.NameSet,
 			s:   &params.Name,
 		},
-		fmt.Sprintf("block.%d.backingIndex", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_BACKINGINDEX, idx): typedParamsFieldInfo{
 			set: &params.BackingIndexSet,
 			ui:  &params.BackingIndex,
 		},
-		fmt.Sprintf("block.%d.path", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_PATH, idx): typedParamsFieldInfo{
 			set: &params.PathSet,
 			s:   &params.Path,
 		},
-		fmt.Sprintf("block.%d.rd.reqs", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_RD_REQS, idx): typedParamsFieldInfo{
 			set: &params.RdReqsSet,
 			ul:  &params.RdReqs,
 		},
-		fmt.Sprintf("block.%d.rd.bytes", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_RD_BYTES, idx): typedParamsFieldInfo{
 			set: &params.RdBytesSet,
 			ul:  &params.RdBytes,
 		},
-		fmt.Sprintf("block.%d.rd.times", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_RD_TIMES, idx): typedParamsFieldInfo{
 			set: &params.RdTimesSet,
 			ul:  &params.RdTimes,
 		},
-		fmt.Sprintf("block.%d.wr.reqs", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_WR_REQS, idx): typedParamsFieldInfo{
 			set: &params.WrReqsSet,
 			ul:  &params.WrReqs,
 		},
-		fmt.Sprintf("block.%d.wr.bytes", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_WR_BYTES, idx): typedParamsFieldInfo{
 			set: &params.WrBytesSet,
 			ul:  &params.WrBytes,
 		},
-		fmt.Sprintf("block.%d.wr.times", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_WR_TIMES, idx): typedParamsFieldInfo{
 			set: &params.WrTimesSet,
 			ul:  &params.WrTimes,
 		},
-		fmt.Sprintf("block.%d.fl.reqs", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_FL_REQS, idx): typedParamsFieldInfo{
 			set: &params.FlReqsSet,
 			ul:  &params.FlReqs,
 		},
-		fmt.Sprintf("block.%d.fl.times", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_FL_TIMES, idx): typedParamsFieldInfo{
 			set: &params.FlTimesSet,
 			ul:  &params.FlTimes,
 		},
-		fmt.Sprintf("block.%d.errors", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_ERRORS, idx): typedParamsFieldInfo{
 			set: &params.ErrorsSet,
 			ul:  &params.Errors,
 		},
-		fmt.Sprintf("block.%d.allocation", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_ALLOCATION, idx): typedParamsFieldInfo{
 			set: &params.AllocationSet,
 			ul:  &params.Allocation,
 		},
-		fmt.Sprintf("block.%d.capacity", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_CAPACITY, idx): typedParamsFieldInfo{
 			set: &params.CapacitySet,
 			ul:  &params.Capacity,
 		},
-		fmt.Sprintf("block.%d.physical", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_PHYSICAL, idx): typedParamsFieldInfo{
 			set: &params.PhysicalSet,
 			ul:  &params.Physical,
+		},
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_BLOCK_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_BLOCK_SUFFIX_THRESHOLD, idx): typedParamsFieldInfo{
+			set: &params.ThresholdSet,
+			ul:  &params.Threshold,
 		},
 	}
 }
@@ -2921,91 +3055,91 @@ type DomainStatsPerf struct {
 
 func getDomainStatsPerfFieldInfo(params *DomainStatsPerf) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		"perf.cmt": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_CMT: typedParamsFieldInfo{
 			set: &params.CmtSet,
 			ul:  &params.Cmt,
 		},
-		"perf.mbmt": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_MBMT: typedParamsFieldInfo{
 			set: &params.MbmtSet,
 			ul:  &params.Mbmt,
 		},
-		"perf.mbml": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_MBML: typedParamsFieldInfo{
 			set: &params.MbmlSet,
 			ul:  &params.Mbml,
 		},
-		"perf.cache_misses": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_CACHE_MISSES: typedParamsFieldInfo{
 			set: &params.CacheMissesSet,
 			ul:  &params.CacheMisses,
 		},
-		"perf.cache_references": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_CACHE_REFERENCES: typedParamsFieldInfo{
 			set: &params.CacheReferencesSet,
 			ul:  &params.CacheReferences,
 		},
-		"perf.instructions": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_INSTRUCTIONS: typedParamsFieldInfo{
 			set: &params.InstructionsSet,
 			ul:  &params.Instructions,
 		},
-		"perf.cpu_cycles": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_CPU_CYCLES: typedParamsFieldInfo{
 			set: &params.CpuCyclesSet,
 			ul:  &params.CpuCycles,
 		},
-		"perf.branch_instructions": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_BRANCH_INSTRUCTIONS: typedParamsFieldInfo{
 			set: &params.BranchInstructionsSet,
 			ul:  &params.BranchInstructions,
 		},
-		"perf.branch_misses": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_BRANCH_MISSES: typedParamsFieldInfo{
 			set: &params.BranchMissesSet,
 			ul:  &params.BranchMisses,
 		},
-		"perf.bus_cycles": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_BUS_CYCLES: typedParamsFieldInfo{
 			set: &params.BusCyclesSet,
 			ul:  &params.BusCycles,
 		},
-		"perf.stalled_cycles_frontend": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_STALLED_CYCLES_FRONTEND: typedParamsFieldInfo{
 			set: &params.StalledCyclesFrontendSet,
 			ul:  &params.StalledCyclesFrontend,
 		},
-		"perf.stalled_cycles_backend": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_STALLED_CYCLES_BACKEND: typedParamsFieldInfo{
 			set: &params.StalledCyclesBackendSet,
 			ul:  &params.StalledCyclesBackend,
 		},
-		"perf.ref_cpu_cycles": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_REF_CPU_CYCLES: typedParamsFieldInfo{
 			set: &params.RefCpuCyclesSet,
 			ul:  &params.RefCpuCycles,
 		},
-		"perf.cpu_clock": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_CPU_CLOCK: typedParamsFieldInfo{
 			set: &params.CpuClockSet,
 			ul:  &params.CpuClock,
 		},
-		"perf.task_clock": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_TASK_CLOCK: typedParamsFieldInfo{
 			set: &params.TaskClockSet,
 			ul:  &params.TaskClock,
 		},
-		"perf.page_faults": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_PAGE_FAULTS: typedParamsFieldInfo{
 			set: &params.PageFaultsSet,
 			ul:  &params.PageFaults,
 		},
-		"perf.context_switches": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_CONTEXT_SWITCHES: typedParamsFieldInfo{
 			set: &params.ContextSwitchesSet,
 			ul:  &params.ContextSwitches,
 		},
-		"perf.cpu_migrations": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_CPU_MIGRATIONS: typedParamsFieldInfo{
 			set: &params.CpuMigrationsSet,
 			ul:  &params.CpuMigrations,
 		},
-		"perf.page_faults_min": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_PAGE_FAULTS_MIN: typedParamsFieldInfo{
 			set: &params.PageFaultsMinSet,
 			ul:  &params.PageFaultsMin,
 		},
-		"perf.page_faults_maj": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_PAGE_FAULTS_MAJ: typedParamsFieldInfo{
 			set: &params.PageFaultsMajSet,
 			ul:  &params.PageFaultsMaj,
 		},
-		"perf.alignment_faults": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_ALIGNMENT_FAULTS: typedParamsFieldInfo{
 			set: &params.AlignmentFaultsSet,
 			ul:  &params.AlignmentFaults,
 		},
-		"perf.emulation_faults": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_PERF_EMULATION_FAULTS: typedParamsFieldInfo{
 			set: &params.EmulationFaultsSet,
 			ul:  &params.EmulationFaults,
 		},
@@ -3026,11 +3160,13 @@ type DomainStatsMemoryBandwidthMonitor struct {
 
 func getDomainStatsMemoryBandwidthMonitorFieldInfo(idx int, params *DomainStatsMemoryBandwidthMonitor) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		fmt.Sprintf("memory.bandwidth.monitor.%d.name", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NAME, idx): typedParamsFieldInfo{
 			set: &params.NameSet,
 			s:   &params.Name,
 		},
-		fmt.Sprintf("memory.bandwidth.monitor.%d.vcpus", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_VCPUS, idx): typedParamsFieldInfo{
 			set: &params.VCPUsSet,
 			s:   &params.VCPUs,
 		},
@@ -3044,7 +3180,8 @@ type domainStatsMemoryBandwidthMonitorLengths struct {
 
 func getDomainStatsMemoryBandwidthMonitorLengthsFieldInfo(idx int, params *domainStatsMemoryBandwidthMonitorLengths) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		fmt.Sprintf("memory.bandwidth.monitor.%d.node.count", idx): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_COUNT, idx): typedParamsFieldInfo{
 			set: &params.NodeCountSet,
 			ui:  &params.NodeCount,
 		},
@@ -3062,17 +3199,38 @@ type DomainStatsMemoryBandwidthMonitorNode struct {
 
 func getDomainStatsMemoryBandwidthMonitorNodeFieldInfo(idx1, idx2 int, params *DomainStatsMemoryBandwidthMonitorNode) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		fmt.Sprintf("memory.bandwidth.monitor.%d.node.%d.id", idx1, idx2): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_SUFFIX_ID, idx1, idx2): typedParamsFieldInfo{
 			set: &params.IDSet,
 			ui:  &params.ID,
 		},
-		fmt.Sprintf("memory.bandwidth.monitor.%d.node.%d.bytes.local", idx1, idx2): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_SUFFIX_BYTES_LOCAL, idx1, idx2): typedParamsFieldInfo{
 			set: &params.BytesLocalSet,
 			ul:  &params.BytesLocal,
 		},
-		fmt.Sprintf("memory.bandwidth.monitor.%d.node.%d.bytes.total", idx1, idx2): typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_SUFFIX_BYTES_TOTAL, idx1, idx2): typedParamsFieldInfo{
 			set: &params.BytesTotalSet,
 			ul:  &params.BytesTotal,
+		},
+	}
+}
+
+type DomainStatsDirtyRateVCPU struct {
+	MegabytesPerSecondSet bool
+	MegabytesPerSecond    int64
+}
+
+func getDomainStatsDirtyRateVCPUFieldInfo(idx int, params *DomainStatsDirtyRateVCPU) map[string]typedParamsFieldInfo {
+	return map[string]typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_DIRTYRATE_VCPU_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_DIRTYRATE_VCPU_SUFFIX_MEGABYTES_PER_SECOND, idx): typedParamsFieldInfo{
+			set: &params.MegabytesPerSecondSet,
+			l:   &params.MegabytesPerSecond,
 		},
 	}
 }
@@ -3086,25 +3244,65 @@ type DomainStatsDirtyRate struct {
 	CalcPeriod            int
 	MegabytesPerSecondSet bool
 	MegabytesPerSecond    int64
+	CalcModeSet           bool
+	CalcMode              string
+	VCPUS                 []DomainStatsDirtyRateVCPU
 }
 
 func getDomainStatsDirtyRateFieldInfo(params *DomainStatsDirtyRate) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		"dirtyrate.calc_status": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_DIRTYRATE_CALC_STATUS: typedParamsFieldInfo{
 			set: &params.CalcStatusSet,
 			i:   &params.CalcStatus,
 		},
-		"dirtyrate.calc_start_time": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_DIRTYRATE_CALC_START_TIME: typedParamsFieldInfo{
 			set: &params.CalcStartTimeSet,
 			l:   &params.CalcStartTime,
 		},
-		"dirtyrate.calc_period": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_DIRTYRATE_CALC_PERIOD: typedParamsFieldInfo{
 			set: &params.CalcPeriodSet,
 			i:   &params.CalcPeriod,
 		},
-		"dirtyrate.megabytes_per_second": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_DIRTYRATE_MEGABYTES_PER_SECOND: typedParamsFieldInfo{
 			set: &params.MegabytesPerSecondSet,
 			l:   &params.MegabytesPerSecond,
+		},
+		C.VIR_DOMAIN_STATS_DIRTYRATE_CALC_MODE: typedParamsFieldInfo{
+			set: &params.CalcModeSet,
+			s:   &params.CalcMode,
+		},
+	}
+}
+
+type DomainStatsIOThread struct {
+	PollMaxNSSet  bool
+	PollMaxNS     uint64
+	PollGrowSet   bool
+	PollGrow      uint
+	PollGrow64    uint64
+	PollShrinkSet bool
+	PollShrink    uint
+	PollShrink64  uint64
+}
+
+func getDomainStatsIOThreadFieldInfo(idx int, params *DomainStatsIOThread) map[string]typedParamsFieldInfo {
+	return map[string]typedParamsFieldInfo{
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_IOTHREAD_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_IOTHREAD_SUFFIX_POLL_MAX_NS, idx): typedParamsFieldInfo{
+			set: &params.PollMaxNSSet,
+			ul:  &params.PollMaxNS,
+		},
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_IOTHREAD_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_IOTHREAD_SUFFIX_POLL_GROW, idx): typedParamsFieldInfo{
+			set: &params.PollGrowSet,
+			ui:  &params.PollGrow,
+			ul:  &params.PollGrow64,
+		},
+		fmt.Sprintf(C.VIR_DOMAIN_STATS_IOTHREAD_PREFIX+"%d"+
+			C.VIR_DOMAIN_STATS_IOTHREAD_SUFFIX_POLL_SHRINK, idx): typedParamsFieldInfo{
+			set: &params.PollShrinkSet,
+			ui:  &params.PollShrink,
+			ul:  &params.PollShrink64,
 		},
 	}
 }
@@ -3121,6 +3319,7 @@ type DomainStats struct {
 	Memory    *DomainStatsMemory
 	DirtyRate *DomainStatsDirtyRate
 	VM        []TypedParamValue
+	IOThread  []DomainStatsIOThread
 }
 
 type domainStatsLengths struct {
@@ -3134,31 +3333,46 @@ type domainStatsLengths struct {
 	BlockCount        uint
 	BandwidthCountSet bool
 	BandwidthCount    uint
+	IOThreadCountSet  bool
+	IOThreadCount     uint
 }
 
 func getDomainStatsLengthsFieldInfo(params *domainStatsLengths) map[string]typedParamsFieldInfo {
 	return map[string]typedParamsFieldInfo{
-		"vcpu.current": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_VCPU_CURRENT: typedParamsFieldInfo{
 			set: &params.VcpuCurrentSet,
 			ui:  &params.VcpuCurrent,
 		},
-		"vcpu.maximum": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_VCPU_MAXIMUM: typedParamsFieldInfo{
 			set: &params.VcpuMaximumSet,
 			ui:  &params.VcpuMaximum,
 		},
-		"net.count": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_NET_COUNT: typedParamsFieldInfo{
 			set: &params.NetCountSet,
 			ui:  &params.NetCount,
 		},
-		"block.count": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_BLOCK_COUNT: typedParamsFieldInfo{
 			set: &params.BlockCountSet,
 			ui:  &params.BlockCount,
 		},
-		"memory.bandwidth.monitor.count": typedParamsFieldInfo{
+		C.VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_COUNT: typedParamsFieldInfo{
 			set: &params.BandwidthCountSet,
 			ui:  &params.BandwidthCount,
 		},
+		C.VIR_DOMAIN_STATS_IOTHREAD_COUNT: typedParamsFieldInfo{
+			set: &params.IOThreadCountSet,
+			ui:  &params.IOThreadCount,
+		},
 	}
+}
+
+func filterCustomStats(key string) bool {
+	if !strings.HasSuffix(key, C.VIR_DOMAIN_STATS_CUSTOM_SUFFIX_TYPE_CUR) &&
+		!strings.HasSuffix(key, C.VIR_DOMAIN_STATS_CUSTOM_SUFFIX_TYPE_MAX) &&
+		!strings.HasSuffix(key, C.VIR_DOMAIN_STATS_CUSTOM_SUFFIX_TYPE_SUM) {
+		return false
+	}
+	return true
 }
 
 // See also https://libvirt.org/html/libvirt-libvirt-domain.html#virConnectGetAllDomainStats
@@ -3221,6 +3435,47 @@ func (c *Connect) GetAllDomainStats(doms []*Domain, statsTypes DomainStatsTypes,
 			domstats.Cpu = cpu
 		}
 
+		cpuLengths := domainStatsCPULengths{}
+		cpuLengthsInfo := getDomainStatsCPULengthsFieldInfo(&cpuLengths)
+
+		_, gerr = typedParamsUnpack(cdomstats.params, cdomstats.nparams, cpuLengthsInfo)
+		if gerr != nil {
+			return nil, gerr
+		}
+
+		if cpuLengths.CacheMonitorCountSet && cpuLengths.CacheMonitorCount > 0 {
+			cpu.CacheMonitors = make([]DomainStatsCPUCacheMonitor, cpuLengths.CacheMonitorCount)
+			for i := 0; i < int(cpuLengths.CacheMonitorCount); i++ {
+				cpuCacheInfo := getDomainStatsCPUCacheMonitorFieldInfo(i, &cpu.CacheMonitors[i])
+
+				_, gerr = typedParamsUnpack(cdomstats.params, cdomstats.nparams, cpuCacheInfo)
+				if gerr != nil {
+					return nil, gerr
+				}
+
+				cpuCacheMonitorLengths := domainStatsCPUCacheMonitorLengths{}
+				cpuCacheMonitorLengthsInfo := getDomainStatsCPUCacheMonitorLengthsFieldInfo(i, &cpuCacheMonitorLengths)
+
+				_, gerr = typedParamsUnpack(cdomstats.params, cdomstats.nparams, cpuCacheMonitorLengthsInfo)
+				if gerr != nil {
+					return nil, gerr
+				}
+
+				if cpuCacheMonitorLengths.BankCountSet && cpuCacheMonitorLengths.BankCount > 0 {
+					cpu.CacheMonitors[i].Banks = make([]DomainStatsCPUCacheMonitorBank, cpuCacheMonitorLengths.BankCount)
+					for j := 0; j < int(cpuCacheMonitorLengths.BankCount); j++ {
+						cpuCacheBankInfo := getDomainStatsCPUCacheMonitorBankFieldInfo(i, j, &cpu.CacheMonitors[i].Banks[j])
+
+						_, gerr = typedParamsUnpack(cdomstats.params, cdomstats.nparams, cpuCacheBankInfo)
+						if gerr != nil {
+							return nil, gerr
+						}
+					}
+				}
+
+			}
+		}
+
 		balloon := &DomainStatsBalloon{}
 		balloonInfo := getDomainStatsBalloonFieldInfo(balloon)
 
@@ -3270,6 +3525,14 @@ func (c *Connect) GetAllDomainStats(doms []*Domain, statsTypes DomainStatsTypes,
 					vcpu.StateSet = true
 					vcpu.State = VCPU_OFFLINE
 				}
+
+				vcpu.Custom, gerr = typedParamsUnpackRaw(
+					fmt.Sprintf("vcpu.%d.", j), filterCustomStats,
+					cdomstats.params, cdomstats.nparams)
+				if gerr != nil {
+					return []DomainStats{}, gerr
+				}
+
 				domstats.Vcpu[j] = vcpu
 			}
 		}
@@ -3361,7 +3624,41 @@ func (c *Connect) GetAllDomainStats(doms []*Domain, statsTypes DomainStatsTypes,
 			domstats.DirtyRate = dirtyrate
 		}
 
-		domstats.VM, gerr = typedParamsUnpackRaw("vm.", cdomstats.params, cdomstats.nparams)
+		vcpuCount, gerr := domstats.Domain.GetVcpusFlags(DOMAIN_VCPU_MAXIMUM)
+		if vcpuCount > 0 {
+			dirtyrate.VCPUS = make([]DomainStatsDirtyRateVCPU, count)
+			for j := 0; j < int(vcpuCount); j++ {
+				vcpu := DomainStatsDirtyRateVCPU{}
+				vcpuInfo := getDomainStatsDirtyRateVCPUFieldInfo(j, &vcpu)
+
+				count, gerr = typedParamsUnpack(cdomstats.params, cdomstats.nparams, vcpuInfo)
+				if gerr != nil {
+					return []DomainStats{}, gerr
+				}
+				if count != 0 {
+					dirtyrate.VCPUS[j] = vcpu
+				}
+			}
+		}
+
+		if lengths.IOThreadCountSet && lengths.IOThreadCount > 0 {
+			domstats.IOThread = make([]DomainStatsIOThread, lengths.IOThreadCount)
+			for j := 0; j < int(lengths.IOThreadCount); j++ {
+				block := DomainStatsIOThread{}
+				blockInfo := getDomainStatsIOThreadFieldInfo(j, &block)
+
+				count, gerr = typedParamsUnpack(cdomstats.params, cdomstats.nparams, blockInfo)
+				if gerr != nil {
+					return []DomainStats{}, gerr
+				}
+				if count != 0 {
+					domstats.IOThread[j] = block
+				}
+			}
+		}
+
+		domstats.VM, gerr = typedParamsUnpackRaw(C.VIR_DOMAIN_STATS_VM_PREFIX,
+			filterCustomStats, cdomstats.params, cdomstats.nparams)
 		if gerr != nil {
 			return []DomainStats{}, gerr
 		}

--- a/vendor/libvirt.org/go/libvirt/domain_events_helper.go
+++ b/vendor/libvirt.org/go/libvirt/domain_events_helper.go
@@ -261,6 +261,7 @@ void domainEventMemoryFailureCallbackHelper(virConnectPtr conn,
     domainEventMemoryFailureCallback(conn, dom, recipient, action, flags, (int)(intptr_t)opaque);
 }
 
+
 extern void domainEventMemoryDeviceSizeChangeCallback(virConnectPtr, virDomainPtr, const char *, unsigned long long, int);
 void domainEventMemoryDeviceSizeChangeCallbackHelper(virConnectPtr conn,
 						virDomainPtr dom,
@@ -271,6 +272,17 @@ void domainEventMemoryDeviceSizeChangeCallbackHelper(virConnectPtr conn,
   domainEventMemoryDeviceSizeChangeCallback(conn, dom, alias, size, (int)(intptr_t)opaque);
 }
 
+
+extern void domainEventNICMACChangeCallback(virConnectPtr, virDomainPtr, const char *, const char *, const char *, int);
+void domainEventNICMACChangeCallbackHelper(virConnectPtr conn,
+                                           virDomainPtr dom,
+                                           const char *alias,
+                                           const char *oldMAC,
+                                           const char *newMAC,
+void *opaque)
+{
+	domainEventNICMACChangeCallback(conn, dom, alias, oldMAC, newMAC, (int)(intptr_t)opaque);
+}
 
 int
 virConnectDomainEventRegisterAnyHelper(virConnectPtr conn,

--- a/vendor/libvirt.org/go/libvirt/domain_events_helper.h
+++ b/vendor/libvirt.org/go/libvirt/domain_events_helper.h
@@ -229,6 +229,13 @@ domainEventMemoryDeviceSizeChangeCallbackHelper(virConnectPtr conn,
 						unsigned long long size,
 						void *opaque);
 
+void
+domainEventNICMACChangeCallbackHelper(virConnectPtr conn,
+                                      virDomainPtr dom,
+                                      const char *alias,
+                                      const char *oldMAC,
+                                      const char *newMAC,
+                                      void *opaque);
 
 int
 virConnectDomainEventRegisterAnyHelper(virConnectPtr conn,

--- a/vendor/libvirt.org/go/libvirt/error.go
+++ b/vendor/libvirt.org/go/libvirt/error.go
@@ -395,6 +395,12 @@ const (
 
 	// The metadata is not present
 	ERR_NO_NETWORK_METADATA = ErrorNumber(C.VIR_ERR_NO_NETWORK_METADATA)
+
+	// Guest agent didn't respond to a non-sync command within timeout
+	ERR_AGENT_COMMAND_TIMEOUT = ErrorNumber(C.VIR_ERR_AGENT_COMMAND_TIMEOUT)
+
+	// Guest agent responded with failure to a command
+	ERR_AGENT_COMMAND_FAILED = ErrorNumber(C.VIR_ERR_AGENT_COMMAND_FAILED)
 )
 
 type ErrorDomain int

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_callbacks.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_callbacks.h
@@ -205,6 +205,15 @@ typedef void (*virConnectDomainEventMigrationIterationCallback)(virConnectPtr co
                                                                 void * opaque);
 #endif
 
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+typedef void (*virConnectDomainEventNICMACChangeCallback)(virConnectPtr conn,
+                                                          virDomainPtr dom,
+                                                          const char * alias,
+                                                          const char * oldMAC,
+                                                          const char * newMAC,
+                                                          void * opaque);
+#endif
+
 #if !LIBVIR_CHECK_VERSION(0, 9, 11)
 typedef void (*virConnectDomainEventPMSuspendCallback)(virConnectPtr conn,
                                                        virDomainPtr dom,

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_enums.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_enums.h
@@ -226,6 +226,11 @@
 #    define VIR_CONNECT_GET_ALL_DOMAINS_STATS_ENFORCE_STATS (1U << 31)
 #  endif
 
+/* enum virConnectGetDomainCapabilitiesFlags */
+#  if !LIBVIR_CHECK_VERSION(11, 0, 0)
+#    define VIR_CONNECT_GET_DOMAIN_CAPABILITIES_DISABLE_DEPRECATED_FEATURES (1 << 0)
+#  endif
+
 /* enum virConnectListAllDomainsFlags */
 #  if !LIBVIR_CHECK_VERSION(0, 9, 13)
 #    define VIR_CONNECT_LIST_DOMAINS_ACTIVE (1 << 0)
@@ -370,6 +375,12 @@
 #  endif
 #  if !LIBVIR_CHECK_VERSION(7, 9, 0)
 #    define VIR_CONNECT_LIST_NODE_DEVICES_CAP_VPD (1 << 21)
+#  endif
+#  if !LIBVIR_CHECK_VERSION(11, 1, 0)
+#    define VIR_CONNECT_LIST_NODE_DEVICES_CAP_CCWGROUP_DEV (1 << 22)
+#  endif
+#  if !LIBVIR_CHECK_VERSION(11, 1, 0)
+#    define VIR_CONNECT_LIST_NODE_DEVICES_CAP_CCWGROUP_MEMBER (1 << 23)
 #  endif
 #  if !LIBVIR_CHECK_VERSION(10, 1, 0)
 #    define VIR_CONNECT_LIST_NODE_DEVICES_PERSISTENT (1 << 28)
@@ -980,8 +991,11 @@
 #  if !LIBVIR_CHECK_VERSION(7, 9, 0)
 #    define VIR_DOMAIN_EVENT_ID_MEMORY_DEVICE_SIZE_CHANGE 26
 #  endif
+#  if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#    define VIR_DOMAIN_EVENT_ID_NIC_MAC_CHANGE 27
+#  endif
 #  if !LIBVIR_CHECK_VERSION(0, 8, 0)
-#    define VIR_DOMAIN_EVENT_ID_LAST 27
+#    define VIR_DOMAIN_EVENT_ID_LAST 28
 #  endif
 
 /* enum virDomainEventIOErrorAction */
@@ -1258,6 +1272,9 @@
 #  if !LIBVIR_CHECK_VERSION(7, 10, 0)
 #    define VIR_DOMAIN_GUEST_INFO_INTERFACES (1 << 6)
 #  endif
+#  if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#    define VIR_DOMAIN_GUEST_INFO_LOAD (1 << 7)
+#  endif
 
 /* enum virDomainInterfaceAddressesSource */
 #  if !LIBVIR_CHECK_VERSION(1, 2, 14)
@@ -1482,6 +1499,9 @@
 #  endif
 #  if !LIBVIR_CHECK_VERSION(7, 1, 0)
 #    define VIR_DOMAIN_MESSAGE_TAINTING (1 << 1)
+#  endif
+#  if !LIBVIR_CHECK_VERSION(11, 1, 0)
+#    define VIR_DOMAIN_MESSAGE_IOERRORS (1 << 2)
 #  endif
 
 /* enum virDomainMetadataType */
@@ -2821,8 +2841,14 @@
 #  if !LIBVIR_CHECK_VERSION(9, 7, 0)
 #    define VIR_ERR_NO_NETWORK_METADATA 111
 #  endif
+#  if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#    define VIR_ERR_AGENT_COMMAND_TIMEOUT 112
+#  endif
+#  if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#    define VIR_ERR_AGENT_COMMAND_FAILED 113
+#  endif
 #  if !LIBVIR_CHECK_VERSION(5, 0, 0)
-#    define VIR_ERR_NUMBER_LAST 112
+#    define VIR_ERR_NUMBER_LAST 114
 #  endif
 
 /* enum virEventHandleType */

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_functions.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_functions.h
@@ -712,6 +712,12 @@ virDomainDelIOThreadWrapper(virDomainPtr domain,
                             virErrorPtr err);
 
 int
+virDomainDelThrottleGroupWrapper(virDomainPtr dom,
+                                 const char * group,
+                                 unsigned int flags,
+                                 virErrorPtr err);
+
+int
 virDomainDestroyWrapper(virDomainPtr domain,
                         virErrorPtr err);
 
@@ -777,6 +783,11 @@ int
 virDomainGetAutostartWrapper(virDomainPtr domain,
                              int * autostart,
                              virErrorPtr err);
+
+int
+virDomainGetAutostartOnceWrapper(virDomainPtr domain,
+                                 int * autostart,
+                                 virErrorPtr err);
 
 int
 virDomainGetBlkioParametersWrapper(virDomainPtr domain,
@@ -1437,6 +1448,11 @@ virDomainSetAutostartWrapper(virDomainPtr domain,
                              virErrorPtr err);
 
 int
+virDomainSetAutostartOnceWrapper(virDomainPtr domain,
+                                 int autostart,
+                                 virErrorPtr err);
+
+int
 virDomainSetBlkioParametersWrapper(virDomainPtr domain,
                                    virTypedParameterPtr params,
                                    int nparams,
@@ -1559,6 +1575,14 @@ virDomainSetSchedulerParametersFlagsWrapper(virDomainPtr domain,
                                             int nparams,
                                             unsigned int flags,
                                             virErrorPtr err);
+
+int
+virDomainSetThrottleGroupWrapper(virDomainPtr dom,
+                                 const char * group,
+                                 virTypedParameterPtr params,
+                                 int nparams,
+                                 unsigned int flags,
+                                 virErrorPtr err);
 
 int
 virDomainSetTimeWrapper(virDomainPtr dom,

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_functions_dlopen_domain.go
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_functions_dlopen_domain.go
@@ -1511,6 +1511,38 @@ virDomainDelIOThreadWrapper(virDomainPtr domain,
 }
 
 typedef int
+(*virDomainDelThrottleGroupFuncType)(virDomainPtr dom,
+                                     const char * group,
+                                     unsigned int flags);
+
+int
+virDomainDelThrottleGroupWrapper(virDomainPtr dom,
+                                 const char * group,
+                                 unsigned int flags,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+    static virDomainDelThrottleGroupFuncType virDomainDelThrottleGroupSymbol;
+    static bool once;
+    static bool success;
+
+    if (!libvirtSymbol("virDomainDelThrottleGroup",
+                       (void**)&virDomainDelThrottleGroupSymbol,
+                       &once,
+                       &success,
+                       err)) {
+        return ret;
+    }
+    ret = virDomainDelThrottleGroupSymbol(dom,
+                                          group,
+                                          flags);
+    if (ret < 0) {
+        virCopyLastErrorWrapper(err);
+    }
+    return ret;
+}
+
+typedef int
 (*virDomainDestroyFuncType)(virDomainPtr domain);
 
 int
@@ -1871,6 +1903,35 @@ virDomainGetAutostartWrapper(virDomainPtr domain,
     }
     ret = virDomainGetAutostartSymbol(domain,
                                       autostart);
+    if (ret < 0) {
+        virCopyLastErrorWrapper(err);
+    }
+    return ret;
+}
+
+typedef int
+(*virDomainGetAutostartOnceFuncType)(virDomainPtr domain,
+                                     int * autostart);
+
+int
+virDomainGetAutostartOnceWrapper(virDomainPtr domain,
+                                 int * autostart,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+    static virDomainGetAutostartOnceFuncType virDomainGetAutostartOnceSymbol;
+    static bool once;
+    static bool success;
+
+    if (!libvirtSymbol("virDomainGetAutostartOnce",
+                       (void**)&virDomainGetAutostartOnceSymbol,
+                       &once,
+                       &success,
+                       err)) {
+        return ret;
+    }
+    ret = virDomainGetAutostartOnceSymbol(domain,
+                                          autostart);
     if (ret < 0) {
         virCopyLastErrorWrapper(err);
     }
@@ -5224,6 +5285,35 @@ virDomainSetAutostartWrapper(virDomainPtr domain,
 }
 
 typedef int
+(*virDomainSetAutostartOnceFuncType)(virDomainPtr domain,
+                                     int autostart);
+
+int
+virDomainSetAutostartOnceWrapper(virDomainPtr domain,
+                                 int autostart,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+    static virDomainSetAutostartOnceFuncType virDomainSetAutostartOnceSymbol;
+    static bool once;
+    static bool success;
+
+    if (!libvirtSymbol("virDomainSetAutostartOnce",
+                       (void**)&virDomainSetAutostartOnceSymbol,
+                       &once,
+                       &success,
+                       err)) {
+        return ret;
+    }
+    ret = virDomainSetAutostartOnceSymbol(domain,
+                                          autostart);
+    if (ret < 0) {
+        virCopyLastErrorWrapper(err);
+    }
+    return ret;
+}
+
+typedef int
 (*virDomainSetBlkioParametersFuncType)(virDomainPtr domain,
                                        virTypedParameterPtr params,
                                        int nparams,
@@ -5841,6 +5931,44 @@ virDomainSetSchedulerParametersFlagsWrapper(virDomainPtr domain,
                                                      params,
                                                      nparams,
                                                      flags);
+    if (ret < 0) {
+        virCopyLastErrorWrapper(err);
+    }
+    return ret;
+}
+
+typedef int
+(*virDomainSetThrottleGroupFuncType)(virDomainPtr dom,
+                                     const char * group,
+                                     virTypedParameterPtr params,
+                                     int nparams,
+                                     unsigned int flags);
+
+int
+virDomainSetThrottleGroupWrapper(virDomainPtr dom,
+                                 const char * group,
+                                 virTypedParameterPtr params,
+                                 int nparams,
+                                 unsigned int flags,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+    static virDomainSetThrottleGroupFuncType virDomainSetThrottleGroupSymbol;
+    static bool once;
+    static bool success;
+
+    if (!libvirtSymbol("virDomainSetThrottleGroup",
+                       (void**)&virDomainSetThrottleGroupSymbol,
+                       &once,
+                       &success,
+                       err)) {
+        return ret;
+    }
+    ret = virDomainSetThrottleGroupSymbol(dom,
+                                          group,
+                                          params,
+                                          nparams,
+                                          flags);
     if (ret < 0) {
         virCopyLastErrorWrapper(err);
     }

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_functions_static_domain.go
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_functions_static_domain.go
@@ -962,6 +962,26 @@ virDomainDelIOThreadWrapper(virDomainPtr domain,
 }
 
 int
+virDomainDelThrottleGroupWrapper(virDomainPtr dom,
+                                 const char * group,
+                                 unsigned int flags,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+    setVirError(err, "Function virDomainDelThrottleGroup not available prior to libvirt version 11.2.0");
+#else
+    ret = virDomainDelThrottleGroup(dom,
+                                    group,
+                                    flags);
+    if (ret < 0) {
+        virCopyLastError(err);
+    }
+#endif
+    return ret;
+}
+
+int
 virDomainDestroyWrapper(virDomainPtr domain,
                         virErrorPtr err)
 {
@@ -1182,6 +1202,24 @@ virDomainGetAutostartWrapper(virDomainPtr domain,
 #else
     ret = virDomainGetAutostart(domain,
                                 autostart);
+    if (ret < 0) {
+        virCopyLastError(err);
+    }
+#endif
+    return ret;
+}
+
+int
+virDomainGetAutostartOnceWrapper(virDomainPtr domain,
+                                 int * autostart,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+    setVirError(err, "Function virDomainGetAutostartOnce not available prior to libvirt version 11.2.0");
+#else
+    ret = virDomainGetAutostartOnce(domain,
+                                    autostart);
     if (ret < 0) {
         virCopyLastError(err);
     }
@@ -3282,6 +3320,24 @@ virDomainSetAutostartWrapper(virDomainPtr domain,
 }
 
 int
+virDomainSetAutostartOnceWrapper(virDomainPtr domain,
+                                 int autostart,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+    setVirError(err, "Function virDomainSetAutostartOnce not available prior to libvirt version 11.2.0");
+#else
+    ret = virDomainSetAutostartOnce(domain,
+                                    autostart);
+    if (ret < 0) {
+        virCopyLastError(err);
+    }
+#endif
+    return ret;
+}
+
+int
 virDomainSetBlkioParametersWrapper(virDomainPtr domain,
                                    virTypedParameterPtr params,
                                    int nparams,
@@ -3666,6 +3722,30 @@ virDomainSetSchedulerParametersFlagsWrapper(virDomainPtr domain,
                                                params,
                                                nparams,
                                                flags);
+    if (ret < 0) {
+        virCopyLastError(err);
+    }
+#endif
+    return ret;
+}
+
+int
+virDomainSetThrottleGroupWrapper(virDomainPtr dom,
+                                 const char * group,
+                                 virTypedParameterPtr params,
+                                 int nparams,
+                                 unsigned int flags,
+                                 virErrorPtr err)
+{
+    int ret = -1;
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+    setVirError(err, "Function virDomainSetThrottleGroup not available prior to libvirt version 11.2.0");
+#else
+    ret = virDomainSetThrottleGroup(dom,
+                                    group,
+                                    params,
+                                    nparams,
+                                    flags);
     if (ret < 0) {
         virCopyLastError(err);
     }

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_macros.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_macros.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #if !LIBVIR_CHECK_VERSION(0, 0, 1)
-#  define LIBVIR_VERSION_NUMBER 10009000
+#  define LIBVIR_VERSION_NUMBER 11002000
 #endif
 
 #if !LIBVIR_CHECK_VERSION(5, 8, 0)
@@ -272,6 +272,218 @@
 #  define VIR_DOMAIN_CPU_STATS_VCPUTIME "vcpu_time"
 #endif
 
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_COUNT "disk.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_PREFIX "disk."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_ALIAS ".alias"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_DEPENDENCY_COUNT ".dependency.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_DEPENDENCY_PREFIX ".dependency."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_DEPENDENCY_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_GUEST_ALIAS ".guest_alias"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_GUEST_BUS ".guest_bus"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_PARTITION ".partition"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_DISK_SUFFIX_SERIAL ".serial"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_COUNT "fs.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_PREFIX "fs."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_DISK_COUNT ".disk.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_DISK_PREFIX ".disk."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_DISK_SUFFIX_ALIAS ".alias"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_DISK_SUFFIX_DEVICE ".device"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_DISK_SUFFIX_SERIAL ".serial"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_FSTYPE ".fstype"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_MOUNTPOINT ".mountpoint"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_TOTAL_BYTES ".total-bytes"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_FS_SUFFIX_USED_BYTES ".used-bytes"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_HOSTNAME_HOSTNAME "hostname"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_COUNT "if.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_PREFIX "if."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_SUFFIX_ADDR_COUNT ".addr.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_SUFFIX_ADDR_PREFIX ".addr."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_SUFFIX_ADDR_SUFFIX_ADDR ".addr"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_SUFFIX_ADDR_SUFFIX_PREFIX ".prefix"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_SUFFIX_ADDR_SUFFIX_TYPE ".type"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_SUFFIX_HWADDR ".hwaddr"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_IF_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_LOAD_15M "load.15m"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_LOAD_1M "load.1m"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_LOAD_5M "load.5m"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_ID "os.id"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_KERNEL_RELEASE "os.kernel-release"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_KERNEL_VERSION "os.kernel-version"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_MACHINE "os.machine"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_NAME "os.name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_PRETTY_NAME "os.pretty-name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_VARIANT "os.variant"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_VARIANT_ID "os.variant-id"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_VERSION "os.version"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_OS_VERSION_ID "os.version-id"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_TIMEZONE_NAME "timezone.name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_TIMEZONE_OFFSET "timezone.offset"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_USER_COUNT "user.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_USER_PREFIX "user."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_USER_SUFFIX_DOMAIN ".domain"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_USER_SUFFIX_LOGIN_TIME ".login-time"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_GUEST_INFO_USER_SUFFIX_NAME ".name"
+#endif
+
 #if !LIBVIR_CHECK_VERSION(4, 10, 0)
 #  define VIR_DOMAIN_IOTHREAD_POLL_GROW "poll_grow"
 #endif
@@ -512,6 +724,14 @@
 #  define VIR_DOMAIN_SAVE_PARAM_FILE "file"
 #endif
 
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_SAVE_PARAM_IMAGE_FORMAT "image_format"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_SAVE_PARAM_PARALLEL_CHANNELS "parallel.channels"
+#endif
+
 #if !LIBVIR_CHECK_VERSION(0, 9, 7)
 #  define VIR_DOMAIN_SCHEDULER_CAP "cap"
 #endif
@@ -574,6 +794,458 @@
 
 #if !LIBVIR_CHECK_VERSION(0, 9, 3)
 #  define VIR_DOMAIN_SEND_KEY_MAX_KEYS 16
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_AVAILABLE "balloon.available"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_CURRENT "balloon.current"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_DISK_CACHES "balloon.disk_caches"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_HUGETLB_PGALLOC "balloon.hugetlb_pgalloc"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_HUGETLB_PGFAIL "balloon.hugetlb_pgfail"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_LAST_UPDATE "balloon.last-update"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_MAJOR_FAULT "balloon.major_fault"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_MAXIMUM "balloon.maximum"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_MINOR_FAULT "balloon.minor_fault"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_RSS "balloon.rss"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_SWAP_IN "balloon.swap_in"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_SWAP_OUT "balloon.swap_out"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_UNUSED "balloon.unused"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BALLOON_USABLE "balloon.usable"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_COUNT "block.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_PREFIX "block."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_ALLOCATION ".allocation"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_BACKINGINDEX ".backingIndex"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_CAPACITY ".capacity"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_ERRORS ".errors"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_FL_REQS ".fl.reqs"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_FL_TIMES ".fl.times"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_PATH ".path"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_PHYSICAL ".physical"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_RD_BYTES ".rd.bytes"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_RD_REQS ".rd.reqs"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_RD_TIMES ".rd.times"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_THRESHOLD ".threshold"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_WR_BYTES ".wr.bytes"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_WR_REQS ".wr.reqs"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_BLOCK_SUFFIX_WR_TIMES ".wr.times"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_COUNT "cpu.cache.monitor.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_PREFIX "cpu.cache.monitor."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_COUNT ".bank.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_PREFIX ".bank."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_SUFFIX_BYTES ".bytes"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_BANK_SUFFIX_ID ".id"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_CACHE_MONITOR_SUFFIX_VCPUS ".vcpus"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_HALTPOLL_FAIL_TIME "cpu.haltpoll.fail.time"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_HALTPOLL_SUCCESS_TIME "cpu.haltpoll.success.time"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_SYSTEM "cpu.system"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_TIME "cpu.time"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CPU_USER "cpu.user"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CUSTOM_SUFFIX_TYPE_CUR ".cur"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CUSTOM_SUFFIX_TYPE_MAX ".max"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_CUSTOM_SUFFIX_TYPE_SUM ".sum"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_DIRTYRATE_CALC_MODE "dirtyrate.calc_mode"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_DIRTYRATE_CALC_PERIOD "dirtyrate.calc_period"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_DIRTYRATE_CALC_START_TIME "dirtyrate.calc_start_time"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_DIRTYRATE_CALC_STATUS "dirtyrate.calc_status"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_DIRTYRATE_MEGABYTES_PER_SECOND "dirtyrate.megabytes_per_second"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_DIRTYRATE_VCPU_PREFIX "dirtyrate.vcpu."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_DIRTYRATE_VCPU_SUFFIX_MEGABYTES_PER_SECOND ".megabytes_per_second"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_IOTHREAD_COUNT "iothread.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_IOTHREAD_PREFIX "iothread."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_IOTHREAD_SUFFIX_POLL_GROW ".poll-grow"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_IOTHREAD_SUFFIX_POLL_MAX_NS ".poll-max-ns"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_IOTHREAD_SUFFIX_POLL_SHRINK ".poll-shrink"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_COUNT "memory.bandwidth.monitor.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_PREFIX "memory.bandwidth.monitor."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_COUNT ".node.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_PREFIX ".node."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_SUFFIX_BYTES_LOCAL ".bytes.local"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_SUFFIX_BYTES_TOTAL ".bytes.total"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_NODE_SUFFIX_ID ".id"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_MEMORY_BANDWIDTH_MONITOR_SUFFIX_VCPUS ".vcpus"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_COUNT "net.count"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_PREFIX "net."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_NAME ".name"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_RX_BYTES ".rx.bytes"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_RX_DROP ".rx.drop"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_RX_ERRS ".rx.errs"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_RX_PKTS ".rx.pkts"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_TX_BYTES ".tx.bytes"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_TX_DROP ".tx.drop"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_TX_ERRS ".tx.errs"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_NET_SUFFIX_TX_PKTS ".tx.pkts"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_ALIGNMENT_FAULTS "perf.alignment_faults"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_BRANCH_INSTRUCTIONS "perf.branch_instructions"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_BRANCH_MISSES "perf.branch_misses"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_BUS_CYCLES "perf.bus_cycles"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_CACHE_MISSES "perf.cache_misses"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_CACHE_REFERENCES "perf.cache_references"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_CMT "perf.cmt"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_CONTEXT_SWITCHES "perf.context_switches"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_CPU_CLOCK "perf.cpu_clock"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_CPU_CYCLES "perf.cpu_cycles"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_CPU_MIGRATIONS "perf.cpu_migrations"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_EMULATION_FAULTS "perf.emulation_faults"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_INSTRUCTIONS "perf.instructions"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_MBML "perf.mbml"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_MBMT "perf.mbmt"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_PAGE_FAULTS "perf.page_faults"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_PAGE_FAULTS_MAJ "perf.page_faults_maj"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_PAGE_FAULTS_MIN "perf.page_faults_min"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_REF_CPU_CYCLES "perf.ref_cpu_cycles"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_STALLED_CYCLES_BACKEND "perf.stalled_cycles_backend"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_STALLED_CYCLES_FRONTEND "perf.stalled_cycles_frontend"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_PERF_TASK_CLOCK "perf.task_clock"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_STATE_REASON "state.reason"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_STATE_STATE "state.state"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_CURRENT "vcpu.current"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_MAXIMUM "vcpu.maximum"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_PREFIX "vcpu."
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_SUFFIX_DELAY ".delay"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_SUFFIX_HALTED ".halted"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_SUFFIX_STATE ".state"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_SUFFIX_TIME ".time"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VCPU_SUFFIX_WAIT ".wait"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 2, 0)
+#  define VIR_DOMAIN_STATS_VM_PREFIX "vm."
 #endif
 
 #if !LIBVIR_CHECK_VERSION(1, 2, 9)
@@ -722,6 +1394,10 @@
 
 #if !LIBVIR_CHECK_VERSION(1, 1, 0)
 #  define VIR_MIGRATE_PARAM_BANDWIDTH "bandwidth"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(11, 1, 0)
+#  define VIR_MIGRATE_PARAM_BANDWIDTH_AVAIL_SWITCHOVER "bandwidth.avail.switchover"
 #endif
 
 #if !LIBVIR_CHECK_VERSION(5, 1, 0)

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_typedefs.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_typedefs.h
@@ -276,6 +276,10 @@ typedef int virConnectFlags;
 typedef int virConnectGetAllDomainStatsFlags;
 #endif
 
+#if !LIBVIR_CHECK_VERSION(11, 0, 0)
+typedef int virConnectGetDomainCapabilitiesFlags;
+#endif
+
 #if !LIBVIR_CHECK_VERSION(0, 9, 13)
 typedef int virConnectListAllDomainsFlags;
 #endif

--- a/vendor/libvirt.org/go/libvirt/stream.go
+++ b/vendor/libvirt.org/go/libvirt/stream.go
@@ -114,6 +114,10 @@ func (v *Stream) Recv(p []byte) (int, error) {
 		pPtr = (*C.char)(unsafe.Pointer(&p[0]))
 	}
 	n := C.virStreamRecvWrapper(v.ptr, pPtr, C.size_t(np), &err)
+	// -2 == blocking, -3 == in hole
+	if n == -2 || n == -3 {
+		return int(n), nil
+	}
 	if n < 0 {
 		return 0, makeError(&err)
 	}
@@ -133,6 +137,10 @@ func (v *Stream) RecvFlags(p []byte, flags StreamRecvFlagsValues) (int, error) {
 		pPtr = (*C.char)(unsafe.Pointer(&p[0]))
 	}
 	n := C.virStreamRecvFlagsWrapper(v.ptr, pPtr, C.size_t(np), C.uint(flags), &err)
+	// -2 == blocking, -3 == in hole
+	if n == -2 || n == -3 {
+		return int(n), nil
+	}
 	if n < 0 {
 		return 0, makeError(&err)
 	}
@@ -164,6 +172,10 @@ func (v *Stream) Send(p []byte) (int, error) {
 		pPtr = (*C.char)(unsafe.Pointer(&p[0]))
 	}
 	n := C.virStreamSendWrapper(v.ptr, pPtr, C.size_t(np), &err)
+	// -2 == blocking
+	if n == -2 {
+		return int(n), nil
+	}
 	if n < 0 {
 		return 0, makeError(&err)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1288,7 +1288,7 @@ kubevirt.io/controller-lifecycle-operator-sdk/api
 ## explicit; go 1.16
 kubevirt.io/qe-tools/pkg/ginkgo-reporters
 kubevirt.io/qe-tools/pkg/polarion-xml
-# libvirt.org/go/libvirt v1.10009.1
+# libvirt.org/go/libvirt v1.11002.0
 ## explicit; go 1.11
 libvirt.org/go/libvirt
 # libvirt.org/go/libvirtxml v1.11000.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This upgrade resolves a bug in getting
the user's login time from libvirt API,
that currently is always 0 because of
the typo bug in this library.

Jira-Url: https://issues.redhat.com/browse/CNV-63874

### References

This upgrade includes the resolved bug in libvirt-go as mentioned [here](https://gitlab.com/libvirt/libvirt-go-module/-/commit/602a3c5a9493d75598967685c82ea6cc38f71c1b).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```