### PR TITLE
Remove e2e PreferredStorageClassName test and add test_id to unit covering it

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -415,13 +415,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			Expect(*dataVolumeTemapltes[0].Spec.Storage.StorageClassName).To(Equal(expectedStorageClassName))
 		}
 
-		It("should apply PreferredStorageClassName to PVC", func() {
+		It("[test_id:10328]should apply PreferredStorageClassName to PVC", func() {
 			vm.Spec.DataVolumeTemplates[0].Spec.PVC = &k8sv1.PersistentVolumeClaimSpec{}
 			vmSpec, _ := getVMSpecMetaFromResponseCreate(rt.GOARCH)
 			assertPVCStorageClassName(vmSpec.DataVolumeTemplates, preference.Spec.Volumes.PreferredStorageClassName)
 		})
 
-		It("should apply PreferredStorageClassName to Storage", func() {
+		It("[test_id:10329]should apply PreferredStorageClassName to Storage", func() {
 			vm.Spec.DataVolumeTemplates[0].Spec.Storage = &cdiv1.StorageSpec{}
 			vmSpec, _ := getVMSpecMetaFromResponseCreate(rt.GOARCH)
 			assertStorageStorageClassName(vmSpec.DataVolumeTemplates, preference.Spec.Volumes.PreferredStorageClassName)


### PR DESCRIPTION
### What this PR does
#### Before this PR:
There was a e2e test for `PreferredStorageClassName` which is already covered by a unit test in [vm-mutator_test.go](https://github.com/kubevirt/kubevirt/blob/96471d5212257b42a885326c10f07f0c5d87412b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go#L419-L429)

#### After this PR:
 - `should use PreferredStorageClassName when storage class not provided by VM` test is removed
 - test_id added to unit tests under vm-mutator_test.go
 - refactor the test to reduce the complexity of the test - we only need a single test scope since the test only verify a single option
 
### References
Links to places where the discussion took place: #14991 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

