### PR TITLE
handler: wait for migration being finalized

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -42,6 +42,7 @@ source hack/config-default.sh
 CANNIER_IMAGE="${CANNIER_IMAGE-quay.io/kubevirtci/cannier:v20250328-a1ef64e}"
 
 export TIMESTAMP=${TIMESTAMP:-1}
+export JOB_NAME="pull-kubevirt-k8s-1.33-check-tests-for-flakes"
 
 function usage() {
     cat <<EOF

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -2096,8 +2096,13 @@ func (c *Controller) outboundMigrationsOnNode(node string, runningMigrations []*
 	sum := 0
 	for _, migration := range runningMigrations {
 		key := controller.NamespacedKey(migration.Namespace, migration.Spec.VMIName)
-		if vmi, exists, _ := c.vmiStore.GetByKey(key); exists {
-			if vmi.(*virtv1.VirtualMachineInstance).Status.NodeName == node {
+		if obj, exists, _ := c.vmiStore.GetByKey(key); exists {
+			vmi := obj.(*virtv1.VirtualMachineInstance)
+			if vmi.Status.NodeName == node ||
+				(vmi.Status.MigrationState != nil &&
+					vmi.Status.MigrationState.SourceNode == node &&
+					!vmi.Status.MigrationState.Completed &&
+					!vmi.Status.MigrationState.Failed) {
 				sum = sum + 1
 			}
 		}

--- a/pkg/virt-handler/controller.go
+++ b/pkg/virt-handler/controller.go
@@ -276,9 +276,13 @@ func isMigrationInProgress(vmi *v1.VirtualMachineInstance, domain *api.Domain) b
 	var domainMigrationMetadata *api.MigrationMetadata
 	if vmi != nil &&
 		vmi.Status.MigrationState != nil &&
-		vmi.Status.MigrationState.StartTimestamp != nil &&
-		vmi.Status.MigrationState.EndTimestamp == nil {
-		return true
+		vmi.Status.MigrationState.StartTimestamp != nil {
+		if vmi.Status.MigrationState.EndTimestamp == nil {
+			return true
+		}
+		if !vmi.Status.MigrationState.Completed != !vmi.Status.MigrationState.Failed {
+			return true
+		}
 	}
 
 	if domain != nil {

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -415,11 +415,14 @@ func (c *MigrationSourceController) execute(key string) error {
 }
 
 func (c *MigrationSourceController) isMigrationSource(vmi *v1.VirtualMachineInstance) bool {
+	if vmi.IsDecentralizedMigration() {
+		return vmi.Status.MigrationState != nil &&
+			vmi.Status.MigrationState.SourceNode == c.host &&
+			vmi.IsMigrationSource()
+	}
 	return vmi.Status.MigrationState != nil &&
-		vmi.Status.MigrationState.SourceNode == c.host &&
-		(!vmi.IsDecentralizedMigration() || vmi.IsMigrationSource()) &&
-		vmi.Status.MigrationState.TargetNodeAddress != "" &&
-		!vmi.Status.MigrationState.Completed
+		vmi.Status.NodeName == c.host &&
+		vmi.Status.MigrationState.SourceNode == c.host
 }
 
 func (c *MigrationSourceController) handleSourceMigrationProxy(vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -313,7 +313,8 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 					SourceNode:        host,
 					TargetNodeAddress: "othernode",
 					Completed:         false,
-				}))))
+				}), libvmistatus.WithNodeName(host)),
+			))
 			d.Spec.Metadata.KubeVirt.Migration.FailureReason = "some failure happened"
 
 			controller.setMigrationProgressStatus(vmi, d)

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -199,10 +199,10 @@ func domainIsActiveOnTarget(domain *api.Domain) bool {
 
 func (c *MigrationTargetController) ackMigrationCompletion(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	vmi.Status.MigrationState.EndTimestamp = domain.Spec.Metadata.KubeVirt.Migration.EndTimestamp
-	vmi.Labels[v1.NodeNameLabel] = c.host
-	delete(vmi.Labels, v1.OutdatedLauncherImageLabel)
-	vmi.Status.LauncherContainerImageVersion = ""
-	vmi.Status.NodeName = c.host
+	//vmi.Labels[v1.NodeNameLabel] = c.host
+	//delete(vmi.Labels, v1.OutdatedLauncherImageLabel)
+	//vmi.Status.LauncherContainerImageVersion = ""
+	//vmi.Status.NodeName = c.host
 	// clean the evacuation node name since have already migrated to a new node
 	vmi.Status.EvacuationNodeName = ""
 	// update the vmi migrationTransport to indicate that next migration should use unix URI
@@ -988,5 +988,9 @@ func (c *MigrationTargetController) finalizeMigration(vmi *v1.VirtualMachineInst
 	}
 
 	vmi.Status.MigrationState.Completed = true
+	vmi.Labels[v1.NodeNameLabel] = c.host
+	delete(vmi.Labels, v1.OutdatedLauncherImageLabel)
+	vmi.Status.LauncherContainerImageVersion = ""
+	vmi.Status.NodeName = c.host
 	return nil
 }

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -421,7 +421,8 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 			})
 		})
 		Context("with multiple VMIs with eviction policies set", Serial, func() {
-			It("[QUARANTINE][release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", decorators.Quarantine, func() {
+			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
+
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := alpineVMIWithEvictionStrategy()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Once the migration target has set the migration Endtimestamp,
the vmi handler starts processing the normal lifecycle back.
Actually, it should also wait for the migration to be finalized,
and hence the `Completed` field set.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

