### PR TITLE
Restore isMigrationSource to original

### DIFF
--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -415,11 +415,14 @@ func (c *MigrationSourceController) execute(key string) error {
 }
 
 func (c *MigrationSourceController) isMigrationSource(vmi *v1.VirtualMachineInstance) bool {
+	if vmi.IsDecentralizedMigration() {
+		return vmi.Status.MigrationState != nil &&
+			vmi.Status.MigrationState.SourceNode == c.host &&
+			vmi.IsMigrationSource()
+	}
 	return vmi.Status.MigrationState != nil &&
-		vmi.Status.MigrationState.SourceNode == c.host &&
-		(!vmi.IsDecentralizedMigration() || vmi.IsMigrationSource()) &&
-		vmi.Status.MigrationState.TargetNodeAddress != "" &&
-		!vmi.Status.MigrationState.Completed
+		vmi.Status.NodeName == c.host &&
+		vmi.Status.MigrationState.SourceNode == c.host
 }
 
 func (c *MigrationSourceController) handleSourceMigrationProxy(vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -313,7 +313,8 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 					SourceNode:        host,
 					TargetNodeAddress: "othernode",
 					Completed:         false,
-				}))))
+				}), libvmistatus.WithNodeName(host)),
+			))
 			d.Spec.Metadata.KubeVirt.Migration.FailureReason = "some failure happened"
 
 			controller.setMigrationProgressStatus(vmi, d)


### PR DESCRIPTION
### What this PR does
The core decentralized live migration PR didn't completely isolate its functionality behind the feature gate. The isMigrationSource check was affected by the change while it should not have been. This PR restores the original functionality when the feature gate is disabled (aka the migration is not decentralized)

  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/24

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

