### PR TITLE
tests: virt-handler cache: increase too short timeout

### DIFF
--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -330,7 +330,9 @@ var _ = Describe("Domain informer", func() {
 			defer d.Stop()
 
 			timedOut := false
-			timeout := time.After(5 * time.Second)
+			// The timeout on trying to dial the socket is 5 seconds, doubling that to make sure we reach that point
+			// before our own timeout.
+			timeout := time.After(10 * time.Second)
 			select {
 			case event := <-d.eventChan:
 				Expect(event.Type).To(Equal(watch.Modified))

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Domain informer", func() {
 	var resyncPeriod int
 	var ghostRecordStore *GhostRecordStore
 
-	podUID := "1234"
+	const podUID = "1234"
 
 	BeforeEach(func() {
 		resyncPeriod = 5
@@ -78,7 +78,7 @@ var _ = Describe("Domain informer", func() {
 		cmdclient.SetPodsBaseDir(podsDir)
 
 		socketPath = cmdclient.SocketFilePathOnHost(podUID)
-		os.MkdirAll(filepath.Dir(socketPath), 0755)
+		Expect(os.MkdirAll(filepath.Dir(socketPath), 0755)).To(Succeed())
 
 		informer = NewSharedInformer(shareDir, 10, nil, nil, time.Duration(resyncPeriod)*time.Second)
 		Expect(err).ToNot(HaveOccurred())
@@ -90,9 +90,9 @@ var _ = Describe("Domain informer", func() {
 	AfterEach(func() {
 		close(stopChan)
 		wg.Wait()
-		os.RemoveAll(shareDir)
-		os.RemoveAll(podsDir)
-		os.RemoveAll(ghostCacheDir)
+		Expect(os.RemoveAll(shareDir)).To(Succeed())
+		Expect(os.RemoveAll(podsDir)).To(Succeed())
+		Expect(os.RemoveAll(ghostCacheDir)).To(Succeed())
 	})
 
 	verifyObj := func(key string, domain *api.Domain, g Gomega) {
@@ -270,7 +270,6 @@ var _ = Describe("Domain informer", func() {
 		})
 
 		It("should resync active domains after resync period.", func() {
-
 			domain := api.NewMinimalDomain("test")
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{domain}, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
@@ -310,19 +309,18 @@ var _ = Describe("Domain informer", func() {
 		})
 
 		It("should detect unresponsive sockets.", func() {
-
 			f, err := os.Create(socketPath)
 			Expect(err).ToNot(HaveOccurred())
-			f.Close()
+			Expect(f.Close()).To(Succeed())
 
-			ghostRecordStore.Add("test", "test", socketPath, "1234")
+			Expect(ghostRecordStore.Add("test", "test", socketPath, "1234")).To(Succeed())
 
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,
 				virtShareDir:             shareDir,
 				watchdogTimeout:          1,
 				unresponsiveSockets:      make(map[string]int64),
-				resyncPeriod:             time.Duration(1) * time.Hour,
+				resyncPeriod:             1 * time.Hour,
 			}
 
 			err = d.startBackground()
@@ -342,11 +340,9 @@ var _ = Describe("Domain informer", func() {
 			}
 
 			Expect(timedOut).To(BeFalse())
-
 		})
 
 		It("should detect responsive sockets and not mark for deletion.", func() {
-
 			l, err := net.Listen("unix", socketPath)
 			Expect(err).ToNot(HaveOccurred())
 			defer l.Close()
@@ -358,12 +354,11 @@ var _ = Describe("Domain informer", func() {
 						// closes when socket listener is closed
 						return
 					}
-					conn.Close()
+					Expect(conn.Close()).To(Succeed())
 				}
 			}()
 
-			err = ghostRecordStore.Add("test", "test", socketPath, "1234")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(ghostRecordStore.Add("test", "test", socketPath, "1234")).To(Succeed())
 
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The test waits 5 seconds for something that happens after 5 seconds, leading to potential flakes:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15058/pull-kubevirt-unit-test/1940380205600215040

#### After this PR:
The test waits 10 seconds + misc cleanup

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

