### PR TITLE
Image upload: Label PVCs to add support for rendering webhook 

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -70,6 +70,10 @@ const (
 	UsePopulatorAnnotation          = "cdi.kubevirt.io/storage.usePopulator"
 	PVCPrimeNameAnnotation          = "cdi.kubevirt.io/storage.populator.pvcPrime"
 
+	// labelApplyStorageProfile is a label used by the CDI mutating webhook
+	// to modify the PVC according to the storage profile.
+	labelApplyStorageProfile = "cdi.kubevirt.io/applyStorageProfile"
+
 	uploadReadyWaitInterval = 2 * time.Second
 
 	processingWaitInterval = 2 * time.Second
@@ -757,11 +761,21 @@ func (c *command) createUploadPVC() (*v1.PersistentVolumeClaim, error) {
 		contentTypeAnnotation:   contentType,
 	}
 
+	labels := map[string]string{
+		// Adding this label to allow the PVC to be processed by the CDI WebhookPvcRendering mutating webhook,
+		// which must be enabled in the CDI CR via feature gate.
+		// This mutating webhook processes the PVC based on its associated StorageProfile.
+		// For example, a profile can define a minimum supported volume size via the annotation:
+		// cdi.kubevirt.io/minimumSupportedPvcSize: 4Gi
+		labelApplyStorageProfile: "true",
+	}
+
 	if c.forceBind {
 		annotations[forceImmediateBindingAnnotation] = ""
 	}
 
 	pvc.ObjectMeta.Annotations = annotations
+	pvc.ObjectMeta.Labels = labels
 	c.setDefaultInstancetypeLabels(&pvc.ObjectMeta)
 
 	pvc, err = c.client.CoreV1().PersistentVolumeClaims(c.namespace).Create(context.Background(), pvc, metav1.CreateOptions{})

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -44,6 +44,7 @@ const (
 	deleteAfterCompletionAnnotation = "cdi.kubevirt.io/storage.deleteAfterCompletion"
 	UsePopulatorAnnotation          = "cdi.kubevirt.io/storage.usePopulator"
 	PVCPrimeNameAnnotation          = "cdi.kubevirt.io/storage.populator.pvcPrime"
+	labelApplyStorageProfile        = "cdi.kubevirt.io/applyStorageProfile"
 )
 
 const (
@@ -408,6 +409,8 @@ var _ = Describe("ImageUpload", func() {
 		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Get(context.Background(), targetName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		validateDefaultInstancetypeLabels(pvc.ObjectMeta.Labels)
+		// This label is applied by default to all imageupload-created PVCs
+		Expect(pvc.ObjectMeta.Labels).To(HaveKeyWithValue(labelApplyStorageProfile, "true"))
 	}
 
 	validateDataVolumeDefaultInstancetypeLabels := func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR adds the `cdi.kubevirt.io/applyStorageProfile: "true"` label to PVCs created by the image-upload command. This allows the PVCs to be mutated by CDI's WebhookPvcRendering feature if enabled via feature gate.

This is mainly to support applying a minimum supported PVC size via the storage profile annotation cdi.kubevirt.io/minimumSupportedPvcSize, which helps with provisioners that don't support small sizes.
  
- Fixes # https://issues.redhat.com/browse/CNV-64464

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Label upload PVCs to support CDI WebhookPvcRendering 
```

