### PR TITLE
Stop agent poller when VM is paused

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -455,13 +455,7 @@ func (n *Notifier) StartDomainNotifier(
 				domainCache = util.NewDomainFromName(event.Domain, vmi.UID)
 				eventCaller.eventCallback(domainConn, domainCache, event, n, deleteNotificationSent, interfaceStatuses, guestOsInfo, vmi, fsFreezeStatus, metadataCache)
 				log.Log.Infof("Domain name event: %v", domainCache.Spec.Name)
-				if event.AgentEvent != nil {
-					if event.AgentEvent.State == libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_CONNECTED {
-						agentPoller.Start()
-					} else if event.AgentEvent.State == libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_DISCONNECTED {
-						agentPoller.Stop()
-					}
-				}
+				agentPoller.UpdateFromEvent(event.Event, event.AgentEvent)
 			case agentUpdate := <-agentStore.AgentUpdated:
 				metadataCache.ResetNotification()
 				interfaceStatuses = agentUpdate.DomainInfo.Interfaces

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -244,6 +244,130 @@ var _ = Describe("Qemu agent poller", func() {
 			Expect(commandExecutions).To(Equal(expectedExecutions))
 		})
 	})
+
+	Context("UpdateFromEvent", func() {
+		var agentPoller *AgentPoller
+
+		BeforeEach(func() {
+			agentPoller = &AgentPoller{
+				Connection: mockLibvirt.VirtConnection,
+				domainName: "test-domain",
+				agentStore: &agentStore,
+			}
+		})
+
+		It("should stop agent poller on domain suspend event", func() {
+			agentPoller.Start()
+			Expect(agentPoller.agentDone).ToNot(BeNil())
+
+			domainEvent := &libvirt.DomainEventLifecycle{
+				Event:  libvirt.DOMAIN_EVENT_SUSPENDED,
+				Detail: int(libvirt.DOMAIN_EVENT_SUSPENDED_PAUSED),
+			}
+			agentPoller.UpdateFromEvent(domainEvent, nil)
+
+			Expect(agentPoller.agentDone).To(BeNil())
+		})
+
+		It("should start agent poller on domain resume event when agent is connected", func() {
+			Expect(agentPoller.agentDone).To(BeNil())
+
+			agentConnectEvent := &libvirt.DomainEventAgentLifecycle{
+				State:  libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_CONNECTED,
+				Reason: libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_REASON_CHANNEL,
+			}
+			agentPoller.UpdateFromEvent(nil, agentConnectEvent)
+
+			// Stop to simulate domain suspend
+			agentPoller.Stop()
+			Expect(agentPoller.agentDone).To(BeNil())
+
+			domainEvent := &libvirt.DomainEventLifecycle{
+				Event:  libvirt.DOMAIN_EVENT_RESUMED,
+				Detail: int(libvirt.DOMAIN_EVENT_RESUMED_UNPAUSED),
+			}
+			agentPoller.UpdateFromEvent(domainEvent, nil)
+
+			Expect(agentPoller.agentDone).ToNot(BeNil())
+		})
+
+		It("should not start agent poller on domain resume event when agent is not connected", func() {
+			Expect(agentPoller.agentDone).To(BeNil())
+
+			Expect(agentPoller.agentConnected).To(BeFalse())
+
+			domainEvent := &libvirt.DomainEventLifecycle{
+				Event:  libvirt.DOMAIN_EVENT_RESUMED,
+				Detail: int(libvirt.DOMAIN_EVENT_RESUMED_UNPAUSED),
+			}
+			agentPoller.UpdateFromEvent(domainEvent, nil)
+
+			Expect(agentPoller.agentDone).To(BeNil())
+		})
+
+		It("should stop agent poller on agent disconnect event", func() {
+			agentConnectEvent := &libvirt.DomainEventAgentLifecycle{
+				State:  libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_CONNECTED,
+				Reason: libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_REASON_CHANNEL,
+			}
+			agentPoller.UpdateFromEvent(nil, agentConnectEvent)
+			Expect(agentPoller.agentDone).ToNot(BeNil())
+			Expect(agentPoller.agentConnected).To(BeTrue())
+
+			agentDisconnectEvent := &libvirt.DomainEventAgentLifecycle{
+				State:  libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_DISCONNECTED,
+				Reason: libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_REASON_CHANNEL,
+			}
+			agentPoller.UpdateFromEvent(nil, agentDisconnectEvent)
+
+			Expect(agentPoller.agentDone).To(BeNil())
+			Expect(agentPoller.agentConnected).To(BeFalse())
+		})
+
+		It("should start agent poller on agent connect event", func() {
+			Expect(agentPoller.agentDone).To(BeNil())
+			Expect(agentPoller.agentConnected).To(BeFalse())
+
+			agentEvent := &libvirt.DomainEventAgentLifecycle{
+				State:  libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_CONNECTED,
+				Reason: libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_REASON_CHANNEL,
+			}
+			agentPoller.UpdateFromEvent(nil, agentEvent)
+
+			Expect(agentPoller.agentDone).ToNot(BeNil())
+			Expect(agentPoller.agentConnected).To(BeTrue())
+		})
+
+		It("should not start or stop agent poller on unrelated events", func() {
+			agentPoller.Start()
+			originalState := agentPoller.agentDone
+			Expect(originalState).ToNot(BeNil())
+
+			unrelatedDomainEvent := &libvirt.DomainEventLifecycle{
+				Event:  libvirt.DOMAIN_EVENT_STARTED, // Different event
+				Detail: int(libvirt.DOMAIN_EVENT_STARTED_BOOTED),
+			}
+			agentPoller.UpdateFromEvent(unrelatedDomainEvent, nil)
+
+			// State should remain unchanged
+			Expect(agentPoller.agentDone).To(Equal(originalState))
+
+			anotherUnrelatedEvent := &libvirt.DomainEventLifecycle{
+				Event:  libvirt.DOMAIN_EVENT_STOPPED,
+				Detail: int(libvirt.DOMAIN_EVENT_STOPPED_SHUTDOWN),
+			}
+			agentPoller.UpdateFromEvent(anotherUnrelatedEvent, nil)
+
+			// State should still remain unchanged
+			Expect(agentPoller.agentDone).To(Equal(originalState))
+
+			// Test with completely empty events
+			agentPoller.UpdateFromEvent(nil, nil)
+
+			// State should still remain unchanged
+			Expect(agentPoller.agentDone).To(Equal(originalState))
+		})
+	})
 })
 
 // runPollAndCountCommandExecution runs a PollerWorker with the specified polling interval


### PR DESCRIPTION
When VM is paused, virt-launcher logs are filled with qemu agent command failures (generated from the agent poller).
Ensure that agent poller stops when a VM is paused and start it when VM is resumed. This prevents unnecessary polling of the guest agent (that will fail anyway) when the VM is not running. 

Implementation:
Added UpdateFromEvent() function that handles both domain lifecycle events (suspend/resume) and agent lifecycle events (connect/disconnect) for starting/stopping the agent poller.
Testing:
Added 5 test cases covering all agent poller lifecycle scenarios

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
When VM is paused, virt-launcher logs spams qemu guest agent command failures
#### After this PR:
When VM is paused, agent poller will stop until the VM is resumed.
### References
  was discovered while working on #10759 PR: https://github.com/kubevirt/kubevirt/pull/15001
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
@codingben FYI
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

