### PR TITLE
virt-operator, tests: Move external CA tests under correct parent

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2322,138 +2322,138 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				}, 1*time.Minute, 5*time.Second).Should(Succeed())
 			})
 		})
+	})
 
-		Context("external CA", func() {
-			createCrt := func(duration time.Duration) *tls.Certificate {
-				caKeyPair, _ := triple.NewCA("test.kubevirt.io", duration)
+	Context("external CA", func() {
+		createCrt := func(duration time.Duration) *tls.Certificate {
+			caKeyPair, _ := triple.NewCA("test.kubevirt.io", duration)
 
-				encodedCert := cert.EncodeCertPEM(caKeyPair.Cert)
-				encodedKey := cert.EncodePrivateKeyPEM(caKeyPair.Key)
+			encodedCert := cert.EncodeCertPEM(caKeyPair.Cert)
+			encodedKey := cert.EncodePrivateKeyPEM(caKeyPair.Key)
 
-				crt, err := tls.X509KeyPair(encodedCert, encodedKey)
-				Expect(err).ToNot(HaveOccurred())
-				leaf, err := cert.ParseCertsPEM(encodedCert)
-				Expect(err).ToNot(HaveOccurred())
-				crt.Leaf = leaf[0]
+			crt, err := tls.X509KeyPair(encodedCert, encodedKey)
+			Expect(err).ToNot(HaveOccurred())
+			leaf, err := cert.ParseCertsPEM(encodedCert)
+			Expect(err).ToNot(HaveOccurred())
+			crt.Leaf = leaf[0]
 
-				return &crt
-			}
+			return &crt
+		}
 
-			It("should create a blank configmap", func() {
-				Eventually(func(g Gomega) {
-					cm, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
-					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(cm.Data).To(HaveKeyWithValue(components.CABundleKey, ""))
-				}, 1*time.Minute, 5*time.Second).Should(Succeed())
-			})
-
-			It("should properly manage adding entries to the configmap", func() {
-				// add an entry to the configmap
+		It("should create a blank configmap", func() {
+			Eventually(func(g Gomega) {
 				cm, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cm.Data).To(HaveKeyWithValue(components.CABundleKey, ""))
+			}, 1*time.Minute, 5*time.Second).Should(Succeed())
+		})
 
-				cert1 := createCrt(time.Hour)
-				cert2 := createCrt(time.Hour)
-				cert3 := createCrt(time.Millisecond)
-				cert1Encoded := cert.EncodeCertPEM(cert1.Leaf)
-				cert2Encoded := cert.EncodeCertPEM(cert2.Leaf)
-				cert3Encoded := cert.EncodeCertPEM(cert3.Leaf)
-				// Sleep a bit to ensure the third cert is expired
-				time.Sleep(10 * time.Millisecond)
-				now := time.Now()
-				By("ensure cert1 is valid")
-				Expect(cert1.Leaf.NotBefore).To(BeTemporally("<", now))
-				Expect(cert1.Leaf.NotAfter).To(BeTemporally(">", now))
-				By("ensure cert2 is valid")
-				Expect(cert2.Leaf.NotBefore).To(BeTemporally("<", now))
-				Expect(cert2.Leaf.NotAfter).To(BeTemporally(">", now))
-				By("ensure cert3 is expired")
-				Expect(cert3.Leaf.NotBefore).To(BeTemporally("<", now))
-				Expect(cert3.Leaf.NotAfter).To(BeTemporally("<", now))
+		It("should properly manage adding entries to the configmap", func() {
+			// add an entry to the configmap
+			cm, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
-				By("Adding the first cert")
-				cm.Data[components.CABundleKey] = string(cert1Encoded)
-				_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(func(g Gomega) {
-					cm, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
-					g.Expect(err).ToNot(HaveOccurred())
-					val, ok := cm.Data[components.CABundleKey]
-					g.Expect(ok).To(BeTrue())
-					g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
-				}, 10*time.Second, time.Second).Should(Succeed())
-				cm, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+			cert1 := createCrt(time.Hour)
+			cert2 := createCrt(time.Hour)
+			cert3 := createCrt(time.Millisecond)
+			cert1Encoded := cert.EncodeCertPEM(cert1.Leaf)
+			cert2Encoded := cert.EncodeCertPEM(cert2.Leaf)
+			cert3Encoded := cert.EncodeCertPEM(cert3.Leaf)
+			// Sleep a bit to ensure the third cert is expired
+			time.Sleep(10 * time.Millisecond)
+			now := time.Now()
+			By("ensure cert1 is valid")
+			Expect(cert1.Leaf.NotBefore).To(BeTemporally("<", now))
+			Expect(cert1.Leaf.NotAfter).To(BeTemporally(">", now))
+			By("ensure cert2 is valid")
+			Expect(cert2.Leaf.NotBefore).To(BeTemporally("<", now))
+			Expect(cert2.Leaf.NotAfter).To(BeTemporally(">", now))
+			By("ensure cert3 is expired")
+			Expect(cert3.Leaf.NotBefore).To(BeTemporally("<", now))
+			Expect(cert3.Leaf.NotAfter).To(BeTemporally("<", now))
 
-				By("Adding an invalid string to the configmap, should be ignored and removed from the external CA configmap")
-				cm.Data[components.CABundleKey] = "invalid"
-				_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(func(g Gomega) {
-					cm, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
-					g.Expect(err).ToNot(HaveOccurred())
-					val, ok := cm.Data[components.CABundleKey]
-					g.Expect(ok).To(BeTrue())
-					g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
-					g.Expect(val).ToNot(ContainSubstring("invalid"))
-				}, 10*time.Second, time.Second).Should(Succeed())
-				cm, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+			By("Adding the first cert")
+			cm.Data[components.CABundleKey] = string(cert1Encoded)
+			_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				cm, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				val, ok := cm.Data[components.CABundleKey]
+				g.Expect(ok).To(BeTrue())
+				g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
+			}, 10*time.Second, time.Second).Should(Succeed())
+			cm, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
-				By("Adding the second cert")
-				cm.Data[components.CABundleKey] = string(cert2Encoded)
-				_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(func(g Gomega) {
-					kubevirtCAConfigMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
-					g.Expect(err).ToNot(HaveOccurred())
-					val, ok := kubevirtCAConfigMap.Data[components.CABundleKey]
-					g.Expect(ok).To(BeTrue())
-					g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
-					g.Expect(val).ToNot(ContainSubstring("invalid"))
-					g.Expect(val).To(ContainSubstring(string(cert2Encoded)))
-				}, 10*time.Second, time.Second).Should(Succeed())
-				cm, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+			By("Adding an invalid string to the configmap, should be ignored and removed from the external CA configmap")
+			cm.Data[components.CABundleKey] = "invalid"
+			_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				cm, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				val, ok := cm.Data[components.CABundleKey]
+				g.Expect(ok).To(BeTrue())
+				g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
+				g.Expect(val).ToNot(ContainSubstring("invalid"))
+			}, 10*time.Second, time.Second).Should(Succeed())
+			cm, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
-				By("Adding the third cert, which is expired, it should not be added to the kubevirt-ca configmap")
-				cm.Data[components.CABundleKey] = string(cert3Encoded)
-				_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(func(g Gomega) {
-					kubevitCAConfigMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
-					g.Expect(err).ToNot(HaveOccurred())
-					val, ok := kubevitCAConfigMap.Data[components.CABundleKey]
-					g.Expect(ok).To(BeTrue())
-					g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
-					g.Expect(val).ToNot(ContainSubstring("invalid"))
-					g.Expect(val).To(ContainSubstring(string(cert2Encoded)))
-					g.Expect(val).ToNot(ContainSubstring(string(cert3Encoded)))
-				}, 10*time.Second, time.Second).Should(Succeed())
+			By("Adding the second cert")
+			cm.Data[components.CABundleKey] = string(cert2Encoded)
+			_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				kubevirtCAConfigMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				val, ok := kubevirtCAConfigMap.Data[components.CABundleKey]
+				g.Expect(ok).To(BeTrue())
+				g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
+				g.Expect(val).ToNot(ContainSubstring("invalid"))
+				g.Expect(val).To(ContainSubstring(string(cert2Encoded)))
+			}, 10*time.Second, time.Second).Should(Succeed())
+			cm, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.ExternalKubeVirtCAConfigMapName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Adding the third cert, which is expired, it should not be added to the kubevirt-ca configmap")
+			cm.Data[components.CABundleKey] = string(cert3Encoded)
+			_, err = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Update(context.Background(), cm, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
 				kubevitCAConfigMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				certBytes := kubevitCAConfigMap.Data[components.CABundleKey]
-				certs, err := cert.ParseCertsPEM([]byte(certBytes))
-				Expect(err).ToNot(HaveOccurred())
-				count := 0
-				cert1Hash := sha256.Sum256(cert1.Leaf.Raw)
-				cert1HashString := hex.EncodeToString(cert1Hash[:])
-				cert2Hash := sha256.Sum256(cert2.Leaf.Raw)
-				cert2HashString := hex.EncodeToString(cert2Hash[:])
-				cert3Hash := sha256.Sum256(cert3.Leaf.Raw)
-				cert3HashString := hex.EncodeToString(cert3Hash[:])
-				for _, cert := range certs {
-					certHash := sha256.Sum256(cert.Raw)
-					certHashString := hex.EncodeToString(certHash[:])
-					if certHashString == cert1HashString || certHashString == cert2HashString {
-						count++
-					}
-					if certHashString == cert3HashString {
-						Fail("cert3 should not be in the kubevirt-ca configmap")
-					}
+				g.Expect(err).ToNot(HaveOccurred())
+				val, ok := kubevitCAConfigMap.Data[components.CABundleKey]
+				g.Expect(ok).To(BeTrue())
+				g.Expect(val).To(ContainSubstring(string(cert1Encoded)))
+				g.Expect(val).ToNot(ContainSubstring("invalid"))
+				g.Expect(val).To(ContainSubstring(string(cert2Encoded)))
+				g.Expect(val).ToNot(ContainSubstring(string(cert3Encoded)))
+			}, 10*time.Second, time.Second).Should(Succeed())
+			kubevitCAConfigMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			certBytes := kubevitCAConfigMap.Data[components.CABundleKey]
+			certs, err := cert.ParseCertsPEM([]byte(certBytes))
+			Expect(err).ToNot(HaveOccurred())
+			count := 0
+			cert1Hash := sha256.Sum256(cert1.Leaf.Raw)
+			cert1HashString := hex.EncodeToString(cert1Hash[:])
+			cert2Hash := sha256.Sum256(cert2.Leaf.Raw)
+			cert2HashString := hex.EncodeToString(cert2Hash[:])
+			cert3Hash := sha256.Sum256(cert3.Leaf.Raw)
+			cert3HashString := hex.EncodeToString(cert3Hash[:])
+			for _, cert := range certs {
+				certHash := sha256.Sum256(cert.Raw)
+				certHashString := hex.EncodeToString(certHash[:])
+				if certHashString == cert1HashString || certHashString == cert2HashString {
+					count++
 				}
-				Expect(count).To(Equal(2))
-			})
+				if certHashString == cert3HashString {
+					Fail("cert3 should not be in the kubevirt-ca configmap")
+				}
+			}
+			Expect(count).To(Equal(2))
 		})
 	})
 })


### PR DESCRIPTION
/cc @awels 

### What this PR does

Nothing urgent, just noticed when reviewing a CI failure below:

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15061/pull-kubevirt-e2e-k8s-1.33-sig-operator/1940793698753187840

#### Before this PR:
```
$ ginkgo outline --format json tests/operator/operator.go | jq 'def find_path_recursive(target_text; node): if node.text and (node.text | contains(target_text)) then [node.text] elif node.nodes then node.nodes[] as
     $child_node | find_path_recursive(target_text; $child_node) | select(length > 0) | [node.text] + . else empty end; .[] as $top_node |
     find_path_recursive("external CA"; $top_node) | join(" ")'
"[sig-operator]Operator  Deployment of common-instancetypes external CA"
```
#### After this PR:
```
$ ginkgo outline --format json tests/operator/operator.go | jq 'def find_path_recursive(target_text; node): if node.text and (node.text | contains(target_text)) then [node.text] elif node.nodes then node.nodes[] as
     $child_node | find_path_recursive(target_text; $child_node) | select(length > 0) | [node.text] + . else empty end; .[] as $top_node |
     find_path_recursive("external CA"; $top_node) | join(" ")'
"[sig-operator]Operator external CA"
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

