### PR TITLE
Add Enum validation for HugePages pageSize field

### DIFF
--- a/pkg/virt-operator/resource/generate/components/crds_test.go
+++ b/pkg/virt-operator/resource/generate/components/crds_test.go
@@ -333,6 +333,34 @@ var _ = Describe("CRDs", func() {
 			"RestoreInProgress", "test-source", "test-target",
 		),
 	)
+
+	It("should have enum validation for hugepages pageSize", func() {
+		vmiCrd, err := NewVirtualMachineInstanceCrd()
+		Expect(err).ToNot(HaveOccurred())
+
+		pageSizeSchema := vmiCrd.Spec.Versions[0].Schema.OpenAPIV3Schema.
+			Properties["spec"].
+			Properties["domain"].
+			Properties["memory"].
+			Properties["hugepages"].
+			Properties["pageSize"]
+
+		Expect(pageSizeSchema.Enum).ToNot(BeEmpty())
+
+		var enumStrings []string
+		unmarshal := func(raw []byte) string {
+			var s string
+			err := json.Unmarshal(raw, &s)
+			Expect(err).ToNot(HaveOccurred())
+			return s
+		}
+
+		for _, enumVal := range pageSizeSchema.Enum {
+			enumStrings = append(enumStrings, unmarshal(enumVal.Raw))
+		}
+
+		Expect(enumStrings).To(ConsistOf("2Mi", "1Gi"))
+	})
 })
 
 func createTime() metav1.Time {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6991,6 +6991,9 @@ var CRDsValidation map[string]string = map[string]string{
                             pageSize:
                               description: PageSize specifies the hugepage size, for
                                 x86_64 architecture valid values are 1Gi and 2Mi.
+                              enum:
+                              - 1Gi
+                              - 2Mi
                               type: string
                           type: object
                         maxGuest:
@@ -9147,6 +9150,9 @@ var CRDsValidation map[string]string = map[string]string{
                 pageSize:
                   description: PageSize specifies the hugepage size, for x86_64 architecture
                     valid values are 1Gi and 2Mi.
+                  enum:
+                  - 1Gi
+                  - 2Mi
                   type: string
               type: object
             maxGuest:
@@ -12431,6 +12437,9 @@ var CRDsValidation map[string]string = map[string]string{
                     pageSize:
                       description: PageSize specifies the hugepage size, for x86_64
                         architecture valid values are 1Gi and 2Mi.
+                      enum:
+                      - 1Gi
+                      - 2Mi
                       type: string
                   type: object
                 maxGuest:
@@ -16130,6 +16139,9 @@ var CRDsValidation map[string]string = map[string]string{
                     pageSize:
                       description: PageSize specifies the hugepage size, for x86_64
                         architecture valid values are 1Gi and 2Mi.
+                      enum:
+                      - 1Gi
+                      - 2Mi
                       type: string
                   type: object
                 maxGuest:
@@ -18627,6 +18639,9 @@ var CRDsValidation map[string]string = map[string]string{
                             pageSize:
                               description: PageSize specifies the hugepage size, for
                                 x86_64 architecture valid values are 1Gi and 2Mi.
+                              enum:
+                              - 1Gi
+                              - 2Mi
                               type: string
                           type: object
                         maxGuest:
@@ -20051,6 +20066,9 @@ var CRDsValidation map[string]string = map[string]string{
                 pageSize:
                   description: PageSize specifies the hugepage size, for x86_64 architecture
                     valid values are 1Gi and 2Mi.
+                  enum:
+                  - 1Gi
+                  - 2Mi
                   type: string
               type: object
             maxGuest:
@@ -23314,6 +23332,9 @@ var CRDsValidation map[string]string = map[string]string{
                                       description: PageSize specifies the hugepage
                                         size, for x86_64 architecture valid values
                                         are 1Gi and 2Mi.
+                                      enum:
+                                      - 1Gi
+                                      - 2Mi
                                       type: string
                                   type: object
                                 maxGuest:
@@ -28673,6 +28694,9 @@ var CRDsValidation map[string]string = map[string]string{
                                           description: PageSize specifies the hugepage
                                             size, for x86_64 architecture valid values
                                             are 1Gi and 2Mi.
+                                          enum:
+                                          - 1Gi
+                                          - 2Mi
                                           type: string
                                       type: object
                                     maxGuest:

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -418,6 +418,7 @@ type MemoryStatus struct {
 // Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.
 type Hugepages struct {
 	// PageSize specifies the hugepage size, for x86_64 architecture valid values are 1Gi and 2Mi.
+	// +kubebuilder:validation:Enum={"1Gi","2Mi"}
 	PageSize string `json:"pageSize,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -218,7 +218,7 @@ func (MemoryStatus) SwaggerDoc() map[string]string {
 func (Hugepages) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.",
-		"pageSize": "PageSize specifies the hugepage size, for x86_64 architecture valid values are 1Gi and 2Mi.",
+		"pageSize": "PageSize specifies the hugepage size, for x86_64 architecture valid values are 1Gi and 2Mi.\n+kubebuilder:validation:Enum={\"1Gi\",\"2Mi\"}",
 	}
 }
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1048,35 +1048,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Entry("[test_id:1672]hugepages-1Gi", decorators.RequiresHugepages1Gi, Serial, libvmi.WithHugepages("1Gi"), libvmi.WithMemoryRequest("1Gi"), noGuestOption()),
 				Entry("[test_id:1672]hugepages-2Mi with guest memory set explicitly", decorators.RequiresHugepages2Mi, Serial, libvmi.WithHugepages("2Mi"), libvmi.WithMemoryRequest("70Mi"), libvmi.WithGuestMemory("64Mi")),
 			)
-
-			Context("with unsupported page size", func() {
-				It("[test_id:1673]should failed to schedule the pod", func() {
-					hugepagesVmi := libvmifact.NewCirros(
-						libvmi.WithMemoryRequest("66Mi"),
-						libvmi.WithHugepages("3Mi"),
-					)
-
-					By("Starting a VM")
-					hugepagesVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(hugepagesVmi)).Create(context.Background(), hugepagesVmi, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					var vmiCondition v1.VirtualMachineInstanceCondition
-					Eventually(func() bool {
-						vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(hugepagesVmi)).Get(context.Background(), hugepagesVmi.Name, metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-
-						for _, cond := range vmi.Status.Conditions {
-							if cond.Type == v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled) && cond.Status == k8sv1.ConditionFalse {
-								vmiCondition = cond
-								return true
-							}
-						}
-						return false
-					}, 30*time.Second, time.Second).Should(BeTrue())
-					Expect(vmiCondition.Message).To(ContainSubstring("Insufficient hugepages-3Mi"))
-					Expect(vmiCondition.Reason).To(Equal("Unschedulable"))
-				})
-			})
 		})
 
 		Context("[rfe_id:893][crit:medium][vendor:cnv-qe@redhat.com][level:component]with rng", func() {


### PR DESCRIPTION
Adds kubebuilder Enum validation to restrict spec.domain.memory.hugepages.pageSize to only "1Gi" and "2Mi".

Removes unnecessary Eventually block where it wan't needed.



Please see https://github.com/kubernetes-sigs/controller-tools/issues/547 ( reference for the kubebuilder syntax)

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

