### PR TITLE
pod-eviction-admitter, webhooks: handle eviction of volume hotplug pod

### DIFF
--- a/docs/handling-eviction-requests.md
+++ b/docs/handling-eviction-requests.md
@@ -31,7 +31,10 @@ The eviction strategy affects the way the VirtualMachineInstance will be evacuat
 kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io virt-api-validator -o yaml
 ```
 
-The purpose of this webhook is to trigger VMI evacuation in cases where it is required.
+The webhook serves two purposes:
+1. To trigger VMI evacuation in cases where it is required.
+2. To prevent evacuation of associated hotplug pods.
+
 The way the webhook triggers the evacuation is by setting the VMI's `Status.EvacuationNodeName` field to the node name it is currently running on, so the [evacuation controller](#evacuation-controller) will know it needs to migrate it to another node.
 
 The webhook has the ability to:
@@ -40,8 +43,7 @@ The webhook has the ability to:
 
 The webhook admits eviction requests **before** `kube-api` checks them against [Pod Distribution Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) objects.
 
-In case the pod is not a `virt-launcher` pod - the eviction request is approved.
-Otherwise, depending on the VMI's eviction strategy and whether it is migratable - the webhook will potentially mark the VMI for evacuation and approve or deny the eviction request: 
+In case the pod is not a `virt-launcher` or a `hp-volume-` pod - the eviction request is approved. Otherwise, depending on the VMI's eviction strategy and whether it is migratable - the webhook will potentially mark the VMI for evacuation and approve or deny the eviction request: 
 
 | Eviction Strategy     | Is VMI migratable | Is VMI marked for evacuation | Does Webhook approve eviction | Webhook Response                                 |
 |-----------------------|-------------------|------------------------------|-------------------------------|--------------------------------------------------|

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -963,7 +963,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 	http.HandleFunc(components.StatusValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeStatusValidation(w, r, app.clusterConfig, app.virtCli, informers, app.kubeVirtServiceAccounts)
 	})
-	http.HandleFunc(components.LauncherEvictionValidatePath, func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(components.PodEvictionValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServePodEvictionInterceptor(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.MigrationPolicyCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
A recent transition from PDBs to using an admission webhook to intercept the eviction API[1] has made it possible to block evictions of virt-launcher Pods when the associated VMI is capable of live migration.

[1] https://github.com/kubevirt/kubevirt/pull/12214

#### After this PR:
Building on that foundation, this PR extends the same protection to hotplug pods owned by the virt-launcher, ensuring they are not prematurely terminated during an ongoing live migration. This prevents potential inconsistencies or failures caused by the hotplug pod shutting down before the migration completes.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes#
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->
- Partially addresses:  https://issues.redhat.com/browse/CNV-63616
- Fixes #12637 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Previously, it was assumed that any lingering host-level references to a volume, such as active mounts or open file descriptors, would naturally cause a CSI driver to fail the `NodeUnstageVolume` call with an `EBUSY` error or otherwise. This assumption holds true for _some_ drivers that perform safety checks before tearing down a volume. However, others, such as [Trident](https://github.com/NetApp/trident), do not enforce such protections. This behavior is technically compliant with the CSI specification, which does not mandate such checks. Moreover, Trident relies on low-level kernel mechanisms (e.g., direct sysfs device deletion) for some of its flows that operate independently of userland concepts like mounts or open file handles and provide no error feedback when a device is still in use[1]. As a result, volumes can be forcibly removed from the system even when they are not truly safe to detach, ergo the need for this PR.

Other operations that may take down the hotplug pod include:
- Hotplug volume addition/removal - Handled[2].
- Force majeure / accidental deletion - Irrelevant as that would be the user responsibility.

[1] https://github.com/NetApp/trident/blob/79510e1b18b3f29bda0050ce8173ebba97e8856b/utils/devices/devices.go#L709
[2] https://github.com/kubevirt/kubevirt/pull/10275
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: volume hotplug pod is no longer evicted when associated VM can live migrate.
```