### PR TITLE
virt-cntrl, svc, template: Istio deprecation

### DIFF
--- a/pkg/network/istio/BUILD.bazel
+++ b/pkg/network/istio/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "annotations.go",
+        "decorators.go",
         "ports.go",
         "proxy.go",
     ],

--- a/pkg/network/istio/decorators.go
+++ b/pkg/network/istio/decorators.go
@@ -20,8 +20,10 @@
 package istio
 
 const (
-	// InjectSidecarAnnotation Specifies whether an Envoy sidecar should be automatically injected into the workload
-	// https://istio.io/latest/docs/reference/config/annotations/#SidecarInject
+	// InjectSidecarLabel Specifies whether an Envoy sidecar should be automatically injected into the workload
+	// https://istio.io/latest/docs/reference/config/labels/#SidecarInject
+	InjectSidecarLabel = "sidecar.istio.io/inject"
+	// InjectSidecarAnnotation in VM/VMI API, propagates sidecar.istio.io/inject label to the virt-launcher pod
 	InjectSidecarAnnotation = "sidecar.istio.io/inject"
 
 	// KubeVirtTrafficAnnotation Specifies a comma separated list of virtual interfaces

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1570,6 +1570,9 @@ func podLabels(vmi *v1.VirtualMachineInstance, hostName string) map[string]strin
 	labels[v1.AppLabel] = "virt-launcher"
 	labels[v1.CreatedByLabel] = string(vmi.UID)
 	labels[v1.VirtualMachineNameLabel] = hostName
+	if val, exists := vmi.Annotations[istio.InjectSidecarAnnotation]; exists {
+		labels[istio.InjectSidecarLabel] = val
+	}
 	return labels
 }
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1026,8 +1026,10 @@ var _ = Describe("Template", func() {
 				pod, err = svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 			})
-			It("should mount default serviceAccountToken", func() {
+			It("should mount default serviceAccountToken, propagate label and annotation", func() {
 				Expect(*pod.Spec.AutomountServiceAccountToken).To(BeTrue())
+				Expect(pod.Labels).To(HaveKeyWithValue(istio.InjectSidecarLabel, "true"))
+				Expect(pod.Annotations).To(HaveKeyWithValue(istio.InjectSidecarAnnotation, "true"))
 			})
 		})
 		Context("with node selectors", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Istio has deprecated the [pod annotation](https://istio.io/latest/docs/reference/config/annotations/#SidecarInject) to inject the sidecar container, which KubeVirt currently populates
It has been replaced in Istio with a [label](https://istio.io/latest/docs/reference/config/labels/#SidecarInject).
To address this, KubeVirt will populate the label in the pod when the annotation is used in the VM/VMI API.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/15031
### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE.
```

