### PR TITLE
vmi-create-admitter: drop firmware.serial validation

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -194,7 +194,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateHugepagesMemoryRequests(field, spec)...)
 	causes = append(causes, validateGuestMemoryLimit(field, spec, config)...)
 	causes = append(causes, validateEmulatedMachine(field, spec, config)...)
-	causes = append(causes, validateFirmwareSerial(field, spec)...)
 	causes = append(causes, validateFirmwareACPI(field.Child("acpi"), spec)...)
 	causes = append(causes, validateCPURequestNotNegative(field, spec)...)
 	causes = append(causes, validateCPULimitNotNegative(field, spec)...)
@@ -981,34 +980,6 @@ func validateCPURequestNotNegative(field *k8sfield.Path, spec *v1.VirtualMachine
 			Field: field.Child("domain", "resources", "requests", "cpu").String(),
 		})
 	}
-	return causes
-}
-
-func validateFirmwareSerial(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
-	var causes []metav1.StatusCause
-	if spec.Domain.Firmware == nil || len(spec.Domain.Firmware.Serial) == 0 {
-		return causes
-	}
-	// Verify serial number is within valid length, if provided
-	if len(spec.Domain.Firmware.Serial) > maxStrLen {
-		causes = append(causes, metav1.StatusCause{
-			Type: metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s must be less than or equal to %d in length, if specified",
-				field.Child("domain", "firmware", "serial").String(),
-				maxStrLen,
-			),
-			Field: field.Child("domain", "firmware", "serial").String(),
-		})
-	}
-	// Verify serial number is made up of valid characters for libvirt, if provided
-	if !isValidExpression(spec.Domain.Firmware.Serial) {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s must be made up of the following characters [A-Za-z0-9_.+-], if specified", field.Child("domain", "firmware", "serial").String()),
-			Field:   field.Child("domain", "firmware", "serial").String(),
-		})
-	}
-
 	return causes
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -4355,28 +4355,6 @@ var _ = Describe("additional tests", func() {
 		Expect(causes[0].Field).To(ContainSubstring("bootOrder"))
 	})
 
-	It("should reject a serial number whose length is greater than 256", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		sn := strings.Repeat("1", maxStrLen+1)
-
-		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
-
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Field).To(ContainSubstring("serial"))
-	})
-
-	It("should reject a serial number with invalid characters", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		sn := "$$$$"
-
-		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
-
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Field).To(ContainSubstring("serial"))
-	})
-
 	It("should accept a valid serial number", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		sn := "6a1a24a1-4061-4607-8bf4-a3963d0c5895"


### PR DESCRIPTION
When migrating a VM from another hypervisor, it is important to keep its
serial number, which may include spaces. libvirt (at least
libvirt-11.0.0 which I just tested) allows spaces, dollars and
other special characters in its system serial entry, as well as accepts
a string longer than 256.

```release-note
Drop an arbitrary limitation on VM's domain.firmaware.serial. Any string is passed verbatim to smbios. Illegal may be tweaked or ignored based on qemu/smbios version.
```

