### PR TITLE
fix: pkg/virtctl/console lint errors

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -28,6 +28,7 @@ pkg/storage/velero
 pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/configuration
+pkg/virtctl/console
 pkg/virtctl/create/params
 pkg/virtctl/create/vm
 pkg/virtctl/credentials

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -37,6 +37,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 
+const defaultTimeoutMinutes = 5
+
 type consoleCommand struct {
 	timeout int
 }
@@ -50,7 +52,8 @@ func NewCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE:    c.run,
 	}
-	cmd.Flags().IntVar(&c.timeout, "timeout", 5, "The number of minutes to wait for the virtual machine instance to be ready.")
+	cmd.Flags().IntVar(&c.timeout, "timeout", defaultTimeoutMinutes,
+		"The number of minutes to wait for the virtual machine instance to be ready.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -88,7 +91,8 @@ func (c *consoleCommand) handleConsoleConnection(client kubecli.KubevirtClient, 
 	signal.Notify(waitInterrupt, os.Interrupt)
 
 	go func() {
-		con, err := client.VirtualMachineInstance(namespace).SerialConsole(vmi, &kvcorev1.SerialConsoleOptions{ConnectionTimeout: time.Duration(c.timeout) * time.Minute})
+		con, err := client.VirtualMachineInstance(namespace).SerialConsole(vmi,
+			&kvcorev1.SerialConsoleOptions{ConnectionTimeout: time.Duration(c.timeout) * time.Minute})
 		runningChan <- err
 
 		if err != nil {
@@ -114,7 +118,6 @@ func (c *consoleCommand) handleConsoleConnection(client kubecli.KubevirtClient, 
 	err := Attach(stdinReader, stdoutReader, stdinWriter, stdoutWriter,
 		fmt.Sprintf("Successfully connected to %s console. Press Ctrl+] or Ctrl+5 to exit console.\n", vmi),
 		resChan)
-
 	if err != nil {
 		if e, ok := err.(*websocket.CloseError); ok && e.Code == websocket.CloseAbnormalClosure {
 			fmt.Fprint(os.Stderr, "\n"+
@@ -131,16 +134,26 @@ func (c *consoleCommand) handleConsoleConnection(client kubecli.KubevirtClient, 
 // Attach attaches stdin and stdout to the console
 // in -> stdinWriter | stdinReader -> console
 // out <- stdoutReader | stdoutWriter <- console
-func Attach(stdinReader, stdoutReader *io.PipeReader, stdinWriter, stdoutWriter *io.PipeWriter, message string, resChan <-chan error) (err error) {
+func Attach(stdinReader, stdoutReader *io.PipeReader, stdinWriter, stdoutWriter *io.PipeWriter,
+	message string, resChan <-chan error,
+) (err error) {
+	const (
+		escapeSequenceCode = 29
+		bufferSize         = 1024
+	)
 	stopChan := make(chan struct{}, 1)
 	writeStop := make(chan error)
 	readStop := make(chan error)
 	if term.IsTerminal(int(os.Stdin.Fd())) {
-		state, err := term.MakeRaw(int(os.Stdin.Fd()))
-		if err != nil {
-			return fmt.Errorf("Make raw terminal failed: %s", err)
+		state, makeRawErr := term.MakeRaw(int(os.Stdin.Fd()))
+		if makeRawErr != nil {
+			return fmt.Errorf("make raw terminal failed: %s", makeRawErr)
 		}
-		defer term.Restore(int(os.Stdin.Fd()), state)
+		defer func() {
+			if restoreErr := term.Restore(int(os.Stdin.Fd()), state); restoreErr != nil {
+				fmt.Fprintf(os.Stderr, "failed to restore terminal: %v\n", restoreErr)
+			}
+		}()
 	}
 	fmt.Fprint(os.Stderr, message)
 
@@ -155,26 +168,26 @@ func Attach(stdinReader, stdoutReader *io.PipeReader, stdinWriter, stdoutWriter 
 	}()
 
 	go func() {
-		_, err := io.Copy(out, stdoutReader)
-		readStop <- err
+		_, copyErr := io.Copy(out, stdoutReader)
+		readStop <- copyErr
 	}()
 
 	go func() {
 		defer close(writeStop)
-		buf := make([]byte, 1024, 1024)
+		buf := make([]byte, bufferSize)
 		for {
 			// reading from stdin
-			n, err := in.Read(buf)
-			if err != nil && err != io.EOF {
-				writeStop <- err
+			n, readErr := in.Read(buf)
+			if readErr != nil && readErr != io.EOF {
+				writeStop <- readErr
 				return
 			}
-			if n == 0 && err == io.EOF {
+			if n == 0 && readErr == io.EOF {
 				return
 			}
 
 			// the escape sequence
-			if buf[0] == 29 {
+			if buf[0] == escapeSequenceCode {
 				return
 			}
 			// Writing out to the console connection


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Running the linter against `pkg/virtctl/console` gives errors.
#### After this PR:
Now it succeeds without errors or warnings

### References
- Fixes  #14193

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

