### PR TITLE
fix: lint: pkg/virtctl/create/clone errors

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -30,6 +30,7 @@ pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/configuration
 pkg/virtctl/console
+pkg/virtctl/create/clone
 pkg/virtctl/create/params
 pkg/virtctl/create/vm
 pkg/virtctl/credentials

--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -69,8 +69,10 @@ type createClone struct {
 	newSmbiosSerial           string
 }
 
-type cloneSpec clone.VirtualMachineCloneSpec
-type optionFn func(*createClone, *cloneSpec) error
+type (
+	cloneSpec clone.VirtualMachineCloneSpec
+	optionFn  func(*createClone, *cloneSpec) error
+)
 
 var optFns = map[string]optionFn{
 	NewMacAddressesFlag: withNewMacAddresses,
@@ -88,17 +90,28 @@ func NewCommand() *cobra.Command {
 	const emptyValue = ""
 	const supportsMultipleFlags = "Can be provided multiple times."
 
-	cmd.Flags().StringVar(&c.name, NameFlag, emptyValue, "Specify the name of the clone. If not specified, name would be randomized.")
-	cmd.Flags().StringVar(&c.sourceName, SourceNameFlag, emptyValue, "Specify the clone's source name.")
-	cmd.Flags().StringVar(&c.targetName, TargetNameFlag, emptyValue, "Specify the clone's target name.")
-	cmd.Flags().StringVar(&c.sourceType, SourceTypeFlag, emptyValue, "Specify the clone's source type. Default type is VM. Supported types: "+supportedSourceTypes)
-	cmd.Flags().StringVar(&c.targetType, TargetTypeFlag, emptyValue, "Specify the clone's target type. Default type is VM. Supported types: "+supportedTargetTypes)
-	cmd.Flags().StringArrayVar(&c.labelFilters, LabelFilterFlag, nil, "Specify clone's label filters. "+supportsMultipleFlags)
-	cmd.Flags().StringArrayVar(&c.annotationFilters, AnnotationFilterFlag, nil, "Specify clone's annotation filters. "+supportsMultipleFlags)
-	cmd.Flags().StringArrayVar(&c.templateLabelFilters, TemplateLabelFilterFlag, nil, "Specify clone's template label filters. "+supportsMultipleFlags)
-	cmd.Flags().StringArrayVar(&c.templateAnnotationFilters, TemplateAnnotationFilterFlag, nil, "Specify clone's template annotation filters. "+supportsMultipleFlags)
-	cmd.Flags().StringArrayVar(&c.newMacAddresses, NewMacAddressesFlag, nil, "Specify clone's new mac addresses. For example: 'interfaceName0:newAddress0'")
-	cmd.Flags().StringVar(&c.newSmbiosSerial, NewSMBiosSerialFlag, emptyValue, "Specify the clone's new smbios serial")
+	cmd.Flags().StringVar(&c.name, NameFlag, emptyValue,
+		"Specify the name of the clone. If not specified, name would be randomized.")
+	cmd.Flags().StringVar(&c.sourceName, SourceNameFlag, emptyValue,
+		"Specify the clone's source name.")
+	cmd.Flags().StringVar(&c.targetName, TargetNameFlag, emptyValue,
+		"Specify the clone's target name.")
+	cmd.Flags().StringVar(&c.sourceType, SourceTypeFlag, emptyValue,
+		"Specify the clone's source type. Default type is VM. Supported types: "+supportedSourceTypes)
+	cmd.Flags().StringVar(&c.targetType, TargetTypeFlag, emptyValue,
+		"Specify the clone's target type. Default type is VM. Supported types: "+supportedTargetTypes)
+	cmd.Flags().StringArrayVar(&c.labelFilters, LabelFilterFlag, nil,
+		"Specify clone's label filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.annotationFilters, AnnotationFilterFlag, nil,
+		"Specify clone's annotation filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.templateLabelFilters, TemplateLabelFilterFlag, nil,
+		"Specify clone's template label filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.templateAnnotationFilters, TemplateAnnotationFilterFlag, nil,
+		"Specify clone's template annotation filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.newMacAddresses, NewMacAddressesFlag, nil,
+		"Specify clone's new mac addresses. For example: 'interfaceName0:newAddress0'")
+	cmd.Flags().StringVar(&c.newSmbiosSerial, NewSMBiosSerialFlag, emptyValue,
+		"Specify the clone's new smbios serial")
 
 	if err := cmd.MarkFlagRequired(SourceNameFlag); err != nil {
 		panic(err)
@@ -108,9 +121,10 @@ func NewCommand() *cobra.Command {
 }
 
 func withNewMacAddresses(c *createClone, cloneSpec *cloneSpec) error {
+	const expectedMacParts = 2
 	for _, param := range c.newMacAddresses {
 		splitParam := strings.Split(param, ":")
-		if len(splitParam) != 2 {
+		if len(splitParam) != expectedMacParts {
 			return fmt.Errorf("newMacAddress parameter %s is invalid: exactly one ':' is expected. For example: 'interface0:address0'", param)
 		}
 
@@ -220,6 +234,7 @@ func (c *createClone) applyFlags(cmd *cobra.Command, spec *clone.VirtualMachineC
 }
 
 func (c *createClone) run(cmd *cobra.Command, _ []string) error {
+	const cloneRandomSuffixLength = 5
 	if err := c.setDefaults(cmd.Context()); err != nil {
 		return err
 	}
@@ -229,21 +244,21 @@ func (c *createClone) run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	clone, err := c.newClone()
+	vmClone, err := c.newClone()
 	if err != nil {
 		return err
 	}
 
-	err = c.applyFlags(cmd, &clone.Spec)
+	err = c.applyFlags(cmd, &vmClone.Spec)
 	if err != nil {
 		return err
 	}
 
-	if clone.Name == "" {
-		clone.Name = "clone-" + rand.String(5)
+	if vmClone.Name == "" {
+		vmClone.Name = "clone-" + rand.String(cloneRandomSuffixLength)
 	}
 
-	cloneBytes, err := yaml.Marshal(clone)
+	cloneBytes, err := yaml.Marshal(vmClone)
 	if err != nil {
 		return err
 	}
@@ -252,7 +267,13 @@ func (c *createClone) run(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, sourceOrTargetName string, isSource bool) (*v1.TypedLocalObjectReference, error) {
+func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, sourceOrTargetName string,
+	isSource bool,
+) (*v1.TypedLocalObjectReference, error) {
+	const (
+		virtualMachineKind         = "VirtualMachine"
+		virtualMachineSnapshotKind = "VirtualMachineSnapshot"
+	)
 	var kind, apiGroup string
 
 	generateErr := func() error {
@@ -271,15 +292,15 @@ func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, source
 	}
 
 	switch sourceOrTargetType {
-	case "vm", "VM", "VirtualMachine", "virtualmachine":
-		kind = "VirtualMachine"
+	case "vm", "VM", virtualMachineKind, "virtualmachine":
+		kind = virtualMachineKind
 		apiGroup = "kubevirt.io"
-	case "snapshot", "VirtualMachineSnapshot", "vmsnapshot", "VMSnapshot":
+	case "snapshot", virtualMachineSnapshotKind, "vmsnapshot", "VMSnapshot":
 		if !isSource {
 			return nil, generateErr()
 		}
 
-		kind = "VirtualMachineSnapshot"
+		kind = virtualMachineSnapshotKind
 		apiGroup = "snapshot.kubevirt.io"
 	default:
 		return nil, generateErr()
@@ -294,6 +315,7 @@ func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, source
 
 func (c *createClone) setDefaults(ctx context.Context) error {
 	_, namespace, overridden, err := clientconfig.ClientAndNamespaceFromContext(ctx)
+	const cloneRandomSuffixLength = 5
 	if err != nil {
 		return err
 	}
@@ -302,7 +324,7 @@ func (c *createClone) setDefaults(ctx context.Context) error {
 	}
 
 	if c.name == "" {
-		c.name = "clone-" + rand.String(5)
+		c.name = "clone-" + rand.String(cloneRandomSuffixLength)
 	}
 
 	const defaultType = "vm"

--- a/pkg/virtctl/create/clone/clone_test.go
+++ b/pkg/virtctl/create/clone/clone_test.go
@@ -36,9 +36,10 @@ import (
 const (
 	create = "create"
 
-	vmKind, vmApiGroup             = "VirtualMachine", "kubevirt.io"
-	snapshotKind, snapshotApiGroup = "VirtualMachineSnapshot", "snapshot.kubevirt.io"
+	vmKind, vmAPIGroup             = "VirtualMachine", "kubevirt.io"
+	snapshotKind, snapshotAPIGroup = "VirtualMachineSnapshot", "snapshot.kubevirt.io"
 )
+
 const (
 	labelFilters = iota
 	annotationsFilters
@@ -50,7 +51,6 @@ const (
 
 var _ = Describe("create clone", func() {
 	Context("required arguments", func() {
-
 		It("source name must be specified", func() {
 			_, err := newCommand()
 			Expect(err).To(HaveOccurred())
@@ -64,38 +64,38 @@ var _ = Describe("create clone", func() {
 	})
 
 	Context("source and target", func() {
+		DescribeTable("supported types",
+			func(sourceType, expectedSourceKind, expectedSourceApiGroup, targetType, expectedTargetKind, expectedTargetApiGroup string) {
+				const sourceName, targetName = "source-name", "target-name"
 
-		DescribeTable("supported types", func(sourceType, expectedSourceKind, expectedSourceApiGroup, targetType, expectedTargetKind, expectedTargetApiGroup string) {
-			const sourceName, targetName = "source-name", "target-name"
+				flags := addFlag(nil, virtctlclone.SourceNameFlag, sourceName)
+				flags = addFlag(flags, virtctlclone.TargetNameFlag, targetName)
+				flags = addFlag(flags, virtctlclone.SourceTypeFlag, sourceType)
+				flags = addFlag(flags, virtctlclone.TargetTypeFlag, targetType)
 
-			flags := addFlag(nil, virtctlclone.SourceNameFlag, sourceName)
-			flags = addFlag(flags, virtctlclone.TargetNameFlag, targetName)
-			flags = addFlag(flags, virtctlclone.SourceTypeFlag, sourceType)
-			flags = addFlag(flags, virtctlclone.TargetTypeFlag, targetType)
+				cloneObj, err := newCommand(flags...)
+				Expect(err).ToNot(HaveOccurred())
 
-			cloneObj, err := newCommand(flags...)
-			Expect(err).ToNot(HaveOccurred())
+				Expect(cloneObj.Spec.Source.Name).To(Equal(sourceName))
+				Expect(cloneObj.Spec.Source.Kind).To(Equal(expectedSourceKind))
+				Expect(cloneObj.Spec.Source.APIGroup).ToNot(BeNil())
+				Expect(*cloneObj.Spec.Source.APIGroup).To(Equal(expectedSourceApiGroup))
 
-			Expect(cloneObj.Spec.Source.Name).To(Equal(sourceName))
-			Expect(cloneObj.Spec.Source.Kind).To(Equal(expectedSourceKind))
-			Expect(cloneObj.Spec.Source.APIGroup).ToNot(BeNil())
-			Expect(*cloneObj.Spec.Source.APIGroup).To(Equal(expectedSourceApiGroup))
+				Expect(cloneObj.Spec.Target.Name).To(Equal(targetName))
+				Expect(cloneObj.Spec.Target.Kind).To(Equal(expectedTargetKind))
+				Expect(cloneObj.Spec.Target.APIGroup).ToNot(BeNil())
+				Expect(*cloneObj.Spec.Target.APIGroup).To(Equal(expectedTargetApiGroup))
+			},
+			Entry("vm source, vm target", "vm", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VM source, vm target", "VM", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VirtualMachine source, vm target", "VirtualMachine", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("virtualmachine, vm target", "virtualmachine", vmKind, vmAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("vm source, VirtualMachine target", "vm", vmKind, vmAPIGroup, "VirtualMachine", vmKind, vmAPIGroup),
 
-			Expect(cloneObj.Spec.Target.Name).To(Equal(targetName))
-			Expect(cloneObj.Spec.Target.Kind).To(Equal(expectedTargetKind))
-			Expect(cloneObj.Spec.Target.APIGroup).ToNot(BeNil())
-			Expect(*cloneObj.Spec.Target.APIGroup).To(Equal(expectedTargetApiGroup))
-		},
-			Entry("vm source, vm target", "vm", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VM source, vm target", "VM", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VirtualMachine source, vm target", "VirtualMachine", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("virtualmachine, vm target", "virtualmachine", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("vm source, VirtualMachine target", "vm", vmKind, vmApiGroup, "VirtualMachine", vmKind, vmApiGroup),
-
-			Entry("snapshot source, vm target", "snapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VirtualMachineSnapshot source, vm target", "VirtualMachineSnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("vmsnapshot source, vm target", "vmsnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
-			Entry("VMSnapshot source, vm target", "VMSnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("snapshot source, vm target", "snapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VirtualMachineSnapshot source, vm target", "VirtualMachineSnapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("vmsnapshot source, vm target", "vmsnapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
+			Entry("VMSnapshot source, vm target", "VMSnapshot", snapshotKind, snapshotAPIGroup, "vm", vmKind, vmAPIGroup),
 		)
 
 		It("snapshot is not supported as a target type", func() {
@@ -127,11 +127,9 @@ var _ = Describe("create clone", func() {
 			_, err := newCommand()
 			Expect(err).To(HaveOccurred())
 		})
-
 	})
 
 	Context("label and annotation filters", func() {
-
 		DescribeTable("with", func(filterType int) {
 			flags := getSourceNameFlags()
 
@@ -180,7 +178,6 @@ var _ = Describe("create clone", func() {
 				Expect(cloneObj.Spec.Template.LabelFilters).To(HaveLen(expectedLen))
 				Expect(cloneObj.Spec.Template.AnnotationFilters).To(HaveLen(expectedLen))
 			}
-
 		},
 			Entry("label filters", labelFilters),
 			Entry("annotation filters", annotationsFilters),
@@ -253,7 +250,6 @@ var _ = Describe("create clone", func() {
 
 		Expect(cloneObj.Namespace).To(Equal(namespace))
 	})
-
 })
 
 func addFlag(s []string, flag, value string) []string {
@@ -261,8 +257,7 @@ func addFlag(s []string, flag, value string) []string {
 }
 
 func newCommand(createCloneFlags ...string) (*clone.VirtualMachineClone, error) {
-	baseArgs := []string{create, virtctlclone.Clone}
-	args := append(baseArgs, createCloneFlags...)
+	args := append([]string{create, virtctlclone.Clone}, createCloneFlags...)
 
 	bytes, err := testing.NewRepeatableVirtctlCommandWithOut(args...)()
 	if err != nil {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Running the linter against pkg/virtctl/create/clone gives errors.
#### After this PR:
Added  pkg/virtctl/create/clone to hack/linter/lint-paths.txt and ran make lint. Fixed the lint issue in this package

### References
- Fixes #14194

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

