### PR TITLE
virt-handler: ensure grace period metadata sync before shutdown

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1546,32 +1546,34 @@ func (c *VirtualMachineController) processVmShutdown(vmi *v1.VirtualMachineInsta
 // If the grace period has started but not expired, timeLeft represents
 // the time in seconds left until the period expires.
 // If the grace period has not started, timeLeft will be set to -1.
-func (c *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (hasExpired bool, timeLeft int64) {
+func (c *VirtualMachineController) hasGracePeriodExpired(terminationGracePeriod *int64, dom *api.Domain) (bool, int64) {
+	var hasExpired bool
+	var timeLeft int64
 
-	hasExpired = false
-	timeLeft = 0
-
-	if dom == nil {
-		hasExpired = true
-		return
+	gracePeriod := int64(0)
+	if terminationGracePeriod != nil {
+		gracePeriod = *terminationGracePeriod
+	} else if dom != nil && dom.Spec.Metadata.KubeVirt.GracePeriod != nil {
+		gracePeriod = dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds
 	}
-
-	startTime := int64(0)
-	if dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp != nil {
-		startTime = dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp.UTC().Unix()
-	}
-	gracePeriod := dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds
 
 	// If gracePeriod == 0, then there will be no startTime set, deletion
 	// should occur immediately during shutdown.
 	if gracePeriod == 0 {
 		hasExpired = true
-		return
-	} else if startTime == 0 {
+		return hasExpired, timeLeft
+	}
+
+	startTime := int64(0)
+	if dom != nil && dom.Spec.Metadata.KubeVirt.GracePeriod != nil && dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp != nil {
+		startTime = dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp.UTC().Unix()
+	}
+
+	if startTime == 0 {
 		// If gracePeriod > 0, then the shutdown signal needs to be sent
 		// and the gracePeriod start time needs to be set.
 		timeLeft = -1
-		return
+		return hasExpired, timeLeft
 	}
 
 	now := time.Now().UTC().Unix()
@@ -1579,14 +1581,14 @@ func (c *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (hasEx
 
 	if diff >= gracePeriod {
 		hasExpired = true
-		return
+		return hasExpired, timeLeft
 	}
 
 	timeLeft = gracePeriod - diff
 	if timeLeft < 1 {
 		timeLeft = 1
 	}
-	return
+	return hasExpired, timeLeft
 }
 
 func (c *VirtualMachineController) helperVmShutdown(vmi *v1.VirtualMachineInstance, domain *api.Domain, tryGracefully bool) error {
@@ -1598,7 +1600,7 @@ func (c *VirtualMachineController) helperVmShutdown(vmi *v1.VirtualMachineInstan
 	}
 
 	if domainHasGracePeriod(domain) && tryGracefully {
-		if expired, timeLeft := c.hasGracePeriodExpired(domain); !expired {
+		if expired, timeLeft := c.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain); !expired {
 			return c.handleVMIShutdown(vmi, domain, client, timeLeft)
 		}
 		c.logger.Object(vmi).Infof("Grace period expired, killing deleted VirtualMachineInstance %s", vmi.GetObjectMeta().GetName())

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -373,6 +373,37 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMIGracefulShutdown)
 		})
 
+		It("should attempt graceful shutdown and take the VMI grace period over the cached Domain grace", func() {
+			vmi := libvmi.New(libvmi.WithName("testvmi"),
+				libvmi.WithNamespace(k8sv1.NamespaceDefault),
+				libvmi.WithTerminationGracePeriod(0))
+
+			initialGrace := int64(30)
+			domain := api.NewMinimalDomainWithNS(vmi.Namespace, vmi.Name)
+			domain.Spec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{DeletionGracePeriodSeconds: initialGrace}
+
+			hasExpired, timeLeft := controller.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain)
+			Expect(timeLeft).To(BeEquivalentTo(0))
+			Expect(hasExpired).To(BeTrue())
+		})
+
+		It("should attempt graceful shutdown and and fall back to cached Domain grace period when VMI grace is unset", func() {
+			vmi := libvmi.New(libvmi.WithName("testvmi"),
+				libvmi.WithNamespace(k8sv1.NamespaceDefault))
+
+			initialGrace := int64(30)
+			now := metav1.Time{Time: time.Now()}
+			domain := api.NewMinimalDomainWithNS(vmi.Namespace, vmi.Name)
+			domain.Spec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{
+				DeletionGracePeriodSeconds: initialGrace,
+				DeletionTimestamp:          &now,
+			}
+
+			hasExpired, timeLeft := controller.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain)
+			Expect(timeLeft).To(BeEquivalentTo(initialGrace))
+			Expect(hasExpired).To(BeFalse())
+		})
+
 		It("should do nothing if vmi and domain do not match", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = "other uuid"

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1212,6 +1212,8 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 		return nil, err
 	}
 
+	l.syncGracePeriod(vmi)
+
 	// TODO: check if VirtualMachineInstance Spec and Domain Spec are equal or if we have to sync
 	return oldSpec, nil
 }
@@ -2597,6 +2599,16 @@ func (l *LibvirtDomainManager) linkImageVolumeFilePaths(vmi *v1.VirtualMachineIn
 	}
 
 	return nil
+}
+
+func (l *LibvirtDomainManager) syncGracePeriod(vmi *v1.VirtualMachineInstance) {
+	l.metadataCache.GracePeriod.WithSafeBlock(func(gracePeriodMetadata *api.GracePeriodMetadata, _ bool) {
+		gracePeriod := converter.GracePeriodSeconds(vmi)
+		if gracePeriodMetadata.DeletionGracePeriodSeconds != gracePeriod {
+			gracePeriodMetadata.DeletionGracePeriodSeconds = gracePeriod
+			log.Log.Object(vmi).Infof("Set new termination grace period: %d", gracePeriod)
+		}
+	})
 }
 
 func getDiskTargetPathFromImageVolumeView(volumeIndex int, volumePath string) (*safepath.Path, error) {


### PR DESCRIPTION
### What this PR does
Ensures that the cached grace period metadata inside virt-handler is synchronized with the `spec.TerminationGracePeriodSeconds` field from the VMI.

Special thanks to @Acedus and @akalenyu for their help in debugging and patching this issue.

### Before this PR

Force stop commands like:
```bash
virtctl stop vm --force --grace-period=0
```

may not take effect on unresponsive VMs. 
The cached grace period in virt-handler could remain stale, ignoring updated values from the VMI spec. This leads to situations where shutdown appears to hang, especially on VMs that don't respond to ACPI signals (e.g., empty or diskless/ alpine VMs).

### After this PR

The metadata cache inside virt-launcher is now explicitly updated during each sync loop, ensuring that any changes to `spec.TerminationGracePeriodSeconds` are honored while prioritizing in the virt-handler side to honor the `vmi.Spec.TerminationGracePeriodSeconds` over the cached domain value before initiating shutdown.

### References

### Special notes for reviewers

One open question remains: responsive VMs (e.g., running Cirros or Fedora) can still be force stopped even without this patch. But unresponsive VMs (e.g., empty vms or disk less, or even alpine) require this metadata update. I'm unsure why the difference insights are welcome.

/sig compute

### Release note
```release-note
bugfix: ensure grace period metadata cache is synced in virt-launcher
```

