### PR TITLE
[release-1.5] Restore: include meaningful status message when target not ready

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -75,13 +75,20 @@ const (
 	restoreVMNotReadyEvent = "RestoreTargetNotReady"
 
 	restoreDataVolumeCreateErrorEvent = "RestoreDataVolumeCreateError"
+
+	waitEventuallyMessage = "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"
+	stopTargetMessage     = "Automatically stopping restore target for restore operation"
+
+	vmiExistsEventMessage        = "Restore target VMI still exists, please stop the restore target to proceed with restore"
+	targetNotReadyFailureMessage = "Restore target VMI must be powered off before restore operation"
+
+	restoreFailedEvent           = "Operation failed"
+	errorRestoreToExistingTarget = "restore source and restore target are different but restore target already exists"
 )
 
 var (
-	restoreGracePeriodExceededError = fmt.Sprintf("Restore target failed to be ready within %s", snapshotv1.DefaultGracePeriod)
-	restoreTargetNotReady           = "Restore target not ready"
-	restoredFailed                  = "Operation failed"
-	errorRestoreToExistingTarget    = "restore source and restore target are different but restore target already exists"
+	restoreGracePeriodExceededError = fmt.Sprintf("Restore target failed to be ready within %s. Please power off the target VM before attempting restore", snapshotv1.DefaultGracePeriod)
+	waitGracePeriodMessage          = fmt.Sprintf("Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after %s", snapshotv1.DefaultGracePeriod)
 )
 
 type restoreTarget interface {
@@ -263,23 +270,35 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 }
 
 func (ctrl *VMRestoreController) doUpdateError(restore *snapshotv1.VirtualMachineRestore, err error) error {
-	ctrl.Recorder.Eventf(
-		restore,
-		corev1.EventTypeWarning,
-		restoreErrorEvent,
-		"VirtualMachineRestore encountered error %s",
-		err.Error(),
-	)
-
-	updated := restore.DeepCopy()
-
-	updateRestoreCondition(updated, newProgressingCondition(corev1.ConditionFalse, err.Error()))
-	updateRestoreCondition(updated, newReadyCondition(corev1.ConditionFalse, err.Error()))
-	if err2 := ctrl.doUpdateStatus(restore, updated); err2 != nil {
-		return err2
+	if updateErr := ctrl.doUpdateErrorWithFailure(restore, err.Error(), false); updateErr != nil {
+		return updateErr
 	}
 
 	return err
+}
+
+func (ctrl *VMRestoreController) doUpdateErrorWithFailure(restore *snapshotv1.VirtualMachineRestore, errMsg string, fail bool) error {
+	updated := restore.DeepCopy()
+
+	eventReason := restoreErrorEvent
+	eventMsg := fmt.Sprintf("VirtualMachineRestore encountered error %s", errMsg)
+
+	updateRestoreCondition(updated, newProgressingCondition(corev1.ConditionFalse, errMsg))
+	updateRestoreCondition(updated, newReadyCondition(corev1.ConditionFalse, errMsg))
+	if fail {
+		eventReason = restoreFailedEvent
+		eventMsg = fmt.Sprintf("VirtualMachineRestore failed %s", errMsg)
+		updateRestoreCondition(updated, newFailureCondition(corev1.ConditionTrue, errMsg))
+	}
+
+	ctrl.Recorder.Eventf(
+		restore,
+		corev1.EventTypeWarning,
+		eventReason,
+		eventMsg,
+	)
+
+	return ctrl.doUpdateStatus(restore, updated)
 }
 
 func (ctrl *VMRestoreController) doUpdateStatus(original, updated *snapshotv1.VirtualMachineRestore) error {
@@ -334,29 +353,44 @@ func (ctrl *VMRestoreController) handleVMRestoreTargetNotReady(vmRestore *snapsh
 		policy = *vmRestore.Spec.TargetReadinessPolicy
 	}
 
-	eventMsg := "Restore target VMI still exists"
-	ctrl.Recorder.Event(vmRestoreCpy, corev1.EventTypeNormal, restoreVMNotReadyEvent, eventMsg)
-	reason := "Waiting for target to be ready"
-	updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, reason))
-	updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, reason))
+	var reason, eventMsg string
 
 	switch policy {
 	case snapshotv1.VirtualMachineRestoreWaitEventually:
+		reason = waitEventuallyMessage
+		eventMsg = vmiExistsEventMessage
 	case snapshotv1.VirtualMachineRestoreStopTarget:
-		err := target.Stop()
-		if err != nil {
-			return ctrl.doUpdateError(vmRestore, err)
-		}
+		return ctrl.stopTarget(vmRestore, target)
 	case snapshotv1.VirtualMachineRestoreWaitGracePeriodAndFail:
 		if vmRestoreTargetReadyGracePeriodExceeded(vmRestore) {
-			updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, restoredFailed))
-			updateRestoreCondition(vmRestoreCpy, newFailureCondition(corev1.ConditionTrue, restoreGracePeriodExceededError))
-			updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, restoredFailed))
+			return ctrl.doUpdateErrorWithFailure(vmRestore, restoreGracePeriodExceededError, true)
 		}
+
+		reason = waitGracePeriodMessage
+		eventMsg = vmiExistsEventMessage
 	case snapshotv1.VirtualMachineRestoreFailImmediate:
-		updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, restoredFailed))
-		updateRestoreCondition(vmRestoreCpy, newFailureCondition(corev1.ConditionTrue, restoreTargetNotReady))
-		updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, restoredFailed))
+		return ctrl.doUpdateErrorWithFailure(vmRestore, targetNotReadyFailureMessage, true)
+	default:
+		return fmt.Errorf("unknown targetReadinessPolicy: %v", policy)
+	}
+
+	ctrl.Recorder.Event(vmRestoreCpy, corev1.EventTypeWarning, restoreVMNotReadyEvent, eventMsg)
+	updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, reason))
+	updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, reason))
+
+	return ctrl.doUpdateStatus(vmRestore, vmRestoreCpy)
+}
+
+func (ctrl *VMRestoreController) stopTarget(vmRestore *snapshotv1.VirtualMachineRestore, target restoreTarget) error {
+	vmRestoreCpy := vmRestore.DeepCopy()
+	ctrl.Recorder.Event(vmRestoreCpy, corev1.EventTypeWarning, restoreVMNotReadyEvent, stopTargetMessage)
+	updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, stopTargetMessage))
+	updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, stopTargetMessage))
+
+	// Stop the restore target
+	err := target.Stop()
+	if err != nil {
+		return ctrl.doUpdateError(vmRestoreCpy, err)
 	}
 	return ctrl.doUpdateStatus(vmRestore, vmRestoreCpy)
 }

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -517,8 +517,8 @@ var _ = Describe("Restore controller", func() {
 				rc2.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
-						newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-						newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+						newProgressingCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
 					},
 				}
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
@@ -674,7 +674,7 @@ var _ = Describe("Restore controller", func() {
 					Spec: corev1.PersistentVolumeClaimSpec{
 						Resources: corev1.VolumeResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("2Gi"),
+								corev1.ResourceStorage: resource.MustParse("2Gi"),
 							},
 						},
 						VolumeName:       "volume2",
@@ -1517,8 +1517,8 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-							newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"),
+							newReadyCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1540,8 +1540,8 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-							newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Automatically stopping restore target for restore operation"),
+							newReadyCondition(corev1.ConditionFalse, "Automatically stopping restore target for restore operation"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1569,9 +1569,9 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Operation failed"),
-							newReadyCondition(corev1.ConditionFalse, "Operation failed"),
-							newFailureCondition(corev1.ConditionTrue, "Restore target failed to be ready within 5m0s"),
+							newProgressingCondition(corev1.ConditionFalse, "Restore target failed to be ready within 5m0s. Please power off the target VM before attempting restore"),
+							newReadyCondition(corev1.ConditionFalse, "Restore target failed to be ready within 5m0s. Please power off the target VM before attempting restore"),
+							newFailureCondition(corev1.ConditionTrue, "Restore target failed to be ready within 5m0s. Please power off the target VM before attempting restore"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1579,7 +1579,7 @@ var _ = Describe("Restore controller", func() {
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
-					testutils.ExpectEvent(recorder, "RestoreTargetNotReady")
+					testutils.ExpectEvent(recorder, "Operation failed")
 					Expect(*updateStatusCalls).To(Equal(1))
 				})
 
@@ -1588,8 +1588,8 @@ var _ = Describe("Restore controller", func() {
 					r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
-							newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
+							newReadyCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore, or the operation will fail after 5m0s"),
 						},
 					}
 					//change creation time such that it will make the default grace period pass
@@ -1626,9 +1626,9 @@ var _ = Describe("Restore controller", func() {
 					rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
 						Complete: pointer.P(false),
 						Conditions: []snapshotv1.Condition{
-							newProgressingCondition(corev1.ConditionFalse, "Operation failed"),
-							newReadyCondition(corev1.ConditionFalse, "Operation failed"),
-							newFailureCondition(corev1.ConditionTrue, "Restore target not ready"),
+							newProgressingCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newReadyCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newFailureCondition(corev1.ConditionTrue, "Restore target VMI must be powered off before restore operation"),
 						},
 					}
 					vmSource.Add(vm)
@@ -1636,8 +1636,32 @@ var _ = Describe("Restore controller", func() {
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
-					testutils.ExpectEvent(recorder, "RestoreTargetNotReady")
+					testutils.ExpectEvent(recorder, "Operation failed")
 					Expect(*updateStatusCalls).To(Equal(1))
+				})
+
+				It("should not change from failure status even if VM becomes ready", func() {
+					r := createRestoreWithOwner()
+					r.Spec.TargetReadinessPolicy = pointer.P(snapshotv1.VirtualMachineRestoreFailImmediate)
+					// Set up restore with failure condition already present
+					r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+						Complete: pointer.P(false),
+						Conditions: []snapshotv1.Condition{
+							newProgressingCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newReadyCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+							newFailureCondition(corev1.ConditionTrue, "Restore target VMI must be powered off before restore operation"),
+						},
+					}
+					vm := createModifiedVM()
+					// Add VM without VMI (VM is ready), but restore already has failure condition
+					vmSource.Add(vm)
+
+					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, r)
+
+					addVirtualMachineRestore(r)
+					controller.processVMRestoreWorkItem()
+					// Verify no status update occurred since restore is already in terminal failure state
+					Expect(*updateStatusCalls).To(Equal(0))
 				})
 			})
 
@@ -1647,9 +1671,9 @@ var _ = Describe("Restore controller", func() {
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
-						newProgressingCondition(corev1.ConditionFalse, "Operation failed"),
-						newReadyCondition(corev1.ConditionFalse, "Operation failed"),
-						newFailureCondition(corev1.ConditionTrue, "Restore target not ready"),
+						newProgressingCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+						newReadyCondition(corev1.ConditionFalse, "Restore target VMI must be powered off before restore operation"),
+						newFailureCondition(corev1.ConditionTrue, "Restore target VMI must be powered off before restore operation"),
 					},
 				}
 				vm := createModifiedVM()

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1022,7 +1022,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				if !stopVMBeforeRestore {
-					events.ExpectEvent(restore, corev1.EventTypeNormal, "RestoreTargetNotReady")
+					events.ExpectEvent(restore, corev1.EventTypeWarning, "RestoreTargetNotReady")
 					By(stoppingVM)
 					vm = libvmops.StopVirtualMachine(vm)
 				}
@@ -1171,7 +1171,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				events.ExpectEvent(restore, corev1.EventTypeNormal, "RestoreTargetNotReady")
+				events.ExpectEvent(restore, corev1.EventTypeWarning, "RestoreTargetNotReady")
 				By(stoppingVM)
 				vm = libvmops.StopVirtualMachine(vm)
 


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/15010

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

