### PR TITLE
fix: pkg/virtctl/create/preference linting issues

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -31,6 +31,7 @@ pkg/virtctl/clientconfig
 pkg/virtctl/configuration
 pkg/virtctl/console
 pkg/virtctl/create/params
+pkg/virtctl/create/preference
 pkg/virtctl/create/vm
 pkg/virtctl/credentials
 pkg/virtctl/testing

--- a/pkg/virtctl/create/preference/preference.go
+++ b/pkg/virtctl/create/preference/preference.go
@@ -33,11 +33,12 @@ import (
 )
 
 const (
-	CPUTopologyFlag        = "cpu-topology"
-	VolumeStorageClassFlag = "volume-storage-class"
-	MachineTypeFlag        = "machine-type"
-	NameFlag               = "name"
-	NamespacedFlag         = "namespaced"
+	CPUTopologyFlag         = "cpu-topology"
+	VolumeStorageClassFlag  = "volume-storage-class"
+	MachineTypeFlag         = "machine-type"
+	NameFlag                = "name"
+	NamespacedFlag          = "namespaced"
+	defaultNameSuffixLength = 5
 )
 
 type createPreference struct {
@@ -57,7 +58,10 @@ func NewCommand() *cobra.Command {
 		Example: c.usage(),
 		RunE:    c.run,
 	}
-	cmd.Flags().BoolVar(&c.namespaced, NamespacedFlag, c.namespaced, "Specify if VirtualMachinePreference should be created. By default VirtualMachineClusterPreference is created.")
+	cmd.Flags().BoolVar(&c.namespaced,
+		NamespacedFlag,
+		c.namespaced,
+		"Specify if VirtualMachinePreference should be created. By default VirtualMachineClusterPreference is created.")
 	cmd.Flags().StringVar(&c.name, NameFlag, c.name, "Specify the name of the Preference.")
 	cmd.Flags().StringVar(&c.preferredStorageClass, VolumeStorageClassFlag, c.preferredStorageClass, "Defines the preferred storage class")
 	cmd.Flags().StringVar(&c.machineType, MachineTypeFlag, c.machineType, "Defines the preferred machine type to use.")
@@ -81,9 +85,9 @@ func (c *createPreference) setDefaults(cmd *cobra.Command) error {
 	}
 
 	if c.namespaced {
-		c.name = "preference-" + rand.String(5)
+		c.name = "preference-" + rand.String(defaultNameSuffixLength)
 	} else {
-		c.name = "clusterpreference-" + rand.String(5)
+		c.name = "clusterpreference-" + rand.String(defaultNameSuffixLength)
 	}
 
 	return nil
@@ -188,7 +192,8 @@ func (c *createPreference) run(cmd *cobra.Command, _ []string) error {
 	if c.namespaced {
 		preference := c.newPreference()
 
-		if err := c.applyFlags(cmd, &preference.Spec); err != nil {
+		err = c.applyFlags(cmd, &preference.Spec)
+		if err != nil {
 			return err
 		}
 
@@ -199,7 +204,8 @@ func (c *createPreference) run(cmd *cobra.Command, _ []string) error {
 	} else {
 		clusterPreference := c.newClusterPreference()
 
-		if err := c.applyFlags(cmd, &clusterPreference.Spec); err != nil {
+		err = c.applyFlags(cmd, &clusterPreference.Spec)
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
pkg/virtctl/create/preference directory was not checked when running `make lint` and linter checks failed
#### After this PR:
pkg/virtctl/create/preference directory is now checked by make lint and successfully passes
### References
- Fixes #14197


### Release note
```
NONE
```

