### PR TITLE
fix: convert login time to seconds

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17100,6 +17100,7 @@
       "type": "string"
      },
      "loginTime": {
+      "description": "Time of login of this user on the computer. If multiple instances of the user are logged in, the earliest login time is reported. The value is in fractional seconds since epoch time.",
       "type": "number",
       "format": "double"
      },

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -506,7 +506,7 @@ func convertToUsers(guestInfo *libvirt.DomainGuestInfo) []api.User {
 			users = append(users, api.User{
 				Name:      user.Name,
 				Domain:    user.Domain,
-				LoginTime: float64(user.LoginTime),
+				LoginTime: (time.Duration(user.LoginTime) * time.Millisecond).Seconds(),
 			})
 		}
 	}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2669,8 +2669,10 @@ type VirtualMachineInstanceGuestOSUserList struct {
 
 // VirtualMachineGuestOSUser is the single user of the guest os
 type VirtualMachineInstanceGuestOSUser struct {
-	UserName  string  `json:"userName"`
-	Domain    string  `json:"domain,omitempty"`
+	UserName string `json:"userName"`
+	Domain   string `json:"domain,omitempty"`
+
+	// Time of login of this user on the computer. If multiple instances of the user are logged in, the earliest login time is reported. The value is in fractional seconds since epoch time.
 	LoginTime float64 `json:"loginTime,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -767,7 +767,8 @@ func (VirtualMachineInstanceGuestOSUserList) SwaggerDoc() map[string]string {
 
 func (VirtualMachineInstanceGuestOSUser) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "VirtualMachineGuestOSUser is the single user of the guest os",
+		"":          "VirtualMachineGuestOSUser is the single user of the guest os",
+		"loginTime": "Time of login of this user on the computer. If multiple instances of the user are logged in, the earliest login time is reported. The value is in fractional seconds since epoch time.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25944,8 +25944,9 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceGuestOSUser(ref common.
 					},
 					"loginTime": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"number"},
-							Format: "double",
+							Description: "Time of login of this user on the computer. If multiple instances of the user are logged in, the earliest login time is reported. The value is in fractional seconds since epoch time.",
+							Type:        []string{"number"},
+							Format:      "double",
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Libvirt API returns milliseconds of the
loginTime, and previously KubeVirt
API was using QEMU directly that
represents seconds only.

This conversion from milliseconds to
seconds is essential to keep consistency
of what is expected from the KubeVirt
API in the response of loginTime.

Also update the description of the
loginTime in the KubeVirt API
to ensure that user understands
the returned value of it.

Jira-Url: https://issues.redhat.com/browse/CNV-64776

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
