### PR TITLE
e2e, net, link state: Add linkState tests for scenario: migration

### DIFF
--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -37,26 +37,32 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = Describe(SIG("interface state up/down", func() {
-	It("status and guest should show correct iface state", func() {
-		const (
-			primaryLogicalNetName    = "default"
-			secondary2LogicalNetName = "bridge2"
-			nadName                  = "bridge-nad"
-		)
-
+	const (
+		primaryLogicalNetName    = "default"
+		secondary2LogicalNetName = "bridge2"
+		nadName                  = "bridge-nad"
+	)
+	const (
+		waitForGAConnectedTimout        = 6 * time.Minute
+		waitForGAConnectedRetryInterval = 3 * time.Second
+	)
+	const waitForExpectedIfaceStatusesTimeout = 60 * time.Second
+	BeforeEach(func() {
 		testNamespace := testsuite.GetTestNamespace(nil)
-
-		var err error
-		_, err = libnet.CreateNetAttachDef(context.Background(), testNamespace,
+		_, err := libnet.CreateNetAttachDef(context.Background(), testNamespace,
 			libnet.NewBridgeNetAttachDef(nadName, "br02"))
 		Expect(err).NotTo(HaveOccurred())
+	})
 
+	It("status and guest should show correct iface state", func() {
+		testNamespace := testsuite.GetTestNamespace(nil)
 		mac1, err := libnet.GenerateRandomMac()
 		Expect(err).NotTo(HaveOccurred())
 		mac2, err := libnet.GenerateRandomMac()
@@ -87,11 +93,6 @@ var _ = Describe(SIG("interface state up/down", func() {
 		vm, err = kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		const (
-			waitForGAConnectedTimout        = 6 * time.Minute
-			waitForGAConnectedRetryInterval = 3 * time.Second
-		)
-
 		Eventually(matcher.ThisVM(vm)).
 			WithTimeout(waitForGAConnectedTimout).
 			WithPolling(waitForGAConnectedRetryInterval).
@@ -105,7 +106,6 @@ var _ = Describe(SIG("interface state up/down", func() {
 			{Name: secondary2LogicalNetName, LinkState: string(v1.InterfaceStateLinkDown)},
 		}
 
-		const waitForExpectedIfaceStatusesTimeout = 60 * time.Second
 		Eventually(func() ([]v1.VirtualMachineInstanceNetworkInterface, error) {
 			fetchedVMI, err := kubevirt.Client().VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			if err != nil {
@@ -143,6 +143,84 @@ var _ = Describe(SIG("interface state up/down", func() {
 		timeout = 30 * time.Second
 		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac1.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
 		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac2.String(), v1.InterfaceStateLinkUp), timeout)).To(Succeed())
+	})
+
+	It("status and guest should show iface is down when vm with ifaces down is migrated", func() {
+		testNamespace := testsuite.GetTestNamespace(nil)
+		mac1, err := libnet.GenerateRandomMac()
+		Expect(err).NotTo(HaveOccurred())
+		mac2, err := libnet.GenerateRandomMac()
+		Expect(err).NotTo(HaveOccurred())
+
+		vmi := libvmifact.NewFedora(
+			libvmi.WithInterface(v1.Interface{
+				Name: primaryLogicalNetName,
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{
+					Masquerade: &v1.InterfaceMasquerade{},
+				},
+				MacAddress: mac1.String(),
+				State:      v1.InterfaceStateLinkDown,
+			}),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithInterface(v1.Interface{
+				Name: secondary2LogicalNetName,
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{
+					Bridge: &v1.InterfaceBridge{},
+				},
+				MacAddress: mac2.String(),
+				State:      v1.InterfaceStateLinkDown,
+			}),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondary2LogicalNetName, nadName)),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		vm, err = kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(matcher.ThisVM(vm)).
+			WithTimeout(waitForGAConnectedTimout).
+			WithPolling(waitForGAConnectedRetryInterval).
+			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+		vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+		expectedIfaceStatuses := []v1.VirtualMachineInstanceNetworkInterface{
+			{Name: primaryLogicalNetName, LinkState: string(v1.InterfaceStateLinkDown)},
+			{Name: secondary2LogicalNetName, LinkState: string(v1.InterfaceStateLinkDown)},
+		}
+
+		Eventually(func() ([]v1.VirtualMachineInstanceNetworkInterface, error) {
+			fetchedVMI, err := kubevirt.Client().VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return normalizeIfaceStatuses(fetchedVMI.Status.Interfaces), nil
+		}).WithTimeout(waitForExpectedIfaceStatusesTimeout).Should(ConsistOf(expectedIfaceStatuses))
+
+		timeout := 5 * time.Second
+		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac1.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
+		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac2.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
+
+		By("migrating the vmi")
+		migration := libmigration.New(vmi.Name, vmi.Namespace)
+		migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
+		libmigration.ConfirmVMIPostMigration(kubevirt.Client(), vmi, migration)
+
+		vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() ([]v1.VirtualMachineInstanceNetworkInterface, error) {
+			fetchedVMI, err := kubevirt.Client().VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return normalizeIfaceStatuses(fetchedVMI.Status.Interfaces), nil
+		}).WithTimeout(waitForExpectedIfaceStatusesTimeout).Should(ConsistOf(expectedIfaceStatuses))
+
+		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac1.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
+		Expect(console.RunCommand(vmi, assertLinkStateCmd(mac2.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
+
 	})
 }))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Verifies that migrating a VMI, whose primary and secondary ifaces are down, preserves the iface state.
From KubeVirt v1.5.0 we can specify the state of an interface when creating a VM. While we have tests that verify that we can set the interface state and update it, we did not explicitly test a scenario where a VM with both interfaces down is migrated.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

