### PR TITLE
better tests for firmware.serial

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2076,6 +2076,15 @@ var _ = Describe("Converter", func() {
 		)
 	})
 
+	It("should not include serial entry in sysinfo when firmware.serial is not set", func() {
+		vmi := libvmi.New()
+		v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+		domain := vmiToDomain(vmi, &ConverterContext{Architecture: archconverter.NewConverter(runtime.GOARCH), AllowEmulation: true})
+		Expect(domain.Spec.SysInfo.System).ToNot(ContainElement(HaveField("Name", Equal("serial"))),
+			"serial entry should not be present in sysinfo",
+		)
+	})
+
 	Context("IOThreads", func() {
 
 		DescribeTable("Should use correct IOThreads policies", func(policy v1.IOThreadsPolicy, cpuCores int, threadCount int, threadIDs []int) {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1364,24 +1364,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 				Expect(domXML).To(ContainSubstring("<entry name='serial'>4b2f5496-f3a3-460b-a375-168223f68845</entry>"), "Should have serial-number present")
 			})
-
-			It("[test_id:3122]should not have serial-number set when not present", func() {
-				By("Starting a VirtualMachineInstance")
-				snVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), libvmifact.NewAlpine(), metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStart(snVmi)
-
-				getOptions := metav1.GetOptions{}
-				var freshVMI *v1.VirtualMachineInstance
-
-				freshVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(snVmi)).Get(context.Background(), snVmi.Name, getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-
-				domXML, err := libdomain.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
-				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
-
-				Expect(domXML).ToNot(ContainSubstring("<entry name='serial'>"), "Should have serial-number present")
-			})
 		})
 
 		Context("with TSC timer", func() {


### PR DESCRIPTION
This PR drops a redundant test, which defines a VM and waits for it to starts, only to test that its domxml does not have a harmless entry. I don't think that it is an important behavior to test. In fact, other vm management systems assign a unique serial number to every VM without explicit request. But let us keep the test for now, in a unit test form.

This PR also improves the quality of the remaining e2e test for firmware.serial, making it a true end-to-end test, which ensures that the guest behaves as expected. I am not a big fan of this test - the only thing it adds over a simple converter unit test is that it tests libvirt, which is another project. But let us keep it now that it is a proper e2e test, due to doubts whether libvirt supports spaces in firmware.serial.

```release-note
NONE
```

