### PR TITLE
[release-1.6] Un-quarantine should not migrate more than two VMIs at the same time from a node

### DIFF
--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -421,7 +421,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 			})
 		})
 		Context("with multiple VMIs with eviction policies set", Serial, func() {
-			It("[QUARANTINE][release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", decorators.Quarantine, func() {
+			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := alpineVMIWithEvictionStrategy()


### PR DESCRIPTION
### What this PR does

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Known issue: ParallelOutboundMigrationsPerNode might be ignored because of race condition 
```

