### PR TITLE
Remove PodCacheStore, not used

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -114,18 +114,6 @@ const (
 	MigrationBackoffReason = "MigrationBackoff"
 )
 
-type PodCacheStore struct {
-	indexer cache.Indexer
-}
-
-func NewPodCacheStore(indexer cache.Indexer) *PodCacheStore {
-	return &PodCacheStore{indexer: indexer}
-}
-
-func (p *PodCacheStore) CurrentPod(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error) {
-	return CurrentVMIPod(vmi, p.indexer)
-}
-
 // NewListWatchFromClient creates a new ListWatch from the specified client, resource, kubevirtNamespace and field selector.
 func NewListWatchFromClient(c cache.Getter, resource string, namespace string, fieldSelector fields.Selector, labelSelector labels.Selector) *cache.ListWatch {
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {


### PR DESCRIPTION
### What this PR does
Removes code, leftover from https://github.com/kubevirt/kubevirt/pull/14311

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

