### PR TITLE
hack: Force IMAGE_PULL_POLICY to Always when using cluster-sync

### DIFF
--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -31,7 +31,9 @@ function main() {
     CLEAN_PID=$!
 
     ./hack/cluster-build.sh
-    ./hack/manifests.sh
+    # We always want to check for updated digests as we are using a single devel tag so set our imagePullPolicy to Always
+    # See https://github.com/kubevirt/kubevirt/issues/15218 for more context
+    IMAGE_PULL_POLICY=Always ./hack/manifests.sh
 
     echo "waiting for cluster-clean to finish"
     if ! wait $CLEAN_PID; then


### PR DESCRIPTION
### What this PR does

As set out in bug #15218 1a311c24b759a9c4f627dcf7587a5bae0c3064e1 accidentally broke the `cluster-sync` flow when KubeVirt is already deployed.

This change forces all components to use the Always imagePullPolicy in these environments to force kubelet to query the registry even when the tag hasn't changed to ensure the digest is up to date. As is the case in our kubevirtci envs where we use a single `devel` tag for all builds.

### References

- Fixes #15218

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

