### PR TITLE
virt-operator: Stop using deprecated node-role.kubernetes.io/master taint

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1372,9 +1372,6 @@ spec:
                     - matchExpressions:
                       - key: node-role.kubernetes.io/control-plane
                         operator: Exists
-                    - matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: Exists
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
                   - podAffinityTerm:
@@ -1458,9 +1455,6 @@ spec:
                 operator: Exists
               - effect: NoSchedule
                 key: node-role.kubernetes.io/control-plane
-                operator: Exists
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/master
                 operator: Exists
               volumes:
               - name: kubevirt-operator-certs

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -383,7 +383,6 @@ var nodeLabels = map[string]string{
 	"kubernetes.io/os":                                                 "linux",
 	"kubevirt.io/schedulable":                                          "true",
 	"node-role.kubernetes.io/control-plane":                            "",
-	"node-role.kubernetes.io/master":                                   "",
 	"node.kubernetes.io/exclude-from-external-load-balancers":          "",
 	"scheduling.node.kubevirt.io/tsc-frequency-2111998000":             "true",
 }

--- a/pkg/virt-operator/resource/placement/placement.go
+++ b/pkg/virt-operator/resource/placement/placement.go
@@ -63,14 +63,6 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 											},
 										},
 									},
-									{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{
-												Key:      "node-role.kubernetes.io/master",
-												Operator: corev1.NodeSelectorOpExists,
-											},
-										},
-									},
 								},
 							},
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
@@ -91,11 +83,6 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 					Tolerations: []corev1.Toleration{
 						{
 							Key:      "node-role.kubernetes.io/control-plane",
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-						{
-							Key:      "node-role.kubernetes.io/master",
 							Operator: corev1.TolerationOpExists,
 							Effect:   corev1.TaintEffectNoSchedule,
 						},

--- a/pkg/virt-operator/resource/placement/placement_test.go
+++ b/pkg/virt-operator/resource/placement/placement_test.go
@@ -386,7 +386,6 @@ var _ = Describe("Placement", func() {
 		Context("default scheduling to CP nodes", func() {
 			DescribeTable("should require scheduling to control-plane nodes and avoid worker nodes", func(config *v1.ComponentConfig) {
 				const (
-					masterLabel       = "node-role.kubernetes.io/master"
 					controlPlaceLabel = "node-role.kubernetes.io/control-plane"
 					workerLabel       = "node-role.kubernetes.io/worker"
 				)
@@ -398,7 +397,7 @@ var _ = Describe("Placement", func() {
 
 				By("Testing scheduling requirements")
 				Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).ToNot(BeNil())
-				Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(2))
+				Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 
 				requirementSelectorTerm := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
 				Expect(requirementSelectorTerm.MatchFields).To(BeEmpty())
@@ -406,14 +405,6 @@ var _ = Describe("Placement", func() {
 
 				requirementMatchExpression := requirementSelectorTerm.MatchExpressions[0]
 				Expect(requirementMatchExpression.Key).To(Equal(controlPlaceLabel))
-				Expect(requirementMatchExpression.Operator).To(Equal(corev1.NodeSelectorOpExists))
-
-				requirementSelectorTerm = podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[1]
-				Expect(requirementSelectorTerm.MatchFields).To(BeEmpty())
-				Expect(requirementSelectorTerm.MatchExpressions).To(HaveLen(1))
-
-				requirementMatchExpression = requirementSelectorTerm.MatchExpressions[0]
-				Expect(requirementMatchExpression.Key).To(Equal(masterLabel))
 				Expect(requirementMatchExpression.Operator).To(Equal(corev1.NodeSelectorOpExists))
 
 				By("Testing scheduling preferences")
@@ -431,11 +422,6 @@ var _ = Describe("Placement", func() {
 				Expect(podSpec.Tolerations).To(ContainElements(
 					corev1.Toleration{
 						Key:      "node-role.kubernetes.io/control-plane",
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectNoSchedule,
-					},
-					corev1.Toleration{
-						Key:      "node-role.kubernetes.io/master",
 						Operator: corev1.TolerationOpExists,
 						Effect:   corev1.TaintEffectNoSchedule,
 					},


### PR DESCRIPTION
### What this PR does

node-role.kubernetes.io/master was deprecated back in k8s v1.20 [1] and has been removed from nodes on upgrade since k8s v1.25 [2]. As we currently only support >= v1.30.0 it should be safe to remove the use of this taint now and rely on the existing use of the node-role.kubernetes.io/control-plane that replaces it.

[1] https://github.com/kubernetes/kubernetes/blob/49945dbfab342a6d7dee7e83778bb1cc3886bdbe/CHANGELOG/CHANGELOG-1.20.md?plain=1#L1923
[2] https://github.com/kubernetes/kubernetes/blob/49945dbfab342a6d7dee7e83778bb1cc3886bdbe/CHANGELOG/CHANGELOG-1.25.md?plain=1#L2335

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

A followup `kubevirtci` change will remove the remaining uses of this taint in the codebase.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

