### PR TITLE
Add alerts when VM is in unhealthy status

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -237,6 +237,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+
   # All virt controllers are not ready (ImagePullBackOff)
   - interval: 1m
     input_series:
@@ -854,3 +855,183 @@ tests:
       - eval_time: 3m
         alertname: GuestVCPUQueueHighCritical
         exp_alerts: []
+
+  # VM stuck without VMI (early lifecycle states and errors)
+  - interval: 1m
+    input_series:
+      # VMs that SHOULD alert (in problematic states without VMI)
+      - series: 'kubevirt_vm_info{name="vm-stuck-provisioning", namespace="test-ns", status="provisioning", status_group="starting"}'
+        values: "1x16"
+      - series: 'kubevirt_vm_info{name="vm-stuck-starting-no-vmi", namespace="test-ns", status="starting", status_group="starting"}'
+        values: "1x16"
+      - series: 'kubevirt_vm_info{name="vm-unschedulable", namespace="test-ns", status="ErrorUnschedulable", status_group="error"}'
+        values: "1x16"
+      - series: 'kubevirt_vm_info{name="vm-pvc-missing", namespace="test-ns", status="ErrorPvcNotFound", status_group="error"}'
+        values: "1x16"
+      - series: 'kubevirt_vm_info{name="vm-terminating-no-vmi", namespace="test-ns", status="terminating", status_group="non_running"}'
+        values: "1x16"
+      # VMs that should NOT alert (in healthy states without VMI)
+      - series: 'kubevirt_vm_info{name="vm-stopped", namespace="test-ns", status="stopped", status_group="non_running"}'
+        values: "1x16"
+
+    alert_rule_test:
+      # no alert before 10 minutes
+      - eval_time: 9m
+        alertname: VirtualMachineStuckInUnhealthyState
+        exp_alerts: []
+      # alert should fire after 10 minutes only for VMs in problematic states
+      - eval_time: 10m
+        alertname: VirtualMachineStuckInUnhealthyState
+        exp_alerts:
+          - exp_annotations:
+              summary: "Virtual machine in provisioning state for more than 10 minutes"
+              description: "Virtual machine vm-stuck-provisioning in namespace test-ns has been in provisioning state for more than 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckInUnhealthyState"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-stuck-provisioning"
+              namespace: "test-ns"
+              status: "provisioning"
+          - exp_annotations:
+              summary: "Virtual machine in starting state for more than 10 minutes"
+              description: "Virtual machine vm-stuck-starting-no-vmi in namespace test-ns has been in starting state for more than 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckInUnhealthyState"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-stuck-starting-no-vmi"
+              namespace: "test-ns"
+              status: "starting"
+          - exp_annotations:
+              summary: "Virtual machine in ErrorUnschedulable state for more than 10 minutes"
+              description: "Virtual machine vm-unschedulable in namespace test-ns has been in ErrorUnschedulable state for more than 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckInUnhealthyState"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-unschedulable"
+              namespace: "test-ns"
+              status: "ErrorUnschedulable"
+          - exp_annotations:
+              summary: "Virtual machine in ErrorPvcNotFound state for more than 10 minutes"
+              description: "Virtual machine vm-pvc-missing in namespace test-ns has been in ErrorPvcNotFound state for more than 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckInUnhealthyState"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-pvc-missing"
+              namespace: "test-ns"
+              status: "ErrorPvcNotFound"
+          - exp_annotations:
+              summary: "Virtual machine in terminating state for more than 10 minutes"
+              description: "Virtual machine vm-terminating-no-vmi in namespace test-ns has been in terminating state for more than 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckInUnhealthyState"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-terminating-no-vmi"
+              namespace: "test-ns"
+              status: "terminating"
+
+  # VM stuck with VMI (runtime states and errors)
+  - interval: 1m
+    input_series:
+      # VMs that SHOULD alert (in problematic states with VMI)
+      - series: 'kubevirt_vm_info{name="vm-stuck-starting", namespace="test-ns", status="starting", status_group="starting"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-stuck-starting", namespace="test-ns", node="worker-node-1"}'
+        values: "1x11"
+      - series: 'kubevirt_vm_info{name="vm-image-error", namespace="test-ns", status="ErrImagePull", status_group="error"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-image-error", namespace="test-ns", node="worker-node-2"}'
+        values: "1x11"
+      - series: 'kubevirt_vm_info{name="vm-stuck-stopping", namespace="test-ns", status="stopping", status_group="non_running"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-stuck-stopping", namespace="test-ns", node="worker-node-3"}'
+        values: "1x11"
+      - series: 'kubevirt_vm_info{name="vm-terminating-with-vmi", namespace="test-ns", status="terminating", status_group="non_running"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-terminating-with-vmi", namespace="test-ns", node="worker-node-4"}'
+        values: "1x11"
+      # VMs that should NOT alert (in healthy states with VMI)
+      - series: 'kubevirt_vm_info{name="vm-running", namespace="test-ns", status="running", status_group="running"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-running", namespace="test-ns", node="worker-node-5"}'
+        values: "1x11"
+      - series: 'kubevirt_vm_info{name="vm-paused", namespace="test-ns", status="paused", status_group="running"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-paused", namespace="test-ns", node="worker-node-6"}'
+        values: "1x11"
+
+    alert_rule_test:
+      # no alert before 5 minutes
+      - eval_time: 4m
+        alertname: VirtualMachineStuckOnNode
+        exp_alerts: []
+      # alerts should fire after 5 minutes only for VMs in problematic states
+      - eval_time: 5m
+        alertname: VirtualMachineStuckOnNode
+        exp_alerts:
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-stuck-starting in namespace test-ns on node worker-node-1 has been in starting state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-stuck-starting"
+              namespace: "test-ns"
+              status: "starting"
+              node: "worker-node-1"
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-image-error in namespace test-ns on node worker-node-2 has been in ErrImagePull state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-image-error"
+              namespace: "test-ns"
+              status: "ErrImagePull"
+              node: "worker-node-2"
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-stuck-stopping in namespace test-ns on node worker-node-3 has been in stopping state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-stuck-stopping"
+              namespace: "test-ns"
+              status: "stopping"
+              node: "worker-node-3"
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-terminating-with-vmi in namespace test-ns on node worker-node-4 has been in terminating state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-terminating-with-vmi"
+              namespace: "test-ns"
+              status: "terminating"
+              node: "worker-node-4"

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -102,5 +102,31 @@ var (
 				operatorHealthImpactLabelKey: "none",
 			},
 		},
+		{
+			Alert: "VirtualMachineStuckInUnhealthyState",
+			Expr:  intstr.FromString("sum by (name, namespace, status)(kubevirt_vm_info{status='provisioning'}==1 or kubevirt_vm_info{status='starting'} == 1 or kubevirt_vm_info{status='terminating'} == 1 or kubevirt_vm_info{status_group='error'} == 1) unless on(name, namespace) kubevirt_vmi_info"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				"summary":     "Virtual machine in {{ $labels.status }} state for more than 10 minutes",
+				"description": "Virtual machine {{ $labels.name }} in namespace {{ $labels.namespace }} has been in {{ $labels.status }} state for more than 10 minutes.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "none",
+			},
+		},
+		{
+			Alert: "VirtualMachineStuckOnNode",
+			Expr:  intstr.FromString("sum by (name, namespace, status, node)((kubevirt_vm_info{status='starting'} == 1 or kubevirt_vm_info{status='stopping'} == 1 or kubevirt_vm_info{status='terminating'} == 1 or (kubevirt_vm_info{status_group='error'} == 1 and on(name, namespace) kubevirt_vmi_info) ) * on(name, namespace) group_left(node) kubevirt_vmi_info)"),
+			For:   ptr.To(promv1.Duration("5m")),
+			Annotations: map[string]string{
+				"summary":     "Virtual machine stuck in unhealthy state for more than 5 minutes",
+				"description": "Virtual machine {{ $labels.name }} in namespace {{ $labels.namespace }} on node {{ $labels.node }} has been in {{ $labels.status }} state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "none",
+			},
+		},
 	}
 )


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
No indication in alerts when a VM is stuck in an unhealthy status.

#### After this PR:

PR adds 2 alerts:
1. VM that is in unhealthy status or in transitional status for more than 10 minutes, but doesnt have a VMI for more than 5 minutes
2. VM that is in unhealthy status or in transitional status and has a VMI for more than 5 minutes.

Signed-off-by: Shirly Radco [sradco@redhat.com](mailto:sradco@redhat.com)

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #

 https://issues.redhat.com/browse/CNV-49530

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New VM alerts - VirtualMachineStuckInUnhealthyState, VirtualMachineStuckOnNode
```

