### PR TITLE
Improve error message when restoring VMs with backend storage

### DIFF
--- a/pkg/storage/admitters/vmrestore.go
+++ b/pkg/storage/admitters/vmrestore.go
@@ -216,7 +216,7 @@ func (admitter *VMRestoreAdmitter) validateTargetVM(ctx context.Context, field *
 		if backendstorage.IsBackendStorageNeededForVMI(&snapshotVM.Spec.Template.Spec) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "Restore to a different VM not supported when using backend storage",
+				Message: "Restore to a different VM is not supported when snapshotted VM has backend storage (persistent TPM or EFI)",
 				Field:   field.String(),
 			})
 		}

--- a/pkg/storage/admitters/vmrestore_test.go
+++ b/pkg/storage/admitters/vmrestore_test.go
@@ -564,7 +564,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
-				Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("Restore to a different VM not supported when using backend storage"))
+				Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("Restore to a different VM is not supported when snapshotted VM has backend storage (persistent TPM or EFI)"))
 			},
 				Entry("target doesn't exist", false),
 				Entry("target exists", true),


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

The previous error message only mentioned "backend storage," which may be unclear to users. This PR improves the wording to explicitly mention persistent TPM or EFI as examples

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

-->

- Fixes # https://issues.redhat.com/browse/CNV-62854
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

