### PR TITLE
Add an alert for VM with high CPU usage

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -814,3 +814,56 @@ tests:
       - eval_time: 13m
         alertname: KubeVirtDeprecatedAPIRequested
         exp_alerts: []
+
+  # VM High CPU Usage Alert - Alert should not fire for normal CPU usage
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_cpu_usage_seconds_total{name="test-vm", namespace="test-ns", node="node1"}'
+        values: '0+30x15'  # 50% CPU usage: 30s/60s = 0.5 cpu-seconds/second rate, extend to 15 minutes
+      - series: 'kubevirt_vmi_vcpu_seconds_total{name="test-vm", namespace="test-ns", node="node1", id="0"}'
+        values: '0+30x15'  # 1 vCPU
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: KubeVirtVMHighCPUUsage
+        exp_alerts: []
+
+  # VM High CPU Usage Alert - Alert should fire for sustained high CPU usage
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_cpu_usage_seconds_total{name="high-cpu-vm", namespace="test-namespace", node="node2"}'
+        values: '0+195x15'  # 81% CPU usage: 195s/60s = 3.25 cpu-seconds/second, 3.25/4 = 81.25%, extend to 15 minutes
+      - series: 'kubevirt_vmi_vcpu_seconds_total{name="high-cpu-vm", namespace="test-namespace", node="node2", id="0"}'
+        values: '0+48x15'  # vCPU 0
+      - series: 'kubevirt_vmi_vcpu_seconds_total{name="high-cpu-vm", namespace="test-namespace", node="node2", id="1"}'
+        values: '0+49x15'  # vCPU 1
+      - series: 'kubevirt_vmi_vcpu_seconds_total{name="high-cpu-vm", namespace="test-namespace", node="node2", id="2"}'
+        values: '0+49x15'  # vCPU 2
+      - series: 'kubevirt_vmi_vcpu_seconds_total{name="high-cpu-vm", namespace="test-namespace", node="node2", id="3"}'
+        values: '0+49x15'  # vCPU 3
+
+    alert_rule_test:
+      # Alert should not fire before 5 minutes
+      - eval_time: 4m
+        alertname: KubeVirtVMHighCPUUsage
+        exp_alerts: []
+      # Alert should not fire exactly at 5 minutes (condition needs to be true FOR 5 minutes)
+      - eval_time: 5m
+        alertname: KubeVirtVMHighCPUUsage
+        exp_alerts: []
+      # Alert should fire at 6 minutes (condition true from minute 1, For: 5m means fire at 1+5=6)
+      - eval_time: 6m
+        alertname: KubeVirtVMHighCPUUsage
+        exp_alerts:
+          - exp_annotations:
+              description: "The Virtual machine high-cpu-vm in namespace test-namespace, running on node node2, has high CPU usage (81.25%) for more than 5 minutes."
+              summary: "The Virtual machine has high CPU usage."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMHighCPUUsage"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "high-cpu-vm"
+              namespace: "test-namespace"
+              node: "node2"

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -78,5 +78,18 @@ var (
 				operatorHealthImpactLabelKey: "none",
 			},
 		},
+		{
+			Alert: "KubeVirtVMHighCPUUsage",
+			Expr:  intstr.FromString("(sum by (name, namespace, node) (rate(kubevirt_vmi_cpu_usage_seconds_total[1m])) / on(name, namespace, node) (count by (name, namespace, node) (kubevirt_vmi_vcpu_seconds_total))) > 0.8"),
+			For:   ptr.To(promv1.Duration("5m")),
+			Annotations: map[string]string{
+				"description": "The Virtual machine {{ $labels.name }} in namespace {{ $labels.namespace }}, running on node {{ $labels.node }}, has high CPU usage ({{ $value | humanizePercentage }}) for more than 5 minutes.",
+				"summary":     "The Virtual machine has high CPU usage.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "none",
+			},
+		},
 	}
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
No alert when a VM has a high CPU usage.

#### After this PR:
This PR adds an alert when a VM is experiencing a high CPU usage for at least 5 minutes.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #

- Partially addresses #
-->

Fixes # https://issues.redhat.com/browse/CNV-66071

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added a KubeVirtVMHighCPUUsage alert  for Virtual machines with high CPU usage
```

