### PR TITLE
Add Guest memory alerts

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -369,6 +369,24 @@ How many seconds of work has done that is in progress and hasn't been observed b
 ### kubevirt_workqueue_work_duration_seconds
 How long in seconds processing an item from workqueue takes. Type: Histogram.
 
+### vmi:kubevirt_vmi_memory_available_bytes:sum
+Sum of available memory bytes per VMI (aggregated by name, namespace). Type: Gauge.
+
+### vmi:kubevirt_vmi_memory_headroom_ratio:sum
+Usable memory to available memory ratio per VMI (aggregated by name, namespace). Type: Gauge.
+
+### vmi:kubevirt_vmi_pgmajfaults:rate30m
+Rate of major page faults over 30 minutes per VMI (aggregated by name, namespace). Type: Gauge.
+
+### vmi:kubevirt_vmi_pgmajfaults:rate5m
+Rate of major page faults over 5 minutes per VMI (aggregated by name, namespace). Type: Gauge.
+
+### vmi:kubevirt_vmi_swap_traffic_bytes:rate30m
+Total swap I/O traffic rate over 30 minutes per VMI (swap in + swap out, aggregated by name, namespace). Type: Gauge.
+
+### vmi:kubevirt_vmi_swap_traffic_bytes:rate5m
+Total swap I/O traffic rate over 5 minutes per VMI (swap in + swap out, aggregated by name, namespace). Type: Gauge.
+
 ### vmi:kubevirt_vmi_vcpu:count
 The number of the VMI vCPUs. Type: Gauge.
 

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1246,3 +1246,82 @@ tests:
       - eval_time: 3m
         alertname: GuestFilesystemAlmostOutOfSpace
         exp_alerts: []
+  # VM memory pressure with swap activity
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_memory_available_bytes{name="virt-launcher-vm1", namespace="test-ns"}'
+        values: '1000000000x10'
+      - series: 'kubevirt_vmi_memory_usable_bytes{name="virt-launcher-vm1", namespace="test-ns"}'
+        values: '40000000x10' # 4% usable -> low usable memory
+      - series: 'kubevirt_vmi_memory_swap_in_traffic_bytes{name="virt-launcher-vm1", namespace="test-ns"}'
+        values: '0+100000000x10'
+      - series: 'kubevirt_vmi_memory_swap_out_traffic_bytes{name="virt-launcher-vm1", namespace="test-ns"}'
+        values: '0+100000000x10'
+      - series: 'kubevirt_vmi_info{name="vm1", namespace="test-ns", phase="running", vmi_pod="virt-launcher-vm1"}'
+        values: '1x10'
+
+    alert_rule_test:
+      # should not trigger before 5 minutes pending time elapses
+      - eval_time: 2m
+        alertname: KubeVirtVMGuestMemoryPressure
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: KubeVirtVMGuestMemoryPressure
+        exp_alerts: []
+      # after 5m pending, with low usable mem and swap traffic >1MiB/s
+      - eval_time: 7m
+        alertname: KubeVirtVMGuestMemoryPressure
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachine vm1 in namespace test-ns is under memory pressure: low usable memory with elevated major faults and/or swap IO."
+              summary: "The VirtualMachine is under memory pressure (possible thrashing)"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMGuestMemoryPressure"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "virt-launcher-vm1"
+              vm: "vm1"
+              namespace: "test-ns"
+
+  # VM low available memory without swap and without major faults
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_memory_available_bytes{name="virt-launcher-vm2", namespace="test-ns"}'
+        values: '1000000000x40'
+      - series: 'kubevirt_vmi_memory_usable_bytes{name="virt-launcher-vm2", namespace="test-ns"}'
+        values: '20000000x40' # 2% usable -> below 3% threshold
+      - series: 'kubevirt_vmi_memory_swap_in_traffic_bytes{name="virt-launcher-vm2", namespace="test-ns"}'
+        values: '0x40'
+      - series: 'kubevirt_vmi_memory_swap_out_traffic_bytes{name="virt-launcher-vm2", namespace="test-ns"}'
+        values: '0x40'
+      - series: 'kubevirt_vmi_memory_pgmajfault_total{name="virt-launcher-vm2", namespace="test-ns"}'
+        values: '0x40'
+      - series: 'kubevirt_vmi_info{name="vm2", namespace="test-ns", phase="running", vmi_pod="virt-launcher-vm2"}'
+        values: '1x40'
+
+    alert_rule_test:
+      # should not trigger before 30 minutes pending time elapses
+      - eval_time: 15m
+        alertname: KubeVirtVMGuestMemoryAvailableLow
+        exp_alerts: []
+      - eval_time: 29m
+        alertname: KubeVirtVMGuestMemoryAvailableLow
+        exp_alerts: []
+      # after 30m pending with very low available memory and negligible swap and pgmajfault rates
+      - eval_time: 31m
+        alertname: KubeVirtVMGuestMemoryAvailableLow
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachine vm2 in namespace test-ns has very low available memory (<3% headroom) for 30 minutes with no meaningful swap IO (likely no swap)."
+              summary: "The VirtualMachine has low available memory without swap"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMGuestMemoryAvailableLow"
+            exp_labels:
+              severity: "info"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "virt-launcher-vm2"
+              vm: "vm2"
+              namespace: "test-ns"

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -57,4 +57,52 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 		MetricType: operatormetrics.GaugeType,
 		Expr:       intstr.FromString("clamp_min(kubevirt_vmi_guest_load_1m - vmi:kubevirt_vmi_vcpu:count, 0)"),
 	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_memory_headroom_ratio:sum",
+			Help: "Usable memory to available memory ratio per VMI (aggregated by name, namespace).",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum by (name, namespace) (kubevirt_vmi_memory_usable_bytes) / sum by (name, namespace) (kubevirt_vmi_memory_available_bytes)"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_pgmajfaults:rate5m",
+			Help: "Rate of major page faults over 5 minutes per VMI (aggregated by name, namespace).",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum by (name, namespace) (rate(kubevirt_vmi_memory_pgmajfault_total[5m]))"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_swap_traffic_bytes:rate5m",
+			Help: "Total swap I/O traffic rate over 5 minutes per VMI (swap in + swap out, aggregated by name, namespace).",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes[5m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes[5m]))"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_memory_available_bytes:sum",
+			Help: "Sum of available memory bytes per VMI (aggregated by name, namespace).",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum by (name, namespace) (kubevirt_vmi_memory_available_bytes)"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_pgmajfaults:rate30m",
+			Help: "Rate of major page faults over 30 minutes per VMI (aggregated by name, namespace).",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum by (name, namespace) (rate(kubevirt_vmi_memory_pgmajfault_total[30m]))"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_swap_traffic_bytes:rate30m",
+			Help: "Total swap I/O traffic rate over 30 minutes per VMI (swap in + swap out, aggregated by name, namespace).",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes[30m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes[30m]))"),
+	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
There is no alert for cases where the VM is experiencing high memory pressure.
#### After this PR:

Adds two guest-OS memory alerts. Guest signals reflect true application pressure better than host/cgroup views.

- KubeVirtVMGuestMemoryPressure (warning, for: 5m)
  - Fires when: available/total < 5% AND (major faults > 5/s OR swap IO > 1 MiB/s).
  - Why these thresholds: 5% headroom + sustained >5 pgmajfaults/s or significant swap IO indicates real pressure/thrashing; 5m window filters brief bursts and alerts well before OOM.

- KubeVirtVMGuestMemoryAvailableLow (info, for: 30m)
  - Fires when: available/total < 3% for 30m AND negligible swap IO (<2 KiB/s) AND low major faults (<1/s).
  - Why these thresholds: Flags persistently tiny headroom in guests likely without swap; long window avoids noise and excludes thrashing cases already covered by the Pressure alert.

Defaults are conservative and can be tuned per workload/SLO.

Assisted-by: Cursor for creating Prometheus unit tests.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
Fixes #https://issues.redhat.com/browse/CNV-54116

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The KubeVirtVMGuestMemoryPressure
and KubeVirtVMGuestMemoryAvailableLow alerts were added to alert when a VM memory is in pressure.
```

