### PR TITLE
Object Graph: Fix typo in API resources

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -704,7 +704,7 @@ func (app *virtAPIApp) composeSubresources() {
 						Namespaced: true,
 					},
 					{
-						Name:       "virtualmachinesinstances/objectgraph",
+						Name:       "virtualmachineinstances/objectgraph",
 						Namespaced: true,
 					},
 					{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR fixes a typo in the object graph API resource name for VMIs, correcting `virtualmachinesinstances/objectgraph` to `virtualmachineinstances/objectgraph`.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

