### PR TITLE
Fix decentralized live migration with vTPM devices

### DIFF
--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -146,6 +146,13 @@ func RunAndMonitor(containerDiskDir, uid string) (int, error) {
 	}
 
 	dumpLogFile(passtLogFile)
+	entries, err := os.ReadDir("/run/kubevirt-private/libvirt/qemu/log")
+	if err != nil {
+		log.Log.Reason(err).Error("failed to read qemu log directory")
+	}
+	for _, entry := range entries {
+		dumpLogFile(filepath.Join("/run/kubevirt-private/libvirt/qemu/log", entry.Name()))
+	}
 
 	// give qemu some time to shut down in case it survived virt-handler
 	// Most of the time we call `qemu-system=* binaries, but qemu-system-* packages

--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -12,8 +12,10 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",
+        "//pkg/tpm:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/tests/migration/BUILD.bazel
+++ b/tests/migration/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmigration:go_default_library",
         "//tests/libnet:go_default_library",
+        "//tests/libnet/cloudinit:go_default_library",
         "//tests/libnet/job:go_default_library",
         "//tests/libnet/service:go_default_library",
         "//tests/libnet/vmnetserver:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The vTPM device was checking the source pod/vmi for the name of the source vTPM backend storage PVC name. Which is based on a prefix and the vmi name. There is also a label to associate the PVC with the VMI.

This changes the logic to ignore the check for the source vTPM PVC, and it automatically creates the target vTPM device in the target namespace/cluster

#### Before this PR:
When doing a decentralized live migration with a VM that contains a vTPM device it would fail to create the target.

#### After this PR:
Doing a decentralized live migration with a VM that contains a vTPM device will succeed.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses #
-->
- Fixes https://issues.redhat.com/browse/CNV-66095

  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/24

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

