### PR TITLE
Restore test: reduce runtime and complexity

### DIFF
--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -258,9 +258,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var pvcInformer cache.SharedIndexInformer
-		var pvcSource *framework.FakeControllerSource
-
 		var storageClassInformer cache.SharedIndexInformer
 		var storageClassSource *framework.FakeControllerSource
 
@@ -279,12 +276,10 @@ var _ = Describe("Restore controller", func() {
 		var virtClient *kubecli.MockKubevirtClient
 
 		syncCaches := func(stop chan struct{}) {
-			go pvcInformer.Run(stop)
 			go storageClassInformer.Run(stop)
 			go crInformer.Run(stop)
 			Expect(cache.WaitForCacheSync(
 				stop,
-				pvcInformer.HasSynced,
 				storageClassInformer.HasSynced,
 				crInformer.HasSynced,
 			)).To(BeTrue())
@@ -301,7 +296,7 @@ var _ = Describe("Restore controller", func() {
 			vmiInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachineInstance{})
 			vmInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachine{})
 			dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
-			pvcInformer, pvcSource = testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
+			pvcInformer, _ := testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
 			storageClassInformer, storageClassSource = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 			crInformer, crSource = testutils.NewFakeInformerWithIndexersFor(&appsv1.ControllerRevision{}, virtcontroller.GetControllerRevisionInformerIndexers())
 
@@ -368,9 +363,7 @@ var _ = Describe("Restore controller", func() {
 
 		addPVC := func(pvc *corev1.PersistentVolumeClaim) {
 			syncCaches(stop)
-			mockVMRestoreQueue.ExpectAdds(1)
-			pvcSource.Add(pvc)
-			mockVMRestoreQueue.Wait()
+			Expect(controller.PVCInformer.GetStore().Add(pvc)).To(Succeed())
 		}
 
 		addVM := func(vm *kubevirtv1.VirtualMachine) {
@@ -774,6 +767,7 @@ var _ = Describe("Restore controller", func() {
 					pvc.Status.Phase = corev1.ClaimPending
 					addPVC(&pvc)
 				}
+				enqueueVMR(r)
 				controller.processVMRestoreWorkItem()
 			})
 
@@ -858,7 +852,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				Expect(controller.DataVolumeInformer.GetStore().Add(dv)).To(Succeed())
-				pvcSource.Add(&pvc)
+				Expect(controller.PVCInformer.GetStore().Add(&pvc)).To(Succeed())
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
@@ -927,7 +921,7 @@ var _ = Describe("Restore controller", func() {
 					*metav1.NewControllerRef(dv, schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1beta1", Kind: "DataVolume"}),
 				}
 
-				pvcSource.Add(&pvc)
+				Expect(controller.PVCInformer.GetStore().Add(&pvc)).To(Succeed())
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
@@ -1156,6 +1150,7 @@ var _ = Describe("Restore controller", func() {
 					pvc.Status.Phase = corev1.ClaimBound
 					addPVC(&pvc)
 				}
+				enqueueVMR(r)
 				controller.processVMRestoreWorkItem()
 				Expect(*pvcUpdateCalls).To(Equal(1))
 				Expect(*updateStatusCalls).To(Equal(1))
@@ -1221,7 +1216,7 @@ var _ = Describe("Restore controller", func() {
 				})
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Status.Phase = corev1.ClaimBound
-					pvcSource.Add(&pvc)
+					Expect(controller.PVCInformer.GetStore().Add(&pvc)).To(Succeed())
 				}
 
 				rc := r.DeepCopy()
@@ -1278,7 +1273,7 @@ var _ = Describe("Restore controller", func() {
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Annotations["cdi.kubevirt.io/storage.populatedFor"] = pvc.Name
 					pvc.Status.Phase = corev1.ClaimBound
-					pvcSource.Add(&pvc)
+					Expect(controller.PVCInformer.GetStore().Add(&pvc)).To(Succeed())
 				}
 
 				addVM(vm)
@@ -1349,7 +1344,7 @@ var _ = Describe("Restore controller", func() {
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Annotations["cdi.kubevirt.io/storage.populatedFor"] = pvc.Name
 					pvc.Status.Phase = corev1.ClaimBound
-					pvcSource.Add(&pvc)
+					Expect(controller.PVCInformer.GetStore().Add(&pvc)).To(Succeed())
 				}
 
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
@@ -1523,7 +1518,7 @@ var _ = Describe("Restore controller", func() {
 					} else {
 						calls = expectDataVolumeCreate(cdiClient, "restore-uid-disk1")
 					}
-					pvcSource.Add(&pvc)
+					Expect(controller.PVCInformer.GetStore().Add(&pvc)).To(Succeed())
 					return calls
 				}
 
@@ -1623,6 +1618,7 @@ var _ = Describe("Restore controller", func() {
 						pvc.Status.Phase = corev1.ClaimBound
 						addPVC(&pvc)
 					}
+					enqueueVMR(vmRestore)
 
 					Expect(vmRestore.Status.Restores).To(HaveLen(1))
 					vmRestore.Status.Restores[0].DataVolumeName = pointer.P(restoreDVName(vmRestore, vmRestore.Status.Restores[0].VolumeName, ""))
@@ -1741,6 +1737,7 @@ var _ = Describe("Restore controller", func() {
 							pvc.Status.Phase = corev1.ClaimBound
 							addPVC(&pvc)
 						}
+						enqueueVMR(r)
 
 						changeMacAddressPatch = fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "%s"}`, newMacAddress)
 					})

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -254,30 +253,17 @@ var _ = Describe("Restore controller", func() {
 	}
 
 	Context("One valid Restore controller given", func() {
-
-		var ctrl *gomock.Controller
-
-		var stop chan struct{}
 		var controller *VMRestoreController
 		var recorder *record.FakeRecorder
-		var mockVMRestoreQueue *testutils.MockWorkQueue[string]
 		var fakeVolumeSnapshotProvider *MockVolumeSnapshotProvider
 
 		var kubevirtClient *kubevirtfake.Clientset
 		var k8sClient *k8sfake.Clientset
 		var cdiClient *cdifake.Clientset
-		var virtClient *kubecli.MockKubevirtClient
-
-		syncCaches := func(stop chan struct{}) {
-			Expect(cache.WaitForCacheSync(
-				stop,
-			)).To(BeTrue())
-		}
 
 		BeforeEach(func() {
-			stop = make(chan struct{})
-			ctrl = gomock.NewController(GinkgoT())
-			virtClient = kubecli.NewMockKubevirtClient(ctrl)
+			ctrl := gomock.NewController(GinkgoT())
+			virtClient := kubecli.NewMockKubevirtClient(ctrl)
 
 			vmRestoreInformer, _ := testutils.NewFakeInformerWithIndexersFor(&snapshotv1.VirtualMachineRestore{}, virtcontroller.GetVirtualMachineRestoreInformerIndexers())
 			vmSnapshotInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
@@ -313,8 +299,7 @@ var _ = Describe("Restore controller", func() {
 			controller.Init()
 
 			// Wrap our workqueue to have a way to detect when we are done processing updates
-			mockVMRestoreQueue = testutils.NewMockWorkQueue(controller.vmRestoreQueue)
-			controller.vmRestoreQueue = mockVMRestoreQueue
+			controller.vmRestoreQueue = testutils.NewMockWorkQueue(controller.vmRestoreQueue)
 
 			// Set up mock client
 			kubevirtClient = kubevirtfake.NewSimpleClientset()
@@ -333,6 +318,7 @@ var _ = Describe("Restore controller", func() {
 
 			cdiClient = cdifake.NewSimpleClientset()
 			virtClient.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
+			virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
 
 			k8sClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				Expect(action).To(BeNil())
@@ -343,7 +329,6 @@ var _ = Describe("Restore controller", func() {
 		})
 
 		addVirtualMachineRestore := func(r *snapshotv1.VirtualMachineRestore) {
-			syncCaches(stop)
 			Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 			key, err := virtcontroller.KeyFunc(r)
 			Expect(err).ToNot(HaveOccurred())
@@ -351,12 +336,10 @@ var _ = Describe("Restore controller", func() {
 		}
 
 		addPVC := func(pvc *corev1.PersistentVolumeClaim) {
-			syncCaches(stop)
 			Expect(controller.PVCInformer.GetStore().Add(pvc)).To(Succeed())
 		}
 
 		addVM := func(vm *kubevirtv1.VirtualMachine) {
-			syncCaches(stop)
 			Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 		}
 
@@ -2062,8 +2045,6 @@ var _ = Describe("Restore controller", func() {
 			nilPrefrenceMatcher := func() *kubevirtv1.PreferenceMatcher { return nil }
 
 			BeforeEach(func() {
-				virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
-
 				originalVM = createRestoreInProgressVM()
 				originalVM.Spec.DataVolumeTemplates = []kubevirtv1.DataVolumeTemplateSpec{}
 				restore = createRestoreWithOwner()

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -258,9 +258,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var dataVolumeInformer cache.SharedIndexInformer
-		var dataVolumeSource *framework.FakeControllerSource
-
 		var pvcInformer cache.SharedIndexInformer
 		var pvcSource *framework.FakeControllerSource
 
@@ -283,13 +280,11 @@ var _ = Describe("Restore controller", func() {
 
 		syncCaches := func(stop chan struct{}) {
 			go pvcInformer.Run(stop)
-			go dataVolumeInformer.Run(stop)
 			go storageClassInformer.Run(stop)
 			go crInformer.Run(stop)
 			Expect(cache.WaitForCacheSync(
 				stop,
 				pvcInformer.HasSynced,
-				dataVolumeInformer.HasSynced,
 				storageClassInformer.HasSynced,
 				crInformer.HasSynced,
 			)).To(BeTrue())
@@ -305,7 +300,7 @@ var _ = Describe("Restore controller", func() {
 			vmSnapshotContentInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
 			vmiInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachineInstance{})
 			vmInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachine{})
-			dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+			dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 			pvcInformer, pvcSource = testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
 			storageClassInformer, storageClassSource = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 			crInformer, crSource = testutils.NewFakeInformerWithIndexersFor(&appsv1.ControllerRevision{}, virtcontroller.GetControllerRevisionInformerIndexers())
@@ -862,7 +857,7 @@ var _ = Describe("Restore controller", func() {
 					*metav1.NewControllerRef(dv, schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1beta1", Kind: "DataVolume"}),
 				}
 
-				dataVolumeSource.Add(dv)
+				Expect(controller.DataVolumeInformer.GetStore().Add(dv)).To(Succeed())
 				pvcSource.Add(&pvc)
 
 				ur := r.DeepCopy()
@@ -925,7 +920,7 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 
-				dataVolumeSource.Add(dv)
+				Expect(controller.DataVolumeInformer.GetStore().Add(dv)).To(Succeed())
 
 				pvc := getRestorePVCs(r)[0]
 				pvc.OwnerReferences = []metav1.OwnerReference{
@@ -1278,7 +1273,7 @@ var _ = Describe("Restore controller", func() {
 							Namespace: testNamespace,
 						},
 					}
-					dataVolumeSource.Add(dv)
+					Expect(controller.DataVolumeInformer.GetStore().Add(dv)).To(Succeed())
 				}
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Annotations["cdi.kubevirt.io/storage.populatedFor"] = pvc.Name
@@ -1522,7 +1517,7 @@ var _ = Describe("Restore controller", func() {
 								Phase: phase,
 							},
 						}
-						dataVolumeSource.Add(dv)
+						Expect(controller.DataVolumeInformer.GetStore().Add(dv)).To(Succeed())
 						pvc.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(dv, schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1beta1", Kind: "DataVolume"})}
 						r.Status.DeletedDataVolumes = getDeletedDataVolumes(vm)
 					} else {
@@ -1740,7 +1735,7 @@ var _ = Describe("Restore controller", func() {
 									Phase: cdiv1.Succeeded,
 								},
 							}
-							dataVolumeSource.Add(dv)
+							Expect(controller.DataVolumeInformer.GetStore().Add(dv)).To(Succeed())
 							pvc.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(dv, schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1beta1", Kind: "DataVolume"})}
 							pvc.Annotations["cdi.kubevirt.io/storage.populatedFor"] = pvc.Name
 							pvc.Status.Phase = corev1.ClaimBound

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -41,7 +41,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -258,9 +257,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var crInformer cache.SharedIndexInformer
-		var crSource *framework.FakeControllerSource
-
 		var stop chan struct{}
 		var controller *VMRestoreController
 		var recorder *record.FakeRecorder
@@ -273,10 +269,8 @@ var _ = Describe("Restore controller", func() {
 		var virtClient *kubecli.MockKubevirtClient
 
 		syncCaches := func(stop chan struct{}) {
-			go crInformer.Run(stop)
 			Expect(cache.WaitForCacheSync(
 				stop,
-				crInformer.HasSynced,
 			)).To(BeTrue())
 		}
 
@@ -293,7 +287,7 @@ var _ = Describe("Restore controller", func() {
 			dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 			pvcInformer, _ := testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
 			storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
-			crInformer, crSource = testutils.NewFakeInformerWithIndexersFor(&appsv1.ControllerRevision{}, virtcontroller.GetControllerRevisionInformerIndexers())
+			crInformer, _ := testutils.NewFakeInformerWithIndexersFor(&appsv1.ControllerRevision{}, virtcontroller.GetControllerRevisionInformerIndexers())
 
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true
@@ -2088,17 +2082,17 @@ var _ = Describe("Restore controller", func() {
 				var err error
 				instancetypeOriginalCR, err = revision.CreateControllerRevision(originalVM, instancetypeObj)
 				Expect(err).ToNot(HaveOccurred())
-				crSource.Add(instancetypeOriginalCR)
+				Expect(controller.CRInformer.GetStore().Add(instancetypeOriginalCR)).To(Succeed())
 
 				instancetypeSnapshotCR = createInstancetypeVirtualMachineSnapshotCR(originalVM, vmSnapshot, instancetypeObj)
-				crSource.Add(instancetypeSnapshotCR)
+				Expect(controller.CRInformer.GetStore().Add(instancetypeSnapshotCR)).To(Succeed())
 
 				preferenceObj = createPreference()
 				preferenceOriginalCR, err = revision.CreateControllerRevision(originalVM, preferenceObj)
 				Expect(err).ToNot(HaveOccurred())
-				crSource.Add(preferenceOriginalCR)
+				Expect(controller.CRInformer.GetStore().Add(preferenceOriginalCR)).To(Succeed())
 				preferenceSnapshotCR = createInstancetypeVirtualMachineSnapshotCR(originalVM, vmSnapshot, preferenceObj)
-				crSource.Add(preferenceSnapshotCR)
+				Expect(controller.CRInformer.GetStore().Add(preferenceSnapshotCR)).To(Succeed())
 			})
 
 			DescribeTable("with an existing VirtualMachine",
@@ -2181,10 +2175,9 @@ var _ = Describe("Restore controller", func() {
 
 					// We need to be able to find the created CR from the controller so add it to the source
 					expectedCreatedCR.Namespace = testNamespace
-					crSource.Add(expectedCreatedCR)
+					Expect(controller.CRInformer.GetStore().Add(expectedCreatedCR)).To(Succeed())
 
 					expectedUpdatedCR := expectedCreatedCR.DeepCopy()
-					expectedUpdatedCR.ResourceVersion = "5"
 					newVM.UID = newVMUID
 					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, kubevirtv1.VirtualMachineGroupVersionKind)}
 					crUpdates := expectControllerRevisionUpdate(k8sClient, expectedUpdatedCR)
@@ -2263,10 +2256,9 @@ var _ = Describe("Restore controller", func() {
 
 					// We need to be able to find the created CR from the controller so add it to the source
 					expectedCreatedCR.Namespace = testNamespace
-					crSource.Add(expectedCreatedCR)
+					Expect(controller.CRInformer.GetStore().Add(expectedCreatedCR)).To(Succeed())
 
 					expectedUpdatedCR := expectedCreatedCR.DeepCopy()
-					expectedUpdatedCR.ResourceVersion = "5"
 					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, kubevirtv1.VirtualMachineGroupVersionKind)}
 					crUpdates := expectControllerRevisionUpdate(k8sClient, expectedUpdatedCR)
 
@@ -2338,7 +2330,7 @@ var _ = Describe("Restore controller", func() {
 				instancetypeObj.Spec.CPU.Guest = uint32(5)
 				instancetypeOriginalCR, err := revision.CreateControllerRevision(originalVM, instancetypeObj)
 				Expect(err).ToNot(HaveOccurred())
-				crSource.Modify(instancetypeOriginalCR)
+				Expect(controller.CRInformer.GetStore().Update(instancetypeOriginalCR)).To(Succeed())
 
 				originalVM.Spec.Instancetype = &kubevirtv1.InstancetypeMatcher{
 					Name:         instancetypeObj.Name,

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -258,9 +258,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var vmInformer cache.SharedIndexInformer
-		var vmSource *framework.FakeControllerSource
-
 		var vmiInformer cache.SharedIndexInformer
 		var vmiSource *framework.FakeControllerSource
 
@@ -288,7 +285,6 @@ var _ = Describe("Restore controller", func() {
 		var virtClient *kubecli.MockKubevirtClient
 
 		syncCaches := func(stop chan struct{}) {
-			go vmInformer.Run(stop)
 			go pvcInformer.Run(stop)
 			go vmiInformer.Run(stop)
 			go dataVolumeInformer.Run(stop)
@@ -296,7 +292,6 @@ var _ = Describe("Restore controller", func() {
 			go crInformer.Run(stop)
 			Expect(cache.WaitForCacheSync(
 				stop,
-				vmInformer.HasSynced,
 				pvcInformer.HasSynced,
 				vmiInformer.HasSynced,
 				dataVolumeInformer.HasSynced,
@@ -314,7 +309,7 @@ var _ = Describe("Restore controller", func() {
 			vmSnapshotInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
 			vmSnapshotContentInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
 			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachineInstance{})
-			vmInformer, vmSource = testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachine{})
+			vmInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachine{})
 			dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 			pvcInformer, pvcSource = testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
 			storageClassInformer, storageClassSource = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
@@ -390,9 +385,13 @@ var _ = Describe("Restore controller", func() {
 
 		addVM := func(vm *kubevirtv1.VirtualMachine) {
 			syncCaches(stop)
-			mockVMRestoreQueue.ExpectAdds(1)
-			vmSource.Add(vm)
-			mockVMRestoreQueue.Wait()
+			Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
+		}
+
+		enqueueVMR := func(r *snapshotv1.VirtualMachineRestore) {
+			key, err := virtcontroller.KeyFunc(r)
+			Expect(err).ToNot(HaveOccurred())
+			controller.vmRestoreQueue.Add(key)
 		}
 
 		Context("with initialized snapshot and content", func() {
@@ -436,7 +435,7 @@ var _ = Describe("Restore controller", func() {
 				if vmSnapshot != nil {
 					Expect(controller.VMSnapshotInformer.GetStore().Add(vmSnapshot)).To(Succeed())
 				}
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -465,8 +464,8 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 
-				vmSource.Add(vm)
-				vmSource.Add(newVM)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
+				Expect(controller.VMInformer.GetStore().Add(newVM)).To(Succeed())
 
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
@@ -490,7 +489,7 @@ var _ = Describe("Restore controller", func() {
 						newReadyCondition(corev1.ConditionFalse, "Initializing VirtualMachineRestore"),
 					},
 				}
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -526,7 +525,7 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				vmiSource.Add(vmi)
 
 				addVirtualMachineRestore(r)
@@ -564,7 +563,7 @@ var _ = Describe("Restore controller", func() {
 				addInitialVolumeRestores(rc2)
 
 				vm := createModifiedVM()
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				vmStatusUpdate := vm.DeepCopy()
 				vmStatusUpdate.Status.RestoreInProgress = &vmRestoreName
 				addVirtualMachineRestore(r)
@@ -591,7 +590,7 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 				addInitialVolumeRestores(rc)
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -620,7 +619,7 @@ var _ = Describe("Restore controller", func() {
 				}
 				addVolumeRestores(rc)
 
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				addVirtualMachineRestore(r)
 
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
@@ -638,7 +637,7 @@ var _ = Describe("Restore controller", func() {
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
 					},
 				}
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				addVolumeRestores(r)
 				pvcSize := resource.MustParse("2Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
@@ -716,7 +715,7 @@ var _ = Describe("Restore controller", func() {
 				fakeVolumeSnapshotProvider.Add(vs1)
 				fakeVolumeSnapshotProvider.Add(vs2)
 
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				addVirtualMachineRestore(r)
 
 				calls := expectPVCCreates(k8sClient, r, pvcSize)
@@ -734,7 +733,7 @@ var _ = Describe("Restore controller", func() {
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
 					},
 				}
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				addVolumeRestores(r)
 				q := resource.MustParse("3Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
@@ -755,7 +754,7 @@ var _ = Describe("Restore controller", func() {
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
 					},
 				}
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				addVolumeRestores(r)
 				q := resource.MustParse("1Gi")
 				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
@@ -779,7 +778,7 @@ var _ = Describe("Restore controller", func() {
 				addVolumeRestores(r)
 
 				vm := createRestoreInProgressVM()
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 				for _, pvc := range getRestorePVCs(r) {
 					pvc.Status.Phase = corev1.ClaimPending
@@ -812,7 +811,7 @@ var _ = Describe("Restore controller", func() {
 				vm := createSnapshotVM()
 				vm.Spec.RunStrategy = pointer.P(kubevirtv1.RunStrategyManual)
 				vm.Status.RestoreInProgress = &vmRestoreName
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				uvm := vm.DeepCopy()
 				uvm.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 				uvm.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
@@ -851,7 +850,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createRestoreInProgressVM()
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 
 				dv := &cdiv1.DataVolume{
 					ObjectMeta: metav1.ObjectMeta{
@@ -915,7 +914,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createRestoreInProgressVM()
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 
 				// We expect the one and only PVC on that VM to get deleted, so we create it first and link it to its DV
 				dv := &cdiv1.DataVolume{
@@ -982,7 +981,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createRestoreInProgressVM()
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
@@ -1015,7 +1014,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createRestoreInProgressVM()
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
@@ -1126,7 +1125,7 @@ var _ = Describe("Restore controller", func() {
 				fakeVolumeSnapshotProvider.Add(vs1)
 				fakeVolumeSnapshotProvider.Add(vs2)
 
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				addVirtualMachineRestore(r)
 
 				expectedLabels := map[string]string{"newlabel": "value"}
@@ -1159,7 +1158,7 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				vm := createRestoreInProgressVM()
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 				pvcUpdateCalls := expectPVCUpdates(k8sClient, ur)
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, ur)
@@ -1248,7 +1247,7 @@ var _ = Describe("Restore controller", func() {
 					PersistentVolumeClaimName: "restore-uid-disk2",
 					VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk2",
 				})
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				addVirtualMachineRestore(r)
 
 				pvcUpdateCalls := expectPVCUpdates(k8sClient, rc)
@@ -1293,9 +1292,9 @@ var _ = Describe("Restore controller", func() {
 				}
 
 				addVM(vm)
+				enqueueVMR(r)
 
 				updatedVM := vm.DeepCopy()
-				updatedVM.ResourceVersion = "1"
 				updatedVM.Status.RestoreInProgress = nil
 
 				ur := r.DeepCopy()
@@ -1365,6 +1364,7 @@ var _ = Describe("Restore controller", func() {
 
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 				addVM(vm)
+				enqueueVMR(r)
 				controller.processVMRestoreWorkItem()
 				testutils.ExpectEvent(recorder, "VirtualMachineRestoreComplete")
 				Expect(*updateStatusCalls).To(Equal(1))
@@ -1388,6 +1388,7 @@ var _ = Describe("Restore controller", func() {
 
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 				addVM(vm)
+				enqueueVMR(r)
 
 				updatedVMRestore := r.DeepCopy()
 				updatedVMRestore.Status.Conditions = []snapshotv1.Condition{
@@ -1419,6 +1420,7 @@ var _ = Describe("Restore controller", func() {
 
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 				addVM(vm)
+				enqueueVMR(r)
 
 				updatedVMRestore := r.DeepCopy()
 				updatedVMRestore.Finalizers = []string{}
@@ -1443,6 +1445,7 @@ var _ = Describe("Restore controller", func() {
 
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 				addVM(vm)
+				enqueueVMR(r)
 
 				vmUpdated := vm.DeepCopy()
 				vmUpdated.Status.RestoreInProgress = nil
@@ -1476,6 +1479,7 @@ var _ = Describe("Restore controller", func() {
 
 				Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 				addVM(vm)
+				enqueueVMR(r)
 
 				updatedVMRestore := r.DeepCopy()
 				updatedVMRestore.Finalizers = []string{}
@@ -1538,10 +1542,10 @@ var _ = Describe("Restore controller", func() {
 
 					Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 					addVM(vm)
+					enqueueVMR(r)
 					updateVMCalls := pointer.P(0)
 					if expecteUpdateVM {
 						updatedVM := vm.DeepCopy()
-						updatedVM.ResourceVersion = "1"
 						updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 						updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
 						updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
@@ -1569,9 +1573,9 @@ var _ = Describe("Restore controller", func() {
 					Expect(controller.VMRestoreInformer.GetStore().Add(r)).To(Succeed())
 
 					addVM(vm)
+					enqueueVMR(r)
 					updatedVM := createSnapshotVM()
 					updatedVM.Status.RestoreInProgress = &vmRestoreName
-					updatedVM.ResourceVersion = "1"
 					updatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
 					updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
 					updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
@@ -1593,9 +1597,9 @@ var _ = Describe("Restore controller", func() {
 					sc.Spec.Source.VirtualMachine.Spec.Template.Spec.Domain.Firmware = existingFirmware
 
 					addVM(vm)
+					enqueueVMR(r)
 					updatedVM := createSnapshotVM()
 					updatedVM.Status.RestoreInProgress = &vmRestoreName
-					updatedVM.ResourceVersion = "1"
 					updatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
 					updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
 					updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
@@ -1664,7 +1668,7 @@ var _ = Describe("Restore controller", func() {
 					newVM.Status.RestoreInProgress = &vmRestoreName
 					newVM.UID = newVMUID
 					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
-					vmSource.Add(newVM)
+					Expect(controller.VMInformer.GetStore().Add(newVM)).To(Succeed())
 
 					By("Creating VM restore")
 					vmRestore := createRestore()
@@ -1840,7 +1844,7 @@ var _ = Describe("Restore controller", func() {
 							newReadyCondition(corev1.ConditionFalse, "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"),
 						},
 					}
-					vmSource.Add(vm)
+					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 					vmiSource.Add(vmi)
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
@@ -1863,7 +1867,7 @@ var _ = Describe("Restore controller", func() {
 							newReadyCondition(corev1.ConditionFalse, "Automatically stopping restore target for restore operation"),
 						},
 					}
-					vmSource.Add(vm)
+					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 					vmiSource.Add(vmi)
 					stopCalled := expectVMStop(kubevirtClient)
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
@@ -1893,7 +1897,7 @@ var _ = Describe("Restore controller", func() {
 							newFailureCondition(corev1.ConditionTrue, "Restore target failed to be ready within 5m0s. Please power off the target VM before attempting restore"),
 						},
 					}
-					vmSource.Add(vm)
+					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 					vmiSource.Add(vmi)
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
@@ -1928,7 +1932,7 @@ var _ = Describe("Restore controller", func() {
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 
 					vm := createRestoreInProgressVM()
-					vmSource.Add(vm)
+					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
@@ -1950,7 +1954,7 @@ var _ = Describe("Restore controller", func() {
 							newFailureCondition(corev1.ConditionTrue, "Restore target VMI must be powered off before restore operation"),
 						},
 					}
-					vmSource.Add(vm)
+					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 					vmiSource.Add(vmi)
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
@@ -1973,7 +1977,7 @@ var _ = Describe("Restore controller", func() {
 					}
 					vm := createModifiedVM()
 					// Add VM without VMI (VM is ready), but restore already has failure condition
-					vmSource.Add(vm)
+					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, r)
 
@@ -1997,7 +2001,7 @@ var _ = Describe("Restore controller", func() {
 				}
 				vm := createModifiedVM()
 				vmi := createVMI(vm)
-				vmSource.Add(vm)
+				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 				vmiSource.Add(vmi)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -2016,7 +2020,7 @@ var _ = Describe("Restore controller", func() {
 				CreationTime: timeFunc(),
 				ReadyToUse:   pointer.P(true),
 			}
-			vmSource.Add(vm)
+			Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 			Expect(controller.VMSnapshotInformer.GetStore().Add(s)).To(Succeed())
 			Expect(controller.VMSnapshotContentInformer.GetStore().Add(sc)).To(Succeed())
 			storageClassSource.Add(storageClass)
@@ -2119,7 +2123,7 @@ var _ = Describe("Restore controller", func() {
 				func(getVMInstancetypeMatcher, getSnapshotInstancetypeMatcher func() *kubevirtv1.InstancetypeMatcher, getVMPreferenceMatcher, getSnapshotPreferenceMatcher func() *kubevirtv1.PreferenceMatcher, getExpectedCR func() *appsv1.ControllerRevision) {
 					originalVM.Spec.Instancetype = getVMInstancetypeMatcher()
 					originalVM.Spec.Preference = getVMPreferenceMatcher()
-					vmSource.Add(originalVM)
+					Expect(controller.VMInformer.GetStore().Add(originalVM)).To(Succeed())
 
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Instancetype = getSnapshotInstancetypeMatcher()
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Preference = getSnapshotPreferenceMatcher()
@@ -2173,7 +2177,7 @@ var _ = Describe("Restore controller", func() {
 				func(getVMInstancetypeMatcher, getSnapshotInstancetypeMatcher func() *kubevirtv1.InstancetypeMatcher, getVMPreferenceMatcher, getSnapshotPreferenceMatcher func() *kubevirtv1.PreferenceMatcher, getExpectedCR func() *appsv1.ControllerRevision) {
 					originalVM.Spec.Instancetype = getVMInstancetypeMatcher()
 					originalVM.Spec.Preference = getVMPreferenceMatcher()
-					vmSource.Add(originalVM)
+					Expect(controller.VMInformer.GetStore().Add(originalVM)).To(Succeed())
 
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Instancetype = getSnapshotInstancetypeMatcher()
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Preference = getSnapshotPreferenceMatcher()
@@ -2255,7 +2259,7 @@ var _ = Describe("Restore controller", func() {
 				func(getVMInstancetypeMatcher, getSnapshotInstancetypeMatcher func() *kubevirtv1.InstancetypeMatcher, getVMPreferenceMatcher, getSnapshotPreferenceMatcher func() *kubevirtv1.PreferenceMatcher, getExpectedCR func() *appsv1.ControllerRevision) {
 					originalVM.Spec.Instancetype = getVMInstancetypeMatcher()
 					originalVM.Spec.Preference = getVMPreferenceMatcher()
-					vmSource.Add(originalVM)
+					Expect(controller.VMInformer.GetStore().Add(originalVM)).To(Succeed())
 
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Instancetype = getSnapshotInstancetypeMatcher()
 					vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Preference = getSnapshotPreferenceMatcher()
@@ -2359,7 +2363,7 @@ var _ = Describe("Restore controller", func() {
 					Kind:         instancetypeapi.SingularResourceName,
 					RevisionName: instancetypeOriginalCR.Name,
 				}
-				vmSource.Add(originalVM)
+				Expect(controller.VMInformer.GetStore().Add(originalVM)).To(Succeed())
 
 				vmSnapshotContent.Spec.Source.VirtualMachine.Spec.Instancetype = &kubevirtv1.InstancetypeMatcher{
 					Name:         instancetypeObj.Name,

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -258,9 +258,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var storageClassInformer cache.SharedIndexInformer
-		var storageClassSource *framework.FakeControllerSource
-
 		var crInformer cache.SharedIndexInformer
 		var crSource *framework.FakeControllerSource
 
@@ -276,11 +273,9 @@ var _ = Describe("Restore controller", func() {
 		var virtClient *kubecli.MockKubevirtClient
 
 		syncCaches := func(stop chan struct{}) {
-			go storageClassInformer.Run(stop)
 			go crInformer.Run(stop)
 			Expect(cache.WaitForCacheSync(
 				stop,
-				storageClassInformer.HasSynced,
 				crInformer.HasSynced,
 			)).To(BeTrue())
 		}
@@ -297,7 +292,7 @@ var _ = Describe("Restore controller", func() {
 			vmInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachine{})
 			dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 			pvcInformer, _ := testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
-			storageClassInformer, storageClassSource = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
+			storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 			crInformer, crSource = testutils.NewFakeInformerWithIndexersFor(&appsv1.ControllerRevision{}, virtcontroller.GetControllerRevisionInformerIndexers())
 
 			recorder = record.NewFakeRecorder(100)
@@ -399,7 +394,7 @@ var _ = Describe("Restore controller", func() {
 				}
 				Expect(controller.VMSnapshotInformer.GetStore().Add(s)).To(Succeed())
 				Expect(controller.VMSnapshotContentInformer.GetStore().Add(sc)).To(Succeed())
-				storageClassSource.Add(storageClass)
+				Expect(controller.StorageClassInformer.GetStore().Add(storageClass)).To(Succeed())
 			})
 
 			DescribeTable("should error if snapshot", func(vmSnapshot *snapshotv1.VirtualMachineSnapshot, expectedError string) {
@@ -2010,7 +2005,7 @@ var _ = Describe("Restore controller", func() {
 			Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
 			Expect(controller.VMSnapshotInformer.GetStore().Add(s)).To(Succeed())
 			Expect(controller.VMSnapshotContentInformer.GetStore().Add(sc)).To(Succeed())
-			storageClassSource.Add(storageClass)
+			Expect(controller.StorageClassInformer.GetStore().Add(storageClass)).To(Succeed())
 
 			// Actual test
 			r := createRestoreWithOwner()

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -258,9 +258,6 @@ var _ = Describe("Restore controller", func() {
 
 		var ctrl *gomock.Controller
 
-		var vmiInformer cache.SharedIndexInformer
-		var vmiSource *framework.FakeControllerSource
-
 		var dataVolumeInformer cache.SharedIndexInformer
 		var dataVolumeSource *framework.FakeControllerSource
 
@@ -286,14 +283,12 @@ var _ = Describe("Restore controller", func() {
 
 		syncCaches := func(stop chan struct{}) {
 			go pvcInformer.Run(stop)
-			go vmiInformer.Run(stop)
 			go dataVolumeInformer.Run(stop)
 			go storageClassInformer.Run(stop)
 			go crInformer.Run(stop)
 			Expect(cache.WaitForCacheSync(
 				stop,
 				pvcInformer.HasSynced,
-				vmiInformer.HasSynced,
 				dataVolumeInformer.HasSynced,
 				storageClassInformer.HasSynced,
 				crInformer.HasSynced,
@@ -308,7 +303,7 @@ var _ = Describe("Restore controller", func() {
 			vmRestoreInformer, _ := testutils.NewFakeInformerWithIndexersFor(&snapshotv1.VirtualMachineRestore{}, virtcontroller.GetVirtualMachineRestoreInformerIndexers())
 			vmSnapshotInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
 			vmSnapshotContentInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
-			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachineInstance{})
+			vmiInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachineInstance{})
 			vmInformer, _ := testutils.NewFakeInformerFor(&kubevirtv1.VirtualMachine{})
 			dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 			pvcInformer, pvcSource = testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
@@ -526,7 +521,7 @@ var _ = Describe("Restore controller", func() {
 				}
 				updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc2)
 				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
-				vmiSource.Add(vmi)
+				Expect(controller.VMIInformer.GetStore().Add(vmi)).To(Succeed())
 
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -1845,7 +1840,7 @@ var _ = Describe("Restore controller", func() {
 						},
 					}
 					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
-					vmiSource.Add(vmi)
+					Expect(controller.VMIInformer.GetStore().Add(vmi)).To(Succeed())
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
@@ -1868,7 +1863,7 @@ var _ = Describe("Restore controller", func() {
 						},
 					}
 					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
-					vmiSource.Add(vmi)
+					Expect(controller.VMIInformer.GetStore().Add(vmi)).To(Succeed())
 					stopCalled := expectVMStop(kubevirtClient)
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
@@ -1898,7 +1893,7 @@ var _ = Describe("Restore controller", func() {
 						},
 					}
 					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
-					vmiSource.Add(vmi)
+					Expect(controller.VMIInformer.GetStore().Add(vmi)).To(Succeed())
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
@@ -1955,7 +1950,7 @@ var _ = Describe("Restore controller", func() {
 						},
 					}
 					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
-					vmiSource.Add(vmi)
+					Expect(controller.VMIInformer.GetStore().Add(vmi)).To(Succeed())
 					updateStatusCalls := expectVMRestoreUpdateStatus(kubevirtClient, rc)
 					addVirtualMachineRestore(r)
 					controller.processVMRestoreWorkItem()
@@ -2002,7 +1997,7 @@ var _ = Describe("Restore controller", func() {
 				vm := createModifiedVM()
 				vmi := createVMI(vm)
 				Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
-				vmiSource.Add(vmi)
+				Expect(controller.VMIInformer.GetStore().Add(vmi)).To(Succeed())
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
 			})

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -2889,11 +2889,11 @@ func expectControllerRevisionCreate(client *k8sfake.Clientset, expectedCR *appsv
 		create, ok := action.(testing.CreateAction)
 		Expect(ok).To(BeTrue())
 
-		// We don't expect the namespace or resourceversion to be set during creation
-		expectedCR.Namespace = ""
+		// We don't expect the resourceversion to be set during creation
 		expectedCR.ResourceVersion = ""
 
 		createObj := create.GetObject().(*appsv1.ControllerRevision)
+		createObj.Namespace = action.GetNamespace()
 		expectControllerRevisionToEqualExpected(createObj, expectedCR)
 
 		calls++
@@ -2909,11 +2909,11 @@ func expectCreateControllerRevisionAlreadyExists(client *k8sfake.Clientset, expe
 		create, ok := action.(testing.CreateAction)
 		Expect(ok).To(BeTrue())
 
-		// We don't expect the namespace or resourceversion to be set during creation
-		expectedCR.Namespace = ""
+		// We don't expect the resourceversion to be set during creation
 		expectedCR.ResourceVersion = ""
 
 		createObj := create.GetObject().(*appsv1.ControllerRevision)
+		createObj.Namespace = action.GetNamespace()
 		expectControllerRevisionToEqualExpected(createObj, expectedCR)
 
 		calls++
@@ -2928,8 +2928,8 @@ func expectControllerRevisionUpdate(client *k8sfake.Clientset, expectedCR *appsv
 	client.Fake.PrependReactor("update", "controllerrevisions", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 		update, ok := action.(testing.UpdateAction)
 		Expect(ok).To(BeTrue())
-
 		updateObj := update.GetObject().(*appsv1.ControllerRevision)
+		updateObj.Namespace = action.GetNamespace()
 		expectControllerRevisionToEqualExpected(updateObj, expectedCR)
 
 		calls++


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Refactor restore unit tests to reduce complexity and runtime from ~18 seconds to ~12 seconds.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Doing the same for `snapshot_tests` should reduce the runtime more, but I opted for a follow-up,
reducing conflicts and reviewer burden.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```