### PR TITLE
Honor external imagePullPolicy setting

### DIFF
--- a/automation/conformance.sh
+++ b/automation/conformance.sh
@@ -3,6 +3,7 @@
 set -eExuo pipefail
 
 export WORKSPACE="${WORKSPACE:-$PWD}"
+export IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 mkdir -p "$ARTIFACTS_PATH"
 

--- a/automation/perfscale-test.sh
+++ b/automation/perfscale-test.sh
@@ -20,6 +20,7 @@
 set -ex
 
 kubectl() { KUBEVIRTCI_VERBOSE=false kubevirtci/cluster-up/kubectl.sh "$@"; }
+export IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 
 _prometheus_port_forward_pid=""
 trap "clean_up" EXIT SIGINT SIGTERM SIGQUIT

--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -34,6 +34,7 @@ set -euo pipefail
 KUBEVIRT_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
 
 # include defaults for retrieving proper vendored cluster-up version
+export IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 export DOCKER_TAG_ALT=''
 export IMAGE_PREFIX=''
 export IMAGE_PREFIX_ALT=''

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -22,6 +22,7 @@ set -ex
 export TIMESTAMP=${TIMESTAMP:-1}
 
 export WORKSPACE="${WORKSPACE:-$PWD}"
+export IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="gs://kubevirt-vm-images"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -33,7 +33,7 @@ function main() {
     ./hack/cluster-build.sh
     # We always want to check for updated digests as we are using a single devel tag so set our imagePullPolicy to Always
     # See https://github.com/kubevirt/kubevirt/issues/15218 for more context
-    IMAGE_PULL_POLICY=Always ./hack/manifests.sh
+    IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-Always} ./hack/manifests.sh
 
     echo "waiting for cluster-clean to finish"
     if ! wait $CLEAN_PID; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
With https://github.com/kubevirt/kubevirt/pull/15220 the imagePullPolicy is always set to `Always`,
even if a developer explicitly set it to something else.

This is wrong, since CI or other might want to use a different policy.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

