### PR TITLE
Fix Volume Migration Tests

### DIFF
--- a/tests/default-ceph-config.json
+++ b/tests/default-ceph-config.json
@@ -6,5 +6,6 @@
     "storageRWOFileSystem":    "local",
     "storageRWOBlock":         "rook-ceph-block",
     "storageSnapshot":         "rook-ceph-block",
-    "storageVMState":          "rook-ceph-block"
+    "storageVMState":          "rook-ceph-block",
+    "storageClassCSI":         "rook-ceph-block"
 }

--- a/tests/libstorage/config.go
+++ b/tests/libstorage/config.go
@@ -46,6 +46,8 @@ type KubeVirtTestsConfiguration struct {
 	StorageSnapshot string `json:"storageSnapshot"`
 	// StorageVMState is the storage class for backend PVCs (TPM/EFI)
 	StorageVMState string `json:"storageVMState"`
+	// StorageClass supporting CSI
+	StorageClassCSI string `json:"storageClassCSI"`
 }
 
 const kubevirtIoTest = "kubevirt.io/test"

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -117,8 +117,14 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			currentKv.ResourceVersion,
 			config.ExpectResourceVersionToBeLessEqualThanConfigVersion,
 			time.Minute)
+
 		scName, err := getCSIStorageClass(virtClient)
 		Expect(err).ToNot(HaveOccurred())
+
+		if scName == "" {
+			scName = libstorage.GetAvailableCSIStorageClass()
+		}
+
 		if scName == "" {
 			Fail("Fail test when a CSI storage class is not present")
 		}
@@ -1107,7 +1113,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				checkFileOnHotpluggedVol(vmi)
 			})
 
-			DescribeTable("with a datavolume and an hotplugged datavolume migrating", func(srcBlock, dstBlock bool) {
+			DescribeTable("with a datavolume and an hotplugged datavolume migrating", decorators.RequiresBlockStorage, func(srcBlock, dstBlock bool) {
 				ns := testsuite.GetTestNamespace(nil)
 				rootVolName := "root"
 				hpVolName := "hp"

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -933,7 +933,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 					}
 				}
 				return ""
-			}).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(Equal(""))
+			}).WithTimeout(360 * time.Second).WithPolling(2 * time.Second).ShouldNot(Equal(""))
 		}
 
 		DescribeTable("should be able to add and remove a volume with the volume migration feature gate enabled", func(persist bool) {
@@ -1339,7 +1339,7 @@ func waitForMigrationToSucceed(virtClient kubecli.KubevirtClient, vmiName, ns st
 		vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vmiName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return vmi.Status.MigrationState
-	}, 120*time.Second, time.Second).Should(And(Not(BeNil()), gstruct.PointTo(
+	}, 360*time.Second, time.Second).Should(And(Not(BeNil()), gstruct.PointTo(
 		gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 			"Failed":    BeFalse(),
 			"Completed": BeTrue(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Adding new StorageClassCSI config to KubeVirtTestsConfiguration that will define a CSI enabled storage class

#### Before this PR:
Migration tests would fail on HPP lanes because they relied on the StorageSnapshot value which is not set in the `default-config.json`

#### After this PR:
Migration tests now pass after leveraging new config field

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

