### PR TITLE
e2e, net, hotplug: Update hotplug tests to cover ifaces states up/down

### DIFF
--- a/tests/libnet/hotplug.go
+++ b/tests/libnet/hotplug.go
@@ -21,7 +21,6 @@ package libnet
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -56,7 +55,7 @@ func VerifyDynamicInterfaceChange(
 	ExpectWithOffset(1, nonAbsentSecondaryIfaces).NotTo(BeEmpty())
 
 	EventuallyWithOffset(1, func() []v1.VirtualMachineInstanceNetworkInterface {
-		return cleanMACAddressesFromStatus(vmiCurrentInterfaces(vmi.GetNamespace(), vmi.GetName()))
+		return normalizeIfaceStatuses(vmiCurrentInterfaces(vmi.GetNamespace(), vmi.GetName()))
 	}).
 		WithTimeout(timeout).
 		WithPolling(pollInterval).
@@ -117,21 +116,20 @@ func indexVMsSecondaryNetworks(vmi *v1.VirtualMachineInstance) map[string]v1.Net
 	return indexedSecondaryNetworks
 }
 
-func cleanMACAddressesFromStatus(status []v1.VirtualMachineInstanceNetworkInterface) []v1.VirtualMachineInstanceNetworkInterface {
+func normalizeIfaceStatuses(status []v1.VirtualMachineInstanceNetworkInterface) []v1.VirtualMachineInstanceNetworkInterface {
 	for i := range status {
 		status[i].MAC = ""
+		status[i].InterfaceName = ""
 	}
 	return status
 }
 
 func interfaceStatusFromInterfaces(queueCount int32, ifaces []v1.Interface) []v1.VirtualMachineInstanceNetworkInterface {
-	const initialIfacesInVMI = 1
 	var ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface
 
-	for i, iface := range ifaces {
+	for _, iface := range ifaces {
 		newIfaceStatus := v1.VirtualMachineInstanceNetworkInterface{
-			Name:          iface.Name,
-			InterfaceName: fmt.Sprintf("eth%d", i+initialIfacesInVMI),
+			Name: iface.Name,
 			InfoSource: vmispec.NewInfoSource(
 				vmispec.InfoSourceDomain, vmispec.InfoSourceGuestAgent, vmispec.InfoSourceMultusStatus),
 			QueueCount:       queueCount,
@@ -144,7 +142,6 @@ func interfaceStatusFromInterfaces(queueCount int32, ifaces []v1.Interface) []v1
 
 		ifaceStatuses = append(ifaceStatuses, newIfaceStatus)
 	}
-
 	return ifaceStatuses
 }
 

--- a/tests/libnet/hotplug.go
+++ b/tests/libnet/hotplug.go
@@ -125,11 +125,7 @@ func cleanMACAddressesFromStatus(status []v1.VirtualMachineInstanceNetworkInterf
 }
 
 func interfaceStatusFromInterfaces(queueCount int32, ifaces []v1.Interface) []v1.VirtualMachineInstanceNetworkInterface {
-	const (
-		initialIfacesInVMI = 1
-
-		linkStateUp = "up"
-	)
+	const initialIfacesInVMI = 1
 	var ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface
 
 	for i, iface := range ifaces {
@@ -143,13 +139,20 @@ func interfaceStatusFromInterfaces(queueCount int32, ifaces []v1.Interface) []v1
 		}
 
 		if iface.SRIOV == nil {
-			newIfaceStatus.LinkState = linkStateUp
+			newIfaceStatus.LinkState = normalizeState(iface.State)
 		}
 
 		ifaceStatuses = append(ifaceStatuses, newIfaceStatus)
 	}
 
 	return ifaceStatuses
+}
+
+func normalizeState(state v1.InterfaceState) string {
+	if state == "" {
+		return "up"
+	}
+	return string(state)
 }
 
 func PatchVMWithNewInterface(vm *v1.VirtualMachine, newNetwork v1.Network, newIface v1.Interface) error {

--- a/tests/libnet/interface.go
+++ b/tests/libnet/interface.go
@@ -68,3 +68,24 @@ func LookupNetworkByName(networks []v1.Network, name string) *v1.Network {
 
 	return nil
 }
+
+func NewLinkStateAssersionCmd(mac string, desiredLinkState v1.InterfaceState) string {
+	const (
+		linkStateUPRegex   = "'state[[:space:]]+UP'"
+		linkStateDOWNRegex = "'NO-CARRIER.+state[[:space:]]+DOWN'"
+		ipLinkTemplate     = "ip -one link | grep %s | grep -E %s\n"
+	)
+
+	var linkStateRegex string
+
+	switch desiredLinkState {
+	case v1.InterfaceStateLinkUp:
+		linkStateRegex = linkStateUPRegex
+	case v1.InterfaceStateLinkDown:
+		linkStateRegex = linkStateDOWNRegex
+	case v1.InterfaceStateAbsent:
+		// noop
+	}
+
+	return fmt.Sprintf(ipLinkTemplate, mac, linkStateRegex)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- This PR adds coverage for hotplugging interface in down state.

- We are removing the InterfaceName key in the dict array of interface
status that is returned (to compare against) and cleaning off the
InterfaceName of the interface specs that is being compared.
Thus we make sure the correct interface has the correct state
(and other specs) irrespective of the guest interface it connects to.

- To test hotplugging interface in down state we need to compare the state in interface status with the state in interface specs. In the specs, if the state is unspecified, it is considered as up. This needs to be reflected in the interfaceStatusFromInterfaces function where we fetch the info from the specs to compare with the info from status. 
So we are adding a new normalizeState function that returns the state up in case no state is specified.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
#### Compromise:
This will technically test 2 things in a single test, but it is better than adding a new test (with its setup again) just for this small use case.
In a follow up patch we can try to optimize the set up first and then split this into a different test.
#### Note:
Since this is being tested in an Alpine VM, we cannot verify the state of the guest interface (up/no-carrier...down) before explicitly doing ip link set <interface> up. The interfaces in the VM looks like this after just hotplugging:
```
4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group ...
    link/ether 02:ac:d2:00:00:30 brd ff:ff:ff:ff:ff:ff
5: eth3: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group ...
    link/ether 02:ac:d2:00:00:31 brd ff:ff:ff:ff:ff:ff
```
Only after setting the interface to up, it shows the carrier state. This is Alpine specific and is not needed on Fedora guests (for example)

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

