### PR TITLE
tests: Convert VMI configuration tests from integration to end-to-end

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3277,6 +3277,45 @@ var _ = Describe("Converter", func() {
 				Expect(domain.Spec.Memory.Unit).To(Equal("b"))
 				Expect(domain.Spec.Memory.Value).To(Equal(uint64(guestMemory.Value())))
 			})
+
+			DescribeTable("should correctly convert memory configuration from VMI spec to domain",
+				func(expectedMemoryMiB int64, opts ...libvmi.Option) {
+
+					vmi := libvmi.New(opts...)
+
+					v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+
+					testContext := &ConverterContext{
+						VirtualMachine: vmi,
+						AllowEmulation: true,
+						Architecture:   archconverter.NewConverter(runtime.GOARCH),
+					}
+
+					apiDomainSpec := vmiToDomainXMLToDomainSpec(vmi, testContext)
+
+					expectedBytes := expectedMemoryMiB * 1024 * 1024
+					Expect(apiDomainSpec.Memory.Value).To(Equal(uint64(expectedBytes)),
+						"Memory value should be %d bytes (%d MiB)", expectedBytes, expectedMemoryMiB)
+					Expect(apiDomainSpec.Memory.Unit).To(Equal("b"))
+				},
+				Entry("provided by domain spec directly (guest memory takes precedence over limits)",
+					int64(512),
+					libvmi.WithGuestMemory("512Mi"),
+				),
+				Entry("provided by resources limits (no guest memory, no request)",
+					int64(256),
+					libvmi.WithMemoryLimit("256Mi"),
+				),
+				Entry("provided by resources requests (request takes precedence over limit when both set)",
+					int64(64),
+					libvmi.WithMemoryRequest("64Mi"),
+					libvmi.WithMemoryLimit("256Gi"),
+				),
+				Entry("provided by resources requests only",
+					int64(128),
+					libvmi.WithMemoryRequest("128Mi"),
+				),
+			)
 		})
 	})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2743,11 +2743,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(err).ToNot(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi)
 
-			By("Check values on domain XML")
-			domXml, err := libdomain.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
-
 			By("Expecting console")
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 


### PR DESCRIPTION
In the process of reducing the usage of domain XML for tests to e2e, few changes were made to memory configuration tests, block/net queues and removing unneeded domain XML, relying on what is actually being passed into the guest instead.

the changes includes:

1. Move memory configuration tests from `tests/vmi_configuration_test.go` to unit tests under `pkg/virt-launcher/virtwrap/converter/converter_test.go` while keeping the same test coverage.

2. Multiqueue functionality testing has been converted from XML domain inspection to actual guest verification by checking block device queues via `/sys/block/vda/mq` and network interface queues via `/sys/class/net/eth0/queues`. 

3. Remove redundant Chassis value XML check since this functionality is already covered by end-to-end testing that verifies the actual guest behavior.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### References
this PR is part of the effort to reduce libdomain usage:
https://issues.redhat.com/browse/CNV-38614
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->



### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

