### PR TITLE
tests: Remove e2e VM defined storage class over PreferredStorageClass Name

### DIFF
--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1beta1:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",


### PR DESCRIPTION
### What this PR does
#### Before this PR:
A test was executed to verify that the `PreferredStorageClassName` is ignored when a `storageClassName` is already defined in the `DataVolumeTemplate`.

#### After this PR:
The redundant test is removed, as the scenario is already covered and does not require additional validation.

### References
https://github.com/kubevirt/kubevirt/blob/4f44500bd2a0afc31f5d5a6114317b853e9dfc4d/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go#L438
https://github.com/kubevirt/kubevirt/blob/4f44500bd2a0afc31f5d5a6114317b853e9dfc4d/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go#L451

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/15053

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

