### PR TITLE
q(operator): flaky tests id 3149-3151

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1098,7 +1098,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		})
 
 		// this test ensures that we can deal with image prefixes in case they are not used for tests already
-		It("[test_id:3149]should be able to create kubevirt install with image prefix", decorators.Upgrade, func() {
+		It("[QUARANTINE][test_id:3149]should be able to create kubevirt install with image prefix", decorators.Quarantine, decorators.Upgrade, func() {
 
 			if flags.ImagePrefixAlt == "" {
 				Skip("Skip operator imagePrefix test because imagePrefixAlt is not present")
@@ -1167,7 +1167,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			allKvInfraPodsAreReady(kv)
 		})
 
-		It("[test_id:3150]should be able to update kubevirt install with custom image tag", decorators.Upgrade, func() {
+		It("[QUARANTINE][test_id:3150]should be able to update kubevirt install with custom image tag", decorators.Quarantine, decorators.Upgrade, func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}
@@ -1243,7 +1243,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		// NOTE - this test verifies new operators can grab the leader election lease
 		// during operator updates. The only way the new infrastructure is deployed
 		// is if the update operator is capable of getting the lease.
-		It("[test_id:3151]should be able to update kubevirt install when operator updates if no custom image tag is set", decorators.Upgrade, func() {
+		It("[QUARANTINE][test_id:3151]should be able to update kubevirt install when operator updates if no custom image tag is set", decorators.Quarantine, decorators.Upgrade, func() {
 
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

# What happened

<!-- insert test name -->
Flaky tests detected:

`[sig-operator]Operator [rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]infrastructure management [test_id:3149]should be able to create kubevirt install with image prefix` [1]

[1]: https://github.com/kubevirt/kubevirt/blob/9a0c3ce97465d00c97c7b00eba14ac11f59264c6/tests/operator/operator.go#L1101

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-operator%5DOperator+%5C%5Brfe_id%3A2291%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5Dinfrastructure+management+%5C%5Btest_id%3A3149%5Dshould+be+able+to+create+kubevirt+install+with+image+prefix&maxAge=72h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 21% over 72h on
[pull-kubevirt-e2e-k8s-1.33-sig-operator](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.33-sig-operator):
Failures: [6h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14804/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949599420387430400) [11h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949528074810822656) [14h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15288/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949479057527672832) [17h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949439977544749056) [20h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15045/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949398773872463872) [33h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15132/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949202326535278592) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948863297142919168) [18h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15287/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949427039157096448) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948656007718637568)

`[sig-operator]Operator [rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]infrastructure management [test_id:3150]should be able to update kubevirt install with custom image tag` [2]

[2]: https://github.com/kubevirt/kubevirt/blob/9a0c3ce97465d00c97c7b00eba14ac11f59264c6/tests/operator/operator.go#L1170

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-operator%5DOperator+%5C%5Brfe_id%3A2291%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5Dinfrastructure+management+%5C%5Btest_id%3A3150%5Dshould+be+able+to+update+kubevirt+install+with+custom+image+tag&maxAge=72h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 21% over 72h on
[pull-kubevirt-e2e-k8s-1.33-sig-operator](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.33-sig-operator):
Failures: [6h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14804/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949599420387430400) [11h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949528074810822656) [14h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15288/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949479057527672832) [17h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949439977544749056) [18h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15287/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949427039157096448) [20h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15045/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949398773872463872) [33h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15132/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949202326535278592) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948863297142919168) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948656007718637568)

`[sig-operator]Operator [rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]infrastructure management [test_id:3151]should be able to update kubevirt install when operator updates if no custom image tag is set` [3]

[3]: https://github.com/kubevirt/kubevirt/blob/9a0c3ce97465d00c97c7b00eba14ac11f59264c6/tests/operator/operator.go#L1246

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-operator%5DOperator+%5C%5Brfe_id%3A2291%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5Dinfrastructure+management+%5C%5Btest_id%3A3151%5Dshould+be+able+to+update+kubevirt+install+when+operator+updates+if+no+custom+image+tag+is+set&maxAge=72h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 33% over 72h on
[pull-kubevirt-e2e-k8s-1.32-sig-operator](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.32-sig-operator):
Failures: [11h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.32-sig-operator/1949528074718547968) [16h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.32-sig-operator/1949461270293909504) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.32-sig-operator/1948753461680017408) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.32-sig-operator/1948715959019638784) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.32-sig-operator/1948670817038503936)

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-operator%5DOperator+%5C%5Brfe_id%3A2291%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5Dinfrastructure+management+%5C%5Btest_id%3A3151%5Dshould+be+able+to+update+kubevirt+install+when+operator+updates+if+no+custom+image+tag+is+set&maxAge=72h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 26% over 72h on
[pull-kubevirt-e2e-k8s-1.33-sig-operator](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.33-sig-operator):
Failures: [6h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14804/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949599420387430400) [11h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949528074810822656) [14h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15288/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949479057527672832) [17h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949439977544749056) [18h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15287/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949427039157096448) [20h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15045/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949398773872463872) [21h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15287/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949382034736549888) [29h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949258768520843264) [33h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15132/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949202326535278592) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948863297142919168) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948656007718637568)

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-operator%5DOperator+%5C%5Brfe_id%3A2291%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5Dinfrastructure+management+%5C%5Btest_id%3A3151%5Dshould+be+able+to+update+kubevirt+install+when+operator+updates+if+no+custom+image+tag+is+set&maxAge=336h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 6% over 336h on
[pull-kubevirt-e2e-k8s-1.32-sig-operator](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.32-sig-operator):
Failures: [11h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.32-sig-operator/1949528074718547968) [16h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.32-sig-operator/1949461270293909504) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.32-sig-operator/1948753461680017408) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.32-sig-operator/1948715959019638784) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.32-sig-operator/1948670817038503936)

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-operator%5DOperator+%5C%5Brfe_id%3A2291%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5Dinfrastructure+management+%5C%5Btest_id%3A3151%5Dshould+be+able+to+update+kubevirt+install+when+operator+updates+if+no+custom+image+tag+is+set&maxAge=336h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 5% over 336h on
[pull-kubevirt-e2e-k8s-1.33-sig-operator](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.33-sig-operator):
Failures: [6h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14804/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949599420387430400) [11h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949528074810822656) [14h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15288/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949479057527672832) [17h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949439977544749056) [18h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15287/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949427039157096448) [20h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15045/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949398773872463872) [21h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15287/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949382034736549888) [29h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15285/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949258768520843264) [33h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15132/pull-kubevirt-e2e-k8s-1.33-sig-operator/1949202326535278592) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948863297142919168) [48h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948656007718637568) [72h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948534425767645184) [72h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15268/pull-kubevirt-e2e-k8s-1.33-sig-operator/1948398476182163456) [168h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14976/pull-kubevirt-e2e-k8s-1.33-sig-operator/1947064142439387136) [192h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14976/pull-kubevirt-e2e-k8s-1.33-sig-operator/1946725137336242176)

<!-- labels for flaky tests -->
/kind flake
/priority critical-urgent

<!-- sig assignment
     all tests contain a sig identifier, please assign the corresponding SIG to the issue, i.e.
     for a test name containing [sig-compute] or [sig-operator]
-->
/sig compute

/cc @fossedihelm @lyarwood 

#### After this PR:

Tests are flaky and are therefore quarantined.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

@fossedihelm mentioned failures might be related to the removal of shasums

<!--
from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
### Release notes
```release-note
NONE
```

