### PR TITLE
Fix hotplug decentralized live migration

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1366,15 +1366,27 @@ func alignPodMultiCategorySecurity(pod *k8sv1.Pod, selinuxType string, dockerSEL
 
 func matchSELinuxLevelOfVMI(pod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) error {
 	if vmi.Status.SelinuxContext == "" {
+		if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.SourceState != nil && vmi.Status.MigrationState.SourceState.SelinuxContext != "" {
+			selinuxContext := vmi.Status.MigrationState.SourceState.SelinuxContext
+			if selinuxContext != "none" {
+				return setSELinuxContext(selinuxContext, pod)
+			}
+			return nil
+		}
 		return fmt.Errorf("VMI is missing SELinux context")
 	} else if vmi.Status.SelinuxContext != "none" {
-		ctx := strings.Split(vmi.Status.SelinuxContext, ":")
-		if len(ctx) < 4 {
-			return fmt.Errorf("VMI has invalid SELinux context: %s", vmi.Status.SelinuxContext)
-		}
-		pod.Spec.Containers[0].SecurityContext.SELinuxOptions.Level = strings.Join(ctx[3:], ":")
+		return setSELinuxContext(vmi.Status.SelinuxContext, pod)
 	}
 
+	return nil
+}
+
+func setSELinuxContext(selinuxContext string, pod *k8sv1.Pod) error {
+	ctx := strings.Split(selinuxContext, ":")
+	if len(ctx) < 4 {
+		return fmt.Errorf("VMI has invalid SELinux context: %s", selinuxContext)
+	}
+	pod.Spec.Containers[0].SecurityContext.SELinuxOptions.Level = strings.Join(ctx[3:], ":")
 	return nil
 }
 

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -707,7 +707,7 @@ func (c *Controller) processMigrationPhase(
 			migrationCopy.Status.Phase = virtv1.MigrationPreparingTarget
 		}
 	case virtv1.MigrationPreparingTarget:
-		if (migration.IsLocalOrDecentralizedSource() && vmi.IsMigrationSourceSynchronized()) ||
+		if (migration.IsLocalOrDecentralizedSource() && vmi.IsMigrationSourceSynchronized() && vmi.Status.MigrationState.TargetState.NodeAddress != nil) ||
 			(migration.IsLocalOrDecentralizedTarget() && vmi.Status.MigrationState.TargetNode != "" && vmi.Status.MigrationState.TargetNodeAddress != "") {
 			migrationCopy.Status.Phase = virtv1.MigrationTargetReady
 		}

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -273,6 +273,9 @@ func checkIfHotplugDisksReadyToUse(vmi *v1.VirtualMachineInstance) error {
 		// Wait some time before checking again
 		time.Sleep(sleepTime)
 	}
+	if len(entries) != vmiHotplugCount {
+		return fmt.Errorf("found %d hotplugged disks files, expected %d", len(entries), vmiHotplugCount)
+	}
 
 	readyCount := 0
 	for i := 0; i < retryCount && readyCount < vmiHotplugCount; i++ {
@@ -294,9 +297,10 @@ func checkIfHotplugDisksReadyToUse(vmi *v1.VirtualMachineInstance) error {
 		// Wait some time before checking again
 		time.Sleep(sleepTime)
 	}
-	if readyCount == vmiHotplugCount {
-		logger.Info("all hotplugged disks are ready to use")
+	if readyCount != vmiHotplugCount {
+		return fmt.Errorf("not all hotplugged disks are ready to use, found %d ready, expected %d", readyCount, vmiHotplugCount)
 	}
+	logger.Info("all hotplugged disks are ready to use")
 	return nil
 }
 

--- a/tests/libmigration/BUILD.bazel
+++ b/tests/libmigration/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -16,6 +16,8 @@ import (
 
 	k8snetworkplumbingwgv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	k8sv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -77,9 +79,15 @@ func ExpectMigrationToSucceedWithDefaultTimeout(virtClient kubecli.KubevirtClien
 
 func ExpectMigrationToSucceedWithOffset(offset int, virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) *v1.VirtualMachineInstanceMigration {
 	By("Waiting until the Migration Completes")
+	var err error
+	isDecentralized := migration.IsDecentralized()
 	EventuallyWithOffset(offset, func() error {
-		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
+		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 		if err != nil {
+			if k8serrors.IsNotFound(err) && isDecentralized {
+				migration = nil
+				return nil
+			}
 			return err
 		}
 
@@ -133,8 +141,8 @@ func RunDecentralizedMigrationAndExpectToComplete(virtClient kubecli.KubevirtCli
 	}, 30*time.Second, 1*time.Second).ShouldNot(BeNil())
 	targetMigration = RunMigration(virtClient, targetMigration)
 	CheckSynchronizationAddressPopulated(virtClient, targetMigration)
-	sourceMigration = ExpectMigrationToSucceed(virtClient, sourceMigration, timeout)
 	targetMigration = ExpectMigrationToSucceed(virtClient, targetMigration, timeout)
+	sourceMigration = ExpectMigrationToSucceed(virtClient, sourceMigration, timeout)
 	return sourceMigration, targetMigration
 }
 

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -341,7 +341,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 
 			Eventually(func() error {
 				return virtClient.VirtualMachine(namespace).AddVolume(context.Background(), name, opts)
-			}, 3*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+			}, 3*time.Second, 1*time.Second).Should(Succeed())
 		}
 
 		It("should live migrate a container disk vm, with an additional hotpluggedPVC mounted, should stay mounted after migration", decorators.RequiresRWXBlock, func() {
@@ -417,7 +417,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				// Verify that the VMI doesn't exist, and that the VM is in the correct state.
 				By("Verifying the VMI doesn't exist")
 				_, err := virtClient.VirtualMachineInstance(sourceVMI.Namespace).Get(context.Background(), sourceVMI.Name, metav1.GetOptions{})
-				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+				Expect(err).To(MatchError(k8serrors.IsNotFound, "k8serrors.IsNotFound"))
 
 				By("Verifying the VM is in the correct state")
 				Eventually(func() virtv1.VirtualMachineRunStrategy {

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -356,6 +356,8 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithCPURequest("1"), libvmi.WithMemoryRequest("128Mi"),
+				libvmi.WithCPULimit("1"), libvmi.WithMemoryLimit("128Mi"),
 				libvmi.WithAnnotation("kubevirt.io/libvirt-log-filters", "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"),
 			)
 

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -356,6 +356,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithAnnotation("kubevirt.io/libvirt-log-filters", "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"),
 			)
 
 			sourceVM := createAndStartVMFromVMISpec(sourceVMI)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Fixes a bug in decentralized live migration, where migrating a VM with a hotplugged volume would fail.

#### Before this PR:
Unable to migrate a VM with a persistent hotplugged volume.

#### After this PR:
Successfully migrate a VM with a persistent hotplugged volume.

### References
 
- Fixes https://issues.redhat.com/browse/CNV-64972

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

