### PR TITLE
passt BP, sidecar: Infer pod iface name from VMI

### DIFF
--- a/cmd/sidecars/network-passt-binding/callback/callback.go
+++ b/cmd/sidecars/network-passt-binding/callback/callback.go
@@ -29,11 +29,11 @@ import (
 // TODO: move to Kubevirt domain API package
 const libvirtDomainQemuSchema = "http://libvirt.org/schemas/domain/qemu/1.0"
 
-type DomainSpecMutator interface {
+type domainSpecMutator interface {
 	Mutate(*domainschema.DomainSpec) (*domainschema.DomainSpec, error)
 }
 
-func OnDefineDomain(domainXML []byte, domSpecMutator DomainSpecMutator) ([]byte, error) {
+func OnDefineDomain(domainXML []byte, domSpecMutator domainSpecMutator) ([]byte, error) {
 	domainSpec := &domainschema.DomainSpec{
 		// Unmarshalling domain spec makes the XML namespace attribute empty.
 		// Some domain parameters requires namespace to be defined.

--- a/cmd/sidecars/network-passt-binding/domain/BUILD.bazel
+++ b/cmd/sidecars/network-passt-binding/domain/BUILD.bazel
@@ -6,15 +6,12 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-passt-binding/domain",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/network/driver/netlink:go_default_library",
         "//pkg/network/istio:go_default_library",
-        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )
 
@@ -31,6 +28,5 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )

--- a/cmd/sidecars/network-passt-binding/server/server.go
+++ b/cmd/sidecars/network-passt-binding/server/server.go
@@ -91,7 +91,12 @@ func (s V1alpha3Server) OnDefineDomain(
 		IstioProxyInjectionEnabled: istioProxyInjectionEnabled,
 	}
 
-	passtConfigurator, err := domain.NewPasstNetworkConfigurator(vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, opts, nil)
+	passtConfigurator, err := domain.NewPasstNetworkConfigurator(
+		vmi.Spec.Domain.Devices.Interfaces,
+		vmi.Spec.Networks,
+		vmi.Status.Interfaces,
+		opts,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create passt configurator: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the passt binding plugin's sidecar tries to check whether some custom interface name exists inside the pod - and uses it in case it exists instead of using the traditional "eth0".

Replace this logic by inferring the pod interface's name from the VMI interface statuses.

This is done in order to:
 - Be in sync with the dynamic primary NIC name feature [1][2]
 - Simplify the code and tests
 - Reduce external dependencies

Note: The PodInterfaceName field is expected to contain a valid value by the time it reaches this stage, so there is no need for a fallback.

[1] https://github.com/kubevirt/community/pull/324
[2] https://github.com/kubevirt/community/pull/357

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

