### PR TITLE
[release-1.5] Enforce CNs for aggregated API 

### DIFF
--- a/pkg/util/tls/ca-manager.go
+++ b/pkg/util/tls/ca-manager.go
@@ -21,6 +21,7 @@ package tls
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -40,6 +41,11 @@ type ClientCAManager interface {
 	GetCurrentRaw() ([]byte, error)
 }
 
+type KubernetesCAManager interface {
+	ClientCAManager
+	GetCNs() ([]string, error)
+}
+
 type manager struct {
 	store        cache.Store
 	lock         *sync.Mutex
@@ -52,14 +58,63 @@ type manager struct {
 	lastRaw  []byte
 }
 
-func NewKubernetesClientCAManager(configMapCache cache.Store) ClientCAManager {
-	return &manager{
-		store:        configMapCache,
-		lock:         &sync.Mutex{},
-		namespace:    metav1.NamespaceSystem,
-		name:         util.ExtensionAPIServerAuthenticationConfigMap,
-		secretKey:    util.RequestHeaderClientCAFileKey,
-		lastRevision: "-1",
+type kubeManager struct {
+	manager
+	lastCNs        []string
+	lastCNRevision string
+}
+
+func (m *kubeManager) GetCNs() ([]string, error) {
+	obj, exists, err := m.store.GetByKey(m.namespace + "/" + m.name)
+
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		m.lock.Lock()
+		defer m.lock.Unlock()
+		if m.lastPool != nil {
+			return m.lastCNs, nil
+		}
+
+		return nil, fmt.Errorf("configmap %s not found. Unable to detect request header CA", m.name)
+	}
+
+	configMap := obj.(*k8sv1.ConfigMap)
+
+	// no change detected.
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.lastCNRevision == configMap.ResourceVersion {
+		return m.lastCNs, nil
+	}
+
+	CNstring, ok := configMap.Data["requestheader-allowed-names"]
+	if !ok {
+		return nil, fmt.Errorf("requestheader-allowed-names not found in configmap %s/%s", m.namespace, m.name)
+	}
+	CNs := []string{}
+	if CNstring != "" {
+		err = json.Unmarshal([]byte(CNstring), &CNs)
+		if err != nil {
+			return CNs, err
+		}
+	}
+
+	m.lastCNs = CNs
+	m.lastCNRevision = configMap.ResourceVersion
+	return CNs, nil
+}
+
+func NewKubernetesClientCAManager(configMapCache cache.Store) *kubeManager {
+	return &kubeManager{
+		manager: manager{
+			store:        configMapCache,
+			lock:         &sync.Mutex{},
+			namespace:    metav1.NamespaceSystem,
+			name:         util.ExtensionAPIServerAuthenticationConfigMap,
+			secretKey:    util.RequestHeaderClientCAFileKey,
+			lastRevision: "-1",
+		},
 	}
 }
 

--- a/pkg/util/tls/tls.go
+++ b/pkg/util/tls/tls.go
@@ -91,7 +91,7 @@ func SetupExportProxyTLS(certManager certificate.Manager, kubeVirtStore cache.St
 	return tlsConfig
 }
 
-func SetupTLSWithCertManager(caManager ClientCAManager, certManager certificate.Manager, clientAuth tls.ClientAuthType, clusterConfig *virtconfig.ClusterConfig) *tls.Config {
+func SetupTLSWithCertManager(caManager KubernetesCAManager, certManager certificate.Manager, clientAuth tls.ClientAuthType, clusterConfig *virtconfig.ClusterConfig) *tls.Config {
 	tlsConfig := &tls.Config{
 		GetCertificate: func(info *tls.ClientHelloInfo) (certificate *tls.Certificate, err error) {
 			cert := certManager.Current()
@@ -122,6 +122,32 @@ func SetupTLSWithCertManager(caManager ClientCAManager, certManager certificate.
 				Certificates: []tls.Certificate{*cert},
 				ClientCAs:    clientCAPool,
 				ClientAuth:   clientAuth,
+				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+					if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
+						return nil
+					}
+
+					certificate, err := x509.ParseCertificate(rawCerts[0])
+					if err != nil {
+						return fmt.Errorf("failed to parse peer certificate: %v", err)
+					}
+
+					CNs, err := caManager.GetCNs()
+					if err != nil {
+						return err
+					}
+
+					if len(CNs) == 0 {
+						return nil
+					}
+					for _, CN := range CNs {
+						if certificate.Subject.CommonName == CN {
+							return nil
+						}
+					}
+
+					return fmt.Errorf("common name is invalid")
+				},
 			}
 
 			config.BuildNameToCertificate()

--- a/pkg/util/tls/tls_test.go
+++ b/pkg/util/tls/tls_test.go
@@ -31,6 +31,7 @@ import (
 
 type mockCAManager struct {
 	caBundle []byte
+	cns      []string
 }
 
 type mockCertManager struct {
@@ -66,9 +67,13 @@ func (m *mockCAManager) GetCurrentRaw() ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (m *mockCAManager) GetCNs() ([]string, error) {
+	return m.cns, nil
+}
+
 var _ = Describe("TLS", func() {
 
-	var caManager kvtls.ClientCAManager
+	var caManager kvtls.KubernetesCAManager
 	var certmanagers map[string]certificate.Manager
 	var clusterConfig *virtconfig.ClusterConfig
 	var kubeVirtStore cache.Store
@@ -220,7 +225,8 @@ var _ = Describe("TLS", func() {
 		}),
 	)
 
-	DescribeTable("should verify self-signed client and server certificates", func(serverSecret, clientSecret string, errStr string) {
+	DescribeTable("should verify self-signed client and server certificates", func(serverSecret, clientSecret, errStr string, cns []string) {
+		caManager.(*mockCAManager).cns = cns
 		serverTLSConfig := kvtls.SetupTLSWithCertManager(caManager, certmanagers[serverSecret], tls.RequireAndVerifyClientCert, clusterConfig)
 		clientTLSConfig := kvtls.SetupTLSForVirtHandlerClients(caManager, certmanagers[clientSecret], false)
 		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -248,18 +254,35 @@ var _ = Describe("TLS", func() {
 			components.VirtHandlerServerCertSecretName,
 			components.VirtHandlerCertSecretName,
 			"",
+			[]string{"kubevirt.io:system:client:virt-handler"},
+		),
+		Entry(
+			"connect with proper certificates with no CN auth",
+			components.VirtHandlerServerCertSecretName,
+			components.VirtHandlerCertSecretName,
+			"",
+			[]string{},
+		),
+		Entry(
+			"fail if client uses an invalid certificates (CN)",
+			components.VirtHandlerServerCertSecretName,
+			components.VirtHandlerCertSecretName,
+			"remote error: tls: bad certificate",
+			[]string{"kubevirt.io:system:clientv2:virt-handler"},
 		),
 		Entry(
 			"fail if client uses an invalid certificate",
 			components.VirtHandlerServerCertSecretName,
 			components.VirtHandlerServerCertSecretName,
 			"remote error: tls: bad certificate",
+			[]string{"kubevirt.io:system:client:virt-handler"},
 		),
 		Entry(
 			"fail if server uses an invalid certificate",
 			components.VirtHandlerCertSecretName,
 			components.VirtHandlerCertSecretName,
 			"x509: certificate specifies an incompatible key usage",
+			[]string{"kubevirt.io:system:client:virt-handler"},
 		),
 	)
 

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -960,7 +960,7 @@ func (app *virtAPIApp) registerMutatingWebhook(informers *webhooks.Informers) {
 	})
 }
 
-func (app *virtAPIApp) setupTLS(k8sCAManager kvtls.ClientCAManager, kubevirtCAManager kvtls.ClientCAManager) {
+func (app *virtAPIApp) setupTLS(k8sCAManager kvtls.KubernetesCAManager, kubevirtCAManager kvtls.ClientCAManager) {
 
 	// A VerifyClientCertIfGiven request means we're not guaranteed
 	// a client has been authenticated unless they provide a peer


### PR DESCRIPTION
### What this PR does
Follows https://kubernetes.io/docs/tasks/extend-kubernetes/setup-extension-api-server/

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Common Names are now enforce for aggregated API
```

