### PR TITLE
[release-1.3] Enforce CNs for aggregated API

### DIFF
--- a/pkg/util/tls/ca-manager.go
+++ b/pkg/util/tls/ca-manager.go
@@ -21,6 +21,7 @@ package tls
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -40,6 +41,11 @@ type ClientCAManager interface {
 	GetCurrentRaw() ([]byte, error)
 }
 
+type KubernetesCAManager interface {
+	ClientCAManager
+	GetCNs() ([]string, error)
+}
+
 type manager struct {
 	store        cache.Store
 	lock         *sync.Mutex
@@ -52,14 +58,63 @@ type manager struct {
 	lastRaw  []byte
 }
 
-func NewKubernetesClientCAManager(configMapCache cache.Store) ClientCAManager {
-	return &manager{
-		store:        configMapCache,
-		lock:         &sync.Mutex{},
-		namespace:    metav1.NamespaceSystem,
-		name:         util.ExtensionAPIServerAuthenticationConfigMap,
-		secretKey:    util.RequestHeaderClientCAFileKey,
-		lastRevision: "-1",
+type kubeManager struct {
+	manager
+	lastCNs        []string
+	lastCNRevision string
+}
+
+func (m *kubeManager) GetCNs() ([]string, error) {
+	obj, exists, err := m.store.GetByKey(m.namespace + "/" + m.name)
+
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		m.lock.Lock()
+		defer m.lock.Unlock()
+		if m.lastPool != nil {
+			return m.lastCNs, nil
+		}
+
+		return nil, fmt.Errorf("configmap %s not found. Unable to detect request header CA", m.name)
+	}
+
+	configMap := obj.(*k8sv1.ConfigMap)
+
+	// no change detected.
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.lastCNRevision == configMap.ResourceVersion {
+		return m.lastCNs, nil
+	}
+
+	CNstring, ok := configMap.Data["requestheader-allowed-names"]
+	if !ok {
+		return nil, fmt.Errorf("requestheader-allowed-names not found in configmap %s/%s", m.namespace, m.name)
+	}
+	CNs := []string{}
+	if CNstring != "" {
+		err = json.Unmarshal([]byte(CNstring), &CNs)
+		if err != nil {
+			return CNs, err
+		}
+	}
+
+	m.lastCNs = CNs
+	m.lastCNRevision = configMap.ResourceVersion
+	return CNs, nil
+}
+
+func NewKubernetesClientCAManager(configMapCache cache.Store) *kubeManager {
+	return &kubeManager{
+		manager: manager{
+			store:        configMapCache,
+			lock:         &sync.Mutex{},
+			namespace:    metav1.NamespaceSystem,
+			name:         util.ExtensionAPIServerAuthenticationConfigMap,
+			secretKey:    util.RequestHeaderClientCAFileKey,
+			lastRevision: "-1",
+		},
 	}
 }
 

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -943,7 +943,7 @@ func (app *virtAPIApp) registerMutatingWebhook(informers *webhooks.Informers) {
 	})
 }
 
-func (app *virtAPIApp) setupTLS(k8sCAManager kvtls.ClientCAManager, kubevirtCAManager kvtls.ClientCAManager) {
+func (app *virtAPIApp) setupTLS(k8sCAManager kvtls.KubernetesCAManager, kubevirtCAManager kvtls.ClientCAManager) {
 
 	// A VerifyClientCertIfGiven request means we're not guaranteed
 	// a client has been authenticated unless they provide a peer


### PR DESCRIPTION
### What this PR does
Follows https://kubernetes.io/docs/tasks/extend-kubernetes/setup-extension-api-server/

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Common Names are now enforce for aggregated API
```

