### PR TITLE
Move performance job artifacts to the base artifacts directory

### DIFF
--- a/hack/perfscale-tests.sh
+++ b/hack/perfscale-tests.sh
@@ -29,10 +29,8 @@ export PROMETHEUS_URL=${PROMETHEUS_URL:-http://127.0.0.1}
 export PERFSCALE_WORKLOAD=${PERFSCALE_WORKLOAD:-${_perfscale_workload}}
 
 echo 'Preparing directory for artifacts'
-export ARTIFACTS=${ARTIFACTS}/performance-density
 export AUDIT_CONFIG=${ARTIFACTS}/perfscale-audit-cfg.json
 export AUDIT_RESULTS=${ARTIFACTS}/perfscale-audit-results.json
-rm -rf $ARTIFACTS
 mkdir -p $ARTIFACTS
 
 # in kubevirt CI/CD the node we run the job is on a different cluster, so time is not synced across all nodes

--- a/hack/perftests.sh
+++ b/hack/perftests.sh
@@ -41,10 +41,8 @@ echo 'Performance testing'
 export KUBEVIRT_E2E_PERF_TEST=true
 
 echo 'Preparing directory for artifacts'
-export ARTIFACTS=${ARTIFACTS}/performance
 export AUDIT_CONFIG=${ARTIFACTS}/perfscale-audit-cfg.json
 export AUDIT_RESULTS=${ARTIFACTS}/perfscale-audit-results.json
-rm -rf $ARTIFACTS
 mkdir -p $ARTIFACTS
 
 export TESTS_OUT_DIR=${TESTS_OUT_DIR}


### PR DESCRIPTION
### What this PR does
Move the performance job tests up a directory level so results can be discovered by prow.

#### Before this PR:
Prow was not able to see the published juitfile

#### After this PR:
Prow will now discover the file - https://github.com/kubevirt/project-infra/blob/7be6a09db6484ff087f36c5a99e7697a30be4d51/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml#L52

### References
  
- Fixes #15296 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

