### PR TITLE
vm-mutator: assign default firmware.Serial for new VMs

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -87,7 +87,7 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	// On update, the mutator does not modify the UUID field to avoid
 	// race conditions with the VM controller.
 	if ar.Request.Operation == admissionv1.Create {
-		setFirmwareUUIDIfEmpty(vm)
+		setFirmwareDefaultsIfEmpty(vm)
 	}
 
 	// Set VM defaults
@@ -119,11 +119,17 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	}
 }
 
-func setFirmwareUUIDIfEmpty(vm *v1.VirtualMachine) {
+func setFirmwareDefaultsIfEmpty(vm *v1.VirtualMachine) {
 	if vm.Spec.Template.Spec.Domain.Firmware == nil {
 		vm.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{}
 	}
-	if vm.Spec.Template.Spec.Domain.Firmware.UUID == "" {
-		vm.Spec.Template.Spec.Domain.Firmware.UUID = types.UID(uuid.New().String())
+	fw := vm.Spec.Template.Spec.Domain.Firmware
+
+	if fw.UUID == "" {
+		fw.UUID = types.UID(uuid.New().String())
+	}
+
+	if fw.Serial == "" {
+		fw.Serial = uuid.New().String()
 	}
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -166,6 +166,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		vmSpec, _ := getVMSpecMetaFromResponseCreate(arch)
 		Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal(result))
 		Expect(vmSpec.Template.Spec.Domain.Firmware.UUID).ToNot(BeNil())
+		Expect(vmSpec.Template.Spec.Domain.Firmware.Serial).ToNot(BeNil())
 	},
 		Entry("ppc64le", "ppc64le", "pseries"),
 		Entry("arm64", "arm64", "virt"),
@@ -680,7 +681,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			})
 		})
 
-		It("should NOT assign new UUID when VM template spec lacks one on update", func() {
+		It("should NOT assign new UUID or Serial when VM template spec lacks them on update", func() {
 			oldVM.Spec.Template.Spec.Domain.Firmware = nil
 			newVM.Spec.Template.Spec.Domain.Firmware = nil
 
@@ -718,6 +719,25 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmSpec.Template.Spec.Domain.Firmware).ToNot(BeNil())
 			Expect(vmSpec.Template.Spec.Domain.Firmware.UUID).To(Equal(newUUID))
+		})
+
+		It("should preserve existing Serial when VM template spec has one", func() {
+			oldVM.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{Serial: "existing-serial"}
+			newVM.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{Serial: "new-serial"}
+
+			resp := getResponseFromVMUpdate(oldVM, newVM)
+			Expect(resp.Allowed).To(BeTrue())
+
+			vmSpec := &v1.VirtualMachineSpec{}
+			vmMeta := &k8smetav1.ObjectMeta{}
+			patchOps := []patch.PatchOperation{
+				{Value: vmSpec},
+				{Value: vmMeta},
+			}
+			err := json.Unmarshal(resp.Patch, &patchOps)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmSpec.Template.Spec.Domain.Firmware).ToNot(BeNil())
+			Expect(vmSpec.Template.Spec.Domain.Firmware.Serial).To(Equal("new-serial"))
 		})
 	})
 

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -147,7 +147,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			expectEqualStrMap(targetVM.Spec.Template.ObjectMeta.Annotations, sourceVM.Spec.Template.ObjectMeta.Annotations, fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "template.annotations"), keysToExclude...)
 		}
 
-		expectSpecsToEqualExceptForMacAddressAndUUID := func(vm1, vm2 *virtv1.VirtualMachine) {
+		expectVMsToEqualExcludingMACAndFirmwareIDs := func(vm1, vm2 *virtv1.VirtualMachine) {
 			vm1Spec := vm1.Spec.DeepCopy()
 			vm2Spec := vm2.Spec.DeepCopy()
 
@@ -157,19 +157,21 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				}
 				if spec.Template.Spec.Domain.Firmware != nil {
 					spec.Template.Spec.Domain.Firmware.UUID = ""
+					spec.Template.Spec.Domain.Firmware.Serial = ""
 				}
 			}
 
 			Expect(vm1Spec).To(Equal(vm2Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec not including mac addresses and firmware UUID"))
 		}
 
-		expectSpecsToEqualExceptForFirmwareUUID := func(vm1, vm2 *virtv1.VirtualMachine) {
+		expectSpecsToEqualExceptForFirmwareUUIDAndSerial := func(vm1, vm2 *virtv1.VirtualMachine) {
 			vm1Spec := vm1.Spec.DeepCopy()
 			vm2Spec := vm2.Spec.DeepCopy()
 
 			for _, spec := range []*virtv1.VirtualMachineSpec{vm1Spec, vm2Spec} {
 				if spec.Template.Spec.Domain.Firmware != nil {
 					spec.Template.Spec.Domain.Firmware.UUID = ""
+					spec.Template.Spec.Domain.Firmware.Serial = ""
 				}
 			}
 
@@ -200,7 +202,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				By("Making sure target is runnable")
 				targetVM = expectVMRunnable(targetVM)
 
-				expectSpecsToEqualExceptForFirmwareUUID(sourceVM, targetVM)
+				expectSpecsToEqualExceptForFirmwareUUIDAndSerial(sourceVM, targetVM)
 				expectEqualLabels(targetVM, sourceVM)
 				expectEqualAnnotations(targetVM, sourceVM)
 				expectEqualTemplateLabels(targetVM, sourceVM)
@@ -276,7 +278,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				By("Making sure target is runnable")
 				targetVM = expectVMRunnable(targetVM)
 
-				expectSpecsToEqualExceptForFirmwareUUID(sourceVM, targetVM)
+				expectSpecsToEqualExceptForFirmwareUUIDAndSerial(sourceVM, targetVM)
 				expectEqualLabels(targetVM, sourceVM, key2)
 				expectEqualAnnotations(targetVM, sourceVM, key2)
 			})
@@ -348,7 +350,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				By("Making sure new mac address is applied to target VM")
 				Expect(targetInterface.MacAddress).ToNot(Equal(srcInterface.MacAddress))
 
-				expectSpecsToEqualExceptForMacAddressAndUUID(targetVM, sourceVM)
+				expectVMsToEqualExcludingMACAndFirmwareIDs(targetVM, sourceVM)
 				expectEqualLabels(targetVM, sourceVM)
 				expectEqualAnnotations(targetVM, sourceVM)
 				expectEqualTemplateLabels(targetVM, sourceVM)


### PR DESCRIPTION
### What this PR does
This PR extends the firmware defaulting logic to ensure that a unique `Firmware.Serial` value is assigned to newly created VMs when one is not explicitly provided.

#### Use-case

The main use-case is for cluster administrators who want every newly created VM in the cluster to have a unique and consistent `firmware.serial` value. This allows them to track and identify VMs reliably from within the guest OS by reading the DMI-exposed field at `/sys/devices/virtual/dmi/id/subsystem/id/product_serial`.

#### Before this PR:
- `Firmware.Serial` was not defaulted.

#### After this PR:
- If `Firmware.Serial` is unset, it is defaulted with a new UUID.

### References

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
ensure default Firmware.Serial value on newly created vms
```

