### PR TITLE
virt-handler: domain watcher to trust sockets from ghost record only

### DIFF
--- a/pkg/virt-handler/cache/BUILD.bazel
+++ b/pkg/virt-handler/cache/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     srcs = [
         "cache_suite_test.go",
         "cache_test.go",
+        "domain-watcher_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -21,6 +21,7 @@ package cache
 
 import (
 	"encoding/xml"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -44,71 +45,22 @@ import (
 )
 
 var _ = Describe("Domain informer", func() {
-	var shareDir string
-	var podsDir string
 	var ghostCacheDir string
-	var informer cache.SharedInformer
-	var stopChan chan struct{}
-	var wg *sync.WaitGroup
-	var ctrl *gomock.Controller
-	var domainManager *virtwrap.MockDomainManager
-	var socketPath string
-	var resyncPeriod int
 	var ghostRecordStore *GhostRecordStore
 
-	podUID := "1234"
-
 	BeforeEach(func() {
-		resyncPeriod = 5
-		stopChan = make(chan struct{})
-		wg = &sync.WaitGroup{}
-
 		var err error
-		shareDir, err = os.MkdirTemp("", "kubevirt-share")
-		Expect(err).ToNot(HaveOccurred())
-
-		podsDir, err = os.MkdirTemp("", "")
-		Expect(err).ToNot(HaveOccurred())
 
 		ghostCacheDir, err = os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 
 		ghostRecordStore = InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
-
-		cmdclient.SetPodsBaseDir(podsDir)
-
-		socketPath = cmdclient.SocketFilePathOnHost(podUID)
-		os.MkdirAll(filepath.Dir(socketPath), 0755)
-
-		informer = NewSharedInformer(shareDir, 10, nil, nil, time.Duration(resyncPeriod)*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-
-		ctrl = gomock.NewController(GinkgoT())
-		domainManager = virtwrap.NewMockDomainManager(ctrl)
 	})
 
 	AfterEach(func() {
-		close(stopChan)
-		wg.Wait()
-		os.RemoveAll(shareDir)
-		os.RemoveAll(podsDir)
-		os.RemoveAll(ghostCacheDir)
+		ghostRecordStore = nil
+		Expect(os.RemoveAll(ghostCacheDir)).To(Succeed())
 	})
-
-	verifyObj := func(key string, domain *api.Domain, g Gomega) {
-		obj, exists, err := informer.GetStore().GetByKey(key)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		if domain != nil {
-			g.Expect(exists).To(BeTrue())
-
-			eventDomain := obj.(*api.Domain)
-			eventDomain.Spec.XMLName = xml.Name{}
-			g.Expect(equality.Semantic.DeepEqual(&domain.Spec, &eventDomain.Spec)).To(BeTrue())
-		} else {
-			g.Expect(exists).To(BeFalse())
-		}
-	}
 
 	Context("with ghost record cache", func() {
 		It("Should be able to retrieve uid", func() {
@@ -189,12 +141,74 @@ var _ = Describe("Domain informer", func() {
 		})
 	})
 
-	Context("with notification server", func() {
+	Context("with cmd server", func() {
+		const podUID = "1234"
+		const domainName = "testvmi1"
+		const domainNamespace = "default"
+		const resyncPeriod = 5
+
+		var shareDir string
+		var podsDir string
+		var informer cache.SharedInformer
+		var stopChan chan struct{}
+		var wg *sync.WaitGroup
+		var ctrl *gomock.Controller
+		var domainManager *virtwrap.MockDomainManager
+		var socketPath string
+
+		BeforeEach(func() {
+			var err error
+
+			stopChan = make(chan struct{})
+			wg = &sync.WaitGroup{}
+
+			shareDir, err = os.MkdirTemp("", "kubevirt-share")
+			Expect(err).ToNot(HaveOccurred())
+
+			podsDir, err = os.MkdirTemp("", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			cmdclient.SetPodsBaseDir(podsDir)
+
+			socketPath = cmdclient.SocketFilePathOnHost(podUID)
+			Expect(os.MkdirAll(filepath.Dir(socketPath), 0755)).To(Succeed())
+			Expect(ghostRecordStore.Add(domainNamespace, domainName, socketPath, podUID)).To(Succeed())
+
+			informer = NewSharedInformer(shareDir, 10, nil, nil, time.Duration(resyncPeriod)*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctrl = gomock.NewController(GinkgoT())
+			domainManager = virtwrap.NewMockDomainManager(ctrl)
+		})
+
+		AfterEach(func() {
+			Expect(ghostRecordStore.Delete(domainNamespace, domainName)).To(Succeed())
+			close(stopChan)
+			wg.Wait()
+
+			Expect(os.RemoveAll(shareDir)).To(Succeed())
+			Expect(os.RemoveAll(podsDir)).To(Succeed())
+		})
+
+		verifyObj := func(key string, domain *api.Domain, g Gomega) {
+			obj, exists, err := informer.GetStore().GetByKey(key)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if domain != nil {
+				g.Expect(exists).To(BeTrue())
+
+				eventDomain := obj.(*api.Domain)
+				eventDomain.Spec.XMLName = xml.Name{}
+				g.Expect(equality.Semantic.DeepEqual(&domain.Spec, &eventDomain.Spec)).To(BeTrue())
+			} else {
+				g.Expect(exists).To(BeFalse())
+			}
+		}
+
 		It("should list current domains.", func() {
 			var list []*api.Domain
 
-			list = append(list, api.NewMinimalDomain("testvmi1"))
-
+			list = append(list, api.NewMinimalDomain(domainName))
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
 			domainManager.EXPECT().InterfacesStatus().Return([]api.InterfaceStatus{})
@@ -220,7 +234,7 @@ var _ = Describe("Domain informer", func() {
 		It("should list current domains including inactive domains with ghost record", func() {
 			var list []*api.Domain
 
-			list = append(list, api.NewMinimalDomain("testvmi1"))
+			list = append(list, api.NewMinimalDomain(domainName))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
@@ -249,7 +263,7 @@ var _ = Describe("Domain informer", func() {
 		It("should detect active domains at startup.", func() {
 			var list []*api.Domain
 
-			domain := api.NewMinimalDomain("test")
+			domain := api.NewMinimalDomain(domainName)
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
@@ -266,12 +280,12 @@ var _ = Describe("Domain informer", func() {
 			runInformer(wg, stopChan, informer)
 			cache.WaitForCacheSync(stopChan, informer.HasSynced)
 
-			verifyObj("default/test", domain, Default)
+			key := fmt.Sprintf("%s/%s", domainNamespace, domainName)
+			verifyObj(key, domain, Default)
 		})
 
 		It("should resync active domains after resync period.", func() {
-
-			domain := api.NewMinimalDomain("test")
+			domain := api.NewMinimalDomain(domainName)
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{domain}, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
 			domainManager.EXPECT().InterfacesStatus().Return([]api.InterfaceStatus{})
@@ -294,11 +308,12 @@ var _ = Describe("Domain informer", func() {
 			runInformer(wg, stopChan, informer)
 			cache.WaitForCacheSync(stopChan, informer.HasSynced)
 
-			verifyObj("default/test", domain, Default)
+			key := fmt.Sprintf("%s/%s", domainNamespace, domainName)
+			verifyObj(key, domain, Default)
 
 			time.Sleep(time.Duration(resyncPeriod+1) * time.Second)
 
-			obj, exists, err := informer.GetStore().GetByKey("default/test")
+			obj, exists, err := informer.GetStore().GetByKey(key)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exists).To(BeTrue())
 
@@ -314,8 +329,6 @@ var _ = Describe("Domain informer", func() {
 			f, err := os.Create(socketPath)
 			Expect(err).ToNot(HaveOccurred())
 			f.Close()
-
-			ghostRecordStore.Add("test", "test", socketPath, "1234")
 
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,
@@ -360,9 +373,6 @@ var _ = Describe("Domain informer", func() {
 				}
 			}()
 
-			err = ghostRecordStore.Add("test", "test", socketPath, "1234")
-			Expect(err).ToNot(HaveOccurred())
-
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,
 				virtShareDir:             shareDir,
@@ -390,7 +400,7 @@ var _ = Describe("Domain informer", func() {
 		It("should not return errors when encountering disconnected clients at startup.", func() {
 			var list []*api.Domain
 
-			domain := api.NewMinimalDomain("test")
+			domain := api.NewMinimalDomain(domainName)
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
@@ -406,8 +416,10 @@ var _ = Describe("Domain informer", func() {
 			runInformer(wg, stopChan, informer)
 			cache.WaitForCacheSync(stopChan, informer.HasSynced)
 
-			verifyObj("default/test", domain, Default)
+			key := fmt.Sprintf("%s/%s", domainNamespace, domainName)
+			verifyObj(key, domain, Default)
 		})
+
 		It("should watch for domain events.", func() {
 			domain := api.NewMinimalDomain("test")
 

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -341,24 +341,8 @@ func (d *domainWatcher) ResultChan() <-chan watch.Event {
 func listSockets(ghostRecords []ghostRecord) ([]string, error) {
 	var sockets []string
 
-	knownSocketFiles, err := cmdclient.ListAllSockets()
-	if err != nil {
-		return sockets, err
-	}
-
-	sockets = append(sockets, knownSocketFiles...)
-
 	for _, record := range ghostRecords {
-		exists := false
-		for _, socket := range knownSocketFiles {
-			if record.SocketFile == socket {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			sockets = append(sockets, record.SocketFile)
-		}
+		sockets = append(sockets, record.SocketFile)
 	}
 
 	return sockets, nil

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package cache
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Domain Watcher", func() {
+	Context("listSockets ", func() {
+		It("should return socket list from ghost record cache", func() {
+			const podUID = "5678"
+			const socketPath = "/path/to/domainsock"
+
+			ghostCacheDir := GinkgoT().TempDir()
+
+			ghostRecordStore := InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+
+			err := ghostRecordStore.Add("test-ns", "test-domain", socketPath, podUID)
+			Expect(err).ToNot(HaveOccurred())
+
+			socketFiles, err := listSockets(ghostRecordStore.list())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(socketFiles).To(HaveLen(1))
+			Expect(socketFiles[0]).To(Equal(socketPath))
+
+		})
+	})
+})

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -134,32 +134,6 @@ func SetPodsBaseDir(baseDir string) {
 	podsBaseDir = baseDir
 }
 
-func ListAllSockets() ([]string, error) {
-	var socketFiles []string
-
-	dirs, err := os.ReadDir(podsBaseDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, dir := range dirs {
-		if !dir.IsDir() {
-			continue
-		}
-
-		socketPath := SocketFilePathOnHost(dir.Name())
-		exists, err := diskutils.FileExists(socketPath)
-		if err != nil {
-			return socketFiles, err
-		}
-
-		if exists {
-			socketFiles = append(socketFiles, socketPath)
-		}
-	}
-
-	return socketFiles, nil
-}
-
 func SocketsDirectory() string {
 	return filepath.Join(baseDir, "sockets")
 }

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -96,17 +96,6 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(sock).To(Equal(filepath.Join(shareDir, "sockets", StandardLauncherSocketFileName)))
 		})
 
-		It("Listing all sockets", func() {
-			sockets, err := ListAllSockets()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sockets).To(HaveLen(1))
-			By("Expecting to only find cmd socket in launcher's context")
-			Expect(sockets[0]).To(And(
-				HaveSuffix("launcher-sock"),
-				ContainSubstring(podUID),
-			))
-		})
-
 		It("Detect unresponsive socket", func() {
 			sock, err := FindSocket(vmi)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

### What this PR does
This is a manual backport of #15323 



### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

