### PR TITLE
[descheduler] align opt-out annotation name

### DIFF
--- a/pkg/virt-controller/watch/descheduler/descheduler.go
+++ b/pkg/virt-controller/watch/descheduler/descheduler.go
@@ -48,9 +48,9 @@ const EvictionInProgressAnnotation = "descheduler.alpha.kubernetes.io/eviction-i
 // The descheduler will only check the presence of the annotation and not its value.
 const EvictPodAnnotationKeyAlpha = "descheduler.alpha.kubernetes.io/evict"
 
-// EvictPodAnnotationKeyBeta can be used to explicitly opt-in/out a pod to be eventually descheduled.
-// The descheduler will check the annotation value with a Boolean logic.
-const EvictPodAnnotationKeyBeta = "descheduler.beta.kubernetes.io/evict"
+// EvictPodAnnotationKeyAlphaPreferNoEviction can be used to explicitly opt-out a pod to be eventually descheduled.
+// The descheduler will only check the presence of the annotation and not its value.
+const EvictPodAnnotationKeyAlphaPreferNoEviction = "descheduler.alpha.kubernetes.io/prefer-no-eviction"
 
 func MarkEvictionInProgress(virtClient kubecli.KubevirtClient, sourcePod *k8sv1.Pod) error {
 	if _, exists := sourcePod.GetAnnotations()[EvictionInProgressAnnotation]; exists {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3076,7 +3076,7 @@ func (c *Controller) syncVMAnnotationsToVMI(vm *virtv1.VirtualMachine, vmi *virt
 
 	annotationsToSync := []string{
 		descheduler.EvictPodAnnotationKeyAlpha,
-		descheduler.EvictPodAnnotationKeyBeta,
+		descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction,
 	}
 
 	newVMIAnnotations := map[string]string{}

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -3205,7 +3205,7 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		Context("dynamic annotations", func() {
-			const selectedKey = descheduler.EvictPodAnnotationKeyBeta
+			const selectedKey = descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction
 			const ignoredKey = "anotherAnnotation"
 			const intitialValue = "initialValue"
 			const updatedValue = "updatedValue"

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -646,7 +646,7 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToPod(vmi *virtv1.VirtualMac
 	)
 
 	syncMap(
-		[]string{descheduler.EvictPodAnnotationKeyAlpha, descheduler.EvictPodAnnotationKeyBeta},
+		[]string{descheduler.EvictPodAnnotationKeyAlpha, descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction},
 		vmi.Annotations, newPodAnnotations, pod.ObjectMeta.Annotations, "annotations",
 	)
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -2121,19 +2121,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("when VMI and pod annotations differ",
 					&testData{
 						vmiAnnotations: map[string]string{
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						podAnnotations: map[string]string{
-							descheduler.EvictPodAnnotationKeyBeta: "true",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "true",
 						},
 						expectedLabels: map[string]string{
 							"kubevirt.io":            "virt-launcher",
 							"kubevirt.io/created-by": "1234",
 						},
 						expectedAnnotations: map[string]string{
-							"kubevirt.io/domain":                  "testvmi",
-							descheduler.EvictOnlyAnnotation:       "",
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							"kubevirt.io/domain":                                   "testvmi",
+							descheduler.EvictOnlyAnnotation:                        "",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						expectedPatch: true,
 					},
@@ -2141,19 +2141,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("when VMI and pod annotations are the same",
 					&testData{
 						vmiAnnotations: map[string]string{
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						podAnnotations: map[string]string{
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						expectedLabels: map[string]string{
 							"kubevirt.io":            "virt-launcher",
 							"kubevirt.io/created-by": "1234",
 						},
 						expectedAnnotations: map[string]string{
-							"kubevirt.io/domain":                  "testvmi",
-							descheduler.EvictOnlyAnnotation:       "",
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							"kubevirt.io/domain":                                   "testvmi",
+							descheduler.EvictOnlyAnnotation:                        "",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						expectedPatch: false,
 					},
@@ -2161,7 +2161,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("when POD annotation doesn't exist",
 					&testData{
 						vmiAnnotations: map[string]string{
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						podAnnotations: map[string]string{
 							"kubevirt.io/domain":            "testvmi",
@@ -2172,9 +2172,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 							"kubevirt.io/created-by": "1234",
 						},
 						expectedAnnotations: map[string]string{
-							"kubevirt.io/domain":                  "testvmi",
-							descheduler.EvictOnlyAnnotation:       "",
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							"kubevirt.io/domain":                                   "testvmi",
+							descheduler.EvictOnlyAnnotation:                        "",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						expectedPatch: true,
 					},
@@ -2183,9 +2183,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					&testData{
 						vmiAnnotations: map[string]string{},
 						podAnnotations: map[string]string{
-							"kubevirt.io/domain":                  "testvmi",
-							descheduler.EvictOnlyAnnotation:       "",
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							"kubevirt.io/domain":                                   "testvmi",
+							descheduler.EvictOnlyAnnotation:                        "",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						expectedLabels: map[string]string{
 							"kubevirt.io":            "virt-launcher",
@@ -2201,10 +2201,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("when both annotations and labels differ between VMI and pod",
 					&testData{
 						vmiAnnotations: map[string]string{
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						podAnnotations: map[string]string{
-							descheduler.EvictPodAnnotationKeyBeta: "true",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "true",
 						},
 						vmiLabels: map[string]string{
 							virtv1.NodeNameLabel: "node2",
@@ -2218,9 +2218,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 							virtv1.NodeNameLabel:     "node2",
 						},
 						expectedAnnotations: map[string]string{
-							"kubevirt.io/domain":                  "testvmi",
-							descheduler.EvictOnlyAnnotation:       "",
-							descheduler.EvictPodAnnotationKeyBeta: "false",
+							"kubevirt.io/domain":                                   "testvmi",
+							descheduler.EvictOnlyAnnotation:                        "",
+							descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction: "false",
 						},
 						expectedPatch: true,
 					},


### PR DESCRIPTION
### What this PR does
The proposal of introducing `descheduler.beta.kubernetes.io/evict` annotation with Boolean logic to dynamically opt-in/opt-out selected pods as eviction candidates got refused.
We got instead an additional alpha annotation named `descheduler.alpha.kubernetes.io/prefer-no-eviction` that can be used to opt-out selected pods.
See: https://github.com/kubernetes-sigs/descheduler/pull/1723
Let's align the code to handle `descheduler.alpha.kubernetes.io/prefer-no-eviction` instead of `descheduler.beta.kubernetes.io/evict`.

This is just a change in the name of the handled annotation, no actual logic changes.

#### Before this PR:
The code was syncing `descheduler.alpha.kubernetes.io/evict` and  `descheduler.beta.kubernetes.io/evict` (that is ignored by the Descheduler) from VM template -> VMI -> virt-launcher pod

#### After this PR:
The code is syncing `descheduler.alpha.kubernetes.io/evict` and  `descheduler.alpha.kubernetes.io/prefer-no-eviction` (that is correctly processed by the Descheduler) from VM template -> VMI -> virt-launcher pod

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes https://issues.redhat.com/browse/CNV-61248

### Why we need it and why it was done in this way
Links to places where the discussion took place:
https://github.com/kubernetes-sigs/descheduler/pull/1673 with `descheduler.beta.kubernetes.io/evict` got refused,
https://github.com/kubernetes-sigs/descheduler/pull/1723 with `descheduler.alpha.kubernetes.io/prefer-no-eviction` got merged instead.

### Special notes for your reviewer
This is just a change in the name of the handled annotation, no actual logic changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Aligning descheduler opt-out annotation name
```

