### PR TITLE
[release-1.4] virt-handler: validate sockets listed by the domain informer cache with ghost record cache

### DIFF
--- a/pkg/virt-handler/cache/BUILD.bazel
+++ b/pkg/virt-handler/cache/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     srcs = [
         "cache_suite_test.go",
         "cache_test.go",
+        "domain-watcher_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -118,7 +118,7 @@ func LastKnownUIDFromGhostRecordCache(key string) types.UID {
 	return record.UID
 }
 
-func getGhostRecords() ([]ghostRecord, error) {
+func getGhostRecords() []ghostRecord {
 	ghostRecordGlobalMutex.Lock()
 	defer ghostRecordGlobalMutex.Unlock()
 
@@ -128,7 +128,7 @@ func getGhostRecords() ([]ghostRecord, error) {
 		records = append(records, record)
 	}
 
-	return records, nil
+	return records
 }
 
 func findGhostRecordBySocket(socketFile string) (ghostRecord, bool) {

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -34,7 +34,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/checkpoint"
 	"kubevirt.io/kubevirt/pkg/util"
-	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -219,36 +218,6 @@ func DeleteGhostRecord(namespace string, name string) error {
 	delete(ghostRecordGlobalCache, key)
 
 	return nil
-}
-
-func listSockets() ([]string, error) {
-	var sockets []string
-
-	knownSocketFiles, err := cmdclient.ListAllSockets()
-	if err != nil {
-		return sockets, err
-	}
-	ghostRecords, err := getGhostRecords()
-	if err != nil {
-		return sockets, err
-	}
-
-	sockets = append(sockets, knownSocketFiles...)
-
-	for _, record := range ghostRecords {
-		exists := false
-		for _, socket := range knownSocketFiles {
-			if record.SocketFile == socket {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			sockets = append(sockets, record.SocketFile)
-		}
-	}
-
-	return sockets, nil
 }
 
 func NewSharedInformer(virtShareDir string, watchdogTimeout int, recorder record.EventRecorder, vmiStore cache.Store, resyncPeriod time.Duration) cache.SharedInformer {

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -128,7 +128,7 @@ func (d *domainWatcher) startBackground() error {
 }
 
 func (d *domainWatcher) handleResync() {
-	socketFiles, err := listSockets()
+	socketFiles, err := listSockets(getGhostRecords())
 	if err != nil {
 		log.Log.Reason(err).Error("failed to list sockets")
 		return
@@ -164,7 +164,7 @@ func (d *domainWatcher) handleResync() {
 func (d *domainWatcher) handleStaleSocketConnections() error {
 	var unresponsive []string
 
-	socketFiles, err := listSockets()
+	socketFiles, err := listSockets(getGhostRecords())
 	if err != nil {
 		log.Log.Reason(err).Error("failed to list sockets")
 		return err
@@ -241,7 +241,7 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 func (d *domainWatcher) listAllKnownDomains() ([]*api.Domain, error) {
 	var domains []*api.Domain
 
-	socketFiles, err := listSockets()
+	socketFiles, err := listSockets(getGhostRecords())
 	if err != nil {
 		return nil, err
 	}
@@ -336,4 +336,14 @@ func (d *domainWatcher) Stop() {
 
 func (d *domainWatcher) ResultChan() <-chan watch.Event {
 	return d.eventChan
+}
+
+func listSockets(ghostRecords []ghostRecord) ([]string, error) {
+	var sockets []string
+
+	for _, record := range ghostRecords {
+		sockets = append(sockets, record.SocketFile)
+	}
+
+	return sockets, nil
 }

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package cache
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Domain Watcher", func() {
+	Context("listSockets ", func() {
+		It("should return socket list from ghost record cache", func() {
+			const podUID = "5678"
+			const socketPath = "/path/to/domainsock"
+
+			ghostCacheDir := GinkgoT().TempDir()
+
+			Expect(InitializeGhostRecordCache(ghostCacheDir)).To(Succeed())
+
+			err := AddGhostRecord("test-ns", "test-domain", socketPath, podUID)
+			Expect(err).ToNot(HaveOccurred())
+
+			socketFiles, err := listSockets(getGhostRecords())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(socketFiles).To(HaveLen(1))
+			Expect(socketFiles[0]).To(Equal(socketPath))
+
+		})
+	})
+})

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -132,32 +132,6 @@ func SetPodsBaseDir(baseDir string) {
 	podsBaseDir = baseDir
 }
 
-func ListAllSockets() ([]string, error) {
-	var socketFiles []string
-
-	dirs, err := os.ReadDir(podsBaseDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, dir := range dirs {
-		if !dir.IsDir() {
-			continue
-		}
-
-		socketPath := SocketFilePathOnHost(dir.Name())
-		exists, err := diskutils.FileExists(socketPath)
-		if err != nil {
-			return socketFiles, err
-		}
-
-		if exists {
-			socketFiles = append(socketFiles, socketPath)
-		}
-	}
-
-	return socketFiles, nil
-}
-
 func SocketsDirectory() string {
 	return filepath.Join(baseDir, "sockets")
 }

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -95,17 +95,6 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(sock).To(Equal(filepath.Join(shareDir, "sockets", StandardLauncherSocketFileName)))
 		})
 
-		It("Listing all sockets", func() {
-			sockets, err := ListAllSockets()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sockets).To(HaveLen(1))
-			By("Expecting to only find cmd socket in launcher's context")
-			Expect(sockets[0]).To(And(
-				HaveSuffix("launcher-sock"),
-				ContainSubstring(podUID),
-			))
-		})
-
 		It("Detect unresponsive socket", func() {
 			sock, err := FindSocketOnHost(vmi)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/15323/

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

