### PR TITLE
[release-1.4] Improve error message when restoring VMs with backend storage

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -226,7 +226,7 @@ func (admitter *VMRestoreAdmitter) validateSourceVM(ctx context.Context, field *
 		if backendstorage.IsBackendStorageNeededForVMI(&snapshotVM.Spec.Template.Spec) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "Restore to a different VM not supported when using backend storage",
+				Message: "Restore to a different VM is not supported when snapshotted VM has backend storage (persistent TPM or EFI)",
 				Field:   field.String(),
 			})
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -568,7 +568,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
-				Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("Restore to a different VM not supported when using backend storage"))
+				Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("Restore to a different VM is not supported when snapshotted VM has backend storage (persistent TPM or EFI)"))
 			})
 
 			It("when target VM is different from source VM", func() {
@@ -627,7 +627,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
-				Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("Restore to a different VM not supported when using backend storage"))
+				Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("Restore to a different VM is not supported when snapshotted VM has backend storage (persistent TPM or EFI)"))
 			})
 
 			Context("when using Patches", func() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/15229. Just had to address some conflicts in utests.
  
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

