### PR TITLE
tests: remove redundant block multiqueue integration test

### DIFF
--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -22,9 +22,7 @@ package tests_test
 import (
 	"context"
 	"fmt"
-	"strconv"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,9 +39,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/libdomain"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -91,43 +87,5 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 			Entry("[test_id:4599] with default virtio interface", v1.VirtIO, numCpus),
 			Entry("with e1000 interface", "e1000", int32(1)),
 		)
-
-		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {
-			Expect(availableCPUs).To(BeNumerically(">=", numCpus),
-				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
-			)
-
-			cpuResources := strconv.Itoa(int(numCpus))
-			vmi := libvmifact.NewAlpine(libvmi.WithCPURequest(cpuResources), libvmi.WithContainerDisk("disk1", cd.ContainerDiskFor(cd.ContainerDiskCirros)))
-			vmi.Spec.Domain.Devices.BlockMultiQueue = pointer.P(true)
-
-			By("Creating VMI with 2 disks, 3 CPUs and multi-queue enabled")
-			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Waiting for VMI to start")
-			libwait.WaitForSuccessfulVMIStart(vmi)
-
-			getOptions := metav1.GetOptions{}
-			var newVMI *v1.VirtualMachineInstance
-
-			By("Fetching VMI from cluster")
-			newVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, getOptions)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verifying VMI")
-			newCpuReq := newVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU]
-			Expect(int32(newCpuReq.Value())).To(Equal(numCpus))
-			Expect(*newVMI.Spec.Domain.Devices.BlockMultiQueue).To(BeTrue())
-
-			By("Fetching Domain XML from running pod")
-			domSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Ensuring each disk has three queues assigned")
-			for _, disk := range domSpec.Devices.Disks {
-				Expect(int32(*disk.Driver.Queues)).To(Equal(numCpus))
-			}
-		})
 	})
 })


### PR DESCRIPTION
Remove test `[test_id:959][rfe_id:2065] 'Should honor multiQueue requests'` from vmi_multiqueue_test.go as it duplicates functionality already covered by converter unit tests.

The test was validating VMI spec to libvirt domain conversion for block multiqueue settings, which is tested in
https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/converter/converter_test.go#L2403
 where the same functionality is already covered including: Queue assignment when BlockMultiQueue=true, Queue count matching CPU count, Multiple disk scenarios and CPU topology considerations.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


### References
convert BlockMultiQueue test to a unit test: https://issues.redhat.com/browse/CNV-64739

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

