### PR TITLE
WIP/DNM - Introduce `PreferredArchitecture` and `Architecture` requirements to preferences

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19731,6 +19731,10 @@
    "v1beta1.PreferenceRequirements": {
     "type": "object",
     "properties": {
+     "architecture": {
+      "description": "Required Architecture of the VM referencing this preference",
+      "type": "string"
+     },
      "cpu": {
       "description": "Required CPU related attributes of the instancetype.",
       "$ref": "#/definitions/v1beta1.CPUPreferenceRequirement"
@@ -20584,6 +20588,10 @@
       "description": "PreferSpreadSocketToCoreRatio defines the ratio to spread vCPUs between cores and sockets, it defaults to 2.",
       "type": "integer",
       "format": "int64"
+     },
+     "preferredArchitecture": {
+      "description": "PreferredArchitecture defines a prefeerred architecture for the VirtualMachine",
+      "type": "string"
      },
      "preferredSubdomain": {
       "description": "Subdomain of the VirtualMachineInstance",

--- a/pkg/instancetype/preference/apply/architecture.go
+++ b/pkg/instancetype/preference/apply/architecture.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package apply
+
+import (
+	virtv1 "kubevirt.io/api/core/v1"
+	v1beta1 "kubevirt.io/api/instancetype/v1beta1"
+)
+
+func applyArchitecturePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
+	if preferenceSpec.PreferredArchitecture == nil || *preferenceSpec.PreferredArchitecture == "" {
+		return
+	}
+
+	if vmiSpec.Architecture == "" {
+		vmiSpec.Architecture = *preferenceSpec.PreferredArchitecture
+	}
+}

--- a/pkg/instancetype/preference/apply/architecture_test.go
+++ b/pkg/instancetype/preference/apply/architecture_test.go
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package apply_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	v1beta1 "kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/apply"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+)
+
+var _ = Describe("Preference.Architecture", func() {
+	var (
+		vmi              *virtv1.VirtualMachineInstance
+		instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec
+		preferenceSpec   *v1beta1.VirtualMachinePreferenceSpec
+
+		field      = k8sfield.NewPath("spec", "template", "spec")
+		vmiApplier = apply.NewVMIApplier()
+	)
+
+	BeforeEach(func() {
+		vmi = libvmi.New()
+	})
+
+	It("should apply preferred architecture to VMI when architecture is not set", func() {
+		preferenceSpec = &v1beta1.VirtualMachinePreferenceSpec{
+			PreferredArchitecture: ptr.To("arm64"),
+		}
+
+		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
+
+		Expect(vmi.Spec.Architecture).To(Equal("arm64"))
+	})
+
+	It("should not override existing architecture in VMI", func() {
+		vmi.Spec.Architecture = "amd64"
+		preferenceSpec = &v1beta1.VirtualMachinePreferenceSpec{
+			PreferredArchitecture: ptr.To("arm64"),
+		}
+
+		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
+
+		Expect(vmi.Spec.Architecture).To(Equal("amd64"))
+	})
+
+	It("should not apply when PreferredArchitecture is nil", func() {
+		preferenceSpec = &v1beta1.VirtualMachinePreferenceSpec{}
+
+		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
+
+		Expect(vmi.Spec.Architecture).To(BeEmpty())
+	})
+
+	It("should not apply when PreferredArchitecture is empty string", func() {
+		preferenceSpec = &v1beta1.VirtualMachinePreferenceSpec{
+			PreferredArchitecture: ptr.To(""),
+		}
+
+		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
+
+		Expect(vmi.Spec.Architecture).To(BeEmpty())
+	})
+})

--- a/pkg/instancetype/preference/apply/vmi.go
+++ b/pkg/instancetype/preference/apply/vmi.go
@@ -48,5 +48,6 @@ func (a *vmiApplier) Apply(
 	applyClockPreferences(preferenceSpec, vmiSpec)
 	applySubdomain(preferenceSpec, vmiSpec)
 	applyTerminationGracePeriodSeconds(preferenceSpec, vmiSpec)
+	applyArchitecturePreferences(preferenceSpec, vmiSpec)
 	applyPreferenceAnnotations(preferenceSpec.Annotations, vmiMetadata)
 }

--- a/pkg/instancetype/preference/requirements/arch.go
+++ b/pkg/instancetype/preference/requirements/arch.go
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package requirements
+
+import (
+	"fmt"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
+)
+
+const (
+	requiredArchitectureNotUsedErrFmt = "preference requires architecture %s but %s is being requested"
+)
+
+func checkArch(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) (conflict.Conflicts, error) {
+	if vmiSpec.Architecture != *preferenceSpec.Requirements.Architecture {
+		return conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
+			fmt.Errorf(requiredArchitectureNotUsedErrFmt, *preferenceSpec.Requirements.Architecture, vmiSpec.Architecture)
+	}
+	return nil, nil
+}

--- a/pkg/instancetype/preference/requirements/arch_test.go
+++ b/pkg/instancetype/preference/requirements/arch_test.go
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+package requirements_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+	v1beta1 "kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
+	"kubevirt.io/kubevirt/pkg/instancetype/preference/requirements"
+	"kubevirt.io/kubevirt/pkg/pointer"
+)
+
+var _ = Describe("Architecture requirements", func() {
+	requirementsChecker := requirements.New()
+
+	DescribeTable("should pass when architecture requirement is met",
+		func(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) {
+			conflicts, err := requirementsChecker.Check(nil, preferenceSpec, vmiSpec)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(conflicts).ToNot(HaveOccurred())
+		},
+		Entry("when preference requires amd64 and vmi uses amd64",
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{
+					Architecture: pointer.P("amd64"),
+				},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Architecture: "amd64",
+			},
+		),
+		Entry("when preference requires arm64 and vmi uses arm64",
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{
+					Architecture: pointer.P("arm64"),
+				},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Architecture: "arm64",
+			},
+		),
+		Entry("when preference has no architecture requirement",
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Architecture: "amd64",
+			},
+		),
+		Entry("when preference has no requirements at all",
+			&v1beta1.VirtualMachinePreferenceSpec{},
+			&v1.VirtualMachineInstanceSpec{
+				Architecture: "amd64",
+			},
+		),
+	)
+
+	DescribeTable("should be rejected when architecture requirement is not met",
+		func(
+			preferenceSpec *v1beta1.VirtualMachinePreferenceSpec,
+			vmiSpec *v1.VirtualMachineInstanceSpec,
+			expectedConflict conflict.Conflicts,
+			errSubString string,
+		) {
+			conflicts, err := requirementsChecker.Check(nil, preferenceSpec, vmiSpec)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(errSubString))
+			Expect(conflicts).To(Equal(expectedConflict))
+		},
+		Entry("when preference requires amd64 but vmi uses arm64",
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{
+					Architecture: pointer.P("amd64"),
+				},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Architecture: "arm64",
+			},
+			conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
+			fmt.Sprintf("preference requires architecture %s but %s is being requested", "amd64", "arm64"),
+		),
+		Entry("when preference requires arm64 but vmi uses amd64",
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{
+					Architecture: pointer.P("arm64"),
+				},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Architecture: "amd64",
+			},
+			conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
+			fmt.Sprintf("preference requires architecture %s but %s is being requested", "arm64", "amd64"),
+		),
+		Entry("when preference requires amd64 but vmi uses empty architecture",
+			&v1beta1.VirtualMachinePreferenceSpec{
+				Requirements: &v1beta1.PreferenceRequirements{
+					Architecture: pointer.P("amd64"),
+				},
+			},
+			&v1.VirtualMachineInstanceSpec{
+				Architecture: "",
+			},
+			conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
+			fmt.Sprintf("preference requires architecture %s but %s is being requested", "amd64", ""),
+		),
+	)
+})

--- a/pkg/instancetype/preference/requirements/checker.go
+++ b/pkg/instancetype/preference/requirements/checker.go
@@ -52,5 +52,11 @@ func (c *checker) Check(
 		}
 	}
 
+	if preferenceSpec.Requirements.Architecture != nil {
+		if conflicts, err := checkArch(preferenceSpec, vmiSpec); err != nil {
+			return conflicts, err
+		}
+	}
+
 	return nil, nil
 }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9822,6 +9822,10 @@ var CRDsValidation map[string]string = map[string]string{
             between cores and sockets, it defaults to 2.
           format: int32
           type: integer
+        preferredArchitecture:
+          description: PreferredArchitecture defines a prefeerred architecture for
+            the VirtualMachine
+          type: string
         preferredSubdomain:
           description: Subdomain of the VirtualMachineInstance
           type: string
@@ -9834,6 +9838,9 @@ var CRDsValidation map[string]string = map[string]string{
           description: Requirements defines the minium amount of instance type defined
             resources required by a set of preferences
           properties:
+            architecture:
+              description: Required Architecture of the VM referencing this preference
+              type: string
             cpu:
               description: Required CPU related attributes of the instancetype.
               properties:
@@ -25162,6 +25169,10 @@ var CRDsValidation map[string]string = map[string]string{
             between cores and sockets, it defaults to 2.
           format: int32
           type: integer
+        preferredArchitecture:
+          description: PreferredArchitecture defines a prefeerred architecture for
+            the VirtualMachine
+          type: string
         preferredSubdomain:
           description: Subdomain of the VirtualMachineInstance
           type: string
@@ -25174,6 +25185,9 @@ var CRDsValidation map[string]string = map[string]string{
           description: Requirements defines the minium amount of instance type defined
             resources required by a set of preferences
           properties:
+            architecture:
+              description: Required Architecture of the VM referencing this preference
+              type: string
             cpu:
               description: Required CPU related attributes of the instancetype.
               properties:

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha1/conversion_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha1/conversion_generated.go
@@ -787,6 +787,7 @@ func autoConvert_v1beta1_VirtualMachinePreferenceSpec_To_v1alpha1_VirtualMachine
 	// WARNING: in.Requirements requires manual conversion: does not exist in peer-type
 	// WARNING: in.Annotations requires manual conversion: does not exist in peer-type
 	// WARNING: in.PreferSpreadSocketToCoreRatio requires manual conversion: does not exist in peer-type
+	// WARNING: in.PreferredArchitecture requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha2/conversion_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha2/conversion_generated.go
@@ -797,6 +797,7 @@ func autoConvert_v1beta1_VirtualMachinePreferenceSpec_To_v1alpha2_VirtualMachine
 	// WARNING: in.Requirements requires manual conversion: does not exist in peer-type
 	// WARNING: in.Annotations requires manual conversion: does not exist in peer-type
 	// WARNING: in.PreferSpreadSocketToCoreRatio requires manual conversion: does not exist in peer-type
+	// WARNING: in.PreferredArchitecture requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
@@ -403,6 +403,11 @@ func (in *PreferenceRequirements) DeepCopyInto(out *PreferenceRequirements) {
 		*out = new(MemoryPreferenceRequirement)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Architecture != nil {
+		in, out := &in.Architecture, &out.Architecture
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -797,6 +802,11 @@ func (in *VirtualMachinePreferenceSpec) DeepCopyInto(out *VirtualMachinePreferen
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.PreferredArchitecture != nil {
+		in, out := &in.PreferredArchitecture, &out.PreferredArchitecture
+		*out = new(string)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -298,6 +298,11 @@ type VirtualMachinePreferenceSpec struct {
 	//
 	//+optional
 	PreferSpreadSocketToCoreRatio uint32 `json:"preferSpreadSocketToCoreRatio,omitempty"`
+
+	// PreferredArchitecture defines a prefeerred architecture for the VirtualMachine
+	//
+	//+optional
+	PreferredArchitecture *string `json:"preferredArchitecture,omitempty"`
 }
 
 type VolumePreferences struct {
@@ -629,6 +634,11 @@ type PreferenceRequirements struct {
 	//
 	//+optional
 	Memory *MemoryPreferenceRequirement `json:"memory,omitempty"`
+
+	// Required Architecture of the VM referencing this preference
+	//
+	//+optional
+	Architecture *string `json:"architecture,omitempty"`
 }
 
 type CPUPreferenceRequirement struct {

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -109,6 +109,7 @@ func (VirtualMachinePreferenceSpec) SwaggerDoc() map[string]string {
 		"requirements":                           "Requirements defines the minium amount of instance type defined resources required by a set of preferences\n\n+optional",
 		"annotations":                            "Optionally defines preferred Annotations to be applied to the VirtualMachineInstance\n\n+optional",
 		"preferSpreadSocketToCoreRatio":          "PreferSpreadSocketToCoreRatio defines the ratio to spread vCPUs between cores and sockets, it defaults to 2.\n\n+optional",
+		"preferredArchitecture":                  "PreferredArchitecture defines a prefeerred architecture for the VirtualMachine\n\n+optional",
 	}
 }
 
@@ -205,8 +206,9 @@ func (ClockPreferences) SwaggerDoc() map[string]string {
 
 func (PreferenceRequirements) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"cpu":    "Required CPU related attributes of the instancetype.\n\n+optional",
-		"memory": "Required Memory related attributes of the instancetype.\n\n+optional",
+		"cpu":          "Required CPU related attributes of the instancetype.\n\n+optional",
+		"memory":       "Required Memory related attributes of the instancetype.\n\n+optional",
+		"architecture": "Required Architecture of the VM referencing this preference\n\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -32259,6 +32259,13 @@ func schema_kubevirtio_api_instancetype_v1beta1_PreferenceRequirements(ref commo
 							Ref:         ref("kubevirt.io/api/instancetype/v1beta1.MemoryPreferenceRequirement"),
 						},
 					},
+					"architecture": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Required Architecture of the VM referencing this preference",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -32881,6 +32888,13 @@ func schema_kubevirtio_api_instancetype_v1beta1_VirtualMachinePreferenceSpec(ref
 							Description: "PreferSpreadSocketToCoreRatio defines the ratio to spread vCPUs between cores and sockets, it defaults to 2.",
 							Type:        []string{"integer"},
 							Format:      "int64",
+						},
+					},
+					"preferredArchitecture": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PreferredArchitecture defines a prefeerred architecture for the VirtualMachine",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},


### PR DESCRIPTION
/area instancetype

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

