### PR TITLE
virt-config: Align DefaultVirtAPI{QPS,Burst} and DefaultVirtWebhookClient{QPS,Burst}

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -83,8 +83,8 @@ const (
 	DefaultVirtHandlerBurst               = 10
 	DefaultVirtControllerQPS      float32 = 200
 	DefaultVirtControllerBurst            = 400
-	DefaultVirtAPIQPS             float32 = 5
-	DefaultVirtAPIBurst                   = 10
+	DefaultVirtAPIQPS             float32 = 200
+	DefaultVirtAPIBurst                   = 400
 	DefaultVirtWebhookClientQPS           = 200
 	DefaultVirtWebhookClientBurst         = 400
 


### PR DESCRIPTION
/sig scale
/sig compute

### What this PR does
`DefaultVirtAPI{QPS,Burst}` provide default rate limiting values for the client used by our individual webhooks.

`DefaultVirtWebhookClient{QPS,Burst}` provide defaulting rate limiting values for the `SubjectAccessReview` client used by our authorizer implementation.

This change aligns the default client rate limit values of `DefaultVirtAPI{QPS,Burst}` with `DefaultVirtWebhookClient{QPS,Burst}` to avoid situations where the webhook client becomes saturated by requests that have been authorised thanks to the much higher defaults provided to the authorizer client.

Refactoring the names of these defaults and their associated rate
limiters is left for a follow up.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `DefaultVirtWebhookClient{QPS,Burst}` values are aligned with `DefaultVirtWebhookClient{QPS,Burst}` to help avoid saturating the webhook client with requests it is unable to serve during mass eviction events
```

