### PR TITLE
[Release-1.5] virt-handler: sync grace period metadata from VMI before shutdown

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -468,32 +468,34 @@ func (c *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan
 // If the grace period has started but not expired, timeLeft represents
 // the time in seconds left until the period expires.
 // If the grace period has not started, timeLeft will be set to -1.
-func (c *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (hasExpired bool, timeLeft int64) {
+func (c *VirtualMachineController) hasGracePeriodExpired(terminationGracePeriod *int64, dom *api.Domain) (bool, int64) {
+	var hasExpired bool
+	var timeLeft int64
 
-	hasExpired = false
-	timeLeft = 0
-
-	if dom == nil {
-		hasExpired = true
-		return
+	gracePeriod := int64(0)
+	if terminationGracePeriod != nil {
+		gracePeriod = *terminationGracePeriod
+	} else if dom != nil && dom.Spec.Metadata.KubeVirt.GracePeriod != nil {
+		gracePeriod = dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds
 	}
-
-	startTime := int64(0)
-	if dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp != nil {
-		startTime = dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp.UTC().Unix()
-	}
-	gracePeriod := dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds
 
 	// If gracePeriod == 0, then there will be no startTime set, deletion
 	// should occur immediately during shutdown.
 	if gracePeriod == 0 {
 		hasExpired = true
-		return
-	} else if startTime == 0 {
+		return hasExpired, timeLeft
+	}
+
+	startTime := int64(0)
+	if dom != nil && dom.Spec.Metadata.KubeVirt.GracePeriod != nil && dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp != nil {
+		startTime = dom.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp.UTC().Unix()
+	}
+
+	if startTime == 0 {
 		// If gracePeriod > 0, then the shutdown signal needs to be sent
 		// and the gracePeriod start time needs to be set.
 		timeLeft = -1
-		return
+		return hasExpired, timeLeft
 	}
 
 	now := time.Now().UTC().Unix()
@@ -501,14 +503,14 @@ func (c *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (hasEx
 
 	if diff >= gracePeriod {
 		hasExpired = true
-		return
+		return hasExpired, timeLeft
 	}
 
-	timeLeft = int64(gracePeriod - diff)
+	timeLeft = gracePeriod - diff
 	if timeLeft < 1 {
 		timeLeft = 1
 	}
-	return
+	return hasExpired, timeLeft
 }
 
 func (c *VirtualMachineController) hasTargetDetectedReadyDomain(vmi *v1.VirtualMachineInstance) (bool, int64) {
@@ -2335,7 +2337,7 @@ func (c *VirtualMachineController) helperVmShutdown(vmi *v1.VirtualMachineInstan
 	}
 
 	if domainHasGracePeriod(domain) && tryGracefully {
-		if expired, timeLeft := c.hasGracePeriodExpired(domain); !expired {
+		if expired, timeLeft := c.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain); !expired {
 			return c.handleVMIShutdown(vmi, domain, client, timeLeft)
 		}
 		log.Log.Object(vmi).Infof("Grace period expired, killing deleted VirtualMachineInstance %s", vmi.GetObjectMeta().GetName())

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -442,6 +442,38 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMIGracefulShutdown)
 		})
 
+		It("should attempt graceful shutdown and take the VMI grace period over the cached Domain grace", func() {
+			vmi := libvmi.New(libvmi.WithName("testvmi"),
+				libvmi.WithNamespace(k8sv1.NamespaceDefault),
+				libvmi.WithTerminationGracePeriod(0))
+
+			initialGrace := int64(30)
+			domain := api.NewMinimalDomainWithNS(vmi.Namespace, vmi.Name)
+			domain.Spec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{DeletionGracePeriodSeconds: initialGrace}
+
+			hasExpired, timeLeft := controller.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain)
+			Expect(timeLeft).To(BeEquivalentTo(0))
+			Expect(hasExpired).To(BeTrue())
+		})
+
+		It("should attempt graceful shutdown and and fall back to cached Domain grace period when VMI grace is unset", func() {
+			vmi := libvmi.New(libvmi.WithName("testvmi"),
+				libvmi.WithNamespace(k8sv1.NamespaceDefault))
+			vmi.Spec.TerminationGracePeriodSeconds = nil
+
+			initialGrace := int64(30)
+			now := metav1.Time{Time: time.Now()}
+			domain := api.NewMinimalDomainWithNS(vmi.Namespace, vmi.Name)
+			domain.Spec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{
+				DeletionGracePeriodSeconds: initialGrace,
+				DeletionTimestamp:          &now,
+			}
+
+			hasExpired, timeLeft := controller.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain)
+			Expect(timeLeft).To(BeEquivalentTo(initialGrace))
+			Expect(hasExpired).To(BeFalse())
+		})
+
 		It("should do nothing if vmi and domain do not match", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = "other uuid"

--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -77,9 +77,9 @@ var _ = SIGDescribe("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 		Expect(newVMI.UID).ToNot(Equal(vmi.UID))
 	})
 
-	It("should force stop a VM with terminationGracePeriodSeconds>0", func() {
+	DescribeTable("should force stop a VM with terminationGracePeriodSeconds>0", func(vmiFactory func(...libvmi.Option) *v1.VirtualMachineInstance) {
 		By("getting a VM with high TerminationGracePeriod")
-		vm := libvmi.NewVirtualMachine(libvmifact.NewFedora(libvmi.WithTerminationGracePeriod(600)), libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		vm := libvmi.NewVirtualMachine(vmiFactory(libvmi.WithTerminationGracePeriod(600)), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
@@ -119,7 +119,10 @@ var _ = SIGDescribe("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 
 		Expect(updated).To(Receive(), "vmi should be updated")
 		done <- true
-	})
+	},
+		Entry("with Fedora based VMI", libvmifact.NewFedora),
+		Entry("with unresponsive empty-disk VMI", libvmifact.NewGuestless),
+	)
 
 	Context("with paused vmi", func() {
 		It("[test_id:4598][test_id:3060]should signal paused/unpaused state with condition", decorators.Conformance, func() {


### PR DESCRIPTION
### What this PR does
Manual backport #15170

automatic backport failied due to conflicts in the mock components in the unit-tests

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: ensure grace period metadata cache is synced in virt-launcher
```

