### PR TITLE
cleanup: instancetype applyCPU

### DIFF
--- a/pkg/instancetype/apply/cpu.go
+++ b/pkg/instancetype/apply/cpu.go
@@ -44,7 +44,7 @@ func applyCPU(
 		return conflicts
 	}
 
-	if vmiSpec.Domain.CPU.Model == "" && instancetypeSpec.CPU.Model != nil {
+	if instancetypeSpec.CPU.Model != nil {
 		vmiSpec.Domain.CPU.Model = *instancetypeSpec.CPU.Model
 	}
 
@@ -56,11 +56,11 @@ func applyCPU(
 		vmiSpec.Domain.CPU.IsolateEmulatorThread = *instancetypeSpec.CPU.IsolateEmulatorThread
 	}
 
-	if vmiSpec.Domain.CPU.NUMA == nil && instancetypeSpec.CPU.NUMA != nil {
+	if instancetypeSpec.CPU.NUMA != nil {
 		vmiSpec.Domain.CPU.NUMA = instancetypeSpec.CPU.NUMA.DeepCopy()
 	}
 
-	if vmiSpec.Domain.CPU.Realtime == nil && instancetypeSpec.CPU.Realtime != nil {
+	if instancetypeSpec.CPU.Realtime != nil {
 		vmiSpec.Domain.CPU.Realtime = instancetypeSpec.CPU.Realtime.DeepCopy()
 	}
 


### PR DESCRIPTION
### What this PR does
When applying an instancetype to a vmispec.domain.cpu, the validateCPU() function checks for conflicts in the instancetypespec.cpu and vmispec.domain.cpu. The nil checks in the applyCPU() function can be simplified to enhance clarity.

### References
Partially addresses #13044 point n.1.
Overriding cpu.model is not possible. Specifying the spec.template.spec.domain.cpu.model in a vm and also referencing an instancetype with a set cpu model results in a conflict.

<!-- optional -->

### Checklist

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

