### PR TITLE
Register workqueue metrics on init

### DIFF
--- a/pkg/monitoring/metrics/common/workqueue/metrics.go
+++ b/pkg/monitoring/metrics/common/workqueue/metrics.go
@@ -24,14 +24,17 @@ import (
 	k8sworkqueue "k8s.io/client-go/util/workqueue"
 )
 
-func SetupMetrics() error {
+type prometheusMetricsProvider struct{}
+
+func init() {
 	k8sworkqueue.SetProvider(prometheusMetricsProvider{})
+}
+
+func SetupMetrics() error {
 	return nil
 }
 
-type prometheusMetricsProvider struct{}
-
-func (_ prometheusMetricsProvider) NewDepthMetric(name string) k8sworkqueue.GaugeMetric {
+func (prometheusMetricsProvider) NewDepthMetric(name string) k8sworkqueue.GaugeMetric {
 	depth := operatormetrics.NewGauge(operatormetrics.MetricOpts{
 		Name:        "kubevirt_workqueue_depth",
 		Help:        "Current depth of workqueue",
@@ -42,7 +45,7 @@ func (_ prometheusMetricsProvider) NewDepthMetric(name string) k8sworkqueue.Gaug
 	return depth
 }
 
-func (_ prometheusMetricsProvider) NewAddsMetric(name string) k8sworkqueue.CounterMetric {
+func (prometheusMetricsProvider) NewAddsMetric(name string) k8sworkqueue.CounterMetric {
 	adds := operatormetrics.NewCounter(operatormetrics.MetricOpts{
 		Name:        "kubevirt_workqueue_adds_total",
 		Help:        "Total number of adds handled by workqueue",
@@ -53,7 +56,7 @@ func (_ prometheusMetricsProvider) NewAddsMetric(name string) k8sworkqueue.Count
 	return adds
 }
 
-func (_ prometheusMetricsProvider) NewLatencyMetric(name string) k8sworkqueue.HistogramMetric {
+func (prometheusMetricsProvider) NewLatencyMetric(name string) k8sworkqueue.HistogramMetric {
 	latency := operatormetrics.NewHistogram(
 		operatormetrics.MetricOpts{
 			Name:        "kubevirt_workqueue_queue_duration_seconds",
@@ -69,7 +72,7 @@ func (_ prometheusMetricsProvider) NewLatencyMetric(name string) k8sworkqueue.Hi
 	return latency
 }
 
-func (_ prometheusMetricsProvider) NewWorkDurationMetric(name string) k8sworkqueue.HistogramMetric {
+func (prometheusMetricsProvider) NewWorkDurationMetric(name string) k8sworkqueue.HistogramMetric {
 	workDuration := operatormetrics.NewHistogram(
 		operatormetrics.MetricOpts{
 			Name:        "kubevirt_workqueue_work_duration_seconds",
@@ -85,7 +88,7 @@ func (_ prometheusMetricsProvider) NewWorkDurationMetric(name string) k8sworkque
 	return workDuration
 }
 
-func (_ prometheusMetricsProvider) NewRetriesMetric(name string) k8sworkqueue.CounterMetric {
+func (prometheusMetricsProvider) NewRetriesMetric(name string) k8sworkqueue.CounterMetric {
 	retries := operatormetrics.NewCounter(operatormetrics.MetricOpts{
 		Name:        "kubevirt_workqueue_retries_total",
 		Help:        "Total number of retries handled by workqueue",
@@ -96,7 +99,7 @@ func (_ prometheusMetricsProvider) NewRetriesMetric(name string) k8sworkqueue.Co
 	return retries
 }
 
-func (_ prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) k8sworkqueue.SettableGaugeMetric {
+func (prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) k8sworkqueue.SettableGaugeMetric {
 	longestRunningProcessor := operatormetrics.NewGauge(operatormetrics.MetricOpts{
 		Name:        "kubevirt_workqueue_longest_running_processor_seconds",
 		Help:        "How many seconds has the longest running processor for workqueue been running.",
@@ -107,7 +110,7 @@ func (_ prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name 
 	return longestRunningProcessor
 }
 
-func (_ prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) k8sworkqueue.SettableGaugeMetric {
+func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) k8sworkqueue.SettableGaugeMetric {
 	unfinishedWork := operatormetrics.NewGauge(operatormetrics.MetricOpts{
 		Name: "kubevirt_workqueue_unfinished_work_seconds",
 		Help: "How many seconds of work has done that is in progress and hasn't " +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

No workqueue metrics are being exposed in the components' metrics endpoints

#### After this PR:

Workqueue metrics are being exposed

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

