### PR TITLE
[release-1.1] Fix project build related to functests dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -376,6 +376,13 @@ http_file(
 
 # some repos which are not part of go_rules anymore
 go_repository(
+    name = "org_golang_x_sys",
+    importpath = "golang.org/x/sys",
+    sum = "h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=",
+    version = "v0.12.0",
+)
+
+go_repository(
     name = "com_github_golang_glog",
     importpath = "github.com/golang/glog",
     sum = "h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=",

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -478,6 +478,9 @@ spec:
 EOF
 fi
 
+if [ "${KUBEVIRT_PSA:-false}" = "false" ]; then
+  add_to_label_filter '(!CustomSeccomp)' '&&'
+fi
 
 # Run functional tests
 FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER='--label-filter='${label_filter} make functest

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -66,6 +66,10 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
+    if [ "${KUBEVIRT_PSA:-false}" = "false" ]; then
+        KUBEVIRT_FUNC_TEST_SUITE_ARGS="-use-custom-seccomp-profile=false ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
+    fi
+
     _out/tests/ginkgo -timeout=3h -r "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
 }
 

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -41,6 +41,7 @@ var (
 	VMX                          = []interface{}{Label("VMX")}
 	Upgrade                      = []interface{}{Label("Upgrade")}
 	CustomSELinux                = []interface{}{Label("CustomSELinux")}
+	CustomSeccomp                = []interface{}{Label("CustomSeccomp")}
 	Istio                        = []interface{}{Label("Istio")}
 	InPlaceHotplugNICs           = []interface{}{Label("in-place-hotplug-NICs")}
 	MigrationBasedHotplugNICs    = []interface{}{Label("migration-based-hotplug-NICs")}

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -63,6 +63,8 @@ var MigrationNetworkNIC = "eth1"
 
 var DisableCustomSELinuxPolicy bool
 
+var UseCustomSeccompProfile bool
+
 func init() {
 	kubecli.Init()
 	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
@@ -98,6 +100,8 @@ func init() {
 	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
 	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
 	flag.BoolVar(&DisableCustomSELinuxPolicy, "disable-custom-selinux-policy", false, "disables the installation and use of the custom SELinux policy for virt-launcher")
+	flag.BoolVar(&UseCustomSeccompProfile, "use-custom-seccomp-profile", true, "enables the installation and use of the custom custom seccomp profile for virt-launcher")
+
 }
 
 func NormalizeFlags() {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2919,7 +2919,7 @@ spec:
 		})
 	})
 
-	Context("[Serial] Seccomp configuration", Serial, func() {
+	Context("[Serial] Seccomp configuration", Serial, decorators.CustomSeccomp, func() {
 
 		Context("Kubevirt profile", func() {
 			var nodeName string

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/utils/pointer"
+
 	"kubevirt.io/kubevirt/tests/libstorage"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -36,8 +38,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/utils/pointer"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -85,13 +85,6 @@ func AdjustKubeVirtResource() {
 		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{}
 	}
 
-	kv.Spec.Configuration.SeccompConfiguration = &v1.SeccompConfiguration{
-		VirtualMachineInstanceProfile: &v1.VirtualMachineInstanceProfile{
-			CustomProfile: &v1.CustomProfile{
-				LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
-			},
-		},
-	}
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
 		virtconfig.CPUManager,
 		virtconfig.IgnitionGate,
@@ -107,7 +100,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.ExpandDisksGate,
 		virtconfig.WorkloadEncryptionSEV,
 		virtconfig.VMExportGate,
-		virtconfig.KubevirtSeccompProfile,
 		virtconfig.HotplugNetworkIfacesGate,
 		virtconfig.VMPersistentState,
 		virtconfig.VMLiveUpdateFeaturesGate,
@@ -116,6 +108,19 @@ func AdjustKubeVirtResource() {
 	if flags.DisableCustomSELinuxPolicy {
 		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
 			virtconfig.DisableCustomSELinuxPolicy,
+		)
+	}
+
+	if flags.UseCustomSeccompProfile {
+		kv.Spec.Configuration.SeccompConfiguration = &v1.SeccompConfiguration{
+			VirtualMachineInstanceProfile: &v1.VirtualMachineInstanceProfile{
+				CustomProfile: &v1.CustomProfile{
+					LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
+				},
+			},
+		}
+		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+			virtconfig.KubevirtSeccompProfile,
 		)
 	}
 


### PR DESCRIPTION
Signed-off-by: fossedihelm <ffossemo@redhat.com>
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

### What this PR does
Fix build functests dependency

google.golang.org/grpc v1.30 defined in WORKSPACE
has golang.org/x/sys:v0.0.0-20190215142949-d0b11bdaac8a as dependency, as
defined in https://deps.dev/go/google.golang.org%2Fgrpc/v1.30.0/dependencies.

https://pkg.go.dev/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a this version disappeared.

### Release notes
```release-note
NONE
```

