### PR TITLE
virt-config: Refactor the virt-api client rate limiting configuration 

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -127,14 +127,14 @@ type virtAPIApp struct {
 	handlerTLSConfiguration *tls.Config
 	handlerCertManager      certificate2.Manager
 
-	caConfigMapName              string
-	tlsCertFilePath              string
-	tlsKeyFilePath               string
-	handlerCertFilePath          string
-	handlerKeyFilePath           string
-	externallyManaged            bool
-	reloadableRateLimiter        *ratelimiter.ReloadableRateLimiter
-	reloadableWebhookRateLimiter *ratelimiter.ReloadableRateLimiter
+	caConfigMapName             string
+	tlsCertFilePath             string
+	tlsKeyFilePath              string
+	handlerCertFilePath         string
+	handlerKeyFilePath          string
+	externallyManaged           bool
+	clientRateLimiter           *ratelimiter.ReloadableRateLimiter
+	authorizorClientRateLimiter *ratelimiter.ReloadableRateLimiter
 
 	// indicates if controllers were started with or without CDI/DataSource support
 	hasCDIDataSource bool
@@ -163,28 +163,38 @@ func (app *virtAPIApp) Execute() {
 		panic(err)
 	}
 
-	app.reloadableRateLimiter = ratelimiter.NewReloadableRateLimiter(flowcontrol.NewTokenBucketRateLimiter(virtconfig.DefaultVirtAPIQPS, virtconfig.DefaultVirtAPIBurst))
-	app.reloadableWebhookRateLimiter = ratelimiter.NewReloadableRateLimiter(flowcontrol.NewTokenBucketRateLimiter(virtconfig.DefaultVirtWebhookClientQPS, virtconfig.DefaultVirtWebhookClientBurst))
-
 	clientmetrics.RegisterRestConfigHooks()
 	clientConfig, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
 		panic(err)
 	}
-	clientConfig.RateLimiter = app.reloadableRateLimiter
+
+	app.clientRateLimiter = ratelimiter.NewReloadableRateLimiter(
+		flowcontrol.NewTokenBucketRateLimiter(
+			virtconfig.DefaultVirtAPIQPS,
+			virtconfig.DefaultVirtAPIBurst,
+		),
+	)
+
+	clientConfig.RateLimiter = app.clientRateLimiter
 	app.virtCli, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
 	if err != nil {
 		panic(err)
 	}
 
-	authorizor, err := rest.NewAuthorizor(app.reloadableWebhookRateLimiter)
+	app.authorizorClientRateLimiter = ratelimiter.NewReloadableRateLimiter(
+		flowcontrol.NewTokenBucketRateLimiter(
+			virtconfig.DefaultVirtAPIAuthorizorQPS,
+			virtconfig.DefaultVirtAPIAuthorizorBurst,
+		),
+	)
+
+	app.authorizor, err = rest.NewAuthorizor(app.authorizorClientRateLimiter)
 	if err != nil {
 		panic(err)
 	}
 
 	app.aggregatorClient = aggregatorclient.NewForConfigOrDie(clientConfig)
-
-	app.authorizor = authorizor
 
 	app.certsDirectory, err = os.MkdirTemp("", "certsdir")
 	if err != nil {
@@ -1133,7 +1143,7 @@ func (app *virtAPIApp) Run() {
 	app.hasCDIDataSource = app.clusterConfig.HasDataSourceAPI()
 	app.clusterConfig.SetConfigModifiedCallback(app.configModificationCallback)
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeLogVerbosity)
-	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeRateLimiter)
+	app.clusterConfig.SetConfigModifiedCallback(app.changeRateLimiter)
 
 	var dataSourceInformer cache.SharedIndexInformer
 	if app.hasCDIDataSource {
@@ -1197,17 +1207,19 @@ func (app *virtAPIApp) shouldChangeLogVerbosity() {
 	log.Log.V(2).Infof("set log verbosity to %d", verbosity)
 }
 
-// Update virt-handler rate limiter
-func (app *virtAPIApp) shouldChangeRateLimiter() {
+// Update virt-api rate limiters
+func (app *virtAPIApp) changeRateLimiter() {
 	config := app.clusterConfig.GetConfig()
+
 	qps := config.APIConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS
 	burst := config.APIConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst
-	app.reloadableRateLimiter.Set(flowcontrol.NewTokenBucketRateLimiter(qps, burst))
+	app.clientRateLimiter.Set(flowcontrol.NewTokenBucketRateLimiter(qps, burst))
 	log.Log.V(2).Infof("setting rate limiter for the API to %v QPS and %v Burst", qps, burst)
+
 	qps = config.WebhookConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS
 	burst = config.WebhookConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst
-	app.reloadableWebhookRateLimiter.Set(flowcontrol.NewTokenBucketRateLimiter(qps, burst))
-	log.Log.V(2).Infof("setting rate limiter for webhooks to %v QPS and %v Burst", qps, burst)
+	app.authorizorClientRateLimiter.Set(flowcontrol.NewTokenBucketRateLimiter(qps, burst))
+	log.Log.V(2).Infof("setting rate limiter for the API Authorizor to %v QPS and %v Burst", qps, burst)
 }
 
 func (app *virtAPIApp) AddFlags() {

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -241,8 +241,8 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 		},
 		WebhookConfiguration: &v1.ReloadableComponentConfiguration{
 			RestClient: &v1.RESTClientConfiguration{RateLimiter: &v1.RateLimiter{TokenBucketRateLimiter: &v1.TokenBucketRateLimiter{
-				QPS:   DefaultVirtWebhookClientQPS,
-				Burst: DefaultVirtWebhookClientBurst,
+				QPS:   DefaultVirtAPIAuthorizorQPS,
+				Burst: DefaultVirtAPIAuthorizorBurst,
 			}}},
 		},
 		ArchitectureConfiguration: &v1.ArchConfiguration{

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -83,8 +83,8 @@ const (
 	DefaultVirtHandlerBurst               = 10
 	DefaultVirtControllerQPS      float32 = 200
 	DefaultVirtControllerBurst            = 400
-	DefaultVirtAPIQPS             float32 = 5
-	DefaultVirtAPIBurst                   = 10
+	DefaultVirtAPIQPS             float32 = 200
+	DefaultVirtAPIBurst                   = 400
 	DefaultVirtWebhookClientQPS           = 200
 	DefaultVirtWebhookClientBurst         = 400
 

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -78,15 +78,15 @@ const (
 	DefaultVirtLauncherLogVerbosity                 = 2
 	DefaultVirtOperatorLogVerbosity                 = 2
 
-	// Default REST configuration settings
+	// Default client rate limiting configuration settings
 	DefaultVirtHandlerQPS         float32 = 5
 	DefaultVirtHandlerBurst               = 10
 	DefaultVirtControllerQPS      float32 = 200
 	DefaultVirtControllerBurst            = 400
 	DefaultVirtAPIQPS             float32 = 200
 	DefaultVirtAPIBurst                   = 400
-	DefaultVirtWebhookClientQPS           = 200
-	DefaultVirtWebhookClientBurst         = 400
+	DefaultVirtAPIAuthorizorQPS           = 200
+	DefaultVirtAPIAuthorizorBurst         = 400
 
 	DefaultMaxHotplugRatio   = 4
 	DefaultVMRolloutStrategy = v1.VMRolloutStrategyLiveUpdate


### PR DESCRIPTION
Follow up to https://github.com/kubevirt/kubevirt/pull/15422 if that lands...

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

