### PR TITLE
Revert "virt-operator: Stop using deprecated node-role.kubernetes.io/master taint"

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1371,6 +1371,9 @@ spec:
                     - matchExpressions:
                       - key: node-role.kubernetes.io/control-plane
                         operator: Exists
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
                   - podAffinityTerm:
@@ -1454,6 +1457,9 @@ spec:
                 operator: Exists
               - effect: NoSchedule
                 key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
                 operator: Exists
               volumes:
               - name: kubevirt-operator-certs

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -383,6 +383,7 @@ var nodeLabels = map[string]string{
 	"kubernetes.io/os":                                                 "linux",
 	"kubevirt.io/schedulable":                                          "true",
 	"node-role.kubernetes.io/control-plane":                            "",
+	"node-role.kubernetes.io/master":                                   "",
 	"node.kubernetes.io/exclude-from-external-load-balancers":          "",
 	"scheduling.node.kubevirt.io/tsc-frequency-2111998000":             "true",
 }

--- a/pkg/virt-operator/resource/placement/placement.go
+++ b/pkg/virt-operator/resource/placement/placement.go
@@ -63,6 +63,14 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 											},
 										},
 									},
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "node-role.kubernetes.io/master",
+												Operator: corev1.NodeSelectorOpExists,
+											},
+										},
+									},
 								},
 							},
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
@@ -83,6 +91,11 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 					Tolerations: []corev1.Toleration{
 						{
 							Key:      "node-role.kubernetes.io/control-plane",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:      "node-role.kubernetes.io/master",
 							Operator: corev1.TolerationOpExists,
 							Effect:   corev1.TaintEffectNoSchedule,
 						},

--- a/pkg/virt-operator/resource/placement/placement_test.go
+++ b/pkg/virt-operator/resource/placement/placement_test.go
@@ -386,6 +386,7 @@ var _ = Describe("Placement", func() {
 		Context("default scheduling to CP nodes", func() {
 			DescribeTable("should require scheduling to control-plane nodes and avoid worker nodes", func(config *v1.ComponentConfig) {
 				const (
+					masterLabel       = "node-role.kubernetes.io/master"
 					controlPlaceLabel = "node-role.kubernetes.io/control-plane"
 					workerLabel       = "node-role.kubernetes.io/worker"
 				)
@@ -397,7 +398,7 @@ var _ = Describe("Placement", func() {
 
 				By("Testing scheduling requirements")
 				Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).ToNot(BeNil())
-				Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
+				Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(2))
 
 				requirementSelectorTerm := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
 				Expect(requirementSelectorTerm.MatchFields).To(BeEmpty())
@@ -405,6 +406,14 @@ var _ = Describe("Placement", func() {
 
 				requirementMatchExpression := requirementSelectorTerm.MatchExpressions[0]
 				Expect(requirementMatchExpression.Key).To(Equal(controlPlaceLabel))
+				Expect(requirementMatchExpression.Operator).To(Equal(corev1.NodeSelectorOpExists))
+
+				requirementSelectorTerm = podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[1]
+				Expect(requirementSelectorTerm.MatchFields).To(BeEmpty())
+				Expect(requirementSelectorTerm.MatchExpressions).To(HaveLen(1))
+
+				requirementMatchExpression = requirementSelectorTerm.MatchExpressions[0]
+				Expect(requirementMatchExpression.Key).To(Equal(masterLabel))
 				Expect(requirementMatchExpression.Operator).To(Equal(corev1.NodeSelectorOpExists))
 
 				By("Testing scheduling preferences")
@@ -422,6 +431,11 @@ var _ = Describe("Placement", func() {
 				Expect(podSpec.Tolerations).To(ContainElements(
 					corev1.Toleration{
 						Key:      "node-role.kubernetes.io/control-plane",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+					corev1.Toleration{
+						Key:      "node-role.kubernetes.io/master",
 						Operator: corev1.TolerationOpExists,
 						Effect:   corev1.TaintEffectNoSchedule,
 					},


### PR DESCRIPTION
/cc @xpivarc 
/cc @iholder101 

### What this PR does

This reverts commit 0b0100200055035f7eb72321bb50505d749c40de.

While node labels are present some downstream environments only apply the original `node-role.kubernetes.io/master` taint so we can't remove this just yet. For now the original change is reverted and I will continue to monitor if we can switch over.

```shell
$ oc get nodes -o json | jq '.items.[] | select(.metadata.labels[] | contains("master")) | .spec.taints'
```
```json
[
  {
    "effect": "NoSchedule",
    "key": "node-role.kubernetes.io/master"
  }
]
[
  {
    "effect": "NoSchedule",
    "key": "node-role.kubernetes.io/master"
  }
]
[
  {
    "effect": "NoSchedule",
    "key": "node-role.kubernetes.io/master"
  }
]
```


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

