### PR TITLE
Improve migration controller sync time

### DIFF
--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -139,7 +139,7 @@ func NewSynchronizationController(
 
 	if err := syncController.migrationInformer.AddIndexers(map[string]cache.IndexFunc{
 		"byUID":               indexByMigrationUID,
-		"byVMIName":           indexByVmiName,
+		"byActiveVMIName":     indexByActiveVmiName,
 		"byTargetMigrationID": indexByTargetMigrationID,
 		"bySourceMigrationID": indexBySourceMigrationID,
 	}); err != nil {
@@ -628,7 +628,7 @@ func (s *SynchronizationController) handleTargetState(vmi *virtv1.VirtualMachine
 }
 
 func (s *SynchronizationController) getMigrationForVMI(vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachineInstanceMigration, error) {
-	objects, err := s.migrationInformer.GetIndexer().ByIndex("byVMIName", vmi.Name)
+	objects, err := s.migrationInformer.GetIndexer().ByIndex("byActiveVMIName", vmi.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -1018,7 +1018,7 @@ func indexByMigrationUID(obj interface{}) ([]string, error) {
 	return []string{string(migration.UID)}, nil
 }
 
-func indexByVmiName(obj interface{}) ([]string, error) {
+func indexByActiveVmiName(obj interface{}) ([]string, error) {
 	migration, ok := obj.(*virtv1.VirtualMachineInstanceMigration)
 	if !ok {
 		return nil, nil

--- a/pkg/synchronization-controller/synchronization-controller_test.go
+++ b/pkg/synchronization-controller/synchronization-controller_test.go
@@ -986,7 +986,7 @@ var _ = Describe("VMI status synchronization controller", func() {
 		res, err := indexByMigrationUID("invalid")
 		Expect(res).To(BeNil())
 		Expect(err).ToNot(HaveOccurred())
-		res, err = indexByVmiName("invalid")
+		res, err = indexByActiveVmiName("invalid")
 		Expect(res).To(BeNil())
 		Expect(err).ToNot(HaveOccurred())
 		res, err = indexBySourceMigrationID("invalid")

--- a/pkg/util/migrations/BUILD.bazel
+++ b/pkg/util/migrations/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/util/migrations",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/controller:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -43,7 +43,7 @@ type EvacuationController struct {
 	Queue                 workqueue.TypedRateLimitingInterface[string]
 	vmiIndexer            cache.Indexer
 	vmiPodIndexer         cache.Indexer
-	migrationStore        cache.Store
+	migrationIndexer      cache.Indexer
 	recorder              record.EventRecorder
 	migrationExpectations *controller.UIDTrackingControllerExpectations
 	nodeStore             cache.Store
@@ -67,7 +67,7 @@ func NewEvacuationController(
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-evacuation"},
 		),
 		vmiIndexer:            vmiInformer.GetIndexer(),
-		migrationStore:        migrationInformer.GetStore(),
+		migrationIndexer:      migrationInformer.GetIndexer(),
 		nodeStore:             nodeInformer.GetStore(),
 		vmiPodIndexer:         vmiPodInformer.GetIndexer(),
 		recorder:              recorder,
@@ -351,7 +351,7 @@ func (c *EvacuationController) execute(key string) error {
 		return fmt.Errorf("failed to list VMIs on node: %v", err)
 	}
 
-	migrations := migrationutils.ListUnfinishedMigrations(c.migrationStore)
+	migrations := migrationutils.ListUnfinishedMigrations(c.migrationIndexer)
 
 	return c.sync(node, vmis, migrations)
 }

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -22,6 +22,7 @@ import (
 
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -59,7 +60,7 @@ var _ = Describe("Evacuation", func() {
 				return []string{obj.(*v1.VirtualMachineInstance).Status.NodeName}, nil
 			},
 		})
-		migrationInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
+		migrationInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstanceMigration{}, virtcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 		nodeInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Node{})
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(100)
@@ -91,7 +92,7 @@ var _ = Describe("Evacuation", func() {
 
 	sanityExecute := func() {
 		controllertesting.SanityExecute(controller, []cache.Store{
-			controller.vmiIndexer, controller.vmiPodIndexer, controller.migrationStore, controller.nodeStore,
+			controller.vmiIndexer, controller.vmiPodIndexer, controller.migrationIndexer, controller.nodeStore,
 		}, Default)
 
 	}
@@ -187,11 +188,11 @@ var _ = Describe("Evacuation", func() {
 			controller.vmiIndexer.Add(vmi)
 			controller.vmiIndexer.Add(vmi1)
 
-			controller.migrationStore.Add(newMigration("mig1", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig2", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig1", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig2", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
 
 			sanityExecute()
 
@@ -206,12 +207,12 @@ var _ = Describe("Evacuation", func() {
 			vmi1 := newVirtualMachineMarkedForEviction("testvmi1", node.Name)
 			migration1 := newMigration("mig1", vmi1.Name, v1.MigrationRunning)
 			controller.vmiIndexer.Add(vmi1)
-			controller.migrationStore.Add(migration1)
+			controller.migrationIndexer.Add(migration1)
 
 			vmi2 := newVirtualMachineMarkedForEviction("testvmi2", node.Name)
 			migration2 := newMigration("mig2", vmi1.Name, v1.MigrationRunning)
 			controller.vmiIndexer.Add(vmi2)
-			controller.migrationStore.Add(migration2)
+			controller.migrationIndexer.Add(migration2)
 
 			vmi3 := newVirtualMachineMarkedForEviction("testvmi3", node.Name)
 			controller.vmiIndexer.Add(vmi3)
@@ -221,7 +222,7 @@ var _ = Describe("Evacuation", func() {
 			Expect(recorder.Events).To(BeEmpty())
 
 			migration2.Status.Phase = v1.MigrationSucceeded
-			controller.migrationStore.Update(migration2)
+			controller.migrationIndexer.Update(migration2)
 
 			enqueue(node)
 			sanityExecute()
@@ -283,11 +284,11 @@ var _ = Describe("Evacuation", func() {
 			}
 			vmi.Status.EvacuationNodeName = node.Name
 			controller.vmiIndexer.Add(vmi)
-			controller.migrationStore.Add(newMigration("mig1", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig2", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
-			controller.migrationStore.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig1", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig2", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
 			sanityExecute()
 		})
 
@@ -311,7 +312,7 @@ var _ = Describe("Evacuation", func() {
 			for i := 1; i <= activeMigrations; i++ {
 				vmiName := fmt.Sprintf("testvmi-migrating-%d", i)
 				controller.vmiIndexer.Add(newVirtualMachineMarkedForEviction(vmiName, nodeName))
-				controller.migrationStore.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationRunning))
+				controller.migrationIndexer.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationRunning))
 			}
 
 			sanityExecute()
@@ -335,7 +336,7 @@ var _ = Describe("Evacuation", func() {
 			migration := newMigration("mig1", vmi.Name, v1.MigrationRunning)
 			migration.Status.Phase = v1.MigrationRunning
 
-			controller.migrationStore.Add(migration)
+			controller.migrationIndexer.Add(migration)
 
 			sanityExecute()
 		})
@@ -439,7 +440,7 @@ var _ = Describe("Evacuation", func() {
 			for i := 1; i <= activeMigrationsFromThisSourceNode; i++ {
 				vmiName := fmt.Sprintf("testvmi%d", i)
 				controller.vmiIndexer.Add(newVirtualMachineMarkedForEviction(vmiName, nodeName))
-				controller.migrationStore.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationRunning))
+				controller.migrationIndexer.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationRunning))
 			}
 
 			By(fmt.Sprintf("Creating %d migration candidates from source node %s", migrationCandidatesFromThisSourceNode, nodeName))
@@ -477,7 +478,7 @@ var _ = Describe("Evacuation", func() {
 			for i := 1; i <= pendingMigrations; i++ {
 				vmiName := fmt.Sprintf("testvmi%d", i)
 				controller.vmiIndexer.Add(newVirtualMachineMarkedForEviction(vmiName, nodeName))
-				controller.migrationStore.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationPending))
+				controller.migrationIndexer.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationPending))
 			}
 
 			By(fmt.Sprintf("Creating a migration candidate from source node %s", nodeName))

--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/tpm:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/migrations:go_default_library",
+        "//pkg/util/trace:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -36,6 +37,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+        "//vendor/k8s.io/utils/trace:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
+	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 	"kubevirt.io/client-go/api"
@@ -228,7 +229,7 @@ var _ = Describe("Migration watcher", func() {
 		virtClientset = kubevirtfake.NewSimpleClientset()
 
 		vmiInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
-		migrationInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
+		migrationInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstanceMigration{}, virtcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		resourceQuotaInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		namespaceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -208,7 +208,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
-		migrationInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
+		migrationInformer, _ := testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstanceMigration{}, kvcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 		storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		storageClassStore = storageClassInformer.GetStore()
 		cdiInformer, _ := testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -65,7 +65,7 @@ type WorkloadUpdateController struct {
 	queue                 workqueue.TypedRateLimitingInterface[string]
 	vmiStore              cache.Store
 	podIndexer            cache.Indexer
-	migrationStore        cache.Store
+	migrationIndexer      cache.Indexer
 	recorder              record.EventRecorder
 	migrationExpectations *controller.UIDTrackingControllerExpectations
 	kubeVirtStore         cache.Store
@@ -109,7 +109,7 @@ func NewWorkloadUpdateController(
 		),
 		vmiStore:              vmiInformer.GetStore(),
 		podIndexer:            podInformer.GetIndexer(),
-		migrationStore:        migrationInformer.GetStore(),
+		migrationIndexer:      migrationInformer.GetIndexer(),
 		kubeVirtStore:         kubeVirtInformer.GetStore(),
 		recorder:              recorder,
 		clientset:             clientset,
@@ -347,7 +347,7 @@ func (c *WorkloadUpdateController) doesRequireMigration(vmi *virtv1.VirtualMachi
 }
 
 func (c *WorkloadUpdateController) shouldAbortMigration(vmi *virtv1.VirtualMachineInstance) bool {
-	numMig := len(migrationutils.ListWorkloadUpdateMigrations(c.migrationStore, vmi.Name, vmi.Namespace))
+	numMig := len(migrationutils.ListWorkloadUpdateMigrations(c.migrationIndexer, vmi.Name, vmi.Namespace))
 	if metav1.HasAnnotation(vmi.ObjectMeta, virtv1.WorkloadUpdateMigrationAbortionAnnotation) {
 		return numMig > 0
 	}
@@ -368,7 +368,7 @@ func (c *WorkloadUpdateController) getUpdateData(kv *virtv1.KubeVirt) *updateDat
 
 	lookup := make(map[string]bool)
 
-	migrations := migrationutils.ListUnfinishedMigrations(c.migrationStore)
+	migrations := migrationutils.ListUnfinishedMigrations(c.migrationIndexer)
 
 	for _, migration := range migrations {
 		lookup[migration.Namespace+"/"+migration.Spec.VMIName] = true
@@ -627,7 +627,7 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 	for _, vmi := range data.abortChangeVMIs {
 		go func(vmi *virtv1.VirtualMachineInstance) {
 			defer wg.Done()
-			migList := migrationutils.ListWorkloadUpdateMigrations(c.migrationStore, vmi.Name, vmi.Namespace)
+			migList := migrationutils.ListWorkloadUpdateMigrations(c.migrationIndexer, vmi.Name, vmi.Namespace)
 			for _, mig := range migList {
 				err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), mig.Name, metav1.DeleteOptions{})
 				if err != nil && !errors.IsNotFound(err) {

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Workload Updater", func() {
 
 	sanityExecute := func() {
 		controllertesting.SanityExecute(controller, []cache.Store{
-			controller.vmiStore, controller.podIndexer, controller.migrationStore, controller.kubeVirtStore,
+			controller.vmiStore, controller.podIndexer, controller.migrationIndexer, controller.kubeVirtStore,
 		}, Default)
 	}
 
@@ -89,7 +89,7 @@ var _ = Describe("Workload Updater", func() {
 				return []string{obj.(*v1.VirtualMachineInstance).Status.NodeName}, nil
 			},
 		})
-		migrationInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
+		migrationInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstanceMigration{}, virtcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(200)
 		recorder.IncludeObject = true
@@ -270,7 +270,7 @@ var _ = Describe("Workload Updater", func() {
 
 			By("populating with pending migrations that should be ignored while counting the threshold")
 			for i := 0; i < vmsPendingMigration; i++ {
-				controller.migrationStore.Add(newMigration(fmt.Sprintf("vmim-pending-%d", i), fmt.Sprintf("testvm-migratable-pending-%d", i), v1.MigrationPending))
+				controller.migrationIndexer.Add(newMigration(fmt.Sprintf("vmim-pending-%d", i), fmt.Sprintf("testvm-migratable-pending-%d", i), v1.MigrationPending))
 			}
 
 			var reasons []string
@@ -281,13 +281,13 @@ var _ = Describe("Workload Updater", func() {
 				controller.podIndexer.Add(pod)
 				// create enough migrations to only allow one more active one to be created
 				if i < int(virtconfig.ParallelMigrationsPerClusterDefault)-1 {
-					controller.migrationStore.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationRunning))
+					controller.migrationIndexer.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationRunning))
 				} else if i < int(virtconfig.ParallelMigrationsPerClusterDefault) {
-					controller.migrationStore.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationSucceeded))
+					controller.migrationIndexer.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationSucceeded))
 					// expect only a single migration to occur due to global limit
 					reasons = append(reasons, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 				} else {
-					controller.migrationStore.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationSucceeded))
+					controller.migrationIndexer.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationSucceeded))
 				}
 			}
 
@@ -409,12 +409,12 @@ var _ = Describe("Workload Updater", func() {
 			pod := newLauncherPodForVMI(vmi)
 			controller.vmiStore.Add(vmi)
 			controller.podIndexer.Add(pod)
-			controller.migrationStore.Add(newMigration("vmim-1", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("vmim-1", vmi.Name, v1.MigrationRunning))
 			vmi = newVirtualMachineInstance("testvm-nonmigratable", false, "madeup")
 			pod = newLauncherPodForVMI(vmi)
 			controller.vmiStore.Add(vmi)
 			controller.podIndexer.Add(pod)
-			controller.migrationStore.Add(newMigration("vmim-2", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("vmim-2", vmi.Name, v1.MigrationRunning))
 
 			waitForNumberOfInstancesOnVMIInformerCache(controller, desiredNumberOfVMs)
 
@@ -554,7 +554,7 @@ var _ = Describe("Workload Updater", func() {
 		createMig := func(vmiName string, phase v1.VirtualMachineInstanceMigrationPhase) *v1.VirtualMachineInstanceMigration {
 			mig := newMigration("test", vmiName, phase)
 			mig.Annotations = map[string]string{v1.WorkloadUpdateMigrationAnnotation: ""}
-			controller.migrationStore.Add(mig)
+			controller.migrationIndexer.Add(mig)
 			_, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(mig.Namespace).Create(context.Background(), mig, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return mig


### PR DESCRIPTION
### What this PR does
Optimizes the migration controller by adding custom indexers to migration informers, reducing full-list scans (O(n)) to indexed lookups (O(1)) for better performance at scale 


#### Before this PR:
Functions like `listMigrationsMatchingVMI`, `filterMigrations`, `findRunningMigrations`, and `ListUnfinishedMigrations` iterateed over all migrations in a namespace using c.migrationIndexer.ByIndex(cache.NamespaceIndex, namespace) followed by in-memory filtering - this led to high CPU/memory usage and delays in large clusters

#### After this PR:
 - add indexers to improve complexity and lookup time
 - Next: move GC into a separate goroutine (in a separate PR)
 - 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

