### PR TITLE
tests/infra/prometheus: refactor metrics tests to use MetricsFetcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
 	github.com/prometheus/procfs v0.15.1
+	github.com/rhobs/operator-observability-toolkit v0.0.29
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/vishvananda/netlink v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -2255,6 +2255,8 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rhobs/operator-observability-toolkit v0.0.29 h1:C6Z+Qk8OCgHwnIYg7eVfqAkgFy6vFQiYdo2K1r6FZF0=
+github.com/rhobs/operator-observability-toolkit v0.0.29/go.mod h1:a6bL5LZGNVA32pGsfMY74HYgfftQL7/90BD7rCCf1lI=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
+        "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/testutil:go_default_library",
         "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -42,6 +42,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	metricsutil "github.com/rhobs/operator-observability-toolkit/pkg/testutil"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	netutils "k8s.io/utils/net"
@@ -186,37 +187,12 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 
 var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", func() {
 	var (
-		virtClient kubecli.KubevirtClient
-		err        error
-
+		virtClient          kubecli.KubevirtClient
 		preparedVMIs        []*v1.VirtualMachineInstance
 		pod                 *k8sv1.Pod
 		handlerMetricIPs    []string
 		controllerMetricIPs []string
 	)
-
-	// collect metrics whose key contains the given string, expects non-empty result
-	collectMetrics := func(ip, metricSubstring string) map[string]float64 {
-		By("Scraping the Prometheus endpoint")
-		var metrics map[string]float64
-		var lines []string
-
-		Eventually(func() map[string]float64 {
-			out := libmonitoring.GetKubevirtVMMetrics(pod, ip)
-			lines = libinfra.TakeMetricsWithPrefix(out, metricSubstring)
-			metrics, err = libinfra.ParseMetricsToMap(lines)
-			Expect(err).ToNot(HaveOccurred())
-			return metrics
-		}, 30*time.Second, 2*time.Second).ShouldNot(BeEmpty())
-
-		// troubleshooting helper
-		_, err = fmt.Fprintf(GinkgoWriter, "metrics [%s]:\nlines=%s\n%#v\n", metricSubstring, lines, metrics)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(metrics)).To(BeNumerically(">=", float64(1.0)))
-		Expect(metrics).To(HaveLen(len(lines)))
-
-		return metrics
-	}
 
 	prepareVMIForTests := func(preferredNodeName string) string {
 		By("Creating the VirtualMachineInstance")
@@ -387,8 +363,7 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 				req, _ := http.NewRequest("GET", metricsURL, http.NoBody)
 				resp, err := client.Do(req)
 				if err != nil {
-					_, fprintfErr := fmt.Fprintf(GinkgoWriter, "client: request: %v #%d: %v\n", req, ix, err) // troubleshooting helper
-					Expect(fprintfErr).ToNot(HaveOccurred())
+					GinkgoLogr.Info("client: request", "request", req, "index", ix, "error", err) // troubleshooting helper
 				} else {
 					Expect(resp.Body.Close()).To(Succeed())
 				}
@@ -419,24 +394,25 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 		Entry("[test_id:6227] by using IPv6", k8sv1.IPv6Protocol),
 	)
 
-	DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
+	DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricName, operator string) {
 		libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 		ip := libnet.GetIP(handlerMetricIPs, family)
-
-		metrics := collectMetrics(ip, metricSubstring)
-		By("Checking the collected metrics")
-		keys := libinfra.GetKeysFromMetrics(metrics)
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
 		for _, vmi := range preparedVMIs {
 			for _, vol := range vmi.Spec.Volumes {
-				key := libinfra.GetMetricKeyForVmiDisk(keys, vmi.Name, vol.Name)
-				Expect(key).To(Not(BeEmpty()))
+				fetcher := metricsutil.NewMetricsFetcher("")
+				fetcher.AddNameFilter(metricName)
+				fetcher.AddLabelFilter("name", vmi.Name, "drive", vol.Name)
 
-				value := metrics[key]
-				_, err := fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(value).To(BeNumerically(operator, float64(0.0)))
+				metrics, err := fetcher.LoadMetrics(metricsPayload)
+				Expect(err).ToNot(HaveOccurred(), "should load metrics without error")
 
+				results := metrics[metricName]
+				Expect(results).ToNot(BeEmpty(), "Expected to find metric for VMI %s and disk %s", vmi.Name, vol.Name)
+
+				GinkgoLogr.Info("Metric value", "value", results[0].Value)
+				Expect(results[0].Value).To(BeNumerically(operator, 0.0))
 			}
 		}
 	},
@@ -474,15 +450,19 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 		libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 		ip := libnet.GetIP(handlerMetricIPs, family)
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
 
-		metrics := collectMetrics(ip, metricSubstring)
-		By("Checking the collected metrics")
-		keys := libinfra.GetKeysFromMetrics(metrics)
-		for _, key := range keys {
-			value := metrics[key]
-			_, err := fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(value).To(BeNumerically(operator, float64(0.0)))
+		fetcher := metricsutil.NewMetricsFetcher("")
+		fetcher.AddNameFilter(metricSubstring)
+
+		metrics, err := fetcher.LoadMetrics(metricsPayload)
+		Expect(err).ToNot(HaveOccurred(), "should load metrics without error")
+		Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected for %s", metricSubstring)
+
+		for _, results := range metrics {
+			for _, result := range results {
+				Expect(result.Value).To(BeNumerically(operator, float64(0.0)))
+			}
 		}
 	},
 		Entry("[test_id:4143] network metrics by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_network_", ">="),
@@ -502,32 +482,42 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 
 		ip := libnet.GetIP(handlerMetricIPs, family)
 
-		metrics := collectMetrics(ip, "kubevirt_vmi_")
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+
+		fetcher := metricsutil.NewMetricsFetcher("")
+		fetcher.AddNameFilter("kubevirt_vmi_")
+
+		metrics, err := fetcher.LoadMetrics(metricsPayload)
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Checking the collected metrics")
-		keys := libinfra.GetKeysFromMetrics(metrics)
 		nodeName := pod.Spec.NodeName
 
-		nameMatchers := []gomegatypes.GomegaMatcher{}
+		var nameMatchers []gomegatypes.GomegaMatcher
 		for _, vmi := range preparedVMIs {
-			nameMatchers = append(nameMatchers, ContainSubstring(`name="%s"`, vmi.Name))
+			nameMatchers = append(nameMatchers, HaveKeyWithValue("name", vmi.Name))
 		}
 
-		for _, key := range keys {
+		for metricName, results := range metrics {
 			// we don't care about the ordering of the labels
-			if strings.HasPrefix(key, "kubevirt_vmi_info") {
+			if strings.HasPrefix(metricName, "kubevirt_vmi_info") {
 				// special case: namespace and name don't make sense for this metric
-				Expect(key).To(ContainSubstring(`node="%s"`, nodeName))
+				for _, metricResult := range results {
+					Expect(metricResult.Labels).To(HaveKeyWithValue("node", nodeName))
+				}
 				continue
 			}
 
-			Expect(key).To(SatisfyAll(
-				ContainSubstring(`node="%s"`, nodeName),
-				// all testing VMIs are on the same node and namespace,
-				// so checking the namespace of any random VMI is fine
-				ContainSubstring(`namespace="%s"`, preparedVMIs[0].Namespace),
-				// otherwise, each key must refer to exactly one the prepared VMIs.
-				SatisfyAny(nameMatchers...),
-			))
+			for _, metricResult := range results {
+				Expect(metricResult.Labels).To(SatisfyAll(
+					HaveKeyWithValue("node", nodeName),
+					// all testing VMIs are on the same node and namespace,
+					// so checking the namespace of any random VMI is fine
+					HaveKeyWithValue("namespace", preparedVMIs[0].Namespace),
+					// otherwise, each result must refer to exactly one the prepared VMIs.
+					SatisfyAny(nameMatchers...),
+				))
+			}
 		}
 	},
 		Entry("[test_id:4145] by IPv4", k8sv1.IPv4Protocol),
@@ -539,13 +529,19 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 
 		ip := libnet.GetIP(handlerMetricIPs, family)
 
-		metrics := collectMetrics(ip, "kubevirt_vmi_")
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+
+		fetcher := metricsutil.NewMetricsFetcher("")
+		fetcher.AddNameFilter("kubevirt_vmi_")
+		fetcher.AddLabelFilter("phase", "Running")
+
+		metrics, err := fetcher.LoadMetrics(metricsPayload)
+		Expect(err).ToNot(HaveOccurred())
+
 		By("Checking the collected metrics")
-		keys := libinfra.GetKeysFromMetrics(metrics)
-		for _, key := range keys {
-			if strings.Contains(key, `phase="running"`) {
-				value := metrics[key]
-				Expect(value).To(Equal(float64(len(preparedVMIs))))
+		for _, results := range metrics {
+			for _, metricResult := range results {
+				Expect(metricResult.Value).To(Equal(float64(len(preparedVMIs))))
 			}
 		}
 	},
@@ -558,15 +554,18 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 
 		ip := libnet.GetIP(controllerMetricIPs, family)
 
-		metrics := collectMetrics(ip, "kubevirt_vmi_non_evictable")
-		By("Checking the collected metrics")
-		keys := libinfra.GetKeysFromMetrics(metrics)
-		for _, key := range keys {
-			value := metrics[key]
-			_, err := fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(value).To(BeNumerically(">=", float64(0.0)))
-		}
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+
+		fetcher := metricsutil.NewMetricsFetcher("")
+		fetcher.AddNameFilter("kubevirt_vmi_non_evictable")
+
+		metrics, err := fetcher.LoadMetrics(metricsPayload)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected")
+
+		results := metrics["kubevirt_vmi_non_evictable"]
+		Expect(results).ToNot(BeEmpty())
+		Expect(results[0].Value).To(BeNumerically(">=", float64(0.0)))
 	},
 		Entry("[test_id:4148] by IPv4", k8sv1.IPv4Protocol),
 		Entry("[test_id:6243] by IPv6", k8sv1.IPv6Protocol),
@@ -577,15 +576,25 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 
 		ip := libnet.GetIP(handlerMetricIPs, family)
 
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+
+		fetcher := metricsutil.NewMetricsFetcher("")
+		fetcher.AddNameFilter("kubevirt_vmi_vcpu_seconds_total")
+
+		metrics, err := fetcher.LoadMetrics(metricsPayload)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected")
+
 		// Every VMI is labeled with kubevirt.io/nodeName, so just creating a VMI should
 		// be enough to its metrics to contain a kubernetes label
-		metrics := collectMetrics(ip, "kubevirt_vmi_vcpu_seconds_total")
-		By("Checking collected metrics")
-		keys := libinfra.GetKeysFromMetrics(metrics)
 		containK8sLabel := false
-		for _, key := range keys {
-			if strings.Contains(key, "kubernetes_vmi_label_") {
-				containK8sLabel = true
+		for _, results := range metrics {
+			for _, metricResult := range results {
+				for label := range metricResult.Labels {
+					if strings.Contains(label, "kubernetes_vmi_label_") {
+						containK8sLabel = true
+					}
+				}
 			}
 		}
 		Expect(containK8sLabel).To(BeTrue())
@@ -600,16 +609,24 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 
 		ip := libnet.GetIP(handlerMetricIPs, family)
 
-		metrics := collectMetrics(ip, "kubevirt_vmi_memory_swap_")
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+
+		fetcher := metricsutil.NewMetricsFetcher("")
+		fetcher.AddNameFilter("kubevirt_vmi_memory_swap_")
+
+		metrics, err := fetcher.LoadMetrics(metricsPayload)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected")
+
 		var in, out bool
-		for k := range metrics {
+		for metricName := range metrics {
 			if in && out {
 				break
 			}
-			if strings.Contains(k, `swap_in`) {
+			if strings.Contains(metricName, "swap_in") {
 				in = true
 			}
-			if strings.Contains(k, `swap_out`) {
+			if strings.Contains(metricName, "swap_out") {
 				out = true
 			}
 		}

--- a/tests/libinfra/metrics.go
+++ b/tests/libinfra/metrics.go
@@ -133,13 +133,3 @@ func GetKeysFromMetrics(metrics map[string]float64) []string {
 	sort.Strings(keys)
 	return keys
 }
-
-func GetMetricKeyForVmiDisk(keys []string, vmiName string, diskName string) string {
-	for _, key := range keys {
-		if strings.Contains(key, "name=\""+vmiName+"\"") &&
-			strings.Contains(key, "drive=\""+diskName+"\"") {
-			return key
-		}
-	}
-	return ""
-}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -446,6 +446,11 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 github.com/prometheus/procfs/sysfs
+# github.com/rhobs/operator-observability-toolkit v0.0.29
+## explicit; go 1.21
+github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics
+github.com/rhobs/operator-observability-toolkit/pkg/operatorrules
+github.com/rhobs/operator-observability-toolkit/pkg/testutil
 # github.com/rivo/uniseg v0.2.0
 ## explicit; go 1.12
 github.com/rivo/uniseg


### PR DESCRIPTION
Manual backport of #13758.

Automated backport failed due to missing dependency of `github.com/rhobs/operator-observability-toolkit/pkg/testutil` in release-1.5

### What this PR does
This PR removes the `collectMetrics` lambda in favor of the `MetricsFetcher` interface. With this refactoring, metrics are now collected in a structured way, using a map from metric name to a slice of `MetricResult` structs, which improves clarity and test consistency.

It also fixes a bug where metrics containing timestamps were collected multiple times in the fetching period, causing a mismatch in the expected count of loaded metrics.

#### Before this PR:
- Metrics tests involving timestamps could fail depending on the fetching period, in contrast to Prometheus’s scrape interval.

#### After this PR:
- By moving to a structured data representation for metrics, this flakiness is eliminated.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
none
```

