### PR TITLE
[Release-1.6] virt-handler: sync grace period metadata from VMI before shutdown

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -371,6 +371,38 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMIGracefulShutdown)
 		})
 
+		It("should attempt graceful shutdown and take the VMI grace period over the cached Domain grace", func() {
+			vmi := libvmi.New(libvmi.WithName("testvmi"),
+				libvmi.WithNamespace(k8sv1.NamespaceDefault),
+				libvmi.WithTerminationGracePeriod(0))
+
+			initialGrace := int64(30)
+			domain := api.NewMinimalDomainWithNS(vmi.Namespace, vmi.Name)
+			domain.Spec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{DeletionGracePeriodSeconds: initialGrace}
+
+			hasExpired, timeLeft := controller.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain)
+			Expect(timeLeft).To(BeEquivalentTo(0))
+			Expect(hasExpired).To(BeTrue())
+		})
+
+		It("should attempt graceful shutdown and and fall back to cached Domain grace period when VMI grace is unset", func() {
+			vmi := libvmi.New(libvmi.WithName("testvmi"),
+				libvmi.WithNamespace(k8sv1.NamespaceDefault))
+			vmi.Spec.TerminationGracePeriodSeconds = nil
+
+			initialGrace := int64(30)
+			now := metav1.Time{Time: time.Now()}
+			domain := api.NewMinimalDomainWithNS(vmi.Namespace, vmi.Name)
+			domain.Spec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{
+				DeletionGracePeriodSeconds: initialGrace,
+				DeletionTimestamp:          &now,
+			}
+
+			hasExpired, timeLeft := controller.hasGracePeriodExpired(vmi.Spec.TerminationGracePeriodSeconds, domain)
+			Expect(timeLeft).To(BeEquivalentTo(initialGrace))
+			Expect(hasExpired).To(BeFalse())
+		})
+
 		It("should do nothing if vmi and domain do not match", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = "other uuid"

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1212,6 +1212,8 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 		return nil, err
 	}
 
+	l.syncGracePeriod(vmi)
+
 	// TODO: check if VirtualMachineInstance Spec and Domain Spec are equal or if we have to sync
 	return oldSpec, nil
 }
@@ -2597,6 +2599,16 @@ func (l *LibvirtDomainManager) linkImageVolumeFilePaths(vmi *v1.VirtualMachineIn
 	}
 
 	return nil
+}
+
+func (l *LibvirtDomainManager) syncGracePeriod(vmi *v1.VirtualMachineInstance) {
+	l.metadataCache.GracePeriod.WithSafeBlock(func(gracePeriodMetadata *api.GracePeriodMetadata, _ bool) {
+		gracePeriod := converter.GracePeriodSeconds(vmi)
+		if gracePeriodMetadata.DeletionGracePeriodSeconds != gracePeriod {
+			gracePeriodMetadata.DeletionGracePeriodSeconds = gracePeriod
+			log.Log.Object(vmi).Infof("Set new termination grace period: %d", gracePeriod)
+		}
+	})
 }
 
 func getDiskTargetPathFromImageVolumeView(volumeIndex int, volumePath string) (*safepath.Path, error) {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1773,6 +1773,36 @@ var _ = Describe("Manager", func() {
 			})
 		})
 	})
+
+	It("should update grace period metadata if cached value differs", func() {
+		const initialGracePeriod int64 = 30
+		const updatedGracePeriod int64 = 0
+
+		vmi := newVMI(testNamespace, testVmName)
+		vmi.Spec.TerminationGracePeriodSeconds = virtpointer.P(updatedGracePeriod)
+
+		metadataCache.GracePeriod.WithSafeBlock(func(gp *api.GracePeriodMetadata, _ bool) {
+			gp.DeletionGracePeriodSeconds = initialGracePeriod
+		})
+
+		mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).Return(mockLibvirt.VirtDomain, nil)
+		mockLibvirt.DomainEXPECT().GetXMLDesc(gomock.Any()).Return("<domain></domain>", nil)
+		mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 0, nil)
+		mockLibvirt.DomainEXPECT().Free()
+
+		manager, _ := newLibvirtDomainManagerDefault()
+
+		_, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		var actualGracePeriod int64
+		metadataCache.GracePeriod.WithSafeBlock(func(gp *api.GracePeriodMetadata, _ bool) {
+			actualGracePeriod = gp.DeletionGracePeriodSeconds
+		})
+
+		Expect(actualGracePeriod).To(Equal(updatedGracePeriod))
+	})
+
 	Context("test marking graceful shutdown", func() {
 		It("Should set metadata when calling MarkGracefulShutdown api", func() {
 			manager, _ := newLibvirtDomainManagerDefault()


### PR DESCRIPTION
Manual backport of #15170

Unit tests were failing in the automated backport PR https://github.com/kubevirt/kubevirt/pull/15425
due to implicit initialization of `terminationGracePeriodSeconds` field at `libvmi.New()`

### What this PR does
Ensure the cached GracePeriod metadata is synced from the VMI in both virt-launcher and virt-handler to reflect the current termination grace period during shutdown.

Previously, virt-launcher only set the grace period at domain creation. We now sync it during regular domain syncs as well, so the cached value remains accurate if the VMI is updated.

In addition, virt-handler also syncs the cached grace period before sending the ShutdownVirtualMachine call, ensuring that commands like:

  virtctl stop vm --force --grace-period=0

take effect even if the domain was created with a longer timeout and the updated VMI value wasn’t yet reflected.

Together, this ensures the grace period cache is consistently updated and respected across both components.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: ensure grace period metadata cache is synced in virt-launcher
```

