### PR TITLE
Fix monitoring virt-controller unit to test 2 vms

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -71,9 +71,7 @@ var _ = Describe("VM Stats Collector", func() {
 
 		DescribeTable("Add VM status metrics", func(status k6tv1.VirtualMachinePrintableStatus, metric operatormetrics.Metric) {
 			t := time.Now()
-			vms := []*k6tv1.VirtualMachine{
-				createVM(status, t),
-			}
+			vms := cloneVM(createVM(status, t))
 
 			cr := reportVmsStats(vms)
 
@@ -107,56 +105,27 @@ var _ = Describe("VM Stats Collector", func() {
 		})
 
 		It("should show annotation types and machine_type labels correctly", func() {
-			vms := []*k6tv1.VirtualMachine{
-				{
-					Spec: k6tv1.VirtualMachineSpec{
-						Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									annotationPrefix + "os":       "centos8",
-									annotationPrefix + "workload": "server",
-									annotationPrefix + "flavor":   "tiny",
-									"other":                       "other",
-								},
+			vms := cloneVM(&k6tv1.VirtualMachine{
+				Spec: k6tv1.VirtualMachineSpec{
+					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								annotationPrefix + "os":       "centos8",
+								annotationPrefix + "workload": "server",
+								annotationPrefix + "flavor":   "tiny",
+								"other":                       "other",
 							},
-							Spec: k6tv1.VirtualMachineInstanceSpec{
-								Domain: k6tv1.DomainSpec{
-									Machine: &k6tv1.Machine{
-										Type: "q35",
-									},
-								},
+						},
+						Spec: k6tv1.VirtualMachineInstanceSpec{
+							Domain: k6tv1.DomainSpec{
+								Machine: &k6tv1.Machine{Type: "q35"},
 							},
 						},
 					},
-					Status: k6tv1.VirtualMachineStatus{
-						PrintableStatus: k6tv1.VirtualMachineStatusCrashLoopBackOff,
-					},
 				},
-				{
-					Spec: k6tv1.VirtualMachineSpec{
-						Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									annotationPrefix + "os":       "centos8",
-									annotationPrefix + "workload": "server",
-									annotationPrefix + "flavor":   "tiny",
-									annotationPrefix + "phase":    "dummy",
-								},
-							},
-							Spec: k6tv1.VirtualMachineInstanceSpec{
-								Domain: k6tv1.DomainSpec{
-									Machine: &k6tv1.Machine{
-										Type: "q35",
-									},
-								},
-							},
-						},
-					},
-					Status: k6tv1.VirtualMachineStatus{
-						PrintableStatus: k6tv1.VirtualMachineStatusCrashLoopBackOff,
-					},
-				},
-			}
+				Status: k6tv1.VirtualMachineStatus{PrintableStatus: k6tv1.VirtualMachineStatusCrashLoopBackOff},
+			})
+			vms[1].Spec.Template.ObjectMeta.Annotations[annotationPrefix+"phase"] = "dummy"
 
 			crs := CollectVMsInfo(vms)
 			Expect(crs).To(HaveLen(2), "Expected 2 metrics")
@@ -191,19 +160,20 @@ var _ = Describe("VM Stats Collector", func() {
 				}
 			}
 
-			vms := []*k6tv1.VirtualMachine{{
+			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
 				Spec:       k6tv1.VirtualMachineSpec{Instancetype: instanceType},
-			}}
-			crs := CollectVMsInfo(vms)
-			Expect(crs).To(HaveLen(1), "Expected 1 metric")
+			}
+			crs := CollectVMsInfo(cloneVM(vm))
+			Expect(crs).To(HaveLen(2), "Expected 2 metrics")
 
-			cr := crs[0]
-			Expect(cr).ToNot(BeNil())
-			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
-			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(10))
-			Expect(cr.GetLabelValue("instance_type")).To(Equal(expected))
+			for _, cr := range crs {
+				Expect(cr).ToNot(BeNil())
+				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
+				Expect(cr.Value).To(BeEquivalentTo(1))
+				Expect(cr.Labels).To(HaveLen(10))
+				Expect(cr.GetLabelValue("instance_type")).To(Equal(expected))
+			}
 		},
 			Entry("with no instance type expect empty string", "VirtualMachineInstancetype", "", ""),
 			Entry("with managed instance type expect its name", "VirtualMachineInstancetype", "i-managed", "i-managed"),
@@ -226,19 +196,19 @@ var _ = Describe("VM Stats Collector", func() {
 				}
 			}
 
-			vms := []*k6tv1.VirtualMachine{{
+			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
 				Spec:       k6tv1.VirtualMachineSpec{Preference: preference},
-			}}
-			crs := CollectVMsInfo(vms)
-			Expect(crs).To(HaveLen(1), "Expected 1 metric")
+			}
+			crs := CollectVMsInfo(cloneVM(vm))
+			Expect(crs).To(HaveLen(2), "Expected 2 metrics")
 
-			cr := crs[0]
-
-			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
-			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(10))
-			Expect(cr.GetLabelValue("preference")).To(Equal(expected))
+			for _, cr := range crs {
+				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
+				Expect(cr.Value).To(BeEquivalentTo(1))
+				Expect(cr.Labels).To(HaveLen(10))
+				Expect(cr.GetLabelValue("preference")).To(Equal(expected))
+			}
 		},
 			Entry("with no preference expect empty string", "VirtualMachinePreference", "", ""),
 			Entry("with managed preference expect its name", "VirtualMachinePreference", "p-managed", "p-managed"),
@@ -269,8 +239,19 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
-			expectDefaultCPUResourceRequests(crs)
+			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
+			expectVMs(crs, "testvm", "test-ns", func(crs []operatormetrics.CollectorResult, name, ns string) {
+				Expect(crs).To(HaveLen(3), "Expected 3 metrics")
+				Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[0].Value).To(BeEquivalentTo(1))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "cpu", "cores", "default"}))
+				Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[1].Value).To(BeEquivalentTo(1))
+				Expect(crs[1].Labels).To(Equal([]string{name, ns, "cpu", "threads", "default"}))
+				Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[2].Value).To(BeEquivalentTo(1))
+				Expect(crs[2].Labels).To(Equal([]string{name, ns, "cpu", "sockets", "default"}))
+			})
 		})
 
 		It("should collect VM memory resource requests and limits", func() {
@@ -297,19 +278,31 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
+			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
 
-			By("checking the resource requests")
-			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[0].Value).To(BeEquivalentTo(1024))
-			Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes", "domain"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				By("checking the resource requests")
+				Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[0].Value).To(BeEquivalentTo(1024))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "memory", "bytes", "domain"}))
 
-			By("checking the resource limits")
-			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_limits"))
-			Expect(crs[1].Value).To(BeEquivalentTo(2048))
-			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes"}))
+				By("checking the resource limits")
+				Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_limits"))
+				Expect(crs[1].Value).To(BeEquivalentTo(2048))
+				Expect(crs[1].Labels).To(Equal([]string{name, ns, "memory", "bytes"}))
 
-			expectDefaultCPUResourceRequests(crs[2:])
+				Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[2].Value).To(BeEquivalentTo(1))
+				Expect(crs[2].Labels).To(Equal([]string{name, ns, "cpu", "cores", "default"}))
+				Expect(crs[3].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[3].Value).To(BeEquivalentTo(1))
+				Expect(crs[3].Labels).To(Equal([]string{name, ns, "cpu", "threads", "default"}))
+				Expect(crs[4].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[4].Value).To(BeEquivalentTo(1))
+				Expect(crs[4].Labels).To(Equal([]string{name, ns, "cpu", "sockets", "default"}))
+			}
+
+			expectVMs(crs, "testvm", "test-ns", expectVM)
 		})
 
 		It("should collect VM memory guest and hugepages requests", func() {
@@ -334,19 +327,31 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
+			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
 
-			By("checking the memory guest requests")
-			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[0].Value).To(BeEquivalentTo(1024))
-			Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes", "guest"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				By("checking the memory guest requests")
+				Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[0].Value).To(BeEquivalentTo(1024))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "memory", "bytes", "guest"}))
 
-			By("checking the memory hugepages requests")
-			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[1].Value).To(BeEquivalentTo(2097152))
-			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes", "hugepages"}))
+				By("checking the memory hugepages requests")
+				Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[1].Value).To(BeEquivalentTo(2097152))
+				Expect(crs[1].Labels).To(Equal([]string{name, ns, "memory", "bytes", "hugepages"}))
 
-			expectDefaultCPUResourceRequests(crs[2:])
+				Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[2].Value).To(BeEquivalentTo(1))
+				Expect(crs[2].Labels).To(Equal([]string{name, ns, "cpu", "cores", "default"}))
+				Expect(crs[3].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[3].Value).To(BeEquivalentTo(1))
+				Expect(crs[3].Labels).To(Equal([]string{name, ns, "cpu", "threads", "default"}))
+				Expect(crs[4].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[4].Value).To(BeEquivalentTo(1))
+				Expect(crs[4].Labels).To(Equal([]string{name, ns, "cpu", "sockets", "default"}))
+			}
+
+			expectVMs(crs, "testvm", "test-ns", expectVM)
 		})
 
 		It("should collect VM CPU resource requests and limits", func() {
@@ -373,18 +378,21 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
-			Expect(crs).To(HaveLen(2), "Expected 2 metrics")
+			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
 
-			By("checking the resource requests")
-			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[0].Value).To(BeEquivalentTo(0.5))
-			Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores", "requests"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				Expect(crs).To(HaveLen(2), "Expected 2 metrics")
+				By("checking the resource requests")
+				Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[0].Value).To(BeEquivalentTo(0.5))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "cpu", "cores", "requests"}))
+				By("checking the resource limits")
+				Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_limits"))
+				Expect(crs[1].Value).To(BeEquivalentTo(1))
+				Expect(crs[1].Labels).To(Equal([]string{name, ns, "cpu", "cores"}))
+			}
 
-			By("checking the resource limits")
-			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_limits"))
-			Expect(crs[1].Value).To(BeEquivalentTo(1))
-			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores"}))
+			expectVMs(crs, "testvm", "test-ns", expectVM)
 		})
 
 		It("should collect VM CPU resource requests from domain", func() {
@@ -408,20 +416,33 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
-			Expect(crs).To(HaveLen(3), "Expected 3 metrics")
+			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
+			vm1 := filterResultsByVM(crs, "testvm", "test-ns")
+			Expect(vm1).To(HaveLen(3), "Expected 3 metrics")
 
-			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[0].Value).To(BeEquivalentTo(2))
-			Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores", "domain"}))
+			Expect(vm1[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(vm1[0].Value).To(BeEquivalentTo(2))
+			Expect(vm1[0].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores", "domain"}))
 
-			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[1].Value).To(BeEquivalentTo(4))
-			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "threads", "domain"}))
+			Expect(vm1[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(vm1[1].Value).To(BeEquivalentTo(4))
+			Expect(vm1[1].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "threads", "domain"}))
 
-			Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[2].Value).To(BeEquivalentTo(1))
-			Expect(crs[2].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "sockets", "domain"}))
+			Expect(vm1[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(vm1[2].Value).To(BeEquivalentTo(1))
+			Expect(vm1[2].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "sockets", "domain"}))
+
+			vm2 := filterResultsByVM(crs, "testvm-2", "test-ns")
+			Expect(vm2).To(HaveLen(3), "Expected 3 metrics")
+			Expect(vm2[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(vm2[0].Value).To(BeEquivalentTo(2))
+			Expect(vm2[0].Labels).To(Equal([]string{"testvm-2", "test-ns", "cpu", "cores", "domain"}))
+			Expect(vm2[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(vm2[1].Value).To(BeEquivalentTo(4))
+			Expect(vm2[1].Labels).To(Equal([]string{"testvm-2", "test-ns", "cpu", "threads", "domain"}))
+			Expect(vm2[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+			Expect(vm2[2].Value).To(BeEquivalentTo(1))
+			Expect(vm2[2].Labels).To(Equal([]string{"testvm-2", "test-ns", "cpu", "sockets", "domain"}))
 		})
 
 		It("should collect VM CPU and Memory resource requests from Instance Type", func() {
@@ -439,23 +460,27 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			crs := CollectResourceRequestsAndLimits([]*k6tv1.VirtualMachine{vm})
+			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
 
-			Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[0].Value).To(BeEquivalentTo(2048))
-			Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "memory", "bytes", "guest"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				Expect(crs).To(HaveLen(4), "Expected 4 metrics")
+				// memory from instancetype
+				Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[0].Value).To(BeEquivalentTo(2048))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "memory", "bytes", "guest"}))
+				// cpu cores/threads/sockets from instancetype
+				Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[1].Value).To(BeEquivalentTo(1))
+				Expect(crs[1].Labels).To(Equal([]string{name, ns, "cpu", "cores", "domain"}))
+				Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[2].Value).To(BeEquivalentTo(1))
+				Expect(crs[2].Labels).To(Equal([]string{name, ns, "cpu", "threads", "domain"}))
+				Expect(crs[3].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
+				Expect(crs[3].Value).To(BeEquivalentTo(2))
+				Expect(crs[3].Labels).To(Equal([]string{name, ns, "cpu", "sockets", "domain"}))
+			}
 
-			Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[1].Value).To(BeEquivalentTo(1))
-			Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores", "domain"}))
-
-			Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[2].Value).To(BeEquivalentTo(1))
-			Expect(crs[2].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "threads", "domain"}))
-
-			Expect(crs[3].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-			Expect(crs[3].Value).To(BeEquivalentTo(2))
-			Expect(crs[3].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "sockets", "domain"}))
+			expectVMs(crs, "testvm", "test-ns", expectVM)
 		})
 	})
 
@@ -513,12 +538,16 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			results := CollectDiskAllocatedSize([]*k6tv1.VirtualMachine{vm})
+			results := CollectDiskAllocatedSize(cloneVM(vm))
 
 			Expect(results).ToNot(BeEmpty())
-			Expect(results[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
-			Expect(results[0].Value).To(Equal(float64(5 * 1024 * 1024 * 1024)))
-			Expect(results[0].Labels).To(Equal([]string{"test-vm", "default", "test-vm-pvc", "Filesystem", "rootdisk"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				Expect(crs).To(HaveLen(1))
+				Expect(crs[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
+				Expect(crs[0].Value).To(Equal(float64(5 * 1024 * 1024 * 1024)))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "test-vm-pvc", "Filesystem", "rootdisk"}))
+			}
+			expectVMs(results, "test-vm", "default", expectVM)
 		})
 
 		It("should handle PVC with nil volume mode", func() {
@@ -551,12 +580,16 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			results := CollectDiskAllocatedSize([]*k6tv1.VirtualMachine{vm})
+			results := CollectDiskAllocatedSize(cloneVM(vm))
 
 			Expect(results).ToNot(BeEmpty())
-			Expect(results[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
-			Expect(results[0].Value).To(Equal(float64(3 * 1024 * 1024 * 1024)))
-			Expect(results[0].Labels).To(Equal([]string{"test-vm-nil-mode", "default", "test-vm-pvc-nil-mode", "", "rootdisk"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				Expect(crs).To(HaveLen(1))
+				Expect(crs[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
+				Expect(crs[0].Value).To(Equal(float64(3 * 1024 * 1024 * 1024)))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "test-vm-pvc-nil-mode", "", "rootdisk"}))
+			}
+			expectVMs(results, "test-vm-nil-mode", "default", expectVM)
 		})
 
 		It("should prioritize DataVolume template size over PVC size", func() {
@@ -603,12 +636,16 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			results := CollectDiskAllocatedSize([]*k6tv1.VirtualMachine{vm})
+			results := CollectDiskAllocatedSize(cloneVM(vm))
 
 			Expect(results).ToNot(BeEmpty())
-			Expect(results[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
-			Expect(results[0].Value).To(Equal(float64(2 * 1024 * 1024 * 1024)))
-			Expect(results[0].Labels).To(Equal([]string{"test-vm-dv", "default", "test-dv-pvc", "Filesystem", "datavolumedisk"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				Expect(crs).To(HaveLen(1))
+				Expect(crs[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
+				Expect(crs[0].Value).To(Equal(float64(2 * 1024 * 1024 * 1024)))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, "test-dv-pvc", "Filesystem", "datavolumedisk"}))
+			}
+			expectVMs(results, "test-vm-dv", "default", expectVM)
 		})
 	})
 
@@ -627,12 +664,16 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			results := collectVMCreationTimestamp([]*k6tv1.VirtualMachine{vm})
+			results := collectVMCreationTimestamp(cloneVM(vm))
 
 			Expect(results).ToNot(BeEmpty())
-			Expect(results[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_create_date_timestamp_seconds"))
-			Expect(results[0].Value).To(Equal(float64(testTime.Unix())))
-			Expect(results[0].Labels).To(Equal([]string{"test-vm", "test-ns"}))
+			expectVM := func(crs []operatormetrics.CollectorResult, name, ns string) {
+				Expect(crs).To(HaveLen(1))
+				Expect(crs[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_create_date_timestamp_seconds"))
+				Expect(crs[0].Value).To(Equal(float64(testTime.Unix())))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns}))
+			}
+			expectVMs(results, "test-vm", "test-ns", expectVM)
 		})
 
 		It("should collect correct creation times for multiple VMs", func() {
@@ -677,9 +718,10 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			results := collectVMCreationTimestamp([]*k6tv1.VirtualMachine{vm})
+			results := collectVMCreationTimestamp(cloneVM(vm))
 
-			Expect(results).To(BeEmpty(), "kubevirt_vm_create_date_timestamp_seconds should not be collected for VMs with zero creation timestamp")
+			Expect(filterResultsByVM(results, "test-vm-zero-time", "test-ns")).To(BeEmpty())
+			Expect(filterResultsByVM(results, "test-vm-zero-time-2", "test-ns")).To(BeEmpty())
 		})
 	})
 
@@ -746,13 +788,22 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			metrics := CollectVmsVnicInfo([]*k6tv1.VirtualMachine{vm})
-			Expect(metrics).To(HaveLen(4), "Expected metrics for all vNICs")
+			metrics := CollectVmsVnicInfo(cloneVM(vm))
+			Expect(metrics).To(HaveLen(8), "Expected metrics for all vNICs in both VMs")
 
-			Expect(metrics[0].Labels).To(Equal([]string{"test-vm", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
-			Expect(metrics[1].Labels).To(Equal([]string{"test-vm", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
-			Expect(metrics[2].Labels).To(Equal([]string{"test-vm", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
-			Expect(metrics[3].Labels).To(Equal([]string{"test-vm", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
+			vm1 := filterResultsByVM(metrics, "test-vm", "test-ns")
+			Expect(vm1).To(HaveLen(4))
+			Expect(vm1[0].Labels).To(Equal([]string{"test-vm", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
+			Expect(vm1[1].Labels).To(Equal([]string{"test-vm", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
+			Expect(vm1[2].Labels).To(Equal([]string{"test-vm", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
+			Expect(vm1[3].Labels).To(Equal([]string{"test-vm", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
+
+			vm2 := filterResultsByVM(metrics, "test-vm-2", "test-ns")
+			Expect(vm2).To(HaveLen(4))
+			Expect(vm2[0].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
+			Expect(vm2[1].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
+			Expect(vm2[2].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
+			Expect(vm2[3].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
 		})
 		It("should not collect kubevirt_vm_vnic_info metric if no network defined", func() {
 			vm := &k6tv1.VirtualMachine{
@@ -780,24 +831,42 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 			}
 
-			metrics := CollectVmsVnicInfo([]*k6tv1.VirtualMachine{vm})
-			Expect(metrics).To(BeEmpty())
+			metrics := CollectVmsVnicInfo(cloneVM(vm))
+			Expect(filterResultsByVM(metrics, "test-vm", "test-ns")).To(BeEmpty())
+			Expect(filterResultsByVM(metrics, "test-vm-2", "test-ns")).To(BeEmpty())
 		})
 	})
 })
 
-func expectDefaultCPUResourceRequests(crs []operatormetrics.CollectorResult) {
-	Expect(crs).To(HaveLen(3), "Expected 3 metrics")
+// Add helpers for two-VM testing
+func cloneVM(vm *k6tv1.VirtualMachine) []*k6tv1.VirtualMachine {
+	vm2 := vm.DeepCopy()
+	if vm2.Name == "" {
+		vm2.Name = vm.Name + "-2"
+	} else {
+		vm2.Name = vm2.Name + "-2"
+	}
+	if vm2.Namespace == "" {
+		vm2.Namespace = vm.Namespace
+	}
+	return []*k6tv1.VirtualMachine{vm, vm2}
+}
 
-	Expect(crs[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-	Expect(crs[0].Value).To(BeEquivalentTo(1))
-	Expect(crs[0].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "cores", "default"}))
+func filterResultsByVM(crs []operatormetrics.CollectorResult, name, namespace string) []operatormetrics.CollectorResult {
+	var out []operatormetrics.CollectorResult
+	for _, r := range crs {
+		if len(r.Labels) >= 2 && r.Labels[0] == name && r.Labels[1] == namespace {
+			out = append(out, r)
+		}
+	}
+	return out
+}
 
-	Expect(crs[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-	Expect(crs[1].Value).To(BeEquivalentTo(1))
-	Expect(crs[1].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "threads", "default"}))
-
-	Expect(crs[2].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_resource_requests"))
-	Expect(crs[2].Value).To(BeEquivalentTo(1))
-	Expect(crs[2].Labels).To(Equal([]string{"testvm", "test-ns", "cpu", "sockets", "default"}))
+func expectVMs(
+	results []operatormetrics.CollectorResult,
+	name, namespace string,
+	expectVM func([]operatormetrics.CollectorResult, string, string),
+) {
+	expectVM(filterResultsByVM(results, name, namespace), name, namespace)
+	expectVM(filterResultsByVM(results, name+"-2", namespace), name+"-2", namespace)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

- Ensures every virt-controller metrics test in pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go validates behavior with two VMs, not just one.
- Adds concise helpers to reduce duplication while keeping each test’s original semantics intact.

### Why
A recent backport bug slipped through because some tests only exercised a single VM. Doubling coverage per test catches issues that can appear with multiple vms.

#### Before this PR:
Few tests include 2 vms in virt-controller metrics unit tests.

#### After this PR:
All tests include 2 vms in virt-controller metrics unit testes.
 
#### Fixes: 
jira-ticket:https://issues.redhat.com/browse/CNV-59027

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

