### PR TITLE
Add virt-launcher to kubevirt_memory_delta_from_requested_bytes

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -16,7 +16,7 @@ Amount of active Console connections, broken down by namespace and vmi name. Typ
 Version information. Type: Gauge.
 
 ### kubevirt_memory_delta_from_requested_bytes
-The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator. Type: Gauge.
+The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher). Type: Gauge.
 
 ### kubevirt_node_deprecated_machine_types
 List of deprecated machine types based on the capabilities of individual nodes, as detected by virt-handler. Type: Gauge.

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -572,6 +572,27 @@ tests:
         alertname: VMCannotBeEvicted
         exp_alerts: []
 
+  # Test recording rule for operator memory delta including virt-launcher
+  - interval: 1m
+    input_series:
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-foo-1", namespace="ns-a", container="compute"}'
+        values: '1500 1500'
+      - series: 'container_memory_rss{pod="virt-launcher-foo-1", namespace="ns-a", container="compute"}'
+        values: '1200 1200'
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-foo-1", namespace="ns-a", container="compute", resource="memory"}'
+        values: '1000 1000'
+    promql_expr_test:
+      - expr: 'kubevirt_memory_delta_from_requested_bytes{reason="memory_working_set_delta_from_request"}'
+        eval_time: 1m
+        exp_samples:
+          - labels: 'kubevirt_memory_delta_from_requested_bytes{container="compute",namespace="ns-a",pod="virt-launcher-foo-1",reason="memory_working_set_delta_from_request"}'
+            value: 500
+      - expr: 'kubevirt_memory_delta_from_requested_bytes{reason="memory_rss_delta_from_request"}'
+        eval_time: 1m
+        exp_samples:
+          - labels: 'kubevirt_memory_delta_from_requested_bytes{container="compute",namespace="ns-a",pod="virt-launcher-foo-1",reason="memory_rss_delta_from_request"}'
+            value: 200
+
   # Test recording rule
   - interval: 1m
     input_series:

--- a/pkg/monitoring/rules/recordingrules/operator.go
+++ b/pkg/monitoring/rules/recordingrules/operator.go
@@ -28,23 +28,23 @@ var operatorRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "kubevirt_memory_delta_from_requested_bytes",
-			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator.",
+			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher).",
 			ConstLabels: map[string]string{
 				"reason": "memory_working_set_delta_from_request",
 			},
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node)(container_memory_working_set_bytes{container=~\"virt-controller|virt-api|virt-handler|virt-operator\"}  - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator\",resource=\"memory\"})))"),
+		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node, pod)(container_memory_working_set_bytes{container=~\"virt-controller|virt-api|virt-handler|virt-operator|compute\", pod=~\"virt-.*\"} - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator|compute\",resource=\"memory\"})))"),
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "kubevirt_memory_delta_from_requested_bytes",
-			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator.",
+			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher).",
 			ConstLabels: map[string]string{
 				"reason": "memory_rss_delta_from_request",
 			},
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node)(container_memory_rss{container=~\"virt-controller|virt-api|virt-handler|virt-operator\"}  - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator\",resource=\"memory\"})))"),
+		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node, pod)(container_memory_rss{container=~\"virt-controller|virt-api|virt-handler|virt-operator|compute\", pod=~\"virt-.*\"} - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator|compute\",resource=\"memory\"})))"),
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This pr adds virt-launcher to kubevirt_memory_delta_from_requested_bytes which will also means it will be added to [cnv_abnormal](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/d9b7e6e9d8edd94b530c074ea366b641f11f8edc/pkg/monitoring/hyperconverged/rules/recordingrules/operator.go#L42) and [telemeter.](https://github.com/openshift/cluster-monitoring-operator/pull/2291/files)

#### Why
We removed the KubevirtVmHighMemoryUsage alert, but users still need clear visibility when virt-launcher memory usage significantly exceeds its request. 

#### Before this PR:
The records did not include virt-launcher memory delta
#### After this PR:
The records include virt-launcher memory delta
  
#### Fixes 
jira-ticket: https://issues.redhat.com/browse/CNV-49531

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added virt-launcher to kubevirt_memory_delta_from_requested_bytes metric and cnv_abnormal metrics.
```

