### PR TITLE
[e2e]: prefer using guest memory in pci-ports hotplug test

### DIFF
--- a/tests/hotplug/pci-ports.go
+++ b/tests/hotplug/pci-ports.go
@@ -46,7 +46,7 @@ var _ = Describe("[sig-compute]VM Hotplug PCI Port Allocation", decorators.SigCo
 	DescribeTable("should allocate the appropriate number of free ports",
 		func(memory string, additionalDevs, expectedFreePorts int) {
 			options := []libvmi.Option{
-				libvmi.WithResourceMemory(memory),
+				libvmi.WithGuestMemory(memory),
 			}
 			for i := 1; i <= additionalDevs; i++ {
 				options = append(options,


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

### What this PR does
currently the VM API allows users to configure guest memory from two different API fields. We prefer to use the a unified approach and its the domain guest memory field, rather than the memory resource requests.The reason is that the VMI controller itself does memory based calculations and sets the memory requests to the VMI pod. So conceptually memory requests should be managed by a controller rather by the user. Otherwise it looks like the user requested something else than what was configured at the end.

Related Jira issue: https://issues.redhat.com/browse/CNV-27055

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

