### PR TITLE
cleanup(virtctl,portfoward): Drop support for legacy syntax

### DIFF
--- a/pkg/virtctl/portforward/portforward.go
+++ b/pkg/virtctl/portforward/portforward.go
@@ -232,7 +232,7 @@ func examples() string {
   # For continous traffic intensive connections, consider using a dedicated Kubernetes Service.`
 }
 
-// ParseTarget argument supporting the form of type/name[/namespace] or the legacy form of type/name.namespace
+// ParseTarget argument supporting the form of type/name[/namespace]
 func ParseTarget(target string) (kind string, namespace string, name string, err error) {
 	if target == "" {
 		return "", "", "", errors.New("target cannot be empty")
@@ -263,13 +263,6 @@ func ParseTarget(target string) (kind string, namespace string, name string, err
 
 	if name == "" {
 		return "", "", "", errors.New("name cannot be empty")
-	}
-
-	if lastDot := strings.LastIndex(parts[1], "."); len(parts) == 2 && lastDot > -1 {
-		log.Log.Warning("A dot in target without specifying a namespace activates legacy parsing of name and namespace.\n" +
-			"This behavior will be removed in the next release.")
-		name = parts[1][:lastDot]
-		namespace = parts[1][lastDot+1:]
 	}
 
 	return kind, namespace, name, nil

--- a/pkg/virtctl/portforward/portforward_test.go
+++ b/pkg/virtctl/portforward/portforward_test.go
@@ -46,9 +46,10 @@ var _ = Describe("Port forward", func() {
 		Entry("kind vms", "vms/testvm", "", "testvm", "vm", ""),
 		Entry("kind virtualmachine", "virtualmachine/testvm", "", "testvm", "vm", ""),
 		Entry("kind virtualmachines", "virtualmachines/testvm", "", "testvm", "vm", ""),
-		// Legacy parsing
-		Entry("name with dots", "vmi/testvmi.with.dots", "dots", "testvmi.with", "vmi", ""),
-		Entry("kind vmi with name and namespace (legacy)", "vmi/testvmi.default", "default", "testvmi", "vmi", ""),
-		Entry("kind vm with name and namespace (legacy)", "vm/testvm.default", "default", "testvm", "vm", ""),
+		// Before 1.7 these syntaxes resulted in the last part after a dot being parsed as the namespace.
+		// This was changed in 1.7 to not parse as namespace anymore.
+		Entry("name with dots", "vmi/testvmi.with.dots", "", "testvmi.with.dots", "vmi", ""),
+		Entry("kind vmi with name with dot", "vmi/testvmi.default", "", "testvmi.default", "vmi", ""),
+		Entry("kind vm with name with dot", "vm/testvm.default", "", "testvm.default", "vm", ""),
 	)
 })

--- a/pkg/virtctl/ssh/ssh_test.go
+++ b/pkg/virtctl/ssh/ssh_test.go
@@ -54,12 +54,13 @@ var _ = Describe("SSH", func() {
 		Entry("only username", "user@", "", "", "", "", "expected target after '@'"),
 		Entry("only at", "@", "", "", "", "", "expected username before '@'"),
 		Entry("only at and target", "@vmi/testvmi", "", "", "", "", "expected username before '@'"),
-		// Legacy parsing
-		Entry("name with dots", "vmi/testvmi.with.dots", "dots", "testvmi.with", "vmi", "", ""),
-		Entry("name with dots and username", "user@vmi/testvmi.with.dots", "dots", "testvmi.with", "vmi", "user", ""),
-		Entry("kind vmi with name and namespace (legacy)", "vmi/testvmi.default", "default", "testvmi", "vmi", "", ""),
-		Entry("kind vmi with name and namespace and username (legacy)", "user@vmi/testvmi.default", "default", "testvmi", "vmi", "user", ""),
-		Entry("kind vm with name and namespace (legacy)", "vm/testvm.default", "default", "testvm", "vm", "", ""),
-		Entry("kind vm with name and namespace and username (legacy)", "user@vm/testvm.default", "default", "testvm", "vm", "user", ""),
+		// Before 1.7 these syntaxes resulted in the last part after a dot being parsed as the namespace.
+		// This was changed in 1.7 to not parse as namespace anymore.
+		Entry("name with dots", "vmi/testvmi.with.dots", "", "testvmi.with.dots", "vmi", "", ""),
+		Entry("name with dots and username", "user@vmi/testvmi.with.dots", "", "testvmi.with.dots", "vmi", "user", ""),
+		Entry("kind vmi with name with dot", "vmi/testvmi.default", "", "testvmi.default", "vmi", "", ""),
+		Entry("kind vmi with name with dot and username", "user@vmi/testvmi.default", "", "testvmi.default", "vmi", "user", ""),
+		Entry("kind vm with name with dot", "vm/testvm.default", "", "testvm.default", "vm", "", ""),
+		Entry("kind vm with name with dot and username", "user@vm/testvm.default", "", "testvm.default", "vm", "user", ""),
 	)
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Drop support for the legacy syntax that allowed to delimit the name and namespace of a target with a dot. This brings virtctl portforward closer to the syntax of kubectl port-foward.

Before:
'vmi/testvmi.with.dots' is parsed as name 'testvmi.with' and namespace 'dots.

After:
'vmi/testvmi.with.dots' parse as name 'testvmi.with.dots' and empty namespace.

This change affects the portforward, ssh and scp commands of virtctl.

The syntax was deprecated starting with the 1.6 release of KubeVirt, see #13939. 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl (portfoward|ssh|scp): Drop support for legacy dot syntax. In case the old dot syntax was used virtctl could ask for verification of the host key again. In some cases the known_hosts file might need to be updated manually.
```

