### PR TITLE
tests/launchsecurity: Add secure execution e2e test

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -111,6 +111,8 @@ elif [[ $TARGET =~ wg-arm64 ]]; then
     export KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true
 elif [[ $TARGET =~ sev ]]; then
     export KUBEVIRT_PROVIDER=${TARGET/-sev}
+elif [[ $TARGET =~ secure-execution ]]; then
+    export KUBEVIRT_PROVIDER=${TARGET/-secure-execution}
 else
   export KUBEVIRT_PROVIDER=${TARGET}
 fi
@@ -443,19 +445,21 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(VGPU)'
   elif [[ $TARGET =~ sev.* ]]; then
     label_filter='(SEV)'
+  elif [[ $TARGET =~ secure-execution ]]; then
+    label_filter='(secure-execution)'
   elif [[ $TARGET =~ sig-compute-realtime ]]; then
-    label_filter='(sig-compute-realtime) && !(SEV, SEVES)'
+    label_filter='(sig-compute-realtime) && !(SEV, SEVES, secure-execution)'
   elif [[ $TARGET =~ sig-compute-migrations ]]; then
-    label_filter='(sig-compute-migrations && !(GPU,VGPU)) && !(SEV, SEVES)'
+    label_filter='(sig-compute-migrations && !(GPU,VGPU)) && !(SEV, SEVES, secure-execution)'
   elif [[ $TARGET =~ sig-compute-serial ]]; then
     export KUBEVIRT_E2E_PARALLEL=false
-    label_filter='((sig-compute && Serial) && !(GPU,VGPU,sig-compute-migrations) && !(SEV, SEVES))'
+    label_filter='((sig-compute && Serial) && !(GPU,VGPU,sig-compute-migrations) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-compute-parallel ]]; then
-    label_filter='(sig-compute && !(Serial,GPU,VGPU,sig-compute-migrations,sig-storage) && !(SEV, SEVES))'
+    label_filter='(sig-compute && !(Serial,GPU,VGPU,sig-compute-migrations,sig-storage) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-compute-conformance ]]; then
     label_filter='(sig-compute && conformance)'
   elif [[ $TARGET =~ sig-compute ]]; then
-    label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations,sig-storage) && !(SEV, SEVES))'
+    label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations,sig-storage) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-monitoring ]]; then
     label_filter='(sig-monitoring)'
   elif [[ $TARGET =~ sig-operator ]]; then
@@ -484,7 +488,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     add_to_label_filter "(!Sysprep)" "&&"
   fi
 
-  if [[ ! $TARGET =~ wg-s390x ]]; then
+  if [[ ! $TARGET =~ wg-s390x ]] && [[ ! $TARGET =~ secure-execution ]]; then
     add_to_label_filter "(!requires-s390x)" "&&"
   fi
 

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -21,18 +21,19 @@ var (
 
 	/* HW */
 
-	GPU         = Label("GPU")
-	VGPU        = Label("VGPU")
-	SEV         = Label("SEV")
-	SEVES       = Label("SEVES")
-	SEVSNP      = Label("SEVSNP")
-	SRIOV       = Label("SRIOV")
-	StorageReq  = Label("storage-req")
-	Multus      = Label("Multus")
-	Macvtap     = Label("Macvtap")
-	Invtsc      = Label("Invtsc")
-	KSMRequired = Label("KSM-required")
-	ACPI        = Label("ACPI")
+	GPU             = Label("GPU")
+	VGPU            = Label("VGPU")
+	SEV             = Label("SEV")
+	SEVES           = Label("SEVES")
+	SEVSNP          = Label("SEVSNP")
+	SecureExecution = Label("secure-execution")
+	SRIOV           = Label("SRIOV")
+	StorageReq      = Label("storage-req")
+	Multus          = Label("Multus")
+	Macvtap         = Label("Macvtap")
+	Invtsc          = Label("Invtsc")
+	KSMRequired     = Label("KSM-required")
+	ACPI            = Label("ACPI")
 
 	/* Deployment */
 

--- a/tests/launchsecurity/BUILD.bazel
+++ b/tests/launchsecurity/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["sev.go"],
+    srcs = [
+        "secure-execution.go",
+        "sev.go",
+    ],
     importpath = "kubevirt.io/kubevirt/tests/launchsecurity",
     visibility = ["//visibility:public"],
     deps = [
@@ -15,6 +18,7 @@ go_library(
         "//tests/exec:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libconfigmap:go_default_library",
         "//tests/libdomain:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libnode:go_default_library",

--- a/tests/launchsecurity/secure-execution.go
+++ b/tests/launchsecurity/secure-execution.go
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package launchsecurity
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libconfigmap"
+	"kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/libnode"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libvmops"
+	"kubevirt.io/kubevirt/tests/testsuite"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("[sig-compute]IBM Secure Execution", decorators.SecureExecution, decorators.SigCompute, decorators.RequiresS390X, Serial, func() {
+	Context("Node Labels", func() {
+		It("Should have nodes with Secure Execution Label", func() {
+			virtclient := kubevirt.Client()
+			nodes := libnode.GetAllSchedulableNodes(virtclient)
+			hasNodeWithSELabel := false
+			for _, node := range nodes.Items {
+				if _, ok := node.Labels[kubevirtv1.SecureExecutionLabel]; ok {
+					hasNodeWithSELabel = true
+					break
+				}
+			}
+			Expect(hasNodeWithSELabel).To(BeTrue())
+		})
+	})
+	Context("Ensure cluster can run Secure Execution VMs", func() {
+		var vmi *kubevirtv1.VirtualMachineInstance
+
+		const commandTimeout = 10 * time.Second
+		BeforeEach(func() {
+			config.EnableFeatureGate(featuregate.SecureExecution)
+			By("Reading the hostkey from the 'secex-hostkey' configmap in the 'kubevirt-prow-jobs' namespace")
+			cm, err := kubevirt.Client().CoreV1().ConfigMaps("kubevirt-prow-jobs").Get(context.Background(), "secex-hostkey", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating a configmap containing the hostkey")
+			cm = libconfigmap.New(cm.Name, cm.Data)
+			cm, err = kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(cm)).Create(context.Background(), cm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi = libvmifact.NewFedora(
+				libvmi.WithConfigMapDisk(cm.Name, cm.Name),
+			)
+			// Enabling launchsecurity here won't prevent starting non-SE VMs
+			vmi.Spec.Domain.LaunchSecurity = &kubevirtv1.LaunchSecurity{}
+
+			By("Launching a non-SE VM to convert it to Secure Execution")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Logging in to non-SE VM")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+			By("Mounting the secure execution hostkey iso")
+			Expect(console.RunCommand(vmi, "mount /dev/vdb /mnt/", commandTimeout)).To(Succeed())
+
+			By("Writing the kernel cmdline to a file")
+			Expect(console.RunCommand(vmi, "cat /proc/cmdline > /tmp/parmfile.txt", commandTimeout)).To(Succeed())
+
+			By("Creating the encrypted boot image")
+			Expect(console.RunCommand(vmi, "genprotimg --no-verify -o /boot/sdboot -i /boot/vmlinuz-*.s390x -r /boot/initramfs-*.s390x.img -p /tmp/parmfile.txt -k /mnt/secex-hostkey.crt", commandTimeout)).To(Succeed())
+
+			By("Calling zipl to boot from the encrypted image")
+			Expect(console.RunCommand(vmi, "zipl -t /boot -i /boot/sdboot", commandTimeout)).To(Succeed())
+
+			By("Rebooting VM into Secure Execution mode")
+			Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).SoftReboot(context.Background(), vmi.Name)).To(Succeed())
+		})
+
+		It("Should launch a Secure Execution VM", func() {
+			By("Verifying that the VM is running in Secure Execution Mode")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+			output, err := console.RunCommandAndStoreOutput(vmi, "cat /sys/firmware/uv/prot_virt_guest", commandTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output).To(Equal("1"))
+		})
+	})
+})


### PR DESCRIPTION
Implement e2e test for secure execution.
Add new decorator for secure execution test.
Load hostkey needed for encrypting workload from configmap assumed to be present in cluster.
Convert regular VM to secure execution workload and ensure it boots.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
IBM Secure Execution had no e2e tests
#### After this PR:
The secure execution feature can be tested with an e2e test.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/19

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

