### PR TITLE
Convert mediated device disabled display test from e2e to unit test

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1914,6 +1914,55 @@ var _ = Describe("Converter", func() {
 			Expect(Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, domain, c)).To(Succeed())
 			Expect(domain.Spec.Devices.HostDevices).To(Equal([]api.HostDevice{{Type: identifyDevice}}))
 		})
+
+		It("should successfully passthrough a mediated device with a disabled display", func() {
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("1G"),
+			}
+			vGPUs := []v1.GPU{
+				{
+					Name:       "gpu2",
+					DeviceName: "nvidia.com/GRID_T4-1B",
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(false),
+						},
+					},
+				},
+			}
+			vmi.Spec.Domain.Devices.GPUs = vGPUs
+
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+
+			gpuHostDevice := api.HostDevice{
+				Alias: api.NewUserDefinedAlias("ua-gpu2"),
+				Source: api.HostDeviceSource{
+					Address: &api.Address{
+						UUID: "test-mdev-uuid",
+					},
+				},
+				Type:    api.HostDeviceMDev,
+				Mode:    "subsystem",
+				Model:   "vfio-pci",
+				Display: "",
+				RamFB:   "",
+			}
+			c.GPUHostDevices = append(c.GPUHostDevices, gpuHostDevice)
+
+			domain := vmiToDomain(vmi, c)
+			Expect(domain).ToNot(BeNil())
+
+			domXml, err := xml.MarshalIndent(domain.Spec, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+			domXmlString := string(domXml)
+
+			By("Making sure that a boot display is disabled")
+			Expect(domXmlString).ToNot(MatchRegexp(`<hostdev .*display=.?on.?`), "Display should not be enabled")
+			Expect(domXmlString).ToNot(MatchRegexp(`<hostdev .*ramfb=.?on.?`), "RamFB should not be enabled")
+
+			Expect(domXmlString).To(ContainSubstring("<hostdev"), "Should contain hostdev element")
+			Expect(domXmlString).To(ContainSubstring("test-mdev-uuid"), "Should contain the mdev UUID")
+		})
 	})
 
 	Context("graphics and video device", func() {

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -281,35 +281,7 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 			Expect(domXml).To(MatchRegexp(`<hostdev .*display=.?on.?`), "Display should be on")
 			Expect(domXml).To(MatchRegexp(`<hostdev .*ramfb=.?on.?`), "RamFB should be on")
 		})
-		It("Should successfully passthrough a mediated device with a disabled display", func() {
-			_false := false
-			By("Creating a Fedora VMI")
-			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1G")
-			vGPUs := []v1.GPU{
-				{
-					Name:       "gpu2",
-					DeviceName: deviceName,
-					VirtualGPUOptions: &v1.VGPUOptions{
-						Display: &v1.VGPUDisplayOptions{
-							Enabled: &_false,
-						},
-					},
-				},
-			}
-			vmi.Spec.Domain.Devices.GPUs = vGPUs
-			createdVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			vmi = createdVmi
-			libwait.WaitForSuccessfulVMIStart(vmi)
 
-			domXml, err := libdomain.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-			Expect(err).ToNot(HaveOccurred())
-			// make sure that another mdev explicitly turned off its display
-			By("Maiking sure that a boot display is disabled")
-			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*display=.?on.?`), "Display should not be enabled")
-			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*ramfb=.?on.?`), "RamFB should not be enabled")
-		})
 		It("Should override default mdev configuration on a specific node", func() {
 			newDesiredMdevTypeName := "nvidia-223"
 			newExpectedInstancesNum := 8


### PR DESCRIPTION
### What this PR does
In order to reduce dependency in libdomain library, convert the integration test "Should successfully passthrough a mediated device with a disabled display" to a unit test in the virt-launcher converter package.

The new test uses vmiToDomain() to validate domxml output with same regex patterns to verify that Display.Enabled=false results in no display="on" or ramfb="on" attributes in hostdev elements

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

