### PR TITLE
Nominate akalenyu for sig-test approver 

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,6 +46,7 @@ aliases:
     - xpivarc
     - 0xFelix
   sig-test-approvers:
+    - akalenyu
     - kbidarkar
     - phoracek
     - enp0s3


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**Nominate akalenyu for sig-test approver**

I would like to propose Alex Kalenyuk (@akalenyu) for nomination as sig-tests approver. 

Alex is an active contributor in Kubevirt, he has more than 150 [reviews](https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+commenter%3Aakalenyu++author%3Aakalenyu+) and [PRs](https://github.com/kubevirt/kubevirt/pulls?q=is%3Amerged+is%3Apr+author%3Aakalenyu+) in his track record.

Regarding sig-test Alex has impressive effort of [109](https://gist.github.com/enp0s3/1e85fc54c333dbb8b3be484e02f469b4) contributions

* Alex demonstrates thoroughness in his reviews and PRs, being mindful of clean code and cases of test redundancy.
* Alex is consistent with his reviews in the SIG.
* Alex takes care not only to the tests themselves but also for the test infra to make the CI more stable.
* Alex always keeps an eye on the flakes, making sure the CI stable and that fixes are propagated to release branches.
* Alex is responsive to sig-test PR reviews. 



 

 With that being said, I fully support his nomination for sig-tests approver.



### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

