### PR TITLE
Update kubevirt_vm_container_free_memory_* metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -75,11 +75,11 @@ Indication for a virt-operator that is ready to take the lead. Type: Gauge.
 ### kubevirt_virt_operator_up
 The number of virt-operator pods that are up. Type: Gauge.
 
-### kubevirt_vm_container_free_memory_bytes_based_on_rss
-The current available memory of the VM containers based on the rss. Type: Gauge.
+### kubevirt_vm_container_memory_request_margin_based_on_rss_bytes
+Difference between requested memory and rss for VM containers (request margin). Can be negative when usage exceeds request. Type: Gauge.
 
-### kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes
-The current available memory of the VM containers based on the working set. Type: Gauge.
+### kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes
+Difference between requested memory and working set for VM containers (request margin). Can be negative when usage exceeds request. Type: Gauge.
 
 ### kubevirt_vm_create_date_timestamp_seconds
 Virtual Machine creation timestamp. Type: Gauge.

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -520,15 +520,15 @@ tests:
         # time:  0          1          2          3
         values: "1073176576 1073176576 1073176576 1273176576"
     promql_expr_test:
-      - expr: 'kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes'
+      - expr: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes'
         eval_time: 1m
         exp_samples:
-          - labels: 'kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
+          - labels: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
             value: 303706112
-      - expr: 'kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes'
+      - expr: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes'
         eval_time: 3m
         exp_samples:
-          - labels: 'kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
+          - labels: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
             value: 103706112
   # VM eviction strategy is set but vm is not migratable
   - interval: 1m

--- a/pkg/monitoring/rules/recordingrules/vm.go
+++ b/pkg/monitoring/rules/recordingrules/vm.go
@@ -27,16 +27,16 @@ import (
 var vmRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes",
-			Help: "The current available memory of the VM containers based on the working set.",
+			Name: "kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes",
+			Help: "Difference between requested memory and working set for VM containers (request margin). Can be negative when usage exceeds request.",
 		},
 		MetricType: operatormetrics.GaugeType,
 		Expr:       intstr.FromString("sum by(pod, container, namespace) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container, namespace) max by(pod, container, namespace) (container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'}))"),
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_container_free_memory_bytes_based_on_rss",
-			Help: "The current available memory of the VM containers based on the rss.",
+			Name: "kubevirt_vm_container_memory_request_margin_based_on_rss_bytes",
+			Help: "Difference between requested memory and rss for VM containers (request margin). Can be negative when usage exceeds request.",
 		},
 		MetricType: operatormetrics.GaugeType,
 		Expr:       intstr.FromString("sum by(pod, container, namespace) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container, namespace) container_memory_rss{pod=~'virt-launcher-.*', container='compute'})"),


### PR DESCRIPTION

Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:
Update kubevirt_vm_container_free_memory_* metrics names.

### References
Fixes #:
 - https://issues.redhat.com/browse/CNV-67877 
 - https://github.com/kubevirt/kubevirt/issues/15198
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update metric kubevirt_vm_container_free_memory_bytes_based_on_rss and kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes names to kubevirt_vm_container_memory_request_margin_based_on_rss_bytes and kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes so they will be clearer

```

