### PR TITLE
Fix missing workqueue metrics

### DIFF
--- a/pkg/monitoring/metrics/common/workqueue/metrics.go
+++ b/pkg/monitoring/metrics/common/workqueue/metrics.go
@@ -24,6 +24,83 @@ import (
 	k8sworkqueue "k8s.io/client-go/util/workqueue"
 )
 
+var (
+	workqueueMetrics = []operatormetrics.Metric{
+		depth,
+		adds,
+		latency,
+		workDuration,
+		retries,
+		longestRunningProcessor,
+		unfinishedWork,
+	}
+
+	depth = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_workqueue_depth",
+			Help: "Current depth of workqueue",
+		},
+		[]string{"name"},
+	)
+
+	adds = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_workqueue_adds_total",
+			Help: "Total number of adds handled by workqueue",
+		},
+		[]string{"name"},
+	)
+
+	latency = operatormetrics.NewHistogramVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_workqueue_queue_duration_seconds",
+			Help: "How long an item stays in workqueue before being requested.",
+		},
+		prometheus.HistogramOpts{
+			Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+		},
+		[]string{"name"},
+	)
+
+	workDuration = operatormetrics.NewHistogramVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_workqueue_work_duration_seconds",
+			Help: "How long in seconds processing an item from workqueue takes.",
+		},
+		prometheus.HistogramOpts{
+			Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+		},
+		[]string{"name"},
+	)
+
+	retries = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_workqueue_retries_total",
+			Help: "Total number of retries handled by workqueue",
+		},
+		[]string{"name"},
+	)
+
+	longestRunningProcessor = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_workqueue_longest_running_processor_seconds",
+			Help: "How many seconds has the longest running processor for workqueue been running.",
+		},
+		[]string{"name"},
+	)
+
+	unfinishedWork = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_workqueue_unfinished_work_seconds",
+			Help: "How many seconds of work has done that is in progress and hasn't " +
+				"been observed by work_duration. Large values indicate stuck " +
+				"threads. One can deduce the number of stuck threads by observing " +
+				"the rate at which this increases.",
+		},
+		[]string{"name"},
+	)
+)
+
 type Provider struct{}
 
 func init() {
@@ -31,7 +108,7 @@ func init() {
 }
 
 func SetupMetrics() error {
-	return nil
+	return operatormetrics.RegisterMetrics(workqueueMetrics)
 }
 
 func NewPrometheusMetricsProvider() Provider {
@@ -39,91 +116,29 @@ func NewPrometheusMetricsProvider() Provider {
 }
 
 func (Provider) NewDepthMetric(name string) k8sworkqueue.GaugeMetric {
-	depth := operatormetrics.NewGauge(operatormetrics.MetricOpts{
-		Name:        "kubevirt_workqueue_depth",
-		Help:        "Current depth of workqueue",
-		ConstLabels: prometheus.Labels{"name": name},
-	})
-	_ = operatormetrics.RegisterMetrics([]operatormetrics.Metric{depth})
-
-	return depth
+	return depth.WithLabelValues(name)
 }
 
 func (Provider) NewAddsMetric(name string) k8sworkqueue.CounterMetric {
-	adds := operatormetrics.NewCounter(operatormetrics.MetricOpts{
-		Name:        "kubevirt_workqueue_adds_total",
-		Help:        "Total number of adds handled by workqueue",
-		ConstLabels: prometheus.Labels{"name": name},
-	})
-	_ = operatormetrics.RegisterMetrics([]operatormetrics.Metric{adds})
-
-	return adds
+	return adds.WithLabelValues(name)
 }
 
 func (Provider) NewLatencyMetric(name string) k8sworkqueue.HistogramMetric {
-	latency := operatormetrics.NewHistogram(
-		operatormetrics.MetricOpts{
-			Name:        "kubevirt_workqueue_queue_duration_seconds",
-			Help:        "How long an item stays in workqueue before being requested.",
-			ConstLabels: prometheus.Labels{"name": name},
-		},
-		prometheus.HistogramOpts{
-			Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
-		},
-	)
-	_ = operatormetrics.RegisterMetrics([]operatormetrics.Metric{latency})
-
-	return latency
+	return latency.WithLabelValues(name)
 }
 
 func (Provider) NewWorkDurationMetric(name string) k8sworkqueue.HistogramMetric {
-	workDuration := operatormetrics.NewHistogram(
-		operatormetrics.MetricOpts{
-			Name:        "kubevirt_workqueue_work_duration_seconds",
-			Help:        "How long in seconds processing an item from workqueue takes.",
-			ConstLabels: prometheus.Labels{"name": name},
-		},
-		prometheus.HistogramOpts{
-			Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
-		},
-	)
-	_ = operatormetrics.RegisterMetrics([]operatormetrics.Metric{workDuration})
-
-	return workDuration
+	return workDuration.WithLabelValues(name)
 }
 
 func (Provider) NewRetriesMetric(name string) k8sworkqueue.CounterMetric {
-	retries := operatormetrics.NewCounter(operatormetrics.MetricOpts{
-		Name:        "kubevirt_workqueue_retries_total",
-		Help:        "Total number of retries handled by workqueue",
-		ConstLabels: prometheus.Labels{"name": name},
-	})
-	_ = operatormetrics.RegisterMetrics([]operatormetrics.Metric{retries})
-
-	return retries
+	return retries.WithLabelValues(name)
 }
 
 func (Provider) NewLongestRunningProcessorSecondsMetric(name string) k8sworkqueue.SettableGaugeMetric {
-	longestRunningProcessor := operatormetrics.NewGauge(operatormetrics.MetricOpts{
-		Name:        "kubevirt_workqueue_longest_running_processor_seconds",
-		Help:        "How many seconds has the longest running processor for workqueue been running.",
-		ConstLabels: prometheus.Labels{"name": name},
-	})
-	_ = operatormetrics.RegisterMetrics([]operatormetrics.Metric{longestRunningProcessor})
-
-	return longestRunningProcessor
+	return longestRunningProcessor.WithLabelValues(name)
 }
 
 func (Provider) NewUnfinishedWorkSecondsMetric(name string) k8sworkqueue.SettableGaugeMetric {
-	unfinishedWork := operatormetrics.NewGauge(operatormetrics.MetricOpts{
-		Name: "kubevirt_workqueue_unfinished_work_seconds",
-		Help: "How many seconds of work has done that is in progress and hasn't " +
-			"been observed by work_duration. Large values indicate stuck " +
-			"threads. One can deduce the number of stuck threads by observing " +
-			"the rate at which this increases.",
-		ConstLabels: prometheus.Labels{"name": name},
-	})
-	_ = operatormetrics.RegisterMetrics([]operatormetrics.Metric{unfinishedWork})
-
-	return unfinishedWork
+	return unfinishedWork.WithLabelValues(name)
 }

--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/monitoring/metrics/common/workqueue:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -58,6 +58,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/controller"
+	workqueuemetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/workqueue"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	migrationsutil "kubevirt.io/kubevirt/pkg/util/migrations"
@@ -150,6 +151,7 @@ func NewController(templateService services.TemplateService,
 		templateService: templateService,
 		Queue: priorityqueue.New[string]("virt-controller-migration", func(o *priorityqueue.Opts[string]) {
 			o.RateLimiter = workqueue.DefaultTypedControllerRateLimiter[string]()
+			o.MetricProvider = workqueuemetrics.NewPrometheusMetricsProvider()
 		}),
 		vmiStore:             vmiInformer.GetStore(),
 		podIndexer:           podInformer.GetIndexer(),

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -124,6 +124,40 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			metrics := fetchPrometheusMetrics(virtClient, query)
 			Expect(metrics.Data.Result).To(BeEmpty(), "Expected no workqueue_depth metrics for virt workloads")
 		})
+
+		It("kubevirt workqueue metrics should include controllers names", func() {
+			names := []string{
+				"virt-operator",
+				"virt-handler-node-labeller",
+				"virt-handler-source",
+				"virt-handler-target",
+				"virt-handler-vm",
+				"virt-controller-disruption-budget",
+				"virt-controller-evacuation",
+				"virt-controller-export-vmexport",
+				"virt-controller-migration",
+				"virt-controller-node",
+				"virt-controller-pool",
+				"virt-controller-replicaset",
+				"virt-controller-restore-vmrestore",
+				"virt-controller-snapshot-crd",
+				"virt-controller-snapshot-vm",
+				"virt-controller-snapshot-vmsnapshot",
+				"virt-controller-snapshot-vmsnapshotcontent",
+				"virt-controller-snapshot-vmsnashotstatus",
+				"virt-controller-vm",
+				"virt-controller-vmclone",
+				"virt-controller-vmi",
+				"virt-controller-workload-update",
+			}
+
+			for _, name := range names {
+				By("Checking workqueue metrics for " + name)
+				query := "{__name__=\"kubevirt_workqueue_adds_total\",name=\"" + name + "\"}"
+				metrics := fetchPrometheusMetrics(virtClient, query)
+				Expect(metrics.Data.Result).ToNot(BeEmpty(), "Expected workqueue metrics for "+name)
+			}
+		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

Missing workqueue metrics for a few controllers due to single registering the metrics with the name as a const label

#### After this PR:

Use vector metrics and use 'name' as a variable label, so each controller has its own instance of the metric with its own name

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

