### PR TITLE
virt-handler: ensure the VM controller sees VMI deletions during migrations

### DIFF
--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -236,6 +236,9 @@ func (c *MigrationSourceController) updateStatus(vmi *v1.VirtualMachineInstance,
 		vmi.Status.Phase = v1.Failed
 		vmi.Status.MigrationState.Completed = true
 		vmi.Status.MigrationState.Failed = true
+		if vmi.Status.MigrationState.EndTimestamp == nil {
+			vmi.Status.MigrationState.EndTimestamp = pointer.P(metav1.NewTime(time.Now()))
+		}
 
 		c.logger.Object(vmi).Warning("the vmi migrated to an unknown host")
 		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to unknown host."))
@@ -244,6 +247,9 @@ func (c *MigrationSourceController) updateStatus(vmi *v1.VirtualMachineInstance,
 			vmi.Status.Phase = v1.Failed
 			vmi.Status.MigrationState.Completed = true
 			vmi.Status.MigrationState.Failed = true
+			if vmi.Status.MigrationState.EndTimestamp == nil {
+				vmi.Status.MigrationState.EndTimestamp = pointer.P(metav1.NewTime(time.Now()))
+			}
 
 			c.logger.Object(vmi).Warning("the domain was never observed on the taget after the migration completed within the timeout period")
 			c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance's domain was never observed on the target after the migration completed within the timeout period."))

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -499,8 +499,10 @@ func (c *MigrationTargetController) execute(key string) error {
 
 	if vmi.IsFinal() || vmi.DeletionTimestamp != nil {
 		c.logger.V(4).Infof("vmi for key %v is terminating or final, doing only a best-effort cleanup", key)
+		_ = c.unmountVolumes(vmi)
 		_ = c.netConf.Teardown(vmi)
 		c.netStat.Teardown(vmi)
+		c.launcherClients.CloseLauncherClient(vmi)
 		return nil
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -387,7 +387,7 @@ func (c *VirtualMachineController) execute(key string) error {
 		}
 	}
 
-	if isMigrationInProgress(vmi, domain) {
+	if vmi.DeletionTimestamp == nil && isMigrationInProgress(vmi, domain) {
 		c.logger.V(4).Infof("ignoring key %v as migration is in progress", key)
 		return nil
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2939,6 +2939,45 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(updatedVMI.Status.Phase).To(Equal(v1.Failed))
 		})
 	})
+
+	Context("on VM stop / VMI delete during migration", func() {
+		It("should kill the VM", func() {
+			By("Creating a migrating VMI with a domain in failed post-copy migration state")
+			now := metav1.Now()
+			vmi := libvmi.New(
+				libvmi.WithUID(vmiTestUUID),
+				libvmi.WithNamespace("default"),
+				libvmi.WithName("testvmi"),
+				libvmi.WithHostname(host),
+				libvmistatus.WithStatus(
+					libvmistatus.New(
+						libvmistatus.WithPhase(v1.Running),
+						libvmistatus.WithMigrationState(
+							v1.VirtualMachineInstanceMigrationState{
+								TargetNode:                     "abc",
+								TargetNodeAddress:              "127.0.0.1:12345",
+								SourceNode:                     host,
+								MigrationUID:                   "123",
+								TargetNodeDomainDetected:       true,
+								TargetNodeDomainReadyTimestamp: &now,
+								StartTimestamp:                 &now,
+							},
+						),
+					),
+				),
+			)
+			vmi.DeletionTimestamp = &now
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Running
+			domain.Status.Reason = api.ReasonUnknown
+			addVMI(vmi, domain)
+
+			By("Executing the controller")
+			client.EXPECT().KillVirtualMachine(gomock.Any())
+			sanityExecute()
+			expectEvent("VirtualMachineInstance stopping", true)
+		})
+	})
 })
 
 var _ = Describe("CurrentMemory in Libvirt Domain", func() {


### PR DESCRIPTION
And add missing volume unmount in that scenario to avoid stuck pods on deletion

### What this PR does
#### Before this PR:
Stopping a VM that has a migration ongoing keeps the VMI in the running state.
This is because the VM controller in virt-handler ignores VMs that are migrating.

#### After this PR:
The VM controller will **not** ignore migrating VMIs if they are getting deleted.
The added unmounting of volumes in that scenario will also ensure target pods get properly deleted.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

