### PR TITLE
[release-1.5] vm-mutator: ensure default Firmware.Serial value on newly created vms

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -263,7 +263,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 			expectEqualStrMap(targetVM.Spec.Template.ObjectMeta.Annotations, sourceVM.Spec.Template.ObjectMeta.Annotations, fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "template.annotations"), keysToExclude...)
 		}
 
-		expectSpecsToEqualExceptForMacAddress := func(vm1, vm2 *virtv1.VirtualMachine) {
+		expectVMsToEqualExcludingMACAndFirmwareIDs := func(vm1, vm2 *virtv1.VirtualMachine) {
 			vm1Spec := vm1.Spec.DeepCopy()
 			vm2Spec := vm2.Spec.DeepCopy()
 
@@ -271,9 +271,24 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				for i := range spec.Template.Spec.Domain.Devices.Interfaces {
 					spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = ""
 				}
+
+				if spec.Template.Spec.Domain.Firmware != nil {
+					spec.Template.Spec.Domain.Firmware.Serial = ""
+				}
 			}
 
 			Expect(vm1Spec).To(Equal(vm2Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec not including mac adresses"))
+		}
+
+		expectSpecsToEqualExceptForSerial := func(vm1, vm2 *virtv1.VirtualMachine) {
+			vm1Spec := vm1.Spec.DeepCopy()
+			vm2Spec := vm2.Spec.DeepCopy()
+
+			for _, spec := range []*virtv1.VirtualMachineSpec{vm1Spec, vm2Spec} {
+				if spec.Template.Spec.Domain.Firmware != nil {
+					spec.Template.Spec.Domain.Firmware.Serial = ""
+				}
+			}
 		}
 
 		generateCloneFromVM := func() *clone.VirtualMachineClone {
@@ -300,7 +315,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				By("Making sure target is runnable")
 				targetVM = expectVMRunnable(targetVM)
 
-				Expect(targetVM.Spec).To(Equal(sourceVM.Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec"))
+				expectSpecsToEqualExceptForSerial(targetVM, sourceVM)
 				expectEqualLabels(targetVM, sourceVM)
 				expectEqualAnnotations(targetVM, sourceVM)
 				expectEqualTemplateLabels(targetVM, sourceVM)
@@ -380,7 +395,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				By("Making sure target is runnable")
 				targetVM = expectVMRunnable(targetVM)
 
-				Expect(targetVM.Spec).To(Equal(sourceVM.Spec), fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "spec"))
+				expectSpecsToEqualExceptForSerial(targetVM, sourceVM)
 				expectEqualLabels(targetVM, sourceVM, key2)
 				expectEqualAnnotations(targetVM, sourceVM, key2)
 			})
@@ -452,7 +467,7 @@ var _ = Describe("VirtualMachineClone Tests", Serial, func() {
 				By("Making sure new mac address is applied to target VM")
 				Expect(targetInterface.MacAddress).ToNot(Equal(srcInterface.MacAddress))
 
-				expectSpecsToEqualExceptForMacAddress(targetVM, sourceVM)
+				expectVMsToEqualExcludingMACAndFirmwareIDs(targetVM, sourceVM)
 				expectEqualLabels(targetVM, sourceVM)
 				expectEqualAnnotations(targetVM, sourceVM)
 				expectEqualTemplateLabels(targetVM, sourceVM)


### PR DESCRIPTION
Manual backport of #15357

The automated backport failed because the changes from #14130 (which introduced `firmware.uuid` for newly created VMs) were not present in release `v1.5`.
This PR manually introduces the `firmware.Serial` defaulting logic.

fixes: #15667

### Release note
```release-note
ensure default Firmware.Serial value on newly created vms
```

