### PR TITLE
virt-handler: device-manager: avoid spamming the logs

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -351,9 +351,13 @@ func (c *DeviceController) refreshPermittedDevices() {
 		debugDevRemoved = append(debugDevRemoved, resourceName)
 	}
 
-	logger.Info("refreshed device plugins for permitted/forbidden host devices")
-	logger.Infof("enabled device-plugins for: %v", debugDevAdded)
-	logger.Infof("disabled device-plugins for: %v", debugDevRemoved)
+	logger.V(3).Info("refreshed device plugins for permitted/forbidden host devices")
+	if len(debugDevAdded) > 0 {
+		logger.Infof("enabled device-plugins for: %v", debugDevAdded)
+	}
+	if len(debugDevRemoved) > 0 {
+		logger.Infof("disabled device-plugins for: %v", debugDevRemoved)
+	}
 }
 
 func (c *DeviceController) startDevice(resourceName string, dev Device) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Every ~1.5 minutes, every virt-handler prints those 3 lines to the logs:
```
{"component":"virt-handler","level":"info","msg":"refreshed device plugins for permitted/forbidden host devices","pos":"device_controller.go:354","timestamp":"2025-08-29T17:02:41.563993Z"}
{"component":"virt-handler","level":"info","msg":"enabled device-plugins for: []","pos":"device_controller.go:355","timestamp":"2025-08-29T17:02:41.564017Z"}
{"component":"virt-handler","level":"info","msg":"disabled device-plugins for: []","pos":"device_controller.go:356","timestamp":"2025-08-29T17:02:41.564021Z"}
```

#### After this PR:
The first line is only printed at loglevel 3, and the next 2 only print when something relevant happened.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

