### PR TITLE
e2e, netbinding: Don't override binding registration

### DIFF
--- a/tests/libkubevirt/config/netbinding.go
+++ b/tests/libkubevirt/config/netbinding.go
@@ -29,7 +29,9 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 )
 
-func WithNetBindingPlugin(name string, netBindingPlugin v1.InterfaceBindingPlugin) KvChangeOption {
+// WithNetBindingPluginIfNotPresent registers a network binding plugin in KubeVirt CR, only if a plugin of that name
+// is not already registered
+func WithNetBindingPluginIfNotPresent(name string, netBindingPlugin v1.InterfaceBindingPlugin) KvChangeOption {
 	return func(kv *v1.KubeVirt) *patch.PatchSet {
 		patchSet := patch.New()
 		config := kv.Spec.Configuration
@@ -39,6 +41,8 @@ func WithNetBindingPlugin(name string, netBindingPlugin v1.InterfaceBindingPlugi
 			patchSet.AddOption(patch.WithAdd("/spec/configuration/network/binding", map[string]v1.InterfaceBindingPlugin{}))
 		} else if config.NetworkConfiguration.Binding == nil {
 			patchSet.AddOption(patch.WithAdd("/spec/configuration/network/binding", map[string]v1.InterfaceBindingPlugin{}))
+		} else if _, exists := config.NetworkConfiguration.Binding[name]; exists {
+			return &patch.PatchSet{}
 		}
 
 		patchSet.AddOption(patch.WithAdd(fmt.Sprintf("/spec/configuration/network/binding/%s", name), netBindingPlugin))

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -52,7 +52,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
 			err := config.RegisterKubevirtConfigChange(
-				config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
+				config.WithNetBindingPluginIfNotPresent(passtBindingName, v1.InterfaceBindingPlugin{
 					SidecarImage:                passtSidecarImage,
 					NetworkAttachmentDefinition: passtNetAttDefName,
 				}),
@@ -111,7 +111,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 
 		BeforeEach(func() {
 			err := config.RegisterKubevirtConfigChange(
-				config.WithNetBindingPlugin(macvtapBindingName, v1.InterfaceBindingPlugin{
+				config.WithNetBindingPluginIfNotPresent(macvtapBindingName, v1.InterfaceBindingPlugin{
 					DomainAttachmentType: v1.Tap,
 				}),
 			)
@@ -154,7 +154,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 
 		BeforeEach(func() {
 			err := config.RegisterKubevirtConfigChange(
-				config.WithNetBindingPlugin(bindingName, v1.InterfaceBindingPlugin{
+				config.WithNetBindingPluginIfNotPresent(bindingName, v1.InterfaceBindingPlugin{
 					DomainAttachmentType: v1.ManagedTap,
 				}),
 			)

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -55,7 +55,7 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 	BeforeEach(func() {
 		const macvtapBindingName = "macvtap"
 		err := config.RegisterKubevirtConfigChange(
-			config.WithNetBindingPlugin(macvtapBindingName, v1.InterfaceBindingPlugin{
+			config.WithNetBindingPluginIfNotPresent(macvtapBindingName, v1.InterfaceBindingPlugin{
 				DomainAttachmentType: v1.Tap,
 			}),
 		)

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -67,7 +67,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 		passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
 		err := config.RegisterKubevirtConfigChange(
-			config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
+			config.WithNetBindingPluginIfNotPresent(passtBindingName, v1.InterfaceBindingPlugin{
 				SidecarImage:                passtSidecarImage,
 				NetworkAttachmentDefinition: passtNetAttDefName,
 				Migration:                   &v1.InterfaceBindingMigration{},

--- a/tests/network/bindingplugin_slirp.go
+++ b/tests/network/bindingplugin_slirp.go
@@ -56,7 +56,7 @@ var _ = Describe(SIG("Slirp", decorators.Networking, decorators.NetCustomBinding
 		const slirpSidecarImage = "registry:5000/kubevirt/network-slirp-binding:devel"
 
 		err := config.RegisterKubevirtConfigChange(
-			config.WithNetBindingPlugin(slirpBindingName, v1.InterfaceBindingPlugin{
+			config.WithNetBindingPluginIfNotPresent(slirpBindingName, v1.InterfaceBindingPlugin{
 				SidecarImage: slirpSidecarImage,
 			}),
 		)

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -458,7 +458,7 @@ var istioTestsWithPasstBinding = func() {
 		passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
 		err := config.RegisterKubevirtConfigChange(
-			config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
+			config.WithNetBindingPluginIfNotPresent(passtBindingName, v1.InterfaceBindingPlugin{
 				SidecarImage:                passtSidecarImage,
 				NetworkAttachmentDefinition: passtNetAttDefName,
 				Migration:                   &v1.InterfaceBindingMigration{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In some testing setups, KubeVirt is configured by external operators e.g
[HCO](https://github.com/kubevirt/hyperconverged-cluster-operator).
In those setups, this e2e suite should not override preconfigured
values, in particular network binding plugins.
This change makes this suite respect existing configuration, and it only
registers network binding plugins, if they are not already registered.

The decision to override or not is only based on the name of the
plugin (they do not have a type definition) as it appears in the test,
hence external setups that wish to utilize this functionality,
must align the plugin names that they register with those
that are used by VMs in the test code.
For example: passt binding is called `passt` in the test, so do not
register it with the name `passtBinding`.
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

