### PR TITLE
Fix rest handler leak

### DIFF
--- a/pkg/virt-handler/rest/lifecycle.go
+++ b/pkg/virt-handler/rest/lifecycle.go
@@ -16,6 +16,7 @@
  * Copyright The KubeVirt Authors.
  *
  */
+
 package rest
 
 import (
@@ -62,6 +63,7 @@ func (lh *LifecycleHandler) PauseHandler(request *restful.Request, response *res
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	err = client.PauseVirtualMachine(vmi)
 	if err != nil {
@@ -78,6 +80,7 @@ func (lh *LifecycleHandler) UnpauseHandler(request *restful.Request, response *r
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	err = client.UnpauseVirtualMachine(vmi)
 	if err != nil {
@@ -94,6 +97,7 @@ func (lh *LifecycleHandler) FreezeHandler(request *restful.Request, response *re
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	unfreezeTimeout := &v1.FreezeUnfreezeTimeout{}
 	if request.Request.Body == nil {
@@ -136,6 +140,7 @@ func (lh *LifecycleHandler) UnfreezeHandler(request *restful.Request, response *
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	err = client.UnfreezeVirtualMachine(vmi)
 	if err != nil {
@@ -152,6 +157,7 @@ func (lh *LifecycleHandler) ResetHandler(request *restful.Request, response *res
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	err = client.ResetVirtualMachine(vmi)
 	if err != nil {
@@ -169,6 +175,7 @@ func (lh *LifecycleHandler) SoftRebootHandler(request *restful.Request, response
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	err = client.SoftRebootVirtualMachine(vmi)
 	if err != nil {
@@ -187,6 +194,7 @@ func (lh *LifecycleHandler) GetGuestInfo(request *restful.Request, response *res
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	log.Log.Object(vmi).Infof("Retreiving guestinfo from %s", vmi.Name)
 
@@ -206,6 +214,7 @@ func (lh *LifecycleHandler) GetUsers(request *restful.Request, response *restful
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	log.Log.Object(vmi).Infof("Retreiving userlist from %s", vmi.Name)
 
@@ -224,6 +233,7 @@ func (lh *LifecycleHandler) GetFilesystems(request *restful.Request, response *r
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	log.Log.Object(vmi).Infof("Retreiving filesystem list from %s", vmi.Name)
 
@@ -266,6 +276,7 @@ func (lh *LifecycleHandler) SEVFetchCertChainHandler(request *restful.Request, r
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	log.Log.Object(vmi).Infof("Retrieving SEV platform info")
 
@@ -284,6 +295,7 @@ func (lh *LifecycleHandler) SEVQueryLaunchMeasurementHandler(request *restful.Re
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	log.Log.Object(vmi).Infof("Retreiving SEV launch measurement")
 
@@ -302,6 +314,7 @@ func (lh *LifecycleHandler) SEVInjectLaunchSecretHandler(request *restful.Reques
 	if err != nil {
 		return
 	}
+	defer client.Close()
 
 	if request.Request.Body == nil {
 		log.Log.Object(vmi).Reason(err).Error("Request with no body: SEV secret parameters are required")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
All handlers in pkg/virt-handler/rest/lifecycle.go create cmdclient.LauncherClient, but none close the client, causing a leak.

#### After this PR:
All client are properly closed

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes 
- Partially addresses #
-->
- Fixes https://github.com/kubevirt/kubevirt/issues/15556
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: grpc client in handler rest requests are properly closed
```

