### PR TITLE
bazel: Replace deprecated --features race with test specific race config

### DIFF
--- a/cmd/cniplugins/passt-binding/pkg/plugin/BUILD.bazel
+++ b/cmd/cniplugins/passt-binding/pkg/plugin/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "plugin_suite_test.go",
         "plugin_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//vendor/github.com/containernetworking/cni/pkg/skel:go_default_library",

--- a/cmd/container-disk-v2alpha/BUILD.bazel
+++ b/cmd/container-disk-v2alpha/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "$(location //cmd/container-disk-v2alpha:container-disk)",
     ],
     data = ["//cmd/container-disk-v2alpha:container-disk"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/cmd/sidecars/network-passt-binding/callback/BUILD.bazel
+++ b/cmd/sidecars/network-passt-binding/callback/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "callback_suite_test.go",
         "callback_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/cmd/sidecars/network-passt-binding/domain/BUILD.bazel
+++ b/cmd/sidecars/network-passt-binding/domain/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "configurator_test.go",
         "domain_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/cmd/sidecars/network-slirp-binding/callback/BUILD.bazel
+++ b/cmd/sidecars/network-slirp-binding/callback/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "callback_suite_test.go",
         "callback_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/cmd/sidecars/network-slirp-binding/domain/BUILD.bazel
+++ b/cmd/sidecars/network-slirp-binding/domain/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "domain_suite_test.go",
         "domain_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/cmd/virt-freezer/BUILD.bazel
+++ b/cmd/virt-freezer/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "virt-freezer_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/hack/bazel-race.sh
+++ b/hack/bazel-race.sh
@@ -1,0 +1,20 @@
+source hack/common.sh
+source hack/bootstrap.sh
+source hack/config.sh
+
+set -ex
+
+bazel run \
+    --config="${ARCHITECTURE}" \
+    -- :buildozer -types go_test 'set race "on"' \
+    //staging/src/kubevirt.io/...:* \
+    //pkg/...:* \
+    //cmd/...:* \
+    //tools/util/...:* \
+    //tools/cache/...:* \
+    //tests/framework/...:*
+
+bazel run \
+    --config="${ARCHITECTURE}" \
+    -- :buildozer -types go_test 'set race "off"' \
+    //pkg/virt-api/webhooks/fuzz/...:*

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -29,5 +29,4 @@ fi
 
 bazel test \
     --config=${ARCHITECTURE} \
-    --features race \
     --test_output=errors -- ${WHAT}

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -219,3 +219,5 @@ ${KUBEVIRT_DIR}/hack/gen-proto.sh
 mockgen -source pkg/handler-launcher-com/notify/info/info.pb.go -package=info -destination=pkg/handler-launcher-com/notify/info/generated_mock_info.go
 mockgen -source pkg/handler-launcher-com/cmd/info/info.pb.go -package=info -destination=pkg/handler-launcher-com/cmd/info/generated_mock_info.go
 mockgen -source pkg/handler-launcher-com/cmd/v1/cmd.pb.go -package=v1 -destination=pkg/handler-launcher-com/cmd/v1/generated_mock_cmd.go
+
+${KUBEVIRT_DIR}/hack/bazel-race.sh

--- a/pkg/apimachinery/patch/BUILD.bazel
+++ b/pkg/apimachinery/patch/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
         "patch_suite_test.go",
         "patch_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/certificates/BUILD.bazel
+++ b/pkg/certificates/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "certificates_suite_test.go",
         "certificates_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/certificates/bootstrap/BUILD.bazel
+++ b/pkg/certificates/bootstrap/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "cert-manager_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",

--- a/pkg/checkpoint/BUILD.bazel
+++ b/pkg/checkpoint/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "checkpoint_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "cloudinit_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "sysprep_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/container-disk/BUILD.bazel
+++ b/pkg/container-disk/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "container-disk_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "expectations_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/defaults/BUILD.bazel
+++ b/pkg/defaults/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "defaults_suite_test.go",
         "defaults_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libdv:go_default_library",

--- a/pkg/downwardmetrics/vhostmd/BUILD.bazel
+++ b/pkg/downwardmetrics/vhostmd/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/downwardmetrics/vhostmd/api:go_default_library",
         "//pkg/downwardmetrics/vhostmd/metrics:go_default_library",

--- a/pkg/downwardmetrics/vhostmd/metrics/BUILD.bazel
+++ b/pkg/downwardmetrics/vhostmd/metrics/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "metrics_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/downwardmetrics/vhostmd/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/downwardmetrics/virtio-serial/BUILD.bazel
+++ b/pkg/downwardmetrics/virtio-serial/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "server_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/downwardmetrics/vhostmd/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/emptydisk/BUILD.bazel
+++ b/pkg/emptydisk/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "emptydisk_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/ephemeral-disk-utils/BUILD.bazel
+++ b/pkg/ephemeral-disk-utils/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "utils_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/ephemeral-disk/BUILD.bazel
+++ b/pkg/ephemeral-disk/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "ephemeral-disk_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "executor_test.go",
         "pool_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/healthz/BUILD.bazel
+++ b/pkg/healthz/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "healthz_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/hooks/BUILD.bazel
+++ b/pkg/hooks/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "manager_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/hooks/info:go_default_library",
         "//pkg/hooks/v1alpha3:go_default_library",

--- a/pkg/host-disk/BUILD.bazel
+++ b/pkg/host-disk/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "host_disk_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/hotplug-disk/BUILD.bazel
+++ b/pkg/hotplug-disk/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "hotplug-disk_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/unsafepath:go_default_library",

--- a/pkg/ignition/BUILD.bazel
+++ b/pkg/ignition/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "ignition_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/instancetype/annotations/BUILD.bazel
+++ b/pkg/instancetype/annotations/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "annotations_suite_test.go",
         "annotations_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/instancetype/apply/BUILD.bazel
+++ b/pkg/instancetype/apply/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "nodeselector_test.go",
         "scheduler_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/conflict:go_default_library",

--- a/pkg/instancetype/compatibility/BUILD.bazel
+++ b/pkg/instancetype/compatibility/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "compatibility_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",

--- a/pkg/instancetype/controller/vm/BUILD.bazel
+++ b/pkg/instancetype/controller/vm/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "controller_test.go",
         "vm_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/revision:go_default_library",

--- a/pkg/instancetype/find/BUILD.bazel
+++ b/pkg/instancetype/find/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "find_suite_test.go",
         "spec_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/revision:go_default_library",

--- a/pkg/instancetype/infer/BUILD.bazel
+++ b/pkg/instancetype/infer/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "handler_test.go",
         "infer_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/instancetype/preference/annotations/BUILD.bazel
+++ b/pkg/instancetype/preference/annotations/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "annotations_suite_test.go",
         "annotations_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/apply:go_default_library",

--- a/pkg/instancetype/preference/apply/BUILD.bazel
+++ b/pkg/instancetype/preference/apply/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "subdomain_test.go",
         "termination_test.go",
     ],
+    race = "on",
     deps = [
         "//pkg/instancetype/apply:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/instancetype/preference/find/BUILD.bazel
+++ b/pkg/instancetype/preference/find/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "find_suite_test.go",
         "spec_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/revision:go_default_library",

--- a/pkg/instancetype/preference/requirements/BUILD.bazel
+++ b/pkg/instancetype/preference/requirements/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "memory_test.go",
         "requirements_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/conflict:go_default_library",

--- a/pkg/instancetype/preference/webhooks/BUILD.bazel
+++ b/pkg/instancetype/preference/webhooks/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "admitter_test.go",
         "webhooks_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/instancetype/revision/BUILD.bazel
+++ b/pkg/instancetype/revision/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "revision_suite_test.go",
         "store_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/conflict:go_default_library",

--- a/pkg/instancetype/upgrade/BUILD.bazel
+++ b/pkg/instancetype/upgrade/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "upgrade_suite_test.go",
         "upgrade_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/revision:go_default_library",

--- a/pkg/instancetype/webhooks/BUILD.bazel
+++ b/pkg/instancetype/webhooks/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "admitter_test.go",
         "webhooks_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/instancetype/webhooks/vm/BUILD.bazel
+++ b/pkg/instancetype/webhooks/vm/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "admitter_test.go",
         "vm_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/conflict:go_default_library",

--- a/pkg/liveupdate/memory/BUILD.bazel
+++ b/pkg/liveupdate/memory/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "memory_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/monitoring/domainstats/downwardmetrics/BUILD.bazel
+++ b/pkg/monitoring/domainstats/downwardmetrics/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/monitoring/metrics/common/client/BUILD.bazel
+++ b/pkg/monitoring/metrics/common/client/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "client_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/monitoring/metrics/common/labels/BUILD.bazel
+++ b/pkg/monitoring/metrics/common/labels/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "labels_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "vmstats_collector_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/instancetype/apply:go_default_library",
         "//pkg/instancetype/find:go_default_library",

--- a/pkg/monitoring/metrics/virt-handler/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "virt_handler_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/monitoring/metrics/virt-handler/collector/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/collector/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "collector_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/monitoring/metrics/virt-handler/domainstats/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "vcpu_metrics_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/monitoring/metrics/testing:go_default_library",
         "//pkg/monitoring/metrics/virt-handler/collector:go_default_library",

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "migrationstats_collector_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/monitoring/metrics/testing:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",

--- a/pkg/monitoring/profiler/BUILD.bazel
+++ b/pkg/monitoring/profiler/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "profiler_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/monitoring/rules/BUILD.bazel
+++ b/pkg/monitoring/rules/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "rules_suite_test.go",
         "rules_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "passt_test.go",
         "slirp_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/cache/BUILD.bazel
+++ b/pkg/network/cache/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "podinterface_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/os/fs:go_default_library",

--- a/pkg/network/controllers/BUILD.bazel
+++ b/pkg/network/controllers/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "vm_test.go",
         "vmi_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/deviceinfo/BUILD.bazel
+++ b/pkg/network/deviceinfo/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "deviceinfo_suite_test.go",
         "deviceinfo_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/dhcp/BUILD.bazel
+++ b/pkg/network/dhcp/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "masquerade_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/network/cache:go_default_library",

--- a/pkg/network/dhcp/server/BUILD.bazel
+++ b/pkg/network/dhcp/server/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "server_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/network/dhcp/serverv6/BUILD.bazel
+++ b/pkg/network/dhcp/serverv6/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "serverv6_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/insomniacslk/dhcp/dhcpv6:go_default_library",

--- a/pkg/network/dns/BUILD.bazel
+++ b/pkg/network/dns/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "resolveconf_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/network/domainspec/BUILD.bazel
+++ b/pkg/network/domainspec/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "interface_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",

--- a/pkg/network/downwardapi/BUILD.bazel
+++ b/pkg/network/downwardapi/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "downwardapi_suite_test.go",
         "networkinfo_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -24,5 +24,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["driver_suite_test.go"],
+    race = "on",
     deps = ["//staging/src/kubevirt.io/client-go/testutils:go_default_library"],
 )

--- a/pkg/network/driver/nmstate/BUILD.bazel
+++ b/pkg/network/driver/nmstate/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "spec_test.go",
         "status_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/network/driver/netlink/fake:go_default_library",

--- a/pkg/network/link/BUILD.bazel
+++ b/pkg/network/link/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "names_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/network/driver:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/network/migration/BUILD.bazel
+++ b/pkg/network/migration/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "evaluator_test.go",
         "migration_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/multus/BUILD.bazel
+++ b/pkg/network/multus/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "nad_test.go",
         "status_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/network/namescheme/BUILD.bazel
+++ b/pkg/network/namescheme/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "networknamescheme_suite_test.go",
         "networknamescheme_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/network/netbinding/BUILD.bazel
+++ b/pkg/network/netbinding/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "netbinding_suite_test.go",
         "netbinding_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/hooks:go_default_library",

--- a/pkg/network/passt/BUILD.bazel
+++ b/pkg/network/passt/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "passt_suite_test.go",
         "repair_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/pod/annotations/BUILD.bazel
+++ b/pkg/network/pod/annotations/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "annotations_suite_test.go",
         "generator_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "podnic_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/setup/netpod/BUILD.bazel
+++ b/pkg/network/setup/netpod/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "netpod_test.go",
         "state_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",

--- a/pkg/network/setup/netpod/masquerade/BUILD.bazel
+++ b/pkg/network/setup/netpod/masquerade/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "masquerade_suite_test.go",
         "masquerade_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/network/driver/nft:go_default_library",

--- a/pkg/network/vmispec/BUILD.bazel
+++ b/pkg/network/vmispec/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "network_test.go",
         "vmispec_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/network/vmliveupdate/BUILD.bazel
+++ b/pkg/network/vmliveupdate/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "restart_test.go",
         "vmliveupdate_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/os/disk/BUILD.bazel
+++ b/pkg/os/disk/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "validation_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/safepath/BUILD.bazel
+++ b/pkg/safepath/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "safepath_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/unsafepath:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/storage/admitters/BUILD.bazel
+++ b/pkg/storage/admitters/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "vmsnapshot_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "backend-storage_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/storage/cbt/BUILD.bazel
+++ b/pkg/storage/cbt/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "cbt_suite_test.go",
         "cbt_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "vmsnapshot-source_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",

--- a/pkg/storage/export/virt-exportserver/BUILD.bazel
+++ b/pkg/storage/export/virt-exportserver/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "exportserver_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/storage/export/export:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/storage/hotplug/BUILD.bazel
+++ b/pkg/storage/hotplug/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "hotplug_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",

--- a/pkg/storage/memorydump/BUILD.bazel
+++ b/pkg/storage/memorydump/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "memorydump_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/storage/pod/annotations/BUILD.bazel
+++ b/pkg/storage/pod/annotations/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "annotations_suite_test.go",
         "generator_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/storage/snapshot/BUILD.bazel
+++ b/pkg/storage/snapshot/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "snapshot_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/storage/types/BUILD.bazel
+++ b/pkg/storage/types/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "types_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/containerizeddataimporter/fake:go_default_library",

--- a/pkg/storage/utils/BUILD.bazel
+++ b/pkg/storage/utils/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "volumes_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/synchronization-controller/BUILD.bazel
+++ b/pkg/synchronization-controller/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "synchronization-controller_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/certificates:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -37,5 +37,6 @@ go_test(
     name = "go_default_test",
     srcs = ["testutils_suite_test.go"],
     embed = [":go_default_library"],
+    race = "on",
     deps = ["//staging/src/kubevirt.io/client-go/testutils:go_default_library"],
 )

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "util_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/util/cluster/BUILD.bazel
+++ b/pkg/util/cluster/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "cluster_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "hw_utils_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/util/lookup/BUILD.bazel
+++ b/pkg/util/lookup/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "lookup_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/util/net/ip/BUILD.bazel
+++ b/pkg/util/net/ip/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "ip_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/util/openapi/BUILD.bazel
+++ b/pkg/util/openapi/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "openapi_suite_test.go",
         "openapi_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-api/definitions:go_default_library",

--- a/pkg/util/tls/BUILD.bazel
+++ b/pkg/util/tls/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "tls_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     tags = ["cov"],
     deps = [
         "//pkg/certificates/triple:go_default_library",

--- a/pkg/virt-api/BUILD.bazel
+++ b/pkg/virt-api/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "virt-api_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/util:go_default_library",
         "//pkg/virt-api/rest:go_default_library",

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "volumes_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -26,5 +26,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["webhooks_suite_test.go"],
+    race = "on",
     deps = ["//staging/src/kubevirt.io/client-go/testutils:go_default_library"],
 )

--- a/pkg/virt-api/webhooks/fuzz/BUILD.bazel
+++ b/pkg/virt-api/webhooks/fuzz/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
         "fuzz_suite_test.go",
         "fuzz_test.go",
     ],
+    race = "off",
     tags = ["fuzz"],
     deps = [
         "//pkg/instancetype/webhooks/vm:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "vmi-mutator_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/instancetype/webhooks/vm:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -92,6 +92,7 @@ go_test(
         "vms-admitter_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/hooks:go_default_library",

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "configuration_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-config/featuregate/BUILD.bazel
+++ b/pkg/virt-config/featuregate/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "validator_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "virtiofs_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/config:go_default_library",
         "//pkg/container-disk:go_default_library",

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "watch_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/instancetype/controller/vm:go_default_library",

--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "clone_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/virt-controller/watch/dra/BUILD.bazel
+++ b/pkg/virt-controller/watch/dra/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "dra_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/dra:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "disruptionbudget_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller/testing:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "evacuation_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",

--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "migration_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",

--- a/pkg/virt-controller/watch/node/BUILD.bazel
+++ b/pkg/virt-controller/watch/node/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "node_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller/testing:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/pool/BUILD.bazel
+++ b/pkg/virt-controller/watch/pool/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "pool_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",

--- a/pkg/virt-controller/watch/replicaset/BUILD.bazel
+++ b/pkg/virt-controller/watch/replicaset/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "replicaset_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "tsc_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "vm_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "vmi_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",

--- a/pkg/virt-controller/watch/volume-migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/volume-migration/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "volume-migration_suite_test.go",
         "volume-migration_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libdv:go_default_library",

--- a/pkg/virt-controller/watch/vsock/BUILD.bazel
+++ b/pkg/virt-controller/watch/vsock/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "vsock_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "workload-updater_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -99,6 +99,7 @@ go_test(
         "vm_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     tags = ["cov"],
     deps = [
         "//pkg/certificates:go_default_library",

--- a/pkg/virt-handler/cache/BUILD.bazel
+++ b/pkg/virt-handler/cache/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "domain-watcher_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",

--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "cgroup_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-handler/cmd-client/BUILD.bazel
+++ b/pkg/virt-handler/cmd-client/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "cmd_client_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-handler/container-disk/BUILD.bazel
+++ b/pkg/virt-handler/container-disk/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "mount_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/checkpoint:go_default_library",
         "//pkg/container-disk:go_default_library",

--- a/pkg/virt-handler/device-manager/BUILD.bazel
+++ b/pkg/virt-handler/device-manager/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "socket_device_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",

--- a/pkg/virt-handler/filewatcher/BUILD.bazel
+++ b/pkg/virt-handler/filewatcher/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
         "filewatcher_suite_test.go",
         "filewatcher_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-handler/heartbeat/BUILD.bazel
+++ b/pkg/virt-handler/heartbeat/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-handler/hotplug-disk/BUILD.bazel
+++ b/pkg/virt-handler/hotplug-disk/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "mount_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/checkpoint:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",

--- a/pkg/virt-handler/isolation/BUILD.bazel
+++ b/pkg/virt-handler/isolation/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/safepath:go_default_library",
         "//pkg/unsafepath:go_default_library",

--- a/pkg/virt-handler/launcher-clients/BUILD.bazel
+++ b/pkg/virt-handler/launcher-clients/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "launcher-clients_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/testutils:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "migration_proxy_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/certificates:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",

--- a/pkg/virt-handler/multipath-monitor/BUILD.bazel
+++ b/pkg/virt-handler/multipath-monitor/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "multipath_monitor_suite_test.go",
         "multipath_monitor_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/safepath:go_default_library",

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-handler/seccomp/BUILD.bazel
+++ b/pkg/virt-handler/seccomp/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "seccomp_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-handler/selinux/BUILD.bazel
+++ b/pkg/virt-handler/selinux/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "selinux_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     ],
     data = ["//cmd/fake-qemu-process"],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/google/uuid:go_default_library",

--- a/pkg/virt-launcher/metadata/BUILD.bazel
+++ b/pkg/virt-launcher/metadata/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "metadata_suite_test.go",
         "metadata_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-launcher/notify-client/BUILD.bazel
+++ b/pkg/virt-launcher/notify-client/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "notify_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/handler-launcher-com/notify/info:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-launcher/standalone/BUILD.bazel
+++ b/pkg/virt-launcher/standalone/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "standalone_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-launcher/virtwrap:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -92,6 +92,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     embedsrcs = ["testdata/migration_domain.xml"],
+    race = "on",
     tags = ["cov"],
     deps = [
         "//pkg/cloud-init:go_default_library",

--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "access_credentials_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",

--- a/pkg/virt-launcher/virtwrap/agent-poller/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/agent-poller/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "agent_poller_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/testing:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "testdata/domain_numa_topology.xml",
         "testdata/cpu_pinning.xml",
     ],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/arch-defaulter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/arch-defaulter/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "archdefaults_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cli/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cli/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "libvirt_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "server_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/info:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "testdata/domain_x86_64_root.xml.tmpl",
         "testdata/domain_s390x.xml.tmpl",
     ],
+    race = "on",
     deps = [
         "//pkg/config:go_default_library",
         "//pkg/defaults:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/arch/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/arch/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "converter_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "vcpu_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "device_suite_test.go",
         "pciaddress_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "hostdevice_suite_test.go",
         "hotplug_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "gpu_hostdev_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "generic_suite_test.go",
         "hostdev_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "gpu_suite_test.go",
         "hostdev_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "pcipool_netstatus_test.go",
         "sriov_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/network/deviceinfo:go_default_library",

--- a/pkg/virt-launcher/virtwrap/efi/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/efi/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "efi_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/virtwrap/launchsecurity/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/launchsecurity/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "sev_test.go",
     ],
     data = glob(["testdata/**"]),
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-launcher/virtwrap/libvirtxml/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/libvirtxml/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "libvirtxml_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "nichotplug_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",

--- a/pkg/virt-launcher/virtwrap/statsconv/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/statsconv/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "stats_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv/util:go_default_library",

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "util_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/hooks:go_default_library",

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "virt_operator_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     tags = ["cov"],
     deps = [
         "//pkg/apimachinery/patch:go_default_library",

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -92,6 +92,7 @@ go_test(
         "scc_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/triple:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "webhooks_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",

--- a/pkg/virt-operator/resource/generate/install/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/install/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "strategy_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "synchronizationcontroller_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",

--- a/pkg/virt-operator/resource/placement/BUILD.bazel
+++ b/pkg/virt-operator/resource/placement/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "placement_suite_test.go",
         "placement_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-operator/util/BUILD.bazel
+++ b/pkg/virt-operator/util/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "util_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-operator/util/client_test.go
+++ b/pkg/virt-operator/util/client_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Operator Client", func() {
 						LastProbeTime: now,
 					})
 					SetConditionTimestamps(kv1, kv2)
-					Expect(kv2.Status.Conditions[0].LastProbeTime.Time).To(BeTemporally(">", now.Time))
+					Expect(kv2.Status.Conditions[0].LastProbeTime.Time).To(BeTemporally(">=", now.Time))
 					Expect(kv2.Status.Conditions[0].LastTransitionTime).ToNot(Equal(empty))
 					Expect(kv2.Status.Conditions[0].LastTransitionTime).To(Equal(kv2.Status.Conditions[0].LastProbeTime))
 				})

--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "webhooks_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "root_suite_test.go",
         "root_test.go",
     ],
+    race = "on",
     x_defs = version_x_defs(),
     deps = [
         ":go_default_library",

--- a/pkg/virtctl/adm/logverbosity/BUILD.bazel
+++ b/pkg/virtctl/adm/logverbosity/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "logverbosity_suite_test.go",
         "logverbosity_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virtctl/testing:go_default_library",

--- a/pkg/virtctl/clientconfig/BUILD.bazel
+++ b/pkg/virtctl/clientconfig/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "clientconfig_suite_test.go",
         "clientconfig_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virtctl/create/clone/BUILD.bazel
+++ b/pkg/virtctl/create/clone/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "clone_suite_test.go",
         "clone_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virtctl/testing:go_default_library",

--- a/pkg/virtctl/create/instancetype/BUILD.bazel
+++ b/pkg/virtctl/create/instancetype/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "instancetype_suite_test.go",
         "instancetype_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/webhooks:go_default_library",

--- a/pkg/virtctl/create/params/BUILD.bazel
+++ b/pkg/virtctl/create/params/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "params_suite_test.go",
         "params_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virtctl/create/preference/BUILD.bazel
+++ b/pkg/virtctl/create/preference/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "preference_suite_test.go",
         "preference_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/instancetype/preference/webhooks:go_default_library",

--- a/pkg/virtctl/create/vm/BUILD.bazel
+++ b/pkg/virtctl/create/vm/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "vm_suite_test.go",
         "vm_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virtctl/credentials/addkey/BUILD.bazel
+++ b/pkg/virtctl/credentials/addkey/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "addkey_suite_test.go",
         "addkey_test.go",
     ],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/virtctl/credentials/password/BUILD.bazel
+++ b/pkg/virtctl/credentials/password/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "password_suite_test.go",
         "password_test.go",
     ],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/virtctl/credentials/removekey/BUILD.bazel
+++ b/pkg/virtctl/credentials/removekey/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "removekey_suite_test.go",
         "removekey_test.go",
     ],
+    race = "on",
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/virtctl/expose/BUILD.bazel
+++ b/pkg/virtctl/expose/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "expose_suite_test.go",
         "expose_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/virtctl/guestfs/BUILD.bazel
+++ b/pkg/virtctl/guestfs/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "guestfs_suite_test.go",
         "guestfs_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "imageupload_suite_test.go",
         "imageupload_test.go",
     ],
+    race = "on",
     tags = ["cov"],
     deps = [
         ":go_default_library",

--- a/pkg/virtctl/memorydump/BUILD.bazel
+++ b/pkg/virtctl/memorydump/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "memorydump_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/virtctl/testing:go_default_library",

--- a/pkg/virtctl/objectgraph/BUILD.bazel
+++ b/pkg/virtctl/objectgraph/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "objectgraph_suite_test.go",
         "objectgraph_test.go",
     ],
+    race = "on",
     deps = [
         "//pkg/pointer:go_default_library",
         "//pkg/virtctl/testing:go_default_library",

--- a/pkg/virtctl/pause/BUILD.bazel
+++ b/pkg/virtctl/pause/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "pause_suite_test.go",
         "pause_test.go",
     ],
+    race = "on",
     deps = [
         "//pkg/virtctl/testing:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virtctl/portforward/BUILD.bazel
+++ b/pkg/virtctl/portforward/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "ports_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virtctl/reset/BUILD.bazel
+++ b/pkg/virtctl/reset/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "reset_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virtctl/testing:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virtctl/scp/BUILD.bazel
+++ b/pkg/virtctl/scp/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "scp_suite_test.go",
         "scp_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virtctl/ssh:go_default_library",

--- a/pkg/virtctl/softreboot/BUILD.bazel
+++ b/pkg/virtctl/softreboot/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "softreboot_suite_test.go",
         "softreboot_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/virtctl/ssh/BUILD.bazel
+++ b/pkg/virtctl/ssh/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "ssh_suite_test.go",
         "ssh_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virtctl/templates/BUILD.bazel
+++ b/pkg/virtctl/templates/BUILD.bazel
@@ -16,5 +16,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["templates_suite_test.go"],
+    race = "on",
     deps = ["//staging/src/kubevirt.io/client-go/testutils:go_default_library"],
 )

--- a/pkg/virtctl/unpause/BUILD.bazel
+++ b/pkg/virtctl/unpause/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "unpause_suite_test.go",
         "unpause_test.go",
     ],
+    race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/virtctl/testing:go_default_library",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "user_list_test.go",
         "vm_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virtctl/vmexport/BUILD.bazel
+++ b/pkg/virtctl/vmexport/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "vmexport_suite_test.go",
         "vmexport_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virtctl/testing:go_default_library",

--- a/staging/src/kubevirt.io/api/apitesting/BUILD.bazel
+++ b/staging/src/kubevirt.io/api/apitesting/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "roundtrip_test.go",
     ],
     data = glob(["testdata/**"]),
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/apitesting/roundtrip:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/staging/src/kubevirt.io/client-go/api/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/api/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "v1_suite_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
@@ -134,6 +134,7 @@ go_test(
         "vmipreset_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "websocket_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//vendor/github.com/gorilla/websocket:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/staging/src/kubevirt.io/client-go/log/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/log/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "log_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/reporter:go_default_library",

--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "readiness_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/storage/types:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tools/cache/BUILD.bazel
+++ b/tools/cache/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "oneshot-cache_test.go",
         "time-defined-cache_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/tools/cache/time-defined-cache_test.go
+++ b/tools/cache/time-defined-cache_test.go
@@ -113,7 +113,7 @@ var _ = Describe("time defined cache", func() {
 	Context("keep value updated", func() {
 		It("should keep value updated if method is used", func() {
 			By("creating a cache with a refresh duration")
-			cache, err := virtcache.NewTimeDefinedCache(100*time.Millisecond, false, getMockCalcFunc())
+			cache, err := virtcache.NewTimeDefinedCache(100*time.Millisecond, true, getMockCalcFunc())
 			Expect(err).ToNot(HaveOccurred())
 
 			By("using the KeepValueUpdated() method")

--- a/tools/util/BUILD.bazel
+++ b/tools/util/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
     name = "go_default_test",
     srcs = ["marshaller_test.go"],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
/sig buildsystem

### What this PR does

This commit fixes race detection within the unit tests by explicitly
enabling the detector for each target. This replaces the use of the
now unsupported `--features race` command line argument [1].

The replacement command line argument of
`--@io_bazel_rules_go//go/config:race` is not used however as it
currently complains of `cgo` not being used when not explicitly enabled
by a target [2].

[1] https://github.com/bazel-contrib/rules_go/pull/2671
[2] https://github.com/bazel-contrib/rules_go/issues/3548

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

