### PR TITLE
tests: Refactor RegisterKubevirtConfigChange and remove patchWorkloadUpdateMethodAndRolloutRunStrategy

### DIFF
--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
-        "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",

--- a/tests/hotplug/instancetype.go
+++ b/tests/hotplug/instancetype.go
@@ -46,12 +46,15 @@ var _ = Describe("[sig-compute]Instance Type and Preference Hotplug", decorators
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		originalKv := libkubevirt.GetCurrentKv(virtClient)
 		updateStrategy := &virtv1.KubeVirtWorkloadUpdateStrategy{
 			WorkloadUpdateMethods: []virtv1.WorkloadUpdateMethod{virtv1.WorkloadUpdateMethodLiveMigrate},
 		}
 		rolloutStrategy := pointer.P(virtv1.VMRolloutStrategyLiveUpdate)
-		patchWorkloadUpdateMethodAndRolloutStrategy(originalKv.Name, virtClient, updateStrategy, rolloutStrategy)
+		err := config.RegisterKubevirtConfigChange(
+			config.WithWorkloadUpdateStrategy(updateStrategy),
+			config.WithVMRolloutStrategy(rolloutStrategy),
+		)
+		Expect(err).ToNot(HaveOccurred())
 
 		currentKv := libkubevirt.GetCurrentKv(virtClient)
 		config.WaitForConfigToBePropagatedToComponent(

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -39,12 +39,15 @@ var _ = Describe("[sig-compute]Memory Hotplug", decorators.SigCompute, decorator
 	)
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		originalKv := libkubevirt.GetCurrentKv(virtClient)
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{
 			WorkloadUpdateMethods: []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate},
 		}
 		rolloutStrategy := pointer.P(v1.VMRolloutStrategyLiveUpdate)
-		patchWorkloadUpdateMethodAndRolloutStrategy(originalKv.Name, virtClient, updateStrategy, rolloutStrategy)
+		err := config.RegisterKubevirtConfigChange(
+			config.WithWorkloadUpdateStrategy(updateStrategy),
+			config.WithVMRolloutStrategy(rolloutStrategy),
+		)
+		Expect(err).ToNot(HaveOccurred())
 
 		currentKv := libkubevirt.GetCurrentKv(virtClient)
 		config.WaitForConfigToBePropagatedToComponent(

--- a/tests/libkubevirt/config/kvconfig.go
+++ b/tests/libkubevirt/config/kvconfig.go
@@ -80,6 +80,18 @@ func RegisterKubevirtConfigChange(kvChangeOption ...KvChangeOption) error {
 	return err
 }
 
+func WithWorkloadUpdateStrategy(updateStrategy *v1.KubeVirtWorkloadUpdateStrategy) KvChangeOption {
+	return func(kv *v1.KubeVirt) *patch.PatchSet {
+		return patch.New(patch.WithReplace("/spec/workloadUpdateStrategy", updateStrategy))
+	}
+}
+
+func WithVMRolloutStrategy(rolloutStrategy *v1.VMRolloutStrategy) KvChangeOption {
+	return func(kv *v1.KubeVirt) *patch.PatchSet {
+		return patch.New(patch.WithReplace("/spec/configuration/vmRolloutStrategy", rolloutStrategy))
+	}
+}
+
 // UpdateKubeVirtConfigValueAndWait updates the given configuration in the kubevirt custom resource
 // and then waits  to allow the configuration events to be propagated to the consumers.
 func UpdateKubeVirtConfigValueAndWait(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {

--- a/tests/libkubevirt/config/kvconfig.go
+++ b/tests/libkubevirt/config/kvconfig.go
@@ -51,26 +51,32 @@ import (
 
 type compare func(string, string) bool
 
-func RegisterKubevirtConfigChange(change func(c v1.KubeVirtConfiguration) (*patch.PatchSet, error)) error {
+type KvChangeOption func(kv *v1.KubeVirt) *patch.PatchSet
+
+func RegisterKubevirtConfigChange(kvChangeOption ...KvChangeOption) error {
 	kv := libkubevirt.GetCurrentKv(kubevirt.Client())
-	patchSet, err := change(kv.Spec.Configuration)
-	if err != nil {
-		return fmt.Errorf("failed changing the kubevirt configuration: %v", err)
+	var patches []patch.PatchOperation
+
+	for _, c := range kvChangeOption {
+		patches = append(patches, c(kv).GetPatches()...)
 	}
 
-	if patchSet.IsEmpty() {
+	if len(patches) == 0 {
 		return nil
 	}
 
-	return patchKV(kv.Namespace, kv.Name, patchSet)
-}
-
-func patchKV(namespace, name string, patchSet *patch.PatchSet) error {
-	patchData, err := patchSet.GeneratePayload()
+	patchData, err := patch.GeneratePatchPayload(patches...)
 	if err != nil {
 		return err
 	}
-	_, err = kubevirt.Client().KubeVirt(namespace).Patch(context.Background(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+
+	_, err = kubevirt.Client().KubeVirt(kv.Namespace).Patch(
+		context.Background(),
+		kv.Name,
+		types.JSONPatchType,
+		patchData,
+		metav1.PatchOptions{},
+	)
 	return err
 }
 

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -51,10 +51,12 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			const passtBindingName = "passt"
 			passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
-			err := config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
-				SidecarImage:                passtSidecarImage,
-				NetworkAttachmentDefinition: passtNetAttDefName,
-			})
+			err := config.RegisterKubevirtConfigChange(
+				config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
+					SidecarImage:                passtSidecarImage,
+					NetworkAttachmentDefinition: passtNetAttDefName,
+				}),
+			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -108,7 +110,11 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 		})
 
 		BeforeEach(func() {
-			err := config.WithNetBindingPlugin(macvtapBindingName, v1.InterfaceBindingPlugin{DomainAttachmentType: v1.Tap})
+			err := config.RegisterKubevirtConfigChange(
+				config.WithNetBindingPlugin(macvtapBindingName, v1.InterfaceBindingPlugin{
+					DomainAttachmentType: v1.Tap,
+				}),
+			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -147,7 +153,11 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 		)
 
 		BeforeEach(func() {
-			err := config.WithNetBindingPlugin(bindingName, v1.InterfaceBindingPlugin{DomainAttachmentType: v1.ManagedTap})
+			err := config.RegisterKubevirtConfigChange(
+				config.WithNetBindingPlugin(bindingName, v1.InterfaceBindingPlugin{
+					DomainAttachmentType: v1.ManagedTap,
+				}),
+			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -54,9 +54,11 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 
 	BeforeEach(func() {
 		const macvtapBindingName = "macvtap"
-		err := config.WithNetBindingPlugin(macvtapBindingName, v1.InterfaceBindingPlugin{
-			DomainAttachmentType: v1.Tap,
-		})
+		err := config.RegisterKubevirtConfigChange(
+			config.WithNetBindingPlugin(macvtapBindingName, v1.InterfaceBindingPlugin{
+				DomainAttachmentType: v1.Tap,
+			}),
+		)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -66,16 +66,18 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding plugin"
 
 		passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
-		err := config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
-			SidecarImage:                passtSidecarImage,
-			NetworkAttachmentDefinition: passtNetAttDefName,
-			Migration:                   &v1.InterfaceBindingMigration{},
-			ComputeResourceOverhead: &v1.ResourceRequirementsWithoutClaims{
-				Requests: map[k8sv1.ResourceName]resource.Quantity{
-					k8sv1.ResourceMemory: passtComputeMemoryOverheadWhenAllPortsAreForwarded,
+		err := config.RegisterKubevirtConfigChange(
+			config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
+				SidecarImage:                passtSidecarImage,
+				NetworkAttachmentDefinition: passtNetAttDefName,
+				Migration:                   &v1.InterfaceBindingMigration{},
+				ComputeResourceOverhead: &v1.ResourceRequirementsWithoutClaims{
+					Requests: map[k8sv1.ResourceName]resource.Quantity{
+						k8sv1.ResourceMemory: passtComputeMemoryOverheadWhenAllPortsAreForwarded,
+					},
 				},
-			},
-		})
+			}),
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		config.EnableFeatureGate(featuregate.PasstIPStackMigration)

--- a/tests/network/bindingplugin_slirp.go
+++ b/tests/network/bindingplugin_slirp.go
@@ -55,9 +55,12 @@ var _ = Describe(SIG("Slirp", decorators.Networking, decorators.NetCustomBinding
 	BeforeEach(func() {
 		const slirpSidecarImage = "registry:5000/kubevirt/network-slirp-binding:devel"
 
-		Expect(config.WithNetBindingPlugin(slirpBindingName, v1.InterfaceBindingPlugin{
-			SidecarImage: slirpSidecarImage,
-		})).To(Succeed())
+		err := config.RegisterKubevirtConfigChange(
+			config.WithNetBindingPlugin(slirpBindingName, v1.InterfaceBindingPlugin{
+				SidecarImage: slirpSidecarImage,
+			}),
+		)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("VMI with SLIRP interface, custom mac and port is configured correctly", func() {

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -58,12 +58,15 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 	BeforeEach(func() {
 		virtClient := kubevirt.Client()
-		originalKv := libkubevirt.GetCurrentKv(virtClient)
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{
 			WorkloadUpdateMethods: []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate},
 		}
 		rolloutStrategy := pointer.P(v1.VMRolloutStrategyLiveUpdate)
-		patchWorkloadUpdateMethodAndRolloutStrategy(originalKv.Name, virtClient, updateStrategy, rolloutStrategy)
+		err := config.RegisterKubevirtConfigChange(
+			config.WithWorkloadUpdateStrategy(updateStrategy),
+			config.WithVMRolloutStrategy(rolloutStrategy),
+		)
+		Expect(err).ToNot(HaveOccurred())
 
 		currentKv := libkubevirt.GetCurrentKv(virtClient)
 		config.WaitForConfigToBePropagatedToComponent(

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -455,11 +455,13 @@ var istioTestsWithPasstBinding = func() {
 		const passtBindingName = "passt"
 		passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
-		err := config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
-			SidecarImage:                passtSidecarImage,
-			NetworkAttachmentDefinition: passtNetAttDefName,
-			Migration:                   &v1.InterfaceBindingMigration{},
-		})
+		err := config.RegisterKubevirtConfigChange(
+			config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
+				SidecarImage:                passtSidecarImage,
+				NetworkAttachmentDefinition: passtNetAttDefName,
+				Migration:                   &v1.InterfaceBindingMigration{},
+			}),
+		)
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
`patchWorkloadUpdateMethodAndRolloutStrategy` were a set of unexported helper functions with the same name and functionality that existed throughout several test categories. 

#### After this PR:
This PR refactors `RegisterKubevirtConfigChange` to use the builder pattern and replaces `patchWorkloadUpdateMethodAndRolloutStrategy` with corresponding builder options.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

