### PR TITLE
[Release-1.5] Handle freeze on paused VMs during snapshot

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -833,7 +833,9 @@ func updateSnapshotIndications(snapshot *snapshotv1.VirtualMachineSnapshot, sour
 		indications := sets.New(snapshot.Status.Indications...)
 		indications = sets.Insert(indications, snapshotv1.VMSnapshotOnlineSnapshotIndication)
 
-		if source.GuestAgent() {
+		if source.Paused() {
+			indications = sets.Insert(indications, snapshotv1.VMSnapshotPausedIndication)
+		} else if source.GuestAgent() {
 			indications = sets.Insert(indications, snapshotv1.VMSnapshotGuestAgentIndication)
 			snapErr := snapshot.Status.Error
 			if snapErr != nil && snapErr.Message != nil &&
@@ -843,6 +845,7 @@ func updateSnapshotIndications(snapshot *snapshotv1.VirtualMachineSnapshot, sour
 		} else {
 			indications = sets.Insert(indications, snapshotv1.VMSnapshotNoGuestAgentIndication)
 		}
+
 		snapshot.Status.Indications = sets.List(indications)
 	}
 }

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -1581,6 +1581,122 @@ var _ = Describe("Snapshot controlleer", func() {
 				Expect(*snapshotCreates).To(Equal(1))
 			})
 
+			It("should not freeze paused vm with guest agent and show Paused indication", func() {
+				storageClass := createStorageClass()
+				vmSnapshot := createVMSnapshotInProgress()
+				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
+				vmSnapshotContent := createVMSnapshotContent()
+				vmSnapshotContent.UID = contentUID
+				vm := createLockedVM()
+				vmSource.Add(vm)
+				vmSnapshotContentSource.Add(vmSnapshotContent)
+
+				vmi := createVMI(vm)
+				agentCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstanceAgentConnected,
+					LastProbeTime: metav1.Now(),
+					Status:        corev1.ConditionTrue,
+				}
+				pausedCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstancePaused,
+					LastProbeTime: metav1.Now(),
+					Status:        corev1.ConditionTrue,
+				}
+				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition, pausedCondition)
+				vmiSource.Add(vmi)
+
+				updatedContent := vmSnapshotContent.DeepCopy()
+				updatedContent.ResourceVersion = "1"
+				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					ReadyToUse: pointer.P(false),
+				}
+
+				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
+				for i := range volumeSnapshots {
+					vss := snapshotv1.VolumeSnapshotStatus{
+						VolumeSnapshotName: volumeSnapshots[i].Name,
+					}
+					updatedContent.Status.VolumeSnapshotStatus = append(updatedContent.Status.VolumeSnapshotStatus, vss)
+				}
+
+				storageClassSource.Add(storageClass)
+
+				// Paused VM should NOT be frozen
+				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClass.Name, vmSnapshotContent)
+				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
+				vmSnapshotSource.Add(vmSnapshot)
+				addVolumeSnapshotClass(volumeSnapshotClass)
+				controller.processVMSnapshotContentWorkItem()
+				testutils.ExpectEvent(recorder, "SuccessfulVolumeSnapshotCreate")
+				Expect(*updateStatusCalls).To(Equal(1))
+				Expect(*snapshotCreates).To(Equal(1))
+			})
+
+			DescribeTable("should set appropriate indications based on VM state",
+				func(vmiCondition *v1.VirtualMachineInstanceCondition, expectedIndications []snapshotv1.Indication) {
+					vm := createLockedVM()
+					vmSource.Add(vm)
+
+					vmi := createVMI(vm)
+					if vmiCondition != nil {
+						vmi.Status.Conditions = append(vmi.Status.Conditions, *vmiCondition)
+					}
+					vmiSource.Add(vmi)
+
+					vmSnapshot := createVMSnapshotInProgress()
+
+					vmSnapshotContent := createVMSnapshotContent()
+					vmSnapshotContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+						ReadyToUse: pointer.P(false),
+					}
+					vmSnapshotContentSource.Add(vmSnapshotContent)
+					addVirtualMachineSnapshot(vmSnapshot)
+
+					updatedSnapshot := vmSnapshot.DeepCopy()
+					updatedSnapshot.ResourceVersion = "1"
+					updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
+					updatedSnapshot.Status.Indications = expectedIndications
+					updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
+						newReadyCondition(corev1.ConditionFalse, "Not ready"),
+					}
+
+					updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
+
+					controller.processVMSnapshotWorkItem()
+					Expect(*updateStatusCalls).To(Equal(1))
+				},
+				Entry("paused VM without guest agent",
+					&v1.VirtualMachineInstanceCondition{
+						Type:          v1.VirtualMachineInstancePaused,
+						LastProbeTime: metav1.Now(),
+						Status:        corev1.ConditionTrue,
+					},
+					[]snapshotv1.Indication{
+						snapshotv1.VMSnapshotOnlineSnapshotIndication,
+						snapshotv1.VMSnapshotPausedIndication,
+					},
+				),
+				Entry("non-paused VM with guest agent",
+					&v1.VirtualMachineInstanceCondition{
+						Type:          v1.VirtualMachineInstanceAgentConnected,
+						LastProbeTime: metav1.Now(),
+						Status:        corev1.ConditionTrue,
+					},
+					[]snapshotv1.Indication{
+						snapshotv1.VMSnapshotGuestAgentIndication,
+						snapshotv1.VMSnapshotOnlineSnapshotIndication,
+					},
+				),
+				Entry("non-paused VM without guest agent",
+					nil,
+					[]snapshotv1.Indication{
+						snapshotv1.VMSnapshotNoGuestAgentIndication,
+						snapshotv1.VMSnapshotOnlineSnapshotIndication,
+					},
+				),
+			)
+
 			DescribeTable("should update VirtualMachineSnapshotContent", func(readyToUse bool) {
 				vmSnapshot := createVMSnapshotInProgress()
 				vmSnapshotContent := createVMSnapshotContent()
@@ -2456,6 +2572,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			)
 		})
 	})
+
 })
 
 func applyPatch(patch []byte, orig, patched interface{}) error {

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -69,6 +69,7 @@ type snapshotSource interface {
 	Lock() (bool, error)
 	Unlock() (bool, error)
 	Online() bool
+	Paused() bool
 	GuestAgent() bool
 	Frozen() bool
 	Freeze() error
@@ -79,6 +80,7 @@ type snapshotSource interface {
 
 type sourceState struct {
 	online     bool
+	paused     bool
 	guestAgent bool
 	frozen     bool
 	locked     bool
@@ -101,6 +103,7 @@ func (s *vmSnapshotSource) UpdateSourceState() error {
 	online := exists
 
 	condManager := controller.NewVirtualMachineInstanceConditionManager()
+	paused := exists && condManager.HasConditionWithStatus(vmi, kubevirtv1.VirtualMachineInstancePaused, corev1.ConditionTrue)
 	guestAgent := exists && condManager.HasCondition(vmi, kubevirtv1.VirtualMachineInstanceAgentConnected)
 
 	locked := s.vm.Status.SnapshotInProgress != nil &&
@@ -114,6 +117,7 @@ func (s *vmSnapshotSource) UpdateSourceState() error {
 
 	s.state = &sourceState{
 		online:     online,
+		paused:     paused,
 		guestAgent: guestAgent,
 		locked:     locked,
 		frozen:     frozen,
@@ -412,6 +416,10 @@ func (s *vmSnapshotSource) Online() bool {
 	return s.state.online
 }
 
+func (s *vmSnapshotSource) Paused() bool {
+	return s.state.paused
+}
+
 func (s *vmSnapshotSource) GuestAgent() bool {
 	return s.state.guestAgent
 }
@@ -425,6 +433,11 @@ func (s *vmSnapshotSource) Freeze() error {
 		return fmt.Errorf("attempting to freeze unlocked VM")
 	}
 	if s.Frozen() {
+		return nil
+	}
+
+	if s.Paused() {
+		log.Log.Warningf("VM %s is paused - taking snapshot without filesystem freeze. Paused VMs cannot flush memory buffers to disk, which may result in inconsistent snapshots.", s.vm.Name)
 		return nil
 	}
 
@@ -451,7 +464,7 @@ func (s *vmSnapshotSource) Freeze() error {
 }
 
 func (s *vmSnapshotSource) Unfreeze() error {
-	if !s.Locked() || !s.GuestAgent() {
+	if !s.Locked() || !s.GuestAgent() || s.Paused() {
 		return nil
 	}
 

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -62,6 +62,7 @@ import (
 const (
 	unmarshalRequestErrFmt                   = "Can not unmarshal Request body to struct, error: %s"
 	vmNotRunning                             = "VM is not running"
+	vmSnapshotInprogress                     = "VM snapshot is in progress"
 	patchingVMFmt                            = "Patching VM: %s"
 	jsonpatchTestErr                         = "jsonpatch test operation does not apply"
 	patchingVMStatusFmt                      = "Patching VM status: %s"
@@ -756,6 +757,24 @@ func (app *SubresourceAPIApp) PauseVMIRequestHandler(request *restful.Request, r
 }
 
 func (app *SubresourceAPIApp) UnpauseVMIRequestHandler(request *restful.Request, response *restful.Response) {
+
+	name := request.PathParameter("name")
+	namespace := request.PathParameter("namespace")
+
+	// Check VM status - only continue if VM doesn't exist or if it exists without snapshot in progress
+	vm, err := app.fetchVirtualMachine(name, namespace)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			writeError(err, response)
+			return
+		}
+	} else {
+		// VM exists - check if snapshot is in progress
+		if vm.Status.SnapshotInProgress != nil {
+			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(vmSnapshotInprogress)), response)
+			return
+		}
+	}
 
 	validate := func(vmi *v1.VirtualMachineInstance) *errors.StatusError {
 		if vmi.Status.Phase != v1.Running {

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -82,6 +82,7 @@ const (
 	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
 	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
 	VMSnapshotQuiesceFailedIndication  Indication = "QuiesceFailed"
+	VMSnapshotPausedIndication         Indication = "Paused"
 )
 
 // VirtualMachineSnapshotPhase is the current phase of the VirtualMachineSnapshot

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -563,6 +563,52 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}, 30*time.Second, 2*time.Second).Should(BeEmpty())
 			})
 
+			It("[test_id:12182] should succeed snapshot when VM is paused with Paused indication", func() {
+				dvName := "dv-" + rand.String(5)
+				quantity := resource.MustParse("1Gi")
+
+				opts := []libvmi.Option{
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					libvmi.WithDataVolume("blank", dvName),
+				}
+
+				vmi := libvmifact.NewFedora(opts...)
+				vm = libvmi.NewVirtualMachine(vmi)
+
+				dataVolume := libdv.NewDataVolume(
+					libdv.WithName(dvName),
+					libdv.WithBlankImageSource(),
+					libdv.WithStorage(
+						libdv.StorageWithStorageClass(snapshotStorageClass),
+						libdv.StorageWithVolumeSize(quantity.String()),
+					),
+				)
+				libstorage.AddDataVolumeTemplate(vm, dataVolume)
+
+				vm, vmi = createAndStartVM(vm)
+				libwait.WaitForSuccessfulVMIStart(vmi, libwait.WithTimeout(300))
+
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Pausing the VirtualMachineInstance")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})).To(Succeed())
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
+
+				By("Taking the snapshot")
+				snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
+				_, err := virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
+
+				By("Verifying snapshot has Paused indication")
+				expectedIndications := []snapshotv1.Indication{snapshotv1.VMSnapshotOnlineSnapshotIndication, snapshotv1.VMSnapshotPausedIndication}
+				Expect(snapshot.Status.Indications).To(ContainElements(expectedIndications))
+
+				contentName := *snapshot.Status.VirtualMachineSnapshotContentName
+				checkOnlineSnapshotExpectedContentSource(vm, contentName, true)
+			})
+
 			It("[test_id:7472]should succeed online snapshot with hot plug disk", func() {
 				var vmi *v1.VirtualMachineInstance
 				vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)


### PR DESCRIPTION
Manual backport of #15001

Automated backport failed due to missing `pkg/virt-api/rest/lifecycle.go` file as some of changed functions were still under `pkg/virt-api/rest/subresource.go`.

VM snapshot with qemu-guest-agent fails when the domain is paused, because virt-controller sends a freeze/unfreeze request during snapshotting. This freeze/unfreeze is handled by virt-launcher, but it currently fails on paused VMs. Since paused VMs have a consistent filesystem state (similar to frozen), this change makes virt-launcher treat freeze as successful when the domain is paused. This allows snapshotting to continue safely.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

- VM snapshot with qemu-guest-agent fails when the domain is paused. This happens since the snapshot flow trigger a freeze but since the VM is paused, freeze fails causing snapshot flow to also fail. since a Paused VM is considered a safe state to perform a snapshot, we expect it to pass when the VM is paused, but it doesnt.
- it is possible to unpause a VM during snapshot, which is not desired.
- a false warning message is being printed saying it is not safe to snapshot a running VM (without qemu-guest-agent) even though the VM is paused.
- virt-launcher's agent poller is spamming qemu-gest-agent command failures when VM is paused.

#### After this PR:

- Possible to complete a VM (with qemu-guest-agent) snapshot successfully even if the VM is paused.
- Make sure unpause will be rejected if `vm.Status.SnapshotInProgress` is not nil.
- prevent a warning message from being printed for when snapshot is being taken while VM (without qemu-guest-agent)  is still running even though the VM is paused.
- virt-launcher's agent poller skips qemu-guest-agent commands if the VM is paused.

### References
Fixes #10759

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
@ShellyKa13
@codingben (check out the change for agent_poller.go)
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: Enable vmsnapshot for paused VMs
```

