### PR TITLE
WIP/DNM virt-launcher: Fix hot plug PCI port generation

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -650,7 +650,7 @@ type HostDeviceSource struct {
 // Controller represens libvirt controller element https://libvirt.org/formatdomain.html#elementsControllers
 type Controller struct {
 	Type      string            `xml:"type,attr"`
-	Index     string            `xml:"index,attr"`
+	Index     string            `xml:"index,attr,omitempty"`
 	Model     string            `xml:"model,attr,omitempty"`
 	Driver    *ControllerDriver `xml:"driver,omitempty"`
 	Alias     *Alias            `xml:"alias,omitempty"`

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -443,7 +443,7 @@ var _ = Describe("Manager", func() {
 		addPlaceHolderInterfaces := func(vmi *v1.VirtualMachineInstance, domainSpec *api.DomainSpec) *api.DomainSpec {
 			count, err := calculateHotplugPortCount(vmi, domainSpec)
 			Expect(err).ToNot(HaveOccurred())
-			return appendPlaceholderInterfacesToTheDomain(vmi, domainSpec, count)
+			return appendHotPlugPorts(domainSpec, count)
 		}
 
 		setDomainExpectations := func(vmi *v1.VirtualMachineInstance) {


### PR DESCRIPTION
### What this PR does

#### Before this PR:

```
$ virtctl create vm --name foo \
  --instancetype u1.medium \
  --preference windows.2k16 \
  --volume-containerdisk name:fedora,src:quay.io/containerdisks/fedora:latest | kubectl apply -f -
```

Prior to v1.6.0

```
$ lspci -t -v
-[0000:00]-+-00.0  Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
           +-01.0  Device 1234:1111
           +-02.0-[01]----00.0  Intel Corporation 82574L Gigabit Network Connection
           +-02.1-[02]--
           +-02.2-[03]--
           +-02.3-[04]--
           +-02.4-[05]----00.0  Red Hat, Inc. QEMU XHCI Host Controller
           +-02.5-[06]----00.0  Red Hat, Inc. Virtio 1.0 SCSI
           +-02.6-[07]----00.0  Red Hat, Inc. Virtio 1.0 console
           +-02.7-[08]----00.0  Red Hat, Inc. Virtio 1.0 balloon
           +-03.0-[09]--
           +-1f.0  Intel Corporation 82801IB (ICH9) LPC Interface Controller
           +-1f.2  Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
           \-1f.3  Intel Corporation 82801I (ICH9 Family) SMBus Controller
```

After v1.6.0 and https://github.com/kubevirt/kubevirt/pull/14754

```
$ lspci -t -v
-[0000:00]-+-00.0  Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
           +-01.0  Device 1234:1111
           +-02.0-[01]----00.0  Intel Corporation 82574L Gigabit Network Connection
           +-02.1-[02]--
           +-02.2-[03]--
           +-02.3-[04]--
           +-02.4-[05]--
           +-02.5-[06]--
           +-02.6-[07]--
           +-02.7-[08]--
           +-03.0-[09]--
           +-03.1-[0a]--
           +-03.2-[0b]--
           +-03.3-[0c]--
           +-03.4-[0d]----00.0  Red Hat, Inc. QEMU XHCI Host Controller
           +-03.5-[0e]----00.0  Red Hat, Inc. Virtio 1.0 SCSI
           +-03.6-[0f]----00.0  Red Hat, Inc. Virtio 1.0 console
           +-03.7-[10]----00.0  Red Hat, Inc. Virtio 1.0 balloon
           +-04.0-[11]--
           +-1f.0  Intel Corporation 82801IB (ICH9) LPC Interface Controller
           +-1f.2  Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
           \-1f.3  Intel Corporation 82801I (ICH9 Family) SMBus Controller
```

#### After this PR:

```
$ lspci -t -v
-[0000:00]-+-00.0  Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
           +-01.0  Device 1234:1111
           +-02.0-[01]----00.0  Intel Corporation 82574L Gigabit Network Connection
           +-02.1-[02]----00.0  Red Hat, Inc. QEMU XHCI Host Controller
           +-02.2-[03]----00.0  Red Hat, Inc. Virtio 1.0 SCSI
           +-02.3-[04]----00.0  Red Hat, Inc. Virtio 1.0 console
           +-02.4-[05]----00.0  Red Hat, Inc. Virtio 1.0 balloon
           +-02.5-[06]--
           +-02.6-[07]--
           +-02.7-[08]--
           +-03.0-[09]--
           +-03.1-[0a]--
           +-03.2-[0b]--
           +-1f.0  Intel Corporation 82801IB (ICH9) LPC Interface Controller
           +-1f.2  Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
           \-1f.3  Intel Corporation 82801I (ICH9 Family) SMBus Controller
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

