### PR TITLE
[release-1.5] Adjust go version staging

### DIFF
--- a/staging/src/kubevirt.io/api/go.mod
+++ b/staging/src/kubevirt.io/api/go.mod
@@ -1,8 +1,6 @@
 module kubevirt.io/api
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/staging/src/kubevirt.io/client-go/go.mod
+++ b/staging/src/kubevirt.io/client-go/go.mod
@@ -1,8 +1,6 @@
 module kubevirt.io/client-go
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.0
 
 require (
 	github.com/go-kit/kit v0.13.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1232,7 +1232,7 @@ k8s.io/utils/ptr
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # kubevirt.io/api v0.0.0-00010101000000-000000000000 => ./staging/src/kubevirt.io/api
-## explicit; go 1.22.0
+## explicit; go 1.23.0
 kubevirt.io/api/clone
 kubevirt.io/api/clone/v1alpha1
 kubevirt.io/api/clone/v1beta1
@@ -1253,7 +1253,7 @@ kubevirt.io/api/snapshot
 kubevirt.io/api/snapshot/v1alpha1
 kubevirt.io/api/snapshot/v1beta1
 # kubevirt.io/client-go v0.0.0-00010101000000-000000000000 => ./staging/src/kubevirt.io/client-go
-## explicit; go 1.22.0
+## explicit; go 1.23.0
 kubevirt.io/client-go/api
 kubevirt.io/client-go/containerizeddataimporter
 kubevirt.io/client-go/containerizeddataimporter/fake


### PR DESCRIPTION
The golang version in
staging/src/kubevirt.io/api
and
staging/src/kubevirt.io/client-go
is adjusted to the golang version of the root directory. This enables bumping the golang library dependencies in these two directories in kubevirt 1.5 to newer versions depending on a newer golang version.

### What this PR does
#### Before this PR:
staging/src/kubevirt.io/api
and
staging/src/kubevirt.io/client-go
using go 1.22.0

#### After this PR:
staging/src/kubevirt.io/api
and
staging/src/kubevirt.io/client-go
using go 1.23.0
like the root of the project


### References

https://groups.google.com/g/kubevirt-dev/c/yYRcbI_3ViE


### Why we need it and why it was done in this way
The following tradeoffs were made:

- This change might break backward compatibility.


The following alternatives were considered:

Not bumping the golang version would block PRs like https://github.com/kubevirt/kubevirt/pull/15572 and https://github.com/kubevirt/kubevirt/pull/15571 in kubevirt 1.5 .


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Release note

```release-note
bumping to go 1.23.0 in staging/src/kubevirt.io/client-go and staging/src/kubevirt.io/api
```

