### PR TITLE
code quality: instancetype stub rename

### DIFF
--- a/pkg/instancetype/controller/vm/BUILD.bazel
+++ b/pkg/instancetype/controller/vm/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "controller.go",
-        "mock.go",
+        "stub.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/instancetype/controller/vm",
     visibility = ["//visibility:public"],

--- a/pkg/instancetype/controller/vm/stub.go
+++ b/pkg/instancetype/controller/vm/stub.go
@@ -22,15 +22,15 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 )
 
-type mockController struct {
+type controllerStub struct {
 	syncFunc                       func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, error)
 	applyToVMFunc                  func(*virtv1.VirtualMachine) error
 	applyToVMIFunc                 func(*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) error
 	applyAutoAttachPreferencesFunc func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error
 }
 
-func NewMockController() *mockController {
-	return &mockController{
+func NewControllerStub() *controllerStub {
+	return &controllerStub{
 		syncFunc: func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, error) {
 			return vm, nil
 		},
@@ -46,18 +46,18 @@ func NewMockController() *mockController {
 	}
 }
 
-func (m *mockController) ApplyToVM(vm *virtv1.VirtualMachine) error {
+func (m *controllerStub) ApplyToVM(vm *virtv1.VirtualMachine) error {
 	return m.applyToVMFunc(vm)
 }
 
-func (m *mockController) ApplyToVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
+func (m *controllerStub) ApplyToVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
 	return m.applyToVMIFunc(vm, vmi)
 }
 
-func (m *mockController) Sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, error) {
+func (m *controllerStub) Sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, error) {
 	return m.syncFunc(vm, vmi)
 }
 
-func (m *mockController) ApplyAutoAttachPreferences(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
+func (m *controllerStub) ApplyAutoAttachPreferences(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
 	return m.applyAutoAttachPreferencesFunc(vm, vmi)
 }

--- a/pkg/instancetype/webhooks/vm/BUILD.bazel
+++ b/pkg/instancetype/webhooks/vm/BUILD.bazel
@@ -4,8 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "admitter.go",
-        "mock.go",
         "mutator.go",
+        "stub.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/instancetype/webhooks/vm",
     visibility = ["//visibility:public"],

--- a/pkg/instancetype/webhooks/vm/stub.go
+++ b/pkg/instancetype/webhooks/vm/stub.go
@@ -26,7 +26,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 )
 
-type MockAdmitter struct {
+type admitterStub struct {
 	ApplyToVMFunc func(*virtv1.VirtualMachine) (
 		*v1beta1.VirtualMachineInstancetypeSpec,
 		*v1beta1.VirtualMachinePreferenceSpec,
@@ -38,8 +38,8 @@ type MockAdmitter struct {
 	) (conflict.Conflicts, error)
 }
 
-func NewMockAdmitter() *MockAdmitter {
-	return &MockAdmitter{
+func NewAdmitterStub() *admitterStub {
+	return &admitterStub{
 		ApplyToVMFunc: func(*virtv1.VirtualMachine) (
 			*v1beta1.VirtualMachineInstancetypeSpec,
 			*v1beta1.VirtualMachinePreferenceSpec,
@@ -56,7 +56,7 @@ func NewMockAdmitter() *MockAdmitter {
 	}
 }
 
-func (m *MockAdmitter) ApplyToVM(vm *virtv1.VirtualMachine) (
+func (m *admitterStub) ApplyToVM(vm *virtv1.VirtualMachine) (
 	*v1beta1.VirtualMachineInstancetypeSpec,
 	*v1beta1.VirtualMachinePreferenceSpec,
 	[]metav1.StatusCause,
@@ -64,7 +64,7 @@ func (m *MockAdmitter) ApplyToVM(vm *virtv1.VirtualMachine) (
 	return m.ApplyToVMFunc(vm)
 }
 
-func (m *MockAdmitter) Check(
+func (m *admitterStub) Check(
 	instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec,
 	preferenceSpec *v1beta1.VirtualMachinePreferenceSpec,
 	vmiSpec *virtv1.VirtualMachineInstanceSpec,

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -104,7 +104,7 @@ func FuzzAdmitter(f *testing.F) {
 				adm := &admitters.VMsAdmitter{
 					ClusterConfig:           config,
 					KubeVirtServiceAccounts: kubeVirtServiceAccounts,
-					InstancetypeAdmitter:    instancetypeWebhooks.NewMockAdmitter(),
+					InstancetypeAdmitter:    instancetypeWebhooks.NewAdmitterStub(),
 				}
 				return adm.Admit(context.Background(), request)
 			},
@@ -118,7 +118,7 @@ func FuzzAdmitter(f *testing.F) {
 				adm := &admitters.VMsAdmitter{
 					ClusterConfig:           config,
 					KubeVirtServiceAccounts: kubeVirtServiceAccounts,
-					InstancetypeAdmitter:    instancetypeWebhooks.NewMockAdmitter(),
+					InstancetypeAdmitter:    instancetypeWebhooks.NewAdmitterStub(),
 				}
 				return adm.Admit(context.Background(), request)
 			},

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Validating VM Admitter", func() {
 			DataSourceInformer:      dataSourceInformer,
 			NamespaceInformer:       namespaceInformer,
 			ClusterConfig:           config,
-			InstancetypeAdmitter:    instancetypeWebhooks.NewMockAdmitter(),
+			InstancetypeAdmitter:    instancetypeWebhooks.NewAdmitterStub(),
 			KubeVirtServiceAccounts: webhooks.KubeVirtServiceAccounts(kubeVirtNamespace),
 		}
 		virtClient.EXPECT().AuthorizationV1().Return(k8sClient.AuthorizationV1()).AnyTimes()

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Application", func() {
 			config,
 			nil,
 			nil,
-			instancetypecontroller.NewMockController(),
+			instancetypecontroller.NewControllerStub(),
 		)
 		app.migrationController, _ = migration.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -148,7 +148,7 @@ var _ = Describe("VirtualMachine", func() {
 				config,
 				nil,
 				nil,
-				instancetypecontroller.NewMockController(),
+				instancetypecontroller.NewControllerStub(),
 			)
 
 			// Wrap our workqueue to have a way to detect when we are done processing updates


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
After [discussion](https://github.com/kubevirt/kubevirt/issues/14475), we decided to have these renamed to stubs as they are not mocks. mockgen is not currently necessary.
### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

