### PR TITLE
chore: introduce INVOKE_FUNCTEST_ONCE

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -20,11 +20,14 @@ set -euo pipefail
 
 # According to https://dl.acm.org/doi/abs/10.1145/3476105
 #
-# * almost all flaky tests were independent of the execution platform, so environmental issues should be considered with higher priority
+# * almost all flaky tests were independent of the execution platform,
+#   so environmental issues should be considered with higher priority
 # * devs may be unaware of many flakes due to order-dependent tests
-# * simple techniques of reversing or shuffling the test order may be more efficient and effective than more sophisticated approaches
-# * “One study found that 88% of flaky tests were found to consecutively fail up to a maximum of five times before passing,
-#    though another reported finding new flaky tests even after 10,000 test suite runs.”
+# * simple techniques of reversing or shuffling the test order may be more
+#   efficient and effective than more sophisticated approaches
+# * "One study found that 88% of flaky tests were found to consecutively fail
+#    up to a maximum of five times before passing, though another reported
+#    finding new flaky tests even after 10,000 test suite runs."
 #
 # Therefore we by default
 # * use only latest kubevirtci provider,
@@ -48,14 +51,15 @@ function usage() {
     cat <<EOF
 usage: [NUM_TESTS=x] \
        [NEW_TESTS=file_name.json] \
-       [TARGET_COMMIT_RANGE=a1b2c3d4] $0 [TEST_LANE] [--dry-run]
+       [TARGET_COMMIT_RANGE=a1b2c3d4..e5f60718] $0 [TEST_LANE] [--dry-run]
 
     run set of tests repeatedly using a json file containing the names of the tests that have been
     changed or added since last merge commit
     hint: set NEW_TESTS to explicitly name the json file containing test names to run
 
     options:
-        CANNIER_IMAGE       the container image to use to execute cannier command
+        CANNIER_IMAGE       the container image to use to execute cannier
+                            command
         NUM_TESTS           how many times the test lane is run, default is 5
         NEW_TESTS           the json file containing the (textual) names of the
                             tests to run, according to what is shown in the
@@ -104,7 +108,7 @@ function new_tests() {
         -v "${KUBEVIRT_ROOT}:/kubevirt/" \
         -v "${tmp_dir}:/tmp" \
         "${CANNIER_IMAGE}" \
-        extract changed-tests ${target_commit_range} \
+        extract changed-tests "${target_commit_range}" \
         -p /kubevirt \
         -t /kubevirt/tests/ \
         -o /tmp/changed-tests.json
@@ -220,9 +224,9 @@ add_to_label_filter() {
     local label=$1
     local separator=$2
     if [[ -z $label_filter ]]; then
-        label_filter="${1}"
+        label_filter="${label}"
     else
-        label_filter="${label_filter}${separator}${1}"
+        label_filter="${label_filter}${separator}${label}"
     fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

We were suspecting that running a binary repeatedly causes noticeable
overhead on running a (sub)set of tests in a repeated manner to detect
flakiness in test cases.

Side note:
Some docs were missing proper formatting.

#### After this PR:

This change adds a flag that runs the test binary only once,
instead leveraging the `--repeat` flag provided by ginkgo v2 that will
cause the selected subset of tests to be run a number of times.

Measurements have given evidence that the average overhead of running
the test binary repeatedly is around 20% overall. The overhead seems to
increase when the number of tests is increased, although the increase
doesn't seem to be linear.

| run\_functest\_once | num\_tests | runtime | reduct. | red. % | command                                                                                                     | Tests changed |
| :-----------------: | :--------: | :-----: | :-----: | :----: | :---------------------------------------------------------------------------------------------------------: | :-----------: |
| FALSE               | 2          | 0:13:20 |         |        | NUM\_TESTS=2 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh                              | 1             |
| TRUE                | 2          | 0:10:56 | 0:02:25 | 18.08% | RUN\_FUNCTEST\_ONCE='true' NUM\_TESTS=2 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh   | 1             |
| FALSE               | 5          | 0:18:31 |         |        | RUN\_FUNCTEST\_ONCE='false' NUM\_TESTS=5 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh  | 1             |
| TRUE                | 5          | 0:13:39 | 0:04:52 | 26.28% | RUN\_FUNCTEST\_ONCE='true' NUM\_TESTS=5 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh   | 1             |
| FALSE               | 10         | 0:29:26 |         |        | RUN\_FUNCTEST\_ONCE='false' NUM\_TESTS=10 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh | 1             |
| TRUE                | 10         | 0:22:10 | 0:07:16 | 24.69% | RUN\_FUNCTEST\_ONCE='true' NUM\_TESTS=10 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh  | 1             |
| FALSE               | 50         | 1:50:40 |         |        | RUN\_FUNCTEST\_ONCE='false' NUM\_TESTS=50 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh | 1             |
| TRUE                | 50         | 1:14:02 | 0:36:38 | 33.10% | RUN\_FUNCTEST\_ONCE='true' NUM\_TESTS=50 TARGET\_COMMIT\_RANGE=3359e42dad.. ./automation/repeated\_test.sh  | 1             |

Also some cleanup and formatting was performed.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

