### PR TITLE
bazel: Remove use of deprecated --host_javabase no-op option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,19 +12,19 @@ test:x86_64 --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo
 
 build:aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo
 run:aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo
-test:aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo --host_javabase=@local_jdk//:jdk
+test:aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo
 
 build:s390x --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo
 run:s390x --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo
-test:s390x --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo --host_javabase=@local_jdk//:jdk
+test:s390x --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo
 
 build:crossbuild-aarch64 --incompatible_enable_cc_toolchain_resolution --platforms=//bazel/platforms:aarch64-none-linux-gnu --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo
 run:crossbuild-aarch64  --incompatible_enable_cc_toolchain_resolution --platforms=//bazel/platforms:aarch64-none-linux-gnu --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo
-test:crossbuild-aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo --host_javabase=@local_jdk//:jdk
+test:crossbuild-aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo
 
 build:crossbuild-s390x --incompatible_enable_cc_toolchain_resolution --platforms=//bazel/platforms:s390x-none-linux-gnu --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo
 run:crossbuild-s390x  --incompatible_enable_cc_toolchain_resolution --platforms=//bazel/platforms:s390x-none-linux-gnu --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo
-test:crossbuild-s390x --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo --host_javabase=@local_jdk//:jdk
+test:crossbuild-s390x --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo
 
 build --define gotags=selinux
 


### PR DESCRIPTION
### What this PR does
Handles the following warning:

WARNING: Option 'host_javabase' is deprecated

https://bazel.build/docs/user-manual#host-javabase

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

