### PR TITLE
Object Graph: Include NADs and ServiceAccounts

### DIFF
--- a/pkg/virt-api/rest/objectgraph.go
+++ b/pkg/virt-api/rest/objectgraph.go
@@ -100,9 +100,9 @@ func getResourceDependencyType(resource string) DependencyType {
 	case "pods", "virtualmachines", "virtualmachineinstances":
 		return DependencyTypeCompute
 	case "configmaps", "secrets", "virtualmachineinstancetypes", "virtualmachineclusterinstancetypes",
-		"virtualmachinepreferences", "virtualmachineclusterpreferences", "controllerrevisions":
+		"virtualmachinepreferences", "virtualmachineclusterpreferences", "controllerrevisions", "serviceaccounts":
 		return DependencyTypeConfig
-	case "serviceaccounts", "networkattachmentdefinitions":
+	case "networkattachmentdefinitions":
 		return DependencyTypeNetwork
 	default:
 		return DependencyTypeCompute
@@ -344,6 +344,11 @@ func (og *ObjectGraph) addVolumeGraph(obj any, namespace string) ([]v1.ObjectGra
 			}
 		case volume.Secret != nil:
 			node := og.newGraphNode(volume.Secret.SecretName, namespace, "secrets", nil, false)
+			if node != nil {
+				nodes = append(nodes, *node)
+			}
+		case volume.ServiceAccount != nil:
+			node := og.newGraphNode(volume.ServiceAccount.ServiceAccountName, namespace, "serviceaccounts", nil, false)
 			if node != nil {
 				nodes = append(nodes, *node)
 			}

--- a/pkg/virt-api/rest/objectgraph_test.go
+++ b/pkg/virt-api/rest/objectgraph_test.go
@@ -255,6 +255,14 @@ var _ = Describe("Object Graph", func() {
 										},
 									},
 								},
+								{
+									Name: "serviceAccount",
+									VolumeSource: v1.VolumeSource{
+										ServiceAccount: &v1.ServiceAccountVolumeSource{
+											ServiceAccountName: "test-serviceAccount",
+										},
+									},
+								},
 							},
 							Networks: []v1.Network{
 								{
@@ -291,7 +299,7 @@ var _ = Describe("Object Graph", func() {
 			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(graphNodes.Children).To(HaveLen(4))
+			Expect(graphNodes.Children).To(HaveLen(5))
 			Expect(graphNodes.ObjectReference.Name).To(Equal("test-vm"))
 			Expect(graphNodes.Children[0].ObjectReference.Name).To(Equal("test-vm"))
 			// Child nodes of the VMI
@@ -302,6 +310,8 @@ var _ = Describe("Object Graph", func() {
 			Expect(graphNodes.Children[2].ObjectReference.Name).To(Equal("test-root-disk-pvc"))
 			Expect(graphNodes.Children[3].ObjectReference.Name).To(Equal("test-datavolume"))
 			Expect(graphNodes.Children[3].ObjectReference.Kind).To(Equal("DataVolume"))
+			Expect(graphNodes.Children[4].ObjectReference.Name).To(Equal("test-serviceAccount"))
+			Expect(graphNodes.Children[4].ObjectReference.Kind).To(Equal("ServiceAccount"))
 			// Child nodes of the DV
 			Expect(graphNodes.Children[3].Children).To(HaveLen(1))
 			Expect(graphNodes.Children[3].Children[0].ObjectReference.Name).To(Equal("test-datavolume"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR updates the Object Graph to include the following resources:
- NetworkAttachmentDefinitions, as agreed in prior discussions. 
- ServiceAccounts, which were previously unintentionally omitted.

A follow-up POC PR will be later implemented to include a generic resource inclusion mechanism for external dependencies such as IPAMClaims.

### References
- Fixes: https://issues.redhat.com/browse/CNV-64186
 
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Object Graph: Include NADs and ServiceAccounts
```

