### PR TITLE
virt-launcher, network setup: Minor cleanup

### DIFF
--- a/pkg/network/dhcp/bridge.go
+++ b/pkg/network/dhcp/bridge.go
@@ -36,14 +36,14 @@ type BridgeConfigGenerator struct {
 	handler          netdriver.NetworkHandler
 	podInterfaceName string
 	cacheCreator     cacheCreator
-	launcherPID      string
 	vmiSpecIfaces    []v1.Interface
 	vmiSpecIface     *v1.Interface
 	subdomain        string
 }
 
 func (d *BridgeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
-	dhcpConfig, err := cache.ReadDHCPInterfaceCache(d.cacheCreator, d.launcherPID, d.podInterfaceName)
+	const launcherPID = "self"
+	dhcpConfig, err := cache.ReadDHCPInterfaceCache(d.cacheCreator, launcherPID, d.podInterfaceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/dhcp/bridge_test.go
+++ b/pkg/network/dhcp/bridge_test.go
@@ -73,7 +73,6 @@ var _ = Describe("Bridge DHCP configurator", func() {
 			iface := v1.Interface{Name: "network"}
 			generator = BridgeConfigGenerator{
 				cacheCreator:     &cacheCreator,
-				launcherPID:      launcherPID,
 				podInterfaceName: ifaceName,
 				vmiSpecIfaces:    []v1.Interface{iface},
 				vmiSpecIface:     &iface,
@@ -104,7 +103,6 @@ var _ = Describe("Bridge DHCP configurator", func() {
 
 			generator = BridgeConfigGenerator{
 				cacheCreator:     &cacheCreator,
-				launcherPID:      launcherPID,
 				podInterfaceName: ifaceName,
 				subdomain:        subdomain,
 			}

--- a/pkg/network/dhcp/configurator.go
+++ b/pkg/network/dhcp/configurator.go
@@ -53,7 +53,7 @@ type ConfigGenerator interface {
 	Generate() (*cache.DHCPConfig, error)
 }
 
-func NewBridgeConfigurator(cacheCreator cacheCreator, launcherPID string, advertisingIfaceName string, handler netdriver.NetworkHandler, podInterfaceName string,
+func NewBridgeConfigurator(cacheCreator cacheCreator, advertisingIfaceName string, handler netdriver.NetworkHandler, podInterfaceName string,
 	vmiSpecIfaces []v1.Interface, vmiSpecIface *v1.Interface, subdomain string) *configurator {
 	return &configurator{
 		podInterfaceName:     podInterfaceName,
@@ -64,7 +64,6 @@ func NewBridgeConfigurator(cacheCreator cacheCreator, launcherPID string, advert
 			handler:          handler,
 			podInterfaceName: podInterfaceName,
 			cacheCreator:     cacheCreator,
-			launcherPID:      launcherPID,
 			vmiSpecIfaces:    vmiSpecIfaces,
 			vmiSpecIface:     vmiSpecIface,
 			subdomain:        subdomain,

--- a/pkg/network/dhcp/configurator_test.go
+++ b/pkg/network/dhcp/configurator_test.go
@@ -40,7 +40,6 @@ var _ = Describe("DHCP configurator", func() {
 		advertisingCIDR    = "10.10.10.0/24"
 		bridgeName         = "br0"
 		ifaceName          = "eth0"
-		launcherPID        = "self"
 		fakeDhcpStartedDir = "/tmp/dhcpStartedPath"
 	)
 
@@ -57,7 +56,7 @@ var _ = Describe("DHCP configurator", func() {
 	})
 
 	newBridgeConfigurator := func(advertisingIfaceName string) *configurator {
-		configurator := NewBridgeConfigurator(&cacheCreator, launcherPID, advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), "", nil, nil, "")
+		configurator := NewBridgeConfigurator(&cacheCreator, advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), "", nil, nil, "")
 		configurator.dhcpStartedDirectory = fakeDhcpStartedDir
 		return configurator
 	}

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -37,19 +37,6 @@ var _ = Describe("VMNetworkConfigurator", func() {
 		Expect(baseCacheCreator.New("").Delete()).To(Succeed())
 	})
 	Context("interface configuration", func() {
-
-		It("when vm has no network source should propagate errors when phase2 is called", func() {
-			vmi := newVMIBridgeInterface("testnamespace", "testVmName")
-			vmi.Spec.Networks = []v1.Network{{
-				Name:          "default",
-				NetworkSource: v1.NetworkSource{},
-			}}
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, &baseCacheCreator)
-			var domain *api.Domain
-			err := vmNetworkConfigurator.SetupPodNetworkPhase2(domain, vmi.Spec.Networks)
-			Expect(err).To(MatchError("Network not implemented"))
-		})
-
 		Context("when calling []podNIC factory functions", func() {
 			It("should not process SR-IOV networks", func() {
 				const networkName = "sriov"

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -20,8 +20,6 @@
 package network
 
 import (
-	"fmt"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
@@ -48,10 +46,7 @@ type podNIC struct {
 }
 
 func newPhase2PodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface *v1.Interface, handler netdriver.NetworkHandler, cacheCreator cacheCreator, domain *api.Domain, domainAttachment string) (*podNIC, error) {
-	podnic, err := newPodNIC(vmi, network, iface, handler, cacheCreator)
-	if err != nil {
-		return nil, err
-	}
+	podnic := newPodNIC(vmi, network, iface, handler, cacheCreator)
 
 	ifaceLink, err := link.DiscoverByNetwork(podnic.handler, podnic.vmi.Spec.Networks, *podnic.vmiSpecNetwork, vmi.Status.Interfaces)
 	if err != nil {
@@ -69,18 +64,14 @@ func newPhase2PodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface 
 	return podnic, nil
 }
 
-func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface *v1.Interface, handler netdriver.NetworkHandler, cacheCreator cacheCreator) (*podNIC, error) {
-	if network.Pod == nil && network.Multus == nil {
-		return nil, fmt.Errorf("Network not implemented")
-	}
-
+func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface *v1.Interface, handler netdriver.NetworkHandler, cacheCreator cacheCreator) *podNIC {
 	return &podNIC{
 		cacheCreator:   cacheCreator,
 		handler:        handler,
 		vmi:            vmi,
 		vmiSpecNetwork: network,
 		vmiSpecIface:   iface,
-	}, nil
+	}
 }
 
 func (l *podNIC) PlugPhase2(domain *api.Domain) error {

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -39,7 +39,6 @@ const defaultState = cache.PodIfaceNetworkPreparationPending
 type podNIC struct {
 	vmi              *v1.VirtualMachineInstance
 	podInterfaceName string
-	launcherPID      *int
 	vmiSpecIface     *v1.Interface
 	vmiSpecNetwork   *v1.Network
 	handler          netdriver.NetworkHandler
@@ -49,7 +48,7 @@ type podNIC struct {
 }
 
 func newPhase2PodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface *v1.Interface, handler netdriver.NetworkHandler, cacheCreator cacheCreator, domain *api.Domain, domainAttachment string) (*podNIC, error) {
-	podnic, err := newPodNIC(vmi, network, iface, handler, cacheCreator, nil)
+	podnic, err := newPodNIC(vmi, network, iface, handler, cacheCreator)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +69,7 @@ func newPhase2PodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface 
 	return podnic, nil
 }
 
-func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface *v1.Interface, handler netdriver.NetworkHandler, cacheCreator cacheCreator, launcherPID *int) (*podNIC, error) {
+func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface *v1.Interface, handler netdriver.NetworkHandler, cacheCreator cacheCreator) (*podNIC, error) {
 	if network.Pod == nil && network.Multus == nil {
 		return nil, fmt.Errorf("Network not implemented")
 	}
@@ -81,7 +80,6 @@ func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface *v1.In
 		vmi:            vmi,
 		vmiSpecNetwork: network,
 		vmiSpecIface:   iface,
-		launcherPID:    launcherPID,
 	}, nil
 }
 
@@ -136,11 +134,4 @@ func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain, domainAttachment st
 		return domainspec.NewTapLibvirtSpecGenerator(l.vmiSpecIface, *l.vmiSpecNetwork, domain, l.podInterfaceName, l.handler)
 	}
 	return nil
-}
-
-func getPIDString(pid *int) string {
-	if pid != nil {
-		return fmt.Sprintf("%d", *pid)
-	}
-	return "self"
 }

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -21,13 +21,10 @@ package network
 
 import (
 	"fmt"
-	"os"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
-
-	goerrors "errors"
 
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	dhcpconfigurator "kubevirt.io/kubevirt/pkg/network/dhcp"
@@ -140,20 +137,6 @@ func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain, domainAttachment st
 		return domainspec.NewTapLibvirtSpecGenerator(l.vmiSpecIface, *l.vmiSpecNetwork, domain, l.podInterfaceName, l.handler)
 	}
 	return nil
-}
-
-func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
-	var ifaceConfig *api.Interface
-	ifaceConfig, err := cache.ReadDomainInterfaceCache(l.cacheCreator, getPIDString(l.launcherPID), l.vmiSpecIface.Name)
-	if goerrors.Is(err, os.ErrNotExist) {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return ifaceConfig, nil
 }
 
 func getPIDString(pid *int) string {

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -113,7 +113,6 @@ func (l *podNIC) newDHCPConfigurator() dhcpconfigurator.Configurator {
 	if l.vmiSpecIface.Bridge != nil {
 		dhcpConfigurator = dhcpconfigurator.NewBridgeConfigurator(
 			l.cacheCreator,
-			getPIDString(l.launcherPID),
 			link.GenerateBridgeName(l.podInterfaceName),
 			l.handler,
 			l.podInterfaceName,

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -46,7 +46,7 @@ var _ = Describe("podNIC", func() {
 	)
 
 	newPhase2PodNICWithMocks := func(vmi *v1.VirtualMachineInstance) (*podNIC, error) {
-		podnic, err := newPodNIC(vmi, &vmi.Spec.Networks[0], &vmi.Spec.Domain.Devices.Interfaces[0], mockNetwork, &baseCacheCreator, nil)
+		podnic, err := newPodNIC(vmi, &vmi.Spec.Networks[0], &vmi.Spec.Domain.Devices.Interfaces[0], mockNetwork, &baseCacheCreator)
 		if err != nil {
 			return nil, err
 		}
@@ -77,10 +77,12 @@ var _ = Describe("podNIC", func() {
 			api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 			podnic, err = newPhase2PodNICWithMocks(vmi)
 			Expect(err).ToNot(HaveOccurred())
+
+			const launcherPID = "self"
 			Expect(
 				cache.WriteDHCPInterfaceCache(
 					podnic.cacheCreator,
-					getPIDString(podnic.launcherPID),
+					launcherPID,
 					podnic.podInterfaceName,
 					&cache.DHCPConfig{Name: podnic.podInterfaceName},
 				),
@@ -88,7 +90,7 @@ var _ = Describe("podNIC", func() {
 			Expect(
 				cache.WriteDomainInterfaceCache(
 					podnic.cacheCreator,
-					getPIDString(podnic.launcherPID),
+					launcherPID,
 					podnic.vmiSpecIface.Name,
 					&domain.Spec.Devices.Interfaces[0],
 				),

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -45,13 +45,11 @@ var _ = Describe("podNIC", func() {
 		ctrl                 *gomock.Controller
 	)
 
-	newPhase2PodNICWithMocks := func(vmi *v1.VirtualMachineInstance) (*podNIC, error) {
-		podnic, err := newPodNIC(vmi, &vmi.Spec.Networks[0], &vmi.Spec.Domain.Devices.Interfaces[0], mockNetwork, &baseCacheCreator)
-		if err != nil {
-			return nil, err
-		}
+	newPhase2PodNICWithMocks := func(vmi *v1.VirtualMachineInstance) *podNIC {
+		podnic := newPodNIC(vmi, &vmi.Spec.Networks[0], &vmi.Spec.Domain.Devices.Interfaces[0], mockNetwork, &baseCacheCreator)
 		podnic.dhcpConfigurator = mockDHCPConfigurator
-		return podnic, nil
+
+		return podnic
 	}
 	BeforeEach(func() {
 		dutils.MockDefaultOwnershipManager()
@@ -71,12 +69,10 @@ var _ = Describe("podNIC", func() {
 			vmi    *v1.VirtualMachineInstance
 		)
 		BeforeEach(func() {
-			var err error
 			domain = NewDomainWithBridgeInterface()
 			vmi = newVMIBridgeInterface("testnamespace", "testVmName")
 			api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
-			podnic, err = newPhase2PodNICWithMocks(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			podnic = newPhase2PodNICWithMocks(vmi)
 
 			const launcherPID = "self"
 			Expect(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the `podNIC.launcherPID` field is always set to nil, thus it always configures the `BridgeConfigGenerator.launcherPID` field to "self".

- Remove these redundant fields
- Remove the `getPIDString` function
- Remove the unused `podNIC.cachedDomainInterface` method
- Change the signature of `newPodNIC` so it will not return an error

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

