### PR TITLE
netconf: Remove configStateCache upgrade

### DIFF
--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/network/driver:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/link:go_default_library",
-        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/netns:go_default_library",
         "//pkg/network/setup/netpod:go_default_library",
         "//pkg/network/setup/netpod/masquerade:go_default_library",

--- a/pkg/network/setup/configstatecache.go
+++ b/pkg/network/setup/configstatecache.go
@@ -81,20 +81,6 @@ func (c *ConfigStateCache) Write(key string, state cache.PodIfaceState) error {
 	return nil
 }
 
-func (c *ConfigStateCache) Exists(key string) (bool, error) {
-	if _, exists := c.volatilePodIfaceState[key]; exists {
-		return true, nil
-	}
-	_, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, key)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to read pod interface network state from cache: %v", err)
-	}
-	return true, nil
-}
-
 func (c *ConfigStateCache) Delete(key string) error {
 	delete(c.volatilePodIfaceState, key)
 	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, key)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Remove the one-time upgrade mechanism for the `configStateCache`. This logic was introduced in [1] to convert cache keys from the deprecated ordinal naming scheme to logical network names.

Given that more than two years and seven minor releases have passed (1.0-1.6), this compatibility mechanism can now be safely removed to reduce maintenance overhead.

The `ConfigStateCache.Exists` method is also removed as it became unused after this change.

[1] https://github.com/kubevirt/kubevirt/pull/9763

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

