### PR TITLE
[Release-1.4] Handle freeze on paused VMs during snapshot

### DIFF
--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -33,6 +33,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 
+	corev1 "k8s.io/api/core/v1"
+
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/log"
@@ -324,6 +326,15 @@ func (s *vmSnapshotSource) GuestAgent() (bool, error) {
 	return condManager.HasCondition(vmi, kubevirtv1.VirtualMachineInstanceAgentConnected), nil
 }
 
+func (s *vmSnapshotSource) paused() (bool, error) {
+	condManager := controller.NewVirtualMachineInstanceConditionManager()
+	vmi, exists, err := s.controller.getVMI(s.vm)
+	if err != nil || !exists {
+		return false, err
+	}
+	return condManager.HasConditionWithStatus(vmi, kubevirtv1.VirtualMachineInstancePaused, corev1.ConditionTrue), nil
+}
+
 func (s *vmSnapshotSource) Frozen() (bool, error) {
 	vmi, exists, err := s.controller.getVMI(s.vm)
 	if err != nil || !exists {
@@ -338,9 +349,28 @@ func (s *vmSnapshotSource) Freeze() error {
 		return fmt.Errorf("attempting to freeze unlocked VM")
 	}
 
+	paused, err := s.paused()
+	if err != nil {
+		return err
+	}
+	if paused {
+		log.Log.Warningf("VM %s is paused - taking snapshot without filesystem freeze. Paused VMs cannot flush memory buffers to disk, which may result in inconsistent snapshots.", s.vm.Name)
+		return nil
+	}
+
 	exists, err := s.GuestAgent()
 	if !exists || err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		online, err := s.Online()
+		if err != nil {
+			return err
+		}
+		if online {
+			log.Log.Warningf("Guest agent does not exist and VM %s is running. Snapshoting without freezing FS. This can result in inconsistent snapshot!", s.vm.Name)
+		}
+		return nil
 	}
 
 	log.Log.V(3).Infof("Freezing vm %s file system before taking the snapshot", s.vm.Name)
@@ -359,6 +389,14 @@ func (s *vmSnapshotSource) Freeze() error {
 
 func (s *vmSnapshotSource) Unfreeze() error {
 	if !s.Locked() {
+		return nil
+	}
+
+	paused, err := s.paused()
+	if err != nil {
+		return err
+	}
+	if paused {
 		return nil
 	}
 

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -58,6 +58,7 @@ type snapshotSource interface {
 	Lock() (bool, error)
 	Unlock() (bool, error)
 	Online() (bool, error)
+	Paused() (bool, error)
 	GuestAgent() (bool, error)
 	Frozen() (bool, error)
 	Freeze() error
@@ -333,6 +334,10 @@ func (s *vmSnapshotSource) paused() (bool, error) {
 		return false, err
 	}
 	return condManager.HasConditionWithStatus(vmi, kubevirtv1.VirtualMachineInstancePaused, corev1.ConditionTrue), nil
+}
+
+func (s *vmSnapshotSource) Paused() (bool, error) {
+	return s.paused()
 }
 
 func (s *vmSnapshotSource) Frozen() (bool, error) {

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -60,6 +60,7 @@ import (
 const (
 	unmarshalRequestErrFmt                   = "Can not unmarshal Request body to struct, error: %s"
 	vmNotRunning                             = "VM is not running"
+	vmSnapshotInprogress                     = "VM snapshot is in progress"
 	patchingVMFmt                            = "Patching VM: %s"
 	jsonpatchTestErr                         = "jsonpatch test operation does not apply"
 	patchingVMStatusFmt                      = "Patching VM status: %s"
@@ -722,6 +723,24 @@ func (app *SubresourceAPIApp) PauseVMIRequestHandler(request *restful.Request, r
 }
 
 func (app *SubresourceAPIApp) UnpauseVMIRequestHandler(request *restful.Request, response *restful.Response) {
+
+	name := request.PathParameter("name")
+	namespace := request.PathParameter("namespace")
+
+	// Check VM status - only continue if VM doesn't exist or if it exists without snapshot in progress
+	vm, err := app.fetchVirtualMachine(name, namespace)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			writeError(err, response)
+			return
+		}
+	} else {
+		// VM exists - check if snapshot is in progress
+		if vm.Status.SnapshotInProgress != nil {
+			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(vmSnapshotInprogress)), response)
+			return
+		}
+	}
 
 	validate := func(vmi *v1.VirtualMachineInstance) *errors.StatusError {
 		if vmi.Status.Phase != v1.Running {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -2299,6 +2299,9 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			expectVMI(running, paused)
 
+			vm := newVirtualMachineWithRunning(pointer.P(Running))
+			vmClient.EXPECT().Get(context.Background(), testVMIName, k8smetav1.GetOptions{}).Return(vm, nil)
+
 			bytesRepresentation, _ := json.Marshal(unpauseOptions)
 			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
 
@@ -2313,8 +2316,27 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			Entry("a not running VMI with dry-run option", NotRunning, UnPaused, &v1.UnpauseOptions{DryRun: getDryRunOption()}),
 		)
 
-		DescribeTable("Should unpause a running, paused VMI according to options", func(unpauseOptions *v1.UnpauseOptions) {
+		It("Should fail unpausing when snapshot in progress", func() {
 
+			request.PathParameters()["name"] = testVMIName
+			request.PathParameters()["namespace"] = k8smetav1.NamespaceDefault
+
+			vm := newVirtualMachineWithRunning(pointer.P(Running))
+			vm.Status.SnapshotInProgress = &[]string{"test-snapshot"}[0]
+
+			vmClient.EXPECT().Get(context.Background(), testVMIName, k8smetav1.GetOptions{}).Return(vm, nil)
+
+			unpauseOptions := &v1.UnpauseOptions{}
+			bytesRepresentation, _ := json.Marshal(unpauseOptions)
+			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
+
+			app.UnpauseVMIRequestHandler(request, response)
+
+			ExpectStatusErrorWithCode(recorder, http.StatusConflict)
+			Expect(recorder.Body.String()).To(ContainSubstring(vmSnapshotInprogress))
+		})
+
+		DescribeTable("Should unpause a running, paused VMI according to options", func(unpauseOptions *v1.UnpauseOptions) {
 			backend.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("PUT", "/v1/namespaces/default/virtualmachineinstances/testvmi/unpause"),
@@ -2322,6 +2344,8 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				),
 			)
 			expectVMI(Running, Paused)
+			vm := newVirtualMachineWithRunning(pointer.P(Running))
+			vmClient.EXPECT().Get(context.Background(), testVMIName, k8smetav1.GetOptions{}).Return(vm, nil)
 
 			bytesRepresentation, _ := json.Marshal(unpauseOptions)
 			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -81,6 +81,7 @@ const (
 	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
 	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
 	VMSnapshotQuiesceFailedIndication  Indication = "QuiesceFailed"
+	VMSnapshotPausedIndication         Indication = "Paused"
 )
 
 // VirtualMachineSnapshotPhase is the current phase of the VirtualMachineSnapshot

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -620,6 +620,52 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}, 30*time.Second, 2*time.Second).Should(BeEmpty())
 			})
 
+			It("[test_id:12182] should succeed snapshot when VM is paused with Paused indication", func() {
+				dvName := "dv-" + rand.String(5)
+				quantity := resource.MustParse("1Gi")
+
+				opts := []libvmi.Option{
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					libvmi.WithDataVolume("blank", dvName),
+				}
+
+				vmi := libvmifact.NewFedora(opts...)
+				vm = libvmi.NewVirtualMachine(vmi)
+
+				dataVolume := libdv.NewDataVolume(
+					libdv.WithName(dvName),
+					libdv.WithBlankImageSource(),
+					libdv.WithStorage(
+						libdv.StorageWithStorageClass(snapshotStorageClass),
+						libdv.StorageWithVolumeSize(quantity.String()),
+					),
+				)
+				libstorage.AddDataVolumeTemplate(vm, dataVolume)
+
+				vm, vmi = createAndStartVM(vm)
+				libwait.WaitForSuccessfulVMIStart(vmi, libwait.WithTimeout(300))
+
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Pausing the VirtualMachineInstance")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})).To(Succeed())
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
+
+				By("Taking the snapshot")
+				snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
+				_, err := virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
+
+				By("Verifying snapshot has Paused indication")
+				expectedIndications := []snapshotv1.Indication{snapshotv1.VMSnapshotOnlineSnapshotIndication, snapshotv1.VMSnapshotPausedIndication}
+				Expect(snapshot.Status.Indications).To(ContainElements(expectedIndications))
+
+				contentName := *snapshot.Status.VirtualMachineSnapshotContentName
+				checkOnlineSnapshotExpectedContentSource(vm, contentName, true)
+			})
+
 			It("[test_id:7472]should succeed online snapshot with hot plug disk", func() {
 				var vmi *v1.VirtualMachineInstance
 				vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)


### PR DESCRIPTION
Manual backport of #15001

Automated backport failed due to missing function in `pkg/storage/snapshot/snapshot.go` and some other changes in test files.

VM snapshot with qemu-guest-agent fails when the domain is paused, because virt-controller sends a freeze/unfreeze request during snapshotting. This freeze/unfreeze is handled by virt-launcher, but it currently fails on paused VMs. Since paused VMs have a consistent filesystem state (similar to frozen), this change makes virt-launcher treat freeze as successful when the domain is paused. This allows snapshotting to continue safely.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

- VM snapshot with qemu-guest-agent fails when the domain is paused. This happens since the snapshot flow trigger a freeze but sinManual backport of #15001

Automated backport failed due to missing `pkg/virt-api/rest/lifecycle.go` file as some of changed functions were still under `pkg/virt-api/rest/subresource.go`.

VM snapshot with qemu-guest-agent fails when the domain is paused, because virt-controller sends a freeze/unfreeze request during snapshotting. This freeze/unfreeze is handled by virt-launcher, but it currently fails on paused VMs. Since paused VMs have a consistent filesystem state (similar to frozen), this change makes virt-launcher treat freeze as successful whce the VM is paused, freeze fails causing snapshot flow to also fail. since a Paused VM is considered a safe state to perform a snapshot, we expect it to pass when the VM is paused, but it doesnt.
- it is possible to unpause a VM during snapshot, which is not desired.
- a false warning message is being printed saying it is not safe to snapshot a running VM (without qemu-guest-agent) even though the VM is paused.
- virt-launcher's agent poller is spamming qemu-gest-agent command failures when VM is paused.

#### After this PR:

- Possible to complete a VM (with qemu-guest-agent) snapshot successfully even if the VM is paused.
- Make sure unpause will be rejected if `vm.Status.SnapshotInProgress` is not nil.
- prevent a warning message from being printed for when snapshot is being taken while VM (without qemu-guest-agent)  is still running even though the VM is paused.
- virt-launcher's agent poller skips qemu-guest-agent commands if the VM is paused.

### References
Fixes #10759

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
@ShellyKa13
@codingben (check out the change for agent_poller.go)
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: Enable vmsnapshot for paused VMs
```