### PR TITLE
config: sort customizeComponents.flags in command

### DIFF
--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -72,10 +72,16 @@ func addFlagsPatch(name, resource string, flags map[string]string, patches []v1.
 func flagsToArray(flags map[string]string) []string {
 	farr := make([]string, 0)
 
-	for flag, v := range flags {
+	fnames := make([]string, 0, len(flags))
+	for flag := range flags {
+		fnames = append(fnames, flag)
+	}
+	sort.Strings(fnames)
+
+	for _, flag := range fnames {
 		farr = append(farr, fmt.Sprintf("--%s", strings.ToLower(flag)))
-		if v != "" {
-			farr = append(farr, v)
+		if flags[flag] != "" {
+			farr = append(farr, flags[flag])
 		}
 	}
 

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -221,12 +221,15 @@ var _ = Describe("Patches", func() {
 		})
 
 		It("should return flags in sorted order", func() {
-			fa := flagsToArray(flags)
-			Expect(fa).To(HaveLen(5))
-
-			Expect(strings.Join(fa, " ")).To(HavePrefix("--bool-flag"))
-			Expect(strings.Join(fa, " ")).To(ContainSubstring(" --flag 3 "))
-			Expect(strings.Join(fa, " ")).To(HaveSuffix("--flag-one 1"))
+			Consistently(func() []string {
+				return flagsToArray(flags)
+			}).Should(HaveExactElements(
+				"--bool-flag",
+				"--flag",
+				"3",
+				"--flag-one",
+				"1",
+			))
 		})
 
 		It("should add flag patch", func() {

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -220,6 +220,15 @@ var _ = Describe("Patches", func() {
 			Expect(strings.Join(fa, " ")).To(ContainSubstring("--bool-flag"))
 		})
 
+		It("should return flags in sorted order", func() {
+			fa := flagsToArray(flags)
+			Expect(fa).To(HaveLen(5))
+
+			Expect(strings.Join(fa, " ")).To(HavePrefix("--bool-flag"))
+			Expect(strings.Join(fa, " ")).To(ContainSubstring(" --flag 3 "))
+			Expect(strings.Join(fa, " ")).To(HaveSuffix("--flag-one 1"))
+		})
+
 		It("should add flag patch", func() {
 			patches := addFlagsPatch(components.VirtAPIName, resource, flags, []v1.CustomizeComponentsPatch{})
 			Expect(patches).To(HaveLen(1))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Converting from map to array in `flagsToArray` may change flags order. This leads to unnecessary restarts of virt-handler, virt-controller, and virt-api.


#### Before this PR:

Add a few flags for components:

```
kind: KubeVirt
...
spec:
  customizeComponents:
    flags:
      api:
        metrics-listen: 127.0.0.1
        metrics-port: "8080"
      controller:
        metrics-listen: 127.0.0.1
        metrics-port: "8080"
      handler:
        metrics-listen: 127.0.0.1
        metrics-port: "8080"
...
```

I see unnecessary changes in flags order and components restarts:

```
# diff -u <(kubectl -n NSNAME rollout history ds/virt-handler --revision 357 -oyaml) <(kubectl -n NSNAME rollout history ds/virt-handler --revision 365 -oyaml)
--- /dev/fd/63	2025-09-10 16:48:30.749728663 +0300
+++ /dev/fd/62	2025-09-10 16:48:30.749728663 +0300
....
@@ -201,10 +201,10 @@
         - "2"
         command:
         - virt-handler
-        - --metrics-listen
-        - 127.0.0.1
         - --metrics-port
         - "8080"
+        - --metrics-listen
+        - 127.0.0.1
...

# diff -u <(kubectl -n NSNAME rollout history ds/virt-handler --revision 365 -oyaml) <(kubectl -n NSNAME rollout history ds/virt-handler --revision 366 -oyaml)
--- /dev/fd/63	2025-09-10 16:46:47.119034000 +0300
+++ /dev/fd/62	2025-09-10 16:46:47.119034000 +0300
@@ -201,10 +201,10 @@
         - "2"
         command:
         - virt-handler
-        - --metrics-port
-        - "8080"
         - --metrics-listen
         - 127.0.0.1
+        - --metrics-port
+        - "8080"
...
```

#### After this PR:

- Flags order is stable, no unnecessary restarts.
- No more errors like "x509: unknown authority" during long e2e tests.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

We build kubevirt with Go 1.24, may be some changes in 1.24 make unstable order more visible.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

