### PR TITLE
net, istio: Support Istio v1.25 and above 

### DIFF
--- a/pkg/network/istio/decorators.go
+++ b/pkg/network/istio/decorators.go
@@ -29,5 +29,13 @@ const (
 	// KubeVirtTrafficAnnotation Specifies a comma separated list of virtual interfaces
 	// whose inbound traffic (from VM) will be treated as outbound
 	// https://istio.io/latest/docs/reference/config/annotations/#SidecarTrafficKubevirtInterfaces
+	// This annotation was deprecated in Istio 1.25 in favor of RerouteVirtualInterfacesAnnotation
+	// https://istio.io/latest/news/releases/1.25.x/announcing-1.25/change-notes/#deprecation-notices
 	KubeVirtTrafficAnnotation = "traffic.sidecar.istio.io/kubevirtInterfaces"
+
+	// RerouteVirtualInterfacesAnnotation Specifies a comma separated list of virtual interfaces
+	// whose inbound traffic (from VM) will be treated as outbound
+	// https://istio.io/latest/docs/reference/config/annotations/#IoIstioRerouteVirtualInterfaces
+	// Introduced in Istio v1.25
+	RerouteVirtualInterfacesAnnotation = "istio.io/reroute-virtual-interfaces"
 )

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -82,7 +82,9 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 
 	if shouldAddIstioKubeVirtAnnotation(vmi) {
 		const defaultBridgeName = "k6t-eth0"
+		// both annotations do the same thing, but we need to support both for backward compatibility
 		annotations[istio.KubeVirtTrafficAnnotation] = defaultBridgeName
+		annotations[istio.RerouteVirtualInterfacesAnnotation] = defaultBridgeName
 	}
 
 	return annotations, nil

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -137,6 +137,7 @@ var _ = Describe("Annotations Generator", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(annotations).To(HaveKeyWithValue(istio.KubeVirtTrafficAnnotation, "k6t-eth0"))
+			Expect(annotations).To(HaveKeyWithValue(istio.RerouteVirtualInterfacesAnnotation, "k6t-eth0"))
 		})
 
 		DescribeTable("should not generate Istio annotation", func(vmi *v1.VirtualMachineInstance) {
@@ -145,6 +146,7 @@ var _ = Describe("Annotations Generator", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(annotations).To(Not(HaveKey(istio.KubeVirtTrafficAnnotation)))
+			Expect(annotations).To(Not(HaveKey(istio.RerouteVirtualInterfacesAnnotation)))
 		},
 			Entry("when VMI is not connected any network", libvmi.New()),
 			Entry("when VMI is connected to pod network and not using masquerade binding",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In Istio v1.25 a new annotation (`istio.io/reroute-virtual-interfaces`) was introduced as a replacement for  `traffic.sidecar.istio.io/kubevirtInterfaces` which was deprecated.
The old annotation was actually broken since Istio v1.25 due to [1].

In order to maintain BWC, and to continue supporting v1.24.4 alongside more recent versions, KubeVirt annotates pods with both old and new annotations, until it is decided to cease support for Istio versions < 1.25.

[1]  https://github.com/istio/istio/issues/57662#issuecomment-3301658947.
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->

https://github.com/istio/istio/issues/57662
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support Istio versions 1.25 and above.
```

