### PR TITLE
Monitor: Reap all processes

### DIFF
--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -119,16 +119,23 @@ func RunAndMonitor(containerDiskDir, uid string) (int, error) {
 		for sig := range sigs {
 			switch sig {
 			case syscall.SIGCHLD:
-				var wstatus syscall.WaitStatus
-				wpid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
-				if err != nil {
-					log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)
+				for {
+					var wstatus syscall.WaitStatus
+					wpid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
+					if err != nil {
+						log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)
+					}
+					if wpid == 0 {
+						log.Log.Infof("No more processes to be reaped")
+						break
+					}
+					if wpid == cmd.Process.Pid {
+						log.Log.Infof("Reaped Launcher main pid")
+						exitStatus <- wstatus.ExitStatus()
+					}
+					log.Log.Infof("Reaped pid %d with status %d", wpid, int(wstatus))
 				}
-				if wpid == cmd.Process.Pid {
-					log.Log.Infof("Reaped Launcher main pid")
-					exitStatus <- wstatus.ExitStatus()
-				}
-				log.Log.Infof("Reaped pid %d with status %d", wpid, int(wstatus))
+
 			default:
 				log.Log.Infof("signalling virt-launcher to shut down")
 				err := cmd.Process.Signal(syscall.SIGTERM)


### PR DESCRIPTION
### What this PR does

Delivery of signals can actually drop signal
if multiple signals are generated while the signal is being blocked.
In this case only one signal is delivered after it is un-blocked. Because we always do Wait4 per signal we can actually miss a process being terminated.
Sometimes the ordering happen to be unfortunate and the virt-launcher process is missed and never cleaned up.

This cause for the virt-launcher to hang around indefinitely.

Therefore this commit tries to reap as much processes as possible per signal.

This was observed upon successful migration where both source and target Pods continued to be running, see:
```
ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
qemu           1  0.0  0.0 1679844 13328 ?       Ssl  Aug21   0:00 /usr/bin/virt-launcher-monitor --qemu-timeout 248s --name rhel9-3195 --uid 0db4e8a0-c0e4-4e95-9b1c-bd7f2a16c8d4 --namespace vm-ns-32 --kubevirt-
qemu           8  0.0  0.0      0     0 ?        Z    Aug21  13:51 [virt-launcher] <defunct>
qemu         444  0.5  0.0   4452  2688 pts/0    Ss   09:19   0:00 bash
qemu         445  0.0  0.0   7032  2688 pts/0    R+   09:19   0:00 ps aux

```

and logs:

```
{"component":"virt-launcher","level":"info","msg":"Exiting...","pos":"virt-launcher.go:513","timestamp":"2025-08-29T18:18:58.885293Z"}
{"component":"virt-launcher-monitor","level":"info","msg":"Reaped pid 19 with status 9","pos":"virt-launcher-monitor.go:202","timestamp":"2025-08-29T18:18:58.886212Z"}
{"component":"virt-launcher-monitor","level":"info","msg":"Reaped pid 18 with status 9","pos":"virt-launcher-monitor.go:202","timestamp":"2025-08-29T18:18:58.889628Z"}
```

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
It is not clear to me if the go runtime suspend the signal (makes it non blocking) before the signal is send to channel and so there is no race. 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix, virt-launcher is properly reaped
```

