### PR TITLE
tests/taints-and-tolerations: add RequiresDedicatedWorkerNodes decorator

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -59,6 +59,7 @@ var (
 	NetCustomBindingPlugins              = Label("netCustomBindingPlugins")
 	RequiresTwoSchedulableNodes          = Label("requires-two-schedulable-nodes")
 	RequiresThreeSchedulableNodes        = Label("requires-three-schedulable-nodes")
+	RequiresDedicatedWorkerNodes         = Label("requires-dedicated-worker-nodes")
 	VMLiveUpdateRolloutStrategy          = Label("VMLiveUpdateRolloutStrategy")
 	USB                                  = Label("USB")
 	RequiresTwoWorkerNodesWithCPUManager = Label("requires-two-worker-nodes-with-cpu-manager")

--- a/tests/infrastructure/taints-and-tolerations.go
+++ b/tests/infrastructure/taints-and-tolerations.go
@@ -37,6 +37,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnode"
@@ -48,7 +49,7 @@ var _ = Describe(SIGSerial("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com]
 		virtClient = kubevirt.Client()
 	})
 
-	Context("CriticalAddonsOnly taint set on a node", func() {
+	Context("CriticalAddonsOnly taint set on a node", decorators.RequiresDedicatedWorkerNodes, func() {
 		var (
 			possiblyTaintedNodeName string
 			kubevirtPodsOnNode      []string


### PR DESCRIPTION
### What this PR does
Introduce `RequiresDedicatedWorkerNodes` decorator to enable dynamic test filtering based on cluster topology.
Tests marked with this decorator require dedicated worker nodes separate from control plane nodes to run safely.

The `taints-and-tolerations` test is marked with this decorator since it applies `CriticalAddonsOnly` taint which should not be applied to control plane nodes to avoid breaking the test cluster.

This allows test infrastructure to skip these tests on clusters that only have control plane nodes or combined control+worker nodes.

#### Before this PR:

#### After this PR:

### References

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
none
```

