### PR TITLE
virt-operator: Scale virt-api using NodeSchedulable count

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2680,7 +2680,8 @@ var _ = Describe("KubeVirt Operator", func() {
 			var kvTestData KubeVirtTestData
 			const (
 				CustomizedReplicas              int32 = 4
-				numOfNodes                            = 1000
+				numOfUnschedulableNodes               = 1000
+				numOfSchedulableNodes                 = 1000
 				expectedReplicasForLargeCluster int32 = 100
 			)
 
@@ -2691,11 +2692,17 @@ var _ = Describe("KubeVirt Operator", func() {
 
 				var testNodes []k8sv1.Node
 
-				for i := range numOfNodes {
+				totalNodes := numOfSchedulableNodes + numOfUnschedulableNodes
+				for i := range totalNodes {
 					node := k8sv1.Node{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fmt.Sprintf("testnode-%d", i),
 						},
+					}
+					if i < numOfSchedulableNodes {
+						node.Labels = map[string]string{
+							v1.NodeSchedulable: "true",
+						}
 					}
 					testNodes = append(testNodes, node)
 				}

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -391,7 +391,9 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 }
 
 func getDesiredApiReplicas(clientset kubecli.KubevirtClient) (replicas int32, err error) {
-	nodeList, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	nodeList, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", v1.NodeSchedulable, "true"),
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to get number of nodes to determine virt-api replicas: %v", err)
 	}

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -1279,8 +1279,8 @@ var _ = Describe("Apply Apps", func() {
 			Expect(updatedDeploy.Annotations).ToNot(HaveKey(fakeAnnotation))
 		})
 
-		DescribeTable("should calculate correct replicas for deployments based on node count", func(nodesCount int, expectedReplicas int) {
-			createFakeNodes(dpClient, nodesCount)
+		DescribeTable("should calculate correct replicas for deployments based on node count", func(schedulableNodesCount, unschedulableNodeCount, expectedReplicas int) {
+			createFakeNodes(dpClient, schedulableNodesCount, unschedulableNodeCount)
 
 			r := &Reconciler{
 				clientset:    clientset,
@@ -1293,20 +1293,31 @@ var _ = Describe("Apply Apps", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*updatedDeployment.Spec.Replicas).To(BeEquivalentTo(expectedReplicas))
 		},
-			Entry("Single-node cluster", 1, 1),
-			Entry("Small cluster with 5 nodes", 5, 2),
-			Entry("Medium cluster with 50 nodes", 50, 5),
+			Entry("Single-node cluster", 1, 0, 1),
+			Entry("Small cluster with 5 nodes", 5, 0, 2),
+			Entry("Small cluster with 1 schedulable node", 1, 4, 1),
+			Entry("Medium cluster with 50 nodes", 50, 0, 5),
+			Entry("Medium cluster with 10 schedulable nodes", 10, 40, 2),
+			Entry("large cluster with 1000 nodes", 1000, 0, 100),
+			Entry("large cluster with 10 schedulable nodes", 10, 990, 2),
 		)
 	})
 })
 
-func createFakeNodes(client *fake.Clientset, count int) {
-	for i := range count {
-		_, err := client.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+func createFakeNodes(client *fake.Clientset, schedulableNodesCount, unschedulableNodeCount int) {
+	totalNodeCount := schedulableNodesCount + unschedulableNodeCount
+	for i := range totalNodeCount {
+		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("node-%d", i),
 			},
-		}, metav1.CreateOptions{})
+		}
+		if i < schedulableNodesCount {
+			node.Labels = map[string]string{
+				v1.NodeSchedulable: "true",
+			}
+		}
+		_, err := client.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
 }


### PR DESCRIPTION
### What this PR does

Take the number of nodes KubeVirt is able to schedule to into account
when calculating the number of virt-api replicas. This should avoid
spawning too many in larger environments when KubeVirt is not
universally deployed.

### References

- Fixes # https://issues.redhat.com/browse/CNV-68814

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replicas of `virt-api` are now scaled depending on the number of nodes within the environment with the `kubevirt.io/schedulable=true` label.
```

