### PR TITLE
Collect migration metrics without wait

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/handler.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/handler.go
@@ -41,6 +41,7 @@ func newHandler(vmiInformer cache.SharedIndexInformer) (*handler, error) {
 	}
 
 	_, err := vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    h.handleVmiAdd,
 		UpdateFunc: h.handleVmiUpdate,
 	})
 
@@ -73,6 +74,16 @@ func (h *handler) handleVmiUpdate(_oldObj, newObj interface{}) {
 	}
 
 	h.addMigration(newVmi)
+}
+
+func (h *handler) handleVmiAdd(obj interface{}) {
+	vmi := obj.(*v1.VirtualMachineInstance)
+
+	if vmi.Status.MigrationState == nil || vmi.Status.MigrationState.Completed {
+		return
+	}
+
+	h.addMigration(vmi)
 }
 
 func (h *handler) addMigration(vmi *v1.VirtualMachineInstance) {

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/queue.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/queue.go
@@ -76,14 +76,17 @@ func (q *queue) startPolling() {
 
 	ticker := time.NewTicker(pollingInterval)
 	go func() {
-		for range ticker.C {
+		log.Log.V(4).Infof("collecting domain stats for VMI %s/%s (initial)", q.vmi.Namespace, q.vmi.Name)
+		q.collect()
+
+		for {
 			select {
 			case <-q.ctx.Done():
-				log.Log.Infof("stopping domain stats collection for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
+				log.Log.V(2).Infof("stopping domain stats collection for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
 				ticker.Stop()
 				return
-			default:
-				log.Log.Infof("collecting domain stats for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
+			case <-ticker.C:
+				log.Log.V(4).Infof("collecting domain stats for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
 				q.collect()
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

Previously, we would only collect the migration metrics after a delay of 5 seconds

#### After this PR:

As soon as a VMI with an active migration is detected, we collect migration metrics

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

