### PR TITLE
Properly set owner references for restored PVCs

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -78,6 +78,8 @@ const (
 
 	restoreDataVolumeCreateErrorEvent = "RestoreDataVolumeCreateError"
 
+	restoreOwnedByVMLabel = "restore.kubevirt.io/owned-by-vm"
+
 	defaultPvcRestorePrefix = "restore"
 
 	waitEventuallyMessage = "Waiting for target VM to be powered off. Please stop the restore target to proceed with restore"
@@ -276,10 +278,6 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 		return 0, ctrl.doUpdateError(vmRestoreIn, err)
 	}
 	if updated {
-		if err := ctrl.updateRestorePVCOwnership(vmRestoreOut, target); err != nil {
-			logger.Reason(err).Error("Error updating restore pvc ownership")
-			return 0, ctrl.doUpdateError(vmRestoreIn, err)
-		}
 		updateRestoreCondition(vmRestoreOut, newProgressingCondition(corev1.ConditionTrue, "Updating target spec"))
 		updateRestoreCondition(vmRestoreOut, newReadyCondition(corev1.ConditionFalse, "Waiting for target update"))
 		return 0, ctrl.doUpdateStatus(vmRestoreIn, vmRestoreOut)
@@ -311,32 +309,6 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 	updateRestoreCondition(vmRestoreOut, newReadyCondition(corev1.ConditionTrue, "Operation complete"))
 
 	return 0, ctrl.doUpdateStatus(vmRestoreIn, vmRestoreOut)
-}
-
-func (ctrl *VMRestoreController) updateRestorePVCOwnership(vmRestore *snapshotv1.VirtualMachineRestore, target restoreTarget) error {
-	if isVolumeOwnershipPolicyNone(vmRestore) || !target.Exists() {
-		return nil
-	}
-	for _, volume := range target.VirtualMachine().Spec.Template.Spec.Volumes {
-		if volume.PersistentVolumeClaim != nil {
-			pvc, err := ctrl.Client.CoreV1().PersistentVolumeClaims(vmRestore.Namespace).Get(context.Background(), volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			// Check if the PVC is already owned by something else
-			if len(pvc.OwnerReferences) == 0 {
-				target.Own(pvc)
-
-				// Update the PVC to have the owner reference
-				_, err = ctrl.Client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
 }
 
 func (ctrl *VMRestoreController) doUpdateError(restore *snapshotv1.VirtualMachineRestore, err error) error {
@@ -544,7 +516,7 @@ func (ctrl *VMRestoreController) reconcileVolumeRestores(vmRestore *snapshotv1.V
 				dvOwner = *restore.DataVolumeName
 			}
 
-			if err = ctrl.createRestorePVC(vmRestore, target, backup, &restore, content.Spec.Source.VirtualMachine.Name, content.Spec.Source.VirtualMachine.Namespace, dvOwner); err != nil {
+			if err = ctrl.createRestorePVC(vmRestore, target, backup, &restore, content.Spec.Source.VirtualMachine, dvOwner); err != nil {
 				return false, err
 			}
 			createdPVC = true
@@ -1041,7 +1013,41 @@ func (t *vmRestoreTarget) reconcileSpec(restoredVM *kubevirtv1.VirtualMachine) (
 		return false, err
 	}
 
+	if err = t.updateRestorePVCOwnership(); err != nil {
+		return false, err
+	}
+
 	return true, nil
+}
+
+func (t *vmRestoreTarget) updateRestorePVCOwnership() error {
+	if isVolumeOwnershipPolicyNone(t.vmRestore) || !t.Exists() {
+		return nil
+	}
+	for _, volume := range t.VirtualMachine().Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			pvc, err := t.controller.Client.CoreV1().PersistentVolumeClaims(t.vmRestore.Namespace).Get(context.Background(), volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			// Check if the PVC is already owned by something else
+			if len(pvc.OwnerReferences) == 0 {
+				// Only set the owner reference if the PVC was originally owned by the source VM
+				if pvc.Annotations[restoreOwnedByVMLabel] == t.vmRestore.Name {
+					t.Own(pvc)
+					delete(pvc.Annotations, restoreOwnedByVMLabel)
+
+					// Update the PVC to have the owner reference
+					_, err = t.controller.Client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func findDVTemplateIndex(dvName string, vm *snapshotv1.VirtualMachine) int {
@@ -1493,8 +1499,11 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	target restoreTarget,
 	volumeBackup *snapshotv1.VolumeBackup,
 	volumeRestore *snapshotv1.VolumeRestore,
-	sourceVmName, sourceVmNamespace, dvOwner string,
+	sourceVm *snapshotv1.VirtualMachine,
+	dvOwner string,
 ) error {
+	sourceVmName := sourceVm.Name
+	sourceVmNamespace := sourceVm.Namespace
 	if volumeBackup == nil || volumeBackup.VolumeSnapshotName == nil {
 		log.Log.Errorf("VolumeSnapshot name missing %+v", volumeBackup)
 		return fmt.Errorf("missing VolumeSnapshot name")
@@ -1518,16 +1527,19 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	if err != nil {
 		return err
 	}
+	if pvc.Annotations == nil {
+		pvc.Annotations = make(map[string]string)
+	}
 
 	if dvOwner != "" { // PVC is owned by a DV
-		if pvc.Annotations == nil {
-			pvc.Annotations = make(map[string]string)
-		}
-
 		// By setting this annotation, the CDI will set ownership of the PVC to the DV
 		pvc.Annotations[populatedForPVCAnnotation] = dvOwner
 	} else if !isVolumeOwnershipPolicyNone(vmRestore) { // PVC is owned by the VM
-		target.Own(pvc)
+		if target.Exists() {
+			target.Own(pvc)
+		} else if sourcePVCOwnedBySourceVM(volumeBackup, sourceVm) {
+			pvc.Annotations[restoreOwnedByVMLabel] = vmRestore.Name
+		}
 	}
 
 	_, err = ctrl.Client.CoreV1().PersistentVolumeClaims(vmRestore.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
@@ -1536,6 +1548,18 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	}
 
 	return nil
+}
+
+func sourcePVCOwnedBySourceVM(volumeBackup *snapshotv1.VolumeBackup, sourceVm *snapshotv1.VirtualMachine) bool {
+	ownerReferences := volumeBackup.PersistentVolumeClaim.OwnerReferences
+	owned := false
+	for _, ownerReference := range ownerReferences {
+		if ownerReference.Kind == "VirtualMachine" && ownerReference.Name == sourceVm.Name && ownerReference.UID == sourceVm.UID {
+			owned = true
+			break
+		}
+	}
+	return owned
 }
 
 func CreateRestorePVCDef(restorePVCName string, volumeSnapshot *vsv1.VolumeSnapshot, volumeBackup *snapshotv1.VolumeBackup) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -324,7 +324,9 @@ var _ = Describe("Restore controller", func() {
 				Expect(action).To(BeNil())
 				return true, nil, nil
 			})
-
+			k8sClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				return true, nil, nil
+			})
 			currentTime = timeFunc
 		})
 
@@ -2596,6 +2598,9 @@ func expectPVCUpdates(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMa
 
 		updateObj := update.GetObject().(*corev1.PersistentVolumeClaim)
 		found := false
+		if updateObj.Name == "" {
+			return true, nil, nil
+		}
 		for _, vr := range vmRestore.Status.Restores {
 			if vr.DataVolumeName != nil && *vr.DataVolumeName == updateObj.Annotations["cdi.kubevirt.io/storage.populatedFor"] {
 				found = true

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -141,6 +141,13 @@ func GoldenImageRBAC(namespace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
 	return role, roleBinding
 }
 
+func RenderVMIWithPVC(dvName, ns string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
+	defaultOptions := []libvmi.Option{
+		libvmi.WithPersistentVolumeClaim("disk0", dvName),
+	}
+	return renderVMI(ns, append(defaultOptions, opts...)...)
+}
+
 func RenderVMIWithDataVolume(dvName, ns string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
 	defaultOptions := []libvmi.Option{
 		libvmi.WithDataVolume("disk0", dvName),

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1284,7 +1284,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Entry("to a new VM", true),
 			)
 
-			DescribeTable("should restore a vm that boots from a PVC", func(restoreToNewVM bool) {
+			DescribeTable("should restore a vm that boots from a PVC", func(restoreToNewVM, ownedByVM bool) {
 				dv := libdv.NewDataVolume(
 					libdv.WithName("restore-pvc-"+rand.String(12)),
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), cdiv1.RegistryPullNode),
@@ -1306,17 +1306,20 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				By("Ensuring the PVC is owned by the VM")
 				pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), originalPVCName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				pvc.OwnerReferences = []metav1.OwnerReference{
-					{
-						APIVersion: v1.GroupVersion.String(),
-						Kind:       "VirtualMachine",
-						Name:       vm.Name,
-						UID:        vm.UID,
-					},
+				if ownedByVM {
+					pvc.OwnerReferences = []metav1.OwnerReference{
+						{
+							APIVersion: v1.GroupVersion.String(),
+							Kind:       "VirtualMachine",
+							Name:       vm.Name,
+							UID:        vm.UID,
+						},
+					}
+				} else {
+					pvc.OwnerReferences = nil
 				}
 				_, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-
 				doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
 				Expect(restore.Status.Restores).To(HaveLen(1))
 				if restoreToNewVM {
@@ -1336,17 +1339,23 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 						Expect(v.PersistentVolumeClaim.ClaimName).ToNot(Equal(originalPVCName))
 						pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), v.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
-						Expect(pvc.OwnerReferences).ToNot(BeEmpty())
-						Expect(pvc.OwnerReferences[0].APIVersion).To(Equal(v1.GroupVersion.String()))
-						Expect(pvc.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
-						Expect(pvc.OwnerReferences[0].Name).To(Equal(targetVM.Name))
-						Expect(pvc.OwnerReferences[0].UID).To(Equal(targetVM.UID))
+						if ownedByVM {
+							Expect(pvc.OwnerReferences).ToNot(BeEmpty())
+							Expect(pvc.OwnerReferences[0].APIVersion).To(Equal(v1.GroupVersion.String()))
+							Expect(pvc.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
+							Expect(pvc.OwnerReferences[0].Name).To(Equal(targetVM.Name))
+							Expect(pvc.OwnerReferences[0].UID).To(Equal(targetVM.UID))
+						} else {
+							Expect(pvc.OwnerReferences).To(BeEmpty())
+						}
 						Expect(pvc.Labels["restore.kubevirt.io/source-vm-name"]).To(Equal(vm.Name))
+						Expect(pvc.Annotations).ToNot(HaveKey("restore.kubevirt.io/owned-by-vm"))
 					}
 				}
 			},
-				Entry("[test_id:5262] to the same VM", false),
-				Entry("to a new VM", true),
+				Entry("[test_id:5262] to the same VM", false, true),
+				Entry("to a new VM", true, true),
+				Entry("to a new VM, pvc not owned by VM", true, false),
 			)
 
 			DescribeTable("should restore a vm with containerdisk and blank datavolume", func(restoreToNewVM bool) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
When restoring a VM from a VMSnapshot, and if the VM has a regular PVC owned by the VM, the restore would not properly set the owner reference for the restored PVC. This would cause the restored PVC to remain orphaned. Once the user deletes the VM, the restored PVC would not be deleted.

#### Before this PR:
When restoring a VMSnapshot with a regular PVC not owned by a DataVolume, the restored PVC would not be owned by the VM (regardless of the restore policy). The PVC would remain orphaned.

#### After this PR:
If the restore policy is set to VM, then any restored PVCs associated with the VMSnapshot will be owned by the VM. These PVCs will no longer be orphaned when the VM is deleted.

### References
  
- Fixes https://issues.redhat.com/browse/CNV-67307

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Restoring naked PVCs from a VMSnapshot are now properly owned by the VM if the restore policy is set to VM
```

