### PR TITLE
fix: prioritize expired cert removal over 50-cert limit in MergeCABundle

### DIFF
--- a/pkg/virt-operator/resource/generate/components/secrets.go
+++ b/pkg/virt-operator/resource/generate/components/secrets.go
@@ -37,6 +37,7 @@ const (
 	CABundleKey                                       = "ca-bundle"
 	LocalPodDNStemplateString                         = "%s.%s.pod.cluster.local"
 	CaClusterLocal                                    = "cluster.local"
+	maxCertificatesInBundle                           = 50
 )
 
 type CertificateCreationCallback func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey)
@@ -464,6 +465,28 @@ func LoadCertificates(secret *k8sv1.Secret) (serverCrt *tls.Certificate, err err
 	return &crt, nil
 }
 
+// filterValidCertificates filters out certificates that are not valid and sorts them by age.
+// If there are more than maxCount, it truncates the list to maxCount
+func filterValidCertificates(certs []*x509.Certificate, now time.Time, maxCount int) []*x509.Certificate {
+	validCerts := make([]*x509.Certificate, 0, len(certs))
+	for _, crt := range certs {
+		if !crt.NotAfter.Before(now) {
+			validCerts = append(validCerts, crt)
+		}
+	}
+
+	sort.SliceStable(validCerts, func(i, j int) bool {
+		return validCerts[i].NotBefore.Unix() > validCerts[j].NotBefore.Unix()
+	})
+
+	if len(validCerts) > maxCount {
+		log.Log.Warningf("more than %d CA certificates found in the CA bundle, truncating to %d", maxCount, maxCount)
+		return validCerts[:maxCount]
+	}
+
+	return validCerts
+}
+
 func MergeCABundle(currentCert *tls.Certificate, currentBundle []byte, overlapDuration time.Duration) ([]byte, int, error) {
 	current := cert.EncodeCertPEM(currentCert.Leaf)
 	certs, err := cert.ParseCertsPEM(currentBundle)
@@ -471,40 +494,24 @@ func MergeCABundle(currentCert *tls.Certificate, currentBundle []byte, overlapDu
 		return nil, 0, err
 	}
 
-	// ensure that no one does something nasty and adds thousands of certs
-	if len(certs) > 50 {
-		log.Log.Warningf("more than 50 CA certificates found in the CA bundle, truncating to 50")
-		certs = certs[:50]
-	}
-
 	now := time.Now()
+	validCerts := filterValidCertificates(certs, now, maxCertificatesInBundle)
+
 	var newBundle []byte
-
-	// To ensure that no one messes this up, sort
-	// We want the newest certs first
-	sort.SliceStable(certs, func(i, j int) bool {
-		return certs[i].NotBefore.Unix() > certs[j].NotBefore.Unix()
-	})
-
 	certCount := 0
 	// we check for every cert i > 0, if in context to the certificate i-1 it existed already longer than the overlap
 	// duration. We check the certificate i = 0 against the current certificate.
-	for i, crt := range certs {
+	for i, crt := range validCerts {
 		if i == 0 {
 			if currentCert.Leaf.NotBefore.Add(overlapDuration).Before(now) {
 				log.DefaultLogger().Infof("Kept old CA certificates for a duration of at least %v, dropping them now.", overlapDuration)
 				break
 			}
 		} else {
-			if certs[i-1].NotBefore.Add(overlapDuration).Before(now) {
+			if validCerts[i-1].NotBefore.Add(overlapDuration).Before(now) {
 				log.DefaultLogger().Infof("Kept old CA certificates for a duration of at least %v, dropping them now.", overlapDuration)
 				break
 			}
-		}
-
-		// drop expired CAs
-		if crt.NotAfter.Before(now) {
-			continue
 		}
 
 		certBytes := cert.EncodeCertPEM(crt)


### PR DESCRIPTION
### What this PR does
Previously, MergeCABundle would truncate to 50 certificates before removing expired ones, causing valid new certificates to be dropped while expired certificates were retained. Now expired certificates are filtered out first, then the 50-certificate limit is applied to valid certificates only.

Fixes failing test: external CA - should properly manage adding entries to the configmap
Code was assisted by Cursor AI

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: prioritize expired cert removal over 50-cert limit in MergeCABundle
```

