### PR TITLE
virt-config: Align DefaultVirtHandler{Burst,QPS} with other client limits

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -77,8 +77,8 @@ const (
 	DefaultVirtOperatorLogVerbosity                 = 2
 
 	// Default REST configuration settings
-	DefaultVirtHandlerQPS         float32 = 5
-	DefaultVirtHandlerBurst               = 10
+	DefaultVirtHandlerQPS         float32 = 200
+	DefaultVirtHandlerBurst               = 400
 	DefaultVirtControllerQPS      float32 = 200
 	DefaultVirtControllerBurst            = 400
 	DefaultVirtAPIQPS             float32 = 200


### PR DESCRIPTION
/sig scale
/sig compute

### What this PR does

6327aa0aacd8859bf0d9b529e1dca26e7aab67fa recently aligned DefaultVirtAPI{Burst,QPS} with DefaultVirtWebhookClient{QPS,Burst} leaving the DefaultVirtHandler{Burst,QPS} rate limits for the virt-handler the only one on the original low values of 5 and 10.

This change bumps this in-line with all of the other rate limits to avoid introducing a bottleneck within the virt-handler client.

This essentially makes the HighBurst HyperConvergedTuningPolicy profile provided by HCO defunct, this will be deprecated and removed in follow up changes to that project.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `DefaultVirtHandler{QPS,Burst}` values are increased and aligned with all other client rate limits to ensure no bottleneck forms within `virt-handler`
```

