### PR TITLE
Add GuestFilesystemAlmostOutOfSpace alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1056,3 +1056,103 @@ tests:
               namespace: "test-ns"
               status: "terminating"
               node: "worker-node-4"
+
+  # GuestFilesystemAlmostOutOfSpace - Warning (85% usage)
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="test-vm", namespace="test-ns", disk_name="vda", mount_point="/", file_system_type="ext4"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="test-vm", namespace="test-ns", disk_name="vda", mount_point="/", file_system_type="ext4"}'
+        values: "80 80 85 85 85 86 86 86 86 86 86 86 86 75 75"
+
+    alert_rule_test:
+      # at 1m: usage = 80% -> no alert
+      - eval_time: 1m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+      # at 7m: usage = 86% -> no alert (below 10m threshold)
+      - eval_time: 7m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+      # at 12m: usage = 86% for 5+ minutes -> warning alert fires
+      - eval_time: 12m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts:
+          - exp_annotations:
+              summary: "Guest filesystem is running out of space"
+              description: "VirtualMachineInstance test-vm in namespace test-ns has filesystem vda (/) usage above 85% (current: 86%)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/GuestFilesystemAlmostOutOfSpace"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "test-vm"
+              namespace: "test-ns"
+              disk_name: "vda"
+              mount_point: "/"
+              file_system_type: "ext4"
+
+      # at 13m: usage drops to 75% -> alert clears
+      - eval_time: 13m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+  # GuestFilesystemAlmostOutOfSpace - Critical (95% usage)
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="test-vm", namespace="test-ns", disk_name="vda", mount_point="/", file_system_type="ext4"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="test-vm", namespace="test-ns", disk_name="vda", mount_point="/", file_system_type="ext4"}'
+        values: "90 90 95 95 95 96 96 96 85 85"
+
+    alert_rule_test:
+      # at 1m: usage = 90% -> no alert
+      - eval_time: 1m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+      # at 3m: usage = 95% -> alert (no threshold)
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts:
+          - exp_annotations:
+              summary: "Guest filesystem is critically low on space"
+              description: "VirtualMachineInstance test-vm in namespace test-ns has filesystem vda (/) usage above 95% (current: 95%)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/GuestFilesystemAlmostOutOfSpace"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "test-vm"
+              namespace: "test-ns"
+              disk_name: "vda"
+              mount_point: "/"
+              file_system_type: "ext4"
+
+      # at 7m: usage = 96% for 5+ minutes -> alert still fires
+      - eval_time: 7m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts:
+          - exp_annotations:
+              summary: "Guest filesystem is critically low on space"
+              description: "VirtualMachineInstance test-vm in namespace test-ns has filesystem vda (/) usage above 95% (current: 96%)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/GuestFilesystemAlmostOutOfSpace"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "test-vm"
+              namespace: "test-ns"
+              disk_name: "vda"
+              mount_point: "/"
+              file_system_type: "ext4"
+
+      # at 8m: usage drops to 85% -> alert clears
+      - eval_time: 8m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -128,5 +128,30 @@ var (
 				operatorHealthImpactLabelKey: "none",
 			},
 		},
+		{
+			Alert: "GuestFilesystemAlmostOutOfSpace",
+			Expr:  intstr.FromString("(kubevirt_vmi_filesystem_used_bytes / kubevirt_vmi_filesystem_capacity_bytes)*100 >= 85 < 95"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				"summary":     "Guest filesystem is running out of space",
+				"description": "VirtualMachineInstance {{ $labels.name }} in namespace {{ $labels.namespace }} has filesystem {{ $labels.disk_name }} ({{ $labels.mount_point }}) usage above 85% (current: {{ $value }}%).",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "none",
+			},
+		},
+		{
+			Alert: "GuestFilesystemAlmostOutOfSpace",
+			Expr:  intstr.FromString("(kubevirt_vmi_filesystem_used_bytes / kubevirt_vmi_filesystem_capacity_bytes)*100 >= 95"),
+			Annotations: map[string]string{
+				"summary":     "Guest filesystem is critically low on space",
+				"description": "VirtualMachineInstance {{ $labels.name }} in namespace {{ $labels.namespace }} has filesystem {{ $labels.disk_name }} ({{ $labels.mount_point }}) usage above 95% (current: {{ $value }}%).",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "none",
+			},
+		},
 	}
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

No alerts for guest file system high usage

#### After this PR:

Alerts when guest file system is high
>= 85% warning
>= 95% critical

jira-ticket: https://issues.redhat.com/browse/CNV-67061

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add GuestFilesystemAlmostOutOfSpace alerts
```

