### PR TITLE
Add Ephemeral Hotplug Volume Metric

### DIFF
--- a/pkg/monitoring/metrics/virt-api/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-api/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,6 +13,22 @@ go_library(
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/common/workqueue:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "virt_api_suite_test.go",
+        "vm_metrics_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
     ],
 )

--- a/pkg/monitoring/metrics/virt-api/virt_api_suite_test.go
+++ b/pkg/monitoring/metrics/virt-api/virt_api_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virt_api
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVirtApi(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/monitoring/metrics/virt-api/vm_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/vm_metrics.go
@@ -27,6 +27,7 @@ import (
 var (
 	vmMetrics = []operatormetrics.Metric{
 		vmsCreatedCounter,
+		ephemeralHotplugVolumeTotal,
 	}
 
 	vmsCreatedCounter = operatormetrics.NewCounterVec(
@@ -36,8 +37,20 @@ var (
 		},
 		[]string{"namespace"},
 	)
+
+	ephemeralHotplugVolumeTotal = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_ephemeral_hotplug_volume_total",
+			Help: "The total number of ephemeral hotplug volumes",
+		},
+		[]string{"namespace", "vmi-name"},
+	)
 )
 
 func NewVMCreated(vm *v1.VirtualMachine) {
 	vmsCreatedCounter.WithLabelValues(vm.Namespace).Inc()
+}
+
+func NewEphemeralHotplugVolume(namespace, vmiName string) {
+	ephemeralHotplugVolumeTotal.WithLabelValues(namespace, vmiName).Inc()
 }

--- a/pkg/monitoring/metrics/virt-api/vm_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-api/vm_metrics_test.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virt_api
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+)
+
+var _ = Describe("ephemeral hotplug volume metric", func() {
+	Context("NewEphemeralHotplugVolume", func() {
+		BeforeEach(func() {
+			operatormetrics.UnregisterMetrics(vmMetrics)
+			Expect(operatormetrics.RegisterMetrics(vmMetrics)).To(Succeed())
+		})
+
+		It("should setup and increment the metric correctly", func() {
+			Expect(ephemeralHotplugVolumeTotal).ToNot(BeNil(), "ephemeralHotplugVolumeTotal should be initialized")
+
+			counter := 0.0
+			// check if the metric is initialized and is empty
+			val, err := GetEphemeralHotplugVolumeTotal()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(counter))
+
+			By("incrementing the metric")
+			for counter < 3 {
+				NewEphemeralHotplugVolume()
+				counter++
+			}
+
+			val, err = GetEphemeralHotplugVolumeTotal()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(counter))
+
+		})
+	})
+})

--- a/pkg/virt-api/rest/volumes.go
+++ b/pkg/virt-api/rest/volumes.go
@@ -117,7 +117,7 @@ func (app *SubresourceAPIApp) addVolumeRequestHandler(request *restful.Request, 
 			writeError(err, response)
 			return
 		}
-		metrics.NewEphemeralHotplugVolume(namespace, name)
+		metrics.NewEphemeralHotplugVolume()
 	} else if app.clusterConfig.HotplugVolumesEnabled() {
 		if err := app.vmVolumePatchStatus(name, namespace, &volumeRequest); err != nil {
 			writeError(err, response)

--- a/pkg/virt-api/rest/volumes.go
+++ b/pkg/virt-api/rest/volumes.go
@@ -34,6 +34,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-api"
 )
 
 const (
@@ -116,6 +117,7 @@ func (app *SubresourceAPIApp) addVolumeRequestHandler(request *restful.Request, 
 			writeError(err, response)
 			return
 		}
+		metrics.NewEphemeralHotplugVolume(namespace, name)
 	} else if app.clusterConfig.HotplugVolumesEnabled() {
 		if err := app.vmVolumePatchStatus(name, namespace, &volumeRequest); err != nil {
 			writeError(err, response)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
CNV team wants to monitor the use of ephemeral hotplug volumes in production in order to assist with the rollout of new Declarative Hotplug Volumes (which is incompatible with ephemeral hotplug).

Add new metric to collect this data at the `virt-api` level

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Ephemeral Hotplug Volume Metric
```

