### PR TITLE
Add machine-type label to kwok nodes

### DIFF
--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -58,6 +58,7 @@ const (
 	defaultEventuallyPollingInterval = 1 * time.Second
 	defaultKubevirtReadyTimeout      = 5 * time.Minute
 	defaultKWOKNodeCount             = 100
+	defaultMachineType               = "q35"
 )
 
 const HostPathBase = "/tmp/hostImages"
@@ -260,15 +261,16 @@ func newFakeKWOKNode(nodeName string) *k8sv1.Node {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Labels: map[string]string{
-				"beta.kubernetes.io/arch":       "amd64",
-				"beta.kubernetes.io/os":         "linux",
-				"kubernetes.io/arch":            "amd64",
-				"kubernetes.io/hostname":        nodeName,
-				"kubernetes.io/os":              "linux",
-				"kubernetes.io/role":            "agent",
-				"node-role.kubernetes.io/agent": "",
-				"kubevirt.io/schedulable":       "true",
-				"type":                          "kwok",
+				"beta.kubernetes.io/arch":                         "amd64",
+				"beta.kubernetes.io/os":                           "linux",
+				"kubernetes.io/arch":                              "amd64",
+				"kubernetes.io/hostname":                          nodeName,
+				"kubernetes.io/os":                                "linux",
+				"kubernetes.io/role":                              "agent",
+				"node-role.kubernetes.io/agent":                   "",
+				v1.NodeSchedulable:                                "true",
+				v1.SupportedMachineTypeLabel + defaultMachineType: "true",
+				"type": "kwok",
 			},
 			Annotations: map[string]string{
 				"node.alpha.kubernetes.io/ttl": "0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
KWOK density tests are failing for a long time at the create primer step

When looked into the issue, it was found that the virt-launcher pod failed to schedule on the KWOK nodes due to the configured node selector.
The scheduler logs reported the following:

```
0/101 nodes are available: 101 node(s) didn’t match Pod’s node affinity/selector.
no new claims to deallocate, preemption: 0/101 nodes are available: 101 Preemption is not helpful for scheduling.
Virt-launcher pod is having the following node-selectors defined
```
The virt-launcher pod had the following node selectors applied:
`machine-type.node.kubevirt.io/q35: "true"`

This label is added by the Node Labeller based on the VM configuration. Since the KWOK nodes were missing this label, the pod could not be scheduled on them. Hence the tests failed.



#### After this PR: Added the label to the KWOK nodes.

### References

- Fixes #https://github.com/kubevirt/kubevirt/issues/15700
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

