### PR TITLE
[release-1.6] Memory overcommit: re-calculate on migration

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -336,15 +336,7 @@ func setDefaultResourceRequests(clusterConfig *virtconfig.ClusterConfig, spec *v
 			if resources.Requests == nil {
 				resources.Requests = k8sv1.ResourceList{}
 			}
-			overcommit := clusterConfig.GetMemoryOvercommit()
-			if overcommit == 100 {
-				resources.Requests[k8sv1.ResourceMemory] = *memory
-			} else {
-				value := (memory.Value() * int64(100)) / int64(overcommit)
-				resources.Requests[k8sv1.ResourceMemory] = *resource.NewQuantity(value, memory.Format)
-			}
-			memoryRequest := resources.Requests[k8sv1.ResourceMemory]
-			log.Log.V(4).Infof("Set memory-request to %s as a result of memory-overcommit = %v%%", memoryRequest.String(), overcommit)
+			resources.Requests[k8sv1.ResourceMemory] = *memory
 		}
 	}
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -648,25 +648,6 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(vmiSpec.Domain.CPU.Threads).To(Equal(uint32(1)), "Expect threads")
 	})
 
-	It("should apply memory-overcommit when guest-memory is set and memory-request is not set", func() {
-		// no limits wanted on this test, to not copy the limit to requests
-		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
-			Spec: v1.KubeVirtSpec{
-				Configuration: v1.KubeVirtConfiguration{
-					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						MemoryOvercommit: 150,
-					},
-				},
-			},
-		})
-
-		guestMemory := resource.MustParse("3072M")
-		vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
-		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
-		Expect(vmiSpec.Domain.Memory.Guest.String()).To(Equal("3072M"))
-		Expect(vmiSpec.Domain.Resources.Requests.Memory().String()).To(Equal("2048M"))
-	})
-
 	It("should apply memory-overcommit when hugepages are set and memory-request is not set", func() {
 		// no limits wanted on this test, to not copy the limit to requests
 		vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "3072M"}}

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -252,6 +252,14 @@ func WithHugePages(vmMemory *v1.Memory, memoryOverhead resource.Quantity) Resour
 	}
 }
 
+func WithMemoryOvercommit(overcommit int) ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		memory := renderer.vmRequests[k8sv1.ResourceMemory]
+		memory = *resource.NewQuantity((memory.Value()*int64(100))/int64(overcommit), memory.Format)
+		renderer.vmRequests[k8sv1.ResourceMemory] = memory
+	}
+}
+
 func WithMemoryOverhead(guestResourceSpec v1.ResourceRequirements, memoryOverhead resource.Quantity) ResourceRendererOption {
 	return func(renderer *ResourceRenderer) {
 		memoryRequest := renderer.vmRequests[k8sv1.ResourceMemory]

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1526,6 +1526,10 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 	return VMIResourcePredicates{
 		vmi: vmi,
 		resourceRules: []VMIResourceRule{
+			// Run overcommit first to avoid overcommitting overhead memory
+			NewVMIResourceRule(func(vmi *v1.VirtualMachineInstance) bool {
+				return t.clusterConfig.GetMemoryOvercommit() != 100
+			}, WithMemoryOvercommit(t.clusterConfig.GetMemoryOvercommit())),
 			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi, vmi.Annotations, additionalCPUs)),
 			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
 			NewVMIResourceRule(hasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2176,7 +2176,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("3"))
 			})
-			It("should allocate proportinal amount of cpus to vmipod as vcpus with allocation_ratio set to 10", func() {
+			It("should allocate proportional amount of cpus to vmipod as vcpus with allocation_ratio set to 10", func() {
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -2227,6 +2227,58 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("150m"))
+			})
+
+			It("should honor memoryOvercommit when set in the CR", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+
+				By("Creating a VMI")
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Memory: &v1.Memory{
+								Guest: pointer.P(resource.MustParse("1Gi")),
+							},
+							Resources: v1.ResourceRequirements{
+								Requests: k8sv1.ResourceList{
+									// This would usually be set by the mutating webhook
+									k8sv1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				}
+
+				By("Checking how much memory the pod requests by default")
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				mem100 := pod.Spec.Containers[0].Resources.Requests.Memory()
+
+				By("Setting a memory overcommit of 110% in the CR")
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.MemoryOvercommit = 110
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
+
+				By("Checking how much memory the pod requests now")
+				pod, err = svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				mem110 := pod.Spec.Containers[0].Resources.Requests.Memory()
+
+				By("Ensuring the memory was overcommitted by 110%")
+				overhead := mem100.DeepCopy()
+				overhead.Sub(*vmi.Spec.Domain.Memory.Guest)
+				mem100.Sub(overhead)
+				mem110.Sub(overhead)
+				mem100int, res := mem100.AsInt64()
+				Expect(res).To(BeTrue())
+				mem110int, res := mem110.AsInt64()
+				Expect(res).To(BeTrue())
+				Expect(mem100int * 100 / 110).To(Equal(mem110int))
 			})
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -466,26 +466,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			})
 		})
 
-		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied", Serial, func() {
-			BeforeEach(func() {
-				kv := libkubevirt.GetCurrentKv(virtClient)
-
-				config := kv.Spec.Configuration
-				config.DeveloperConfiguration.MemoryOvercommit = 200
-				kvconfig.UpdateKubeVirtConfigValueAndWait(config)
-			})
-
-			It("[test_id:3114]should set requested amount of memory according to the specified virtual memory", func() {
-				vmi := libvmi.New()
-				guestMemory := resource.MustParse("4096M")
-				vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
-				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("2048M"))
-			})
-		})
-
 		Context("with BIOS bootloader method and no disk", func() {
 			It("[test_id:5265]should find no bootable device by default", func() {
 				By("Creating a VMI with no disk and an explicit network interface")


### PR DESCRIPTION
This is a partial manual backport of https://github.com/kubevirt/kubevirt/pull/15681 (the third commit was omitted as it just restricts the API)

This PR doesn't include any API change, but it does alter how an API field is interpreted by the code.

```release-note
Memory overcommit is now recalculated on migration.
Important: deployments that set a memoryOvercommit value below 10 need to bump to 10+ before upgrading.
```
