### PR TITLE
[release-1.6] virt-handler: ensure the VM controller sees VMI deletions during migrations

### DIFF
--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -248,6 +248,9 @@ func (c *MigrationSourceController) updateStatus(vmi *v1.VirtualMachineInstance,
 		vmi.Status.Phase = v1.Failed
 		vmi.Status.MigrationState.Completed = true
 		vmi.Status.MigrationState.Failed = true
+		if vmi.Status.MigrationState.EndTimestamp == nil {
+			vmi.Status.MigrationState.EndTimestamp = pointer.P(metav1.NewTime(time.Now()))
+		}
 
 		log.Log.Object(vmi).Warning("the vmi migrated to an unknown host")
 		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to unknown host."))
@@ -256,6 +259,9 @@ func (c *MigrationSourceController) updateStatus(vmi *v1.VirtualMachineInstance,
 			vmi.Status.Phase = v1.Failed
 			vmi.Status.MigrationState.Completed = true
 			vmi.Status.MigrationState.Failed = true
+			if vmi.Status.MigrationState.EndTimestamp == nil {
+				vmi.Status.MigrationState.EndTimestamp = pointer.P(metav1.NewTime(time.Now()))
+			}
 
 			log.Log.Object(vmi).Warning("the domain was never observed on the taget after the migration completed within the timeout period")
 			c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance's domain was never observed on the target after the migration completed within the timeout period."))

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -506,8 +506,10 @@ func (c *MigrationTargetController) execute(key string) error {
 
 	if vmi.IsFinal() || vmi.DeletionTimestamp != nil {
 		log.Log.V(4).Infof("vmi for key %v is terminating or final, doing only a best-effort cleanup", key)
+		_ = c.unmountVolumes(vmi)
 		_ = c.netConf.Teardown(vmi)
 		c.netStat.Teardown(vmi)
+		c.launcherClients.CloseLauncherClient(vmi)
 		return nil
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -390,7 +390,7 @@ func (c *VirtualMachineController) execute(key string) error {
 		}
 	}
 
-	if isMigrationInProgress(vmi, domain) {
+	if vmi.DeletionTimestamp == nil && isMigrationInProgress(vmi, domain) {
 		log.Log.V(4).Infof("ignoring key %v as migration is in progress", key)
 		return nil
 	}


### PR DESCRIPTION
Manual backport of https://github.com/kubevirt/kubevirt/pull/15540

```release-note
NONE
```
