### PR TITLE
build: update container manifest push to handle new digest file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -250,7 +250,7 @@ oci_push(
 
 oci_push(
     name = "push-pr-helper",
-    image = "//cmd/pr-helper:pr-helper",
+    image = "//cmd/pr-helper:pr-helper-image",
     repository = "quay.io/kubevirt/pr-helper",
 )
 

--- a/cmd/pr-helper/BUILD.bazel
+++ b/cmd/pr-helper/BUILD.bazel
@@ -41,7 +41,7 @@ oci_image(
 )
 
 oci_image(
-    name = "pr-helper",
+    name = "pr-helper-image",
     base = ":version-container",
     entrypoint = ["/usr/bin/qemu-pr-helper"],
     visibility = ["//visibility:public"],

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -40,7 +40,7 @@ other_images_x86_64_aarch64="
     //cmd/sidecars/network-slirp-binding:network-slirp-binding-image
     //cmd/sidecars/network-passt-binding:network-passt-binding-image
     //cmd/cniplugins/passt-binding/cmd:network-passt-binding-cni-image
-    //cmd/pr-helper:pr-helper
+    //cmd/pr-helper:pr-helper-image
     //containerimages:cirros-container-disk-image
     //containerimages:cirros-custom-container-disk-image
     //containerimages:virtio-container-disk-image

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -83,7 +83,7 @@ bazel build \
 rm -rf ${DIGESTS_DIR}/${ARCHITECTURE}
 mkdir -p ${DIGESTS_DIR}/${ARCHITECTURE}
 
-for f in $(find bazel-bin/ -name '*.digest'); do
+for f in $(find bazel-bin/ -name '*.json.sha256' | grep -v 'version-container'); do
     dir=${DIGESTS_DIR}/${ARCHITECTURE}/$(dirname $f)
     mkdir -p ${dir}
     cp -f ${f} ${dir}/$(basename ${f})

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -88,7 +88,7 @@ fi
 rm -rf ${DIGESTS_DIR}/${ARCHITECTURE}
 mkdir -p ${DIGESTS_DIR}/${ARCHITECTURE}
 
-for f in $(find bazel-bin/ -name '*.digest'); do
+for f in $(find bazel-bin/ -name '*.json.sha256' | grep -v 'version-container'); do
     dir=${DIGESTS_DIR}/${ARCHITECTURE}/$(dirname $f)
     mkdir -p ${dir}
     cp -f ${f} ${dir}/$(basename ${f})

--- a/hack/push-container-manifest.sh
+++ b/hack/push-container-manifest.sh
@@ -33,12 +33,8 @@ function podman_push_manifest() {
     echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
     ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
     for ARCH in ${BUILD_ARCH//,/ }; do
-        FORMATED_ARCH=$(format_archname ${ARCH})
-        if [ ! -f ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest ]; then
-            continue
-        fi
-        digest=$(cat ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest)
-        ${KUBEVIRT_CRI} manifest add ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}@${digest}
+        FORMATTED_ARCH=$(format_archname ${ARCH} tag)
+        ${KUBEVIRT_CRI} manifest add ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}-${FORMATTED_ARCH}
     done
     ${KUBEVIRT_CRI} manifest push --all ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
 }
@@ -47,12 +43,8 @@ function docker_push_manifest() {
     image=$1
     MANIFEST_IMAGES=""
     for ARCH in ${BUILD_ARCH//,/ }; do
-        FORMATED_ARCH=$(format_archname ${ARCH})
-        if [ ! -f ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest ]; then
-            continue
-        fi
-        digest=$(cat ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest)
-        MANIFEST_IMAGES="${MANIFEST_IMAGES} --amend ${DOCKER_PREFIX}/${image}@${digest}"
+        FORMATTED_ARCH=$(format_archname ${ARCH} tag)
+        MANIFEST_IMAGES="${MANIFEST_IMAGES} --amend ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}-${FORMATTED_ARCH}"
     done
     echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
     ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
@@ -60,7 +52,7 @@ function docker_push_manifest() {
 }
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
-for image in $(find ${DIGESTS_DIR}/*/bazel-bin/ -name '*.digest' -printf '%f\n' | sed s/^push-//g | sed s/\.digest$//g | sort -u); do
+for image in $(find ${DIGESTS_DIR} -name '*.json.sha256' -printf '%f\n' | sed s/\-image.json.sha256$//g | sort -u); do
     if [ "${KUBEVIRT_CRI}" = "podman" ]; then
         podman_push_manifest $image
     else


### PR DESCRIPTION
### What this PR does

When building the images using rules_oci, the resulting digest file is created like this for virt-launcher

```
bazel-bin/cmd/virt-launcher/virt-launcher-image.json.sha256
```

Update the bazel-build-images.sh & push-container-manifest.sh to handle this change

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #15740 
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @dhiller @xpivarc 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

