### PR TITLE
net, virtwrap, network: Reduce dependency on virtwrap/cli

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/manager.go
+++ b/pkg/virt-launcher/virtwrap/network/manager.go
@@ -20,18 +20,26 @@
 package network
 
 import (
+	"libvirt.org/go/libvirt"
+
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 )
+
+type domainClient interface {
+	AttachDeviceFlags(xml string, flags libvirt.DomainDeviceModifyFlags) error
+	UpdateDeviceFlags(xml string, flags libvirt.DomainDeviceModifyFlags) error
+	DetachDeviceFlags(xml string, flags libvirt.DomainDeviceModifyFlags) error
+	Free() error
+}
 
 func Sync(
 	domain *api.Domain,
 	oldSpec *api.DomainSpec,
-	dom cli.VirDomain,
+	dom domainClient,
 	vmi *v1.VirtualMachineInstance,
 	domainAttachments map[string]string,
 ) error {

--- a/pkg/virt-launcher/virtwrap/network/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/network/nichotplug.go
@@ -24,14 +24,13 @@ import (
 	"fmt"
 	"strings"
 
-	"kubevirt.io/kubevirt/pkg/network/namescheme"
-
 	"libvirt.org/go/libvirt"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
 	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
@@ -44,7 +43,7 @@ type vmConfigurator interface {
 }
 
 type virtIOInterfaceManager struct {
-	dom          cli.VirDomain
+	dom          domainClient
 	configurator vmConfigurator
 }
 
@@ -54,7 +53,7 @@ const (
 )
 
 func newVirtIOInterfaceManager(
-	libvirtClient cli.VirDomain,
+	libvirtClient domainClient,
 	configurator vmConfigurator,
 ) *virtIOInterfaceManager {
 	return &virtIOInterfaceManager{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
We want to start decoupling the network package from the cli package
by introducing a new interface that represents the minimal requirements
of domain client.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

