### PR TITLE
Properly count decentralized migrations for the migration limits

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1284,6 +1284,7 @@ func (c *Controller) handleTargetPodCreation(key string, migration *virtv1.Virtu
 	if err != nil {
 		return fmt.Errorf("failed to determin the number of running migrations: %v", err)
 	}
+	log.Log.V(3).Infof("number of running migrations: %d", len(runningMigrations))
 
 	// XXX: Make this configurable, think about limit per node, bandwidth per migration, and so on.
 	if len(runningMigrations) >= int(*c.clusterConfig.GetMigrationConfiguration().ParallelMigrationsPerCluster) {

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -91,15 +91,23 @@ var _ = Describe("Migration watcher", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pods.Items).To(HaveLen(1))
-		Expect(pods.Items[0].Spec.Affinity).ToNot(BeNil())
-		Expect(pods.Items[0].Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
-		Expect(pods.Items[0].Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(expectedAntiAffinityCount))
-		if expectedAffinityCount > 0 {
-			Expect(pods.Items[0].Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(expectedAffinityCount))
+		if expectedAntiAffinityCount > 0 || expectedAffinityCount > 0 || expectedNodeAffinityCount > 0 {
+			Expect(pods.Items[0].Spec.Affinity).ToNot(BeNil())
+			if expectedAntiAffinityCount > 0 {
+				Expect(pods.Items[0].Spec.Affinity.PodAntiAffinity).ToNot(BeNil())
+				Expect(pods.Items[0].Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(expectedAntiAffinityCount))
+			}
+			if expectedAffinityCount > 0 {
+				Expect(pods.Items[0].Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(expectedAffinityCount))
+			}
+			if expectedNodeAffinityCount > 0 {
+				Expect(pods.Items[0].Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(expectedNodeAffinityCount))
+			}
 		}
-		if expectedNodeAffinityCount > 0 {
-			Expect(pods.Items[0].Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(expectedNodeAffinityCount))
-		}
+	}
+
+	expectReceiverPodCreation := func(namespace string, uid types.UID, migrationUid types.UID) {
+		expectPodCreation(namespace, uid, migrationUid, 0, 0, 0)
 	}
 
 	expectPodDoesNotExist := func(namespace, uid, migrationUid string) {
@@ -602,6 +610,8 @@ var _ = Describe("Migration watcher", func() {
 	})
 
 	Context("Migration object in pending state", func() {
+		const defaultMaxOutboundMigrationsPerNode = 2
+
 		It("should patch VMI with nonroot user", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			delete(vmi.Annotations, virtv1.DeprecatedNonRootVMIAnnotation)
@@ -779,6 +789,39 @@ var _ = Describe("Migration watcher", func() {
 			expectPodCreation(vmi.Namespace, vmi.UID, migration.UID, 1, 0, 0)
 		})
 
+		DescribeTable("should properly count decentralized live migrations when creating the target pod", func(phase virtv1.VirtualMachineInstanceMigrationPhase, otherMigrations int, sameNode, expectedRunning bool) {
+			vmi := newReceiverVirtualMachine("testvmi", virtv1.Pending, "testmigration")
+			migration := newDecentralizedReceiverMigration("testmigration", vmi.Name, phase)
+			addNodeNameToVMI(vmi, "node")
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			for i := 0; i < otherMigrations; i++ {
+				vmi := newReceiverVirtualMachine(fmt.Sprintf("testvmi%v", i), virtv1.WaitingForSync, fmt.Sprintf("testmigration%v", i))
+				migration := newDecentralizedReceiverMigration(fmt.Sprintf("testmigration%v", i), vmi.Name, virtv1.MigrationRunning)
+				if sameNode {
+					addNodeNameToVMI(vmi, "node")
+				} else {
+					addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
+				}
+				addMigration(migration)
+				addVirtualMachineInstance(vmi)
+			}
+			sanityExecute()
+			if expectedRunning {
+				testutils.ExpectEvent(recorder, virtcontroller.SuccessfulCreatePodReason)
+				expectReceiverPodCreation(vmi.Namespace, vmi.UID, migration.UID)
+			} else {
+				expectPodDoesNotExist(vmi.Namespace, "testvmi", "testmigration")
+			}
+		},
+			Entry("per node limit, with a Pending decentralized migration, two others running", virtv1.MigrationPending, defaultMaxOutboundMigrationsPerNode, true, false),
+			Entry("per node limit, with a Pending decentralized migration, one other running", virtv1.MigrationPending, 1, true, true),
+			Entry("cluster limit, with a Pending decentralized migration, two others running", virtv1.MigrationPending, defaultMaxOutboundMigrationsPerNode, false, true),
+			Entry("cluster limit, with a Pending decentralized migration, one other running", virtv1.MigrationPending, 1, false, true),
+			Entry("cluster limit, with a Pending decentralized migration, five others running", virtv1.MigrationPending, 5, false, false),
+		)
+
 		DescribeTable("should not overload the node and only run 2 outbound migrations in parallel",
 			func(generateVMIandMigration func(int)) {
 				// It should create a pod for this one if we would not limit migrations
@@ -789,7 +832,6 @@ var _ = Describe("Migration watcher", func() {
 				addVirtualMachineInstance(vmi)
 				addPod(newSourcePodForVirtualMachine(vmi))
 
-				const defaultMaxOutboundMigrationsPerNode = 2
 				for i := 0; i < defaultMaxOutboundMigrationsPerNode; i++ {
 					generateVMIandMigration(i)
 				}
@@ -2576,6 +2618,14 @@ func newMigration(name string, vmiName string, phase virtv1.VirtualMachineInstan
 	return migration
 }
 
+func newDecentralizedReceiverMigration(name string, vmiName string, phase virtv1.VirtualMachineInstanceMigrationPhase) *virtv1.VirtualMachineInstanceMigration {
+	migration := newMigration(name, vmiName, phase)
+	migration.Spec.Receive = &virtv1.VirtualMachineInstanceMigrationTarget{
+		MigrationID: vmiName,
+	}
+	return migration
+}
+
 func newMigrationWithAddedNodeSelector(name string, vmiName string, phase virtv1.VirtualMachineInstanceMigrationPhase, addedNodeSelector map[string]string) *virtv1.VirtualMachineInstanceMigration {
 	migration := newMigration(name, vmiName, phase)
 	migration.Spec.AddedNodeSelector = addedNodeSelector
@@ -2593,6 +2643,24 @@ func newVirtualMachine(name string, phase virtv1.VirtualMachineInstancePhase) *v
 	vmi.Status.RuntimeUser = 107
 	vmi.ObjectMeta.Annotations = map[string]string{
 		virtv1.DeprecatedNonRootVMIAnnotation: "true",
+	}
+	return vmi
+}
+
+func newReceiverVirtualMachine(name string, phase virtv1.VirtualMachineInstancePhase, migrationUID string) *virtv1.VirtualMachineInstance {
+	vmi := newVirtualMachine(name, phase)
+	vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+		TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+			VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+				MigrationUID: types.UID(migrationUID),
+			},
+		},
+		SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+			VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+				Node:           "testnode",
+				SelinuxContext: "none",
+			},
+		},
 	}
 	return vmi
 }

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -828,6 +828,10 @@ func (m *VirtualMachineInstanceMigration) IsRunning() bool {
 	switch m.Status.Phase {
 	case MigrationFailed, MigrationPending, MigrationPhaseUnset, MigrationSucceeded, MigrationWaitingForSync, MigrationSynchronizing:
 		return false
+	case MigrationScheduling:
+		if m.IsDecentralizedSource() {
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Properly count running and waiting decentralized live migrations

#### Before this PR:
Currently the decentralized migrations are not properly counted for the migration limits. This
is causing the migration limits to not be counted accurately. This causes either too many or too few migrations to be allowed to run.

#### After this PR:
Decentralized live migration are counted properly and migrating across namespaces or clusters takes the migration limit into account.

### References
- Fixes https://issues.redhat.com/browse/CNV-69281
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: The migration limit was not accurately being used with decentralized live migrations
```