### PR TITLE
Cleanup node labels and annotations on Kubevirt deletion

### DIFF
--- a/pkg/virt-operator/resource/apply/delete_test.go
+++ b/pkg/virt-operator/resource/apply/delete_test.go
@@ -200,9 +200,10 @@ var _ = Describe("Deletion", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
 							Labels: map[string]string{
-								"kubevirt.io/schedulable": "true",
-								"kubevirt.io/some-label":  "value",
-								"other-label":             "value",
+								"kubevirt.io/schedulable":            "true",
+								"kubevirt.io/some-label":             "value",
+								"cpu-feature.kubevirt.io/some-label": "value",
+								"other-label":                        "value",
 							},
 						},
 					},
@@ -210,8 +211,9 @@ var _ = Describe("Deletion", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node2",
 							Labels: map[string]string{
-								"kubevirt.io/schedulable":   "true",
-								"kubevirt.io/another-label": "value",
+								"kubevirt.io/schedulable":            "true",
+								"kubevirt.io/another-label":          "value",
+								"cpu-feature.kubevirt.io/some-label": "value",
 							},
 						},
 					},
@@ -231,7 +233,7 @@ var _ = Describe("Deletion", func() {
 			_, err = clientset.CoreV1().Nodes().Create(context.Background(), &nodes.Items[2], metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = deleteKubeVirtLabelsFromNodes(kubevirtClient)
+			err = deleteNodeLabelsAndAnnotations(kubevirtClient)
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedNode1, err := clientset.CoreV1().Nodes().Get(context.Background(), "node1", metav1.GetOptions{})

--- a/pkg/virt-operator/resource/apply/delete_test.go
+++ b/pkg/virt-operator/resource/apply/delete_test.go
@@ -200,10 +200,15 @@ var _ = Describe("Deletion", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node1",
 							Labels: map[string]string{
-								"kubevirt.io/schedulable":            "true",
-								"kubevirt.io/some-label":             "value",
-								"cpu-feature.kubevirt.io/some-label": "value",
-								"other-label":                        "value",
+								"kubevirt.io/schedulable":          "true",
+								"kubevirt.io/some-label":           "value",
+								"prefix.kubevirt.io/another-label": "value",
+								"other-label":                      "value",
+							},
+							Annotations: map[string]string{
+								"kubevirt.io/some-annotation":           "value",
+								"prefix.kubevirt.io/another-annotation": "value",
+								"other-annotation":                      "value",
 							},
 						},
 					},
@@ -211,9 +216,13 @@ var _ = Describe("Deletion", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node2",
 							Labels: map[string]string{
-								"kubevirt.io/schedulable":            "true",
-								"kubevirt.io/another-label":          "value",
-								"cpu-feature.kubevirt.io/some-label": "value",
+								"kubevirt.io/schedulable":          "true",
+								"kubevirt.io/some-label":           "value",
+								"prefix.kubevirt.io/another-label": "value",
+							},
+							Annotations: map[string]string{
+								"kubevirt.io/some-annotation":           "value",
+								"prefix-kubevirt.io/another-annotation": "value",
 							},
 						},
 					},
@@ -239,11 +248,16 @@ var _ = Describe("Deletion", func() {
 			updatedNode1, err := clientset.CoreV1().Nodes().Get(context.Background(), "node1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedNode1.Labels).ToNot(HaveKey("kubevirt.io/some-label"))
+			Expect(updatedNode1.Labels).ToNot(HaveKey("prefix.kubevirt.io/another-label"))
 			Expect(updatedNode1.Labels).To(HaveKey("other-label"))
+			Expect(updatedNode1.Annotations).ToNot(HaveKey("kubevirt.io/some-annotation"))
+			Expect(updatedNode1.Annotations).ToNot(HaveKey("prefix.kubevirt.io/another-annotation"))
+			Expect(updatedNode1.Annotations).To(HaveKey("other-annotation"))
 
 			updatedNode2, err := clientset.CoreV1().Nodes().Get(context.Background(), "node2", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedNode2.Labels).To(BeEmpty())
+			Expect(updatedNode2.Annotations).To(BeEmpty())
 
 			Expect(clientset.Actions()).To(WithTransform(func(actions []testing.Action) []testing.Action {
 				var node3patchActions []testing.Action


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR: After deleting kubevirt, kubevirt labels and annotations still remain on the nodes.

#### After this PR: Kubevirt labels and annotations are deleted from the nodes as by the KubevirtController as part of the cleanup.

### References
- Partially fixes #15380 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Delete all Kubevirt-related node labels and annotations from nodes upon Kubevirt deletion.
```

