### PR TITLE
build: update to use PUSH_TARGETS to generate list of images for hack/push-container-manifest.sh

### DIFF
--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -88,8 +88,8 @@ fi
 rm -rf ${DIGESTS_DIR}/${ARCHITECTURE}
 mkdir -p ${DIGESTS_DIR}/${ARCHITECTURE}
 
-for f in $(find bazel-bin/ -name '*.json.sha256' | grep -v 'version-container'); do
-    dir=${DIGESTS_DIR}/${ARCHITECTURE}/$(dirname $f)
+for target in ${PUSH_TARGETS[@]}; do
+    dir=${DIGESTS_DIR}/${ARCHITECTURE}/${target}
     mkdir -p ${dir}
-    cp -f ${f} ${dir}/$(basename ${f})
+    touch ${dir}/${target}.image
 done

--- a/hack/push-container-manifest.sh
+++ b/hack/push-container-manifest.sh
@@ -34,7 +34,12 @@ function podman_push_manifest() {
     ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
     for ARCH in ${BUILD_ARCH//,/ }; do
         FORMATTED_ARCH=$(format_archname ${ARCH} tag)
-        ${KUBEVIRT_CRI} manifest add ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}-${FORMATTED_ARCH}
+        TAGGED_IMAGE="${DOCKER_PREFIX}/${image}:${DOCKER_TAG}-${FORMATTED_ARCH}"
+        if skopeo inspect docker://${TAGGED_IMAGE} &>/dev/null; then
+            ${KUBEVIRT_CRI} manifest add ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${TAGGED_IMAGE}
+        else
+            echo "Warning: Image ${TAGGED_IMAGE} does not exist, skipping"
+        fi
     done
     ${KUBEVIRT_CRI} manifest push --all ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
 }
@@ -44,7 +49,12 @@ function docker_push_manifest() {
     MANIFEST_IMAGES=""
     for ARCH in ${BUILD_ARCH//,/ }; do
         FORMATTED_ARCH=$(format_archname ${ARCH} tag)
-        MANIFEST_IMAGES="${MANIFEST_IMAGES} --amend ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}-${FORMATTED_ARCH}"
+        TAGGED_IMAGE="${DOCKER_PREFIX}/${image}:${DOCKER_TAG}-${FORMATTED_ARCH}"
+        if skopeo inspect docker://${TAGGED_IMAGE} &>/dev/null; then
+            MANIFEST_IMAGES="${MANIFEST_IMAGES} --amend ${TAGGED_IMAGE}"
+        else
+            echo "Warning: Image ${TAGGED_IMAGE} does not exist, skipping"
+        fi
     done
     echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
     ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}

--- a/hack/push-container-manifest.sh
+++ b/hack/push-container-manifest.sh
@@ -62,7 +62,7 @@ function docker_push_manifest() {
 }
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
-for image in $(find ${DIGESTS_DIR} -name '*.json.sha256' -printf '%f\n' | sed s/\-image.json.sha256$//g | sort -u); do
+for image in $(find ${DIGESTS_DIR} -name '*.image' -printf '%f\n' | sed s/\.image$//g | sort -u); do
     if [ "${KUBEVIRT_CRI}" = "podman" ]; then
         podman_push_manifest $image
     else


### PR DESCRIPTION
### What this PR does

Rather than dynamically finding the images names in hack/bazel-push-images.sh - use the list of PUSH_TARGETS that is already present. This can prevent issues with the find missing images such as with the virtio-container-disk image that is causing the HCO nightly builds to fail

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-hco-push-nightly-build-main/1973237033346273280

Also add a check to see if the remote image exists before adding it to the multiarch manifest. 


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @dhiller @xpivarc 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

