### PR TITLE
reporter: Add `containerd` and `crio` debug on functional test failure

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -108,6 +108,7 @@ elif [[ $TARGET =~ wg-s390x ]]; then
     export KUBEVIRT_PROVIDER=${TARGET/-wg-s390x}
 elif [[ $TARGET =~ wg-arm64 ]]; then
     export KUBEVIRT_PROVIDER=${TARGET/-wg-arm64}
+    export KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true
 elif [[ $TARGET =~ sev ]]; then
     export KUBEVIRT_PROVIDER=${TARGET/-sev}
 else

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -723,6 +723,7 @@ func (r *KubernetesReporter) logContainerdCrictl(pod *v1.Pod, node string, logsd
 		{command: "crictl pods", fileNameSuffix: "crictl-pods"},
 		{command: "crictl images", fileNameSuffix: "crictl-images"},
 		{command: "crictl stats -a", fileNameSuffix: "crictl-stats"},
+		{command: "crictl imagefsinfo", fileNameSuffix: "crictl-imagefsinfo"},
 		{command: "crictl version", fileNameSuffix: "crictl-version"},
 		{command: "ctr -n k8s.io containers list", fileNameSuffix: "ctr-containers"},
 		{command: "ctr -n k8s.io tasks list", fileNameSuffix: "ctr-tasks"},

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -252,7 +252,7 @@ func (r *KubernetesReporter) dumpTestObjects(duration time.Duration, vmiNamespac
 	r.logVirtualMachinePools(virtCli)
 	r.logMigrationPolicies(virtCli)
 
-	// Collect containerd stacks from all nodes, not just nodes with test pods
+	// Collect containerd and cri-o stacks from all nodes, not just nodes with test pods
 	allNodeNames := []string{}
 	if nodes != nil {
 		for _, node := range nodes.Items {
@@ -260,6 +260,7 @@ func (r *KubernetesReporter) dumpTestObjects(duration time.Duration, vmiNamespac
 		}
 	}
 	r.logContainerdStacks(virtCli, nodesDir, allNodeNames)
+	r.logCrioStacks(virtCli, nodesDir, allNodeNames)
 }
 
 // Cleanup cleans up the current content of the artifactsDir
@@ -723,6 +724,132 @@ func (r *KubernetesReporter) logContainerdCrictl(pod *v1.Pod, node string, logsd
 		{command: "ctr -n k8s.io containers list", fileNameSuffix: "ctr-containers"},
 		{command: "ctr -n k8s.io tasks list", fileNameSuffix: "ctr-tasks"},
 		{command: "ctr -n k8s.io namespaces list", fileNameSuffix: "ctr-namespaces"},
+	}
+
+	for _, cmd := range criCommands {
+		command := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/bin/bash",
+			"-c",
+			cmd.command,
+		}
+
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, command)
+		if err != nil {
+			printError("failed to execute %s on node %s, stderr: %s, error: %v", cmd.command, node, stderr, err)
+			continue
+		}
+
+		if stdout == "" {
+			continue
+		}
+
+		fileName := fmt.Sprintf(logFileNameFmt, r.failureCount, node, cmd.fileNameSuffix)
+		err = writeStringToFile(filepath.Join(logsdir, fileName), stdout)
+		if err != nil {
+			printError("failed to write %s for node %s: %v", cmd.fileNameSuffix, node, err)
+			continue
+		}
+	}
+}
+
+func (r *KubernetesReporter) logCrioStacks(virtCli kubecli.KubevirtClient, logsdir string, nodes []string) {
+
+	if logsdir == "" {
+		printError("logsdir is empty, skipping logCrioStacks")
+		return
+	}
+
+	for _, node := range nodes {
+		pod, err := libnode.GetVirtHandlerPod(virtCli, node)
+		if err != nil {
+			printError(failedGetVirtHandlerPodFmt, node, err)
+			continue
+		}
+
+		// Check if cri-o is running on the node
+		checkCommand := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/usr/bin/pgrep",
+			"crio",
+		}
+
+		stdout, _, err := exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, checkCommand)
+		if err != nil || stdout == "" {
+			printInfo("cri-o not running on node %s, skipping cri-o debug collection", node)
+			continue
+		}
+
+		// Send USR1 signal to crio to trigger stack dump
+		signalCommand := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/usr/bin/pkill",
+			"-USR1",
+			"crio",
+		}
+
+		_, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, signalCommand)
+		if err != nil {
+			printError("failed to send USR1 to crio on node %s, stderr: %s, error: %v", node, stderr, err)
+			continue
+		}
+
+		// Wait a moment for cri-o to write the stacks
+		time.Sleep(2 * time.Second)
+
+		// Collect cri-o logs which should contain the stack traces
+		journalCommand := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/usr/bin/journalctl",
+			"-u",
+			"crio",
+			"--since",
+			"-30s",
+			"--no-pager",
+		}
+
+		stdout, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, journalCommand)
+		if err != nil {
+			printError("failed to collect crio logs on node %s, stderr: %s, error: %v", node, stderr, err)
+			continue
+		}
+
+		fileName := fmt.Sprintf(logFileNameFmt, r.failureCount, "crio-journal", node)
+		err = writeStringToFile(filepath.Join(logsdir, fileName), stdout)
+		if err != nil {
+			printError("failed to write crio journal for node %s: %v", node, err)
+			continue
+		}
+
+		// Collect crictl debug information
+		r.logCrioCrictl(pod, node, logsdir)
+	}
+}
+
+func (r *KubernetesReporter) logCrioCrictl(pod *v1.Pod, node string, logsdir string) {
+	criCommands := []commands{
+		{command: "crictl info", fileNameSuffix: "crictl-info"},
+		{command: "crictl ps -a", fileNameSuffix: "crictl-ps"},
+		{command: "crictl pods", fileNameSuffix: "crictl-pods"},
+		{command: "crictl images", fileNameSuffix: "crictl-images"},
+		{command: "crictl stats -a", fileNameSuffix: "crictl-stats"},
+		{command: "crictl version", fileNameSuffix: "crictl-version"},
 	}
 
 	for _, cmd := range criCommands {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1512,6 +1512,8 @@ func (r *KubernetesReporter) executeNodeCommands(virtCli kubecli.KubevirtClient,
 		{command: networkPrefix + bridgeJVlanShow, fileNameSuffix: "brvlan"},
 		{command: networkPrefix + bridgeFdb, fileNameSuffix: "brfdb"},
 		{command: networkPrefix + "nft list ruleset", fileNameSuffix: "nftlist"},
+		{command: "lsfd --summary", fileNameSuffix: "lsfd-summary"},
+		{command: "ulimit -a", fileNameSuffix: "ulimit-a"},
 	}
 
 	if checks.IsRunningOnKindInfra() {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -251,6 +251,15 @@ func (r *KubernetesReporter) dumpTestObjects(duration time.Duration, vmiNamespac
 	r.logCloudInit(virtCli, vmiNamespaces)
 	r.logVirtualMachinePools(virtCli)
 	r.logMigrationPolicies(virtCli)
+
+	// Collect containerd stacks from all nodes, not just nodes with test pods
+	allNodeNames := []string{}
+	if nodes != nil {
+		for _, node := range nodes.Items {
+			allNodeNames = append(allNodeNames, node.Name)
+		}
+	}
+	r.logContainerdStacks(virtCli, nodesDir, allNodeNames)
 }
 
 // Cleanup cleans up the current content of the artifactsDir
@@ -594,6 +603,156 @@ func (r *KubernetesReporter) logNodeCommands(virtCli kubecli.KubevirtClient, nod
 		}
 
 		r.executeNodeCommands(virtCli, logsdir, pod)
+	}
+}
+
+func (r *KubernetesReporter) logContainerdStacks(virtCli kubecli.KubevirtClient, logsdir string, nodes []string) {
+
+	if logsdir == "" {
+		printError("logsdir is empty, skipping logContainerdStacks")
+		return
+	}
+
+	for _, node := range nodes {
+		pod, err := libnode.GetVirtHandlerPod(virtCli, node)
+		if err != nil {
+			printError(failedGetVirtHandlerPodFmt, node, err)
+			continue
+		}
+
+		// Check if containerd is running on the node
+		checkCommand := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/usr/bin/pgrep",
+			"containerd",
+		}
+
+		stdout, _, err := exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, checkCommand)
+		if err != nil || stdout == "" {
+			printInfo("containerd not running on node %s, skipping containerd debug collection", node)
+			continue
+		}
+
+		// Send USR1 signal to containerd to trigger stack dump
+		signalCommand := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/usr/bin/pkill",
+			"-USR1",
+			"containerd",
+		}
+
+		_, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, signalCommand)
+		if err != nil {
+			printError("failed to send USR1 to containerd on node %s, stderr: %s, error: %v", node, stderr, err)
+			continue
+		}
+
+		// Wait a moment for containerd to write the stacks
+		time.Sleep(2 * time.Second)
+
+		// Collect containerd stack dump files from /tmp
+		stackFilesCommand := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/bin/bash",
+			"-c",
+			"cat /proc/1/root/tmp/containerd.*.stacks.log 2>/dev/null || true",
+		}
+
+		stdout, _, err = exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, stackFilesCommand)
+		if err == nil && stdout != "" {
+			fileName := fmt.Sprintf(logFileNameFmt, r.failureCount, "containerd-stacks", node)
+			err = writeStringToFile(filepath.Join(logsdir, fileName), stdout)
+			if err != nil {
+				printError("failed to write containerd stack files for node %s: %v", node, err)
+			}
+		}
+
+		// Collect containerd logs which should also contain the stack traces
+		journalCommand := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/usr/bin/journalctl",
+			"-u",
+			"containerd",
+			"--since",
+			"-30s",
+			"--no-pager",
+		}
+
+		stdout, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, journalCommand)
+		if err != nil {
+			printError("failed to collect containerd logs on node %s, stderr: %s, error: %v", node, stderr, err)
+			continue
+		}
+
+		fileName := fmt.Sprintf(logFileNameFmt, r.failureCount, "containerd-journal", node)
+		err = writeStringToFile(filepath.Join(logsdir, fileName), stdout)
+		if err != nil {
+			printError("failed to write containerd journal for node %s: %v", node, err)
+			continue
+		}
+
+		// Collect crictl debug information
+		r.logContainerdCrictl(pod, node, logsdir)
+	}
+}
+
+func (r *KubernetesReporter) logContainerdCrictl(pod *v1.Pod, node string, logsdir string) {
+	criCommands := []commands{
+		{command: "crictl info", fileNameSuffix: "crictl-info"},
+		{command: "crictl ps -a", fileNameSuffix: "crictl-ps"},
+		{command: "crictl pods", fileNameSuffix: "crictl-pods"},
+		{command: "crictl images", fileNameSuffix: "crictl-images"},
+		{command: "crictl stats -a", fileNameSuffix: "crictl-stats"},
+		{command: "crictl version", fileNameSuffix: "crictl-version"},
+		{command: "ctr -n k8s.io containers list", fileNameSuffix: "ctr-containers"},
+		{command: "ctr -n k8s.io tasks list", fileNameSuffix: "ctr-tasks"},
+		{command: "ctr -n k8s.io namespaces list", fileNameSuffix: "ctr-namespaces"},
+	}
+
+	for _, cmd := range criCommands {
+		command := []string{
+			virt_chroot.GetChrootBinaryPath(),
+			"--mount",
+			virt_chroot.GetChrootNSMountPath(),
+			"exec",
+			"--",
+			"/bin/bash",
+			"-c",
+			cmd.command,
+		}
+
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, virtHandlerName, command)
+		if err != nil {
+			printError("failed to execute %s on node %s, stderr: %s, error: %v", cmd.command, node, stderr, err)
+			continue
+		}
+
+		if stdout == "" {
+			continue
+		}
+
+		fileName := fmt.Sprintf(logFileNameFmt, r.failureCount, node, cmd.fileNameSuffix)
+		err = writeStringToFile(filepath.Join(logsdir, fileName), stdout)
+		if err != nil {
+			printError("failed to write %s for node %s: %v", cmd.fileNameSuffix, node, err)
+			continue
+		}
 	}
 }
 


### PR DESCRIPTION
### What this PR does

This PR optionally collects `containerd` or `crio` debug information on functional test failure when a new `KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG` env var is enabled.

```
$ env | grep KUBEVIRT
KUBEVIRT_PROVIDER=k8s-1.34
KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true

$ ll _out/artifacts/k8s-reporter/nodes/1_*
-rw-r--r-- 1 lyarwood lyarwood 77855 Oct  1 14:07 _out/artifacts/k8s-reporter/nodes/1_crio-journal_node01.log
-rw-r--r-- 1 lyarwood lyarwood  8759 Oct  1 14:07 _out/artifacts/k8s-reporter/nodes/1_node01_crictl-images.log
-rw-r--r-- 1 lyarwood lyarwood  6934 Oct  1 14:07 _out/artifacts/k8s-reporter/nodes/1_node01_crictl-info.log
-rw-r--r-- 1 lyarwood lyarwood  4184 Oct  1 14:07 _out/artifacts/k8s-reporter/nodes/1_node01_crictl-pods.log
-rw-r--r-- 1 lyarwood lyarwood  9466 Oct  1 14:07 _out/artifacts/k8s-reporter/nodes/1_node01_crictl-ps.log
-rw-r--r-- 1 lyarwood lyarwood  3363 Oct  1 14:07 _out/artifacts/k8s-reporter/nodes/1_node01_crictl-stats.log
-rw-r--r-- 1 lyarwood lyarwood    83 Oct  1 14:07 _out/artifacts/k8s-reporter/nodes/1_node01_crictl-version.log

$ cat _out/artifacts/k8s-reporter/nodes/1_node01_crictl-stats.log
CONTAINER           NAME                      CPU %               MEM                 DISK                INODES              SWAP
10b82c5683a3c       provisioner               0.00                41.84MB             0B                  11                  0B
1a58d52901074       sync                      0.02                27.17MB             12B                 17                  0B
23833ab59b515       calico-node               0.38                136MB               9.737kB             104                 0B
27f28f28a3b2e       cdi-uploadproxy           0.00                11.08MB             12B                 19                  0B
2a6ce71fdcb2d       exportproxy               0.00                10.99MB             12B                 16                  0B
3401a297b96b4       virt-handler              0.09                86.26MB             12B                 23                  0B
3c9ef065f743d       virt-controller           0.04                54.23MB             12B                 17                  0B
3f0eeb26d5305       kube-apiserver            1.96                706.1MB             12B                 19                  0B
403c13cd7fed3       virt-operator             0.04                157.4MB             12B                 16                  0B
4a96596241b04       coredns                   0.04                76.51MB             12B                 14                  0B
619a4b2cc058e       virt-api                  0.01                162.8MB             12B                 20                  0B
65be0957f6a3d       kube-scheduler            0.23                73.46MB             12B                 10                  0B
6b056c6700da1       kube-proxy                0.00                65.72MB             174B                26                  0B
736f322ae5316       virt-controller           0.07                41.53MB             12B                 17                  0B
76385dfd1e77e       kube-controller-manager   0.49                156.4MB             12B                 21                  0B
883e2c8b031b3       virt-operator             0.07                228.5MB             12B                 16                  0B
89915f552c48e       cdi-operator              0.07                107.7MB             12B                 16                  0B
9a24dfc526ee2       exportproxy               0.00                10.89MB             12B                 16                  0B
b0937dda3ecc3       cdi-deployment            0.03                45.27MB             12B                 27                  0B
bbece5c30d238       coredns                   0.06                20.86MB             12B                 14                  0B
c3189c7a86e05       etcd                      1.07                114.8MB             12B                 14                  0B
cfb0f92114266       calico-kube-controllers   0.00                61.7MB              152B                18                  0B
d0f0797ef7023       target                    0.00                38.63MB             2.701kB             21                  0B
d2ba514c09e09       cdi-apiserver             0.00                17.27MB             12B                 19                  0B
fdf2a0ad123ac       sync                      0.02                32.03MB             12B                 17                  0B
```

```
$ env | grep KUBEVIRT
KUBEVIRT_PROVIDER=kind-1.34
KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true

$ ll _out/artifacts/k8s-reporter/nodes/1_*
-rw-r--r-- 1 lyarwood lyarwood 1033021 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_containerd-journal_kind-1.34-control-plane.log
-rw-r--r-- 1 lyarwood lyarwood  508838 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_containerd-stacks_kind-1.34-control-plane.log
-rw-r--r-- 1 lyarwood lyarwood    2716 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_crictl-images.log
-rw-r--r-- 1 lyarwood lyarwood    6284 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_crictl-info.log
-rw-r--r-- 1 lyarwood lyarwood    3886 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_crictl-pods.log
-rw-r--r-- 1 lyarwood lyarwood    5165 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_crictl-ps.log
-rw-r--r-- 1 lyarwood lyarwood    3234 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_crictl-stats.log
-rw-r--r-- 1 lyarwood lyarwood      88 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_crictl-version.log
-rw-r--r-- 1 lyarwood lyarwood    7584 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_ctr-containers.log
-rw-r--r-- 1 lyarwood lyarwood      30 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_ctr-namespaces.log
-rw-r--r-- 1 lyarwood lyarwood    3951 Oct  1 14:23 _out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_ctr-tasks.log

$ cat /home/lyarwood/redhat/devel/src/k8s/kubevirt/kubevirt/_out/artifacts/k8s-reporter/nodes/1_kind-1.34-control-plane_crictl-stats.log
CONTAINER           NAME                      CPU %               MEM                 DISK                INODES              SWAP
08f54c2695c9a       exportproxy               0.00                9.671MB             20.48kB             15                  0B
13c1d30bddf74       kube-proxy                0.00                17MB                65.54kB             26                  0B
18ff4006c602f       sync                      0.06                28.56MB             20.48kB             16                  0B
2b4abd4ef6a98       virt-controller           0.03                54.25MB             20.48kB             16                  0B
407d0c8ff69a0       virt-operator             0.07                174.7MB             20.48kB             15                  0B
43c4a40bf8477       kube-apiserver            1.96                621.4MB             24.58kB             16                  0B
56959a673147f       coredns                   0.06                17.56MB             20.48kB             13                  0B
5afce5f4ca3ce       local-path-provisioner    0.00                8.864MB             20.48kB             13                  0B
86e2cd4a013a2       cdi-uploadproxy           0.00                11.29MB             20.48kB             18                  0B
8b2a856f022b5       cdi-apiserver             0.00                14.89MB             20.48kB             18                  0B
8ea685851ff38       virt-handler              0.12                57.26MB             24.58kB             23                  0B
b34a8dd67fdf9       virt-launcher             0.00                0B                  225.3kB             41                  0B
b36fddd4975a8       etcd                      1.05                229MB               16.38kB             12                  0B
b3a3bd255a2a1       sync                      0.01                27.92MB             20.48kB             16                  0B
b62fe23d344e9       kube-scheduler            0.22                28.96MB             12.29kB             9                   0B
bd8eef07fb646       virt-controller           0.02                44.02MB             20.48kB             16                  0B
bea2b0af190d9       kindnet-cni               0.00                13.67MB             61.44kB             27                  0B
ca4e24a9438b0       virt-api                  0.06                155.8MB             24.58kB             19                  0B
cc66b871f2ce9       coredns                   0.06                18.78MB             20.48kB             13                  0B
d247ee1070305       cdi-operator              0.07                55.3MB              20.48kB             15                  0B
dd39d34ef2061       exportproxy               0.00                9.798MB             20.48kB             15                  0B
f9fa047edf779       kube-controller-manager   0.60                84.77MB             24.58kB             22                  0B
fa6497984a0c5       virt-operator             0.05                234.2MB             20.48kB             15                  0B
fb7dc46ce5cf8       cdi-deployment            1.28                22.97MB             24.58kB             26                  0B

$ head -n20  _out/artifacts/k8s-reporter/nodes/1_containerd-stacks_kind-1.34-control-plane.log
goroutine 56 [running]:
github.com/containerd/containerd/v2/cmd/containerd/command.dumpStacks(0x1)
        /containerd/cmd/containerd/command/main.go:389 +0x6b
github.com/containerd/containerd/v2/cmd/containerd/command.handleSignals.func1()
        /containerd/cmd/containerd/command/main_unix.go:57 +0x1e5
created by github.com/containerd/containerd/v2/cmd/containerd/command.handleSignals in goroutine 1
        /containerd/cmd/containerd/command/main_unix.go:40 +0xd3

goroutine 1 [chan receive, 6 minutes]:
github.com/containerd/containerd/v2/cmd/containerd/command.App.func1(0xc00012ea80)
        /containerd/cmd/containerd/command/main.go:298 +0x11f8
github.com/urfave/cli/v2.(*Command).Run(0xc000471080, 0xc00012ea80, {0xc00003e110, 0x1, 0x1})
        /containerd/vendor/github.com/urfave/cli/v2/command.go:276 +0x7be
github.com/urfave/cli/v2.(*App).RunContext(0xc000116400, {0x55ba65e23f18, 0x55ba66b8f120}, {0xc00003e110, 0x1, 0x1})
        /containerd/vendor/github.com/urfave/cli/v2/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(0x0?, {0xc00003e110?, 0x0?, 0x55ba645a81c5?})
        /containerd/vendor/github.com/urfave/cli/v2/app.go:307 +0x2f
main.main()
        /containerd/cmd/containerd/main.go:30 +0x2d

```


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

I've been using a version of this to try to debug https://github.com/kubevirt/kubevirt/issues/15733 but the current hit rate is so low it's almost impossible to catch it against a single PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

