### PR TITLE
Improve reset / unpause error handling

### DIFF
--- a/pkg/virt-handler/rest/lifecycle.go
+++ b/pkg/virt-handler/rest/lifecycle.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/emicklei/go-restful/v3"
 
@@ -87,6 +88,11 @@ func (lh *LifecycleHandler) UnpauseHandler(request *restful.Request, response *r
 	err = client.UnpauseVirtualMachine(vmi)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Failed to unpause VMI")
+		if strings.Contains(err.Error(), "LibvirtError(Code=55") {
+			response.WriteError(http.StatusConflict, fmt.Errorf("Cannot unpause VM during migration"))
+			return
+		}
+
 		response.WriteError(http.StatusInternalServerError, err)
 		return
 	}
@@ -165,6 +171,11 @@ func (lh *LifecycleHandler) ResetHandler(request *restful.Request, response *res
 	err = client.ResetVirtualMachine(vmi)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Failed to reset VMI")
+		if strings.Contains(err.Error(), "LibvirtError(Code=55") {
+			response.WriteError(http.StatusConflict, fmt.Errorf("Cannot reset VM during migration"))
+			return
+		}
+
 		response.WriteError(http.StatusInternalServerError, err)
 		return
 	}


### PR DESCRIPTION
### Problem

Previously, attempting to **reset** or **unpause** a VirtualMachineInstance (VMI) during an active live migration could result in confusing low-level libvirt errors, such as:

`LibvirtError(Code=55, Domain=20, Message='domain is not running')` 

---

### Solution

This PR adds specific error handling to both `UnpauseHandler` and `ResetHandler` in virt-handler/rest/lifecycle.go. 

If a VMI is currently being migrated, the handlers now return **HTTP 409 (Conflict)** with clear messages, e.g.:

- “Cannot unpause VM during migration”
- “Cannot reset VM during migration”

---

**Reset Handler:**

Reset is not allowed during migration because the source domain is in a transitional state.

**Unpause Handler:**

   Unpause is rejected during migration for a paused/unpaused VM 


---

### Release Note

```release-note
Bug fix: Resetting or unpausing a VirtualMachineInstance (VMI) during an active live migration now returns HTTP 409 (Conflict) with a clear, user-friendly message (e.g., "Cannot unpause VM during migration."). Previously, these operations could fail with low-level libvirt errors, resulting in a confusing user experience.
```
