### PR TITLE
[release-1.4] Properly set owner references for restored PVCs

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -73,6 +73,8 @@ const (
 	restoreErrorEvent = "VirtualMachineRestoreError"
 
 	restoreDataVolumeCreateErrorEvent = "RestoreDataVolumeCreateError"
+
+	restoreOwnedByVMLabel = "restore.kubevirt.io/owned-by-vm"
 )
 
 type restoreTarget interface {
@@ -355,7 +357,8 @@ func (ctrl *VMRestoreController) reconcileVolumeRestores(vmRestore *snapshotv1.V
 			if err != nil {
 				return false, err
 			}
-			if err = ctrl.createRestorePVC(vmRestore, target, backup, &restore, content.Spec.Source.VirtualMachine.Name, content.Spec.Source.VirtualMachine.Namespace); err != nil {
+
+			if err = ctrl.createRestorePVC(vmRestore, target, backup, &restore, content.Spec.Source.VirtualMachine); err != nil {
 				return false, err
 			}
 			createdPVC = true
@@ -795,7 +798,41 @@ func (t *vmRestoreTarget) reconcileSpec(restoredVM *kubevirtv1.VirtualMachine) (
 		return false, err
 	}
 
+	if err = t.updateRestorePVCOwnership(); err != nil {
+		return false, err
+	}
+
 	return true, nil
+}
+
+func (t *vmRestoreTarget) updateRestorePVCOwnership() error {
+	if !t.Exists() {
+		return nil
+	}
+	for _, volume := range t.VirtualMachine().Spec.Template.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			pvc, err := t.controller.Client.CoreV1().PersistentVolumeClaims(t.vmRestore.Namespace).Get(context.Background(), volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			// Check if the PVC is already owned by something else
+			if len(pvc.OwnerReferences) == 0 {
+				// Only set the owner reference if the PVC was originally owned by the source VM
+				if pvc.Annotations[restoreOwnedByVMLabel] == t.vmRestore.Name {
+					t.Own(pvc)
+					delete(pvc.Annotations, restoreOwnedByVMLabel)
+
+					// Update the PVC to have the owner reference
+					_, err = t.controller.Client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func findDVTemplateIndex(dvName string, vm *snapshotv1.VirtualMachine) int {
@@ -1231,8 +1268,10 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	target restoreTarget,
 	volumeBackup *snapshotv1.VolumeBackup,
 	volumeRestore *snapshotv1.VolumeRestore,
-	sourceVmName, sourceVmNamespace string,
+	sourceVm *snapshotv1.VirtualMachine,
 ) error {
+	sourceVmName := sourceVm.Name
+	sourceVmNamespace := sourceVm.Namespace
 	if volumeBackup == nil || volumeBackup.VolumeSnapshotName == nil {
 		log.Log.Errorf("VolumeSnapshot name missing %+v", volumeBackup)
 		return fmt.Errorf("missing VolumeSnapshot name")
@@ -1256,7 +1295,11 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	if err != nil {
 		return err
 	}
-	target.Own(pvc)
+	if target.Exists() {
+		target.Own(pvc)
+	} else if sourcePVCOwnedBySourceVM(volumeBackup, sourceVm) { // PVC is owned by the VM
+		pvc.Annotations[restoreOwnedByVMLabel] = vmRestore.Name
+	}
 
 	_, err = ctrl.Client.CoreV1().PersistentVolumeClaims(vmRestore.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 	if err != nil {
@@ -1264,6 +1307,18 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	}
 
 	return nil
+}
+
+func sourcePVCOwnedBySourceVM(volumeBackup *snapshotv1.VolumeBackup, sourceVm *snapshotv1.VirtualMachine) bool {
+	ownerReferences := volumeBackup.PersistentVolumeClaim.OwnerReferences
+	owned := false
+	for _, ownerReference := range ownerReferences {
+		if ownerReference.Kind == "VirtualMachine" && ownerReference.Name == sourceVm.Name && ownerReference.UID == sourceVm.UID {
+			owned = true
+			break
+		}
+	}
+	return owned
 }
 
 func CreateRestorePVCDef(restorePVCName string, volumeSnapshot *vsv1.VolumeSnapshot, volumeBackup *snapshotv1.VolumeBackup) (*corev1.PersistentVolumeClaim, error) {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1226,7 +1226,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("to a new VM", true),
 			)
 
-			DescribeTable("should restore a vm that boots from a PVC", func(restoreToNewVM bool) {
+			DescribeTable("should restore a vm that boots from a PVC", func(restoreToNewVM, ownedByVM bool) {
 				dv := libdv.NewDataVolume(
 					libdv.WithName("restore-pvc-"+rand.String(12)),
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), cdiv1.RegistryPullNode),
@@ -1245,7 +1245,23 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vmi = libstorage.RenderVMIWithDataVolume(originalPVCName, testsuite.GetTestNamespace(nil),
 					libvmi.WithResourceMemory(memory), libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()))
 				vm, vmi = createAndStartVM(libvmi.NewVirtualMachine(vmi))
-
+				By("Ensuring the PVC is owned by the VM")
+				pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), originalPVCName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if ownedByVM {
+					pvc.OwnerReferences = []metav1.OwnerReference{
+						{
+							APIVersion: v1.GroupVersion.String(),
+							Kind:       "VirtualMachine",
+							Name:       vm.Name,
+							UID:        vm.UID,
+						},
+					}
+				} else {
+					pvc.OwnerReferences = nil
+				}
+				_, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 				doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
 				Expect(restore.Status.Restores).To(HaveLen(1))
 				if restoreToNewVM {
@@ -1260,23 +1276,28 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				targetVM, err = virtClient.VirtualMachine(targetVM.Namespace).Get(context.Background(), targetVM.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				if !restoreToNewVM {
-					for _, v := range targetVM.Spec.Template.Spec.Volumes {
-						if v.PersistentVolumeClaim != nil {
-							Expect(v.PersistentVolumeClaim.ClaimName).ToNot(Equal(originalPVCName))
-							pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), v.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
-							Expect(err).ToNot(HaveOccurred())
+				for _, v := range targetVM.Spec.Template.Spec.Volumes {
+					if v.PersistentVolumeClaim != nil {
+						Expect(v.PersistentVolumeClaim.ClaimName).ToNot(Equal(originalPVCName))
+						pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), v.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						if ownedByVM {
+							Expect(pvc.OwnerReferences).ToNot(BeEmpty())
 							Expect(pvc.OwnerReferences[0].APIVersion).To(Equal(v1.GroupVersion.String()))
 							Expect(pvc.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
-							Expect(pvc.OwnerReferences[0].Name).To(Equal(vm.Name))
-							Expect(pvc.OwnerReferences[0].UID).To(Equal(vm.UID))
-							Expect(pvc.Labels["restore.kubevirt.io/source-vm-name"]).To(Equal(vm.Name))
+							Expect(pvc.OwnerReferences[0].Name).To(Equal(targetVM.Name))
+							Expect(pvc.OwnerReferences[0].UID).To(Equal(targetVM.UID))
+						} else {
+							Expect(pvc.OwnerReferences).To(BeEmpty())
 						}
+						Expect(pvc.Labels["restore.kubevirt.io/source-vm-name"]).To(Equal(vm.Name))
+						Expect(pvc.Annotations).ToNot(HaveKey("restore.kubevirt.io/owned-by-vm"))
 					}
 				}
 			},
-				Entry("[test_id:5262] to the same VM", false),
-				Entry("to a new VM", true),
+				Entry("[test_id:5262] to the same VM", false, true),
+				Entry("to a new VM", true, true),
+				Entry("to a new VM, pvc not owned by VM", true, false),
 			)
 
 			DescribeTable("should restore a vm with containerdisk and blank datavolume", func(restoreToNewVM bool) {


### PR DESCRIPTION
Manual backport of #15692

Biggest difference is there is no `VolumeOwnershipPolicy` logic that was introduced recently.

```release-note
BugFix: Restoring naked PVCs from a VMSnapshot are now properly owned by the VM if the restore policy is set to VM
```