### PR TITLE
Openapi runtime

### DIFF
--- a/pkg/util/openapi/openapi_test.go
+++ b/pkg/util/openapi/openapi_test.go
@@ -12,14 +12,18 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-api/definitions"
 )
 
+var validator *openapi.Validator
+
+var _ = BeforeSuite(func() {
+	validator = openapi.CreateOpenAPIValidator(definitions.ComposeAPIDefinitions())
+})
+
 var _ = Describe("Openapi", func() {
 
-	var validator *openapi.Validator
 	var vmi *v1.VirtualMachineInstance
 	var obj *unstructured.Unstructured
 
 	BeforeEach(func() {
-		validator = openapi.CreateOpenAPIValidator(definitions.ComposeAPIDefinitions())
 		vmi = v1.NewVMI("testvm", "")
 		obj = &unstructured.Unstructured{}
 	})

--- a/pkg/util/openapi/openapi_test.go
+++ b/pkg/util/openapi/openapi_test.go
@@ -22,12 +22,14 @@ var _ = Describe("Openapi", func() {
 
 	var expectValidationsToSucceed = func(obj *unstructured.Unstructured) {
 		Expect(validator.Validate(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
+		Expect(validator.ValidateSpec(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
 		Expect(validator.ValidateStatus(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
 	}
 
 	var expectValidationsToFail = func(obj *unstructured.Unstructured) {
 		Expect(validator.Validate(obj.GroupVersionKind(), obj.Object)).ToNot(BeEmpty())
 		Expect(validator.ValidateSpec(obj.GroupVersionKind(), obj.Object)).ToNot(BeEmpty())
+		Expect(validator.ValidateStatus(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
 	}
 
 	It("should accept unknown fields in the status", func() {

--- a/pkg/util/openapi/openapi_test.go
+++ b/pkg/util/openapi/openapi_test.go
@@ -20,47 +20,46 @@ var _ = BeforeSuite(func() {
 
 var _ = Describe("Openapi", func() {
 
-	var vmi *v1.VirtualMachineInstance
-	var obj *unstructured.Unstructured
-
-	BeforeEach(func() {
-		vmi = v1.NewVMI("testvm", "")
-		obj = &unstructured.Unstructured{}
-	})
-
-	var expectValidationsToSucceed = func() {
+	var expectValidationsToSucceed = func(obj *unstructured.Unstructured) {
 		Expect(validator.Validate(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
 		Expect(validator.ValidateStatus(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
 	}
 
-	var expectValidationsToFail = func() {
+	var expectValidationsToFail = func(obj *unstructured.Unstructured) {
 		Expect(validator.Validate(obj.GroupVersionKind(), obj.Object)).ToNot(BeEmpty())
 		Expect(validator.ValidateSpec(obj.GroupVersionKind(), obj.Object)).ToNot(BeEmpty())
 	}
 
 	It("should accept unknown fields in the status", func() {
-		data, err := json.Marshal(vmi)
+		data, err := json.Marshal(v1.NewVMI("testvm", ""))
 		Expect(err).ToNot(HaveOccurred())
+
+		obj := &unstructured.Unstructured{}
 		Expect(json.Unmarshal(data, obj)).To(Succeed())
 		Expect(unstructured.SetNestedField(obj.Object, "something", "status", "unknown")).To(Succeed())
-		expectValidationsToSucceed()
+		expectValidationsToSucceed(obj)
 	})
 
 	It("should reject unknown fields in the spec", func() {
-		data, err := json.Marshal(vmi)
+		data, err := json.Marshal(v1.NewVMI("testvm", ""))
 		Expect(err).ToNot(HaveOccurred())
+
+		obj := &unstructured.Unstructured{}
 		Expect(json.Unmarshal(data, obj)).To(Succeed())
 		Expect(unstructured.SetNestedField(obj.Object, "something", "spec", "unknown")).To(Succeed())
-		expectValidationsToFail()
+		expectValidationsToFail(obj)
 	})
 
 	It("should accept Machine with an empty Type", func() {
 		// This is needed to provide backward compatibility since our example VMIs used to be defined in this way
+		vmi := v1.NewVMI("testvm", "")
 		vmi.Spec.Domain.Machine = &v1.Machine{Type: ""}
 		data, err := json.Marshal(vmi)
 		Expect(err).ToNot(HaveOccurred())
+
+		obj := &unstructured.Unstructured{}
 		Expect(json.Unmarshal(data, obj)).To(Succeed())
-		expectValidationsToSucceed()
+		expectValidationsToSucceed(obj)
 	})
 
 })


### PR DESCRIPTION
### What this PR does
This reduce the runtime of these tests:
1. ~40% without race
2 ~3x with race

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

