### PR TITLE
Add Ephemeral Hotplug Volume Metric

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -123,6 +123,7 @@ func SetupMetrics(
 		migrationStatsCollector,
 		vmiStatsCollector,
 		vmStatsCollector,
+		ephemeralVolumeMetrics,
 	)
 }
 

--- a/pkg/monitoring/metrics/virt-controller/vmi_metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/vmi_metrics.go
@@ -19,6 +19,10 @@
 package virt_controller
 
 import (
+	"strings"
+	"sync"
+	"time"
+
 	ioprometheusclient "github.com/prometheus/client_model/go"
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 
@@ -27,9 +31,27 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
+type EphemeralStatus struct {
+	timestamp int64
+	confirmed bool
+}
+
+type VolumeTracker struct {
+	sync.RWMutex
+	// keys are namespace/vmi_name/volume_name
+	volumes map[string]EphemeralStatus
+}
+
 var (
 	vmiMetrics = []operatormetrics.Metric{
 		vmiLauncherMemoryOverhead,
+	}
+
+	ephemeralVolumeMetrics = operatormetrics.Collector{
+		Metrics: []operatormetrics.Metric{
+			vmiEphemeralHotplugVolumeTotal,
+		},
+		CollectCallback: EphemeralVolumeMetricsCallback,
 	}
 
 	vmiLauncherMemoryOverhead = operatormetrics.NewGaugeVec(
@@ -39,7 +61,126 @@ var (
 		},
 		[]string{"namespace", "name"},
 	)
+
+	vmiEphemeralHotplugVolumeTotal = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_ephemeral_hotplug_volume_total",
+			Help: "Total number of ephemeral hotplug volumes added to the VMI.",
+		},
+		[]string{"namespace", "vmi_name", "volume_name"},
+	)
+
+	volumeTracker = &VolumeTracker{
+		volumes: make(map[string]EphemeralStatus),
+	}
 )
+
+func UpdateEphemeralVolumeCount(vmi *v1.VirtualMachineInstance, vm *v1.VirtualMachine) {
+	volumeTracker.Lock()
+	defer volumeTracker.Unlock()
+
+	vmVolumeMap := make(map[string]v1.Volume)
+	if vmi == nil || vm == nil {
+		return
+	}
+
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		vmVolumeMap[volume.Name] = volume
+	}
+
+	// store vmi volumes so we can check for potential unplugged volumes
+	vmiVolumeMap := make(map[string]v1.Volume)
+
+	// check if the vmi has any volumes that are not in the vm spec
+	for _, volume := range vmi.Spec.Volumes {
+		if !isHotplugVolume(volume) {
+			continue
+		}
+		vmiVolumeMap[volume.Name] = volume
+		trackerKey := vmi.Namespace + "/" + vmi.Name + "/" + volume.Name
+		if _, exists := vmVolumeMap[volume.Name]; !exists {
+			// only set timestamp on first detection
+			if _, exists := volumeTracker.volumes[trackerKey]; exists {
+				continue
+			}
+			// set timestamp for potential ephemeral volume
+			volumeTracker.volumes[trackerKey] = EphemeralStatus{
+				timestamp: time.Now().Unix(),
+				confirmed: false,
+			}
+		} else {
+			// volume exists in both specs
+			volumeStatus, exists := volumeTracker.volumes[trackerKey]
+			if !exists {
+				continue
+			}
+
+			// if we previously marked this as ephemeral, check if it was added recently to spec (within 60s)
+			// then it's actually a persistent hotplug and we can remove the metric
+			timeDiff := time.Now().Unix() - volumeStatus.timestamp
+			if timeDiff <= 60 {
+				delete(volumeTracker.volumes, trackerKey)
+			}
+		}
+	}
+
+	// resets metric for any ephemeral volumes that were unplugged
+	// i.e. volumes that used to be in vmi spec but are no longer
+	for key, volumeStatus := range volumeTracker.volumes {
+		_, _, volumeName := parseVolumeKey(key)
+		if _, exists := vmiVolumeMap[volumeName]; !exists {
+			delete(volumeTracker.volumes, key)
+		} else {
+			// check if we have tracked this volume for more than x seconds,
+			// if so we can confirm it as an ephemeral volume
+			timePassed := time.Now().Unix() - volumeStatus.timestamp
+
+			// TODO: this is probably a poor approrach since we could accidentally confirm non-ephemeral volumes
+			// this is ultimately trying to prevent increasing the metric in previous loop
+			// and then having to remove it in subsequent iterations.
+			timeThreshold := int64(2)
+			if timePassed > timeThreshold {
+				volumeStatus.confirmed = true
+				volumeTracker.volumes[key] = volumeStatus
+			}
+		}
+
+	}
+
+}
+
+func isHotplugVolume(volume v1.Volume) bool {
+	return (volume.VolumeSource.PersistentVolumeClaim != nil &&
+		volume.VolumeSource.PersistentVolumeClaim.Hotpluggable) ||
+		(volume.VolumeSource.DataVolume != nil && volume.VolumeSource.DataVolume.Hotpluggable)
+}
+
+func EphemeralVolumeMetricsCallback() []operatormetrics.CollectorResult {
+	volumeTracker.RLock()
+	defer volumeTracker.RUnlock()
+
+	// TODO: decide whether we care to track volume, or just increment total per VMI
+	results := []operatormetrics.CollectorResult{}
+	for key, volumeStatus := range volumeTracker.volumes {
+		// only report confirmed volumes
+		if !volumeStatus.confirmed {
+			continue
+		}
+		namespace, vmiName, volumeName := parseVolumeKey(key)
+		results = append(results, operatormetrics.CollectorResult{
+			Metric: vmiEphemeralHotplugVolumeTotal,
+			Labels: []string{namespace, vmiName, volumeName},
+			Value:  float64(1),
+		})
+	}
+
+	return results
+}
+
+func parseVolumeKey(key string) (string, string, string) {
+	parts := strings.Split(key, "/")
+	return parts[0], parts[1], parts[2]
+}
 
 func SetVmiLaucherMemoryOverhead(vmi *v1.VirtualMachineInstance, memoryOverhead resource.Quantity) {
 	vmiLauncherMemoryOverhead.

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/monitoring/metrics/virt-controller:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -46,6 +46,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -208,6 +209,8 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 			return common.NewSyncError(fmt.Errorf("failed to get attachment pods: %v", err), controller.FailedHotplugSyncReason), pod
 		}
 
+		c.checkEphemeralHotplugVolumes(vmi)
+
 		if pod.DeletionTimestamp == nil && needsHandleHotplug(hotplugVolumes, hotplugAttachmentPods) {
 			var hotplugSyncErr common.SyncError
 			hotplugSyncErr = c.handleHotplugVolumes(hotplugVolumes, hotplugAttachmentPods, vmi, pod, dataVolumes)
@@ -224,6 +227,34 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 		}
 	}
 	return nil, pod
+}
+
+func (c *Controller) checkEphemeralHotplugVolumes(vmi *virtv1.VirtualMachineInstance) {
+	// checking for ephemeral hotplug volumes
+	// get the owner VM
+	vm := c.getOwnerVM(vmi)
+	if vm == nil {
+		// VMI is ephemeral, tbd? TODO
+		return
+	}
+
+	metrics.UpdateEphemeralVolumeCount(vmi, vm)
+}
+
+func (c *Controller) getOwnerVM(vmi *virtv1.VirtualMachineInstance) *virtv1.VirtualMachine {
+	controllerRef := v1.GetControllerOf(vmi)
+	if controllerRef == nil || controllerRef.Kind != virtv1.VirtualMachineGroupVersionKind.Kind {
+		return nil
+	}
+	obj, exists, _ := c.vmStore.GetByKey(controller.NamespacedKey(vmi.Namespace, controllerRef.Name))
+	if !exists {
+		return nil
+	}
+	ownerVM := obj.(*virtv1.VirtualMachine)
+	if controllerRef.UID == ownerVM.UID {
+		return ownerVM
+	}
+	return nil
 }
 
 // updateStatus handles the VMI's lifecycle status updates.

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,11 +55,14 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libregistry"
@@ -998,6 +1002,111 @@ var _ = Describe(SIG("Hotplug", func() {
 					Entry("with PersistentVolume wait for VM to finish starting", addPVCVolumeVM, removeVolumeVM, k8sv1.PersistentVolumeFilesystem, true),
 					Entry("with Block DataVolume immediate attach", addDVVolumeVM, removeVolumeVM, k8sv1.PersistentVolumeBlock, false),
 				)
+
+				Context("Ephemeral Metrics", decorators.RequiresRWXBlock, func() {
+
+					checkMetrics := func(endpointIP string, pod *k8sv1.Pod, expectedCount int) {
+						// Wait for the ephemeral volume metric to appear
+						Eventually(func() int {
+							// Query the metrics endpoint and filter for ephemeral volume metric
+							shellCmd := fmt.Sprintf("curl -s -L -k https://%s:8443/metrics | grep -v '^#' | grep kubevirt_vmi_ephemeral_hotplug_volume_total", endpointIP)
+							stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "virt-handler", []string{"/bin/sh", "-c", shellCmd})
+
+							if err != nil {
+								if strings.Contains(err.Error(), "exit code 1") {
+									return 0
+								}
+								log.Log.Warningf("curl command error: %v, stderr: %s", err, stderr)
+								return 0
+							}
+
+							// Count the number of lines (each line is a metric)
+							lines := strings.Split(strings.TrimSpace(stdout), "\n")
+							hotplugCount := 0
+							for _, line := range lines {
+								if line != "" {
+									hotplugCount++
+									log.Log.Infof("Found ephemeral volume metric: %s", line)
+								}
+							}
+							return hotplugCount
+						}, 15*time.Second, 2*time.Second).Should(Equal(expectedCount))
+					}
+
+					It("should count only ephemeral volumes, ignoring persistent volumes", Serial, func() {
+						kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
+						kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
+
+						hotplugToVM := addDVVolumeVM
+						hotplugToVMI := addDVVolumeVMI
+
+						dvPersistent := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
+						hotplugToVM(vm.Name, vm.Namespace, "persistent-volume", dvPersistent.Name, v1.DiskBusSCSI, false, "")
+
+						dvEphemeral := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
+						hotplugToVMI(vm.Name, vm.Namespace, "ephemeral-volume", dvEphemeral.Name, v1.DiskBusSCSI, false, "")
+
+						dvEphemeral2 := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
+						hotplugToVMI(vm.Name, vm.Namespace, "ephemeral-volume2", dvEphemeral2.Name, v1.DiskBusSCSI, false, "")
+
+						endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(
+							context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Name, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						nodeName := vmi.Status.NodeName
+						pod, err := libnode.GetVirtHandlerPod(virtClient, nodeName)
+						Expect(err).ToNot(HaveOccurred(), "Should find the virt-handler pod")
+
+						endpointIP := ""
+						for _, ep := range endpoint.Subsets[0].Addresses {
+							if !strings.HasPrefix(ep.TargetRef.Name, "virt-controller") {
+								continue
+							}
+							endpointIP = libnet.FormatIPForURL(ep.IP)
+							break
+						}
+
+						checkMetrics(endpointIP, pod, 2)
+					})
+
+					It("should  ignore delcarative hotplugs as well as unplugged volumes", Serial, func() {
+						kvconfig.EnableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
+						kvconfig.DisableFeatureGate(featuregate.HotplugVolumesGate)
+
+						hotplugToVM := addDVVolumeVM
+
+						dvPersistent := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
+						hotplugToVM(vm.Name, vm.Namespace, "persistent-volume", dvPersistent.Name, v1.DiskBusSCSI, false, "")
+
+						// test that unplugged volumes are not counted towards metric
+						verifyAttachDetachVolume(vm, addDVVolumeVM, removeVolumeVM, sc, k8sv1.PersistentVolumeFilesystem, v1.DiskBusSCSI, false)
+
+						endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(
+							context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Name, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						nodeName := vmi.Status.NodeName
+						pod, err := libnode.GetVirtHandlerPod(virtClient, nodeName)
+						Expect(err).ToNot(HaveOccurred(), "Should find the virt-handler pod")
+
+						endpointIP := ""
+						for _, ep := range endpoint.Subsets[0].Addresses {
+							if !strings.HasPrefix(ep.TargetRef.Name, "virt-controller") {
+								continue
+							}
+							endpointIP = libnet.FormatIPForURL(ep.IP)
+							break
+						}
+
+						checkMetrics(endpointIP, pod, 0)
+					})
+				})
 			})
 
 			Context("with declarative hotplug", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Exposes the ability to monitor the total usage of ephemeral hotplug volumes. This is to assist with the rollout of new `DeclarativeHotplugVolumes` Feature #13847 (which is incompatible the existing `HotplugVolume`s FG).

Add new metric to collect this data at the virt-controller level. We can achieve this by comparing VMI specs against its owner VM spec. If a volume exists in _only_ the VMI, then we know it is an ephemeral hotplug. 

## Draft Notes:
The issue with this is that an unplugged volume can look identical to an ephemeral one. Consider the scenario when a VM unplugs a volume, the volume is removed from VM spec, but still will exists temporarily in VMI spec (which now will appear to be an ephemeral volume until the VMI is re-reconciled).

I want to avoid continuously increasing and decreasing the metric when an unplug occurs, since that could severely skew this statistic. My current approach to avoid this is to keep track of timestamps of when each hotplug volume is detected and flags to mark whether each volume is confirmed to be ephemeral. A volume can only be confirmed if the VMI spec condition is met for a predefined amount of time (i.e. we have observed subsequent reconciles and the volume remains in the spec, so it must not be an unplug). The issue clearly, is that I don't like depending on a `timeThreshold` to detect this niche difference. 

Suggestions for a more dependable solution are welcomed.
 
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Ephemeral Hotplug Volume Metric
```

