### PR TITLE
Pause / Unpause operations - added UX event/log 

### DIFF
--- a/pkg/virt-handler/rest/lifecycle.go
+++ b/pkg/virt-handler/rest/lifecycle.go
@@ -72,6 +72,7 @@ func (lh *LifecycleHandler) PauseHandler(request *restful.Request, response *res
 		return
 	}
 
+	lh.recorder.Eventf(vmi, k8sv1.EventTypeNormal, "Paused", "VirtualMachineInstance paused")
 	response.WriteHeader(http.StatusAccepted)
 }
 
@@ -89,6 +90,7 @@ func (lh *LifecycleHandler) UnpauseHandler(request *restful.Request, response *r
 		return
 	}
 
+	lh.recorder.Eventf(vmi, k8sv1.EventTypeNormal, "Unpaused", "VirtualMachineInstance unpaused")
 	response.WriteHeader(http.StatusAccepted)
 }
 


### PR DESCRIPTION
When attempting to pause a VM during migration, the system would report "scheduled for pause" but the operation didn't produce any logs or events.

Jira: https://issues.redhat.com/browse/CNV-70269

**Release Note**

```release-note
Add event logging for pause and unpause VM operations to align with other VM lifecycle events such as reset
```
