### PR TITLE
tests: Add missing warning to ignore to VMI failure test

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1657,6 +1657,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				"The VirtualMachineInstance crashed",
 				"cannot detect vm",
 				"Can not update a VirtualMachineInstance with unresponsive command server",
+				"failed opening path",
 			},
 			}
 			objectEventWatcher.SetWarningsPolicy(wp)


### PR DESCRIPTION
/wg arch-arm

### What this PR does

As documented in https://github.com/kubevirt/kubevirt/issues/15845 this warning was emitted on the arm64 e2e:

```
13:42:13:   [FAILED] Unexpected Warning event received: testvmi-jvdvd,86037f59-8e6c-4ea7-be44-531a18ea3b87: failed opening path root: /proc/39855/root, relative: /: no such file or directory
13:42:13:   Expected
13:42:13:       <string>: Warning
13:42:13:   not to equal
13:42:13:       <string>: Warning
13:42:13:   In [It] at: tests/watcher/watcher.go:195 @ 10/07/25 13:41:56.171
```

### References

- Fixes #15845

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

