### PR TITLE
Monitor: Break on Wait4 error

### DIFF
--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -124,6 +124,7 @@ func RunAndMonitor(containerDiskDir, uid string) (int, error) {
 					wpid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
 					if err != nil {
 						log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)
+						break
 					}
 					if wpid == 0 {
 						log.Log.Infof("No more processes to be reaped")


### PR DESCRIPTION
### What this PR does
Handles 
```
{"component":"virt-launcher-monitor","level":"error","msg":"Failed to reap process -1","pos":"virt-launcher-monitor.go:126","reason":"no child processes","timestamp":"2025-10-05T14:49:58.896015Z"}
```

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

