### PR TITLE
Fix cgroup incorrect range for /dev/pts/* devices in virt-handler

### DIFF
--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -259,9 +259,9 @@ func GenerateDefaultDeviceRules() []*devices.Rule {
 	// Add PTY slaves. See this for more info:
 	// https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/admin-guide/devices.txt?h=v5.14#n2084
 	const ptyFirstMajor int64 = 136
-	const ptyMajors int64 = 16
+	const ptyLastMajor int64 = 143
 
-	for i := int64(0); i < ptyMajors; i++ {
+	for i := int64(0); i < (ptyLastMajor - ptyFirstMajor + 1); i++ {
 		defaultRules = append(defaultRules,
 			&devices.Rule{
 				Type:        devices.CharDevice,


### PR DESCRIPTION
virt-handler specifies c 136:-1...c 151:-1 for unix98 PTY clients. should adhere to the docs [1] which specifies c 136:-1...c 143:-1.

For more info, see issue https://github.com/kubevirt/kubevirt/issues/14680.

[1] git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/admin-guide/devices.txt?h=master#n2084

### What this PR does
#### Before this PR:
range for /dev/pts/* devices is wrong.

#### After this PR:
range for /dev/pts/* devices is fixed.

### References
- Fixes #14680.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cgroup incorrect range for /dev/pts/* devices in virt-handler
```

