### PR TITLE
[release-1.5] Improve error message when cloning VMs with backend storage

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -381,7 +381,7 @@ func validateCloneVolumeSnapshotSupportVMSnapshotContent(snapshotContents *snaps
 	if backendstorage.IsBackendStorageNeededForVMI(&vm.Spec.Template.Spec) {
 		result = append(result, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Source Virtual Machine requires backend storage, operation not supported",
+			Message: "Clone is not supported when source VM uses backend storage (persistent TPM or EFI)",
 			Field:   sourceField.String(),
 		})
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Already improved the restore msg in https://github.com/kubevirt/kubevirt/pull/15229, but forgot to address the clone msg in previous versions.

The older error message only mentioned "backend storage," which may be unclear to users. This PR improves the wording to explicitly mention persistent TPM or EFI as examples.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

