### PR TITLE
ci: add 3p-kubevirt-api sync and tag workflow

### DIFF
--- a/.github/workflows/3p_kubevirt_api_sync_and_tag.yaml
+++ b/.github/workflows/3p_kubevirt_api_sync_and_tag.yaml
@@ -1,0 +1,34 @@
+name: 3p-kubevirt-api sync and tag
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - ci/*
+
+env:
+  BRANCH_NAME: ${{ github.ref_name }}
+  COMMIT_HASH: ${{ github.sha }}
+
+jobs:
+  sync_and_tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Define the tag
+        run: ./hack/publish-3p-staging-define-tag.sh
+
+      - name: Tag 3p-kubevirt
+        env:
+          GITHUB_TOKEN: ${{ secrets._3P_KUBEVIRT_TOKEN }}
+        run: ./hack/publish-3p-staging.sh 3p-kubevirt
+
+      - name: Run sync script
+        env:
+          GITHUB_TOKEN: ${{ secrets._3P_KUBEVIRT_TOKEN }}
+        run: ./hack/publish-3p-staging.sh 3p-kubevirt-api

--- a/hack/publish-3p-staging-define-tag.sh
+++ b/hack/publish-3p-staging-define-tag.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+function define_tag() {
+    tag_suffix="v12n"
+    # Check if the branch matches the pattern
+    if [[ "$BRANCH_NAME" =~ ^(v[0-9]+\.[0-9]+\.[0-9])+-virtualization$ ]]; then
+    # Extract last index from existing similar tags
+        version="${BASH_REMATCH[1]}"
+        latest_tag=$(git tag --list "${version}-${tag_suffix}.*" --sort=-v:refname | head --lines 1)
+
+        if [[ "$latest_tag" =~ ^.+-${tag_suffix}\.([0-9]+)$ ]]; then
+            last_index=${BASH_REMATCH[1]}
+            next_index=$((last_index + 1))
+        else
+            next_index=1
+        fi
+
+        new_tag="${version}-${tag_suffix}.${next_index}"
+    else
+    # Use commit hash for other branches
+        new_tag="v0.0.0-${tag_suffix}-3p-kubevirt-${COMMIT_HASH}"
+    fi
+
+    echo "TARGET_TAG=${new_tag}" >> $GITHUB_ENV
+}
+
+define_tag

--- a/hack/publish-3p-staging.sh
+++ b/hack/publish-3p-staging.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+GITHUB_FQDN=github.com
+GITHUB_USER="${GIT_AUTHOR_EMAIL:-deckhouse-BOaTswain@users.noreply.github.com}"
+GITHUB_USER_EMAIL="${GIT_AUTHOR_NAME:-deckhouse-BOaTswain}"
+THIRD_PARTY_REPO_NAME=$1
+KUBEVIRT_API_DIR_NAME=api
+
+function prepare_repo() {
+    NAME=$1
+    API_REF_DIR=/tmp/${NAME}
+    GO_API_REF_REPO=deckhouse/${NAME}
+    STAGING_PATH=staging/src/kubevirt.io/${KUBEVIRT_API_DIR_NAME}/
+    rm -rf ${API_REF_DIR}
+    git clone \
+        "https://${GITHUB_TOKEN}@${GITHUB_FQDN}/${GO_API_REF_REPO}.git" \
+        "${API_REF_DIR}" >/dev/null 2>&1
+    pushd ${API_REF_DIR}
+    git checkout -B ${BRANCH_NAME}
+    git pull --rebase origin ${BRANCH_NAME} || echo "Branch $BRANCH_NAME does not exist on remote or pull failed."
+    git rm -rf .
+    git clean -fxd
+    popd
+    cp -rf ${STAGING_PATH}/. "${API_REF_DIR}/"
+
+    # copy files which are the same on both repos
+    cp -f LICENSE "${API_REF_DIR}/"
+    cp -f SECURITY.md "${API_REF_DIR}/"
+
+    pushd ${API_REF_DIR}
+    # Generate .gitignore file. We want to keep bazel files in kubevirt/kubevirt, but not in sync target repos
+    cat >.gitignore <<__EOF__
+BUILD
+BUILD.bazel
+__EOF__
+    popd
+}
+
+function commit_repo() {
+    NAME=$1
+    API_REF_DIR=/tmp/${NAME}
+    pushd ${API_REF_DIR}
+    git config user.email "${GITHUB_USER}"
+    git config user.name "${GITHUB_USER_EMAIL}"
+
+    git add -A
+
+    if [ -n "$(git status --porcelain)" ]; then
+        git commit --message "${NAME} update by 3p-kubevirt ${COMMIT_HASH}"
+    else
+        echo "${NAME} hasn't changed."
+    fi
+    popd
+}
+
+function push_tag() {
+    NAME=$1
+
+    if [[ "${NAME}" == "3p-kubevirt-api" ]]; then
+        API_REF_DIR=/tmp/${NAME}
+        pushd ${API_REF_DIR}
+    fi
+   
+    git config user.email "${GITHUB_USER}"
+    git config user.name "${GITHUB_USER_EMAIL}"
+
+    if [ -n "${TARGET_TAG}" ]; then
+        if [ $(git tag --list "${TARGET_TAG}") ]; then
+            # tag already exists
+            echo "tag already exists remotely, doing nothing."
+            exit 0
+        fi
+        git tag ${TARGET_TAG}
+        git push origin ${TARGET_TAG}
+        echo "${NAME} updated for tag ${TARGET_TAG}."
+    fi
+
+    if [[ "${NAME}" == "3p-kubevirt-api" ]]; then
+        popd
+    fi
+}
+
+function push_repo() {
+    NAME=$1
+    API_REF_DIR=/tmp/${NAME}
+    pushd ${API_REF_DIR}
+
+    git push origin --set-upstream ${BRANCH_NAME}
+    echo "${NAME} updated for ${BRANCH_NAME}."
+
+    popd
+}
+
+if [[ "${THIRD_PARTY_REPO_NAME}" == "3p-kubevirt" ]]; then
+    push_tag ${THIRD_PARTY_REPO_NAME}
+elif [[ ${THIRD_PARTY_REPO_NAME} == "3p-kubevirt-api" ]]; then
+    prepare_repo ${THIRD_PARTY_REPO_NAME}
+    commit_repo ${THIRD_PARTY_REPO_NAME}
+    push_repo ${THIRD_PARTY_REPO_NAME}
+    push_tag ${THIRD_PARTY_REPO_NAME}
+else
+    echo "Unknown repository name: ${THIRD_PARTY_REPO_NAME}."
+    exit 1
+fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
All changes in the KubeVirt API will be automatically synced with `deckhouse/3p-kubevirt-api` repository.
Both `3p-kubevirt` and `3p-kubevirt-api` will also be tagged with the same tag. Supported patterns include:
- `<semantic version>-v12n.<index>`
- `<semantic pseudo version>-v12n-3p-kubevirt-<commit hash>`

Excluded branches:
- `main`
- `ci/*`

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
Work with KubeVirt API is performed in this repository. However, we need to work with this API as a Golang module.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
When changes are pushed to `deckhouse/3p-kubevirt` and there are changes in the KubeVirt API:
- `3p-kubevirt` will be tagged with a tag, for example, v1.3.1-v12n.15.
- API changes will be pushed to `deckhouse/3p-kubevirt-api` and tagged with the same tag.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  /!\ See CONTRIBUTING.md for more details. /!\
  Examples:
  ```changes
  section: core
  type: feature
  summary: "Node restarts can be avoided by pinning a checksum to a node group in config values."
  ---
  section: core
  type: fix
  summary: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
  impact_level: high
  impact: |
    Expect nodes of "Cloud" type to restart.
  ---
  impact_level: low
  ```
-->

```changes
section: ci
type: feature
summary: "All changes in the KubeVirt API will be automatically synced with deckhouse/3p-kubevirt-api repository."
impact_level: low
```
