### PR TITLE
Migration: Optimize listMatchingTargetPods

### DIFF
--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",


### PR DESCRIPTION
### What this PR does
Previously:
```
goos: linux
goarch: amd64
pkg: kubevirt.io/kubevirt/pkg/virt-controller/watch/migration
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkListMatchingTargetPods-12    	     453	   2392964 ns/op	  165370 B/op	      27 allocs/op
PASS
ok  	kubevirt.io/kubevirt/pkg/virt-controller/watch/migration	1.451s
```

The PR:
```
goos: linux
goarch: amd64
pkg: kubevirt.io/kubevirt/pkg/virt-controller/watch/migration
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkListMatchingTargetPods2-12    	 4796457	       240.3 ns/op	      24 B/op	       2 allocs/op
PASS
ok  	kubevirt.io/kubevirt/pkg/virt-controller/watch/migration	1.595s
```
<img width="1337" height="812" alt="Screenshot From 2025-10-10 17-50-39" src="https://github.com/user-attachments/assets/d7a4e560-426c-4210-bdbc-2cc42c58c8b7" />


### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: Thousands of migrations should not cause failures of active migrations
```

