### PR TITLE
pool: support secret ref indexing for CloudInit volumes

### DIFF
--- a/pkg/virt-controller/watch/pool/pool.go
+++ b/pkg/virt-controller/watch/pool/pool.go
@@ -830,6 +830,8 @@ func indexVMSpec(poolSpec *poolv1.VirtualMachinePoolSpec, idx int) *virtv1.Virtu
 		}
 	}
 
+	suffix := "-" + strconv.Itoa(idx)
+
 	for i, volume := range spec.Template.Spec.Volumes {
 		if volume.VolumeSource.PersistentVolumeClaim != nil {
 			indexName, ok := dvNameMap[volume.VolumeSource.PersistentVolumeClaim.ClaimName]
@@ -842,9 +844,23 @@ func indexVMSpec(poolSpec *poolv1.VirtualMachinePoolSpec, idx int) *virtv1.Virtu
 				spec.Template.Spec.Volumes[i].DataVolume.Name = indexName
 			}
 		} else if volume.VolumeSource.ConfigMap != nil && appendIndexToConfigMapRefs {
-			volume.VolumeSource.ConfigMap.Name += "-" + strconv.Itoa(idx)
+			volume.VolumeSource.ConfigMap.Name += suffix
 		} else if volume.VolumeSource.Secret != nil && appendIndexToSecretRefs {
-			volume.VolumeSource.Secret.SecretName += "-" + strconv.Itoa(idx)
+			volume.VolumeSource.Secret.SecretName += suffix
+		} else if volume.VolumeSource.CloudInitNoCloud != nil && appendIndexToSecretRefs {
+			if volume.VolumeSource.CloudInitNoCloud.UserDataSecretRef != nil {
+				volume.CloudInitNoCloud.UserDataSecretRef.Name += suffix
+			}
+			if volume.VolumeSource.CloudInitNoCloud.NetworkDataSecretRef != nil {
+				volume.CloudInitNoCloud.NetworkDataSecretRef.Name += suffix
+			}
+		} else if volume.VolumeSource.CloudInitConfigDrive != nil && appendIndexToSecretRefs {
+			if volume.VolumeSource.CloudInitConfigDrive.UserDataSecretRef != nil {
+				volume.CloudInitConfigDrive.UserDataSecretRef.Name += suffix
+			}
+			if volume.VolumeSource.CloudInitConfigDrive.NetworkDataSecretRef != nil {
+				volume.CloudInitConfigDrive.NetworkDataSecretRef.Name += suffix
+			}
 		}
 	}
 

--- a/pkg/virt-controller/watch/pool/pool_test.go
+++ b/pkg/virt-controller/watch/pool/pool_test.go
@@ -1094,6 +1094,135 @@ var _ = Describe("Pool", func() {
 			Entry("do not append index if set to false", pointer.P(false)),
 			Entry("append index if set to true", pointer.P(true)),
 		)
+
+		DescribeTable("should respect name generation settings for CloudInit volumes", func(appendIndex *bool) {
+			const (
+				userDataSecretName    = "userdata-secret"
+				networkDataSecretName = "networkdata-secret"
+			)
+
+			pool, _ := DefaultPool(3)
+			pool.Spec.VirtualMachineTemplate.Spec.Template.Spec.Volumes = []v1.Volume{
+				{
+					Name: "cloudinitdisk",
+					VolumeSource: v1.VolumeSource{
+						CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+							UserDataSecretRef: &k8sv1.LocalObjectReference{
+								Name: userDataSecretName,
+							},
+							NetworkDataSecretRef: &k8sv1.LocalObjectReference{
+								Name: networkDataSecretName,
+							},
+						},
+					},
+				},
+			}
+			pool.Spec.NameGeneration = &poolv1.VirtualMachinePoolNameGeneration{
+				AppendIndexToSecretRefs: appendIndex,
+			}
+
+			addPool(pool)
+
+			poolRevision := createPoolRevision(pool)
+
+			sanityExecute()
+
+			cr, err := k8sClient.AppsV1().ControllerRevisions(pool.Namespace).Get(context.TODO(), poolRevision.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cr.Name).To(Equal(poolRevision.Name))
+
+			vms, err := fakeVirtClient.KubevirtV1().VirtualMachines(pool.Namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(HaveLen(3))
+
+			for i, vm := range vms.Items {
+				Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(1))
+				Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal("cloudinitdisk"))
+				Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitNoCloud).ToNot(BeNil())
+
+				if appendIndex != nil && *appendIndex {
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.UserDataSecretRef.Name).To(Equal(fmt.Sprintf("%s-%d", userDataSecretName, i)))
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.NetworkDataSecretRef.Name).To(Equal(fmt.Sprintf("%s-%d", networkDataSecretName, i)))
+				} else {
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.UserDataSecretRef.Name).To(Equal(userDataSecretName))
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.NetworkDataSecretRef.Name).To(Equal(networkDataSecretName))
+				}
+			}
+
+			testutils.ExpectEvent(recorder, common.SuccessfulCreateVirtualMachineReason)
+			testutils.ExpectEvent(recorder, common.SuccessfulCreateVirtualMachineReason)
+			testutils.ExpectEvent(recorder, common.SuccessfulCreateVirtualMachineReason)
+			Expect(testing.FilterActions(&fakeVirtClient.Fake, "create", "virtualmachines")).To(HaveLen(3))
+		},
+			Entry("do not append index by default", nil),
+			Entry("do not append index if set to false", pointer.P(false)),
+			Entry("append index if set to true", pointer.P(true)),
+		)
+
+		DescribeTable("should respect name generation settings for CloudInitConfigDrive volumes", func(appendIndex *bool) {
+			const (
+				userDataSecretName    = "userdata-secret"
+				networkDataSecretName = "networkdata-secret"
+			)
+
+			pool, _ := DefaultPool(3)
+			pool.Spec.VirtualMachineTemplate.Spec.Template.Spec.Volumes = []v1.Volume{
+				{
+					Name: "cloudinitdisk",
+					VolumeSource: v1.VolumeSource{
+						CloudInitConfigDrive: &v1.CloudInitConfigDriveSource{
+							UserDataSecretRef: &k8sv1.LocalObjectReference{
+								Name: userDataSecretName,
+							},
+							NetworkDataSecretRef: &k8sv1.LocalObjectReference{
+								Name: networkDataSecretName,
+							},
+						},
+					},
+				},
+			}
+			pool.Spec.NameGeneration = &poolv1.VirtualMachinePoolNameGeneration{
+				AppendIndexToSecretRefs: appendIndex,
+			}
+
+			addPool(pool)
+
+			poolRevision := createPoolRevision(pool)
+
+			sanityExecute()
+
+			cr, err := k8sClient.AppsV1().ControllerRevisions(pool.Namespace).Get(context.TODO(), poolRevision.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cr.Name).To(Equal(poolRevision.Name))
+
+			vms, err := fakeVirtClient.KubevirtV1().VirtualMachines(pool.Namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(HaveLen(3))
+
+			for i, vm := range vms.Items {
+				Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(1))
+				Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal("cloudinitdisk"))
+				Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitConfigDrive).ToNot(BeNil())
+
+				if appendIndex != nil && *appendIndex {
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitConfigDrive.UserDataSecretRef.Name).To(Equal(fmt.Sprintf("%s-%d", userDataSecretName, i)))
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitConfigDrive.NetworkDataSecretRef.Name).To(Equal(fmt.Sprintf("%s-%d", networkDataSecretName, i)))
+				} else {
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitConfigDrive.UserDataSecretRef.Name).To(Equal(userDataSecretName))
+					Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.CloudInitConfigDrive.NetworkDataSecretRef.Name).To(Equal(networkDataSecretName))
+				}
+			}
+
+			testutils.ExpectEvent(recorder, common.SuccessfulCreateVirtualMachineReason)
+			testutils.ExpectEvent(recorder, common.SuccessfulCreateVirtualMachineReason)
+			testutils.ExpectEvent(recorder, common.SuccessfulCreateVirtualMachineReason)
+			Expect(testing.FilterActions(&fakeVirtClient.Fake, "create", "virtualmachines")).To(HaveLen(3))
+		},
+			Entry("do not append index by default", nil),
+			Entry("do not append index if set to false", pointer.P(false)),
+			Entry("append index if set to true", pointer.P(true)),
+		)
+
 		It("should remove finalizer on vms when pool is marked for deletion and VMs are orphaned", func() {
 			pool, vm := DefaultPool(3)
 			addPool(pool)


### PR DESCRIPTION
### What this PR does
   #### Before this PR:
   When using `VirtualMachinePool` with `spec.nameGeneration.appendIndexToSecretRefs: true`, the index was NOT appended to secret references in `cloudInitNoCloud.secretRef`, `cloudInitNoCloud.networkDataSecretRef`,
   `cloudInitConfigDrive.userDataSecretRef`, and `cloudInitConfigDrive.networkDataSecretRef` fields.
   This caused all VMs in the pool to reference the same base secret names (e.g., `test-userdata` instead of `test-userdata-0`, `test-userdata-1`), preventing each VM from having unique cloud-init configurations. Since only the indexed secret names
   existed, VMs would fail to properly initialize with cloud-init data.
   #### After this PR:
   When `appendIndexToSecretRefs: true` is set in a VirtualMachinePool, secret references in CloudInit volumes now correctly have the VM's sequential index appended to the secret name:
   - VM 0 references: `test-userdata-0`, `test-networkdata-0`
   - VM 1 references: `test-userdata-1`, `test-networkdata-1`
   - VM 2 references: `test-userdata-2`, `test-networkdata-2`
   This allows each VM in the pool to have unique cloud-init configurations (different hostnames, IP addresses, SSH keys, etc.) as documented in the KubeVirt user guide.
   ### References
   - Fixes #15810
   ### Why we need it and why it was done in this way
   - Fixes #15810
   ### Special notes for your reviewer
   - The fix adds support for both `CloudInitNoCloud` and `CloudInitConfigDrive` volume types
   - Each volume type supports both `UserDataSecretRef` and `NetworkDataSecretRef` indexing
   ### Checklist
   This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
   Approvers are expected to review this list.
   - [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
   - [x] PR: The PR description is expressive enough and will help future contributors
   - [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
   - [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
   - [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
   - [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
   - [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
   - [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
   ### Release note
   <!--  Write your release note:
   1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
   2. If no release note is required, just write "NONE".
   -->
```release-note
VirtualMachinePool now correctly appends index to CloudInit secret references when appendIndexToSecretRefs: true is set, enabling unique cloud-init configurations for each VM in the pool.
```