### PR TITLE
smbios sidecar: move XML functest to unit test

### DIFF
--- a/cmd/sidecars/smbios/BUILD.bazel
+++ b/cmd/sidecars/smbios/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
@@ -34,4 +34,25 @@ oci_image(
         ":onDefineDomain-tar",
     ],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "smbios_suite_test.go",
+        "smbios_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//pkg/hooks/v1alpha1:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/arch:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/cmd/sidecars/smbios/smbios_suite_test.go
+++ b/cmd/sidecars/smbios/smbios_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestSMBiosSidecar(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/cmd/sidecars/smbios/smbios_test.go
+++ b/cmd/sidecars/smbios/smbios_test.go
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hooksv1alpha1 "kubevirt.io/kubevirt/pkg/hooks/v1alpha1"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
+	archconverter "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/arch"
+
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("SMBios sidecar", func() {
+	It("should properly alter the libvirt domain", func() {
+		vmi := &v1.VirtualMachineInstance{
+			ObjectMeta: k8smeta.ObjectMeta{
+				Name:        "testvmi",
+				Namespace:   "mynamespace",
+				Annotations: renderSidecar(hooksv1alpha1.Version),
+			},
+		}
+
+		c := &converter.ConverterContext{
+			Architecture:   archconverter.NewConverter(runtime.GOARCH),
+			VirtualMachine: vmi,
+			AllowEmulation: true,
+		}
+
+		domain := &api.Domain{}
+		err := converter.Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, domain, c)
+		Expect(err).ToNot(HaveOccurred())
+
+		xml, err := xml.Marshal(domain.Spec)
+		Expect(err).ToNot(HaveOccurred())
+		json, err := json.Marshal(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		domxml, err := onDefineDomain(json, xml)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(domxml).To(ContainSubstring(`<sysinfo type="smbios">`))
+		Expect(domxml).To(ContainSubstring(`<smbios mode="sysinfo">`))
+		Expect(domxml).To(ContainSubstring(`<entry name="manufacturer">Radical Edward</entry>`))
+	})
+})
+
+func renderSidecar(version string) map[string]string {
+	return map[string]string{
+		"hooks.kubevirt.io/hookSidecars":              fmt.Sprintf(`[{"args": ["--version", "%s"],"image": "someimage", "imagePullPolicy": "IfNotPresent"}]`, version),
+		"smbios.vm.kubevirt.io/baseBoardManufacturer": "Radical Edward",
+	}
+}

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -162,17 +162,6 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 					Should(ContainSubstring("OnDefineDomain method has been called"))
 			})
 
-			It("[test_id:3158]should update domain XML with SM BIOS properties", func() {
-				By("Reading domain XML using virsh")
-				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				libwait.WaitForSuccessfulVMIStart(vmi)
-				domainXml, err := libdomain.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(domainXml).Should(ContainSubstring("<sysinfo type='smbios'>"))
-				Expect(domainXml).Should(ContainSubstring("<smbios mode='sysinfo'/>"))
-				Expect(domainXml).Should(ContainSubstring("<entry name='manufacturer'>Radical Edward</entry>"))
-			})
-
 			It("should not start with hook sidecar annotation when the version is not provided", func() {
 				By("Starting a VMI")
 				vmi.ObjectMeta.Annotations = RenderInvalidSMBiosSidecar()


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Test for XML changes is a functional test

#### After this PR:
Test for XML changes is a unit test

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
