### PR TITLE
tests/network: convert SkipIfRunningOnKindInfra to fail

### DIFF
--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -45,10 +45,3 @@ func SkipIfPrometheusRuleIsNotEnabled(virtClient kubecli.KubevirtClient) {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 }
-
-// Deprecated: SkipIfRunningOnKindInfra should be converted to check & fail
-func SkipIfRunningOnKindInfra(message string) {
-	if IsRunningOnKindInfra() {
-		ginkgo.Skip("Skip test on kind infra: " + message)
-	}
-}

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -39,7 +39,9 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 	)
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		checks.SkipIfRunningOnKindInfra("Skip Network Policy tests till issue https://github.com/kubevirt/kubevirt/issues/4081 is fixed")
+		if checks.IsRunningOnKindInfra() {
+			Fail("Network Policy tests cannot run till issue https://github.com/kubevirt/kubevirt/issues/4081 is fixed")
+		}
 
 		serverVMILabels = map[string]string{"type": "test"}
 	})


### PR DESCRIPTION
### What this PR does
Convert all skip functions in tests/framework/checks/ from skipping to failing behavior to eliminate programmatic skips from upstream.

Changes:
- inline the check of `FailTestIfRunningOnKindInfra` since it only used in one place.
- removing `FailTestIfRunningOnKindInfra` from skips.go

This ensures tests fail hard when prerequisites are not met instead of silently skipping, providing clearer feedback about missing requirements.

 Release note
```release-note
none
```

