### PR TITLE
[release-1.6] virt-controller: fix RestartRequired condition handling for hotplug volumes

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -842,37 +842,6 @@ func (c *Controller) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi *v
 		return nil
 	}
 
-	// The pull policy for container disks are only set on the VMI spec and not on the VM spec.
-	// In order to correctly compare the volumes set, we need to set the pull policy on the VM spec as well.
-	vmCopy := vm.DeepCopy()
-	volsVMI := storagetypes.GetVolumesByName(&vmi.Spec)
-	for i, volume := range vmCopy.Spec.Template.Spec.Volumes {
-		vmiVol, ok := volsVMI[volume.Name]
-		if !ok {
-			continue
-		}
-		if vmiVol.ContainerDisk != nil {
-			vmCopy.Spec.Template.Spec.Volumes[i].ContainerDisk.ImagePullPolicy = vmiVol.ContainerDisk.ImagePullPolicy
-		}
-	}
-	hotplugOp := false
-	volsVM := storagetypes.GetVolumesByName(&vmCopy.Spec.Template.Spec)
-	for _, volume := range vmi.Spec.Volumes {
-		hotpluggableVol := (volume.VolumeSource.PersistentVolumeClaim != nil &&
-			volume.VolumeSource.PersistentVolumeClaim.Hotpluggable) ||
-			(volume.VolumeSource.DataVolume != nil && volume.VolumeSource.DataVolume.Hotpluggable)
-		_, ok := volsVM[volume.Name]
-		if !ok && hotpluggableVol {
-			hotplugOp = true
-		}
-	}
-	if hotplugOp {
-		return nil
-	}
-	if equality.Semantic.DeepEqual(vmi.Spec.Volumes, vmCopy.Spec.Template.Spec.Volumes) {
-		return nil
-	}
-	vmConditions := controller.NewVirtualMachineConditionManager()
 	// Abort the volume migration if any of the previous migrated volumes
 	// has changed
 	if volMigAbort, err := volumemig.VolumeMigrationCancel(c.clientset, vmi, vm); volMigAbort {
@@ -885,11 +854,13 @@ func (c *Controller) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi *v
 	switch {
 	case vm.Spec.UpdateVolumesStrategy == nil ||
 		*vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyReplacement:
-		if !vmConditions.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
-			log.Log.Object(vm).Infof("Set restart required condition because of a volumes update")
-			setRestartRequired(vm, "the volumes replacement is effective only after restart")
-		}
+		log.Log.Object(vm).V(4).Infof("not handling replacement update volumes strategy")
 	case *vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyMigration:
+		if !volumemig.PersistentVolumesUpdated(&vm.Spec.Template.Spec, &vmi.Spec) {
+			log.Log.Object(vm).V(4).Infof("No persistent volumes updated")
+			return nil
+		}
+
 		// Validate if the update volumes can be migrated
 		if err := volumemig.ValidateVolumes(vmi, vm, c.dataVolumeStore, c.pvcStore); err != nil {
 			return c.handleValidationErrors(err, vmi, vm)
@@ -3014,16 +2985,17 @@ func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMa
 		return false
 	}
 
+	if validLiveUpdateVolumes(&lastSeenVM.Spec, currentVM) {
+		lastSeenVM.Spec.Template.Spec.Volumes = currentVM.Spec.Template.Spec.Volumes
+	}
+	if validLiveUpdateDisks(&lastSeenVM.Spec, currentVM) {
+		lastSeenVM.Spec.Template.Spec.Domain.Devices.Disks = currentVM.Spec.Template.Spec.Domain.Devices.Disks
+	}
+
 	// Ignore all the live-updatable fields by copying them over. (If the feature gate is disabled, nothing is live-updatable)
 	// Note: this list needs to stay up-to-date with everything that can be live-updated
 	// Note2: destroying lastSeenVM here is fine, we don't need it later
 	if c.clusterConfig.IsVMRolloutStrategyLiveUpdate() {
-		if validLiveUpdateVolumes(&lastSeenVM.Spec, currentVM) {
-			lastSeenVM.Spec.Template.Spec.Volumes = currentVM.Spec.Template.Spec.Volumes
-		}
-		if validLiveUpdateDisks(&lastSeenVM.Spec, currentVM) {
-			lastSeenVM.Spec.Template.Spec.Domain.Devices.Disks = currentVM.Spec.Template.Spec.Domain.Devices.Disks
-		}
 		if lastSeenVM.Spec.Template.Spec.Domain.CPU != nil && currentVM.Spec.Template.Spec.Domain.CPU != nil {
 			lastSeenVM.Spec.Template.Spec.Domain.CPU.Sockets = currentVM.Spec.Template.Spec.Domain.CPU.Sockets
 		}
@@ -3038,19 +3010,6 @@ func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMa
 		lastSeenVM.Spec.Template.Spec.NodeSelector = currentVM.Spec.Template.Spec.NodeSelector
 		lastSeenVM.Spec.Template.Spec.Affinity = currentVM.Spec.Template.Spec.Affinity
 		lastSeenVM.Spec.Template.Spec.Tolerations = currentVM.Spec.Template.Spec.Tolerations
-	} else {
-		// In the case live-updates aren't enable the volume set of the VM can be still changed by volume hotplugging.
-		// For imperative volume hotplug, first the VM status with the request AND the VMI spec are updated, then in the
-		// next iteration, the VM spec is updated as well. Here, we're in this iteration where the currentVM has for the first
-		// time the updated hotplugged volumes. Hence, we can compare the current VM volumes and disks with the ones belonging
-		// to the VMI.
-		// In case of a declarative update, the flow is the opposite, first we update the VM spec and then the VMI. Therefore, if
-		// the change was declarative, then the VMI would still not have the update.
-		if equality.Semantic.DeepEqual(currentVM.Spec.Template.Spec.Volumes, vmi.Spec.Volumes) &&
-			equality.Semantic.DeepEqual(currentVM.Spec.Template.Spec.Domain.Devices.Disks, vmi.Spec.Domain.Devices.Disks) {
-			lastSeenVM.Spec.Template.Spec.Volumes = currentVM.Spec.Template.Spec.Volumes
-			lastSeenVM.Spec.Template.Spec.Domain.Devices.Disks = currentVM.Spec.Template.Spec.Domain.Devices.Disks
-		}
 	}
 
 	if !netvmliveupdate.IsRestartRequired(currentVM, vmi) {

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -5419,29 +5419,6 @@ var _ = Describe("VirtualMachine", func() {
 					newDVName = "newDV"
 					ns        = metav1.NamespaceDefault
 				)
-				DescribeTable("should set the restart condition", func(strategy *v1.UpdateVolumesStrategy) {
-					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
-						Spec: v1.KubeVirtSpec{
-							Configuration: v1.KubeVirtConfiguration{
-								VMRolloutStrategy: &liveUpdate,
-							},
-						},
-					})
-					vm, vmi := watchtesting.DefaultVirtualMachine(true)
-					vm.Spec.UpdateVolumesStrategy = strategy
-					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
-						Name: "vol1"})
-					vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{Name: "vol2"})
-					controller.handleVolumeUpdateRequest(vm, vmi)
-					cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(vm, v1.VirtualMachineRestartRequired)
-					Expect(cond).ToNot(BeNil())
-					Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
-					Expect(cond.Message).To(Equal("the volumes replacement is effective only after restart"))
-				},
-					Entry("without the updateVolumeStrategy field", nil),
-					Entry("with the replacement updateVolumeStrategy",
-						pointer.P(v1.UpdateVolumesStrategyReplacement)),
-				)
 
 				It("should set the restart condition with the Migration updateVolumeStrategy if volumes cannot be migrated", func() {
 					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
@@ -5963,17 +5940,23 @@ var _ = Describe("VirtualMachine", func() {
 						v1.VirtualMachineRestartRequired)).To(BeFalse())
 				})
 
-				It("should appear when the volume is directly added to the spec", func() {
-					By("Creating a VM")
+				DescribeTable("should NOT appear for hotpluggable DataVolume regardless of rollout strategy", func(strategy *v1.VMRolloutStrategy) {
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+						Spec: v1.KubeVirtSpec{
+							Configuration: v1.KubeVirtConfiguration{
+								VMRolloutStrategy: strategy,
+							},
+						},
+					})
+
+					By("Creating a VM with VMI")
 					vmi = controller.setupVMIFromVM(vm)
 					controller.vmiIndexer.Add(vmi)
-
-					By("Creating a Controller Revision")
 					controller.crIndexer.Add(createVMRevision(vm))
 
-					By("Adding an hotplugged volume to the VM")
+					By("Adding hotpluggable DataVolume to VM spec")
 					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
-						Name: "hotplug",
+						Name: "hotplug-vol",
 						VolumeSource: v1.VolumeSource{
 							DataVolume: &v1.DataVolumeSource{
 								Name:         "hotplug-dv",
@@ -5982,21 +5965,189 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 					vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
-						Name: "hotplug",
+						Name: "hotplug-vol",
 						DiskDevice: v1.DiskDevice{
 							Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
-						}})
+						},
+					})
+
 					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
 					Expect(err).To(Succeed())
 					addVirtualMachine(vm)
 
-					By("Executing the controller expecting the RestartRequired not to appear")
 					sanityExecute(vm)
 					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(Succeed())
+
+					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
+						v1.VirtualMachineRestartRequired)).To(BeFalse())
+				},
+					Entry("with no rollout strategy", nil),
+					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
+					Entry("with LiveUpdate rollout strategy", pointer.P(v1.VMRolloutStrategyLiveUpdate)),
+				)
+
+				DescribeTable("should NOT appear for hotpluggable PVC regardless of rollout strategy", func(strategy *v1.VMRolloutStrategy) {
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+						Spec: v1.KubeVirtSpec{
+							Configuration: v1.KubeVirtConfiguration{
+								VMRolloutStrategy: strategy,
+							},
+						},
+					})
+
+					By("Creating a VM with VMI")
+					vmi = controller.setupVMIFromVM(vm)
+					controller.vmiIndexer.Add(vmi)
+					controller.crIndexer.Add(createVMRevision(vm))
+
+					By("Adding hotpluggable PVC volume to VM spec")
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+						Name: "hotplug-pvc",
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "hotplug-claim",
+								},
+								Hotpluggable: true,
+							},
+						},
+					})
+					vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+						Name: "hotplug-pvc",
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
+						},
+					})
+
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					sanityExecute(vm)
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+
+					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
+						v1.VirtualMachineRestartRequired)).To(BeFalse())
+				},
+					Entry("with no rollout strategy", nil),
+					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
+					Entry("with LiveUpdate rollout strategy", pointer.P(v1.VMRolloutStrategyLiveUpdate)),
+				)
+
+				DescribeTable("should appear for non-hotpluggable volumes regardless of rollout strategy", func(strategy *v1.VMRolloutStrategy) {
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+						Spec: v1.KubeVirtSpec{
+							Configuration: v1.KubeVirtConfiguration{
+								VMRolloutStrategy: strategy,
+							},
+						},
+					})
+
+					By("Creating a VM with VMI")
+					vmi = controller.setupVMIFromVM(vm)
+					controller.vmiIndexer.Add(vmi)
+					controller.crIndexer.Add(createVMRevision(vm))
+
+					By("Adding non-hotpluggable volume to VM spec")
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+						Name: "regular-vol",
+						VolumeSource: v1.VolumeSource{
+							DataVolume: &v1.DataVolumeSource{
+								Name:         "regular-dv",
+								Hotpluggable: false,
+							},
+						},
+					})
+					vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+						Name: "regular-vol",
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{Bus: v1.DiskBusVirtio},
+						},
+					})
+
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					sanityExecute(vm)
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+
 					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
 						v1.VirtualMachineRestartRequired)).To(BeTrue())
-				})
+				},
+					Entry("with no rollout strategy", nil),
+					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
+					Entry("with LiveUpdate rollout strategy", pointer.P(v1.VMRolloutStrategyLiveUpdate)),
+				)
+
+				DescribeTable("should appear when mixing hotpluggable and non-hotpluggable volumes", func(strategy *v1.VMRolloutStrategy) {
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+						Spec: v1.KubeVirtSpec{
+							Configuration: v1.KubeVirtConfiguration{
+								VMRolloutStrategy: strategy,
+							},
+						},
+					})
+
+					By("Creating a VM with VMI")
+					vmi = controller.setupVMIFromVM(vm)
+					controller.vmiIndexer.Add(vmi)
+					controller.crIndexer.Add(createVMRevision(vm))
+
+					By("Adding both hotpluggable and non-hotpluggable volumes")
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes,
+						v1.Volume{
+							Name: "hotplug-vol",
+							VolumeSource: v1.VolumeSource{
+								DataVolume: &v1.DataVolumeSource{
+									Name:         "hotplug-dv",
+									Hotpluggable: true,
+								},
+							},
+						},
+						v1.Volume{
+							Name: "regular-vol",
+							VolumeSource: v1.VolumeSource{
+								DataVolume: &v1.DataVolumeSource{
+									Name:         "regular-dv",
+									Hotpluggable: false,
+								},
+							},
+						},
+					)
+					vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks,
+						v1.Disk{
+							Name: "hotplug-vol",
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
+							},
+						},
+						v1.Disk{
+							Name: "regular-vol",
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{Bus: v1.DiskBusVirtio},
+							},
+						},
+					)
+
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					sanityExecute(vm)
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+
+					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
+						v1.VirtualMachineRestartRequired)).To(BeTrue())
+				},
+					Entry("with no rollout strategy", nil),
+					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
+					Entry("with LiveUpdate rollout strategy", pointer.P(v1.VMRolloutStrategyLiveUpdate)),
+				)
 			})
 		})
 


### PR DESCRIPTION
manual backport of #15788

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix RestartRequired handling for hotplug volumes
```

