### PR TITLE
Update VMI Image to use AlpineWithTestTooling instead of Cirros to enable sig-compute tests for s390x Arch

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -175,7 +175,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			const labelKey = "subdomain"
 			const labelValue = "mysub"
 
-			vmi := libvmifact.NewCirros(
+			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithHostname(hostname),
 				withSubdomain(subdomain),
 				libvmi.WithLabel(labelKey, labelValue),
@@ -185,7 +185,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
 
 			By("Starting hello world in the VM")
-			vmnetserver.StartTCPServer(vmi, port, console.LoginToCirros)
+			vmnetserver.StartTCPServer(vmi, port, console.LoginToAlpine)
 
 			By("Exposing headless service matching subdomain")
 			service := service.BuildHeadlessSpec(subdomain, port, port, labelKey, labelValue)

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -228,7 +228,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				libdv.WithStorage(),
 			)
 
-			sourceVMI := libvmifact.NewCirros(
+			sourceVMI := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -262,13 +262,13 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				}
 			}
 			By("Writing data to extra disk")
-			Expect(console.LoginToCirros(sourceVMI)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("sudo mkfs.ext4 /dev/%s", deviceName), 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "mkdir test", 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("sudo mount -t ext4 /dev/%s /home/cirros/test", deviceName), 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "sudo chmod 777 /home/cirros/test", 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "sudo chown cirros:cirros /home/cirros/test", 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "printf 'important data' &> /home/cirros/test/data.txt", 30*time.Second)).To(Succeed())
+			Expect(console.LoginToAlpine(sourceVMI)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("mkfs.ext4 /dev/%s", deviceName), 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "mkdir /home/alpine/test", 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("mount -t ext4 /dev/%s /home/alpine/test", deviceName), 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "chmod 777 /home/alpine/test", 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "chown alpine:alpine /home/alpine/test", 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "printf 'important data' &> /home/alpine/test/data.txt", 30*time.Second)).To(Succeed())
 
 			targetDV, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(targetDV)).Create(context.Background(), targetDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -291,8 +291,8 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				}
 				return ""
 			}).WithTimeout(time.Minute).WithPolling(2 * time.Second).ShouldNot(BeEmpty())
-			Expect(console.LoginToCirros(targetVMI)).To(Succeed())
-			Expect(console.RunCommand(targetVMI, "cat /home/cirros/test/data.txt", 30*time.Second)).To(Succeed())
+			Expect(console.LoginToAlpine(targetVMI)).To(Succeed())
+			Expect(console.RunCommand(targetVMI, "cat /home/alpine/test/data.txt", 30*time.Second)).To(Succeed())
 			By("verifying the runStrategy is properly updated to be what the annotation is")
 			Eventually(func() virtv1.VirtualMachineRunStrategy {
 				targetVM, err = virtClient.VirtualMachine(targetVM.Namespace).Get(context.Background(), targetVM.Name, metav1.GetOptions{})
@@ -352,7 +352,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			migrationID := fmt.Sprintf("mig-%s", rand.String(5))
 			hotpluggedDV := createDVBlock(fmt.Sprintf("dv-%s", migrationID), testsuite.NamespaceTestDefault, sc)
 
-			sourceVMI := libvmifact.NewCirros(
+			sourceVMI := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -388,15 +388,15 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			}
 
 			By("Writing data to extra disk")
-			Expect(console.LoginToCirros(sourceVMI)).To(Succeed())
+			Expect(console.LoginToAlpine(sourceVMI)).To(Succeed())
 			// I am aware I should not use the device name since it is not guaranteed to be the same as the one in the VMI
 			// I should be using the serial number, but not sure how to access that in cirros.
-			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("sudo mkfs.ext4 /dev/%s", deviceName), 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "mkdir test", 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("sudo mount -t ext4 /dev/%s /home/cirros/test", deviceName), 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "sudo chmod 777 /home/cirros/test", 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "sudo chown cirros:cirros /home/cirros/test", 30*time.Second)).To(Succeed())
-			Expect(console.RunCommand(sourceVMI, "printf 'important data' &> /home/cirros/test/data.txt", 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("mkfs.ext4 /dev/%s", deviceName), 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "mkdir /home/alpine/test", 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("mount -t ext4 /dev/%s /home/alpine/test", deviceName), 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "chmod 777 /home/alpine/test", 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "chown alpine:alpine /home/alpine/test", 30*time.Second)).To(Succeed())
+			Expect(console.RunCommand(sourceVMI, "printf 'important data' &> /home/alpine/test/data.txt", 30*time.Second)).To(Succeed())
 
 			By("Creating the target VM and disk")
 			targetVMI := sourceVMI.DeepCopy()
@@ -440,8 +440,8 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				}
 				return ""
 			}).WithTimeout(time.Minute).WithPolling(2 * time.Second).ShouldNot(BeEmpty())
-			Expect(console.LoginToCirros(targetVMI)).To(Succeed())
-			Expect(console.RunCommand(targetVMI, "cat /home/cirros/test/data.txt", 30*time.Second)).To(Succeed())
+			Expect(console.LoginToAlpine(targetVMI)).To(Succeed())
+			Expect(console.RunCommand(targetVMI, "cat /home/alpine/test/data.txt", 30*time.Second)).To(Succeed())
 		})
 
 		Context("with RWOFs backend storage class", func() {

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -56,11 +56,12 @@ import (
 )
 
 const (
-	sshAuthorizedKey     = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key"
-	fedoraPassword       = "fedora"
-	expectedUserDataFile = "cloud-init-userdata-executed"
-	testNetworkData      = "#Test networkData"
-	testUserData         = "#cloud-config"
+	sshAuthorizedKey           = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key"
+	fedoraPassword             = "fedora"
+	expectedUserDataFile       = "cloud-init-userdata-executed"
+	testNoCloudNetworkData     = "#Test networkData"
+	testConfigDriveNetworkData = `{"config":"test networkData"}`
+	testUserData               = "#cloud-config"
 
 	dataSourceNoCloudVolumeID     = "cidata"
 	dataSourceConfigDriveVolumeID = "config-2"
@@ -155,10 +156,10 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Context("with cloudInitConfigDrive", func() {
 			It("[test_id:3178]should have cloud-init data from userDataBase64 source", decorators.Conformance, func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
-				vmi := libvmifact.NewCirros(libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveUserData(userData)))
+				vmi := libvmifact.NewAlpineWithTestTooling(libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveUserData(userData)))
 
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsSmall)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				By("Checking whether the user-data script had created the file")
@@ -238,13 +239,13 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		Context("with cloudInitNoCloud networkData", func() {
 			It("[test_id:3181]should have cloud-init network-config with NetworkData source", func() {
-				vmi := libvmifact.NewCirros(
+				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloud(libcloudinit.WithNoCloudNetworkData(testNetworkData)),
+					libvmi.WithCloudInitNoCloud(libcloudinit.WithNoCloudNetworkData(testNoCloudNetworkData)),
 				)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -252,17 +253,17 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceNoCloudVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "network-config", testNetworkData)
+				checkCloudInitFile(vmi, "network-config", testNoCloudNetworkData)
 
 			})
 			It("[test_id:3182]should have cloud-init network-config with NetworkDataBase64 source", func() {
-				vmi := libvmifact.NewCirros(
+				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloud(libcloudinit.WithNoCloudEncodedNetworkData(testNetworkData)),
+					libvmi.WithCloudInitNoCloud(libcloudinit.WithNoCloudEncodedNetworkData(testNoCloudNetworkData)),
 				)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -270,25 +271,25 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceNoCloudVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "network-config", testNetworkData)
+				checkCloudInitFile(vmi, "network-config", testNoCloudNetworkData)
 
 			})
 			It("[test_id:3183]should have cloud-init network-config from k8s secret", func() {
 				secretID := fmt.Sprintf("%s-test-secret", uuid.NewString())
 
-				vmi := libvmifact.NewCirros(
+				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithCloudInitNoCloud(libcloudinit.WithNoCloudNetworkDataSecretName(secretID)),
 				)
 
 				By("Creating a secret with network data")
-				secret := libsecret.New(secretID, libsecret.DataString{"networkdata": testNetworkData})
+				secret := libsecret.New(secretID, libsecret.DataString{"networkdata": testNoCloudNetworkData})
 				_, err := virtClient.CoreV1().Secrets(testsuite.GetTestNamespace(vmi)).Create(context.Background(), secret, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -296,7 +297,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceNoCloudVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "network-config", testNetworkData)
+				checkCloudInitFile(vmi, "network-config", testNoCloudNetworkData)
 
 				// Expect that the secret is not present on the vmi itself
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
@@ -313,9 +314,11 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		Context("with cloudInitConfigDrive networkData", func() {
 			It("[test_id:3184]should have cloud-init network-config with NetworkData source", func() {
-				vmi := libvmifact.NewCirros(libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveNetworkData(testNetworkData)))
+				vmi := libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveNetworkData(testConfigDriveNetworkData),
+						libcloudinit.WithConfigDriveUserData("#!/bin/bash\necho 'hello'\n")))
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -323,7 +326,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testConfigDriveNetworkData)
 			})
 			It("[test_id:4622]should have cloud-init meta_data with tagged devices", func() {
 				const (
@@ -333,7 +336,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				)
 				testInstancetype := "testInstancetype"
 				vmi := libvmifact.NewCirros(
-					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveNetworkData(testNetworkData)),
+					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveNetworkData(testNoCloudNetworkData)),
 					libvmi.WithInterface(v1.Interface{
 						Name: "default",
 						Tag:  tag,
@@ -371,7 +374,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testNoCloudNetworkData)
 
 				By("checking cloudinit meta-data")
 				const consoleCmd = `cat /mnt/openstack/latest/meta_data.json; printf "@@"`
@@ -384,23 +387,24 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(rawOutput).To(ContainSubstring(string(buf)))
 			})
 			It("[test_id:3185]should have cloud-init network-config with NetworkDataBase64 source", func() {
-				vmi := libvmifact.NewCirros(
-					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveEncodedNetworkData(testNetworkData)),
+				vmi := libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveEncodedNetworkData(testConfigDriveNetworkData),
+						libcloudinit.WithConfigDriveUserData("#!/bin/bash\necho 'hello'\n")),
 				)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 				By("mouting cloudinit iso")
 				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testConfigDriveNetworkData)
 
 			})
 			It("[test_id:3186]should have cloud-init network-config from k8s secret", func() {
 				secretID := fmt.Sprintf("%s-test-secret", uuid.NewString())
-				vmi := libvmifact.NewCirros(
+				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitConfigDrive(
 						libcloudinit.WithConfigDriveUserDataSecretName(secretID),
 						libcloudinit.WithConfigDriveNetworkDataSecretName(secretID),
@@ -411,14 +415,14 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				By("Creating a secret with user and network data")
 				secret := libsecret.New(secretID, libsecret.DataString{
 					"userdata":    testUserData,
-					"networkdata": testNetworkData,
+					"networkdata": testConfigDriveNetworkData,
 				})
 
 				_, err := virtClient.CoreV1().Secrets(testsuite.GetTestNamespace(vmi)).Create(context.Background(), secret, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -426,7 +430,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testConfigDriveNetworkData)
 				checkCloudInitFile(vmi, "openstack/latest/user_data", testUserData)
 
 				// Expect that the secret is not present on the vmi itself
@@ -450,7 +454,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				uSecretID := fmt.Sprintf("%s-test-secret", uuid.NewString())
 				nSecretID := fmt.Sprintf("%s-test-secret", uuid.NewString())
 
-				vmi := libvmifact.NewCirros(
+				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitConfigDrive(
 						libcloudinit.WithConfigDriveUserDataSecretName(uSecretID),
 						libcloudinit.WithConfigDriveNetworkDataSecretName(nSecretID),
@@ -466,13 +470,13 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Creating a secret with network data")
-				nSecret := libsecret.New(nSecretID, libsecret.DataString{networkDataLabel: testNetworkData})
+				nSecret := libsecret.New(nSecretID, libsecret.DataString{networkDataLabel: testConfigDriveNetworkData})
 
 				_, err = virtClient.CoreV1().Secrets(ns).Create(context.Background(), nSecret, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -480,7 +484,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testConfigDriveNetworkData)
 
 				By("checking cloudinit user-data")
 				checkCloudInitFile(vmi, "openstack/latest/user_data", testUserData)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Enables additional sig-compute e2e tests on the s390x architecture by replacing the Cirros VM image with AlpineWithTestTooling.
#### Before this PR:
Sig-compute tests were not enabled for the s390x architecture because the Cirros VM image does not support s390x.
#### After this PR:
Since Cirros is not supported on s390x, it has been replaced with AlpineWithTestTooling for a couple of sig-compute e2e tests, allowing these tests to run on the s390x architecture.

Partially fixes: https://github.com/kubevirt/kubevirt/issues/15043
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

