### PR TITLE
net, generator: Preserve unknown fields added by ext entities to k8s.v1.cni.cncf.io/networks

### DIFF
--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -153,11 +153,16 @@ func (g Generator) generateMultusAnnotation(vmi *v1.VirtualMachineInstance, pod 
 		updatedMultusAnnotation,
 	)
 
-	if updatedMultusAnnotation == currentMultusAnnotation {
+	mergedMultusAnnotation, err := multus.MergeNetworkSelectionElements(updatedMultusAnnotation, currentMultusAnnotation)
+	if err != nil {
 		return "", false
 	}
 
-	return updatedMultusAnnotation, true
+	if mergedMultusAnnotation == currentMultusAnnotation {
+		return "", false
+	}
+
+	return mergedMultusAnnotation, true
 }
 
 func (g Generator) generateDeviceInfoAnnotation(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

External entities may want to add information to existing NetworkSelectionElements defined by KubeVirt in the k8s.v1.cni.cncf.io/networks annotation  (For example ipam-extensions).

Right now kubevirt computes the desired multus annotation based on the interfaces of the VMI and overwrites the existing one if a change is required - thus overwriting the information added by the external entities.

This PR makes kubevirt merge the existing k8s.v1.cni.cncf.io/networks annotation with the one calculated by Kubevirt - thus preserving these unknown fields.
We assume `name`, `namespace`, `mac` and `interface` are fields owned by kubevirt. Any changes to these fields will be
overwritten in the annotation.

#### Before this PR:

#### After this PR:


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Fixes #15480
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- This could have been done by simply unmarshalling the annotation into a `v1.NetworkSelectionElement`, but `v1.NetworkSelectionElement` struct may not always be up to date which will lead to loss of data.
- `cni-args` field is also owned by kubevirt, but it is not considered in this commit for simplicity. It will be addressed in a
follow-up.
- We assume that the combination of name, namespace and interface is unique, and so we use this combination to form a identifier key for comparison.
- The unit test `Should preserve existing unknown fields but update kubevirt owned fields when a second secondary interface is hotplugged` combines testing two scenarios - hotplugging an interface which has the same NAD as the existing interface and hotplugging an interface on a different NAD - to save test run time.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

