### PR TITLE
[release-0.58] virt-handler: validate sockets listed by the domain informer cache with ghost record cache

### DIFF
--- a/pkg/virt-handler/cache/BUILD.bazel
+++ b/pkg/virt-handler/cache/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
         "//pkg/virt-launcher/virtwrap:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cmd-server:go_default_library",
-        "//pkg/watchdog:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -21,6 +21,7 @@ package cache
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -42,82 +43,49 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	cmdserver "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cmd-server"
-	"kubevirt.io/kubevirt/pkg/watchdog"
 )
 
-var _ = Describe("Domain informer", func() {
-	var err error
-	var shareDir string
-	var podsDir string
-	var socketsDir string
-	var ghostCacheDir string
-	var informer cache.SharedInformer
-	var stopChan chan struct{}
-	var wg *sync.WaitGroup
-	var ctrl *gomock.Controller
-	var domainManager *virtwrap.MockDomainManager
-	var socketPath string
-	var resyncPeriod int
+func clearGhostRecordCache() {
+	ghostRecordGlobalMutex.Lock()
+	defer ghostRecordGlobalMutex.Unlock()
+	ghostRecordGlobalCache = make(map[string]ghostRecord)
+}
 
-	podUID := "1234"
+var _ = Describe("Domain informer", func() {
+	var ghostCacheDir string
 
 	BeforeEach(func() {
-		resyncPeriod = 5
-		stopChan = make(chan struct{})
-		wg = &sync.WaitGroup{}
-
-		shareDir, err = ioutil.TempDir("", "kubevirt-share")
-		Expect(err).ToNot(HaveOccurred())
-
-		podsDir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
+		var err error
 
 		ghostCacheDir, err = ioutil.TempDir("", "")
 		Expect(err).ToNot(HaveOccurred())
 
 		InitializeGhostRecordCache(ghostCacheDir)
-
-		cmdclient.SetLegacyBaseDir(shareDir)
-		cmdclient.SetPodsBaseDir(podsDir)
-
-		socketsDir = filepath.Join(shareDir, "sockets")
-		os.Mkdir(socketsDir, 0755)
-		os.Mkdir(filepath.Join(socketsDir, "1234"), 0755)
-
-		socketPath = cmdclient.SocketFilePathOnHost(podUID)
-		os.MkdirAll(filepath.Dir(socketPath), 0755)
-
-		informer, err = NewSharedInformer(shareDir, 10, nil, nil, time.Duration(resyncPeriod)*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-
-		ctrl = gomock.NewController(GinkgoT())
-		domainManager = virtwrap.NewMockDomainManager(ctrl)
 	})
 
 	AfterEach(func() {
-		close(stopChan)
-		wg.Wait()
-		os.RemoveAll(shareDir)
-		os.RemoveAll(podsDir)
-		os.RemoveAll(ghostCacheDir)
-		DeleteGhostRecord("test", "test")
+		Expect(os.RemoveAll(ghostCacheDir)).To(Succeed())
 	})
 
-	verifyObj := func(key string, domain *api.Domain) {
-		obj, exists, err := informer.GetStore().GetByKey(key)
-		Expect(err).ToNot(HaveOccurred())
+	Context("listSockets ", func() {
+		It("should return socket list from ghost record cache", func() {
+			const podUID = "5678"
+			const socketPath = "/path/to/domainsock"
 
-		if domain != nil {
-			Expect(exists).To(BeTrue())
+			ghostCacheDir := GinkgoT().TempDir()
 
-			eventDomain := obj.(*api.Domain)
-			eventDomain.Spec.XMLName = xml.Name{}
-			Expect(equality.Semantic.DeepEqual(&domain.Spec, &eventDomain.Spec)).To(BeTrue())
-		} else {
+			Expect(InitializeGhostRecordCache(ghostCacheDir)).To(Succeed())
 
-			Expect(exists).To(BeFalse())
-		}
-	}
+			err := AddGhostRecord("test-ns", "test-domain", socketPath, podUID)
+			Expect(err).ToNot(HaveOccurred())
+
+			socketFiles, err := listSockets(getGhostRecords())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(socketFiles).To(HaveLen(1))
+			Expect(socketFiles[0]).To(Equal(socketPath))
+
+		})
+	})
 
 	Context("with ghost record cache", func() {
 		It("Should be able to retrieve uid", func() {
@@ -173,7 +141,7 @@ var _ = Describe("Domain informer", func() {
 			_, exists := ghostRecordGlobalCache["test1-namespace/test1"]
 			Expect(exists).To(BeTrue())
 
-			exists, err = diskutils.FileExists(filepath.Join(ghostRecordDir, "1234-1"))
+			exists, err = diskutils.FileExists(filepath.Join(ghostCacheDir, "1234-1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exists).To(BeTrue())
 
@@ -183,7 +151,7 @@ var _ = Describe("Domain informer", func() {
 			_, exists = ghostRecordGlobalCache["test1-namespace/test1"]
 			Expect(exists).To(BeFalse())
 
-			exists, err = diskutils.FileExists(filepath.Join(ghostRecordDir, "1234-1"))
+			exists, err = diskutils.FileExists(filepath.Join(ghostCacheDir, "1234-1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exists).To(BeFalse())
 
@@ -205,12 +173,74 @@ var _ = Describe("Domain informer", func() {
 		})
 	})
 
-	Context("with notification server", func() {
+	Context("with cmd server", func() {
+		const podUID = "1234"
+		const domainName = "testvmi1"
+		const domainNamespace = "default"
+		const resyncPeriod = 5
+
+		var shareDir string
+		var podsDir string
+		var informer cache.SharedInformer
+		var stopChan chan struct{}
+		var wg *sync.WaitGroup
+		var ctrl *gomock.Controller
+		var domainManager *virtwrap.MockDomainManager
+		var socketPath string
+
+		BeforeEach(func() {
+			var err error
+
+			stopChan = make(chan struct{})
+			wg = &sync.WaitGroup{}
+
+			shareDir, err = os.MkdirTemp("", "kubevirt-share")
+			Expect(err).ToNot(HaveOccurred())
+
+			podsDir, err = os.MkdirTemp("", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			cmdclient.SetPodsBaseDir(podsDir)
+
+			socketPath = cmdclient.SocketFilePathOnHost(podUID)
+			Expect(os.MkdirAll(filepath.Dir(socketPath), 0755)).To(Succeed())
+			Expect(AddGhostRecord(domainNamespace, domainName, socketPath, podUID)).To(Succeed())
+
+			informer, err = NewSharedInformer(shareDir, 10, nil, nil, time.Duration(resyncPeriod)*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctrl = gomock.NewController(GinkgoT())
+			domainManager = virtwrap.NewMockDomainManager(ctrl)
+		})
+
+		AfterEach(func() {
+			Expect(DeleteGhostRecord(domainNamespace, domainName)).To(Succeed())
+			close(stopChan)
+			wg.Wait()
+
+			Expect(os.RemoveAll(shareDir)).To(Succeed())
+			Expect(os.RemoveAll(podsDir)).To(Succeed())
+		})
+
+		verifyObj := func(key string, domain *api.Domain, g Gomega) {
+			obj, exists, err := informer.GetStore().GetByKey(key)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if domain != nil {
+				g.Expect(exists).To(BeTrue())
+
+				eventDomain := obj.(*api.Domain)
+				eventDomain.Spec.XMLName = xml.Name{}
+				g.Expect(equality.Semantic.DeepEqual(&domain.Spec, &eventDomain.Spec)).To(BeTrue())
+			} else {
+				g.Expect(exists).To(BeFalse())
+			}
+		}
+
 		It("should list current domains.", func() {
 			var list []*api.Domain
 
-			list = append(list, api.NewMinimalDomain("testvmi1"))
-
+			list = append(list, api.NewMinimalDomain(domainName))
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
 			domainManager.EXPECT().InterfacesStatus().Return([]api.InterfaceStatus{})
@@ -236,7 +266,7 @@ var _ = Describe("Domain informer", func() {
 		It("should list current domains including inactive domains with ghost record", func() {
 			var list []*api.Domain
 
-			list = append(list, api.NewMinimalDomain("testvmi1"))
+			list = append(list, api.NewMinimalDomain(domainName))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
@@ -265,7 +295,7 @@ var _ = Describe("Domain informer", func() {
 		It("should detect active domains at startup.", func() {
 			var list []*api.Domain
 
-			domain := api.NewMinimalDomain("test")
+			domain := api.NewMinimalDomain(domainName)
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
@@ -282,12 +312,12 @@ var _ = Describe("Domain informer", func() {
 			runInformer(wg, stopChan, informer)
 			cache.WaitForCacheSync(stopChan, informer.HasSynced)
 
-			verifyObj("default/test", domain)
+			key := fmt.Sprintf("%s/%s", domainNamespace, domainName)
+			verifyObj(key, domain, Default)
 		})
 
 		It("should resync active domains after resync period.", func() {
-
-			domain := api.NewMinimalDomain("test")
+			domain := api.NewMinimalDomain(domainName)
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{domain}, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
 			domainManager.EXPECT().InterfacesStatus().Return([]api.InterfaceStatus{})
@@ -310,11 +340,12 @@ var _ = Describe("Domain informer", func() {
 			runInformer(wg, stopChan, informer)
 			cache.WaitForCacheSync(stopChan, informer.HasSynced)
 
-			verifyObj("default/test", domain)
+			key := fmt.Sprintf("%s/%s", domainNamespace, domainName)
+			verifyObj(key, domain, Default)
 
 			time.Sleep(time.Duration(resyncPeriod+1) * time.Second)
 
-			obj, exists, err := informer.GetStore().GetByKey("default/test")
+			obj, exists, err := informer.GetStore().GetByKey(key)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exists).To(BeTrue())
 
@@ -325,41 +356,6 @@ var _ = Describe("Domain informer", func() {
 			Expect(val).To(Equal("some-value"))
 		})
 
-		It("should detect expired legacy watchdog file.", func() {
-			f, err := os.Create(socketPath)
-			Expect(err).ToNot(HaveOccurred())
-			f.Close()
-
-			d := &DomainWatcher{
-				backgroundWatcherStarted: false,
-				virtShareDir:             shareDir,
-				watchdogTimeout:          1,
-				unresponsiveSockets:      make(map[string]int64),
-				resyncPeriod:             time.Duration(1) * time.Hour,
-			}
-
-			watchdogFile := watchdog.WatchdogFileFromNamespaceName(shareDir, "default", "test")
-			os.MkdirAll(filepath.Dir(watchdogFile), 0755)
-			watchdog.WatchdogFileUpdate(watchdogFile, "somestring")
-
-			err = d.startBackground()
-			Expect(err).ToNot(HaveOccurred())
-			defer d.Stop()
-
-			timedOut := false
-			timeout := time.After(3 * time.Second)
-			select {
-			case event := <-d.eventChan:
-				Expect(event.Object.(*api.Domain).ObjectMeta.DeletionTimestamp).ToNot(BeNil())
-				Expect(event.Type).To(Equal(watch.Modified))
-			case <-timeout:
-				timedOut = true
-			}
-
-			Expect(timedOut).To(BeFalse())
-
-		})
-
 		It("should detect unresponsive sockets.", func() {
 
 			f, err := os.Create(socketPath)
@@ -367,7 +363,6 @@ var _ = Describe("Domain informer", func() {
 			f.Close()
 
 			AddGhostRecord("test", "test", socketPath, "1234")
-
 			d := &DomainWatcher{
 				backgroundWatcherStarted: false,
 				virtShareDir:             shareDir,
@@ -380,17 +375,14 @@ var _ = Describe("Domain informer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer d.Stop()
 
-			timedOut := false
 			timeout := time.After(5 * time.Second)
 			select {
 			case event := <-d.eventChan:
 				Expect(event.Type).To(Equal(watch.Modified))
 				Expect(event.Object.(*api.Domain).ObjectMeta.DeletionTimestamp).ToNot(BeNil())
 			case <-timeout:
-				timedOut = true
+				Fail("timeout")
 			}
-
-			Expect(timedOut).To(BeFalse())
 
 		})
 
@@ -441,18 +433,13 @@ var _ = Describe("Domain informer", func() {
 		It("should not return errors when encountering disconnected clients at startup.", func() {
 			var list []*api.Domain
 
-			domain := api.NewMinimalDomain("test")
+			domain := api.NewMinimalDomain(domainName)
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
 			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
 			domainManager.EXPECT().InterfacesStatus().Return([]api.InterfaceStatus{})
 
-			// This file doesn't have a unix sock server behind it
-			// verify list still completes regardless
-			f, err := os.Create(filepath.Join(socketsDir, "default_fakevm_sock"))
-			Expect(err).ToNot(HaveOccurred())
-			f.Close()
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 			// ensure we can connect to the server first.
 			client, err := cmdclient.NewClient(socketPath)
@@ -462,8 +449,10 @@ var _ = Describe("Domain informer", func() {
 			runInformer(wg, stopChan, informer)
 			cache.WaitForCacheSync(stopChan, informer.HasSynced)
 
-			verifyObj("default/test", domain)
+			key := fmt.Sprintf("%s/%s", domainNamespace, domainName)
+			verifyObj(key, domain, Default)
 		})
+
 		It("should watch for domain events.", func() {
 			domain := api.NewMinimalDomain("test")
 
@@ -473,23 +462,20 @@ var _ = Describe("Domain informer", func() {
 			client := notifyclient.NewNotifier(shareDir)
 
 			// verify add
-			err = client.SendDomainEvent(watch.Event{Type: watch.Added, Object: domain})
+			err := client.SendDomainEvent(watch.Event{Type: watch.Added, Object: domain})
 			Expect(err).ToNot(HaveOccurred())
-			cache.WaitForCacheSync(stopChan, informer.HasSynced)
-			verifyObj("default/test", domain)
+			Eventually(func(g Gomega) { verifyObj("default/test", domain, g) }, time.Second, 200*time.Millisecond).Should(Succeed())
 
 			// verify modify
 			domain.Spec.UUID = "fakeuuid"
 			err = client.SendDomainEvent(watch.Event{Type: watch.Modified, Object: domain})
 			Expect(err).ToNot(HaveOccurred())
-			cache.WaitForCacheSync(stopChan, informer.HasSynced)
-			verifyObj("default/test", domain)
+			Eventually(func(g Gomega) { verifyObj("default/test", domain, g) }, time.Second, 200*time.Millisecond).Should(Succeed())
 
 			// verify modify
 			err = client.SendDomainEvent(watch.Event{Type: watch.Deleted, Object: domain})
 			Expect(err).ToNot(HaveOccurred())
-			cache.WaitForCacheSync(stopChan, informer.HasSynced)
-			verifyObj("default/test", nil)
+			Eventually(func(g Gomega) { verifyObj("default/test", nil, g) }, time.Second, 200*time.Millisecond).Should(Succeed())
 		})
 	})
 })

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -32,7 +32,6 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -121,59 +120,6 @@ func SetLegacyBaseDir(baseDir string) {
 
 func SetPodsBaseDir(baseDir string) {
 	podsBaseDir = baseDir
-}
-
-func ListAllSockets() ([]string, error) {
-	var socketFiles []string
-
-	socketsDir := filepath.Join(legacyBaseDir, "sockets")
-	exists, err := diskutils.FileExists(socketsDir)
-	if err != nil {
-		return nil, err
-	}
-
-	if exists == false {
-		return socketFiles, nil
-	}
-
-	files, err := os.ReadDir(socketsDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, file := range files {
-		if file.IsDir() || !strings.Contains(file.Name(), "_sock") {
-			continue
-		}
-		// legacy support.
-		// The old way of handling launcher sockets was to
-		// dump them all in the same directory. So if we encounter
-		// a legacy socket, still process it. This is necessary
-		// for update support.
-		socketFiles = append(socketFiles, filepath.Join(socketsDir, file.Name()))
-	}
-
-	podsDir := podsBaseDir
-	dirs, err := os.ReadDir(podsDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, dir := range dirs {
-		if !dir.IsDir() {
-			continue
-		}
-
-		socketPath := SocketFilePathOnHost(dir.Name())
-		exists, err = diskutils.FileExists(socketPath)
-		if err != nil {
-			return socketFiles, err
-		}
-
-		if exists {
-			socketFiles = append(socketFiles, socketPath)
-		}
-	}
-
-	return socketFiles, nil
 }
 
 func LegacySocketsDirectory() string {

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -105,20 +105,6 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(sock).To(Equal(filepath.Join(shareDir, "sockets", "1234_sock")))
 		})
 
-		It("Listing all sockets", func() {
-			// the new socket is already created in the Before function
-
-			// create a legacy socket to ensure we find both new and legacy sockets
-			f, err := os.Create(filepath.Join(socketsDir, "1234_sock"))
-			Expect(err).ToNot(HaveOccurred())
-			f.Close()
-
-			// listing all sockets should detect both the new and legacy sockets
-			sockets, err := ListAllSockets()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sockets).To(HaveLen(2))
-		})
-
 		It("Detect unresponsive socket", func() {
 			sock, err := FindSocketOnHost(vmi)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

A manual backport of the following commits:
* [Cache: getGhostRecords remove error return arg](https://github.com/kubevirt/kubevirt/pull/15709/commits/d2bae6402f4a7f06d60b4b22aa744da9575636da)
* [virt-handler: domain watcher to trust sockets from ghost record only](https://github.com/kubevirt/kubevirt/pull/15709/commits/9221b9071b5de3da49bb0cd0d03d0fc3f0e47974)



from PR #15709


### Release note
```release-note
NONE
```

