### PR TITLE
tests/vm-lifecycle: un-quarantine test_id:3007

### DIFF
--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -48,7 +48,7 @@ var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 		virtClient = kubevirt.Client()
 	})
 
-	It("[test_id:3007][QUARANTINE] Should force restart a VM with terminationGracePeriodSeconds>0", decorators.Quarantine, func() {
+	It("[test_id:3007] Should force restart a VM with terminationGracePeriodSeconds>0", func() {
 		By("getting a VM with high TerminationGracePeriod")
 		vm := libvmi.NewVirtualMachine(libvmifact.NewFedora(libvmi.WithTerminationGracePeriod(600)), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})


### PR DESCRIPTION
un-quarantine this flaky test to verify if it still fails.
Collect relevant artifacts in case of failure for further analysis.

### Release note
```release-note
none
```

