### PR TITLE
virtwrap: fix error check on reconnectIfNecessary()

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -525,48 +525,61 @@ func (l *LibvirtConnection) reconnectIfNecessary() (err error) {
 	defer l.reconnectLock.Unlock()
 	// TODO add a reconnect backoff, and immediately return an error in these cases
 	// We need this to avoid swamping libvirt with reconnect tries
-	if !l.alive {
-		l.Connect, err = newConnection(l.uri, l.user, l.pass)
-		if err != nil {
-			return
-		}
-		l.alive = true
+	if l.alive {
+		return nil
+	}
 
-		log.Log.Info("Established new Libvirt Connection")
+	if l.Connect, err = newConnection(l.uri, l.user, l.pass); err != nil {
+		return err
+	}
+	l.alive = true
 
-		for _, callback := range l.domainEventCallbacks {
-			log.Log.Info("Re-registered domain callback")
-			_, err = l.Connect.DomainEventLifecycleRegister(nil, callback)
-		}
-		for _, callback := range l.domainEventMigrationIterationCallbacks {
-			log.Log.Info("Re-registered iteration callback")
-			_, err = l.Connect.DomainEventMigrationIterationRegister(nil, callback)
-		}
-		for _, callback := range l.agentEventCallbacks {
-			log.Log.Info("Re-registered agent callback")
-			_, err = l.Connect.DomainEventAgentLifecycleRegister(nil, callback)
-		}
-		for _, callback := range l.domainDeviceAddedEventCallbacks {
-			log.Log.Info("Re-registered domain device added callback")
-			_, err = l.Connect.DomainEventDeviceAddedRegister(nil, callback)
-		}
-		for _, callback := range l.domainDeviceRemovedEventCallbacks {
-			log.Log.Info("Re-registered domain device removed callback")
-			_, err = l.Connect.DomainEventDeviceRemovedRegister(nil, callback)
-		}
-		for _, callback := range l.domainDeviceMemoryDeviceSizeChangeCallbacks {
-			log.Log.Info("Re-registered domain memory device size change callback")
-			_, err = l.Connect.DomainEventMemoryDeviceSizeChangeRegister(nil, callback)
-		}
+	log.Log.Info("Established new Libvirt Connection")
 
-		log.Log.Error("Re-registered domain and agent callbacks for new connection")
-
-		if l.reconnect != nil {
-			// Notify the callback about the reconnect through channel.
-			// This way we give the callback a chance to emit an error to the watcher
-			// ListWatcher will re-register automatically afterwards
-			l.reconnect <- true
+	for _, callback := range l.domainEventCallbacks {
+		log.Log.Infof("Re-registered domain callback: %p", callback)
+		if _, err = l.Connect.DomainEventLifecycleRegister(nil, callback); err != nil {
+			return err
 		}
+	}
+	for _, callback := range l.domainEventMigrationIterationCallbacks {
+		log.Log.Infof("Re-registered iteration callback: %p", callback)
+		if _, err = l.Connect.DomainEventMigrationIterationRegister(nil, callback); err != nil {
+			return err
+		}
+	}
+	for _, callback := range l.agentEventCallbacks {
+		log.Log.Infof("Re-registered agent callback: %p", callback)
+		if _, err = l.Connect.DomainEventAgentLifecycleRegister(nil, callback); err != nil {
+			return err
+		}
+	}
+	for _, callback := range l.domainDeviceAddedEventCallbacks {
+		log.Log.Infof("Re-registered domain device added callback: %p", callback)
+		if _, err = l.Connect.DomainEventDeviceAddedRegister(nil, callback); err != nil {
+			return err
+		}
+	}
+	for _, callback := range l.domainDeviceRemovedEventCallbacks {
+		log.Log.Infof("Re-registered domain device removed callback: %p", callback)
+		if _, err = l.Connect.DomainEventDeviceRemovedRegister(nil, callback); err != nil {
+			return err
+		}
+	}
+	for _, callback := range l.domainDeviceMemoryDeviceSizeChangeCallbacks {
+		log.Log.Infof("Re-registered domain memory device size change callback: %p", callback)
+		if _, err = l.Connect.DomainEventMemoryDeviceSizeChangeRegister(nil, callback); err != nil {
+			return err
+		}
+	}
+
+	log.Log.Error("Re-registered domain and agent callbacks for new connection")
+
+	if l.reconnect != nil {
+		// Notify the callback about the reconnect through channel.
+		// This way we give the callback a chance to emit an error to the watcher
+		// ListWatcher will re-register automatically afterwards
+		l.reconnect <- true
 	}
 	return nil
 }


### PR DESCRIPTION
If one of the Register() functions failed, we would keep going. Stop and report back the failure instead.

While at it:
- Return early if connection is alive;
- Make the logs print the callback address to help identify it as it could hint why the Registering failed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
We might not find out that a callback failed to register, leading to unstable/bad state.

#### After this PR:
Should know any callback registration failed.

### Special notes for your reviewer

I do wonder if we had issues in the past with this and did not know. Hopefully we will now... saw this while learning the codebase around libvirt events...

```release-note
NONE
```

