### PR TITLE
Promote VideoConfig FG Alpha -> Beta

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -125,6 +125,8 @@ const (
 	// Requires `autoattachGraphicsDevice` to be true or unset. Alpha feature, defaults unchanged.
 	// Owner: @dasionov
 	// Alpha: v1.6.0
+	// Beta: v1.7.0
+	//
 	VideoConfig = "VideoConfig"
 
 	// Owner: @varunrsekar
@@ -168,7 +170,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HostDevicesWithDRAGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DecentralizedLiveMigration, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DeclarativeHotplugVolumesGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: PanicDevicesGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: PasstIPStackMigration, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IncrementalBackupGate, State: Alpha})

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -122,6 +122,7 @@ func AdjustKubeVirtResource() {
 		featuregate.NodeRestrictionGate,
 		featuregate.DecentralizedLiveMigration,
 		featuregate.PanicDevicesGate,
+		featuregate.VideoConfig,
 	)
 	kv.Spec.Configuration.ChangedBlockTrackingLabelSelectors = &v1.ChangedBlockTrackingSelectors{
 		VirtualMachineLabelSelector: &metav1.LabelSelector{


### PR DESCRIPTION
### What this PR does
VideoConfig VMI API fields were introduced in v1.6.0. This PR promotes it to Beta

We would like this field to be enabled by default so it is more accessible for users.

### Release note
```release-note
Beta: VideoConfig
```

