### PR TITLE
e2e,usb: Quarantine very flaky USB passthrough tests

### DIFF
--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -30,93 +30,94 @@ const (
 	cmdNumberUSBs   = "dmesg | grep -c idVendor=46f4"
 )
 
-var _ = Describe("[sig-compute][USB] host USB Passthrough", Serial, decorators.SigCompute, decorators.USB, func() {
-	var virtClient kubecli.KubevirtClient
-	var config v1.KubeVirtConfiguration
-	var vmi *v1.VirtualMachineInstance
+var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
+	decorators.Quarantine, decorators.SigCompute, decorators.USB, func() {
+		var virtClient kubecli.KubevirtClient
+		var config v1.KubeVirtConfiguration
+		var vmi *v1.VirtualMachineInstance
 
-	BeforeEach(func() {
-		virtClient = kubevirt.Client()
-		kv := libkubevirt.GetCurrentKv(virtClient)
-		config = kv.Spec.Configuration
+		BeforeEach(func() {
+			virtClient = kubevirt.Client()
+			kv := libkubevirt.GetCurrentKv(virtClient)
+			config = kv.Spec.Configuration
 
-		nodeName := libnode.GetNodeNameWithHandler()
-		Expect(nodeName).ToNot(BeEmpty())
+			nodeName := libnode.GetNodeNameWithHandler()
+			Expect(nodeName).ToNot(BeEmpty())
 
-		stdout, err := libnode.ExecuteCommandInVirtHandlerPod(nodeName, []string{"dmesg"})
-		Expect(err).ToNot(HaveOccurred())
-		if strings.Count(stdout, "idVendor=46f4") == 0 {
-			Fail("No emulated USB devices present for functional test.")
-		}
-
-		vmi = libvmifact.NewCirros()
-	})
-
-	AfterEach(func() {
-		// Make sure to delete the VMI before ending the test otherwise a device could still be taken
-		const deleteTimeout = 180
-		err := virtClient.VirtualMachineInstance(
-			testsuite.NamespaceTestDefault).Delete(context.Background(), vmi.ObjectMeta.Name, metav1.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
-
-		libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, deleteTimeout)
-	})
-
-	Context("with usb storage", func() {
-		DescribeTable("with emulated USB devices", func(deviceNames []string) {
-			const resourceName = "kubevirt.io/usb-storage"
-
-			By("Adding the emulated USB device to the permitted host devices")
-			config.DeveloperConfiguration = &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.HostDevicesGate},
+			stdout, err := libnode.ExecuteCommandInVirtHandlerPod(nodeName, []string{"dmesg"})
+			Expect(err).ToNot(HaveOccurred())
+			if strings.Count(stdout, "idVendor=46f4") == 0 {
+				Fail("No emulated USB devices present for functional test.")
 			}
-			config.PermittedHostDevices = &v1.PermittedHostDevices{
-				USB: []v1.USBHostDevice{
-					{
-						ResourceName: resourceName,
-						Selectors: []v1.USBSelector{
-							{
-								Vendor:  "46f4",
-								Product: "0001",
+
+			vmi = libvmifact.NewCirros()
+		})
+
+		AfterEach(func() {
+			// Make sure to delete the VMI before ending the test otherwise a device could still be taken
+			const deleteTimeout = 180
+			err := virtClient.VirtualMachineInstance(
+				testsuite.NamespaceTestDefault).Delete(context.Background(), vmi.ObjectMeta.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
+
+			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, deleteTimeout)
+		})
+
+		Context("with usb storage", func() {
+			DescribeTable("with emulated USB devices", func(deviceNames []string) {
+				const resourceName = "kubevirt.io/usb-storage"
+
+				By("Adding the emulated USB device to the permitted host devices")
+				config.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					FeatureGates: []string{featuregate.HostDevicesGate},
+				}
+				config.PermittedHostDevices = &v1.PermittedHostDevices{
+					USB: []v1.USBHostDevice{
+						{
+							ResourceName: resourceName,
+							Selectors: []v1.USBSelector{
+								{
+									Vendor:  "46f4",
+									Product: "0001",
+								},
 							},
 						},
 					},
-				},
-			}
-			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
+				}
+				kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 
-			By("Creating a Fedora VMI with the usb host device")
-			hostDevs := []v1.HostDevice{}
-			for i, name := range deviceNames {
-				hostDevs = append(hostDevs, v1.HostDevice{
-					Name:       fmt.Sprintf("usb-%d-%s", i, name),
-					DeviceName: resourceName,
-				})
-			}
+				By("Creating a Fedora VMI with the usb host device")
+				hostDevs := []v1.HostDevice{}
+				for i, name := range deviceNames {
+					hostDevs = append(hostDevs, v1.HostDevice{
+						Name:       fmt.Sprintf("usb-%d-%s", i, name),
+						DeviceName: resourceName,
+					})
+				}
 
-			var err error
-			vmi.Spec.Domain.Devices.HostDevices = hostDevs
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				var err error
+				vmi.Spec.Domain.Devices.HostDevices = hostDevs
+				vmi, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-			By("Making sure the usb is present inside the VMI")
-			const expectTimeout = 15
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: fmt.Sprintf("%s\n", cmdNumberUSBs)},
-				&expect.BExp{R: console.RetValue(fmt.Sprintf("%d", len(deviceNames)))},
-			}, expectTimeout)).To(Succeed(), "Device not found")
+				By("Making sure the usb is present inside the VMI")
+				const expectTimeout = 15
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("%s\n", cmdNumberUSBs)},
+					&expect.BExp{R: console.RetValue(fmt.Sprintf("%d", len(deviceNames)))},
+				}, expectTimeout)).To(Succeed(), "Device not found")
 
-			By("Trying to read and write to each USB device inside the guest")
+				By("Trying to read and write to each USB device inside the guest")
 
-			testScript := `for bus in /dev/bus/usb/*; do for dev in "$bus"/*; do echo -n X > "$dev"; cat "$dev"; done; done; echo USB_TEST_DONE`
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: testScript + "\n"},
-				&expect.BExp{R: "USB_TEST_DONE"},
-			}, expectTimeout)).To(Succeed(), "Could not access USB devices from inside the guest")
-		},
-			Entry("Should successfully passthrough 1 emulated USB device", []string{"slow-storage"}),
-			Entry("Should successfully passthrough 2 emulated USB devices", []string{"fast-storage", "low-storage"}),
-		)
+				testScript := `for bus in /dev/bus/usb/*; do for dev in "$bus"/*; do echo -n X > "$dev"; cat "$dev"; done; done; echo USB_TEST_DONE`
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: testScript + "\n"},
+					&expect.BExp{R: "USB_TEST_DONE"},
+				}, expectTimeout)).To(Succeed(), "Could not access USB devices from inside the guest")
+			},
+				Entry("Should successfully passthrough 1 emulated USB device", []string{"slow-storage"}),
+				Entry("Should successfully passthrough 2 emulated USB devices", []string{"fast-storage", "low-storage"}),
+			)
+		})
 	})
-})


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

These tests have become very flaky and are impacting the compute e2e lanes[1][2]

Quarantine for now to allow time to investigate.

[1] https://search.ci.kubevirt.io/?search=USB+Passthrough&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
[2] https://github.com/kubevirt/kubevirt/issues/15907

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @fossedihelm @dhiller @victortoso 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

