### PR TITLE
automation: Support $TARGET $KUBEVIRT_PROVIDER-sig-compute-migrations-wg-arm64

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -61,62 +61,91 @@ if [[ ! $TARGET =~ .*kind.* ]]; then
   export KUBEVIRT_PSA="true"
   export KUBEVIRT_FLANNEL=true
 fi
-if [[ $TARGET =~ windows.* ]]; then
-  echo "picking the default provider for windows tests"
-elif [[ $TARGET =~ sig-network ]]; then
-  export KUBEVIRT_WITH_DYN_NET_CTRL="${KUBEVIRT_WITH_DYN_NET_CTRL:-false}"
-  export KUBEVIRT_NUM_NODES=3
-  export KUBEVIRT_WITH_CNAO=true
-  export KUBEVIRT_DEPLOY_NET_BINDING_CNI=true
-  export KUBEVIRT_DEPLOY_CDI=false
-  export KUBEVIRT_DEPLOY_ISTIO=true
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-network*/}
-elif [[ $TARGET =~ sig-storage ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-storage/}
-  export KUBEVIRT_STORAGE="rook-ceph-default"
-  export KUBEVIRT_DEPLOY_NFS_CSI=true
-  export KUBEVIRT_WITH_ETC_CAPACITY="1G"
-elif [[ $TARGET =~ sig-compute-realtime ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-realtime/}
-  export KUBEVIRT_HUGEPAGES_2M=512
-  export KUBEVIRT_REALTIME_SCHEDULER=true
-elif [[ $TARGET =~ sig-compute-migrations ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations/}
-  export KUBEVIRT_E2E_PARALLEL_NODES=3
-  export KUBEVIRT_NUM_NODES=3
-  export KUBEVIRT_STORAGE="rook-ceph-default"
-  export KUBEVIRT_WITH_CNAO=true
-  export KUBEVIRT_NUM_SECONDARY_NICS=1
-  export KUBEVIRT_DEPLOY_NFS_CSI=true
-  export KUBEVIRT_TEST_CONFIG="${base_dir}/tests/sig-migrations-config.json"
-  source hack/config-default.sh
-elif [[ $TARGET =~ sig-compute-serial ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-serial/}
-elif [[ $TARGET =~ sig-compute-parallel ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-parallel/}
-elif [[ $TARGET =~ sig-compute-conformance ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-conformance/}
-elif [[ $TARGET =~ sig-compute ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
-elif [[ $TARGET =~ sig-operator ]]; then
-  export KUBEVIRT_PROVIDER=${TARGET/-sig-operator*/}
-  export KUBEVIRT_WITH_CNAO=true
-  export KUBEVIRT_NUM_SECONDARY_NICS=1
-elif [[ $TARGET =~ sig-monitoring ]]; then
+
+case "$TARGET" in
+  *windows*)
+    echo "picking the default provider for windows tests"
+    ;;
+  *sig-network*)
+    export KUBEVIRT_WITH_DYN_NET_CTRL="${KUBEVIRT_WITH_DYN_NET_CTRL:-false}"
+    export KUBEVIRT_NUM_NODES=3
+    export KUBEVIRT_WITH_CNAO=true
+    export KUBEVIRT_DEPLOY_NET_BINDING_CNI=true
+    export KUBEVIRT_DEPLOY_CDI=false
+    export KUBEVIRT_DEPLOY_ISTIO=true
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-network*/}
+    ;;
+  *sig-storage*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-storage/}
+    export KUBEVIRT_STORAGE="rook-ceph-default"
+    export KUBEVIRT_DEPLOY_NFS_CSI=true
+    export KUBEVIRT_WITH_ETC_CAPACITY="1G"
+    ;;
+  *sig-compute-realtime*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-realtime/}
+    export KUBEVIRT_HUGEPAGES_2M=512
+    export KUBEVIRT_REALTIME_SCHEDULER=true
+    ;;
+  *sig-compute-migrations-wg-arm64*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations-wg-arm64/}
+    export KUBEVIRT_E2E_PARALLEL_NODES=3
+    export KUBEVIRT_NUM_NODES=3
+    export KUBEVIRT_STORAGE="rook-ceph-default"
+    export KUBEVIRT_WITH_CNAO=true
+    export KUBEVIRT_NUM_SECONDARY_NICS=1
+    export KUBEVIRT_DEPLOY_NFS_CSI=true
+    export KUBEVIRT_TEST_CONFIG="${base_dir}/tests/sig-migrations-config.json"
+    source hack/config-default.sh
+    ;;
+  *sig-compute-migrations*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations/}
+    export KUBEVIRT_E2E_PARALLEL_NODES=3
+    export KUBEVIRT_NUM_NODES=3
+    export KUBEVIRT_STORAGE="rook-ceph-default"
+    export KUBEVIRT_WITH_CNAO=true
+    export KUBEVIRT_NUM_SECONDARY_NICS=1
+    export KUBEVIRT_DEPLOY_NFS_CSI=true
+    export KUBEVIRT_TEST_CONFIG="${base_dir}/tests/sig-migrations-config.json"
+    source hack/config-default.sh
+    ;;
+  *sig-compute-serial*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-serial/}
+    ;;
+  *sig-compute-parallel*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-parallel/}
+    ;;
+  *sig-compute-conformance*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-conformance/}
+    ;;
+  *sig-compute*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
+    ;;
+  *sig-operator*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-operator*/}
+    export KUBEVIRT_WITH_CNAO=true
+    export KUBEVIRT_NUM_SECONDARY_NICS=1
+    ;;
+  *sig-monitoring*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-monitoring/}
     export KUBEVIRT_DEPLOY_PROMETHEUS=true
-elif [[ $TARGET =~ wg-s390x ]]; then
+    ;;
+  *wg-s390x*)
     export KUBEVIRT_PROVIDER=${TARGET/-wg-s390x}
-elif [[ $TARGET =~ wg-arm64 ]]; then
+    ;;
+  *wg-arm64*)
     export KUBEVIRT_PROVIDER=${TARGET/-wg-arm64}
     export KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true
-elif [[ $TARGET =~ sev ]]; then
+    ;;
+  *sev*)
     export KUBEVIRT_PROVIDER=${TARGET/-sev}
-elif [[ $TARGET =~ secure-execution ]]; then
+    ;;
+  *secure-execution*)
     export KUBEVIRT_PROVIDER=${TARGET/-secure-execution}
-else
-  export KUBEVIRT_PROVIDER=${TARGET}
-fi
+    ;;
+  *)
+    export KUBEVIRT_PROVIDER=${TARGET}
+    ;;
+esac
 
 # Single-node single-replica test lanes need nfs csi to run sig-storage tests
 if [[ $KUBEVIRT_NUM_NODES = "1" && $KUBEVIRT_INFRA_REPLICAS = "1" ]]; then
@@ -594,3 +623,4 @@ fi
 
 # Sanity check test execution by looking at results file
 ./automation/assert-not-all-tests-skipped.sh "${ARTIFACTS}/junit.functest.xml"
+


### PR DESCRIPTION
/wg arch-arm
/cc @brianmcarey 

### What this PR does
This change allows arm64 sig-compute-migrations lanes to be introduced using the kind providers.

Required by https://github.com/kubevirt/project-infra/pull/4454

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

