### PR TITLE
Deprecate kubevirt_vmi_migration_data_total_bytes

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -204,6 +204,9 @@ The amount of memory which can be reclaimed by balloon without pushing the guest
 ### kubevirt_vmi_memory_used_bytes
 Amount of `used` memory as seen by the domain. Type: Gauge.
 
+### kubevirt_vmi_migration_data_bytes_total
+The total Guest OS data to be migrated to the new VM. Type: Counter.
+
 ### kubevirt_vmi_migration_data_processed_bytes
 The total Guest OS data processed and migrated to the new VM. Type: Gauge.
 
@@ -211,7 +214,7 @@ The total Guest OS data processed and migrated to the new VM. Type: Gauge.
 The remaining guest OS data to be migrated to the new VM. Type: Gauge.
 
 ### kubevirt_vmi_migration_data_total_bytes
-The total Guest OS data to be migrated to the new VM. Type: Counter.
+[Deprecated] Replaced by kubevirt_vmi_migration_data_bytes_total. Type: Counter.
 
 ### kubevirt_vmi_migration_dirty_memory_rate_bytes
 The rate of memory being dirty in the Guest OS. Type: Gauge.

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector.go
@@ -40,7 +40,7 @@ var (
 
 	migrateVMIDataTotal = operatormetrics.NewCounter(
 		operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_migration_data_total_bytes",
+			Name: "kubevirt_vmi_migration_data_bytes_total",
 			Help: "The total Guest OS data to be migrated to the new VM.",
 		},
 	)

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector_test.go
@@ -52,7 +52,7 @@ var _ = Describe("migration metrics", func() {
 			crs := parse(vmiStats)
 			Expect(crs).To(ContainElement(testing.GomegaContainsCollectorResultMatcher(metric, expectedValue)))
 		},
-			Entry("kubevirt_vmi_migration_data_total_bytes", migrateVMIDataTotal, 3.0),
+			Entry("kubevirt_vmi_migration_data_bytes_total", migrateVMIDataTotal, 3.0),
 			Entry("kubevirt_vmi_migration_data_remaining_bytes", migrateVMIDataRemaining, 1.0),
 			Entry("kubevirt_vmi_migration_data_processed_bytes", migrateVMIDataProcessed, 2.0),
 			Entry("kubevirt_vmi_migration_dirty_memory_rate_bytes", migrateVmiDirtyMemoryRate, 3.0),

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -105,4 +105,12 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 		MetricType: operatormetrics.GaugeType,
 		Expr:       intstr.FromString("sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes[30m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes[30m]))"),
 	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_migration_data_total_bytes",
+			Help: "[Deprecated] Replaced by kubevirt_vmi_migration_data_bytes_total.",
+		},
+		MetricType: operatormetrics.CounterType,
+		Expr:       intstr.FromString("kubevirt_vmi_migration_data_bytes_total"),
+	},
 }

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -516,7 +516,7 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 	var pod *k8sv1.Pod
 	var metricsIPs []string
 	var migrationMetrics = []string{
-		"kubevirt_vmi_migration_data_total_bytes",
+		"kubevirt_vmi_migration_data_bytes_total",
 		"kubevirt_vmi_migration_data_remaining_bytes",
 		"kubevirt_vmi_migration_data_processed_bytes",
 		"kubevirt_vmi_migration_dirty_memory_rate_bytes",

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -85,6 +85,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_migration_dirty_memory_rate_bytes":                     true,
 			"kubevirt_vmi_migration_memory_transfer_rate_bytes":                  true,
 			"kubevirt_vmi_migration_data_total_bytes":                            true,
+			"kubevirt_vmi_migration_data_bytes_total":                            true,
 			"kubevirt_vmi_migration_start_time_seconds":                          true,
 			"kubevirt_vmi_migration_end_time_seconds":                            true,
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
kubevirt_vmi_migration_data_total_bytes doesnt comply with the naming convention and fails the metrics name linter.

#### After this PR:
We deprecated kubevirt_vmi_migration_data_total_bytes in favor of kubevirt_vmi_migration_data_bytes_total, in order to comply with the metrics naming conventions.

### References
- Fixes #https://issues.redhat.com/browse/CNV-71409
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubevirt_vmi_migration_data_total_bytes is deprecated in favor of kubevirt_vmi_migration_data_bytes_total, in order to comply with the metrics naming conventions.
```

