### PR TITLE
virt-api, admit, vmi: Fix hugepages typo

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1002,11 +1002,11 @@ func validateHugepagesMemoryRequests(field *k8sfield.Path, spec *v1.VirtualMachi
 		causes = append(causes, metav1.StatusCause{
 			Type: metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s '%s': %s",
-				field.Child("domain", "hugepages", "size").String(),
+				field.Child("domain", "memory", "hugepages", "pageSize").String(),
 				spec.Domain.Memory.Hugepages.PageSize,
 				resource.ErrFormatWrong,
 			),
-			Field: field.Child("domain", "hugepages", "size").String(),
+			Field: field.Child("domain", "memory", "hugepages", "pageSize").String(),
 		})
 		return causes
 	}
@@ -1017,7 +1017,7 @@ func validateHugepagesMemoryRequests(field *k8sfield.Path, spec *v1.VirtualMachi
 			Message: fmt.Sprintf("%s '%s' must be equal to or larger than page size %s '%s'",
 				field.Child("domain", "resources", "requests", "memory").String(),
 				spec.Domain.Resources.Requests.Memory(),
-				field.Child("domain", "hugepages", "size").String(),
+				field.Child("domain", "memory", "hugepages", "pageSize").String(),
 				spec.Domain.Memory.Hugepages.PageSize,
 			),
 			Field: field.Child("domain", "resources", "requests", "memory").String(),
@@ -1028,7 +1028,7 @@ func validateHugepagesMemoryRequests(field *k8sfield.Path, spec *v1.VirtualMachi
 			Message: fmt.Sprintf("%s '%s' is not a multiple of the page size %s '%s'",
 				field.Child("domain", "resources", "requests", "memory").String(),
 				spec.Domain.Resources.Requests.Memory(),
-				field.Child("domain", "hugepages", "size").String(),
+				field.Child("domain", "memory", "hugepages", "pageSize").String(),
 				spec.Domain.Memory.Hugepages.PageSize,
 			),
 			Field: field.Child("domain", "resources", "requests", "memory").String(),
@@ -1190,7 +1190,7 @@ func ValidateVirtualMachineInstanceMandatoryFields(field *k8sfield.Path, spec *v
 			Type: metav1.CauseTypeFieldValueRequired,
 			Message: fmt.Sprintf("no memory requested, at least one of '%s', '%s' or '%s' must be set",
 				field.Child("domain", "memory", "guest").String(),
-				field.Child("domain", "memory", "hugepages", "size").String(),
+				field.Child("domain", "memory", "hugepages", "pageSize").String(),
 				field.Child("domain", "resources", "requests", "memory").String()),
 		})
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -868,7 +868,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.hugepages.size"))
+			Expect(causes[0].Field).To(Equal("fake.domain.memory.hugepages.pageSize"))
 		})
 
 		It("should reject greater hugepages.size than requests.memory", func() {
@@ -990,7 +990,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 			Expect(causes[0].Message).To(Equal("fake.domain.resources.requests.memory '64Mi' " +
-				"is not a multiple of the page size fake.domain.hugepages.size '10Mi'"))
+				"is not a multiple of the page size fake.domain.memory.hugepages.pageSize '10Mi'"))
 		})
 
 		It("should allow setting guest memory and hugepages", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The API for domain memory hugepages is `pageSize` and noti `size`,
In addition hugepages is under `memory` and not directly under `domain`.
See https://github.com/kubevirt/kubevirt/blob/release-1.6/staging/src/kubevirt.io/api/core/v1/schema.go#L421


Fix validation rules.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

