### PR TITLE
Create an observability Compatibility Policy

### DIFF
--- a/docs/observability/monitoring-guidelines.md
+++ b/docs/observability/monitoring-guidelines.md
@@ -1,5 +1,22 @@
 ## KubeVirt Monitoring
- 
+
+### Observability Compatibility Policy
+
+This policy covers all KubeVirt observability signal. Like: metrics (and their names, label sets, and types), Prometheus recording rules, and alerting rules. Unless explicitly stated otherwise, these signals are considered implementation details and are subject to change.
+
+- Stability: KubeVirt does not guarantee long-term backwards compatibility for observability signals. Names, labels, types, and semantics may change between releases to improve correctness, performance, or operability.
+- Deprecation: When feasible, we will deprecate renamed or removed signals by:
+  - Marking the old name as Deprecated in documentation.
+  - Optionally providing short-lived compatibility recording rules (aliases) that map new signals to old names.
+  - Keeping deprecated signals for at least one minor release when possible. In exceptional cases (security, correctness, or scalability), changes may occur without a deprecation window.
+- Communication: Material changes will be documented in release notes and reflected in `docs/observability/metrics.md`. Alert and rule updates will also be surfaced via PR descriptions.
+- Consumer guidance: Dashboards and alerts should:
+  - When creating PromQL queries, expect label sets to change; avoid relying on exhaustive or fixed labels. Select, join, and group by the minimum labels required.
+    - Example: Prefer `sum by (namespace)(...)` over `sum by (namespace,pod,container,instance)(...)` when possible.
+  - Treat deprecated signals as temporary and migrate to replacements promptly.
+
+Contributors adding or changing observability signals should update documentation, consider temporary compatibility rules if practical, and include migration notes in the PR and release notes.
+
 ### KubeVirt Metrics
 #### Naming a New KubeVirt Metrics:
 
@@ -27,7 +44,8 @@ The KubeVirt metrics for vmi should be:
 
 The Prometheus recording rules appear in Prometheus as metrics.
 
-In order to easily identify the KubeVirt recording rules, they should have a `kubevirt_` prefix.
+Recording rules should be in the format of <level>:<metric>:<operation>, based on the Prometheus naming best practices.
+In order to easily identify the KubeVirt recording rules, they should include a `kubevirt_` prefix in the <metric> section like in metrics.
 
 ### KubeVirt Alerts Rules
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
There was no clear policy regarding KubeVirt observabilty resources like metrics, recording rules and alerts.

#### After this PR:
There is a clear policy regarding KubeVirt observabilty resources like metrics, recording rules and alerts.

### References
- Fixes #https://issues.redhat.com/browse/CNV-71609
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

