### PR TITLE
Transition from guest-get-fsinfo qemu guest agent command to libvirt api

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -39,22 +39,6 @@ func stripAgentStringResponse(agentReply string) string {
 	return result[1]
 }
 
-// Filesystem disk of the host
-type FSDisk struct {
-	Serial  string `json:"serial,omitempty"`
-	BusType string `json:"bus-type"`
-}
-
-// Filesystem of the host
-type Filesystem struct {
-	Name       string   `json:"name"`
-	Mountpoint string   `json:"mountpoint"`
-	Type       string   `json:"type"`
-	UsedBytes  int      `json:"used-bytes,omitempty"`
-	TotalBytes int      `json:"total-bytes,omitempty"`
-	Disk       []FSDisk `json:"disk,omitempty"`
-}
-
 // AgentInfo from the guest VM serves the purpose
 // of checking the GA presence and version compatibility
 type AgentInfo struct {
@@ -72,44 +56,6 @@ func ParseFSFreezeStatus(agentReply string) (api.FSFreeze, error) {
 	return api.FSFreeze{
 		Status: response,
 	}, nil
-}
-
-// parseFilesystem from the agent response
-func parseFilesystem(agentReply string) ([]api.Filesystem, error) {
-	result := []Filesystem{}
-	response := stripAgentResponse(agentReply)
-
-	err := json.Unmarshal([]byte(response), &result)
-	if err != nil {
-		return []api.Filesystem{}, err
-	}
-
-	convertedResult := []api.Filesystem{}
-
-	for _, fs := range result {
-		convertedResult = append(convertedResult, api.Filesystem{
-			Name:       fs.Name,
-			Mountpoint: fs.Mountpoint,
-			Type:       fs.Type,
-			TotalBytes: fs.TotalBytes,
-			UsedBytes:  fs.UsedBytes,
-			Disk:       parseFSDisks(fs.Disk),
-		})
-	}
-
-	return convertedResult, nil
-}
-
-func parseFSDisks(fsDisks []FSDisk) []api.FSDisk {
-	disks := []api.FSDisk{}
-	for _, fsDisk := range fsDisks {
-		disks = append(disks, api.FSDisk{
-			Serial:  fsDisk.Serial,
-			BusType: fsDisk.BusType,
-		})
-	}
-
-	return disks
 }
 
 // parseAgent gets the agent version from response

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -65,42 +65,5 @@ var _ = Describe("Qemu agent poller", func() {
 
 			Expect(response).To(Equal(expectedResponse))
 		})
-
-		It("should parse Filesystem", func() {
-			jsonInput := `{
-                "return":[
-                    {
-                        "name":"main",
-                        "mountpoint":"/",
-                        "type":"ext",
-                        "total-bytes":99999,
-                        "used-bytes":33333,
-                        "disk":[
-                            {
-                                "serial":"testserial-1234",
-                                "bus-type":"scsi"
-                            }
-                        ]
-                    }
-                ]
-            }`
-
-			expectedFilesystem := []api.Filesystem{
-				{
-					Name:       "main",
-					Mountpoint: "/",
-					Type:       "ext",
-					TotalBytes: 99999,
-					UsedBytes:  33333,
-					Disk: []api.FSDisk{
-						{
-							Serial:  "testserial-1234",
-							BusType: "scsi",
-						},
-					},
-				},
-			}
-			Expect(parseFilesystem(jsonInput)).To(Equal(expectedFilesystem))
-		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -68,11 +68,12 @@ var _ = Describe("Qemu agent poller", func() {
 	Context("with libvirt API", func() {
 		It("should store the retrieved guest info when requested", func() {
 			guestInfo := &libvirt.DomainGuestInfo{
-				Interfaces: []libvirt.DomainGuestInfoInterface{{Name: "net0"}},
-				OS:         &libvirt.DomainGuestInfoOS{Name: "fedora"},
-				Hostname:   "test-host",
-				TimeZone:   &libvirt.DomainGuestInfoTimeZone{Name: "EST"},
-				Users:      []libvirt.DomainGuestInfoUser{{Name: "admin"}},
+				Interfaces:  []libvirt.DomainGuestInfoInterface{{Name: "net0"}},
+				OS:          &libvirt.DomainGuestInfoOS{Name: "fedora"},
+				Hostname:    "test-host",
+				TimeZone:    &libvirt.DomainGuestInfoTimeZone{Name: "EST"},
+				Users:       []libvirt.DomainGuestInfoUser{{Name: "admin"}},
+				FileSystems: []libvirt.DomainGuestInfoFileSystem{{Name: "tmpfs"}},
 			}
 			agentPoller := &AgentPoller{
 				Connection: mockLibvirt.VirtConnection,
@@ -83,7 +84,9 @@ var _ = Describe("Qemu agent poller", func() {
 				libvirt.DOMAIN_GUEST_INFO_OS |
 				libvirt.DOMAIN_GUEST_INFO_HOSTNAME |
 				libvirt.DOMAIN_GUEST_INFO_TIMEZONE |
-				libvirt.DOMAIN_GUEST_INFO_USERS
+				libvirt.DOMAIN_GUEST_INFO_USERS |
+				libvirt.DOMAIN_GUEST_INFO_FILESYSTEM |
+				libvirt.DOMAIN_GUEST_INFO_DISKS
 
 			mockLibvirt.DomainEXPECT().Free()
 			mockLibvirt.DomainEXPECT().GetGuestInfo(libvirtTypes, uint32(0)).Return(guestInfo, nil)
@@ -102,6 +105,9 @@ var _ = Describe("Qemu agent poller", func() {
 
 			users := agentStore.GetUsers(1)
 			Expect(users[0].Name).To(Equal("admin"))
+
+			filesystems := agentStore.GetFS(1)
+			Expect(filesystems[0].Name).To(Equal("tmpfs"))
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2542,7 +2542,7 @@ var _ = Describe("Manager", func() {
 				LoginTime: 0,
 			},
 		})
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(agentpoller.FSInfoKey, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2605,7 +2605,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes GetFilesystems", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(agentpoller.FSInfoKey, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2632,7 +2632,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes generateCloudInitEmptyISO and succeeds", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(agentpoller.FSInfoKey, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2678,7 +2678,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes generateCloudInitEmptyISO and fails", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(agentpoller.FSInfoKey, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Removes the qemu guest agent guest-get-fsinfo command execution and uses libvirt api instead to retrieve information about filesystems with the goal of unifying the API.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
-->

- Fixes [CNV-54838](https://issues.redhat.com/browse/CNV-54838)
- Partially addresses #13651 [CNV-54839](https://issues.redhat.com/browse/CNV-54839)

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->


### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

