### PR TITLE
WIP featuregates: Add SupportByArch to FeatureGate

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -153,7 +153,17 @@ const (
 )
 
 func init() {
-	RegisterFeatureGate(FeatureGate{Name: ImageVolume, State: Beta})
+	RegisterFeatureGate(
+		FeatureGate{
+			Name:  ImageVolume,
+			State: Beta,
+			SupportByArch: SupportByArch{
+				AMD64: SUPPORTED,
+				ARM64: UNVERIFIED,
+				S390X: UNVERIFIED,
+			},
+		},
+	)
 	RegisterFeatureGate(FeatureGate{Name: ExpandDisksGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CPUManager, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IgnitionGate, State: Alpha})
@@ -166,7 +176,17 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HostDiskGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DownwardMetricsFeatureGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: Root, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionSEV, State: Alpha})
+	RegisterFeatureGate(
+		FeatureGate{
+			Name:  WorkloadEncryptionSEV,
+			State: Alpha,
+			SupportByArch: SupportByArch{
+				AMD64: SUPPORTED,
+				ARM64: UNSUPPORTED,
+				S390X: UNSUPPORTED,
+			},
+		},
+	)
 	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionTDX, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VSOCKGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: KubevirtSeccompProfile, State: Beta})

--- a/pkg/virt-config/featuregate/feature-gates.go
+++ b/pkg/virt-config/featuregate/feature-gates.go
@@ -25,7 +25,12 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-type State string
+type (
+	State         string
+	Support       string
+	Arch          string
+	SupportByArch map[Arch]Support
+)
 
 const (
 	// Alpha represents features that are under experimentation.
@@ -46,13 +51,23 @@ const (
 
 	WarningPattern = "feature gate %s is deprecated (feature state is %q), therefore it can be safely removed and is redundant. " +
 		"For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md"
+
+	SUPPORTED   Support = "Supported"
+	PENDING     Support = "Pending"
+	UNSUPPORTED Support = "Unsupported"
+	UNVERIFIED  Support = "Unverified"
+
+	AMD64 Arch = "amd64"
+	ARM64 Arch = "arm64"
+	S390X Arch = "s390x"
 )
 
 type FeatureGate struct {
-	Name        string
-	State       State
-	VmiSpecUsed func(spec *v1.VirtualMachineInstanceSpec) bool
-	Message     string
+	Name          string
+	State         State
+	VmiSpecUsed   func(spec *v1.VirtualMachineInstanceSpec) bool
+	Message       string
+	SupportByArch SupportByArch
 }
 
 var featureGates = map[string]FeatureGate{}


### PR DESCRIPTION
### What this PR does

Draft change after getting angry attempting to manually update the user-guide docs for arm64:

https://github.com/kubevirt/user-guide/pull/939

I'll turn this into a VEP on Monday ahead of discussing it at the unconference next week.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

