### PR TITLE
virt-handler: Fix potential panic

### DIFF
--- a/pkg/virt-handler/cache/maps.go
+++ b/pkg/virt-handler/cache/maps.go
@@ -35,6 +35,21 @@ type LauncherClientInfo struct {
 	DomainPipeStopChan  chan struct{}
 	NotInitializedSince time.Time
 	Ready               bool
+	closeOnce           sync.Once
+}
+
+func (l *LauncherClientInfo) Close() {
+	if l == nil {
+		return
+	}
+	l.closeOnce.Do(func() {
+		if l.Client != nil {
+			l.Client.Close()
+		}
+		if l.DomainPipeStopChan != nil {
+			close(l.DomainPipeStopChan)
+		}
+	})
 }
 
 type LauncherClientInfoByVMI struct {

--- a/pkg/virt-handler/launcher-clients/BUILD.bazel
+++ b/pkg/virt-handler/launcher-clients/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     race = "on",
     deps = [
         "//pkg/testutils:go_default_library",
+        "//pkg/virt-handler/cache:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-handler/launcher-clients/launcher-clients.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients.go
@@ -138,9 +138,8 @@ func (l *launcherClientsManager) CloseLauncherClient(vmi *v1.VirtualMachineInsta
 	}
 
 	clientInfo, exists := l.launcherClients.Load(vmi.UID)
-	if exists && clientInfo.Client != nil {
-		clientInfo.Client.Close()
-		close(clientInfo.DomainPipeStopChan)
+	if exists {
+		clientInfo.Close()
 	}
 
 	virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Race condition: `CloseLauncherClient` can be called from multiple places
simultaneously during VMI cleanup:
1. migration-target.go:404 - deferred in `finalCleanup()`
2. migration-target.go:508 - when VMI becomes final during `execute()`
3. vm.go:1530 - from main VM controller `processVmCleanup`

Since those happen in different go routines, and the code is not thread safe, a panic occurs.

Flow that caused panic:

`VirtualMachineController.processVmCleanup` finished, and closed the channel `DomainPipeStopChan` (by calling `CloseLauncherClient`)
```
{"component":"virt-handler","controller":"vm","kind":"Domain","level":"info","msg":"Removing domain from cache during final cleanup","name":"testvmi-8z88p","namespace":"kubevirt-test-alternative3","pos":"vm.go:1537","timestamp":"2025-10-30T18:42:46.822834Z","uid":""}
```

`MigrationTargetController.execute` seeing VMI in final state and calls `CloseLauncherClient` again.
Since those are 2 go routines, it managed to load launcher client, before it was deleted,
because the launcher client Load + Delete isn't atomic.

```
E1030 18:42:46.823075    8385 chan.go:422] "Observed a panic" panic="close of closed channel" panicGoValue="\"close of closed channel\"" stacktrace=<
	goroutine 326 [running]:
	kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2c53810, 0xc003f1d8f0}, {0x240dd60, 0x2c1a240})
		vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xbc
	kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x2c53cf8, 0xc00039e540}, {0x240dd60, 0x2c1a240}, {0x0, 0x0, 0xc002407730?})
		vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x116
	kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x2c53cf8, 0xc00039e540}, {0x0, 0x0, 0x0})
		vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:78 +0x5a
	panic({0x240dd60?, 0x2c1a240?})
		GOROOT/src/runtime/panic.go:792 +0x132
	kubevirt.io/kubevirt/pkg/virt-handler/launcher-clients.(*launcherClientsManager).CloseLauncherClient(0xc00028a640, 0xc0046ff208)
		pkg/virt-handler/launcher-clients/launcher-clients.go:143 +0x69
	kubevirt.io/kubevirt/pkg/virt-handler.(*MigrationTargetController).execute(0xc0002a0460, {0xc004b8d7a0, 0x28})
		pkg/virt-handler/migration-target.go:508 +0x28e
```

Fix it by making sure `CloseLauncherClient` is thread safe (by protecting it with `sync.Once`)

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15983/pull-kubevirt-e2e-k8s-1.34-sig-compute-migrations/1983892566344470528

Happens also here:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15983/pull-kubevirt-e2e-k8s-1.34-sig-compute-migrations/1984957971884412928

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

