### PR TITLE
DefaultObsoleteCPUModels: add Opteron and Penryn

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(cpuModels).To(HaveLen(4), "number of models must match")
+		Expect(cpuModels).To(HaveLen(3), "number of models must match")
 		Expect(cpuFeatures).To(HaveLen(4), "number of features must match")
 	})
 

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -231,8 +231,8 @@ var _ = Describe("Node-labeller ", func() {
 
 		node := retrieveNode(kubeClient)
 		Expect(node.Labels).To(SatisfyAll(
-			HaveKey(v1.CPUModelLabel+"Penryn"),
-			HaveKey(v1.SupportedHostModelMigrationCPU+"Penryn"),
+			HaveKey(v1.CPUModelLabel+"Nehalem"),
+			HaveKey(v1.SupportedHostModelMigrationCPU+"Nehalem"),
 		))
 	})
 

--- a/pkg/virt-handler/node-labeller/util/util.go
+++ b/pkg/virt-handler/node-labeller/util/util.go
@@ -20,7 +20,7 @@
 package util
 
 const (
-	DefaultMinCPUModel = "Penryn"
+	DefaultMinCPUModel = "Nehalem"
 	RequirePolicy      = "require"
 	KVMPath            = "/dev/kvm"
 	VmxFeature         = "vmx"
@@ -45,6 +45,8 @@ var DefaultObsoleteCPUModels = map[string]bool{
 	"core2duo-v1":   true,
 	"Conroe":        true,
 	"Conroe-v1":     true,
+	"Penryn":        true,
+	"Penryn-v1":     true,
 	"athlon":        true,
 	"athlon-v1":     true,
 	"phenom":        true,
@@ -57,6 +59,8 @@ var DefaultObsoleteCPUModels = map[string]bool{
 	"kvm64-v1":      true,
 	"kvm32":         true,
 	"kvm32-v1":      true,
+	"Opteron":       true,
+	"Opteron-v1":    true,
 	"Opteron_G1":    true,
 	"Opteron_G1-v1": true,
 	"Opteron_G2":    true,


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The DefaultMinCPUModel was `Penryn`

#### After this PR:
The DefaultMinCPUModel is `Nehalem` and the following are added to the `DefaultObsoleteCPUModels` list:
 - Penryn
 - Opteron

### Why we need it and why it was done in this way
#### Removed old CPU models:
 - Penryn (2007-2008): Based on Intel's Core 2 architecture, nearly 17 years old
 - Opteron (2003-2005): AMD's first x86-64 processor, now over 20 years old
 - Both are well beyond their manufacturer support lifecycle and represent obsolete technology


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

