### PR TITLE
Fix metric names linter to handle recording rules separately

### DIFF
--- a/hack/prom-metric-linter/metric_name_linter.sh
+++ b/hack/prom-metric-linter/metric_name_linter.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-linter_image_tag="v0.0.6"
+linter_image_tag="v0.0.11"
 
 source $(dirname "$0")/../common.sh
 

--- a/tools/prom-metrics-collector/BUILD.bazel
+++ b/tools/prom-metrics-collector/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tools/prom-metrics-collector",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/monitoring/rules:go_default_library",
         "//vendor/github.com/kubevirt/monitoring/pkg/metrics/parser:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],


### PR DESCRIPTION
### What this PR does
#### Before this PR:
recording rules and metrics sent as metrics to metrics name linter which handled them same
#### After this PR:
recording rules and metrics sent as 2 list (in the same file as before) to metrics name linter which handle them separately
  
Fixes #
jira-ticket: https://issues.redhat.com/browse/CNV-71781


### Why we need it and why it was done in this way
The plan is to add duplicate recording rules with correct name and deprecate the old recording rules after a few versions.
This is what we were asked to do by the openshift observability team that need to be able to distinguish recording rules from metrics.
This linter updat will make sure no new wrong naming recording rules will be added. 

#### The following tradeoffs were made:
To avoid breaking existing rules, the linter (in the monitoring repo) will include an operator-scoped allowlist for current names, any new rule that isn’t on that list will fail CI. this keeps all policy and exceptions in the monitoring repo (no future kubevirt changes), and in a couple of versions, once old names are gone, we just remove the allowlist from monitoring and bump the linter version in kubevirt.
 
#### The following alternatives were considered:
keep testing the rules as metrics like we do now, and fix the linter only when wrong names is deprecated.
since the linter fails also with this solution and to enforces correct naming for all new rules immediately we decided to implement the new linter now and allowlist the existing wrong rules name that will fail the new linter. 

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This pr is blocked until the linter pr will be merged: https://github.com/kubevirt/monitoring/pull/325

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

