### PR TITLE
Fix flakiness in migration priority queue unit tests

### DIFF
--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -2361,26 +2361,43 @@ var _ = Describe("Migration watcher", func() {
 			// Add should bump pending3 higher than pending but lower than active
 			controller.Queue.Add("default/pending3")
 
-			for i := range 5 {
+			runningMigrationsFromQueue := make([]string, 0, 5)
+			for range 5 {
 				item, priority, shutdown := controller.Queue.GetWithPriority()
-				Expect(item).To(BeEquivalentTo(fmt.Sprintf("default/active%d", i)))
+				runningMigrationsFromQueue = append(runningMigrationsFromQueue, item)
 				Expect(priority).To(Equal(migrationsutil.QueuePriorityRunning))
 				Expect(shutdown).To(BeFalse())
 			}
+			Expect(runningMigrationsFromQueue).To(
+				ConsistOf(
+					"default/active0",
+					"default/active1",
+					"default/active2",
+					"default/active3",
+					"default/active4",
+				),
+			)
+
 			item, priority, shutdown := controller.Queue.GetWithPriority()
 			Expect(item).To(BeEquivalentTo("default/pending3"))
 			Expect(priority).To(BeNumerically("<", migrationsutil.QueuePriorityRunning))
 			Expect(priority).To(BeNumerically(">", migrationsutil.QueuePriorityPending))
 			Expect(shutdown).To(BeFalse())
-			for i := range 5 {
-				if i == 3 {
-					continue
-				}
+			runningMigrationsFromQueue = make([]string, 0, 4)
+			for range 4 {
 				item, priority, shutdown := controller.Queue.GetWithPriority()
-				Expect(item).To(BeEquivalentTo(fmt.Sprintf("default/pending%d", i)))
+				runningMigrationsFromQueue = append(runningMigrationsFromQueue, item)
 				Expect(priority).To(Equal(migrationsutil.QueuePriorityPending))
 				Expect(shutdown).To(BeFalse())
 			}
+			Expect(runningMigrationsFromQueue).To(
+				ConsistOf(
+					"default/pending0",
+					"default/pending1",
+					"default/pending2",
+					"default/pending4",
+				),
+			)
 		})
 
 		Context("with MigrationPriorityQueue feature gate enabled", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The items can be in a different order than the expected one.

#### After this PR:
Item's order doesn't matter anymore

### References
- Fixes #16015

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
