### PR TITLE
OWNERS: Introduce sig-control-plane ownership

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -196,3 +196,17 @@ aliases:
   #
   sig-architecture-approvers: []
   sig-architecture-reviewers: []
+
+  #
+  # SIG Control plane
+  # Responsible for the development and enhancement of
+  # KubeVirt control plane.
+  sig-control-plane-approvers: []
+  sig-control-plane-reviewers:
+    - akalenyu
+    - Barakmor1
+    - dasionov
+    - lyarwood
+    - mhenriks
+    - orelmisan
+    - xpivarc

--- a/cmd/synchronization-controller/OWNERS
+++ b/cmd/synchronization-controller/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - sig/control-plane

--- a/cmd/virt-api/OWNERS
+++ b/cmd/virt-api/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - area/api
+  - sig/control-plane

--- a/cmd/virt-controller/OWNERS
+++ b/cmd/virt-controller/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - area/controller
+  - sig/control-plane

--- a/cmd/virt-operator/OWNERS
+++ b/cmd/virt-operator/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - area/operator
+  - sig/control-plane

--- a/pkg/certificates/OWNERS
+++ b/pkg/certificates/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - sig/control-plane

--- a/pkg/controller/OWNERS
+++ b/pkg/controller/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - sig/control-plane

--- a/pkg/healthz/OWNERS
+++ b/pkg/healthz/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - sig/control-plane

--- a/pkg/virt-api/OWNERS
+++ b/pkg/virt-api/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - area/api
+  - sig/control-plane

--- a/pkg/virt-controller/services/OWNERS
+++ b/pkg/virt-controller/services/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - area/controller
+  - sig/control-plane

--- a/pkg/virt-controller/watch/OWNERS
+++ b/pkg/virt-controller/watch/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - area/controller
+  - sig/control-plane

--- a/pkg/virt-operator/OWNERS
+++ b/pkg/virt-operator/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-control-plane-reviewers
+approvers:
+  - sig-control-plane-approvers
+labels:
+  - area/operator
+  - sig/control-plane


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Core control plane paths (`pkg/virt-api/`, `pkg/virt-operator/`, `pkg/virt-controller/watch/`, `cmd/virt-{api,controller,operator}/`, etc.) had no dedicated OWNERS files and required root-level approval. The `sig-control-plane-reviewers` alias was empty.

#### After this PR:

Introduces `sig-control-plane-{approvers,reviewers}` aliases in `OWNERS_ALIASES` and adds OWNERS files across core control plane paths assigning them to `sig-control-plane`.

Reviewers added: @akalenyu, @Barakmor1, @dasionov, @lyarwood, @mhenriks, @orelmisan, @xpivarc

Paths covered:

- `cmd/virt-api/`
- `cmd/virt-controller/`
- `cmd/virt-operator/`
- `cmd/synchronization-controller/`
- `pkg/virt-api/`
- `pkg/virt-operator/`
- `pkg/virt-controller/watch/`
- `pkg/virt-controller/services/`
- `pkg/controller/`
- `pkg/certificates/`
- `pkg/healthz/`

SIG-specific OWNERS in subdirectories (e.g. `watch/vm/` → sig-compute, `watch/volume-migration/` → sig-storage) continue to apply alongside sig-control-plane as `no_parent_owners` is not set.

### References

### Why we need it and why it was done in this way

~32.5% of non-vendor `.go` files in the repo fall back to root-only approval. Many of these are core control plane components that align with the sig-control-plane charter (virt-api, virt-controller, virt-operator deployment, scalability, and performance).

Adding sig-control-plane as owners distributes the review burden from root approvers while keeping root as a fallback.

### Special notes for your reviewer

The `sig-control-plane-approvers` alias is still empty and needs to be populated before approvals can be granted via these OWNERS files.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```