### PR TITLE
Refactor [test_id:1668] and [test_id:4437] to be proper e2e tests

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -163,30 +163,6 @@ func skipInput(scanner *bufio.Scanner) bool {
 	return scanner.Scan()
 }
 
-// SecureBootExpecter should be called on a VMI that has EFI enabled
-// It will parse the kernel output (dmesg) and succeed if it finds that Secure boot is enabled
-// The VMI was just created and may not be running yet. This is because we want to catch early boot logs.
-func SecureBootExpecter(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) error {
-	virtClient := kubevirt.Client()
-	expecter, _, err := NewExpecter(virtClient, vmi, consoleConnectionTimeout)
-	if err != nil {
-		return err
-	}
-	defer expecter.Close()
-
-	b := []expect.Batcher{&expect.BExp{R: "secureboot: Secure boot enabled"}}
-	expectBatchTimeout := 180 * time.Second
-	if len(timeout) > 0 {
-		expectBatchTimeout = timeout[0]
-	}
-	res, err := expecter.ExpectBatch(b, expectBatchTimeout)
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Kernel: %+v", res)
-	}
-
-	return err
-}
-
 // NetBootExpecter should be called on a VMI that has BIOS serial logging enabled
 // It will parse the SeaBIOS output and succeed if it finds the string "iPXE"
 // The VMI was just created and may not be running yet. This is because we want to catch early boot logs.


### PR DESCRIPTION
These tests previously included VMI failure handling to make them pass in some environments. This approach can hide bugs and is not the correct way to handle such cases

External environments that cannot support the tests should skip them instead of relying on failure handling

The tests now check EFI configuration via the domain directly, avoiding reliance on implementation details like fetching the domain XML

/kind cleanup

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

