### PR TITLE
[release-1.5] (manual) Add `preserve-session` option to help avoid disconnect VNC sessions

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8951,6 +8951,9 @@
      },
      {
       "$ref": "#/parameters/namespace-nfszEHZ0"
+     },
+     {
+      "$ref": "#/parameters/preserveSession-FJbSIuEU"
      }
     ]
    },
@@ -10455,6 +10458,9 @@
      },
      {
       "$ref": "#/parameters/namespace-nfszEHZ0"
+     },
+     {
+      "$ref": "#/parameters/preserveSession-FJbSIuEU"
      }
     ]
    },
@@ -20409,6 +20415,13 @@
     "name": "port",
     "in": "query",
     "required": true
+   },
+   "preserveSession-FJbSIuEU": {
+    "uniqueItems": true,
+    "type": "boolean",
+    "description": "Connect only if ongoing session is not disturbed.",
+    "name": "preserveSession",
+    "in": "query"
    },
    "propagationPolicy-6jk3prlO": {
     "uniqueItems": true,

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -516,7 +516,8 @@ func (app *virtHandlerApp) runPrometheusServer(errCh chan error) {
 func (app *virtHandlerApp) runServer(errCh chan error, consoleHandler *rest.ConsoleHandler, lifecycleHandler *rest.LifecycleHandler) {
 	ws := new(restful.WebService)
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/console").To(consoleHandler.SerialHandler))
-	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vnc").To(consoleHandler.VNCHandler))
+	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vnc").To(consoleHandler.VNCHandler).
+		Param(restful.QueryParameter("preserveSession", "Connect only if ongoing session is not disturbed")))
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/usbredir").To(consoleHandler.USBRedirHandler))
 	ws.Route(ws.PUT("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/pause").To(lifecycleHandler.PauseHandler))
 	ws.Route(ws.PUT("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/unpause").To(lifecycleHandler.UnpauseHandler))

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -363,7 +363,9 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.GET(definitions.NamespacedResourcePath(subresourcesvmiGVR) + definitions.SubResourcePath("vnc")).
 			To(subresourceApp.VNCRequestHandler).
-			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
+			Param(definitions.NamespaceParam(subws)).
+			Param(definitions.NameParam(subws)).
+			Param(definitions.PreserveSessionParam(subws)).
 			Operation(version.Version + "VNC").
 			Doc("Open a websocket connection to connect to VNC on the specified VirtualMachineInstance."))
 		subws.Route(subws.GET(definitions.NamespacedResourcePath(subresourcesvmiGVR) + definitions.SubResourcePath("vnc/screenshot")).

--- a/pkg/virt-api/definitions/definitions.go
+++ b/pkg/virt-api/definitions/definitions.go
@@ -565,9 +565,10 @@ func addPatchParams(ws *restful.WebService, builder *restful.RouteBuilder) *rest
 }
 
 const (
-	NamespaceParamName  = "namespace"
-	NameParamName       = "name"
-	MoveCursorParamName = "moveCursor"
+	NamespaceParamName       = "namespace"
+	NameParamName            = "name"
+	MoveCursorParamName      = "moveCursor"
+	PreserveSessionParamName = "preserveSession"
 )
 
 func NameParam(ws *restful.WebService) *restful.Parameter {
@@ -580,6 +581,13 @@ func NamespaceParam(ws *restful.WebService) *restful.Parameter {
 
 func MoveCursorParam(ws *restful.WebService) *restful.Parameter {
 	return ws.QueryParameter(MoveCursorParamName, "Move the cursor on the VNC display to wake up the screen").DataType("boolean").DefaultValue("false")
+}
+
+func PreserveSessionParam(ws *restful.WebService) *restful.Parameter {
+	return ws.
+		QueryParameter(PreserveSessionParamName, "Connect only if ongoing session is not disturbed.").
+		DataType("boolean").
+		DefaultValue("false")
 }
 
 func labelSelectorParam(ws *restful.WebService) *restful.Parameter {

--- a/pkg/virt-api/rest/vnc.go
+++ b/pkg/virt-api/rest/vnc.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"image/png"
 	"io"
+	"strconv"
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/virt-api/definitions"
@@ -29,11 +30,23 @@ func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, respon
 
 	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
 
+	// Default is false: drops the current VNC session if any
+	preserveSessionParam := false
+
+	// Check the request as QueryParameter assumes them to exist
+	if request.Request != nil && request.Request.URL != nil {
+		val, err := strconv.ParseBool(request.QueryParameter(definitions.PreserveSessionParamName))
+		if err != nil {
+			log.DefaultLogger().Reason(err).Warningf("Failed to parse VNC's query parameter: %s", definitions.PreserveSessionParamName)
+		}
+		preserveSessionParam = val
+	}
+
 	streamer := NewRawStreamer(
 		app.FetchVirtualMachineInstance,
 		validateVMIForVNC,
 		app.virtHandlerDialer(func(vmi *v1.VirtualMachineInstance, conn kubecli.VirtHandlerConn) (string, error) {
-			return conn.VNCURI(vmi)
+			return conn.VNCURI(vmi, preserveSessionParam)
 		}),
 	)
 
@@ -49,11 +62,14 @@ func (app *SubresourceAPIApp) VNCScreenshotRequestHandler(request *restful.Reque
 
 	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
 
+	// Screenshot should not take preference over VNC connection
+	const preserveSessionParam = true
+
 	dialer := NewDirectDialer(
 		app.FetchVirtualMachineInstance,
 		validateVMIForVNC,
 		app.virtHandlerDialer(func(vmi *v1.VirtualMachineInstance, conn kubecli.VirtHandlerConn) (string, error) {
-			return conn.VNCURI(vmi)
+			return conn.VNCURI(vmi, preserveSessionParam)
 		}),
 	)
 	namespace := request.PathParameter(definitions.NamespaceParamName)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -65,6 +65,7 @@ const (
 var listenAddressFmt string
 var listenAddress = "127.0.0.1"
 var proxyOnly bool
+var preserveSession bool
 var customPort = 0
 
 func NewCommand() *cobra.Command {
@@ -79,6 +80,8 @@ func NewCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&listenAddress, "address", listenAddress, "--address=127.0.0.1: Setting this will change the listening address of the VNC server. Example: --address=0.0.0.0 will make the server listen on all interfaces.")
 	cmd.Flags().BoolVar(&proxyOnly, "proxy-only", proxyOnly, "--proxy-only=false: Setting this true will run only the virtctl vnc proxy and show the port where VNC viewers can connect")
+	cmd.Flags().BoolVar(&preserveSession, "preserve-session", false,
+		"--preserve-session: This option will preserve an existing VNC session instead of dropping it.")
 	cmd.Flags().IntVar(&customPort, "port", customPort,
 		"--port=0: Assigning a port value to this will try to run the proxy on the given port if the port is accessible; If unassigned, the proxy will run on a random port")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
@@ -97,7 +100,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	vmi := args[0]
 
 	// setup connection with VM
-	vnc, err := virtCli.VirtualMachineInstance(namespace).VNC(vmi)
+	vnc, err := virtCli.VirtualMachineInstance(namespace).VNC(vmi, preserveSession)
 	if err != nil {
 		return fmt.Errorf("Can't access VMI %s: %s", vmi, err.Error())
 	}

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1144,15 +1144,15 @@ func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) USBRedir(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "USBRedir", arg0)
 }
 
-func (_m *MockVirtualMachineInstanceInterface) VNC(name string) (v122.StreamInterface, error) {
-	ret := _m.ctrl.Call(_m, "VNC", name)
+func (_m *MockVirtualMachineInstanceInterface) VNC(name string, preserveSession bool) (v122.StreamInterface, error) {
+	ret := _m.ctrl.Call(_m, "VNC", name, preserveSession)
 	ret0, _ := ret[0].(v122.StreamInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) VNC(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "VNC", arg0)
+func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) VNC(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VNC", arg0, arg1)
 }
 
 func (_m *MockVirtualMachineInstanceInterface) Screenshot(ctx context.Context, name string, options *v121.ScreenshotOptions) ([]byte, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/handler.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/handler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +58,7 @@ type VirtHandlerConn interface {
 	ConnectionDetails() (ip string, port int, err error)
 	ConsoleURI(vmi *virtv1.VirtualMachineInstance) (string, error)
 	USBRedirURI(vmi *virtv1.VirtualMachineInstance) (string, error)
-	VNCURI(vmi *virtv1.VirtualMachineInstance) (string, error)
+	VNCURI(vmi *virtv1.VirtualMachineInstance, preserveSession bool) (string, error)
 	VSOCKURI(vmi *virtv1.VirtualMachineInstance, port string, tls string) (string, error)
 	PauseURI(vmi *virtv1.VirtualMachineInstance) (string, error)
 	UnpauseURI(vmi *virtv1.VirtualMachineInstance) (string, error)
@@ -183,8 +185,19 @@ func (v *virtHandlerConn) USBRedirURI(vmi *virtv1.VirtualMachineInstance) (strin
 	return v.formatURI(usbredirTemplateURI, vmi)
 }
 
-func (v *virtHandlerConn) VNCURI(vmi *virtv1.VirtualMachineInstance) (string, error) {
-	return v.formatURI(vncTemplateURI, vmi)
+func (v *virtHandlerConn) VNCURI(vmi *virtv1.VirtualMachineInstance, preserveSession bool) (string, error) {
+	baseURI, err := v.formatURI(vncTemplateURI, vmi)
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(baseURI)
+	if err != nil {
+		return "", err
+	}
+	queryParams := url.Values{}
+	queryParams.Add("preserveSession", strconv.FormatBool(preserveSession))
+	u.RawQuery = queryParams.Encode()
+	return u.String(), nil
 }
 
 func (v *virtHandlerConn) VSOCKURI(vmi *virtv1.VirtualMachineInstance, port string, tls string) (string, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -63,8 +63,10 @@ func (v *vmis) USBRedir(name string) (kvcorev1.StreamInterface, error) {
 	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "usbredir", url.Values{})
 }
 
-func (v *vmis) VNC(name string) (kvcorev1.StreamInterface, error) {
-	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vnc", url.Values{})
+func (v *vmis) VNC(name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
+	queryParams := url.Values{}
+	queryParams.Add("preserveSession", strconv.FormatBool(preserveSession))
+	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vnc", queryParams)
 }
 
 func (v *vmis) PortForward(name string, port int, protocol string) (kvcorev1.StreamInterface, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 				}
 			},
 		))
-		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm", false)
 		Expect(err).ToNot(HaveOccurred())
 	},
 		Entry("with regular server URL", ""),
@@ -203,7 +203,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 				return
 			},
 		))
-		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm", false)
 		Expect(err).To(HaveOccurred())
 	},
 		Entry("with regular server URL", ""),
@@ -243,7 +243,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 
 		By("establishing connection")
 
-		vnc, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		vnc, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm", false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("wiring the pipes")

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
@@ -38,7 +38,7 @@ func (c *FakeVirtualMachineInstances) USBRedir(vmiName string) (kvcorev1.StreamI
 	return nil, nil
 }
 
-func (c *FakeVirtualMachineInstances) VNC(name string) (kvcorev1.StreamInterface, error) {
+func (c *FakeVirtualMachineInstances) VNC(name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
 	return nil, nil
 }
 

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachineinstance_expansion.go
@@ -40,7 +40,7 @@ type SerialConsoleOptions struct {
 type VirtualMachineInstanceExpansion interface {
 	SerialConsole(name string, options *SerialConsoleOptions) (StreamInterface, error)
 	USBRedir(vmiName string) (StreamInterface, error)
-	VNC(name string) (StreamInterface, error)
+	VNC(name string, preserveSession bool) (StreamInterface, error)
 	Screenshot(ctx context.Context, name string, options *v1.ScreenshotOptions) ([]byte, error)
 	PortForward(name string, port int, protocol string) (StreamInterface, error)
 	Pause(ctx context.Context, name string, pauseOptions *v1.PauseOptions) error
@@ -73,7 +73,7 @@ func (c *virtualMachineInstances) USBRedir(vmiName string) (StreamInterface, err
 	return nil, fmt.Errorf("USBRedir is not implemented yet in generated client")
 }
 
-func (c *virtualMachineInstances) VNC(name string) (StreamInterface, error) {
+func (c *virtualMachineInstances) VNC(name string, preserveSession bool) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("VNC is not implemented yet in generated client")

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -222,7 +222,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 		It("VirtApiRESTErrorsBurst should be triggered when requests to virt-api are failing", func() {
 			By("Creating VNC connections to the virt-api")
 			Eventually(func(g Gomega) {
-				_, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).VNC(rand.String(6))
+				_, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).VNC(rand.String(6), false)
 				g.Expect(err).To(MatchError(ContainSubstring("not found")))
 				g.Expect(libmonitoring.CheckAlertExists(virtClient, virtApi.restErrorsBurtsAlert)).To(BeTrue())
 			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())

--- a/tests/virt-handler_test.go
+++ b/tests/virt-handler_test.go
@@ -83,7 +83,7 @@ var _ = Describe("[sig-compute]virt-handler", decorators.SigCompute, func() {
 					expectNoErr(err)
 				},
 				func() {
-					_, err := vmiInterface.VNC(vmi.Name)
+					_, err := vmiInterface.VNC(vmi.Name, false)
 					expectNoErr(err)
 				},
 				func() {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1443,7 +1443,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Trying to vnc into the VMI")
-			_, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).VNC(vmi.Name)
+			_, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).VNC(vmi.Name, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -72,7 +72,7 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				go func() {
 					defer GinkgoRecover()
-					vnc, err := kubevirt.Client().VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
+					vnc, err := kubevirt.Client().VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name, false)
 					if err != nil {
 						k8ResChan <- err
 						return

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -49,9 +49,22 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
+type ctxKeyTypeVNC string
+
+const connectedKeyVNC ctxKeyTypeVNC = "connected"
+
 var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VNC", decorators.SigCompute, decorators.WgArm64, func() {
 
 	var vmi *v1.VirtualMachineInstance
+	const vncWaitResponseTimeout = time.Second * 45
+	const vncConnectTimeout = time.Second * 5
+
+	newCtxWithConnect := func() (context.Context, context.CancelFunc, chan bool) {
+		connect := make(chan bool)
+		ctx := context.WithValue(context.Background(), connectedKeyVNC, connect)
+		ctx, cancel := context.WithTimeout(ctx, vncWaitResponseTimeout)
+		return ctx, cancel, connect
+	}
 
 	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		BeforeEach(func() {
@@ -63,65 +76,15 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		Context("with VNC connection", func() {
-			vncConnect := func() {
-				pipeOutReader, pipeOutWriter := io.Pipe()
-				defer pipeOutReader.Close()
-
-				k8ResChan := make(chan error)
-				readStop := make(chan string)
-
-				go func() {
-					defer GinkgoRecover()
-					vnc, err := kubevirt.Client().VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name, false)
-					if err != nil {
-						k8ResChan <- err
-						return
-					}
-
-					pipeInReader, _ := io.Pipe()
-					defer pipeInReader.Close()
-
-					k8ResChan <- vnc.Stream(kvcorev1.StreamOptions{
-						In:  pipeInReader,
-						Out: pipeOutWriter,
-					})
-				}()
-				// write to FD <- pipeOutReader
-				By("Reading from the VNC socket")
-				go func() {
-					defer GinkgoRecover()
-					buf := make([]byte, 1024)
-					// reading qemu vnc server
-					n, err := pipeOutReader.Read(buf)
-					if err != nil && err != io.EOF {
-						Expect(err).ToNot(HaveOccurred())
-						return
-					}
-					if n == 0 && err == io.EOF {
-						log.Log.Info("zero bytes read from vnc socket.")
-						return
-					}
-					readStop <- string(buf[0:n])
-				}()
-
-				select {
-				case response := <-readStop:
-					// This is the response capture by wireshark when the VNC server is contacted.
-					// This verifies that the test is able to establish a connection with VNC and
-					// communicate.
-					By("Checking the response from VNC server")
-					Expect(response).To(Equal("RFB 003.008\n"))
-				case err := <-k8ResChan:
-					Expect(err).ToNot(HaveOccurred())
-				case <-time.After(45 * time.Second):
-					Fail("Timeout reached while waiting for valid VNC server response")
-				}
-			}
-
 			It("[test_id:1611]should allow accessing the VNC device multiple times", decorators.Conformance, func() {
-
 				for i := 0; i < 10; i++ {
-					vncConnect()
+					ctx, cancel, connected := newCtxWithConnect()
+					DeferCleanup(cancel)
+					go func() {
+						defer GinkgoRecover()
+						vncConnect(ctx, vmi, false, "")
+					}()
+					Eventually(connected, vncConnectTimeout).Should(Receive(BeTrue()))
 				}
 			})
 		})
@@ -165,6 +128,34 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			_, err = wrappedRoundTripper.RoundTrip(req)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		DescribeTable("Dual connection. Validate default behavior and with 'preserve-session' option", func(preserve1, preserve2 bool) {
+			ctx1, cancel1, connected1 := newCtxWithConnect()
+			DeferCleanup(cancel1)
+			go func() {
+				defer GinkgoRecover()
+				vncConnect(ctx1, vmi, preserve1, "")
+			}()
+			Eventually(connected1, vncConnectTimeout).Should(Receive(BeTrue()))
+
+			ctx2, cancel2, connected2 := newCtxWithConnect()
+			DeferCleanup(cancel2)
+			go func() {
+				defer GinkgoRecover()
+				errMsg := ""
+				if preserve2 {
+					errMsg = "websocket: bad handshake"
+				}
+				vncConnect(ctx2, vmi, preserve2, errMsg)
+			}()
+			Eventually(connected2, vncConnectTimeout).Should(Receive(Not(Equal(preserve2))))
+		},
+			Entry("Second session without preserve", false, false),
+			Entry("Second session with preserve", false, true),
+			// preserve in the first session should not change the behavior
+			Entry("First with preserve, Second session without preserve", true, false),
+			Entry("First with preserve, Second session with preserve", true, true),
+		)
 	})
 })
 
@@ -205,4 +196,90 @@ func upgradeCheckRoundTripperFromConfig(config *rest.Config, subprotocols []stri
 	return &checkUpgradeRoundTripper{
 		Dialer: dialer,
 	}, nil
+}
+
+func vncConnect(
+	ctx context.Context,
+	vmi *v1.VirtualMachineInstance,
+	preserveSession bool,
+	errMsg string,
+) {
+	Expect(ctx).ToNot(BeNil())
+	pipeOutReader, pipeOutWriter := io.Pipe()
+
+	k8ResChan := make(chan error)
+	readStop := make(chan string)
+
+	go func() {
+		defer GinkgoRecover()
+		defer pipeOutWriter.Close()
+		vnc, err := kubevirt.Client().VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name, preserveSession)
+		if err != nil {
+			k8ResChan <- err
+			return
+		}
+
+		pipeInReader, _ := io.Pipe()
+		defer pipeInReader.Close()
+
+		k8ResChan <- vnc.Stream(kvcorev1.StreamOptions{
+			In:  pipeInReader,
+			Out: pipeOutWriter,
+		})
+	}()
+
+	// write to FD <- pipeOutReader
+	By("Reading from the VNC socket")
+	go func() {
+		defer GinkgoRecover()
+		defer pipeOutReader.Close()
+		buf := make([]byte, 1024)
+		// reading qemu vnc server
+		n, err := pipeOutReader.Read(buf)
+		if err != nil && err != io.EOF && errMsg == "" {
+			Expect(err).ToNot(HaveOccurred())
+			return
+		}
+		if n == 0 && err == io.EOF {
+			log.Log.Info("zero bytes read from vnc socket.")
+			return
+		}
+		// successful connect
+		if connected, ok := ctx.Value(connectedKeyVNC).(chan bool); ok {
+			connected <- true
+		}
+		readStop <- string(buf[0:n])
+	}()
+
+	select {
+	case response := <-readStop:
+		// This is the response capture by wireshark when the VNC server is contacted.
+		// This verifies that the test is able to establish a connection with VNC and
+		// communicate.
+		By("Checking the response from VNC server")
+		Expect(response).To(Equal("RFB 003.008\n"))
+	case err := <-k8ResChan:
+		switch errMsg {
+		case "":
+			Expect(err).ToNot(HaveOccurred())
+		default:
+			Expect(err.Error()).To(ContainSubstring(errMsg))
+		}
+		// failed to connect
+		if connected, ok := ctx.Value(connectedKeyVNC).(chan bool); ok {
+			connected <- false
+		}
+	case <-ctx.Done():
+		Expect(ctx.Err()).ToNot(HaveOccurred())
+	}
+
+	// Useful for the multi connection:
+	// We get either the expected response or failure, but we want the
+	// caller to validate it. This will eventually be canceled or timed out.
+	if ctx.Err() == nil {
+		select {
+		case <-ctx.Done():
+			Expect(ctx.Err()).To(HaveOccurred())
+		}
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/kubevirt/kubevirt/pull/15267
Fixes: https://issues.redhat.com/browse/CNV-60117

-->
```release-note
Add `preserve session` option to VNC endpoint
```

