### PR TITLE
[release-1.4] (manual) Add preserve-session option to help avoid disconnect VNC sessions

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8915,6 +8915,9 @@
      },
      {
       "$ref": "#/parameters/namespace-nfszEHZ0"
+     },
+     {
+      "$ref": "#/parameters/preserveSession-FJbSIuEU"
      }
     ]
    },
@@ -10383,6 +10386,9 @@
      },
      {
       "$ref": "#/parameters/namespace-nfszEHZ0"
+     },
+     {
+      "$ref": "#/parameters/preserveSession-FJbSIuEU"
      }
     ]
    },
@@ -20311,6 +20317,13 @@
     "name": "port",
     "in": "query",
     "required": true
+   },
+   "preserveSession-FJbSIuEU": {
+    "uniqueItems": true,
+    "type": "boolean",
+    "description": "Connect only if ongoing session is not disturbed.",
+    "name": "preserveSession",
+    "in": "query"
    },
    "propagationPolicy-6jk3prlO": {
     "uniqueItems": true,

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -564,7 +564,8 @@ func (app *virtHandlerApp) runPrometheusServer(errCh chan error) {
 func (app *virtHandlerApp) runServer(errCh chan error, consoleHandler *rest.ConsoleHandler, lifecycleHandler *rest.LifecycleHandler) {
 	ws := new(restful.WebService)
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/console").To(consoleHandler.SerialHandler))
-	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vnc").To(consoleHandler.VNCHandler))
+	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vnc").To(consoleHandler.VNCHandler).
+		Param(restful.QueryParameter("preserveSession", "Connect only if ongoing session is not disturbed")))
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/usbredir").To(consoleHandler.USBRedirHandler))
 	ws.Route(ws.PUT("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/pause").To(lifecycleHandler.PauseHandler))
 	ws.Route(ws.PUT("/v1/namespaces/{namespace}/virtualmachineinstances/{name}/unpause").To(lifecycleHandler.UnpauseHandler))

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -353,7 +353,9 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.GET(definitions.NamespacedResourcePath(subresourcesvmiGVR) + definitions.SubResourcePath("vnc")).
 			To(subresourceApp.VNCRequestHandler).
-			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
+			Param(definitions.NamespaceParam(subws)).
+			Param(definitions.NameParam(subws)).
+			Param(definitions.PreserveSessionParam(subws)).
 			Operation(version.Version + "VNC").
 			Doc("Open a websocket connection to connect to VNC on the specified VirtualMachineInstance."))
 		subws.Route(subws.GET(definitions.NamespacedResourcePath(subresourcesvmiGVR) + definitions.SubResourcePath("vnc/screenshot")).

--- a/pkg/virt-api/definitions/definitions.go
+++ b/pkg/virt-api/definitions/definitions.go
@@ -565,9 +565,10 @@ func addPatchParams(ws *restful.WebService, builder *restful.RouteBuilder) *rest
 }
 
 const (
-	NamespaceParamName  = "namespace"
-	NameParamName       = "name"
-	MoveCursorParamName = "moveCursor"
+	NamespaceParamName       = "namespace"
+	NameParamName            = "name"
+	MoveCursorParamName      = "moveCursor"
+	PreserveSessionParamName = "preserveSession"
 )
 
 func NameParam(ws *restful.WebService) *restful.Parameter {
@@ -580,6 +581,13 @@ func NamespaceParam(ws *restful.WebService) *restful.Parameter {
 
 func MoveCursorParam(ws *restful.WebService) *restful.Parameter {
 	return ws.QueryParameter(MoveCursorParamName, "Move the cursor on the VNC display to wake up the screen").DataType("boolean").DefaultValue("false")
+}
+
+func PreserveSessionParam(ws *restful.WebService) *restful.Parameter {
+	return ws.
+		QueryParameter(PreserveSessionParamName, "Connect only if ongoing session is not disturbed.").
+		DataType("boolean").
+		DefaultValue("false")
 }
 
 func labelSelectorParam(ws *restful.WebService) *restful.Parameter {

--- a/pkg/virt-api/rest/vnc.go
+++ b/pkg/virt-api/rest/vnc.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"image/png"
 	"io"
+	"strconv"
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/virt-api/definitions"
@@ -29,11 +30,23 @@ func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, respon
 
 	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
 
+	// Default is false: drops the current VNC session if any
+	preserveSessionParam := false
+
+	// Check the request as QueryParameter assumes them to exist
+	if request.Request != nil && request.Request.URL != nil {
+		val, err := strconv.ParseBool(request.QueryParameter(definitions.PreserveSessionParamName))
+		if err != nil {
+			log.DefaultLogger().Reason(err).Warningf("Failed to parse VNC's query parameter: %s", definitions.PreserveSessionParamName)
+		}
+		preserveSessionParam = val
+	}
+
 	streamer := NewRawStreamer(
 		app.FetchVirtualMachineInstance,
 		validateVMIForVNC,
 		app.virtHandlerDialer(func(vmi *v1.VirtualMachineInstance, conn kubecli.VirtHandlerConn) (string, error) {
-			return conn.VNCURI(vmi)
+			return conn.VNCURI(vmi, preserveSessionParam)
 		}),
 	)
 
@@ -49,11 +62,14 @@ func (app *SubresourceAPIApp) VNCScreenshotRequestHandler(request *restful.Reque
 
 	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
 
+	// Screenshot should not take preference over VNC connection
+	const preserveSessionParam = true
+
 	dialer := NewDirectDialer(
 		app.FetchVirtualMachineInstance,
 		validateVMIForVNC,
 		app.virtHandlerDialer(func(vmi *v1.VirtualMachineInstance, conn kubecli.VirtHandlerConn) (string, error) {
-			return conn.VNCURI(vmi)
+			return conn.VNCURI(vmi, preserveSessionParam)
 		}),
 	)
 	namespace := request.PathParameter(definitions.NamespaceParamName)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -66,6 +66,7 @@ const (
 var listenAddressFmt string
 var listenAddress = "127.0.0.1"
 var proxyOnly bool
+var preserveSession bool
 var customPort = 0
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
@@ -82,6 +83,8 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&listenAddress, "address", listenAddress, "--address=127.0.0.1: Setting this will change the listening address of the VNC server. Example: --address=0.0.0.0 will make the server listen on all interfaces.")
 	cmd.Flags().BoolVar(&proxyOnly, "proxy-only", proxyOnly, "--proxy-only=false: Setting this true will run only the virtctl vnc proxy and show the port where VNC viewers can connect")
+	cmd.Flags().BoolVar(&preserveSession, "preserve-session", false,
+		"--preserve-session: This option will preserve an existing VNC session instead of dropping it.")
 	cmd.Flags().IntVar(&customPort, "port", customPort,
 		"--port=0: Assigning a port value to this will try to run the proxy on the given port if the port is accessible; If unassigned, the proxy will run on a random port")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
@@ -107,7 +110,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// setup connection with VM
-	vnc, err := virtCli.VirtualMachineInstance(namespace).VNC(vmi)
+	vnc, err := virtCli.VirtualMachineInstance(namespace).VNC(vmi, preserveSession)
 	if err != nil {
 		return fmt.Errorf("Can't access VMI %s: %s", vmi, err.Error())
 	}

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1144,15 +1144,15 @@ func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) USBRedir(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "USBRedir", arg0)
 }
 
-func (_m *MockVirtualMachineInstanceInterface) VNC(name string) (v122.StreamInterface, error) {
-	ret := _m.ctrl.Call(_m, "VNC", name)
+func (_m *MockVirtualMachineInstanceInterface) VNC(name string, preserveSession bool) (v122.StreamInterface, error) {
+	ret := _m.ctrl.Call(_m, "VNC", name, preserveSession)
 	ret0, _ := ret[0].(v122.StreamInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) VNC(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "VNC", arg0)
+func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) VNC(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VNC", arg0, arg1)
 }
 
 func (_m *MockVirtualMachineInstanceInterface) Screenshot(ctx context.Context, name string, options *v121.ScreenshotOptions) ([]byte, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -63,8 +63,10 @@ func (v *vmis) USBRedir(name string) (kvcorev1.StreamInterface, error) {
 	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "usbredir", url.Values{})
 }
 
-func (v *vmis) VNC(name string) (kvcorev1.StreamInterface, error) {
-	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vnc", url.Values{})
+func (v *vmis) VNC(name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
+	queryParams := url.Values{}
+	queryParams.Add("preserveSession", strconv.FormatBool(preserveSession))
+	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vnc", queryParams)
 }
 
 func (v *vmis) PortForward(name string, port int, protocol string) (kvcorev1.StreamInterface, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 				}
 			},
 		))
-		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm", false)
 		Expect(err).ToNot(HaveOccurred())
 	},
 		Entry("with regular server URL", ""),
@@ -203,7 +203,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 				return
 			},
 		))
-		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm", false)
 		Expect(err).To(HaveOccurred())
 	},
 		Entry("with regular server URL", ""),
@@ -243,7 +243,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 
 		By("establishing connection")
 
-		vnc, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		vnc, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm", false)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("wiring the pipes")

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
@@ -38,7 +38,7 @@ func (c *FakeVirtualMachineInstances) USBRedir(vmiName string) (kvcorev1.StreamI
 	return nil, nil
 }
 
-func (c *FakeVirtualMachineInstances) VNC(name string) (kvcorev1.StreamInterface, error) {
+func (c *FakeVirtualMachineInstances) VNC(name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
 	return nil, nil
 }
 

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachineinstance_expansion.go
@@ -40,7 +40,7 @@ type SerialConsoleOptions struct {
 type VirtualMachineInstanceExpansion interface {
 	SerialConsole(name string, options *SerialConsoleOptions) (StreamInterface, error)
 	USBRedir(vmiName string) (StreamInterface, error)
-	VNC(name string) (StreamInterface, error)
+	VNC(name string, preserveSession bool) (StreamInterface, error)
 	Screenshot(ctx context.Context, name string, options *v1.ScreenshotOptions) ([]byte, error)
 	PortForward(name string, port int, protocol string) (StreamInterface, error)
 	Pause(ctx context.Context, name string, pauseOptions *v1.PauseOptions) error
@@ -72,7 +72,7 @@ func (c *virtualMachineInstances) USBRedir(vmiName string) (StreamInterface, err
 	return nil, fmt.Errorf("USBRedir is not implemented yet in generated client")
 }
 
-func (c *virtualMachineInstances) VNC(name string) (StreamInterface, error) {
+func (c *virtualMachineInstances) VNC(name string, preserveSession bool) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("VNC is not implemented yet in generated client")

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -228,7 +228,6 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 				cmd := clientcmd.NewVirtctlCommand("vnc", randVmName)
 				err := cmd.Execute()
 				Expect(err).To(HaveOccurred())
-
 				g.Expect(libmonitoring.CheckAlertExists(virtClient, virtApi.restErrorsBurtsAlert)).To(BeTrue())
 			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
 		})

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -282,7 +282,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 			By("Trying to vnc into the VM")
-			_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).VNC(vm.ObjectMeta.Name)
+			_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).VNC(vm.ObjectMeta.Name, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/virt-handler_test.go
+++ b/tests/virt-handler_test.go
@@ -84,7 +84,7 @@ var _ = Describe("[sig-compute]virt-handler", decorators.SigCompute, func() {
 					expectNoErr(err)
 				},
 				func() {
-					_, err := vmiInterface.VNC(vmi.Name)
+					_, err := vmiInterface.VNC(vmi.Name, false)
 					expectNoErr(err)
 				},
 				func() {

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -86,7 +86,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 
 				go func() {
 					defer GinkgoRecover()
-					vnc, err := kubevirt.Client().VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
+					vnc, err := kubevirt.Client().VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name, false)
 					if err != nil {
 						k8ResChan <- err
 						return


### PR DESCRIPTION
Backport of https://github.com/kubevirt/kubevirt/pull/15267
4.18 tracker is: https://issues.redhat.com/browse/CNV-72104

```release-note
Add `preserve session` option to VNC endpoint
```

