### PR TITLE
add a helper function to base32 encode device names if needed

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/dra:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
+        "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
@@ -27,6 +27,7 @@ import (
 	drautil "kubevirt.io/kubevirt/pkg/dra"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 
 const (
@@ -73,7 +74,7 @@ func getDRAPCIHostDevices(vmi *v1.VirtualMachineInstance) ([]api.HostDevice, err
 					return nil, fmt.Errorf("failed to create PCI device for %s: %v", hdStatus.Name, err)
 				}
 				hostDevices = append(hostDevices, api.HostDevice{
-					Alias:   api.NewUserDefinedAlias(DRAHostDeviceAliasPrefix + hdStatus.Name),
+					Alias:   api.NewUserDefinedAlias(DRAHostDeviceAliasPrefix + hostdevice.GenerateEncodedAliasIfNeeded(hdStatus.Name)),
 					Source:  api.HostDeviceSource{Address: hostAddr},
 					Type:    api.HostDevicePCI,
 					Managed: "no",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
@@ -28,6 +28,7 @@ import (
 	drautil "kubevirt.io/kubevirt/pkg/dra"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 
 const (
@@ -76,7 +77,7 @@ func getDRAPCIHostDevicesForGPUs(vmi *v1.VirtualMachineInstance) ([]api.HostDevi
 					return nil, fmt.Errorf("failed to create PCI device for %s: %v", gpu.Name, err)
 				}
 				hostDevices = append(hostDevices, api.HostDevice{
-					Alias:   api.NewUserDefinedAlias(AliasPrefix + gpu.Name),
+					Alias:   api.NewUserDefinedAlias(AliasPrefix + hostdevice.GenerateEncodedAliasIfNeeded(gpu.Name)),
 					Source:  api.HostDeviceSource{Address: hostAddr},
 					Type:    api.HostDevicePCI,
 					Managed: "no",
@@ -103,7 +104,7 @@ func getDRAMDEVHostDevicesForGPUs(vmi *v1.VirtualMachineInstance, defaultDisplay
 			if gpu.DeviceResourceClaimStatus.Attributes.MDevUUID != nil {
 				log.Log.V(2).Infof("Adding DRA MDEV GPU device for %s", gpu.Name)
 				hostDevice := api.HostDevice{
-					Alias: api.NewUserDefinedAlias(AliasPrefix + gpu.Name),
+					Alias: api.NewUserDefinedAlias(AliasPrefix + hostdevice.GenerateEncodedAliasIfNeeded(gpu.Name)),
 					Source: api.HostDeviceSource{
 						Address: &api.Address{
 							UUID: *gpu.DeviceResourceClaimStatus.Attributes.MDevUUID,

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool_test.go
@@ -41,6 +41,8 @@ const (
 	hostdevName0 = "hostdev_name0"
 	hostdevName1 = "hostdev_name1"
 
+	hostdevInvalidAliasName = "hostdev.name0"
+
 	hostdevResource0    = "vendor.com/hostdev_name0"
 	hostdevResource1    = "vendor.com/hostdev_name1"
 	envHostDevResource0 = "VENDOR_COM_HOSTDEV_NAME0"

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev.go
@@ -76,7 +76,7 @@ func createHostDevicesMetadata(vmiHostDevices []v1.HostDevice) []hostdevice.Host
 	for _, dev := range vmiHostDevices {
 		hostDevicesMetaData = append(hostDevicesMetaData, hostdevice.HostDeviceMetaData{
 			AliasPrefix:  AliasPrefix,
-			Name:         dev.Name,
+			Name:         hostdevice.GenerateEncodedAliasIfNeeded(dev.Name),
 			ResourceName: dev.DeviceName,
 		})
 	}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool_test.go
@@ -41,6 +41,8 @@ const (
 	gpuName0 = "gpu_name0"
 	gpuName1 = "gpu_name1"
 
+	gpuInvalidAliasName = "gpu.name"
+
 	gpuResource0    = "vendor.com/gpu_name0"
 	gpuResource1    = "vendor.com/gpu_name1"
 	envGPUResource0 = "VENDOR_COM_GPU_NAME0"

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
@@ -67,7 +67,7 @@ func createHostDevicesMetadata(vmiGPUs []v1.GPU) []hostdevice.HostDeviceMetaData
 	for _, dev := range vmiGPUs {
 		hostDevicesMetaData = append(hostDevicesMetaData, hostdevice.HostDeviceMetaData{
 			AliasPrefix:       AliasPrefix,
-			Name:              dev.Name,
+			Name:              hostdevice.GenerateEncodedAliasIfNeeded(dev.Name),
 			ResourceName:      dev.DeviceName,
 			VirtualGPUOptions: dev.VirtualGPUOptions,
 		})

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -20,7 +20,9 @@
 package hostdevice
 
 import (
+	"encoding/base32"
 	"fmt"
+	"regexp"
 	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -188,4 +190,12 @@ func createUSBHostDevice(device HostDeviceMetaData, usbAddress string) (*api.Hos
 			},
 		},
 	}, nil
+}
+
+func GenerateEncodedAliasIfNeeded(aliasName string) string {
+	matched := regexp.MustCompile("^[a-zA-Z0-9_-]+$").MatchString(aliasName)
+	if matched {
+		return aliasName
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(aliasName))
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -115,7 +115,7 @@ func createHostDevicesMetadata(ifaces []v1.Interface) []hostdevice.HostDeviceMet
 	for _, iface := range ifaces {
 		hostDevicesMetaData = append(hostDevicesMetaData, hostdevice.HostDeviceMetaData{
 			AliasPrefix:  deviceinfo.SRIOVAliasPrefix,
-			Name:         iface.Name,
+			Name:         hostdevice.GenerateEncodedAliasIfNeeded(iface.Name),
 			ResourceName: iface.Name,
 			DecorateHook: newDecorateHook(iface),
 		})

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -40,8 +40,9 @@ import (
 )
 
 const (
-	netname1 = "net1"
-	netname2 = "net2"
+	netname1       = "net1"
+	netname2       = "net2"
+	invalidNetname = "net1.dc.com"
 )
 
 var _ = Describe("SRIOV HostDevice", func() {
@@ -186,6 +187,25 @@ var _ = Describe("SRIOV HostDevice", func() {
 			guestPCIAddress1 := api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: "0x01", Slot: "0x01", Function: "0x0"}
 			expectHostDevice1 := api.HostDevice{
 				Alias:   newSRIOVAlias(netname1),
+				Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
+				Type:    api.HostDevicePCI,
+				Managed: "no",
+				Address: &guestPCIAddress1,
+			}
+			Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		})
+
+		It("creates 1 device that has invalid alias name", func() {
+			iface := newSRIOVInterface(invalidNetname)
+			iface.PciAddress = "0000:01:01.0"
+			pool := newPCIAddressPoolStub("0000:81:01.0", "0000:81:02.0")
+
+			devices, err := sriov.CreateHostDevicesFromIfacesAndPool([]v1.Interface{iface}, pool)
+
+			hostPCIAddress1 := api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
+			guestPCIAddress1 := api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: "0x01", Slot: "0x01", Function: "0x0"}
+			expectHostDevice1 := api.HostDevice{
+				Alias:   newSRIOVAlias(hostdevice.GenerateEncodedAliasIfNeeded(invalidNetname)),
 				Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
 				Type:    api.HostDevicePCI,
 				Managed: "no",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Users can define hostDevice / gpuDevice names with special characters such as `.` which is a valid string.

When the hostdevices section is converted to libvirt domain the `name` is used to generate `alias` for the associated device.

Libvirt places the following limitations on alias name

```
To help users identifying devices they care about, every device can have direct child alias element which then has name attribute where users can store identifier for the device. The identifier has to have "ua-" prefix and must be unique within the domain. Additionally, the identifier must consist only of the following characters: [a-zA-Z0-9_-]. Since 3.9.0
```

As a result if a special character is passed in `name` the domain crashes.

#### After this PR:
After this PR users can specific provide names with special characters

```
          gpus:
          - deviceName: nvidia.com/GRID_A100-1-10C
            name: abc.com
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
- Fixes https://github.com/kubevirt/kubevirt/issues/16043

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
Considered adding logic directly in the virtwrap api schema, to always generated encoded alias Names but that would have resulted wider ranging changes across a majority of test cases where generated domain is being compared or passed devices are being compared.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

