### PR TITLE
net, restart: RestartRequired if pod network attached to networkless VM

### DIFF
--- a/pkg/network/vmliveupdate/restart.go
+++ b/pkg/network/vmliveupdate/restart.go
@@ -49,6 +49,13 @@ func shouldIfacesChangeRequireRestart(desiredIfaces, currentIfaces []v1.Interfac
 }
 
 func shouldNetsChangeRequireRestart(desiredNets, currentNets []v1.Network) bool {
+	isPodNetworkInDesiredNets := vmispec.LookupPodNetwork(desiredNets) != nil
+	isPodNetworkInCurrentNets := vmispec.LookupPodNetwork(currentNets) != nil
+
+	if isPodNetworkInDesiredNets && !isPodNetworkInCurrentNets {
+		return true
+	}
+
 	desiredNetsByName := vmispec.IndexNetworkSpecByName(desiredNets)
 	currentNetsByName := vmispec.IndexNetworkSpecByName(currentNets)
 

--- a/pkg/network/vmliveupdate/restart_test.go
+++ b/pkg/network/vmliveupdate/restart_test.go
@@ -207,4 +207,17 @@ var _ = Describe("IsRestartRequired", func() {
 
 		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
 	})
+
+	It("should require restart when pod network is added to networkless VM", func() {
+		vmi := libvmi.New()
+
+		vm := libvmi.NewVirtualMachine(
+			libvmi.New(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			),
+		)
+
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Currently, adding a Pod Network to networkless VM (with autoattachPodInterface=false) does not add the RestartRequired flag. But without a restart the NIC will not be added to the VM.

This PR adds restartRequired flag when a pod network is attached to a networkless VM.

#### Before this PR:
#### After this PR:

### References
- Fixes  https://issues.redhat.com/browse/CNV-69394

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

