### PR TITLE
bugfix: prevent live migration between different vendors

### DIFF
--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -163,6 +163,8 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 				hyperVLabelPresent := false
 				hostCPUModelPresent := false
 				hostCPURequiredFeaturesPresent := false
+				archPresent := false
+				vendorPresent := false
 				for key := range node.Labels {
 					if strings.Contains(key, v1.CPUModelLabel) {
 						cpuModelLabelPresent = true
@@ -180,8 +182,16 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 						hostCPURequiredFeaturesPresent = true
 					}
 
+					if strings.Contains(key, k8sv1.LabelArchStable) {
+						archPresent = true
+					}
+
+					if strings.Contains(key, v1.CPUModelVendorLabel) {
+						vendorPresent = true
+					}
+
 					if cpuModelLabelPresent && cpuFeatureLabelPresent && hyperVLabelPresent && hostCPUModelPresent &&
-						hostCPURequiredFeaturesPresent {
+						hostCPURequiredFeaturesPresent && archPresent && vendorPresent {
 						break
 					}
 				}
@@ -192,6 +202,8 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 				Expect(hyperVLabelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "hyperV"))
 				Expect(hostCPUModelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu model"))
 				Expect(hostCPURequiredFeaturesPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu required features"))
+				Expect(archPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "arch"))
+				Expect(vendorPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "vendor"))
 			}
 		})
 


### PR DESCRIPTION
This commit adds a label selector to the launcher pod that records the vendor of the initial node, ensuring that VMs are not migrated to nodes with a different vendor.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

