### PR TITLE
Remove tests [test_id:3125] and [test_id:6964]

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1500,30 +1500,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(vmi.Status.Machine.Type).To(ContainSubstring("pc-i440"))
 		})
 
-		It("[test_id:3125]should allow creating VM without Machine defined", func() {
-			vmi := libvmifact.NewGuestless()
-			vmi.Spec.Domain.Machine = nil
-			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsTiny)
-			runningVMISpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
-		})
-
-		It("[test_id:6964]should allow creating VM defined with Machine with an empty Type", func() {
-			// This is needed to provide backward compatibility since our example VMIs used to be defined in this way
-			vmi := libvmi.New(
-				libvmi.WithMemoryRequest(enoughMemForSafeBiosEmulation),
-				withMachineType(""),
-			)
-
-			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsTiny)
-			runningVMISpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
-		})
-
 		It("[test_id:3126]should set machine type from kubevirt-config", Serial, func() {
 			kv := libkubevirt.GetCurrentKv(virtClient)
 			testEmulatedMachines := []string{"pc"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Removes redundant tests [test_id:3125] and [test_id:6964] from tests/vmi_configuration_test.go.

#### Before this PR:
The E2E/component suite included tests verifying:
creating a VM without Machine defined
creating a VM with Machine.Type set to an empty string

These scenarios duplicated logic already enforced and tested in the mutator/defaults layers, see:
https://github.com/kubevirt/kubevirt/blob/f292299a4db03d4161db741849303d4efc0732fd/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go#L178
https://github.com/kubevirt/kubevirt/blob/f292299a4db03d4161db741849303d4efc0732fd/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go#L208
https://github.com/kubevirt/kubevirt/blob/f292299a4db03d4161db741849303d4efc0732fd/pkg/util/openapi/openapi_test.go#L55

#### After this PR:
The two redundant tests are removed.

### References
jira-ticket: https://issues.redhat.com/browse/CNV-71961

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

