### PR TITLE
[release-1.7]  bugFix: Clean up old install strategy ConfigMaps before creating new one

### DIFF
--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -1061,6 +1061,12 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 	// add finalizer to prevent deletion of CR before KubeVirt was undeployed
 	util.AddFinalizer(kv)
 
+	//  delete old install strategies to ensure a clean re-creation
+	err = c.deleteAllOldInstallStrategies(config.GetKubeVirtVersion())
+	if err != nil {
+		return err
+	}
+
 	// once all the install strategies are loaded, garbage collect any
 	// install strategy jobs that were created.
 	err = c.garbageCollectInstallStrategyJobs()

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1822,6 +1822,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectKubeVirtUpdateStatusVersion(1, customConfig)
+			kvTestData.shouldExpectInstallStrategyDeletion()
 			kvTestData.controller.Execute()
 			kv = kvTestData.getLatestKubeVirt(kv)
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
@@ -2512,6 +2513,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectRbacBackupCreations()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()
 
@@ -2580,6 +2582,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectRbacBackupCreations()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()
 
@@ -2653,6 +2656,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectRbacBackupCreations()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()
 
@@ -3035,6 +3039,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 			kvTestData.fakeNamespaceModificationEvent()
 			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()
 
@@ -3112,6 +3117,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 			kvTestData.fakeNamespaceModificationEvent()
 			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()
 
@@ -3203,6 +3209,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()
 

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -353,7 +353,6 @@ func getMonitorNamespace(clientset k8coresv1.CoreV1Interface, config *operatorut
 }
 
 func DumpInstallStrategyToConfigMap(clientset kubecli.KubevirtClient, operatorNamespace string) error {
-
 	config, err := operatorutil.GetConfigFromEnv()
 	if err != nil {
 		return err
@@ -371,15 +370,7 @@ func DumpInstallStrategyToConfigMap(clientset kubecli.KubevirtClient, operatorNa
 
 	_, err = clientset.CoreV1().ConfigMaps(config.GetNamespace()).Create(context.Background(), configMap, metav1.CreateOptions{})
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			// force update if already exists
-			_, err = clientset.CoreV1().ConfigMaps(config.GetNamespace()).Update(context.Background(), configMap, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
+		return fmt.Errorf("failed to create new install strategy configmap: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/15005

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

