### PR TITLE
Provide guest agent state based on lifecycle events

### DIFF
--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Virt remote commands", func() {
 				})
 				client.Exec(testDomainName, testCommand, testArgs, testTimeoutSeconds)
 			})
-			It("calls cmdclient.GuestPing", func() {
+			It("calls cmdclient.IsAgentConnected", func() {
 				expectGuestPing().Times(1)
 				client.GuestPing(testDomainName, testTimeoutSeconds)
 			})

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -279,13 +279,12 @@ func incrementPollInterval(interval, maxInterval time.Duration) time.Duration {
 }
 
 type AgentPoller struct {
-	Connection     cli.Connection
-	VmiUID         types.UID
-	domainName     string
-	agentDone      chan struct{}
-	agentConnected bool
-	workers        []PollerWorker
-	agentStore     *AsyncAgentStore
+	Connection cli.Connection
+	VmiUID     types.UID
+	domainName string
+	agentDone  chan struct{}
+	workers    []PollerWorker
+	agentStore *AsyncAgentStore
 }
 
 // CreatePoller creates the new structure that holds guest agent pollers
@@ -301,11 +300,10 @@ func CreatePoller(
 	qemuAgentFSFreezeStatusInterval time.Duration,
 ) *AgentPoller {
 	return &AgentPoller{
-		Connection:     connection,
-		VmiUID:         vmiUID,
-		domainName:     domainName,
-		agentConnected: false,
-		agentStore:     store,
+		Connection: connection,
+		VmiUID:     vmiUID,
+		domainName: domainName,
+		agentStore: store,
 		workers: []PollerWorker{
 			// Polling for QEMU agent commands
 			{
@@ -384,7 +382,7 @@ func (p *AgentPoller) UpdateFromEvent(domainEvent *libvirt.DomainEventLifecycle,
 		if domainEvent.Event == libvirt.DOMAIN_EVENT_RESUMED {
 			// Only start poller on domain resume if agent is still connected
 			// This prevents starting the poller before agent is ready
-			if p.agentConnected {
+			if p.agentStore.IsAgentConnected() {
 				log.Log.Infof("Starting agent poller for %s due to domain resume (agent connected)", p.domainName)
 				p.Start()
 			}
@@ -393,14 +391,12 @@ func (p *AgentPoller) UpdateFromEvent(domainEvent *libvirt.DomainEventLifecycle,
 	case agentEvent != nil:
 		if agentEvent.State == libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_DISCONNECTED {
 			log.Log.Infof("Stopping agent poller for %s due to agent disconnect", p.domainName)
-			p.agentConnected = false
 			p.agentStore.Store(agentConnected, false)
 			p.Stop()
 			return
 		}
 		if agentEvent.State == libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_CONNECTED {
 			log.Log.Infof("Starting agent poller for %s due to agent connect", p.domainName)
-			p.agentConnected = true
 			p.agentStore.Store(agentConnected, true)
 			p.Start()
 			return

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -307,7 +307,7 @@ var _ = Describe("Qemu agent poller", func() {
 		It("should not start agent poller on domain resume event when agent is not connected", func() {
 			Expect(agentPoller.agentDone).To(BeNil())
 
-			Expect(agentPoller.agentConnected).To(BeFalse())
+			Expect(agentPoller.agentStore.IsAgentConnected()).To(BeFalse())
 
 			domainEvent := &libvirt.DomainEventLifecycle{
 				Event:  libvirt.DOMAIN_EVENT_RESUMED,
@@ -325,7 +325,7 @@ var _ = Describe("Qemu agent poller", func() {
 			}
 			agentPoller.UpdateFromEvent(nil, agentConnectEvent)
 			Expect(agentPoller.agentDone).ToNot(BeNil())
-			Expect(agentPoller.agentConnected).To(BeTrue())
+			Expect(agentPoller.agentStore.IsAgentConnected()).To(BeTrue())
 
 			agentDisconnectEvent := &libvirt.DomainEventAgentLifecycle{
 				State:  libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_DISCONNECTED,
@@ -334,12 +334,12 @@ var _ = Describe("Qemu agent poller", func() {
 			agentPoller.UpdateFromEvent(nil, agentDisconnectEvent)
 
 			Expect(agentPoller.agentDone).To(BeNil())
-			Expect(agentPoller.agentConnected).To(BeFalse())
+			Expect(agentPoller.agentStore.IsAgentConnected()).To(BeFalse())
 		})
 
 		It("should start agent poller on agent connect event", func() {
 			Expect(agentPoller.agentDone).To(BeNil())
-			Expect(agentPoller.agentConnected).To(BeFalse())
+			Expect(agentPoller.agentStore.IsAgentConnected()).To(BeFalse())
 
 			agentEvent := &libvirt.DomainEventAgentLifecycle{
 				State:  libvirt.CONNECT_DOMAIN_EVENT_AGENT_LIFECYCLE_STATE_CONNECTED,
@@ -348,7 +348,7 @@ var _ = Describe("Qemu agent poller", func() {
 			agentPoller.UpdateFromEvent(nil, agentEvent)
 
 			Expect(agentPoller.agentDone).ToNot(BeNil())
-			Expect(agentPoller.agentConnected).To(BeTrue())
+			Expect(agentPoller.agentStore.IsAgentConnected()).To(BeTrue())
 		})
 
 		It("should not start or stop agent poller on unrelated events", func() {

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -601,13 +601,15 @@ func (l *Launcher) Exec(ctx context.Context, request *cmdv1.ExecRequest) (*cmdv1
 	return resp, nil
 }
 
-func (l *Launcher) GuestPing(ctx context.Context, request *cmdv1.GuestPingRequest) (*cmdv1.GuestPingResponse, error) {
+func (l *Launcher) GuestPing(_ context.Context, _ *cmdv1.GuestPingRequest) (*cmdv1.GuestPingResponse, error) {
 	resp := &cmdv1.GuestPingResponse{
 		Response: &cmdv1.Response{
 			Success: true,
 		},
 	}
-	err := l.domainManager.GuestPing(request.DomainName)
+	// Qemu guest agent ping command is not used anymore, the guest agent connection state is
+	// determined based on the libvirt agent lifecycle events instead
+	err := l.domainManager.IsAgentConnected()
 	if err != nil {
 		resp.Response.Success = false
 		resp.Response.Message = err.Error()

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -263,20 +263,6 @@ func (mr *MockDomainManagerMockRecorder) GetUsers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsers", reflect.TypeOf((*MockDomainManager)(nil).GetUsers))
 }
 
-// GuestPing mocks base method.
-func (m *MockDomainManager) GuestPing(arg0 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GuestPing", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GuestPing indicates an expected call of GuestPing.
-func (mr *MockDomainManagerMockRecorder) GuestPing(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GuestPing", reflect.TypeOf((*MockDomainManager)(nil).GuestPing), arg0)
-}
-
 // HotplugHostDevices mocks base method.
 func (m *MockDomainManager) HotplugHostDevices(vmi *v1.VirtualMachineInstance) error {
 	m.ctrl.T.Helper()
@@ -317,6 +303,20 @@ func (m *MockDomainManager) InterfacesStatus() []api.InterfaceStatus {
 func (mr *MockDomainManagerMockRecorder) InterfacesStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InterfacesStatus", reflect.TypeOf((*MockDomainManager)(nil).InterfacesStatus))
+}
+
+// IsAgentConnected mocks base method.
+func (m *MockDomainManager) IsAgentConnected() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAgentConnected")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsAgentConnected indicates an expected call of IsAgentConnected.
+func (mr *MockDomainManagerMockRecorder) IsAgentConnected() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAgentConnected", reflect.TypeOf((*MockDomainManager)(nil).IsAgentConnected))
 }
 
 // KillVMI mocks base method.

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -154,7 +154,7 @@ type DomainManager interface {
 	InterfacesStatus() []api.InterfaceStatus
 	GetGuestOSInfo() *api.GuestOSInfo
 	Exec(string, string, []string, int32) (string, error)
-	GuestPing(string) error
+	IsAgentConnected() error
 	MemoryDump(vmi *v1.VirtualMachineInstance, dumpPath string) error
 	GetQemuVersion() (string, error)
 	UpdateVCPUs(vmi *v1.VirtualMachineInstance, options *cmdv1.VirtualMachineOptions) error
@@ -634,10 +634,11 @@ func (l *LibvirtDomainManager) Exec(domainName, command string, args []string, t
 	return agent.GuestExec(l.virConn, domainName, command, args, timeoutSeconds)
 }
 
-func (l *LibvirtDomainManager) GuestPing(domainName string) error {
-	pingCmd := `{"execute":"guest-ping"}`
-	_, err := l.virConn.QemuAgentCommand(pingCmd, domainName)
-	return err
+func (l *LibvirtDomainManager) IsAgentConnected() error {
+	if !l.agentData.IsAgentConnected() {
+		return errors.New("agent not connected")
+	}
+	return nil
 }
 
 func getVMIEphemeralDisksTotalSize(ephemeralDiskDir string) *resource.Quantity {


### PR DESCRIPTION
This PR gets rid of the guest agent ping command execution in virtwrap manager and instead returns the state of the guest agent from the agent poller.
The agent poller stores the state of guest agent based on the guest agent lifecycle events received.
The guest ping can be used as a readiness probe for a vmi if configured by the user.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### References
https://issues.redhat.com/browse/CNV-70177

### Special notes for your reviewer

Roses are red, commits are neat,
Thanks for the review, your feedback’s elite. :)

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

