### PR TITLE
tests/storage/memorydump: restore pod deletion and remove redundant test

### DIFF
--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -99,6 +99,12 @@ var _ = Describe(SIG("Memory dump", func() {
 		return vm
 	}
 
+	deletePod := func(pod *k8sv1.Pod) {
+		Eventually(func() error {
+			return virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+		}, 180*time.Second, time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
+	}
+
 	verifyMemoryDumpNotOnVMI := func(vm *v1.VirtualMachine, memoryDumpPVC string) {
 		Eventually(func() error {
 			updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
@@ -228,6 +234,8 @@ var _ = Describe(SIG("Memory dump", func() {
 		} else {
 			Expect(lsOutput).ToNot(Equal(previousOutput))
 		}
+
+		deletePod(executorPod)
 
 		return lsOutput
 	}
@@ -366,16 +374,6 @@ var _ = Describe(SIG("Memory dump", func() {
 			// verify memory dump didnt reappeared in the VMI
 			verifyMemoryDumpNotOnVMI(vm, memoryDumpPVCName)
 			verifyMemoryDumpOutput(memoryDumpPVC, previousOutput, true)
-		})
-
-		It("[test_id:8501]Run memory dump with pvc too small should fail", func() {
-			By("Trying to get memory dump with small pvc")
-			memoryDumpPVC2 = libstorage.CreateFSPVC(memoryDumpPVCName2, testsuite.GetTestNamespace(vm), "200Mi", libstorage.WithStorageProfile())
-			Eventually(func() error {
-				return virtClient.VirtualMachine(vm.Namespace).MemoryDump(context.Background(), vm.Name, &v1.VirtualMachineMemoryDumpRequest{
-					ClaimName: memoryDumpPVC2.Name,
-				})
-			}, 10*time.Second, 2*time.Second).Should(MatchError(ContainSubstring("should be bigger then")))
 		})
 
 		It("[test_id:9341]Should be able to remove memory dump while memory dump is stuck", func() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Restore the deletePod function that was removed in commit 8284786. Pod deletion is essential for tests running against storage provisioners that don't support multiattach, as multiple pods cannot be attached to the same PVC simultaneously.

Also remove the "[test_id:8501]Run memory dump with pvc too small should fail" test case, as this scenario is already covered by unit tests.

### References
Fixes: https://issues.redhat.com/browse/CNV-72172
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Special notes for your reviewer
@arnongilboa 
<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

