### PR TITLE
Replace host-model and named-model checks with a single CPU model support function

### DIFF
--- a/pkg/virt-handler/node-labeller/amd64.go
+++ b/pkg/virt-handler/node-labeller/amd64.go
@@ -30,11 +30,7 @@ func (archLabellerAMD64) hasHostSupportedFeatures() bool {
 	return true
 }
 
-func (archLabellerAMD64) supportsHostModel() bool {
-	return true
-}
-
-func (archLabellerAMD64) supportsNamedModels() bool {
+func (archLabellerAMD64) supportsCPUModels() bool {
 	return true
 }
 

--- a/pkg/virt-handler/node-labeller/arch_labeller.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller.go
@@ -38,8 +38,7 @@ type archLabeller interface {
 	defaultVendor() string
 	requirePolicy(policy string) bool
 	hasHostSupportedFeatures() bool
-	supportsHostModel() bool
-	supportsNamedModels() bool
+	supportsCPUModels() bool
 	arch() string
 }
 
@@ -70,11 +69,7 @@ func (defaultArchLabeller) hasHostSupportedFeatures() bool {
 	return false
 }
 
-func (defaultArchLabeller) supportsHostModel() bool {
-	return false
-}
-
-func (defaultArchLabeller) supportsNamedModels() bool {
+func (defaultArchLabeller) supportsCPUModels() bool {
 	return false
 }
 

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -90,7 +90,7 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 	knownModels := make([]string, 0)
 	for _, mode := range hostDomCapabilities.CPU.Mode {
 		if mode.Name == v1.CPUModeHostModel {
-			if !n.arch.supportsHostModel() {
+			if !n.arch.supportsCPUModels() {
 				log.Log.Warningf("host-model cpu mode is not supported for %s architecture", n.arch.arch())
 				continue
 			}

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -245,15 +245,6 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
 		}
 	}
 
-	if n.arch.supportsNamedModels() {
-		for _, value := range n.getSupportedCpuModels(obsoleteCPUsx86) {
-			newLabels[kubevirtv1.CPUModelLabel+value] = "true"
-		}
-		for _, value := range n.getKnownCpuModels(obsoleteCPUsx86) {
-			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
-		}
-	}
-
 	for _, machine := range n.supportedMachines {
 		labelKey := kubevirtv1.SupportedMachineTypeLabel + machine.Name
 		newLabels[labelKey] = "true"
@@ -268,7 +259,7 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
 		newLabels[kubevirtv1.CPUTimerLabel+"tsc-scalable"] = fmt.Sprintf("%t", n.cpuCounter.Scaling == "yes")
 	}
 
-	if n.arch.supportsHostModel() {
+	if n.arch.supportsCPUModels() {
 		if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; hostModelObsolete {
 			newLabels[kubevirtv1.NodeHostModelIsObsoleteLabel] = "true"
 			err := n.alertIfHostModelIsObsolete(node, hostCpuModel.Name, obsoleteCPUsx86)
@@ -283,6 +274,13 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
 
 		newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
 		newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
+
+		for _, value := range n.getSupportedCpuModels(obsoleteCPUsx86) {
+			newLabels[kubevirtv1.CPUModelLabel+value] = "true"
+		}
+		for _, value := range n.getKnownCpuModels(obsoleteCPUsx86) {
+			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+		}
 	}
 
 	capable, err := isNodeRealtimeCapable()

--- a/pkg/virt-handler/node-labeller/s390x.go
+++ b/pkg/virt-handler/node-labeller/s390x.go
@@ -40,11 +40,7 @@ func (archLabellerS390X) hasHostSupportedFeatures() bool {
 	return true
 }
 
-func (archLabellerS390X) supportsHostModel() bool {
-	return true
-}
-
-func (archLabellerS390X) supportsNamedModels() bool {
+func (archLabellerS390X) supportsCPUModels() bool {
 	return true
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Replace supportsHostModel() and supportsNamedModels() with supportsCPUModels()

Both functions always returned the same result based on the architecture.
They are now replaced with a single function called supportsCPUModels() to simplify
the archLabeller interface and remove redundant checks.

/kind cleanup

/hold
Waiting for https://github.com/kubevirt/kubevirt/pull/15694 to get merged


FYI @xpivarc 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

