### PR TITLE
virt-launcher-monitor: Move logs about reaped processes to debug

### DIFF
--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -130,14 +130,14 @@ func RunAndMonitor(containerDiskDir, uid string) (int, error) {
 						log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)
 					}
 					if wpid == 0 {
-						log.Log.Infof("No more processes to be reaped")
+						log.Log.V(4).Infof("No more processes to be reaped")
 						break
 					}
 					if wpid == cmd.Process.Pid {
 						log.Log.Infof("Reaped Launcher main pid")
 						exitStatus <- wstatus.ExitStatus()
 					}
-					log.Log.Infof("Reaped pid %d with status %d", wpid, int(wstatus))
+					log.Log.V(4).Infof("Reaped pid %d with status %d", wpid, int(wstatus))
 				}
 
 			default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In virt-launcher pod we have logs like
```
{"component":"virt-launcher-monitor","level":"info","msg":"Reaped pid 64
 with status 0","pos":"virt-launcher-monitor.go:140",
 "timestamp":"2025-11-07T11:48:49.151559Z"}
{"component":"virt-launcher-monitor","level":"info","msg":"No more 
processes to be reaped","pos":"virt-launcher-monitor.go:133",
"timestamp":"2025-11-07T11:48:49.151674Z"}
```
which may not be of relevance to the user wrt daily operations.
This PR moves it to debug level.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

