### PR TITLE
api(instancetype): Fix typos in documentation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19207,7 +19207,7 @@
       "$ref": "#/definitions/v1.ClockOffset"
      },
      "preferredTimer": {
-      "description": "Timer specifies whih timers are attached to the vmi.",
+      "description": "Timer specifies which timers are attached to the vmi.",
       "$ref": "#/definitions/v1.Timer"
      }
     }
@@ -19753,7 +19753,7 @@
       "type": "boolean"
      },
      "preferredUseBiosSerial": {
-      "description": "PreferredUseBiosSerial optionally transmitts BIOS output over the serial.\n\nRequires PreferredUseBios to be enabled.",
+      "description": "PreferredUseBiosSerial optionally transmits BIOS output over the serial.\n\nRequires PreferredUseBios to be enabled.",
       "type": "boolean"
      },
      "preferredUseEfi": {
@@ -21021,7 +21021,7 @@
       "format": "int64"
      },
      "preferredArchitecture": {
-      "description": "PreferredArchitecture defines a prefeerred architecture for the VirtualMachine",
+      "description": "PreferredArchitecture defines a preferred architecture for the VirtualMachine",
       "type": "string"
      },
      "preferredSubdomain": {
@@ -21034,11 +21034,11 @@
       "format": "int64"
      },
      "requirements": {
-      "description": "Requirements defines the minium amount of instance type defined resources required by a set of preferences",
+      "description": "Requirements defines the minimum amount of instance type defined resources required by a set of preferences",
       "$ref": "#/definitions/v1beta1.PreferenceRequirements"
      },
      "volumes": {
-      "description": "Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstace DomainSpec",
+      "description": "Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstance DomainSpec",
       "$ref": "#/definitions/v1beta1.VolumePreferences"
      }
     }
@@ -21457,7 +21457,7 @@
     "type": "object",
     "properties": {
      "preferredStorageClassName": {
-      "description": "PreffereedStorageClassName optionally defines the preferred storageClass",
+      "description": "PreferredStorageClassName optionally defines the preferred storageClass",
       "type": "string"
      }
     }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9395,7 +9395,7 @@ var CRDsValidation map[string]string = map[string]string{
                   type: object
               type: object
             preferredTimer:
-              description: Timer specifies whih timers are attached to the vmi.
+              description: Timer specifies which timers are attached to the vmi.
               properties:
                 hpet:
                   description: HPET (High Precision Event Timer) - multiple timers
@@ -9931,7 +9931,7 @@ var CRDsValidation map[string]string = map[string]string{
               type: boolean
             preferredUseBiosSerial:
               description: |-
-                PreferredUseBiosSerial optionally transmitts BIOS output over the serial.
+                PreferredUseBiosSerial optionally transmits BIOS output over the serial.
 
                 Requires PreferredUseBios to be enabled.
               type: boolean
@@ -9965,7 +9965,7 @@ var CRDsValidation map[string]string = map[string]string{
           format: int32
           type: integer
         preferredArchitecture:
-          description: PreferredArchitecture defines a prefeerred architecture for
+          description: PreferredArchitecture defines a preferred architecture for
             the VirtualMachine
           type: string
         preferredSubdomain:
@@ -9977,7 +9977,7 @@ var CRDsValidation map[string]string = map[string]string{
           format: int64
           type: integer
         requirements:
-          description: Requirements defines the minium amount of instance type defined
+          description: Requirements defines the minimum amount of instance type defined
             resources required by a set of preferences
           properties:
             architecture:
@@ -10009,10 +10009,10 @@ var CRDsValidation map[string]string = map[string]string{
           type: object
         volumes:
           description: Volumes optionally defines preferences associated with the
-            Volumes attribute of a VirtualMachineInstace DomainSpec
+            Volumes attribute of a VirtualMachineInstance DomainSpec
           properties:
             preferredStorageClassName:
-              description: PreffereedStorageClassName optionally defines the preferred
+              description: PreferredStorageClassName optionally defines the preferred
                 storageClass
               type: string
           type: object
@@ -25052,7 +25052,7 @@ var CRDsValidation map[string]string = map[string]string{
                   type: object
               type: object
             preferredTimer:
-              description: Timer specifies whih timers are attached to the vmi.
+              description: Timer specifies which timers are attached to the vmi.
               properties:
                 hpet:
                   description: HPET (High Precision Event Timer) - multiple timers
@@ -25588,7 +25588,7 @@ var CRDsValidation map[string]string = map[string]string{
               type: boolean
             preferredUseBiosSerial:
               description: |-
-                PreferredUseBiosSerial optionally transmitts BIOS output over the serial.
+                PreferredUseBiosSerial optionally transmits BIOS output over the serial.
 
                 Requires PreferredUseBios to be enabled.
               type: boolean
@@ -25622,7 +25622,7 @@ var CRDsValidation map[string]string = map[string]string{
           format: int32
           type: integer
         preferredArchitecture:
-          description: PreferredArchitecture defines a prefeerred architecture for
+          description: PreferredArchitecture defines a preferred architecture for
             the VirtualMachine
           type: string
         preferredSubdomain:
@@ -25634,7 +25634,7 @@ var CRDsValidation map[string]string = map[string]string{
           format: int64
           type: integer
         requirements:
-          description: Requirements defines the minium amount of instance type defined
+          description: Requirements defines the minimum amount of instance type defined
             resources required by a set of preferences
           properties:
             architecture:
@@ -25666,10 +25666,10 @@ var CRDsValidation map[string]string = map[string]string{
           type: object
         volumes:
           description: Volumes optionally defines preferences associated with the
-            Volumes attribute of a VirtualMachineInstace DomainSpec
+            Volumes attribute of a VirtualMachineInstance DomainSpec
           properties:
             preferredStorageClassName:
-              description: PreffereedStorageClassName optionally defines the preferred
+              description: PreferredStorageClassName optionally defines the preferred
                 storageClass
               type: string
           type: object

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -273,7 +273,7 @@ type VirtualMachinePreferenceSpec struct {
 	//+optional
 	Machine *MachinePreferences `json:"machine,omitempty"`
 
-	// Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstace DomainSpec
+	// Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstance DomainSpec
 	//
 	//+optional
 	Volumes *VolumePreferences `json:"volumes,omitempty"`
@@ -288,7 +288,7 @@ type VirtualMachinePreferenceSpec struct {
 	//+optional
 	PreferredTerminationGracePeriodSeconds *int64 `json:"preferredTerminationGracePeriodSeconds,omitempty"`
 
-	// Requirements defines the minium amount of instance type defined resources required by a set of preferences
+	// Requirements defines the minimum amount of instance type defined resources required by a set of preferences
 	//
 	//+optional
 	Requirements *PreferenceRequirements `json:"requirements,omitempty"`
@@ -303,7 +303,7 @@ type VirtualMachinePreferenceSpec struct {
 	//+optional
 	PreferSpreadSocketToCoreRatio uint32 `json:"preferSpreadSocketToCoreRatio,omitempty"`
 
-	// PreferredArchitecture defines a prefeerred architecture for the VirtualMachine
+	// PreferredArchitecture defines a preferred architecture for the VirtualMachine
 	//
 	//+optional
 	PreferredArchitecture *string `json:"preferredArchitecture,omitempty"`
@@ -311,7 +311,7 @@ type VirtualMachinePreferenceSpec struct {
 
 type VolumePreferences struct {
 
-	// PreffereedStorageClassName optionally defines the preferred storageClass
+	// PreferredStorageClassName optionally defines the preferred storageClass
 	//
 	//+optional
 	PreferredStorageClassName string `json:"preferredStorageClassName,omitempty"`
@@ -577,7 +577,7 @@ type FirmwarePreferences struct {
 	// +optional
 	PreferredUseBios *bool `json:"preferredUseBios,omitempty"`
 
-	// PreferredUseBiosSerial optionally transmitts BIOS output over the serial.
+	// PreferredUseBiosSerial optionally transmits BIOS output over the serial.
 	//
 	// Requires PreferredUseBios to be enabled.
 	//
@@ -621,7 +621,7 @@ type ClockPreferences struct {
 	// +optional
 	PreferredClockOffset *v1.ClockOffset `json:"preferredClockOffset,omitempty"`
 
-	// Timer specifies whih timers are attached to the vmi.
+	// Timer specifies which timers are attached to the vmi.
 	//
 	// +optional
 	PreferredTimer *v1.Timer `json:"preferredTimer,omitempty"`

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -104,19 +104,19 @@ func (VirtualMachinePreferenceSpec) SwaggerDoc() map[string]string {
 		"features":                               "Features optionally defines preferences associated with the Features attribute of a VirtualMachineInstance DomainSpec\n\n+optional",
 		"firmware":                               "Firmware optionally defines preferences associated with the Firmware attribute of a VirtualMachineInstance DomainSpec\n\n+optional",
 		"machine":                                "Machine optionally defines preferences associated with the Machine attribute of a VirtualMachineInstance DomainSpec\n\n+optional",
-		"volumes":                                "Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstace DomainSpec\n\n+optional",
+		"volumes":                                "Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstance DomainSpec\n\n+optional",
 		"preferredSubdomain":                     "Subdomain of the VirtualMachineInstance\n\n+optional",
 		"preferredTerminationGracePeriodSeconds": "Grace period observed after signalling a VirtualMachineInstance to stop after which the VirtualMachineInstance is force terminated.\n\n+optional",
-		"requirements":                           "Requirements defines the minium amount of instance type defined resources required by a set of preferences\n\n+optional",
+		"requirements":                           "Requirements defines the minimum amount of instance type defined resources required by a set of preferences\n\n+optional",
 		"annotations":                            "Optionally defines preferred Annotations to be applied to the VirtualMachineInstance\n\n+optional",
 		"preferSpreadSocketToCoreRatio":          "PreferSpreadSocketToCoreRatio defines the ratio to spread vCPUs between cores and sockets, it defaults to 2.\n\n+optional",
-		"preferredArchitecture":                  "PreferredArchitecture defines a prefeerred architecture for the VirtualMachine\n\n+optional",
+		"preferredArchitecture":                  "PreferredArchitecture defines a preferred architecture for the VirtualMachine\n\n+optional",
 	}
 }
 
 func (VolumePreferences) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"preferredStorageClassName": "PreffereedStorageClassName optionally defines the preferred storageClass\n\n+optional",
+		"preferredStorageClassName": "PreferredStorageClassName optionally defines the preferred storageClass\n\n+optional",
 	}
 }
 
@@ -183,7 +183,7 @@ func (FirmwarePreferences) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                       "FirmwarePreferences contains various optional defaults for Firmware.",
 		"preferredUseBios":       "PreferredUseBios optionally enables BIOS\n\n+optional",
-		"preferredUseBiosSerial": "PreferredUseBiosSerial optionally transmitts BIOS output over the serial.\n\nRequires PreferredUseBios to be enabled.\n\n+optional",
+		"preferredUseBiosSerial": "PreferredUseBiosSerial optionally transmits BIOS output over the serial.\n\nRequires PreferredUseBios to be enabled.\n\n+optional",
 		"preferredUseEfi":        "PreferredUseEfi optionally enables EFI\n\n+optional\nDeprecated: Will be removed with v1beta2 or v1",
 		"preferredUseSecureBoot": "PreferredUseSecureBoot optionally enables SecureBoot and the OVMF roms will be swapped for SecureBoot-enabled ones.\n\nRequires PreferredUseEfi and PreferredSmm to be enabled.\n\n+optional\nDeprecated: Will be removed with v1beta2 or v1",
 		"preferredEfi":           "PreferredEfi optionally enables EFI\n\n+optional",
@@ -201,7 +201,7 @@ func (ClockPreferences) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                     "ClockPreferences contains various optional defaults for Clock.",
 		"preferredClockOffset": "ClockOffset allows specifying the UTC offset or the timezone of the guest clock.\n\n+optional",
-		"preferredTimer":       "Timer specifies whih timers are attached to the vmi.\n\n+optional",
+		"preferredTimer":       "Timer specifies which timers are attached to the vmi.\n\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -30082,7 +30082,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_ClockPreferences(ref common.Refe
 					},
 					"preferredTimer": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Timer specifies whih timers are attached to the vmi.",
+							Description: "Timer specifies which timers are attached to the vmi.",
 							Ref:         ref("kubevirt.io/api/core/v1.Timer"),
 						},
 					},
@@ -30346,7 +30346,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_FirmwarePreferences(ref common.R
 					},
 					"preferredUseBiosSerial": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredUseBiosSerial optionally transmitts BIOS output over the serial.\n\nRequires PreferredUseBios to be enabled.",
+							Description: "PreferredUseBiosSerial optionally transmits BIOS output over the serial.\n\nRequires PreferredUseBios to be enabled.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -31069,7 +31069,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_VirtualMachinePreferenceSpec(ref
 					},
 					"volumes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstace DomainSpec",
+							Description: "Volumes optionally defines preferences associated with the Volumes attribute of a VirtualMachineInstance DomainSpec",
 							Ref:         ref("kubevirt.io/api/instancetype/v1beta1.VolumePreferences"),
 						},
 					},
@@ -31089,7 +31089,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_VirtualMachinePreferenceSpec(ref
 					},
 					"requirements": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Requirements defines the minium amount of instance type defined resources required by a set of preferences",
+							Description: "Requirements defines the minimum amount of instance type defined resources required by a set of preferences",
 							Ref:         ref("kubevirt.io/api/instancetype/v1beta1.PreferenceRequirements"),
 						},
 					},
@@ -31118,7 +31118,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_VirtualMachinePreferenceSpec(ref
 					},
 					"preferredArchitecture": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredArchitecture defines a prefeerred architecture for the VirtualMachine",
+							Description: "PreferredArchitecture defines a preferred architecture for the VirtualMachine",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -31139,7 +31139,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_VolumePreferences(ref common.Ref
 				Properties: map[string]spec.Schema{
 					"preferredStorageClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreffereedStorageClassName optionally defines the preferred storageClass",
+							Description: "PreferredStorageClassName optionally defines the preferred storageClass",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
### What this PR does

Corrects several typos in the instancetype.kubevirt.io/v1beta1 API comments:

- VirtualMachineInstace → VirtualMachineInstance
- minium → minimum
- prefeerred → preferred
- PreffereedStorageClassName → PreferredStorageClassName
- transmitts → transmits
- whih → which

These are documentation-only changes with no API impact.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Identified using the [openshift@ai-helpers](https://github.com/openshift-eng/ai-helpers/blob/main/PLUGINS.md#openshift-plugin) plugin for Claude.

https://github.com/lyarwood/kubevirt/blob/instancetype-crd-review/crd-review-report.md

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

