### PR TITLE
api(instancetype): Add validation markers to API

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9146,6 +9146,7 @@ var CRDsValidation map[string]string = map[string]string{
 
                 The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.
               format: int32
+              minimum: 1
               type: integer
             isolateEmulatorThread:
               description: |-
@@ -9156,6 +9157,7 @@ var CRDsValidation map[string]string = map[string]string{
               description: MaxSockets specifies the maximum amount of sockets that
                 can be hotplugged
               format: int32
+              minimum: 1
               type: integer
             model:
               description: |-
@@ -9538,6 +9540,17 @@ var CRDsValidation map[string]string = map[string]string{
             preferredCPUTopology:
               description: PreferredCPUTopology optionally defines the preferred guest
                 visible CPU topology, defaults to PreferSockets.
+              enum:
+              - preferCores
+              - preferSockets
+              - preferThreads
+              - preferSpread
+              - preferAny
+              - cores
+              - sockets
+              - threads
+              - spread
+              - any
               type: string
             spreadOptions:
               properties:
@@ -9545,6 +9558,10 @@ var CRDsValidation map[string]string = map[string]string{
                   description: |-
                     Across optionally defines how to spread vCPUs across the guest visible topology.
                     Default: SocketsCores
+                  enum:
+                  - SocketsCoresThreads
+                  - SocketsCores
+                  - CoresThreads
                   type: string
                 ratio:
                   description: |-
@@ -9556,6 +9573,7 @@ var CRDsValidation map[string]string = map[string]string{
 
                     Default: 2
                   format: int32
+                  minimum: 1
                   type: integer
               type: object
           type: object
@@ -20178,6 +20196,7 @@ var CRDsValidation map[string]string = map[string]string{
 
                 The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.
               format: int32
+              minimum: 1
               type: integer
             isolateEmulatorThread:
               description: |-
@@ -20188,6 +20207,7 @@ var CRDsValidation map[string]string = map[string]string{
               description: MaxSockets specifies the maximum amount of sockets that
                 can be hotplugged
               format: int32
+              minimum: 1
               type: integer
             model:
               description: |-
@@ -25312,6 +25332,17 @@ var CRDsValidation map[string]string = map[string]string{
             preferredCPUTopology:
               description: PreferredCPUTopology optionally defines the preferred guest
                 visible CPU topology, defaults to PreferSockets.
+              enum:
+              - preferCores
+              - preferSockets
+              - preferThreads
+              - preferSpread
+              - preferAny
+              - cores
+              - sockets
+              - threads
+              - spread
+              - any
               type: string
             spreadOptions:
               properties:
@@ -25319,6 +25350,10 @@ var CRDsValidation map[string]string = map[string]string{
                   description: |-
                     Across optionally defines how to spread vCPUs across the guest visible topology.
                     Default: SocketsCores
+                  enum:
+                  - SocketsCoresThreads
+                  - SocketsCores
+                  - CoresThreads
                   type: string
                 ratio:
                   description: |-
@@ -25330,6 +25365,7 @@ var CRDsValidation map[string]string = map[string]string{
 
                     Default: 2
                   format: int32
+                  minimum: 1
                   type: integer
               type: object
           type: object

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -135,6 +135,7 @@ type CPUInstancetype struct {
 	// Required number of vCPUs to expose to the guest.
 	//
 	// The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.
+	// +kubebuilder:validation:Minimum=1
 	Guest uint32 `json:"guest"`
 
 	// Model specifies the CPU model inside the VMI.
@@ -164,6 +165,7 @@ type CPUInstancetype struct {
 	Realtime *v1.Realtime `json:"realtime,omitempty"`
 
 	// MaxSockets specifies the maximum amount of sockets that can be hotplugged
+	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MaxSockets *uint32 `json:"maxSockets,omitempty"`
 }
@@ -362,6 +364,7 @@ type CPUPreferences struct {
 	// PreferredCPUTopology optionally defines the preferred guest visible CPU topology, defaults to PreferSockets.
 	//
 	//+optional
+	// +kubebuilder:validation:Enum=preferCores;preferSockets;preferThreads;preferSpread;preferAny;cores;sockets;threads;spread;any
 	PreferredCPUTopology *PreferredCPUTopology `json:"preferredCPUTopology,omitempty"`
 
 	//
@@ -392,6 +395,7 @@ type SpreadOptions struct {
 	// Default: SocketsCores
 	//
 	//+optional
+	// +kubebuilder:validation:Enum=SocketsCoresThreads;SocketsCores;CoresThreads
 	Across *SpreadAcross `json:"across,omitempty"`
 
 	// Ratio optionally defines the ratio to spread vCPUs across the guest visible topology:
@@ -403,6 +407,7 @@ type SpreadOptions struct {
 	// Default: 2
 	//
 	//+optional
+	// +kubebuilder:validation:Minimum=1
 	Ratio *uint32 `json:"ratio,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -47,13 +47,13 @@ func (VirtualMachineInstancetypeSpec) SwaggerDoc() map[string]string {
 func (CPUInstancetype) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                      "CPUInstancetype contains the CPU related configuration of a given VirtualMachineInstancetypeSpec.\n\nGuest is a required attribute and defines the number of vCPUs to be exposed to the guest by the instancetype.",
-		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
+		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.\n+kubebuilder:validation:Minimum=1",
 		"model":                 "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map.\nIt is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nDefaults to host-model.\n+optional",
 		"dedicatedCPUPlacement": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node\nwith enough dedicated pCPUs and pin the vCPUs to it.\n+optional",
 		"numa":                  "NUMA allows specifying settings for the guest NUMA topology\n+optional",
 		"isolateEmulatorThread": "IsolateEmulatorThread requests one more dedicated pCPU to be allocated for the VMI to place\nthe emulator thread on it.\n+optional",
 		"realtime":              "Realtime instructs the virt-launcher to tune the VMI for lower latency, optional for real time workloads\n+optional",
-		"maxSockets":            "MaxSockets specifies the maximum amount of sockets that can be hotplugged\n+optional",
+		"maxSockets":            "MaxSockets specifies the maximum amount of sockets that can be hotplugged\n+kubebuilder:validation:Minimum=1\n+optional",
 	}
 }
 
@@ -123,7 +123,7 @@ func (VolumePreferences) SwaggerDoc() map[string]string {
 func (CPUPreferences) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                     "CPUPreferences contains various optional CPU preferences.",
-		"preferredCPUTopology": "PreferredCPUTopology optionally defines the preferred guest visible CPU topology, defaults to PreferSockets.\n\n+optional",
+		"preferredCPUTopology": "PreferredCPUTopology optionally defines the preferred guest visible CPU topology, defaults to PreferSockets.\n\n+optional\n+kubebuilder:validation:Enum=preferCores;preferSockets;preferThreads;preferSpread;preferAny;cores;sockets;threads;spread;any",
 		"spreadOptions":        "+optional",
 		"preferredCPUFeatures": "PreferredCPUFeatures optionally defines a slice of preferred CPU features.\n\n+optional",
 	}
@@ -131,8 +131,8 @@ func (CPUPreferences) SwaggerDoc() map[string]string {
 
 func (SpreadOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"across": "Across optionally defines how to spread vCPUs across the guest visible topology.\nDefault: SocketsCores\n\n+optional",
-		"ratio":  "Ratio optionally defines the ratio to spread vCPUs across the guest visible topology:\n\nCoresThreads        - 1:2   - Controls the ratio of cores to threads. Only a ratio of 2 is currently accepted.\nSocketsCores        - 1:N   - Controls the ratio of socket to cores.\nSocketsCoresThreads - 1:N:2 - Controls the ratio of socket to cores. Each core providing 2 threads.\n\nDefault: 2\n\n+optional",
+		"across": "Across optionally defines how to spread vCPUs across the guest visible topology.\nDefault: SocketsCores\n\n+optional\n+kubebuilder:validation:Enum=SocketsCoresThreads;SocketsCores;CoresThreads",
+		"ratio":  "Ratio optionally defines the ratio to spread vCPUs across the guest visible topology:\n\nCoresThreads        - 1:2   - Controls the ratio of cores to threads. Only a ratio of 2 is currently accepted.\nSocketsCores        - 1:N   - Controls the ratio of socket to cores.\nSocketsCoresThreads - 1:N:2 - Controls the ratio of socket to cores. Each core providing 2 threads.\n\nDefault: 2\n\n+optional\n+kubebuilder:validation:Minimum=1",
 	}
 }
 

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -1121,6 +1121,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "instancetype-",
 					},
 					Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU: instancetypev1beta1.CPUInstancetype{
+							Guest: uint32(1),
+						},
 						Memory: instancetypev1beta1.MemoryInstancetype{
 							Guest: resource.MustParse("2Gi"),
 						},
@@ -1450,6 +1453,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "instancetype-",
 					},
 					Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU: instancetypev1beta1.CPUInstancetype{
+							Guest: uint32(1),
+						},
 						Memory: instancetypev1beta1.MemoryInstancetype{
 							Guest: resource.MustParse("1Gi"),
 						},


### PR DESCRIPTION
### What this PR does

Add kubebuilder validation markers to improve API validation for the instancetype v1beta1 resources:

- Add Minimum=1 validation for Guest CPU count field
- Add Minimum=1 validation for MaxSockets field
- Add Enum validation for PreferredCPUTopology field
- Add Enum validation for SpreadAcross field
- Add Minimum=1 validation for Ratio field

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Identified using the [openshift@ai-helpers](https://github.com/openshift-eng/ai-helpers/blob/main/PLUGINS.md#openshift-plugin) plugin for Claude.

https://github.com/lyarwood/kubevirt/blob/instancetype-crd-review/crd-review-report.md

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

