### PR TITLE
build: avoid man pages and pip cache during image build - hack/builder/Dockerfile

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -113,7 +113,7 @@ RUN set -x && \
     go install -v mvdan.cc/gofumpt@v0.8.0 && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOROOT)"/bin $GOLANGCI_LINT_VERSION
 
-RUN pip3 install --upgrade operator-courier==${OPERATOR_COURIER_VERSION}
+RUN pip3 install --no-cache-dir --upgrade operator-courier==${OPERATOR_COURIER_VERSION}
 
 RUN set -x && \
     wget https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${SONOBUOY_ARCH}.tar.gz && \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -13,9 +13,9 @@ ENV GOLANGCI_LINT_VERSION=v2.2.2
 ENV KUBEVIRT_CREATE_BAZELRCS=false
 
 # Install packages
-RUN dnf install -y dnf-plugins-core && \
+RUN dnf install -y --nodocs dnf-plugins-core && \
     dnf config-manager --enable crb && \
-    dnf install -y --setopt=install_weak_deps=False \
+    dnf install -y --nodocs --setopt=install_weak_deps=False \
         java-11-openjdk-devel \
         libvirt-devel \
         cpio \


### PR DESCRIPTION
### What this PR does

This PR introduces two small but meaningful optimizations in the build environment:
	•	DNF installation optimization: disables installation of man pages and other weak dependencies, reducing build time and image size.
	•	PIP3 optimization: adds --no-cache-dir to align Python package installation with the same cleanup consistency applied to DNF.

Before this PR:
	•	DNF installed unnecessary man documentation and weak dependencies, increasing the package footprint.
	•	pip3 install cached packages locally, leaving unused cache data inside the image.

After this PR:
	•	DNF runs with flags that prevent man pages and weak dependencies from being installed, reducing unnecessary content.
	•	pip3 install uses --no-cache-dir, ensuring no Python package cache remains after installation.


### References
	•	N/A (no issue directly linked)

### Why we need it and why it was done in this way

These optimizations help keep images smaller and more efficient by removing components that are not needed at runtime (such as man pages and pip cache files).

### Tradeoffs:
	•	No functional changes; only build-time optimizations.
	•	No downsides identified, since removed items are not required by KubeVirt components.

### Alternatives considered:
	•	Retaining default DNF and pip behavior but cleaning directories manually.
Rejected: less consistent and increases image complexity.

### Special notes for your reviewer
	•	These changes do not modify any runtime logic—only optimize build behavior.
	•	No user-facing changes.
	•	Safe, minimal, and isolated improvements.

### Checklist
	•	Design not required (small optimization, no feature change)
	•	PR description is clear
	•	Code remains simple and readable
	•	Boy Scout Rule: build scripts cleaner than before
	•	No upgrade impact
	•	Test updates not required (build optimization only)
	•	Documentation not required (no user-facing change)
	•	Community announcement not required

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
