### PR TITLE
docs: slight rewording of the network plugin section - network-binding-plugin.md

### DIFF
--- a/docs/network/network-binding-plugin.md
+++ b/docs/network/network-binding-plugin.md
@@ -169,10 +169,11 @@ plugin.
 
 When a standard domain attachment requires customization,
 or when additional services are needed (e.g. DHCP), a sidecar container
-may be executed to integrate with Kubevirt.
+can be used to integrate with Kubevirt.
 
-The sidecar container runs in parallel to the virt-launcher container
-which runs the hypervisor (libvirt and qemu).
+The sidecar container runs alongside the virt-launcher container,
+which is responsible for running the hypervisor components (Libvirt and QEMU).
+
 
 ### Sidecar Protocol
 


### PR DESCRIPTION
### What this PR does

Before this PR:
When a standard domain attachment requires customization,
or when additional services are needed (e.g. DHCP), a sidecar container
may be executed to integrate with Kubevirt.

The sidecar container runs in parallel to the virt-launcher container.

After this PR:
When a standard domain attachment requires customization,
or when additional services are needed (e.g. DHCP), a sidecar container
can be used to integrate with Kubevirt.

The sidecar container runs alongside the virt-launcher container,
which is responsible for running the hypervisor components (Libvirt and QEMU).


### References
No linked issues; this PR focuses on documentation clarity for network-binding-plugin.md.


### Why we need it and why it was done in this way

The wording of the original documentation was slightly ambiguous regarding the relationship
between the sidecar container and the virt-launcher container.
	•	“May be executed” → changed to “can be used” to better indicate optional usage.
	•	“Runs in parallel” → changed to “runs alongside” and added clarification about virt-launcher responsibilities.

### Tradeoffs considered: Minimal change to preserve original structure while improving readability.

### Alternatives considered:
	•	Extensive rewrite of the entire section — rejected as unnecessary for clarity.

### Special notes for your reviewer
	•	This is a documentation-only change.
	•	No code changes or behavioral changes are introduced.

### Checklist
	•	Design: Not required for documentation change
	•	PR: Description is expressive and helps future contributors
	•	Code: Not applicable (documentation only)
	•	Refactor: Not applicable
	•	Upgrade: Not applicable
	•	Testing: Not applicable
	•	Documentation: User-guide update not required; doc clarity improved
	•	Community: Announcement not required


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
