### PR TITLE
Reject non-zero grace periods in stop API

### DIFF
--- a/pkg/virt-api/rest/lifecycle.go
+++ b/pkg/virt-api/rest/lifecycle.go
@@ -180,6 +180,11 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		}
 	}
 
+	if bodyStruct.GracePeriod != nil && *bodyStruct.GracePeriod != 0 {
+		writeError(errors.NewBadRequest(fmt.Sprintf("non-zero grace period is not supported for stop API. Only grace-period=0 is supported, got %d", *bodyStruct.GracePeriod)), response)
+		return
+	}
+
 	vm, statusErr := app.fetchVirtualMachine(name, namespace)
 	if statusErr != nil {
 		writeError(statusErr, response)


### PR DESCRIPTION
### What this PR does
Currently, when a user attempts to stop a VM with a non-zero grace period, the system patches the VMI with the requested grace period value but then terminates the VM immediately anyway. This creates confusion as the API appears to accept the value but doesn't honor it.

This change adds early validation in StopVMRequestHandler to reject non-zero grace periods with a clear BadRequest error. Only grace-period=0 is supported for the stop API, which prevents the confusing behavior.

A unit test has been added to verify this rejection works correctly.

### References

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: 

### Release note
```release-note
Reject non-zero grace periods in stop API
```

