### PR TITLE
net, netpod: Enable HW checksum offload

### DIFF
--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -348,7 +348,6 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 		Name:     link.GenerateBridgeName(podIfaceName),
 		TypeName: nmstate.TypeBridge,
 		State:    nmstate.IfaceStateUp,
-		Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 		Metadata: &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
 	}
 
@@ -430,7 +429,6 @@ func (n NetPod) masqueradeBindingSpec(podIfaceName string, vmiIfaceIndex int, if
 		State:      nmstate.IfaceStateUp,
 		MacAddress: link.StaticMasqueradeBridgeMAC,
 		MTU:        podIface.MTU,
-		Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 		IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 		IPv6:       nmstate.IP{Enabled: pointer.P(false)},
 		Metadata:   &nmstate.IfaceMetadata{NetworkName: vmiNetwork.Name},
@@ -491,7 +489,6 @@ func (n NetPod) managedTapSpec(podIfaceName string, vmiIfaceIndex int, ifaceStat
 		Name:     link.GenerateBridgeName(podIfaceName),
 		TypeName: nmstate.TypeBridge,
 		State:    nmstate.IfaceStateUp,
-		Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 		Metadata: &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
 	}
 

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -241,7 +241,6 @@ var _ = Describe("netpod", func() {
 						State:      nmstate.IfaceStateUp,
 						MacAddress: "02:00:00:00:00:00",
 						MTU:        1500,
-						Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 						IPv4: nmstate.IP{
 							Enabled: pointer.P(true),
 							Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
@@ -358,7 +357,6 @@ var _ = Describe("netpod", func() {
 						Name:     "k6t-eth0",
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
-						Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 						IPv4: nmstate.IP{
 							Enabled: pointer.P(true),
 							Address: []nmstate.IPAddress{{IP: "169.254.75.10", PrefixLen: 32}},
@@ -512,7 +510,6 @@ var _ = Describe("netpod", func() {
 						Name:     "k6t-cust-iface",
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
-						Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 						IPv4: nmstate.IP{
 							Enabled: pointer.P(true),
 							Address: []nmstate.IPAddress{{IP: "169.254.75.10", PrefixLen: 32}},
@@ -623,7 +620,6 @@ var _ = Describe("netpod", func() {
 						Name:     "k6t-eth0",
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
-						Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
@@ -774,7 +770,6 @@ var _ = Describe("netpod", func() {
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "02:00:00:00:00:00",
 					MTU:        1500,
-					Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
@@ -828,7 +823,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-914f438d88d",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
@@ -904,7 +898,6 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							IPv4: nmstate.IP{
 								Enabled: pointer.P(true),
 								Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
@@ -930,7 +923,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-914f438d88d",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
@@ -985,7 +977,6 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							IPv4: nmstate.IP{
 								Enabled: pointer.P(true),
 								Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
@@ -1011,7 +1002,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-net1",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
@@ -1309,7 +1299,6 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
 							LinuxStack: nmstate.LinuxIfaceStack{},
@@ -1329,7 +1318,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-7087ef4cd1f",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
@@ -1354,7 +1342,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-bc6cc93fa1e",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
@@ -1418,7 +1405,6 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
 							LinuxStack: nmstate.LinuxIfaceStack{},
@@ -1438,7 +1424,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-7087ef4cd1f",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
@@ -1463,7 +1448,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-bc6cc93fa1e",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
@@ -1525,7 +1509,6 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
 							LinuxStack: nmstate.LinuxIfaceStack{},
@@ -1545,7 +1528,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-7087ef4cd1f",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
@@ -1579,7 +1561,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-bc6cc93fa1e",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
@@ -1718,7 +1699,6 @@ var _ = Describe("netpod", func() {
 						State:      nmstate.IfaceStateUp,
 						MacAddress: "02:00:00:00:00:00",
 						MTU:        1500,
-						Ethtool:    nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 						IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 						IPv6:       nmstate.IP{Enabled: pointer.P(false)},
 						LinuxStack: nmstate.LinuxIfaceStack{},
@@ -1738,7 +1718,6 @@ var _ = Describe("netpod", func() {
 						Name:     "k6t-7087ef4cd1f",
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
-						Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					{
@@ -1772,7 +1751,6 @@ var _ = Describe("netpod", func() {
 						Name:     "k6t-bc6cc93fa1e",
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateAbsent,
-						Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 					},
 					{
@@ -1872,7 +1850,6 @@ var _ = Describe("netpod", func() {
 							Name:     "k6t-eth0",
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
-							Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -762,8 +762,8 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		})
 	})
 
-	Context("VirtualMachineInstance with TX offload disabled", func() {
-		It("[test_id:1781]should have tx checksumming disabled on interface serving dhcp", func() {
+	Context("VirtualMachineInstance with TX offload enabled", func() {
+		It("[test_id:1781]should have tx checksumming enabled on interface serving dhcp", func() {
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(
 				context.Background(),
 				libvmifact.NewAlpine(libvmi.WithMemoryRequest("1024M")),
@@ -775,7 +775,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				vmi,
 				[]string{"/bin/bash", "-c", "/usr/sbin/ethtool -k k6t-eth0|grep tx-checksumming|awk '{ printf $2 }'"},
 			)
-			ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("off"))
+			ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("on"))
 		})
 	})
 }))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Turning off TX offload on the k6t bridge was implemented in 2018 in
https://github.com/kubevirt/kubevirt/commit/c2b92a63dce80de4a7920899a88a11c5db59572f.
The commit message hints that it was done in order to mitigate a DHCP
issue.
The assumption is that this refers to an issue in the ISC's DHCP client
("dhclient"), which uses an AF_PACKET socket without checking for the
tp_status field in packet metadata (the PACKET_AUXDATA option is off),
and missing the fact that the IP checksum field is not actually
calculated in the responses. See QEMU's commit 1d41b0c1ec66 ("Work
around dhclient brokenness") for more details.

That change hides the issue, but predates the KubeVirt commit disabling
checksum offloads by almost a decade, so we can assume that that
workaround didn't help somehow, perhaps because it only covers
non-vhost data paths (that is, for data actually copied by the QEMU
process).

In any case, the ISC's DHCP client has been unmaintained for four years
now, and testing shows that disabling checksum offloads is not needed
anymore.

Moreover, TCP guest outbound throughput decreases dramatically if TX
checksum offload is disabled, because that implies that, in turn, TCP
Segmentation Offload (TSO) is disabled as well (checksums need to be
recomputed upon segmentation).

Tests done with iperf3 between two KubeVirt guests hosted on an Azure
Dsv6 series machine show TCP throughput decreasing from about 60 Gbps
to approximately 15 Gbps if TSO is disabled.

Note that performance degradation was only observed with masquerade
network binding whereas the performance with bridge network binding was not
affected.

The TSO feature availability check is implemented by the Linux kernel in
netdev_fix_features() in net/core/dev.c:
```c
netdev_fix_features()

 if ((features & NETIF_F_TSO) && !(features & NETIF_F_HW_CSUM) &&
                                 !(features & NETIF_F_IP_CSUM)) {
      netdev_dbg(dev, "Dropping TSO features since no CSUM feature.\n");
      features &= ~NETIF_F_TSO;
      features &= ~NETIF_F_TSO_ECN;
 }
 ```
NETIF_F_TSO is the segmentation offload flag.
NETIF_F_..._CSUM are the checksum offload flags.

Given the above, Don't disable TX checksum offload for all bindings and
update tests accordingly.

The whole investigation was carried out by Cindy Lu <lulu@redhat.com>
with some support from Jason Wang <jasowang@redhat.com>.
This message was partially contributed by Stefano Brivio <sbrivio@redhat.com>.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

