### PR TITLE
[release-1.4]migration: relax host-model check to allow known models

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -41,21 +42,27 @@ const (
 	supportedFeaturesXml = "supported_features.xml"
 )
 
-func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []string {
-	supportedCPUModels := make([]string, 0)
-
-	if obsoleteCPUsx86 == nil {
-		obsoleteCPUsx86 = util.DefaultObsoleteCPUModels
+func (n *NodeLabeller) filterCpuModels(models []string, obsolete map[string]bool) []string {
+	if obsolete == nil {
+		obsolete = util.DefaultObsoleteCPUModels
 	}
 
-	for _, model := range n.hostCapabilities.items {
-		if _, ok := obsoleteCPUsx86[model]; ok {
+	filtered := make([]string, 0, len(models))
+	for _, model := range models {
+		if _, ok := obsolete[model]; ok {
 			continue
 		}
-		supportedCPUModels = append(supportedCPUModels, model)
+		filtered = append(filtered, model)
 	}
+	return filtered
+}
 
-	return supportedCPUModels
+func (n *NodeLabeller) getSupportedCpuModels(obsolete map[string]bool) []string {
+	return n.filterCpuModels(n.hostCapabilities.usableModels, obsolete)
+}
+
+func (n *NodeLabeller) getKnownCpuModels(obsolete map[string]bool) []string {
+	return n.filterCpuModels(n.hostCapabilities.knownModels, obsolete)
 }
 
 func (n *NodeLabeller) getSupportedCpuFeatures() cpuFeatures {
@@ -80,6 +87,7 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 	}
 
 	usableModels := make([]string, 0)
+	knownModels := make([]string, 0)
 	for _, mode := range hostDomCapabilities.CPU.Mode {
 		if mode.Name == v1.CPUModeHostModel {
 			if virtconfig.IsARM64(n.arch) {
@@ -112,14 +120,19 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 		}
 
 		for _, model := range mode.Model {
-			if model.Usable == isUnusable || model.Usable == "" {
+			name := strings.TrimSpace(model.Name)
+			if model.Usable == "" || name == "" {
 				continue
 			}
-			usableModels = append(usableModels, model.Name)
+			knownModels = append(knownModels, name)
+			if model.Usable != isUnusable {
+				usableModels = append(usableModels, name)
+			}
 		}
 	}
 
-	n.hostCapabilities.items = usableModels
+	n.hostCapabilities.usableModels = usableModels
+	n.hostCapabilities.knownModels = knownModels
 	n.SEV = hostDomCapabilities.SEV
 
 	return nil

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -98,6 +98,23 @@ var _ = Describe("Node-labeller config", func() {
 		Expect(cpuFeatures).To(HaveLen(4), "number of features doesn't match")
 	})
 
+	It("should mark all CPU models from domCapabilities as known, regardless of usability", func() {
+		nlController.domCapabilitiesFileName = "virsh_domcapabilities.xml"
+
+		err := nlController.loadDomCapabilities()
+		Expect(err).ToNot(HaveOccurred())
+
+		knownCpuModels := nlController.getKnownCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
+
+		Expect(knownCpuModels).To(ConsistOf(
+			"EPYC-IBPB",
+			"Penryn",
+			"IvyBridge",
+			"Haswell",
+			"Skylake-Client-IBRS",
+		), "expected all CPU models from domCapabilities to be marked as known")
+	})
+
 	It("Should return the cpu features on s390x even without policy='require' property", func() {
 		nlController.arch = "s390x"
 		nlController.volumePath = "testdata/s390x"

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -24,6 +24,11 @@ type supportedFeatures struct {
 	items []string
 }
 
+type supportedModels struct {
+	usableModels []string
+	knownModels  []string
+}
+
 type hostCPUModel struct {
 	Name             string
 	fallback         string

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -67,7 +67,7 @@ type NodeLabeller struct {
 	logger                  *log.FilteredLogger
 	clusterConfig           *virtconfig.ClusterConfig
 	hypervFeatures          supportedFeatures
-	hostCapabilities        supportedFeatures
+	hostCapabilities        supportedModels
 	queue                   workqueue.RateLimitingInterface
 	supportedFeatures       []string
 	cpuModelVendor          string
@@ -237,11 +237,10 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatu
 
 	for _, value := range cpuModels {
 		newLabels[kubevirtv1.CPUModelLabel+value] = "true"
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
 	}
 
-	if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
+	for _, value := range n.getKnownCpuModels(obsoleteCPUsx86) {
+		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
 	}
 
 	for _, key := range n.hypervFeatures.items {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -39,7 +39,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
-	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
 const nodeName = "testNode"
@@ -155,6 +155,17 @@ var _ = Describe("Node-labeller ", func() {
 			HaveKey(v1.HostModelCPULabel+"Skylake-Client-IBRS"),
 			HaveKey(v1.CPUModelLabel+"Skylake-Client-IBRS"),
 			HaveKey(v1.SupportedHostModelMigrationCPU+"Skylake-Client-IBRS"),
+		))
+	})
+
+	It("should not include non-usable CPU models with the CPU model label but include them with the SupportedHostModelMigrationCPU label", func() {
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(SatisfyAll(
+			Not(HaveKey(v1.CPUModelLabel+"EPYC-IBPB")),
+			HaveKey(v1.SupportedHostModelMigrationCPU+"EPYC-IBPB"),
 		))
 	})
 


### PR DESCRIPTION
Manual backport of https://github.com/kubevirt/kubevirt/pull/15694

Had a conflict on `pkg/virt-handler/node-labeller/node_labeller.go`

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

