### PR TITLE
rbac: remove vnc/screenshot from kubevirt.io:edit

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1063,7 +1063,6 @@ spec:
           resources:
           - virtualmachineinstances/console
           - virtualmachineinstances/vnc
-          - virtualmachineinstances/vnc/screenshot
           - virtualmachineinstances/portforward
           - virtualmachineinstances/guestosinfo
           - virtualmachineinstances/filesystemlist

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -1091,7 +1091,6 @@ rules:
   resources:
   - virtualmachineinstances/console
   - virtualmachineinstances/vnc
-  - virtualmachineinstances/vnc/screenshot
   - virtualmachineinstances/portforward
   - virtualmachineinstances/guestosinfo
   - virtualmachineinstances/filesystemlist

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -396,7 +396,6 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					apiVMInstancesConsole,
 					apiVMInstancesVNC,
-					apiVMInstancesVNCScreenshot,
 					apiVMInstancesPortForward,
 					apiVMInstancesGuestOSInfo,
 					apiVMInstancesFileSysList,

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -154,7 +154,6 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 			},
 				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesConsole), virtv1.SubresourceGroupName, apiVMInstancesConsole, "get"),
 				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesVNC), virtv1.SubresourceGroupName, apiVMInstancesVNC, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesVNCScreenshot), virtv1.SubresourceGroupName, apiVMInstancesVNCScreenshot, "get"),
 				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesPortForward), virtv1.SubresourceGroupName, apiVMInstancesPortForward, "get"),
 				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo), virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo, "get"),
 				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesFileSysList), virtv1.SubresourceGroupName, apiVMInstancesFileSysList, "get"),


### PR DESCRIPTION
It can be considered a security issue that all users with `kubevirt.io:edit` might be able to fetch Display images of running VMs that they are not logged in.

Considering the nature of RBAC, that is:

    `Permissions are purely additive (there are no "deny" rules)`

Let's allow only `kubevirt.io:admin` to have that access and if necessary, the admin can define [their custom RBAC roles too]( https://kubevirt.io/user-guide/cluster_admin/authorization)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### Special notes for your reviewer

While this was always a potential problem, with https://github.com/kubevirt/kubevirt/pull/15238 we can have Screenshot without disconnecting existing VNC user session, so it is better to change the defaults.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove vnc/screenshot from kubevirt.io:edit
```

