### PR TITLE
fix(virt-controller): Skip ControllerRevisionRef capture if Matchers nil

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1678,10 +1678,10 @@ func getVMRevisionName(vmUID types.UID, generation int64) string {
 
 func patchVMRevision(vm *virtv1.VirtualMachine) ([]byte, error) {
 	vmCopy := vm.DeepCopy()
-	if revision.HasControllerRevisionRef(vmCopy.Status.InstancetypeRef) {
+	if vmCopy.Spec.Instancetype != nil && revision.HasControllerRevisionRef(vmCopy.Status.InstancetypeRef) {
 		vmCopy.Spec.Instancetype.RevisionName = vmCopy.Status.InstancetypeRef.ControllerRevisionRef.Name
 	}
-	if revision.HasControllerRevisionRef(vm.Status.PreferenceRef) {
+	if vmCopy.Spec.Preference != nil && revision.HasControllerRevisionRef(vm.Status.PreferenceRef) {
 		vmCopy.Spec.Preference.RevisionName = vm.Status.PreferenceRef.ControllerRevisionRef.Name
 	}
 	vmBytes, err := json.Marshal(vmCopy)


### PR DESCRIPTION
### What this PR does
As set out in bug #16071 virt-controller would previously panic if a user removed an instance type or preference from the spec from an existing VM before restarting it to force a new VM ControllerRevision to be captured.

This fix avoids the panic for now by skipping the attempted capture of instance type and preference ControllerRevisionRefs if the associated spec fields are already nil.

A follow up fix will also handle clearing of these ControllerRevisionRefs from status when the spec fields are initially removed from the VM.

### References
- Fixes #16071

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

