### PR TITLE
live-migration-source: Stop polling after migration completes

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -657,9 +657,17 @@ func (m *migrationMonitor) startMonitor() {
 	logInterval := 0
 
 	for {
+		var isOpen bool
 		err = nil
 		select {
-		case err = <-m.migrationErr:
+		case err, isOpen = <-m.migrationErr:
+			if !isOpen {
+				migration, _ := m.l.metadataCache.Migration.Load()
+				if migration.EndTimestamp != nil {
+					logger.V(4).Info("Migration finished and result recorded. Stopping monitor.")
+					return
+				}
+			}
 		case <-time.After(monitorSleepPeriodMS * time.Millisecond):
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Right now the poller keeps polling even after migration completes. This results in generation of a lot of log about "domain not found"
This PR makes the poller check if the channel exists. If the channel is destroyed it assumes that migration is complete and exits.
The check `migration.EndTimestamp != nil`  makes sure the channel is not immediately destroyed in case migration is cancelled, and that it continues to update the correct status before exiting.


I tested locally by creating a VM and migrating it. 
#### Before this PR:
```
kubectl  logs -f virt-launcher-vm-cirros-wc5r7

{"component":"virt-launcher","kind":"","level":"info","msg":"Live migration succeeded.","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:1140","timestamp":"2025-12-10T22:10:18.051453Z","uid":"37222cb8-bf3d-4f42-92a7-011d5aba50d5"}
{"component":"virt-launcher","kind":"","level":"warning","msg":"failed to get domain job info, will retry","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:691","reason":"virError(Code=55, Domain=20, Message='Requested operation is not valid: domain is not running')","timestamp":"2025-12-10T22:10:18.052065Z","uid":"37222cb8-bf3d-4f42-92a7-011d5aba50d5"}
{"component":"virt-launcher","level":"info","msg":"kubevirt domain status: Shutoff(Paused) reason: Migrated(Migration)","pos":"client.go:266","timestamp":"2025-12-10T22:10:18.054269Z"}
{"component":"virt-launcher","level":"info","msg":"Domain name event: default_vm-cirros","pos":"client.go:459","timestamp":"2025-12-10T22:10:18.055961Z"}
{"component":"virt-launcher","kind":"","level":"warning","msg":"failed to get domain job info, will retry","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:691","reason":"virError(Code=55, Domain=20, Message='Requested operation is not valid: domain is not running')","timestamp":"2025-12-10T22:10:18.055996Z","uid":"37222cb8-bf3d-4f42-92a7-011d5aba50d5"}
{"component":"virt-launcher","kind":"","level":"warning","msg":"failed to get domain job info, will retry","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:691","reason":"virError(Code=55, Domain=20, Message='Requested operation is not valid: domain is not running')","timestamp":"2025-12-
....
{"component":"virt-launcher","kind":"","level":"warning","msg":"failed to get domain job info, will retry","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:691","reason":"virError(Code=42, Domain=10, Message='Domain not found: no domain with matching uuid '887bf1ea-5c95-45b2-971c-38b87dce647e' (default_vm-cirros)')","timestamp":"2025-12-10T22:10:18.573108Z","uid":"37222cb8-bf3d-4f42-92a7-011d5aba50d5"}
{"component":"virt-launcher","kind":"","level":"warning","msg":"failed to get domain job info, will retry","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:691","reason":"virError(Code=42, Domain=10, Message='Domain not found: no domain with matching uuid '887bf1ea-5c95-45b2-971c-38b87dce647e' (default_vm-cirros)')","timestamp":"2025-12-10T22:10:18.573293Z","uid":"37222cb8-bf3d-4f42-92a7-011d5aba50d5"}
{"component":"virt-launcher","kind":"","level":"warning","msg":"failed to get domain job info, will retry","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:691","reason":"virError(Code=42, Domain=10, Message='Domain not found: no domain with matching uuid '887bf1ea-5c95-45b2-971c-38b87dce647e' (default_vm-cirros)')","timestamp":"2025-12-10T22:10:18.573473Z","uid":"37222cb8-bf3d-4f42-92a7-011d5aba50d5"}
{"component":"virt-launcher","kind":"","level":"warning","msg":"failed to get domain job info, will retry","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:691","reason":"virError(Code=42, Domain=10, Message='Domain not found: no domain with matching uuid '887bf1ea-5c95-45b2-971c-38b87dce647e' (default_vm-cirros)')","timestamp":"2025-12-10T22:10:18.573634Z","uid":"37222cb8-bf3d-4f42-92a7-011d5aba50d5"}
{"component":"virt-launcher","level":"info","msg":"Process default_vm-cirros and pid 79 is gone!","pos":"monitor.go:179","timestamp":"2025-12-10T22:10:18.573732Z"}
{"component":"virt-launcher","level":"info","msg":"Waiting on final notifications to be sent to virt-handler.","pos":"virt-launcher.go:284","timestamp":"2025-12-10T22:10:18.573774Z"}
{"component":"virt-launcher","level":"info","msg":"Final Delete notification sent","pos":"virt-launcher.go:299","timestamp":"2025-12-10T22:10:18.573786Z"}
```

#### After this PR:
```
kubectl logs -f virt-launcher-vm-cirros-8pd5w

{"component":"virt-launcher","kind":"","level":"info","msg":"Live migration succeeded.","name":"vm-cirros","namespace":"default","pos":"live-migration
-source.go:1148","timestamp":"2025-12-10T21:34:46.650148Z","uid":"5ac5bdaa-7840-44f7-a0ed-eb85e6f46fe9"}
{"component":"virt-launcher","kind":"","level":"info","msg":"Migration finished and result recorded. Stopping monitor.","name":"vm-cirros","namespace":"default","pos":"live-migration-source.go:667","timestamp":"2025-12-10T21:34:46.650803Z","uid":"5ac5bdaa-7840-44f7-a0ed-eb85e6f46fe9"}
{"component":"virt-launcher","kind":"","level":"info","msg":"Domain undefined.","name":"vm-cirros","namespace":"default","pos":"manager.go:2205","timestamp":"2025-12-10T21:34:46.651702Z","uid":"5ac5bdaa-7840-44f7-a0ed-eb85e6f46fe9"}
{"component":"virt-launcher","kind":"","level":"info","msg":"Signaled vmi deletion","name":"vm-cirros","namespace":"default","pos":"server.go:380","timestamp":"2025-12-10T21:34:46.652138Z","uid":"5ac5bdaa-7840-44f7-a0ed-eb85e6f46fe9"}
{"component":"virt-launcher","level":"error","msg":"failed to get domain spec","pos":"libvirt_helper.go:165","reason":"virError(Code=42, Domain=10, Message='Domain not found: no domain with matching uuid '0fecd57a-dd4f-45a4-98a8-4a8ae779f026' (default_vm-cirros)')","timestamp":"2025-12-10T21:34:46.652380Z"}
{"component":"virt-launcher","level":"info","msg":"DomainLifecycle event Domain event=\"undefined\" detail=\"removed\" with event id 1 reason 0 received","pos":"client.go:499","timestamp":"2025-12-10T21:34:46.652379Z"}
{"component":"virt-launcher","level":"info","msg":"Domain name event: ","pos":"client.go:459","timestamp":"2025-12-10T21:34:46.656624Z"}
{"component":"virt-launcher","level":"info","msg":"Domain name event: ","pos":"client.go:459","timestamp":"2025-12-10T21:34:46.659816Z"}
{"component":"virt-launcher","level":"info","msg":"Process default_vm-cirros and pid 79 is gone!","pos":"monitor.go:179","timestamp":"2025-12-10T21:34:46.697863Z"}
{"component":"virt-launcher","level":"info","msg":"Waiting on final notifications to be sent to virt-handler.","pos":"virt-launcher.go:284","timestamp":"2025-12-10T21:34:46.697906Z"}
{"component":"virt-launcher","level":"info","msg":"Final Delete notification sent","pos":"virt-launcher.go:299","timestamp":"2025-12-10T21:34:46.697922Z"}
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

