### PR TITLE
fix(instancetype): Clear InstancetypeStatusRef when Matchers are nil 

### DIFF
--- a/pkg/instancetype/revision/BUILD.bazel
+++ b/pkg/instancetype/revision/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "clear.go",
         "compare.go",
         "handler.go",
         "patch.go",
@@ -38,6 +39,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "clear_test.go",
         "revision_suite_test.go",
         "store_test.go",
     ],
@@ -45,6 +47,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/instancetype/conflict:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/instancetype/revision/clear.go
+++ b/pkg/instancetype/revision/clear.go
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package revision
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+)
+
+func (h *revisionHandler) Clear(vm *virtv1.VirtualMachine) error {
+	patchSet := patch.New()
+	if vm.Spec.Instancetype == nil && vm.Status.InstancetypeRef != nil {
+		patchSet.AddOption(patch.WithRemove(instancetypeStatusRefPath))
+	}
+	if vm.Spec.Preference == nil && vm.Status.PreferenceRef != nil {
+		patchSet.AddOption(patch.WithRemove(preferenceStatusRefPath))
+	}
+	if patchSet.IsEmpty() {
+		return nil
+	}
+	statusPatch, err := patchSet.GeneratePayload()
+	if err != nil {
+		return err
+	}
+	patchedVM, err := h.virtClient.VirtualMachine(vm.Namespace).PatchStatus(
+		context.Background(), vm.Name, types.JSONPatchType, statusPatch, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	// Update the local vm ObjectMeta with the response to ensure ResourceVersion and other server-side fields are current
+	vm.ObjectMeta = patchedVM.ObjectMeta
+	vm.Status = patchedVM.Status
+
+	return nil
+}

--- a/pkg/instancetype/revision/clear_test.go
+++ b/pkg/instancetype/revision/clear_test.go
@@ -1,0 +1,141 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package revision_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/kubevirt/fake"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/revision"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+)
+
+type clearHandler interface {
+	Clear(*virtv1.VirtualMachine) error
+}
+
+var _ = Describe("Instancetype and Preferences revision handler", func() {
+	var (
+		handler    clearHandler
+		virtClient *kubecli.MockKubevirtClient
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+		fakeVMClientset := fake.NewSimpleClientset().KubevirtV1().VirtualMachines(metav1.NamespaceDefault)
+		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(fakeVMClientset).AnyTimes()
+		handler = revision.New(nil, nil, nil, nil, virtClient)
+	})
+
+	instancetypeStatusRef := &virtv1.InstancetypeStatusRef{
+		ControllerRevisionRef: &virtv1.ControllerRevisionRef{
+			Name: "bar",
+		},
+		Name: "foo",
+	}
+	withInstancetypeStatusRef := func() libvmi.VMOption {
+		return func(vm *virtv1.VirtualMachine) {
+			vm.Status.InstancetypeRef = instancetypeStatusRef
+		}
+	}
+	withPreferenceStatusRef := func() libvmi.VMOption {
+		return func(vm *virtv1.VirtualMachine) {
+			vm.Status.PreferenceRef = instancetypeStatusRef
+		}
+	}
+
+	Context("Clear", func() {
+		DescribeTable("should", func(vm *virtv1.VirtualMachine, assertVM func(vm *virtv1.VirtualMachine)) {
+			vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(handler.Clear(vm)).To(Succeed())
+			assertVM(vm)
+
+			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			assertVM(vm)
+		},
+			Entry(
+				"nil vm.status.instancetypeRef when vm.spec.instancetype nil",
+				libvmi.NewVirtualMachine(
+					libvmi.New(
+						libvmi.WithNamespace(metav1.NamespaceDefault),
+					),
+					withInstancetypeStatusRef(),
+				),
+				func(vm *virtv1.VirtualMachine) {
+					Expect(vm.Spec.Instancetype).To(BeNil())
+					Expect(vm.Status.InstancetypeRef).To(BeNil())
+				},
+			),
+			Entry(
+				"not nil vm.status.instancetypeRef when vm.spec.instancetype not nil",
+				libvmi.NewVirtualMachine(
+					libvmi.New(
+						libvmi.WithNamespace(metav1.NamespaceDefault),
+					),
+					libvmi.WithInstancetype("foo"),
+					withInstancetypeStatusRef(),
+				),
+				func(vm *virtv1.VirtualMachine) {
+					Expect(vm.Spec.Instancetype).ToNot(BeNil())
+					Expect(vm.Status.InstancetypeRef).ToNot(BeNil())
+				},
+			),
+			Entry(
+				"nil vm.status.preferenceRef when vm.spec.preference nil",
+				libvmi.NewVirtualMachine(
+					libvmi.New(
+						libvmi.WithNamespace(metav1.NamespaceDefault),
+					),
+					withPreferenceStatusRef(),
+				),
+				func(vm *virtv1.VirtualMachine) {
+					Expect(vm.Spec.Preference).To(BeNil())
+					Expect(vm.Status.PreferenceRef).To(BeNil())
+				},
+			),
+			Entry(
+				"not nil vm.status.preferenceRef when vm.spec.preference not nil",
+				libvmi.NewVirtualMachine(
+					libvmi.New(
+						libvmi.WithNamespace(metav1.NamespaceDefault),
+					),
+					libvmi.WithPreference("foo"),
+					withPreferenceStatusRef(),
+				),
+				func(vm *virtv1.VirtualMachine) {
+					Expect(vm.Spec.Preference).ToNot(BeNil())
+					Expect(vm.Status.PreferenceRef).ToNot(BeNil())
+				},
+			),
+		)
+	})
+})

--- a/pkg/instancetype/revision/patch.go
+++ b/pkg/instancetype/revision/patch.go
@@ -29,6 +29,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 )
 
+const (
+	instancetypeStatusRefPath = "/status/instancetypeRef"
+	preferenceStatusRefPath   = "/status/preferenceRef"
+)
+
 func (h *revisionHandler) patchVM(
 	instancetypeStatusRef, preferenceStatusRef *virtv1.InstancetypeStatusRef,
 	vm *virtv1.VirtualMachine,
@@ -57,13 +62,13 @@ func GeneratePatch(instancetypeStatusRef, preferenceStatusRef *virtv1.Instancety
 	patchSet := patch.New()
 	if instancetypeStatusRef != nil {
 		patchSet.AddOption(
-			patch.WithAdd("/status/instancetypeRef", instancetypeStatusRef),
+			patch.WithAdd(instancetypeStatusRefPath, instancetypeStatusRef),
 		)
 	}
 
 	if preferenceStatusRef != nil {
 		patchSet.AddOption(
-			patch.WithAdd("/status/preferenceRef", preferenceStatusRef),
+			patch.WithAdd(preferenceStatusRefPath, preferenceStatusRef),
 		)
 	}
 

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -4782,12 +4782,11 @@ var _ = Describe("VirtualMachine", func() {
 				addVirtualMachine(vm)
 				sanityExecute(vm)
 
-				//FIXME(lyarwood): status.{InstancetypeRef,PreferenceRef} should also be removed
-				// vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
-				// Expect(err).ToNot(HaveOccurred())
-				//
-				// Expect(revision.HasControllerRevisionRef(vm.Status.InstancetypeRef)).To(BeFalse())
-				// Expect(revision.HasControllerRevisionRef(vm.Status.PreferenceRef)).To(BeFalse())
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(revision.HasControllerRevisionRef(vm.Status.InstancetypeRef)).To(BeFalse())
+				Expect(revision.HasControllerRevisionRef(vm.Status.PreferenceRef)).To(BeFalse())
 
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When `vm.Spec.Instancetype` and `vm.Spec.Preference` matchers were set to nil (e.g., after expanding a VM), the corresponding `vm.Status.InstancetypeRef` and `vm.Status.PreferenceRef` fields were not cleared, leaving stale status references.

#### After this PR:

The instancetype controller now clears `vm.Status.InstancetypeRef` and `vm.Status.PreferenceRef` when their corresponding spec matchers are nil. The new `Clear()` function properly captures the returned VM from `PatchStatus()` and updates the local VM object to ensure `ResourceVersion` and other server-side fields remain current.

### References

- Fixes #16071

### Why we need it and why it was done in this way
The following tradeoffs were made:
- The `Clear()` function updates both `vm.ObjectMeta` and `vm.Status` from the PatchStatus response, consistent with the approach used in `patchVM()` and `Upgrade()`, to prevent ResourceVersion conflicts in subsequent controller operations.

The following alternatives were considered:
- Manually setting only the specific status fields to nil was the original approach, but this didn't propagate the updated ResourceVersion from the API server response.

### Special notes for your reviewer

This commit builds on the fix in the parent commit that propagates ResourceVersion from PatchStatus responses. The `Clear()` function follows the same pattern established there.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit tests added in `clear_test.go`

### Release note
```release-note
Fixed a bug where vm.Status.InstancetypeRef and vm.Status.PreferenceRef were not cleared when their corresponding spec matchers were removed.
```