### PR TITLE
Deprecate migration TargetCPUSet field

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17801,7 +17801,7 @@
       "type": "string"
      },
      "targetCPUSet": {
-      "description": "If the VMI requires dedicated CPUs, this field will hold the dedicated CPU set on the target node",
+      "description": "If the VMI requires dedicated CPUs, this field will hold the dedicated CPU set on the target node Deprecated: The VirtualMachineInstance field \"TargetCPUSet\" is deprecated and will no longer be populated starting from version 1.8.",
       "type": "array",
       "items": {
        "type": "integer",

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/virt-launcher:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",
+        "//pkg/virt-launcher/premigration-hook-server:go_default_library",
         "//pkg/virt-launcher/standalone:go_default_library",
         "//pkg/virt-launcher/virtwrap:go_default_library",
         "//pkg/virt-launcher/virtwrap/agent-poller:go_default_library",

--- a/cmd/virt-launcher/qemu
+++ b/cmd/virt-launcher/qemu
@@ -1,5 +1,13 @@
 #!/bin/bash
-if [ "$2" != "release" ] || [ "$3" != "end" ] || [ "$4" != "migrated" ]; then
-	exit
+
+if [ "$2" = "migrate" ] && [ "$3" = "begin" ]; then
+    ncat -U /var/run/kubevirt/migration-hook-socket 2>/dev/null
+    exit 0
 fi
-touch /run/kubevirt-private/backend-storage-meta/migrated
+
+if [ "$2" = "release" ] && [ "$3" = "end" ] && [ "$4" = "migrated" ]; then
+    touch /run/kubevirt-private/backend-storage-meta/migrated
+    exit 0
+fi
+
+exit 0

--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -21,7 +21,6 @@ package cgroup
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -54,9 +53,6 @@ type Manager interface {
 
 	// GetCgroupVersion returns the current cgroup version (i.e. v1 or v2)
 	GetCgroupVersion() CgroupVersion
-
-	// GetCpuSet returns the cpu set
-	GetCpuSet() (string, error)
 
 	// SetCpuSet returns the cpu set
 	SetCpuSet(subcgroup string, cpulist []int) error
@@ -157,21 +153,6 @@ func GetGlobalCpuSetPath() string {
 		return filepath.Join(cgroupconsts.CgroupBasePath, "cpuset.cpus.effective")
 	}
 	return filepath.Join(cgroupconsts.CgroupBasePath, "cpuset", "cpuset.cpus")
-}
-
-func getCpuSetPath(manager Manager, cpusetFile string) (string, error) {
-	cpuSubsystemPath, err := manager.GetBasePathToHostSubsystem("cpuset")
-	if err != nil {
-		return "", err
-	}
-
-	cpuset, err := os.ReadFile(filepath.Join(cpuSubsystemPath, cpusetFile))
-	if err != nil {
-		return "", err
-	}
-
-	cpusetStr := strings.TrimSpace(string(cpuset))
-	return cpusetStr, nil
 }
 
 // detectVMIsolation detects VM's IsolationResult, which can then be useful for receiving information such as PID.

--- a/pkg/virt-handler/cgroup/cgroup_v1_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v1_manager.go
@@ -132,10 +132,6 @@ func getCurrentlyDefinedRules(runcManager runc_cgroups.Manager) ([]*devices.Rule
 	return currentRules, nil
 }
 
-func (v *v1Manager) GetCpuSet() (string, error) {
-	return getCpuSetPath(v, "cpuset.cpus")
-}
-
 func rw_filecontents(fReadPath string, fWritePath string) (err error) {
 	rFile, err := os.Open(fReadPath)
 	if err != nil {

--- a/pkg/virt-handler/cgroup/cgroup_v2_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v2_manager.go
@@ -109,10 +109,6 @@ func (v *v2Manager) GetCgroupVersion() CgroupVersion {
 	return V2
 }
 
-func (v *v2Manager) GetCpuSet() (string, error) {
-	return getCpuSetPath(v, "cpuset.cpus.effective")
-}
-
 func (v *v2Manager) CreateChildCgroup(name string, subSystem string) error {
 	subSysPath, err := v.GetBasePathToHostSubsystem(subSystem)
 	if err != nil {

--- a/pkg/virt-handler/cgroup/generated_mock_cgroup.go
+++ b/pkg/virt-handler/cgroup/generated_mock_cgroup.go
@@ -113,21 +113,6 @@ func (mr *MockManagerMockRecorder) GetCgroupVersion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCgroupVersion", reflect.TypeOf((*MockManager)(nil).GetCgroupVersion))
 }
 
-// GetCpuSet mocks base method.
-func (m *MockManager) GetCpuSet() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCpuSet")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCpuSet indicates an expected call of GetCpuSet.
-func (mr *MockManagerMockRecorder) GetCpuSet() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCpuSet", reflect.TypeOf((*MockManager)(nil).GetCpuSet))
-}
-
 // Set mocks base method.
 func (m *MockManager) Set(r *configs.Resources) error {
 	m.ctrl.T.Helper()

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -301,11 +301,7 @@ func (c *MigrationTargetController) updateStatus(vmi *v1.VirtualMachineInstance,
 	// If the migrated VMI requires dedicated CPUs, report the new pod CPU set to the source node
 	// via the VMI migration status in order to patch the domain pre migration
 	if vmi.IsCPUDedicated() {
-		err := c.reportDedicatedCPUSetForMigratingVMI(vmi)
-		if err != nil {
-			return err
-		}
-		err = c.reportTargetTopologyForMigratingVMI(vmi)
+		err := c.reportTargetTopologyForMigratingVMI(vmi)
 		if err != nil {
 			return err
 		}
@@ -812,27 +808,6 @@ func (c *MigrationTargetController) updateDomainFunc(old, new interface{}) {
 	if err == nil {
 		c.queue.Add(key)
 	}
-}
-
-func (c *MigrationTargetController) reportDedicatedCPUSetForMigratingVMI(vmi *v1.VirtualMachineInstance) error {
-	cgroupManager, err := getCgroupManager(vmi, c.host)
-	if err != nil {
-		return err
-	}
-
-	cpusetStr, err := cgroupManager.GetCpuSet()
-	if err != nil {
-		return err
-	}
-
-	cpuSet, err := hardware.ParseCPUSetLine(cpusetStr, 50000)
-	if err != nil {
-		return fmt.Errorf("failed to parse target VMI cpuset: %v", err)
-	}
-
-	vmi.Status.MigrationState.TargetCPUSet = cpuSet
-
-	return nil
 }
 
 func (c *MigrationTargetController) reportTargetTopologyForMigratingVMI(vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-launcher/premigration-hook-server/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hook_server.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virt-launcher/premigration-hook-server/compute:go_default_library",
+        "//pkg/virt-launcher/premigration-hook-server/network:go_default_library",
+        "//pkg/virt-launcher/premigration-hook-server/storage:go_default_library",
+        "//pkg/virt-launcher/premigration-hook-server/types:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)

--- a/pkg/virt-launcher/premigration-hook-server/compute/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/compute/BUILD.bazel
@@ -1,9 +1,36 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["compute.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/compute",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/virt-launcher/premigration-hook-server/types:go_default_library"],
+    deps = [
+        "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/virt-launcher/premigration-hook-server/types:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
+        "//pkg/virt-launcher/virtwrap/libvirtxml:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "compute_suite_test.go",
+        "compute_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
 )

--- a/pkg/virt-launcher/premigration-hook-server/compute/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/compute/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
         "//pkg/virt-launcher/virtwrap/libvirtxml:go_default_library",
+        "//pkg/virt-launcher/virtwrap/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",

--- a/pkg/virt-launcher/premigration-hook-server/compute/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/compute/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["compute.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/compute",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/virt-launcher/premigration-hook-server/types:go_default_library"],
+)

--- a/pkg/virt-launcher/premigration-hook-server/compute/OWNERS
+++ b/pkg/virt-launcher/premigration-hook-server/compute/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - sig/compute

--- a/pkg/virt-launcher/premigration-hook-server/compute/compute.go
+++ b/pkg/virt-launcher/premigration-hook-server/compute/compute.go
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package compute
+
+import (
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/types"
+)
+
+func GetComputeHooks() []types.HookFunc {
+	return []types.HookFunc{}
+}

--- a/pkg/virt-launcher/premigration-hook-server/compute/compute_suite_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/compute/compute_suite_test.go
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package compute_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCompute(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Compute Hooks Suite")
+}

--- a/pkg/virt-launcher/premigration-hook-server/compute/compute_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/compute/compute_test.go
@@ -91,7 +91,6 @@ var _ = Describe("Compute Hooks", func() {
 
 			By("saving that topology in the migration state of the VMI")
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				TargetCPUSet:       []int{6, 7},
 				TargetNodeTopology: string(targetNodeTopology),
 			}
 
@@ -101,7 +100,8 @@ var _ = Describe("Compute Hooks", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to parse input domain XML")
 
 			By("running the CPU dedicated hook")
-			compute.CPUDedicatedHook(vmi, &domain)
+			hook := compute.NewCPUDedicatedHook(func() ([]int, error) { return []int{6, 7}, nil })
+			hook(vmi, &domain)
 
 			By("marshaling the modified domain back to XML")
 			newXML, err := domain.Marshal()

--- a/pkg/virt-launcher/premigration-hook-server/compute/compute_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/compute/compute_test.go
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package compute_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"libvirt.org/go/libvirtxml"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/compute"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Compute Hooks", func() {
+	Context("CPU Dedicated Hook", func() {
+		It("should change CPU pinning according to migration metadata", func() {
+			domXML := `<domain type="kvm" id="1">
+  <name>kubevirt</name>
+  <vcpu placement="static">2</vcpu>
+  <cputune>
+    <vcpupin vcpu="0" cpuset="4"></vcpupin>
+    <vcpupin vcpu="1" cpuset="5"></vcpupin>
+  </cputune>
+</domain>`
+			expectedXML := `<domain type="kvm" id="1">
+  <name>kubevirt</name>
+  <vcpu placement="static">2</vcpu>
+  <cputune>
+    <vcpupin vcpu="0" cpuset="6"></vcpupin>
+    <vcpupin vcpu="1" cpuset="7"></vcpupin>
+  </cputune>
+  <cpu>
+    <topology sockets="1" cores="2" threads="1"></topology>
+  </cpu>
+</domain>`
+
+			By("creating a VMI with dedicated CPU cores")
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubevirt",
+					Namespace: "testns",
+				},
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						CPU: &v1.CPU{
+							Cores:                 2,
+							DedicatedCPUPlacement: true,
+						},
+					},
+				},
+			}
+
+			By("making up a target topology")
+			topology := &cmdv1.Topology{NumaCells: []*cmdv1.Cell{{
+				Id: 0,
+				Cpus: []*cmdv1.CPU{
+					{
+						Id:       6,
+						Siblings: []uint32{6},
+					},
+					{
+						Id:       7,
+						Siblings: []uint32{7},
+					},
+				},
+			}}}
+			targetNodeTopology, err := json.Marshal(topology)
+			Expect(err).NotTo(HaveOccurred(), "failed to marshall the topology")
+
+			By("saving that topology in the migration state of the VMI")
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				TargetCPUSet:       []int{6, 7},
+				TargetNodeTopology: string(targetNodeTopology),
+			}
+
+			By("parsing the input domain XML")
+			var domain libvirtxml.Domain
+			err = domain.Unmarshal(domXML)
+			Expect(err).NotTo(HaveOccurred(), "failed to parse input domain XML")
+
+			By("running the CPU dedicated hook")
+			compute.CPUDedicatedHook(vmi, &domain)
+
+			By("marshaling the modified domain back to XML")
+			newXML, err := domain.Marshal()
+			Expect(err).NotTo(HaveOccurred(), "failed to marshal modified domain")
+
+			By("ensuring the generated XML is accurate")
+			Expect(newXML).To(Equal(expectedXML), "the target XML is not as expected")
+		})
+	})
+})

--- a/pkg/virt-launcher/premigration-hook-server/hook_server.go
+++ b/pkg/virt-launcher/premigration-hook-server/hook_server.go
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package premigrationhookserver
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net"
+	"os"
+
+	"libvirt.org/go/libvirtxml"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/compute"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/network"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/storage"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/types"
+)
+
+// PreMigrationHookServer handles libvirt premigration hook communication via unix socket
+type PreMigrationHookServer struct {
+	vmi   *v1.VirtualMachineInstance
+	hooks []types.HookFunc
+}
+
+// NewPreMigrationHookServer creates a new premigration hook server with registered hooks
+func NewPreMigrationHookServer() *PreMigrationHookServer {
+	server := &PreMigrationHookServer{
+		hooks: make([]types.HookFunc, 0),
+	}
+
+	server.registerAllHooks()
+
+	return server
+}
+
+func (h *PreMigrationHookServer) Start(stopChan chan struct{}) (chan struct{}, error) {
+	socketPath := "/var/run/kubevirt/migration-hook-socket"
+
+	socket, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on unix socket %s: %v", socketPath, err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		<-stopChan
+		log.Log.Infof("Stopping premigration hook server")
+		if socket != nil {
+			err := socket.Close()
+			if err != nil {
+				log.Log.Errorf("failed to close premigration hook server socket:%v", err.Error())
+			}
+		}
+		err := os.Remove(socketPath)
+		if err != nil {
+			log.Log.Errorf("failed to remove premigration hook server socket:%v", err.Error())
+		}
+		close(done)
+	}()
+
+	go func() {
+		for {
+			conn, err := socket.Accept()
+			if err != nil {
+				log.Log.Reason(err).Info("Premigration hook server stopped accepting connections")
+				return
+			}
+			h.handleConnection(conn)
+			err = conn.Close()
+			if err != nil {
+				log.Log.Errorf("Failed to close connection: %v", err.Error())
+			}
+		}
+	}()
+
+	log.Log.Infof("Started premigration hook server on %s", socketPath)
+	return done, nil
+}
+
+func (h *PreMigrationHookServer) handleConnection(conn net.Conn) {
+	var domain libvirtxml.Domain
+	decoder := xml.NewDecoder(conn)
+	if err := decoder.Decode(&domain); err != nil {
+		log.Log.Errorf("Failed to decode XML from connection:%v", err.Error())
+		return
+	}
+
+	for _, hook := range h.hooks {
+		hook(h.vmi, &domain)
+	}
+
+	encoder := xml.NewEncoder(conn)
+	encoder.Indent("", "  ")
+	if err := encoder.Encode(&domain); err != nil {
+		log.Log.Errorf("Failed to encode XML to connection:%v", err.Error())
+		return
+	}
+
+	log.Log.Infof("Hook Server successfully processed and returned XML")
+}
+
+func (h *PreMigrationHookServer) SetVMI(fullVMI *v1.VirtualMachineInstance) {
+	h.vmi = fullVMI
+	log.Log.Object(fullVMI).Info("Hook server updated with full VMI including status")
+}
+
+func (h *PreMigrationHookServer) registerAllHooks() {
+	for _, hook := range compute.GetComputeHooks() {
+		h.hooks = append(h.hooks, hook)
+	}
+
+	for _, hook := range storage.GetStorageHooks() {
+		h.hooks = append(h.hooks, hook)
+	}
+
+	for _, hook := range network.GetNetworkHooks() {
+		h.hooks = append(h.hooks, hook)
+	}
+}

--- a/pkg/virt-launcher/premigration-hook-server/network/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/network/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["network.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/network",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/virt-launcher/premigration-hook-server/types:go_default_library"],
+)

--- a/pkg/virt-launcher/premigration-hook-server/network/OWNERS
+++ b/pkg/virt-launcher/premigration-hook-server/network/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-network-reviewers
+approvers:
+  - sig-network-approvers
+labels:
+  - sig/network

--- a/pkg/virt-launcher/premigration-hook-server/network/network.go
+++ b/pkg/virt-launcher/premigration-hook-server/network/network.go
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package network
+
+import (
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/types"
+)
+
+func GetNetworkHooks() []types.HookFunc {
+	return []types.HookFunc{}
+}

--- a/pkg/virt-launcher/premigration-hook-server/storage/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/storage/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["storage.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/storage",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/virt-launcher/premigration-hook-server/types:go_default_library"],
+)

--- a/pkg/virt-launcher/premigration-hook-server/storage/OWNERS
+++ b/pkg/virt-launcher/premigration-hook-server/storage/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-storage-reviewers
+approvers:
+  - sig-storage-approvers
+labels:
+  - sig/storage

--- a/pkg/virt-launcher/premigration-hook-server/storage/storage.go
+++ b/pkg/virt-launcher/premigration-hook-server/storage/storage.go
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package storage
+
+import (
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/types"
+)
+
+func GetStorageHooks() []types.HookFunc {
+	return []types.HookFunc{}
+}

--- a/pkg/virt-launcher/premigration-hook-server/types/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/types/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["types.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/types",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)

--- a/pkg/virt-launcher/premigration-hook-server/types/types.go
+++ b/pkg/virt-launcher/premigration-hook-server/types/types.go
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package types
+
+import (
+	"libvirt.org/go/libvirtxml"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+type HookFunc func(vmi *v1.VirtualMachineInstance, domain *libvirtxml.Domain)

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -62,7 +62,6 @@ go_library(
         "//pkg/virt-launcher/virtwrap/device/hostdevice/sriov:go_default_library",
         "//pkg/virt-launcher/virtwrap/efi:go_default_library",
         "//pkg/virt-launcher/virtwrap/errors:go_default_library",
-        "//pkg/virt-launcher/virtwrap/libvirtxml:go_default_library",
         "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
+        "//pkg/virt-launcher/premigration-hook-server:go_default_library",
         "//pkg/virt-launcher/virtwrap/access-credentials:go_default_library",
         "//pkg/virt-launcher/virtwrap/agent:go_default_library",
         "//pkg/virt-launcher/virtwrap/agent-poller:go_default_library",

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -69,6 +69,7 @@ var _ = Describe("Live migration source", func() {
 				virtconfig.DefaultDiskVerificationMemoryLimitBytes,
 				fakeCpuSetGetter,
 				false, // image volume enabled
+				nil,
 			)
 			libvirtDomainManager = manager.(*LibvirtDomainManager)
 			libvirtDomainManager.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -166,6 +166,9 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 			return err
 		}
 	}
+	if l.hookServer != nil {
+		l.hookServer.SetVMI(vmi)
+	}
 
 	c, err := l.generateConverterContext(vmi, allowEmulation, options, true)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Manager", func() {
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
 	ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
 	newLibvirtDomainManagerDefault := func() (DomainManager, error) {
-		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 	}
 
 	BeforeEach(func() {
@@ -763,7 +763,7 @@ var _ = Describe("Manager", func() {
 				func() {
 					isFreeCalled <- true
 				})
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			Expect(manager.UnpauseVMI(vmi)).To(Succeed())
 			Eventually(func() bool {
 				select {
@@ -857,7 +857,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{
 				VirtualMachineSMBios: &cmdv1.SMBios{},
 				PreallocatedVolumes:  []string{"permvolume1"},
@@ -992,7 +992,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AttachDeviceFlags(strings.ToLower(string(attachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1100,7 +1100,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1174,7 +1174,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1279,7 +1279,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1422,7 +1422,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1556,7 +1556,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1635,7 +1635,7 @@ var _ = Describe("Manager", func() {
 			err = os.WriteFile(filepath.Join(ovmfDir, efi.EFICodeSEV), loaderBytes, 0644)
 			Expect(err).ToNot(HaveOccurred())
 
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			sevMeasurementInfo, err := manager.GetLaunchMeasurement(vmi)
 			if runtime.GOARCH == "amd64" {
 				Expect(err).ToNot(HaveOccurred())
@@ -2331,7 +2331,7 @@ var _ = Describe("Manager", func() {
 			func(state libvirt.DomainState) {
 				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 				mockLibvirt.DomainEXPECT().UndefineFlags(libvirt.DOMAIN_UNDEFINE_KEEP_NVRAM).Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 				Expect(manager.DeleteVMI(newVMI(testNamespace, testVmName))).To(Succeed())
 			},
 			Entry("crashed", libvirt.DOMAIN_CRASHED),
@@ -2489,7 +2489,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			})
 
 			It("should report nil when no OS info exists in the cache", func() {
@@ -2513,7 +2513,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 			})
 
 			It("should return nil when no interfaces exists in the cache", func() {
@@ -2558,7 +2558,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2594,7 +2594,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2621,7 +2621,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2648,7 +2648,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2694,7 +2694,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -14424,6 +14424,8 @@ var CRDsValidation map[string]string = map[string]string{
               description: |-
                 If the VMI requires dedicated CPUs, this field will
                 hold the dedicated CPU set on the target node
+                Deprecated: The VirtualMachineInstance field "TargetCPUSet" is deprecated
+                and will no longer be populated starting from version 1.8.
               items:
                 type: integer
               type: array
@@ -15017,6 +15019,8 @@ var CRDsValidation map[string]string = map[string]string{
               description: |-
                 If the VMI requires dedicated CPUs, this field will
                 hold the dedicated CPU set on the target node
+                Deprecated: The VirtualMachineInstance field "TargetCPUSet" is deprecated
+                and will no longer be populated starting from version 1.8.
               items:
                 type: integer
               type: array

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1025,7 +1025,9 @@ type VirtualMachineInstanceMigrationState struct {
 	// If the VMI requires dedicated CPUs, this field will
 	// hold the dedicated CPU set on the target node
 	// +listType=atomic
-	TargetCPUSet []int `json:"targetCPUSet,omitempty"`
+	// Deprecated: The VirtualMachineInstance field "TargetCPUSet" is deprecated
+	// and will no longer be populated starting from version 1.8.
+	TargetCPUSet []int `json:"targetCPUSet,omitempty"` //
 	// If the VMI requires dedicated CPUs, this field will
 	// hold the numa topology on the target node
 	TargetNodeTopology string `json:"targetNodeTopology,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -304,7 +304,7 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"mode":                           "Lets us know if the vmi is currently running pre or post copy migration",
 		"migrationPolicyName":            "Name of the migration policy. If string is empty, no policy is matched",
 		"migrationConfiguration":         "Migration configurations to apply",
-		"targetCPUSet":                   "If the VMI requires dedicated CPUs, this field will\nhold the dedicated CPU set on the target node\n+listType=atomic",
+		"targetCPUSet":                   "If the VMI requires dedicated CPUs, this field will\nhold the dedicated CPU set on the target node\n+listType=atomic\nDeprecated: The VirtualMachineInstance field \"TargetCPUSet\" is deprecated\nand will no longer be populated starting from version 1.8.",
 		"targetNodeTopology":             "If the VMI requires dedicated CPUs, this field will\nhold the numa topology on the target node",
 		"sourcePersistentStatePVCName":   "If the VMI being migrated uses persistent features (backend-storage), its source PVC name is saved here",
 		"targetPersistentStatePVCName":   "If the VMI being migrated uses persistent features (backend-storage), its target PVC name is saved here",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -26822,7 +26822,7 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationState(ref comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "If the VMI requires dedicated CPUs, this field will hold the dedicated CPU set on the target node",
+							Description: "If the VMI requires dedicated CPUs, this field will hold the dedicated CPU set on the target node Deprecated: The VirtualMachineInstance field \"TargetCPUSet\" is deprecated and will no longer be populated starting from version 1.8.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
Deprecate migration TargetCPUSet field
and switch premigration CPU pinning
hook to read CPU set from launcher cgroups

Waiting for https://github.com/kubevirt/kubevirt/pull/16212 to get merged.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

