### PR TITLE
tests/libwait: use watches instead of gomega polling

### DIFF
--- a/tests/libwait/BUILD.bazel
+++ b/tests/libwait/BUILD.bazel
@@ -17,5 +17,6 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
     ],
 )

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1895,7 +1895,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				libmigration.ConfirmVMIPostMigrationAborted(vmi, string(migration.UID), 180)
 
 				By("Waiting for the migration object to disappear")
-				libwait.WaitForMigrationToDisappearWithTimeout(migration, 240)
+				Expect(libwait.WaitForMigrationToDisappearWithTimeout(migration, 240*time.Second)).To(Succeed())
 			},
 				Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
 				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", decorators.StorageReq, newVirtualMachineInstanceWithFedoraRWXBlockDisk),
@@ -1961,7 +1961,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}, 30*time.Second, 2*time.Second).ShouldNot(HaveOccurred(), "target migration pod is expected to disappear after migration cancellation")
 
 				By("Waiting for the migration object to disappear")
-				libwait.WaitForMigrationToDisappearWithTimeout(migration, 20)
+				Expect(libwait.WaitForMigrationToDisappearWithTimeout(migration, 20*time.Second)).To(Succeed())
 			})
 
 			It("[sig-compute][test_id:8584]Immediate migration cancellation before migration starts running cancel a migration by deleting vmim object", func() {
@@ -1992,7 +1992,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				By("Waiting for the migration object to disappear")
-				libwait.WaitForMigrationToDisappearWithTimeout(migration, 240)
+				Expect(libwait.WaitForMigrationToDisappearWithTimeout(migration, 240*time.Second)).To(Succeed())
 
 				By("Verifying the VMI's phase, migration state and on node")
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -625,9 +625,9 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			libmigration.ConfirmVMIPostMigrationAborted(sourceVMI, string(sourceMigration.UID), timeout)
 
 			By("Waiting for the source migration object to disappear")
-			libwait.WaitForMigrationToDisappearWithTimeout(sourceMigration, timeout)
+			Expect(libwait.WaitForMigrationToDisappearWithTimeout(sourceMigration, timeout*time.Second)).To(Succeed())
 			By("Waiting for the target migration object to disappear")
-			libwait.WaitForMigrationToDisappearWithTimeout(targetMigration, timeout)
+			Expect(libwait.WaitForMigrationToDisappearWithTimeout(targetMigration, timeout*time.Second)).To(Succeed())
 			By("Logging in and ensuring the source VM is still running")
 			Expect(console.LoginToCirros(sourceVMI)).To(Succeed())
 			By("Checking that the receiving VM is in WaitingAsReceiver phase")


### PR DESCRIPTION
This PR replaces polling-based object-deletion waiting with efficient Kubernetes watch mechanisms in `libwaitl.WaitForMigrationToDisappearWithTimeout`. The functions now return errors instead of using Gomega assertions directly, following testing best practices where utility functions should handle errors at the call site.

This is the only the first step of redoing `libwait`.

```release-note
None
```

