### PR TITLE
device-manager: Added secure guest capacity device plugin

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,10 +1,14 @@
 package util
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -244,4 +248,40 @@ func PathForNVram(vmi *v1.VirtualMachineInstance) string {
 	}
 
 	return nvramPath
+}
+
+var miscCapacityPath = filepath.Join(HostRootMount, "/sys/fs/cgroup/misc.capacity")
+
+// GetMiscCapacity reads /sys/fs/cgroup/misc.capacity to return a map where keys
+// are the resource type names and values are their respective capacity limits.
+// Note SEV-SNP and SEV-ES share the same capacity pool, e.g. "sev_es 99"
+func GetMiscCapacity() (map[string]int, error) {
+	caps := make(map[string]int)
+
+	content, err := os.ReadFile(miscCapacityPath)
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+
+		capacityKey := fields[0]
+		capacity, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return nil, err
+		}
+		caps[capacityKey] = capacity
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return caps, nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -20,6 +20,9 @@
 package util
 
 import (
+	"os"
+	"path"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -233,3 +236,56 @@ var _ = DescribeTable("memory lock limit requirements",
 		true,
 	),
 )
+
+var _ = Describe("Misc Capacity", func() {
+	var (
+		originalMiscCapacityPath string
+		tempDir                  string
+	)
+
+	BeforeEach(func() {
+		originalMiscCapacityPath = miscCapacityPath
+		tempDir, err := os.MkdirTemp("", "cgroup")
+		Expect(err).ToNot(HaveOccurred())
+		miscCapacityPath = path.Join(tempDir, "misc.capacity")
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tempDir)).To(Succeed())
+		miscCapacityPath = originalMiscCapacityPath
+	})
+
+	Context("when reading secure guest capacity from misc.capacity", func() {
+		It("should successfully parse TDX capacity", func() {
+			Expect(os.WriteFile(miscCapacityPath, []byte("tdx 15\n"), 0644)).To(Succeed())
+			caps, err := GetMiscCapacity()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(caps).To(HaveLen(1))
+			Expect(caps["tdx"]).To(Equal(15))
+		})
+
+		It("should successfully parse SEV-SNP capacity", func() {
+			Expect(os.WriteFile(miscCapacityPath, []byte("sev 410\nsev_es 99\n"), 0644)).To(Succeed())
+			caps, err := GetMiscCapacity()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(caps).To(HaveLen(2))
+			Expect(caps["sev"]).To(Equal(410))
+			Expect(caps["sev_es"]).To(Equal(99))
+		})
+
+		It("should successfully handle empty file", func() {
+			Expect(os.WriteFile(miscCapacityPath, []byte(""), 0644)).To(Succeed())
+			caps, err := GetMiscCapacity()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(caps).To(BeEmpty())
+		})
+
+		It("should return error when file does not exist", func() {
+			miscCapacityPath = "/nonexisted_path/misc.capacity"
+			caps, err := GetMiscCapacity()
+			Expect(err).To(HaveOccurred())
+			Expect(caps).To(BeNil())
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+	})
+})

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -382,6 +382,15 @@ func WithTDX() ResourceRendererOption {
 	}
 }
 
+func WithSNPCapacity() ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		resources := renderer.ResourceRequirements()
+		requestResource(&resources, SevESidsDevice)
+		copyResources(resources.Limits, renderer.calculatedLimits)
+		copyResources(resources.Requests, renderer.calculatedRequests)
+	}
+}
+
 func WithPersistentReservation() ResourceRendererOption {
 	return func(renderer *ResourceRenderer) {
 		resources := renderer.ResourceRequirements()

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -458,6 +458,17 @@ var _ = Describe("Resource pod spec renderer", func() {
 		}))
 	})
 
+	It("WithSNPCapacity option adds sev-esids resource", func() {
+		esidsResourceKey := kubev1.ResourceName(SevESidsDevice)
+		rr = NewResourceRenderer(nil, nil, WithSNPCapacity())
+		Expect(rr.Requests()).To(Equal(kubev1.ResourceList{
+			esidsResourceKey: *resource.NewQuantity(1, resource.DecimalSI),
+		}))
+		Expect(rr.Limits()).To(Equal(kubev1.ResourceList{
+			esidsResourceKey: *resource.NewQuantity(1, resource.DecimalSI),
+		}))
+	})
+
 	defaultRequest := func() kubev1.ResourceList {
 		return kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("10m"),

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -83,8 +83,10 @@ const TunDevice = K8sDevicePrefix + "/tun"
 const VhostNetDevice = K8sDevicePrefix + "/vhost-net"
 const VhostVsockDevice = K8sDevicePrefix + "/vhost-vsock"
 const PrDevice = K8sDevicePrefix + "/pr-helper"
+const SevESidsDeviceName = "sev-esids"
 const SevDeviceName = "sev"
 const TdxDeviceName = "tdx"
+const SevESidsDevice = K8sDevicePrefix + "/" + SevESidsDeviceName
 const SevDevice = K8sDevicePrefix + "/" + SevDeviceName
 const TdxDevice = K8sDevicePrefix + "/" + TdxDeviceName
 
@@ -1553,6 +1555,7 @@ func (t *TemplateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 			}, WithHostDevicesDRA(vmi.Spec.Domain.Devices.HostDevices)),
 			NewVMIResourceRule(util.IsSEVVMI, WithSEV()),
 			NewVMIResourceRule(util.IsTDXVMI, WithTDX()),
+			NewVMIResourceRule(util.IsSEVSNPVMI, WithSNPCapacity()),
 			NewVMIResourceRule(reservation.HasVMIPersistentReservation, WithPersistentReservation()),
 		},
 	}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1312,6 +1312,26 @@ var _ = Describe("Template", func() {
 					Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue(v1.SEVSNPLabel, "true"))
 				})
 
+				It("should add sev-esids resource with SEV-SNP workload", func() {
+					vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{
+						SNP: &v1.SEVSNP{},
+					}
+
+					pod, err := svc.RenderLaunchManifest(vmi)
+					containers := pod.Spec.Containers
+					Expect(err).ToNot(HaveOccurred())
+					Expect(containers[0].Resources.Limits.Name(SevESidsDevice, resource.DecimalSI)).To(Equal(resource.NewQuantity(1, resource.DecimalSI)))
+				})
+
+				It("should not add sev-esids resource without SEV-SNP workload", func() {
+					vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{}
+
+					pod, err := svc.RenderLaunchManifest(vmi)
+					containers := pod.Spec.Containers
+					Expect(err).ToNot(HaveOccurred())
+					Expect(containers[0].Resources.Limits.Name(SevESidsDevice, resource.DecimalSI)).To(Equal(resource.NewQuantity(0, resource.DecimalSI)))
+				})
+
 				DescribeTable("should not add SEV-ES or SEV-SNP node label selector", func(policy *v1.SEVPolicy) {
 					vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{
 						SEV: &v1.SEV{

--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -20,17 +20,13 @@
 package cgroup
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"kubevirt.io/client-go/log"
-
-	"kubevirt.io/kubevirt/pkg/util"
 
 	runc_cgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -191,31 +187,4 @@ func detectVMIsolation(vm *v1.VirtualMachineInstance) (isolationRes isolation.Is
 	}
 
 	return isolationRes, nil
-}
-
-var miscCapacityPath = path.Join(util.HostRootMount, "/sys/fs/cgroup/misc.capacity")
-
-func GetMiscCapacity(key string) (int, error) {
-	f, err := os.Open(miscCapacityPath)
-	if err != nil {
-		return 0, err
-	}
-	defer f.Close()
-	// File has lines in the format: "key [capacity]"
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.Fields(line)
-		if len(parts) != 2 {
-			continue
-		}
-		if parts[0] == key {
-			capacity, err := strconv.Atoi(parts[1])
-			if err != nil {
-				return 0, err
-			}
-			return capacity, nil
-		}
-	}
-	return 0, fmt.Errorf("key %s not found in misc.capacity", key)
 }

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -20,9 +20,6 @@
 package cgroup
 
 import (
-	"os"
-	"path"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	runc_cgroups "github.com/opencontainers/runc/libcontainer/cgroups"
@@ -195,49 +192,6 @@ var _ = Describe("cgroup manager", func() {
 			[]string{
 				"/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/crio-456.scope",
 			},
-		),
-	)
-})
-
-var _ = Describe("GetMiscCapacity", func() {
-	var originalMiscCapacityPath string
-	var tempDir string
-
-	BeforeEach(func() {
-		tempDir = GinkgoT().TempDir()
-		originalMiscCapacityPath = miscCapacityPath
-		miscCapacityPath = path.Join(tempDir, "misc.capacity")
-	})
-
-	AfterEach(func() {
-		miscCapacityPath = originalMiscCapacityPath
-	})
-
-	DescribeTable("should return correct capacity",
-		func(fileContent string, key string, expectedCapacity int, expectError bool) {
-			if fileContent != "" {
-				err := os.WriteFile(path.Join(tempDir, "misc.capacity"), []byte(fileContent), 0644)
-				Expect(err).ToNot(HaveOccurred())
-			}
-			capacity, err := GetMiscCapacity(key)
-			Expect(capacity).To(Equal(expectedCapacity))
-			if expectError {
-				Expect(err).To(HaveOccurred())
-			} else {
-				Expect(err).ToNot(HaveOccurred())
-			}
-		},
-		Entry("returns capacity for matching key",
-			"tdx 10\nsev 5\n", "tdx", 10, false,
-		),
-		Entry("produces error when key not found",
-			"tdx 10\nsev 5\n", "nonexistent", 0, true,
-		),
-		Entry("produces error for malformed line",
-			"tdx\n", "tdx", 0, true,
-		),
-		Entry("produces error for non-numeric capacity",
-			"tdx abc\n", "tdx", 0, true,
 		),
 	)
 })

--- a/pkg/virt-handler/device-manager/BUILD.bazel
+++ b/pkg/virt-handler/device-manager/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
-        "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/device-manager/deviceplugin/v1beta1:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",
         "//pkg/virt-handler/virt-chroot:go_default_library",

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -33,11 +33,10 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
-	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
-
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
+	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-handler/selinux"
 )
@@ -122,6 +121,51 @@ func PermanentHostDevicePlugins(hypervisorDevice string, maxDevices int, permiss
 	return ret
 }
 
+type secureGuestCapacityDeviceHandler struct {
+	IsFgEnabled                     func() bool
+	UpdateSecureGuestCapacityDevice func(capacity int) (Device, error)
+}
+
+func (c *DeviceController) updateSecureGuestCapacityDevicePlugins() []Device {
+	var capacityDeviceHandlers = map[string]secureGuestCapacityDeviceHandler{
+		"tdx":    {c.virtConfig.WorkloadEncryptionTDXEnabled, c.updateTdxDevice},
+		"sev_es": {c.virtConfig.WorkloadEncryptionSEVEnabled, c.updateSNPCapacityDevice},
+	}
+
+	var caps map[string]int
+	var err error
+	plugins := []Device{}
+	for capKey, deviceHandler := range capacityDeviceHandlers {
+		if deviceHandler.IsFgEnabled() {
+			if len(caps) == 0 {
+				caps, err = util.GetMiscCapacity()
+
+				if err != nil {
+					log.Log.V(4).Infof("Error getting secure guest capacity: %s", err.Error())
+					return nil
+				}
+
+				if len(caps) == 0 {
+					log.Log.V(4).Infof("No secure guest capacity available")
+					return nil
+				}
+			}
+
+			capacity, existed := caps[capKey]
+			if existed {
+				cvmPlugin, err := deviceHandler.UpdateSecureGuestCapacityDevice(capacity)
+				if err != nil {
+					log.Log.Reason(err).Errorf("Failed to update the secure guest capacity device plugin")
+				}
+				plugins = append(plugins, cvmPlugin)
+				break
+			}
+		}
+	}
+
+	return plugins
+}
+
 type DeviceControllerInterface interface {
 	Initialized() bool
 	RefreshMediatedDeviceTypes()
@@ -182,40 +226,28 @@ func (c *DeviceController) NodeHasDevice(devicePath string) bool {
 	return err == nil
 }
 
-func (c *DeviceController) updateTdxDevice() (Device, error) {
-	maxTDXVMs, err := cgroup.GetMiscCapacity("tdx")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get TDX capacity from misc.capacity: %v", err)
-	} else if maxTDXVMs > 0 {
-		var selinuxExecutor selinux.SELinuxExecutor
-		socketPath := c.virtConfig.GetQGSSocketPath()
-		socketDir := path.Dir(socketPath)
-		socketFile := path.Base(socketPath)
-		var tdxPlugin Device
-		var err error
-		if c.virtConfig.RequireQGS() {
-			tdxPlugin, err = NewSocketDevicePlugin(services.TdxDeviceName, socketDir, socketFile, maxTDXVMs, selinuxExecutor, nil, true)
-		} else {
-			tdxPlugin = NewOptionalSocketDevicePlugin(services.TdxDeviceName, socketDir, socketFile, maxTDXVMs, selinuxExecutor, nil, true)
-		}
-		return tdxPlugin, err
+func (c *DeviceController) updateSNPCapacityDevice(capacity int) (Device, error) {
+	return NewGenericDevicePlugin(services.SevESidsDeviceName, "", capacity, "", false), nil
+}
+
+func (c *DeviceController) updateTdxDevice(maxTDXVMs int) (Device, error) {
+	var selinuxExecutor selinux.SELinuxExecutor
+	socketPath := c.virtConfig.GetQGSSocketPath()
+	socketDir := path.Dir(socketPath)
+	socketFile := path.Base(socketPath)
+	var tdxPlugin Device
+	var err error
+	if c.virtConfig.RequireQGS() {
+		tdxPlugin, err = NewSocketDevicePlugin(services.TdxDeviceName, socketDir, socketFile, maxTDXVMs, selinuxExecutor, nil, true)
 	} else {
-		return nil, fmt.Errorf("an invalid device capacity of %d was report for tdx", maxTDXVMs)
+		tdxPlugin = NewOptionalSocketDevicePlugin(services.TdxDeviceName, socketDir, socketFile, maxTDXVMs, selinuxExecutor, nil, true)
 	}
+	return tdxPlugin, err
 }
 
 // updatePermittedHostDevicePlugins returns a slice of device plugins for permitted devices which are present on the node
 func (c *DeviceController) updatePermittedHostDevicePlugins() []Device {
 	var permittedDevices []Device
-
-	if c.virtConfig.WorkloadEncryptionTDXEnabled() {
-		tdxPlugin, err := c.updateTdxDevice()
-		if err != nil {
-			log.Log.Reason(err).Errorf("failed to configure the TDX-QGS device plugin")
-		} else {
-			permittedDevices = append(permittedDevices, tdxPlugin)
-		}
-	}
 
 	var featureGatedGenericDevices = []struct {
 		Name      string
@@ -233,6 +265,11 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() []Device {
 				NewGenericDevicePlugin(dev.Name, dev.Path, c.maxDevices, c.permissions, true),
 			)
 		}
+	}
+
+	cvmPlugins := c.updateSecureGuestCapacityDevicePlugins()
+	if len(cvmPlugins) > 0 {
+		permittedDevices = append(permittedDevices, cvmPlugins...)
 	}
 
 	if c.virtConfig.PersistentReservationEnabled() {

--- a/pkg/virt-handler/device-manager/generic_device_test.go
+++ b/pkg/virt-handler/device-manager/generic_device_test.go
@@ -59,9 +59,11 @@ var _ = Describe("Generic Device", func() {
 
 	})
 
-	It("Should stop if the device plugin socket file is deleted", func() {
+	DescribeTable("Should stop if the device plugin socket file is deleted", func(dummyDevice bool) {
+		if dummyDevice {
+			dpi.devicePath = ""
+		}
 		os.OpenFile(dpi.socketPath, os.O_RDONLY|os.O_CREATE, 0666)
-
 		errChan := make(chan error, 1)
 		go func(errChan chan error) {
 			errChan <- dpi.healthCheck()
@@ -72,7 +74,10 @@ var _ = Describe("Generic Device", func() {
 		Expect(os.Remove(dpi.socketPath)).To(Succeed())
 
 		Expect(<-errChan).ToNot(HaveOccurred())
-	})
+	},
+		Entry("when it is not a dummy device", true),
+		Entry("when it is a dummy device", false),
+	)
 
 	It("Should monitor health of device node", func() {
 


### PR DESCRIPTION
Added device plugin for SEV-SNP secure guest capacity by reading /sys/fs/cgroup/misc.capacity. This enables resource housekeeping to prevent over-scheduling of confidential VMs on worker nodes.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The capacity of starting secure guests per worker node is limited, currently kubevirt doesn't consider it when starting the secure guests.

#### After this PR:
 There are secure guest capacity resources exposed by the worker nodes, which determines how many confidential VMs can be created in the node. The scheduler consumes one for each secure guest. The number of the secure guests started per node is limited.  This is applicable to SNP and the available resources are available under `/sys/fs/cgroup/misc.capacity`.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

