### PR TITLE
Release 1.6 backport : Remove the ValidateVirtualMachineInstanceSpec call

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -27,7 +27,6 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -183,11 +182,6 @@ func admitStorageUpdate(newVolumes, oldVolumes []v1.Volume, newDisks, oldDisks [
 	hotplugAr := verifyHotplugVolumes(newHotplugVolumeMap, oldHotplugVolumeMap, newDiskMap, oldDiskMap, migratedVolumeMap)
 	if hotplugAr != nil {
 		return hotplugAr
-	}
-
-	causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &newVMI.Spec, config)
-	if len(causes) > 0 {
-		return webhookutils.ToAdmissionResponse(causes)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR back ports the commit ffa49bc55c9e234825f6ff35a165d46948308a29 
commit ffa49bc55c9e234825f6ff35a165d46948308a29
Author: Shelly Kagan <skagan@redhat.com>
Date:   Sun Jul 27 14:04:57 2025 +0300    Remove the ValidateVirtualMachineInstanceSpec call
    
    Explanation by Cursor:
    - Redundant storage validation:
    Storage validation is already comprehensive before this call
    - Irrelevant validations:
    95% of what it validates can't change during hotplug
    - Wrong architectural pattern:
    Hotplug operations should only validate the fields that can actually change
    - Performance:
    Unnecessary work re-validating immutable fields
    Conclustion:
    The storage-specific validations already cover everything
    needed for storage operations, and the CPU/memory hotplug functions
    handle their respective validations.
    
    Signed-off-by: Shelly Kagan <skagan@redhat.com>

#### Before this PR:

There is an [issue](https://issues.redhat.com/browse/CNV-68899) relating to invalid name validation, i.e. user can not
re-attach a volume to a VM because of the name validation fails.

#### After this PR:

Backporting the above commit will fix this issue.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfixes: backport fix "Remove the ValidateVirtualMachineInstanceSpec call"
```

