### PR TITLE
tests: Remove redundant HostDisk feature gate e2e test

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2095,6 +2095,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes, config)
 			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("HostDisk feature gate is not enabled"))
 		})
 
 		It("should accept hostDisk volumes if the feature gate is enabled", func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -520,24 +520,6 @@ var _ = Describe(SIG("Storage", func() {
 			})
 		})
 
-		Context("With feature gates disabled for", Serial, func() {
-			It("[test_id:4620]HostDisk, it should fail to start a VMI", func() {
-				config.DisableFeatureGate(featuregate.HostDiskGate)
-				vmi = libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithMemoryRequest("128Mi"),
-					libvmi.WithHostDisk("host-disk", "somepath", v1.HostDiskExistsOrCreate),
-					// hostdisk needs a privileged namespace
-					libvmi.WithNamespace(testsuite.NamespacePrivileged),
-				)
-				virtClient := kubevirt.Client()
-				_, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("HostDisk feature gate is not enabled"))
-			})
-		})
-
 		Context("[rfe_id:2298][crit:medium][vendor:cnv-qe@redhat.com][level:component] With HostDisk and PVC initialization", func() {
 
 			BeforeEach(func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Remove [test_id:4620] e2e test for HostDisk feature gate validation. The validation logic is already covered by unit test: https://github.com/kubevirt/kubevirt/blob/e55112538b2960704c75fc3c71c9f0fdd4a81675/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go#L2085-L2098
as the e2e test only verifies config propagation, which is infrastructure-level and doesn't need per-feature-gate testing.

followup - the only e2e featuregate test left might also be redundant:
https://github.com/kubevirt/kubevirt/blob/e55112538b2960704c75fc3c71c9f0fdd4a81675/tests/vmi_hook_sidecar_test.go#L286-L297

### References
Fixes # https://issues.redhat.com/browse/CNV-74364
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes # 
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->
### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

