### PR TITLE
cloud-init: add NoCloud vendor-data support

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13391,6 +13391,18 @@
      "userDataBase64": {
       "description": "UserDataBase64 contains config drive cloud-init userdata as a base64 encoded string.",
       "type": "string"
+     },
+     "vendorData": {
+      "description": "VendorData contains config drive inline cloud-init vendordata.",
+      "type": "string"
+     },
+     "vendorDataBase64": {
+      "description": "VendorDataBase64 contains config drive cloud-init vendordata as a base64 encoded string.",
+      "type": "string"
+     },
+     "vendorDataSecretRef": {
+      "description": "VendorDataSecretRef references a k8s secret that contains config drive vendordata.",
+      "$ref": "#/definitions/k8s.io.api.core.v1.LocalObjectReference"
      }
     }
    },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13421,6 +13421,18 @@
      "userDataBase64": {
       "description": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.",
       "type": "string"
+     },
+     "vendorData": {
+      "description": "VendorData contains NoCloud inline cloud-init vendordata.",
+      "type": "string"
+     },
+     "vendorDataBase64": {
+      "description": "VendorDataBase64 contains NoCloud cloud-init vendordata as a base64 encoded string.",
+      "type": "string"
+     },
+     "vendorDataSecretRef": {
+      "description": "VendorDataSecretRef references a k8s secret that contains NoCloud vendordata.",
+      "$ref": "#/definitions/k8s.io.api.core.v1.LocalObjectReference"
      }
     }
    },

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -600,6 +600,47 @@ var _ = Describe("CloudInit", func() {
 					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
 				})
 
+				It("should succeed to verify userData with vendorData", func() {
+					userData := "fake\nuser\ndata\n"
+					vendorData := "fake\nvendor\ndata\n"
+					cloudInitData := &v1.CloudInitConfigDriveSource{
+						UserData:   userData,
+						VendorData: vendorData,
+					}
+					verifyCloudInitConfigDriveIso(cloudInitData)
+				})
+
+				It("should succeed to verify userData with vendorDataBase64", func() {
+					userData := "fake\nuser\ndata\n"
+					vendorData := "fake\nvendor\ndata\n"
+					cloudInitData := &v1.CloudInitConfigDriveSource{
+						UserData:         userData,
+						VendorDataBase64: base64.StdEncoding.EncodeToString([]byte(vendorData)),
+					}
+					verifyCloudInitConfigDriveIso(cloudInitData)
+				})
+
+				It("should succeed to verify userDataBase64 with vendorData and networkData", func() {
+					userData := "fake\nuser\ndata\n"
+					networkData := "fake\nnetwork\ndata\n"
+					vendorData := "fake\nvendor\ndata\n"
+					cloudInitData := &v1.CloudInitConfigDriveSource{
+						UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
+						NetworkData:    networkData,
+						VendorData:     vendorData,
+					}
+					verifyCloudInitConfigDriveIso(cloudInitData)
+				})
+
+				It("should fail to verify bad cloudInitConfigDrive VendorDataBase64", func() {
+					source := &v1.CloudInitConfigDriveSource{
+						UserData:         "fake",
+						VendorDataBase64: "#######garbage******",
+					}
+					_, err := readCloudInitConfigDriveSource(source)
+					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
+				})
+
 				Context("with secretRefs", func() {
 					createCloudInitConfigDriveVolume := func(name, secret string) *v1.Volume {
 						return &v1.Volume{
@@ -666,6 +707,48 @@ var _ = Describe("CloudInit", func() {
 						Expect(err.Error()).To(Equal("no cloud-init data-source found at volume: test-volume"))
 						Expect(keys).To(BeEmpty())
 
+					})
+
+					createCloudInitConfigDriveVolumeWithVendorData := func(name, secret string) *v1.Volume {
+						return &v1.Volume{
+							Name: name,
+							VolumeSource: v1.VolumeSource{
+								CloudInitConfigDrive: &v1.CloudInitConfigDriveSource{
+									UserDataSecretRef: &k8sv1.LocalObjectReference{
+										Name: secret,
+									},
+									VendorDataSecretRef: &k8sv1.LocalObjectReference{
+										Name: secret,
+									},
+								},
+							},
+						}
+					}
+
+					It("should resolve vendordata from secret", func() {
+						testVolume := createCloudInitConfigDriveVolumeWithVendorData("test-volume", "test-secret")
+						vmi := createEmptyVMIWithVolumes([]v1.Volume{*testVolume})
+						fakeVolumeMountDir("test-volume", map[string]string{
+							"userdata":   "secret-userdata",
+							"vendordata": "secret-vendordata",
+						})
+						_, err := resolveConfigDriveSecrets(vmi, tmpDir)
+						Expect(err).To(Not(HaveOccurred()), "could not resolve secret volume")
+						Expect(testVolume.CloudInitConfigDrive.UserData).To(Equal("secret-userdata"))
+						Expect(testVolume.CloudInitConfigDrive.VendorData).To(Equal("secret-vendordata"))
+					})
+
+					It("should resolve vendorData with camelCase key from secret", func() {
+						testVolume := createCloudInitConfigDriveVolumeWithVendorData("test-volume", "test-secret")
+						vmi := createEmptyVMIWithVolumes([]v1.Volume{*testVolume})
+						fakeVolumeMountDir("test-volume", map[string]string{
+							"userData":   "secret-userdata",
+							"vendorData": "secret-vendordata",
+						})
+						_, err := resolveConfigDriveSecrets(vmi, tmpDir)
+						Expect(err).To(Not(HaveOccurred()), "could not resolve secret volume")
+						Expect(testVolume.CloudInitConfigDrive.UserData).To(Equal("secret-userdata"))
+						Expect(testVolume.CloudInitConfigDrive.VendorData).To(Equal("secret-vendordata"))
 					})
 				})
 			})

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -354,6 +354,38 @@ var _ = Describe("CloudInit", func() {
 					verifyCloudInitNoCloudIso(cloudInitData)
 				})
 
+				It("should succeed to verify userData with vendorData", func() {
+					userData := "fake\nuser\ndata\n"
+					vendorData := "fake\nvendor\ndata\n"
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserData:   userData,
+						VendorData: vendorData,
+					}
+					verifyCloudInitNoCloudIso(cloudInitData)
+				})
+
+				It("should succeed to verify userData with vendorDataBase64", func() {
+					userData := "fake\nuser\ndata\n"
+					vendorData := "fake\nvendor\ndata\n"
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserData:         userData,
+						VendorDataBase64: base64.StdEncoding.EncodeToString([]byte(vendorData)),
+					}
+					verifyCloudInitNoCloudIso(cloudInitData)
+				})
+
+				It("should succeed to verify userDataBase64 with vendorData and networkData", func() {
+					userData := "fake\nuser\ndata\n"
+					networkData := "fake\nnetwork\ndata\n"
+					vendorData := "fake\nvendor\ndata\n"
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
+						NetworkData:    networkData,
+						VendorData:     vendorData,
+					}
+					verifyCloudInitNoCloudIso(cloudInitData)
+				})
+
 				It("should fail to verify bad cloudInitNoCloud UserDataBase64", func() {
 					source := &v1.CloudInitNoCloudSource{
 						UserDataBase64: "#######garbage******",
@@ -366,6 +398,15 @@ var _ = Describe("CloudInit", func() {
 					source := &v1.CloudInitNoCloudSource{
 						UserData:          "fake",
 						NetworkDataBase64: "#######garbage******",
+					}
+					_, err := readCloudInitNoCloudSource(source)
+					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
+				})
+
+				It("should fail to verify bad cloudInitNoCloud VendorDataBase64", func() {
+					source := &v1.CloudInitNoCloudSource{
+						UserData:         "fake",
+						VendorDataBase64: "#######garbage******",
 					}
 					_, err := readCloudInitNoCloudSource(source)
 					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
@@ -387,6 +428,22 @@ var _ = Describe("CloudInit", func() {
 										Name: secret,
 									},
 									NetworkDataSecretRef: &k8sv1.LocalObjectReference{
+										Name: secret,
+									},
+								},
+							},
+						}
+					}
+
+					createCloudInitSecretRefVolumeWithVendorData := func(name, secret string) *v1.Volume {
+						return &v1.Volume{
+							Name: name,
+							VolumeSource: v1.VolumeSource{
+								CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+									UserDataSecretRef: &k8sv1.LocalObjectReference{
+										Name: secret,
+									},
+									VendorDataSecretRef: &k8sv1.LocalObjectReference{
 										Name: secret,
 									},
 								},
@@ -454,6 +511,32 @@ var _ = Describe("CloudInit", func() {
 						_, err := resolveNoCloudSecrets(vmi, tmpDir)
 						Expect(err).To(HaveOccurred(), "expected a failure when no sources found")
 						Expect(err.Error()).To(Equal("no cloud-init data-source found at volume: test-volume"))
+					})
+
+					It("should resolve vendordata from secret", func() {
+						testVolume := createCloudInitSecretRefVolumeWithVendorData("test-volume", "test-secret")
+						vmi := createEmptyVMIWithVolumes([]v1.Volume{*testVolume})
+						fakeVolumeMountDir("test-volume", map[string]string{
+							"userdata":   "secret-userdata",
+							"vendordata": "secret-vendordata",
+						})
+						_, err := resolveNoCloudSecrets(vmi, tmpDir)
+						Expect(err).To(Not(HaveOccurred()), "could not resolve secret volume")
+						Expect(testVolume.CloudInitNoCloud.UserData).To(Equal("secret-userdata"))
+						Expect(testVolume.CloudInitNoCloud.VendorData).To(Equal("secret-vendordata"))
+					})
+
+					It("should resolve camel-case vendorData from secret", func() {
+						testVolume := createCloudInitSecretRefVolumeWithVendorData("test-volume", "test-secret")
+						vmi := createEmptyVMIWithVolumes([]v1.Volume{*testVolume})
+						fakeVolumeMountDir("test-volume", map[string]string{
+							"userData":   "secret-userdata",
+							"vendorData": "secret-vendordata",
+						})
+						_, err := resolveNoCloudSecrets(vmi, tmpDir)
+						Expect(err).To(Not(HaveOccurred()), "could not resolve secret volume")
+						Expect(testVolume.CloudInitNoCloud.UserData).To(Equal("secret-userdata"))
+						Expect(testVolume.CloudInitNoCloud.VendorData).To(Equal("secret-vendordata"))
 					})
 				})
 			})

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -854,6 +854,30 @@ func (vr *VolumeRenderer) handleCloudInitNoCloud(volume v1.Volume) {
 			ReadOnly:  true,
 		})
 	}
+	if volume.CloudInitNoCloud.VendorDataSecretRef != nil {
+		// attach a secret referenced by the vendordata
+		volumeName := volume.Name + "-vdata"
+		vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{
+			Name: volumeName,
+			VolumeSource: k8sv1.VolumeSource{
+				Secret: &k8sv1.SecretVolumeSource{
+					SecretName: volume.CloudInitNoCloud.VendorDataSecretRef.Name,
+				},
+			},
+		})
+		vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
+			Name:      volumeName,
+			MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "vendordata"),
+			SubPath:   "vendordata",
+			ReadOnly:  true,
+		})
+		vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
+			Name:      volumeName,
+			MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "vendorData"),
+			SubPath:   "vendorData",
+			ReadOnly:  true,
+		})
+	}
 }
 
 func (vr *VolumeRenderer) handleDownwardMetrics(volume v1.Volume) {

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -308,6 +308,30 @@ func (vr *VolumeRenderer) handleCloudInitConfigDrive(volume v1.Volume) {
 				ReadOnly:  true,
 			})
 		}
+		if volume.CloudInitConfigDrive.VendorDataSecretRef != nil {
+			// attach a secret referenced by the vendordata
+			volumeName := volume.Name + "-vdata"
+			vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{
+				Name: volumeName,
+				VolumeSource: k8sv1.VolumeSource{
+					Secret: &k8sv1.SecretVolumeSource{
+						SecretName: volume.CloudInitConfigDrive.VendorDataSecretRef.Name,
+					},
+				},
+			})
+			vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
+				Name:      volumeName,
+				MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "vendordata"),
+				SubPath:   "vendordata",
+				ReadOnly:  true,
+			})
+			vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
+				Name:      volumeName,
+				MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "vendorData"),
+				SubPath:   "vendorData",
+				ReadOnly:  true,
+			})
+		}
 	}
 }
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7905,6 +7905,29 @@ var CRDsValidation map[string]string = map[string]string{
                             description: UserDataBase64 contains config drive cloud-init
                               userdata as a base64 encoded string.
                             type: string
+                          vendorData:
+                            description: VendorData contains config drive inline cloud-init
+                              vendordata.
+                            type: string
+                          vendorDataBase64:
+                            description: VendorDataBase64 contains config drive cloud-init
+                              vendordata as a base64 encoded string.
+                            type: string
+                          vendorDataSecretRef:
+                            description: VendorDataSecretRef references a k8s secret
+                              that contains config drive vendordata.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       cloudInitNoCloud:
                         description: |-
@@ -13436,6 +13459,29 @@ var CRDsValidation map[string]string = map[string]string{
                     description: UserDataBase64 contains config drive cloud-init userdata
                       as a base64 encoded string.
                     type: string
+                  vendorData:
+                    description: VendorData contains config drive inline cloud-init
+                      vendordata.
+                    type: string
+                  vendorDataBase64:
+                    description: VendorDataBase64 contains config drive cloud-init
+                      vendordata as a base64 encoded string.
+                    type: string
+                  vendorDataSecretRef:
+                    description: VendorDataSecretRef references a k8s secret that
+                      contains config drive vendordata.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               cloudInitNoCloud:
                 description: |-
@@ -19728,6 +19774,29 @@ var CRDsValidation map[string]string = map[string]string{
                             description: UserDataBase64 contains config drive cloud-init
                               userdata as a base64 encoded string.
                             type: string
+                          vendorData:
+                            description: VendorData contains config drive inline cloud-init
+                              vendordata.
+                            type: string
+                          vendorDataBase64:
+                            description: VendorDataBase64 contains config drive cloud-init
+                              vendordata as a base64 encoded string.
+                            type: string
+                          vendorDataSecretRef:
+                            description: VendorDataSecretRef references a k8s secret
+                              that contains config drive vendordata.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       cloudInitNoCloud:
                         description: |-
@@ -24769,6 +24838,30 @@ var CRDsValidation map[string]string = map[string]string{
                                     description: UserDataBase64 contains config drive
                                       cloud-init userdata as a base64 encoded string.
                                     type: string
+                                  vendorData:
+                                    description: VendorData contains config drive
+                                      inline cloud-init vendordata.
+                                    type: string
+                                  vendorDataBase64:
+                                    description: VendorDataBase64 contains config
+                                      drive cloud-init vendordata as a base64 encoded
+                                      string.
+                                    type: string
+                                  vendorDataSecretRef:
+                                    description: VendorDataSecretRef references a
+                                      k8s secret that contains config drive vendordata.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               cloudInitNoCloud:
                                 description: |-
@@ -30243,6 +30336,31 @@ var CRDsValidation map[string]string = map[string]string{
                                           drive cloud-init userdata as a base64 encoded
                                           string.
                                         type: string
+                                      vendorData:
+                                        description: VendorData contains config drive
+                                          inline cloud-init vendordata.
+                                        type: string
+                                      vendorDataBase64:
+                                        description: VendorDataBase64 contains config
+                                          drive cloud-init vendordata as a base64
+                                          encoded string.
+                                        type: string
+                                      vendorDataSecretRef:
+                                        description: VendorDataSecretRef references
+                                          a k8s secret that contains config drive
+                                          vendordata.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                   cloudInitNoCloud:
                                     description: |-

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7958,6 +7958,29 @@ var CRDsValidation map[string]string = map[string]string{
                             description: UserDataBase64 contains NoCloud cloud-init
                               userdata as a base64 encoded string.
                             type: string
+                          vendorData:
+                            description: VendorData contains NoCloud inline cloud-init
+                              vendordata.
+                            type: string
+                          vendorDataBase64:
+                            description: VendorDataBase64 contains NoCloud cloud-init
+                              vendordata as a base64 encoded string.
+                            type: string
+                          vendorDataSecretRef:
+                            description: VendorDataSecretRef references a k8s secret
+                              that contains NoCloud vendordata.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       configMap:
                         description: |-
@@ -13464,6 +13487,28 @@ var CRDsValidation map[string]string = map[string]string{
                     description: UserDataBase64 contains NoCloud cloud-init userdata
                       as a base64 encoded string.
                     type: string
+                  vendorData:
+                    description: VendorData contains NoCloud inline cloud-init vendordata.
+                    type: string
+                  vendorDataBase64:
+                    description: VendorDataBase64 contains NoCloud cloud-init vendordata
+                      as a base64 encoded string.
+                    type: string
+                  vendorDataSecretRef:
+                    description: VendorDataSecretRef references a k8s secret that
+                      contains NoCloud vendordata.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
                 type: object
               configMap:
                 description: |-
@@ -19736,6 +19781,29 @@ var CRDsValidation map[string]string = map[string]string{
                             description: UserDataBase64 contains NoCloud cloud-init
                               userdata as a base64 encoded string.
                             type: string
+                          vendorData:
+                            description: VendorData contains NoCloud inline cloud-init
+                              vendordata.
+                            type: string
+                          vendorDataBase64:
+                            description: VendorDataBase64 contains NoCloud cloud-init
+                              vendordata as a base64 encoded string.
+                            type: string
+                          vendorDataSecretRef:
+                            description: VendorDataSecretRef references a k8s secret
+                              that contains NoCloud vendordata.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       configMap:
                         description: |-
@@ -24754,6 +24822,29 @@ var CRDsValidation map[string]string = map[string]string{
                                     description: UserDataBase64 contains NoCloud cloud-init
                                       userdata as a base64 encoded string.
                                     type: string
+                                  vendorData:
+                                    description: VendorData contains NoCloud inline
+                                      cloud-init vendordata.
+                                    type: string
+                                  vendorDataBase64:
+                                    description: VendorDataBase64 contains NoCloud
+                                      cloud-init vendordata as a base64 encoded string.
+                                    type: string
+                                  vendorDataSecretRef:
+                                    description: VendorDataSecretRef references a
+                                      k8s secret that contains NoCloud vendordata.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               configMap:
                                 description: |-
@@ -30207,6 +30298,30 @@ var CRDsValidation map[string]string = map[string]string{
                                           cloud-init userdata as a base64 encoded
                                           string.
                                         type: string
+                                      vendorData:
+                                        description: VendorData contains NoCloud inline
+                                          cloud-init vendordata.
+                                        type: string
+                                      vendorDataBase64:
+                                        description: VendorDataBase64 contains NoCloud
+                                          cloud-init vendordata as a base64 encoded
+                                          string.
+                                        type: string
+                                      vendorDataSecretRef:
+                                        description: VendorDataSecretRef references
+                                          a k8s secret that contains NoCloud vendordata.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                   configMap:
                                     description: |-

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -752,7 +752,12 @@
                 "name": "nameValue"
               },
               "networkDataBase64": "networkDataBase64Value",
-              "networkData": "networkDataValue"
+              "networkData": "networkDataValue",
+              "vendorDataSecretRef": {
+                "name": "nameValue"
+              },
+              "vendorDataBase64": "vendorDataBase64Value",
+              "vendorData": "vendorDataValue"
             },
             "cloudInitConfigDrive": {
               "secretRef": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -769,7 +769,12 @@
                 "name": "nameValue"
               },
               "networkDataBase64": "networkDataBase64Value",
-              "networkData": "networkDataValue"
+              "networkData": "networkDataValue",
+              "vendorDataSecretRef": {
+                "name": "nameValue"
+              },
+              "vendorDataBase64": "vendorDataBase64Value",
+              "vendorData": "vendorDataValue"
             },
             "sysprep": {
               "secret": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -733,6 +733,10 @@ spec:
             name: nameValue
           userData: userDataValue
           userDataBase64: userDataBase64Value
+          vendorData: vendorDataValue
+          vendorDataBase64: vendorDataBase64Value
+          vendorDataSecretRef:
+            name: nameValue
         cloudInitNoCloud:
           networkData: networkDataValue
           networkDataBase64: networkDataBase64Value

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -742,6 +742,10 @@ spec:
             name: nameValue
           userData: userDataValue
           userDataBase64: userDataBase64Value
+          vendorData: vendorDataValue
+          vendorDataBase64: vendorDataBase64Value
+          vendorDataSecretRef:
+            name: nameValue
         configMap:
           name: nameValue
           optional: true

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -709,7 +709,12 @@
             "name": "nameValue"
           },
           "networkDataBase64": "networkDataBase64Value",
-          "networkData": "networkDataValue"
+          "networkData": "networkDataValue",
+          "vendorDataSecretRef": {
+            "name": "nameValue"
+          },
+          "vendorDataBase64": "vendorDataBase64Value",
+          "vendorData": "vendorDataValue"
         },
         "sysprep": {
           "secret": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -692,7 +692,12 @@
             "name": "nameValue"
           },
           "networkDataBase64": "networkDataBase64Value",
-          "networkData": "networkDataValue"
+          "networkData": "networkDataValue",
+          "vendorDataSecretRef": {
+            "name": "nameValue"
+          },
+          "vendorDataBase64": "vendorDataBase64Value",
+          "vendorData": "vendorDataValue"
         },
         "cloudInitConfigDrive": {
           "secretRef": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -537,6 +537,10 @@ spec:
         name: nameValue
       userData: userDataValue
       userDataBase64: userDataBase64Value
+      vendorData: vendorDataValue
+      vendorDataBase64: vendorDataBase64Value
+      vendorDataSecretRef:
+        name: nameValue
     cloudInitNoCloud:
       networkData: networkDataValue
       networkDataBase64: networkDataBase64Value

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -546,6 +546,10 @@ spec:
         name: nameValue
       userData: userDataValue
       userDataBase64: userDataBase64Value
+      vendorData: vendorDataValue
+      vendorDataBase64: vendorDataBase64Value
+      vendorDataSecretRef:
+        name: nameValue
     configMap:
       name: nameValue
       optional: true

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -557,6 +557,11 @@ func (in *CloudInitConfigDriveSource) DeepCopyInto(out *CloudInitConfigDriveSour
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.VendorDataSecretRef != nil {
+		in, out := &in.VendorDataSecretRef, &out.VendorDataSecretRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -583,6 +583,11 @@ func (in *CloudInitNoCloudSource) DeepCopyInto(out *CloudInitNoCloudSource) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.VendorDataSecretRef != nil {
+		in, out := &in.VendorDataSecretRef, &out.VendorDataSecretRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -191,6 +191,15 @@ type CloudInitConfigDriveSource struct {
 	// NetworkData contains config drive inline cloud-init networkdata.
 	// + optional
 	NetworkData string `json:"networkData,omitempty"`
+	// VendorDataSecretRef references a k8s secret that contains config drive vendordata.
+	// + optional
+	VendorDataSecretRef *v1.LocalObjectReference `json:"vendorDataSecretRef,omitempty"`
+	// VendorDataBase64 contains config drive cloud-init vendordata as a base64 encoded string.
+	// + optional
+	VendorDataBase64 string `json:"vendorDataBase64,omitempty"`
+	// VendorData contains config drive inline cloud-init vendordata.
+	// + optional
+	VendorData string `json:"vendorData,omitempty"`
 }
 
 type DomainSpec struct {

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -159,6 +159,15 @@ type CloudInitNoCloudSource struct {
 	// NetworkData contains NoCloud inline cloud-init networkdata.
 	// + optional
 	NetworkData string `json:"networkData,omitempty"`
+	// VendorDataSecretRef references a k8s secret that contains NoCloud vendordata.
+	// + optional
+	VendorDataSecretRef *v1.LocalObjectReference `json:"vendorDataSecretRef,omitempty"`
+	// VendorDataBase64 contains NoCloud cloud-init vendordata as a base64 encoded string.
+	// + optional
+	VendorDataBase64 string `json:"vendorDataBase64,omitempty"`
+	// VendorData contains NoCloud inline cloud-init vendordata.
+	// + optional
+	VendorData string `json:"vendorData,omitempty"`
 }
 
 // Represents a cloud-init config drive user data source.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -67,6 +67,9 @@ func (CloudInitNoCloudSource) SwaggerDoc() map[string]string {
 		"networkDataSecretRef": "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.\n+ optional",
 		"networkDataBase64":    "NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.\n+ optional",
 		"networkData":          "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
+		"vendorDataSecretRef":  "VendorDataSecretRef references a k8s secret that contains NoCloud vendordata.\n+ optional",
+		"vendorDataBase64":     "VendorDataBase64 contains NoCloud cloud-init vendordata as a base64 encoded string.\n+ optional",
+		"vendorData":           "VendorData contains NoCloud inline cloud-init vendordata.\n+ optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -82,6 +82,9 @@ func (CloudInitConfigDriveSource) SwaggerDoc() map[string]string {
 		"networkDataSecretRef": "NetworkDataSecretRef references a k8s secret that contains config drive networkdata.\n+ optional",
 		"networkDataBase64":    "NetworkDataBase64 contains config drive cloud-init networkdata as a base64 encoded string.\n+ optional",
 		"networkData":          "NetworkData contains config drive inline cloud-init networkdata.\n+ optional",
+		"vendorDataSecretRef":  "VendorDataSecretRef references a k8s secret that contains config drive vendordata.\n+ optional",
+		"vendorDataBase64":     "VendorDataBase64 contains config drive cloud-init vendordata as a base64 encoded string.\n+ optional",
+		"vendorData":           "VendorData contains config drive inline cloud-init vendordata.\n+ optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18406,6 +18406,26 @@ func schema_kubevirtio_api_core_v1_CloudInitConfigDriveSource(ref common.Referen
 							Format:      "",
 						},
 					},
+					"vendorDataSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VendorDataSecretRef references a k8s secret that contains config drive vendordata.",
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+						},
+					},
+					"vendorDataBase64": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VendorDataBase64 contains config drive cloud-init vendordata as a base64 encoded string.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"vendorData": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VendorData contains config drive inline cloud-init vendordata.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18461,6 +18461,26 @@ func schema_kubevirtio_api_core_v1_CloudInitNoCloudSource(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"vendorDataSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VendorDataSecretRef references a k8s secret that contains NoCloud vendordata.",
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+						},
+					},
+					"vendorDataBase64": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VendorDataBase64 contains NoCloud cloud-init vendordata as a base64 encoded string.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"vendorData": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VendorData contains NoCloud inline cloud-init vendordata.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
# Add cloud-init NoCloud vendor-data support

## What this PR does / why we need it

This PR implements support for **vendor-data** in cloud-init NoCloud datasource for KubeVirt VirtualMachines, as requested in issue #16156.

Vendor-data is a cloud-init feature that allows cloud providers/administrators to provide additional configuration that gets merged with user-provided cloud-init data. This is useful for:
- Setting organization-wide defaults
- Injecting monitoring agents or security configurations
- Pre-configuring networking or storage settings
- Adding vendor-specific customizations without modifying user data

The implementation follows the same pattern as existing `userData` and `networkData` fields.

## Which issue(s) this PR fixes

Fixes #16156

## Changes Made

### API Schema (`staging/src/kubevirt.io/api/core/v1/schema.go`)

Added three new fields to `CloudInitNoCloudSource`:

```go
// VendorData contains NoCloud inline cloud-init vendordata.
// +optional
VendorData string `json:"vendorData,omitempty"`

// VendorDataBase64 contains NoCloud cloud-init vendordata as a base64 encoded string.
// +optional  
VendorDataBase64 string `json:"vendorDataBase64,omitempty"`

// VendorDataSecretRef references a k8s secret that contains NoCloud vendordata.
// +optional
VendorDataSecretRef *corev1.LocalObjectReference `json:"vendorDataSecretRef,omitempty"`
```

### Core Logic (`pkg/cloud-init/cloud-init.go`)

- Added `VendorData` field to `CloudInitData` struct
- Updated `readCloudInitNoCloudSource()` to read vendor-data from inline, base64, or secret
- Updated `GenerateLocalData()` to write `vendor-data` file to the ISO (NoCloud only)
- Updated `resolveNoCloudSecrets()` to handle `VendorDataSecretRef`
- Updated `findCloudInitNoCloudSecretVolume()` to include vendor-data secret

### Volume Rendering (`pkg/virt-controller/services/rendervolumes.go`)

Added volume mount handling for `VendorDataSecretRef` in the virt-launcher pod.

## Testing

### Unit Tests

Added 6 new test cases in `pkg/cloud-init/cloud-init_test.go`:
- Inline vendor data
- Base64-encoded vendor data  
- Vendor data from secret reference
- Bad base64 vendor data (error handling)
- CamelCase secret key resolution

```bash
$ go test ./pkg/cloud-init/... -v -count=1

=== RUN   TestCloudInit
...
Ran 211 of 211 Specs in 1.013 seconds
SUCCESS! -- 211 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestCloudInit (1.01s)
PASS
ok      kubevirt.io/kubevirt/pkg/cloud-init     1.013s
```

### Functional Testing

Deployed the modified KubeVirt to a test cluster and verified vendor-data works end-to-end:

**1. Cluster Setup:**
```bash
$ make cluster-up
$ make cluster-sync
```

**2. KubeVirt Deployment Status:**
```bash
$ ./kubevirtci/cluster-up/kubectl.sh get pods -n kubevirt
NAME                               READY   STATUS    RESTARTS   AGE
disks-images-provider-v9n6b        1/1     Running   0          14m
virt-api-896cb86d8-n88xc           1/1     Running   0          12m
virt-controller-6955584fd9-4b6g7   1/1     Running   0          12m
virt-controller-6955584fd9-4q4l5   1/1     Running   0          12m
virt-handler-8ftbj                 1/1     Running   0          12m
virt-operator-78b6c8944-7q22v      1/1     Running   0          14m
virt-operator-78b6c8944-qfqj6      1/1     Running   0          14m

$ ./kubevirtci/cluster-up/kubectl.sh -n kubevirt get kv kubevirt
NAME       AGE   PHASE
kubevirt   13m   Deployed
```

**3. Test VM with vendor-data:**

Created a test VM with inline vendor-data:
```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: test-vendordata
spec:
  running: true
  template:
    spec:
      domain:
        devices:
          disks:
            - name: containerdisk
              disk:
                bus: virtio
            - name: cloudinitdisk
              disk:
                bus: virtio
        resources:
          requests:
            memory: 512Mi
      volumes:
        - name: containerdisk
          containerDisk:
            image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
        - name: cloudinitdisk
          cloudInitNoCloud:
            vendorData: |
              #cloud-config
              write_files:
                - content: |
                    VENDOR_NAME="kubevirt-vendor"
                    VENDOR_VERSION="1.0"
                    PROVISIONED_BY="cloud-init-vendor-data"
                  path: /etc/vendor_specific_data
                  permissions: '0644'
            userData: |
              #cloud-config
              user: fedora
              password: fedora
              chpasswd:
                expire: false
```

**4. VM Running Successfully:**
```bash
$ ./kubevirtci/cluster-up/kubectl.sh get vmi test-vendordata
NAME              AGE     PHASE     IP            NODENAME   READY
test-vendordata   6m13s   Running   10.244.0.30   node01     True
```

**5. Verified cloud-init ISO contains vendor-data:**
```bash
$ ./kubevirtci/cluster-up/kubectl.sh cp default/virt-launcher-test-vendordata-dhmms:/var/run/kubevirt-ephemeral-disks/cloud-init-data/default/test-vendordata/noCloud.iso /tmp/noCloud.iso -c compute

$ sudo mount -o loop /tmp/noCloud.iso /tmp/iso_mount
$ ls -la /tmp/iso_mount
-rw-------  89 107  meta-data
-rw------- 128 107  user-data
-rw------- 211 107  vendor-data   # <-- NEW FILE

$ sudo cat /tmp/iso_mount/vendor-data
#cloud-config
write_files:
  - content: |
      VENDOR_NAME="kubevirt-vendor"
      VENDOR_VERSION="1.0"
      PROVISIONED_BY="cloud-init-vendor-data"
    path: /etc/vendor_specific_data
    permissions: '0644'
```

## Files Changed

```
api/openapi-spec/swagger.json
pkg/cloud-init/cloud-init.go
pkg/cloud-init/cloud-init_test.go
pkg/virt-controller/services/rendervolumes.go
pkg/virt-operator/resource/generate/components/validations_generated.go
staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
staging/src/kubevirt.io/api/core/v1/schema.go
staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
staging/src/kubevirt.io/client-go/api/openapi_generated.go
```

## Usage Example

```yaml
# Option 1: Inline vendor data
cloudInitNoCloud:
  vendorData: |
    #cloud-config
    write_files:
      - content: "vendor config"
        path: /etc/vendor.conf

# Option 2: Base64-encoded vendor data
cloudInitNoCloud:
  vendorDataBase64: I2Nsb3VkLWNvbmZpZwp3cml0ZV9maWxlczoKICAtIGNvbnRlbnQ6ICJ2ZW5kb3IgY29uZmlnIgogICAgcGF0aDogL2V0Yy92ZW5kb3IuY29uZg==

# Option 3: Vendor data from secret
cloudInitNoCloud:
  vendorDataSecretRef:
    name: my-vendor-data-secret
```


```release-note
Add vendor-data support for cloud-init NoCloud datasource with vendorData, vendorDataBase64, and vendorDataSecretRef fields
```
