### PR TITLE
virtctl: change add/remove volume to persist in VMs by default

### DIFF
--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -7,7 +7,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/events"
-	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/watcher"
 
@@ -30,7 +29,6 @@ import (
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -568,12 +566,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				checkOnlineSnapshotExpectedContentSource(vm, contentName, true)
 			})
 
-			DescribeTable("should succeed online snapshot with hot plug disk", func(withEphemeralHotplug bool) {
-				if withEphemeralHotplug {
-					kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
-					kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
-				}
-
+			It("should succeed online snapshot with hot plug disk", func() {
 				var vmi *v1.VirtualMachineInstance
 				vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)
 				vm, vmi = createAndStartVM(vm)
@@ -581,12 +574,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
-				persistVolName := AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, false)
-				var tempVolName string
-				if withEphemeralHotplug {
-					By("Add temporary hotplug disk")
-					tempVolName = AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, true)
-				}
+				persistVolName := AddVolumeAndVerify(virtClient, snapshotStorageClass, vm)
 				By("Create Snapshot")
 				snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
@@ -604,16 +592,12 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				contentVMTemplate := content.Spec.Source.VirtualMachine.Spec.Template
 				Expect(contentVMTemplate.Spec.Volumes).Should(HaveLen(len(updatedVM.Spec.Template.Spec.Volumes)))
 				foundHotPlug := false
-				foundTempHotPlug := false
 				for _, volume := range contentVMTemplate.Spec.Volumes {
 					if volume.Name == persistVolName {
 						foundHotPlug = true
-					} else if volume.Name == tempVolName {
-						foundTempHotPlug = true
 					}
 				}
 				Expect(foundHotPlug).To(BeTrue())
-				Expect(foundTempHotPlug).To(BeFalse())
 
 				Expect(content.Spec.VolumeBackups).Should(HaveLen(len(updatedVM.Spec.Template.Spec.Volumes)))
 				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes).Should(HaveLen(len(content.Spec.VolumeBackups)))
@@ -646,10 +630,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 					}
 					Expect(found).To(BeTrue())
 				}
-			},
-				Entry("[test_id:7472] with ephemeral hotplug disk", Serial, true),
-				Entry("without ephemeral hotplug disk", false),
-			)
+			})
 
 			It("should report appropriate event when freeze fails", func() {
 				// Activate SELinux and reboot machine so we can force fsfreeze failure
@@ -1505,7 +1486,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 	})
 }))
 
-func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, vm *v1.VirtualMachine, addVMIOnly bool) string {
+func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, vm *v1.VirtualMachine) string {
 	dv := libdv.NewDataVolume(
 		libdv.WithBlankImageSource(),
 		libdv.WithStorage(libdv.StorageWithStorageClass(storageClass), libdv.StorageWithVolumeSize(cd.BlankVolumeSize)),
@@ -1534,16 +1515,10 @@ func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, 
 		VolumeSource: volumeSource,
 	}
 
-	if addVMIOnly {
-		Eventually(func() error {
-			return virtClient.VirtualMachineInstance(vm.Namespace).AddVolume(context.Background(), vm.Name, addVolumeOptions)
-		}, 3*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-	} else {
-		Eventually(func() error {
-			return virtClient.VirtualMachine(vm.Namespace).AddVolume(context.Background(), vm.Name, addVolumeOptions)
-		}, 3*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-		verifyVolumeAndDiskVMAdded(virtClient, vm, addVolumeName)
-	}
+	Eventually(func() error {
+		return virtClient.VirtualMachine(vm.Namespace).AddVolume(context.Background(), vm.Name, addVolumeOptions)
+	}, 3*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	verifyVolumeAndDiskVMAdded(virtClient, vm, addVolumeName)
 
 	vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In preparation to make `DeclarativeHotplugVolumes` [#13847](https://github.com/kubevirt/kubevirt/pull/13847) GA we need to begin to deprecate the older `HotplugVolumes` feature gate. Currently, `HotplugVolumes` allows users to hotplug volumes directly to a running VMI, that do not persist in the associated VM (these are known as ephemeral hotplugs). However, `DeclarativeHotplugVolumes` does not support the use of ephemeral hotplugs. This PR is intended to remove the ability to create new ephemeral hotplug volumes using virtctl

#### Before this PR:
`virtctl addvolume` would default to adding the volume to _only_ the VMI unless the `--persist` flag was present, thus creating an ephemeral hotplug volume. Same behavior for `virtctl removevolume`

#### After this PR:
The `--persist` flag is deprecated and the default behavior of `virtctl addvolume` will be to persist the new volume in both the VM and VMI specs. Same behavior for `virtctl removevolume`. This change will not affect hotplugs for standalone VMIs

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
deprecate --persist flag from virtctl add/remove volume
```

