### PR TITLE
Revert "virt-api: reject stop requests for paused VMIs"

### DIFF
--- a/pkg/virt-api/rest/lifecycle.go
+++ b/pkg/virt-api/rest/lifecycle.go
@@ -201,14 +201,6 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		return
 	}
 
-	if hasVMI {
-		condManager := controller.NewVirtualMachineInstanceConditionManager()
-		if condManager.HasConditionWithStatus(vmi, v1.VirtualMachineInstancePaused, k8sv1.ConditionTrue) {
-			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("cannot stop a paused VirtualMachineInstance; it must be unpaused first")), response)
-			return
-		}
-	}
-
 	var oldGracePeriodSeconds int64
 	var patchErr error
 	if hasVMI && !vmi.IsFinal() && bodyStruct.GracePeriod != nil {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -56,7 +56,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
@@ -503,32 +502,6 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				Entry("in status Running with dry-run", v1.Running, &v1.StopOptions{GracePeriod: gracePeriodZero, DryRun: withDryRun()}),
 				Entry("in status Failed with dry-run", v1.Failed, &v1.StopOptions{GracePeriod: gracePeriodZero, DryRun: withDryRun()}),
 			)
-
-			It("should fail to stop a paused VMI", func() {
-				request.PathParameters()["name"] = testVMName
-				request.PathParameters()["namespace"] = k8smetav1.NamespaceDefault
-
-				vmi := libvmi.New(
-					libvmi.WithNamespace(k8smetav1.NamespaceDefault),
-					libvmi.WithName(testVMName),
-					libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running),
-						libvmistatus.WithCondition(v1.VirtualMachineInstanceCondition{
-							Type:   v1.VirtualMachineInstancePaused,
-							Status: k8sv1.ConditionTrue,
-						}),
-					)),
-				)
-
-				vm := libvmi.NewVirtualMachine(vmi)
-
-				vmClient.EXPECT().Get(context.Background(), vm.Name, k8smetav1.GetOptions{}).Return(vm, nil)
-				vmiClient.EXPECT().Get(context.Background(), vmi.Name, k8smetav1.GetOptions{}).Return(vmi, nil)
-
-				app.StopVMRequestHandler(request, response)
-
-				status := ExpectStatusErrorWithCode(recorder, http.StatusConflict)
-				Expect(status.Error()).To(ContainSubstring("cannot stop a paused VirtualMachineInstance; it must be unpaused first"))
-			})
 		})
 	})
 

--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -138,6 +138,32 @@ var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
 		})
 
+		It("[test_id:3085]should be stopped successfully", decorators.Conformance, func() {
+			vm := libvmi.NewVirtualMachine(libvmifact.NewCirros(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				withStartStrategy(pointer.P(v1.StartStrategyPaused))),
+				libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			)
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			By("Stopping the VM")
+			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking deletion of VMI")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(300*time.Second).WithPolling(time.Second).Should(matcher.BeGone(), "The VMI did not disappear")
+
+			By("Checking status of VM")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(Not(matcher.BeReady()))
+
+			By("Ensuring a second invocation should fail")
+			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+			Expect(err).To(MatchError(ContainSubstring("VM is not running")))
+		})
+
 		It("[test_id:3229]should gracefully handle being started again", func() {
 			vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),


### PR DESCRIPTION
This PR reverts #15405

The implementation is racefull, we should revert this and introduce a better alternative.

for example: the virt-controller will be the one to perform stop validation, and if stop is not possible due to the existence of the paused condition, we can patch a new condition e.g InvalidStop
which can be monitored by virtctl and alert the user when needed.

### Release note
```release-note
none
```

