### PR TITLE
access-credentials: Fix issue where a valid Kubernetes Secret Could Fail to be Launched

### DIFF
--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     race = "on",
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
@@ -33,5 +34,6 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
     ],
 )

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -189,7 +189,7 @@ func resolveSSHPublicKeys(accessCredentials []v1.AccessCredential, secretSourceD
 			continue
 		}
 
-		baseDir := filepath.Join(secretSourceDir, secretName+"-access-cred")
+		baseDir := filepath.Join(secretSourceDir, dns.SanitizeAccessCredentialVolumeName(secretName))
 		files, err := os.ReadDir(baseDir)
 		if err != nil {
 			return keys, err

--- a/pkg/util/net/dns/BUILD.bazel
+++ b/pkg/util/net/dns/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/openshift/library-go/pkg/build/naming:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
     ],
 )

--- a/pkg/util/net/dns/sanitize.go
+++ b/pkg/util/net/dns/sanitize.go
@@ -22,9 +22,16 @@ package dns
 import (
 	"strings"
 
+	"github.com/openshift/library-go/pkg/build/naming"
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	v1 "kubevirt.io/api/core/v1"
+)
+
+const (
+	// AccessCredentialsSuffix is the suffix used for access credentials volume names
+	// to ensure they remain DNS-1123 compliant even when the secret name is long
+	AccessCredentialsSuffix = "access-cred"
 )
 
 // Sanitize hostname according to DNS label rules
@@ -41,4 +48,11 @@ func SanitizeHostname(vmi *v1.VirtualMachineInstance) string {
 	}
 
 	return hostName
+}
+
+// SanitizeAccessCredentialVolumeName ensures the volume name conforms to DNS-1123 label standard.
+// It uses [naming.GetName] to properly handle length constraints while preserving
+// the AccessCredentialsSuffix, ensuring consistency with getSecretDir.
+func SanitizeAccessCredentialVolumeName(secretName string) string {
+	return naming.GetName(secretName, AccessCredentialsSuffix, validation.DNS1123LabelMaxLength)
 }

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-controller/watch/topology:go_default_library",

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -23,6 +23,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
 	"kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virtiofs"
 )
@@ -361,7 +362,7 @@ func withAccessCredentials(accessCredentials []v1.AccessCredential) VolumeRender
 			if secretName == "" {
 				continue
 			}
-			volumeName := secretName + "-access-cred"
+			volumeName := dns.SanitizeAccessCredentialVolumeName(secretName)
 			renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 				Name: volumeName,
 				VolumeSource: k8sv1.VolumeSource{

--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config:go_default_library",
+        "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
         "//pkg/virt-launcher/virtwrap/agent:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/config"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -109,7 +110,7 @@ func getSecretDirs(vmi *v1.VirtualMachineInstance) []string {
 }
 
 func getSecretDir(secretName string) string {
-	return filepath.Join(getSecretBaseDir(), secretName+"-access-cred")
+	return filepath.Join(getSecretBaseDir(), dns.SanitizeAccessCredentialVolumeName(secretName))
 }
 
 func getSecretBaseDir() string {

--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//vendor/k8s.io/api/policy/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
     ],
 )


### PR DESCRIPTION

### What this PR does
Fixed an issue where virt-launcher pods failed to start when the access credential secret name exceeded 51 characters. This occurred because the secret name and -access-cred were concatenated to form the volume mount name, causing it to exceed Kubernetes’ 63-character limit. As a result, valid secrets could not be mounted. KubeVirt now supports secret names up to the full 63-character limit.
#### Before this PR:
```
message: 'failed to create virtual machine pod: Pod "virt-launcher-ci-integration-2fclaubetr-combined-testing-nm7zjq"  is invalid: [spec.volumes[8].name: Invalid value: "ci-integration-2fclaubetr-combined-testing-new emulation-on-e1m-ac cess-cred":  must be no more than 63 characters, spec.containers[0].volumeMounts[6].name:              
```
#### After this PR:
VM Launches successfully with a secret of length 51+

### References
- Fixes #16277
### Why we need it and why it was done in this way
The following alternatives were considered: 

One simpler alternative to this PR is to not hash the volume mount name and just make the volume mount name the same as the secret. I chose to do a hash as I believe the -access-cred prefix is useful metadata to know why the mount exists on the virt-launcher pod.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered


-->
```release-note
Fixed an issue where a VM failed to launch when injecting access credentials from a source secret longer than 51 characters. (#16277 , @aidanleuck)
```

