### PR TITLE
converter: Extract KVM hypervisor logic to separate Builder module

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "console.go",
         "graphics.go",
         "host_device.go",
+        "hypervisor.go",
         "input_device.go",
         "launch_security.go",
         "rng.go",
@@ -29,6 +30,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/converter/virtio:go_default_library",
         "//pkg/virt-launcher/virtwrap/launchsecurity:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )
 
@@ -42,6 +44,7 @@ go_test(
         "console_test.go",
         "graphics_test.go",
         "host_device_test.go",
+        "hypervisor_test.go",
         "input_device_test.go",
         "launch_security_test.go",
         "rng_test.go",

--- a/pkg/virt-launcher/virtwrap/converter/compute/hypervisor.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/hypervisor.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package compute
+
+import (
+	"fmt"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+type HypervisorDomainConfigurator struct {
+	allowEmulation bool
+	kvmAvailable   bool
+}
+
+// NewHypervisorDomainConfigurator creates a new hypervisor domain configurator
+func NewHypervisorDomainConfigurator(allowEmulation bool, kvmAvailable bool) HypervisorDomainConfigurator {
+	return HypervisorDomainConfigurator{
+		allowEmulation: allowEmulation,
+		kvmAvailable:   kvmAvailable,
+	}
+}
+
+// Configure configures the domain hypervisor settings based on KVM availability and emulation settings
+func (h HypervisorDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+	if !h.kvmAvailable {
+		if h.allowEmulation {
+			logger := log.DefaultLogger()
+			logger.Infof("kvm not present. Using software emulation.")
+			domain.Spec.Type = "qemu"
+		} else {
+			return fmt.Errorf("kvm not present")
+		}
+	}
+
+	return nil
+}

--- a/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_test.go
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package compute_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
+)
+
+var _ = Describe("Hypervisor Domain Configurator", func() {
+	var (
+		vmi    *v1.VirtualMachineInstance
+		domain api.Domain
+	)
+	const (
+		kvmEnabled       = true
+		emulationAllowed = true
+	)
+
+	BeforeEach(func() {
+		vmi = libvmi.New()
+		domain = api.Domain{}
+	})
+
+	Context("When KVM is available", func() {
+		It("Should not modify domain type", func() {
+			configurator := compute.NewHypervisorDomainConfigurator(!emulationAllowed, kvmEnabled)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal(""))
+			Expect(domain).To(Equal(api.Domain{}))
+
+		})
+
+		It("Should not modify domain type even when emulation is allowed", func() {
+			configurator := compute.NewHypervisorDomainConfigurator(emulationAllowed, kvmEnabled)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal(""))
+			Expect(domain).To(Equal(api.Domain{}))
+		})
+	})
+
+	Context("When KVM is not available", func() {
+		It("Should return error when emulation is not allowed", func() {
+			configurator := compute.NewHypervisorDomainConfigurator(!emulationAllowed, !kvmEnabled)
+			err := configurator.Configure(vmi, &domain)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("kvm not present"))
+		})
+
+		It("Should set domain type to qemu when emulation is allowed", func() {
+			configurator := compute.NewHypervisorDomainConfigurator(emulationAllowed, !kvmEnabled)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal("qemu"))
+		})
+	})
+})

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -89,6 +89,7 @@ type EFIConfiguration struct {
 type ConverterContext struct {
 	Architecture                    arch.Converter
 	AllowEmulation                  bool
+	KvmAvailable                    bool
 	Secrets                         map[string]*k8sv1.Secret
 	VirtualMachine                  *v1.VirtualMachineInstance
 	CPUSet                          []int
@@ -1420,6 +1421,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		),
 		compute.TPMDomainConfigurator{},
 		compute.VSOCKDomainConfigurator{},
+		compute.NewHypervisorDomainConfigurator(c.AllowEmulation, c.KvmAvailable),
 		compute.NewLaunchSecurityDomainConfigurator(architecture),
 		compute.ChannelsDomainConfigurator{},
 		compute.ClockDomainConfigurator{},
@@ -1467,19 +1469,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	// set the maximum number of sockets here to allow hot-plug CPUs
 	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.Architecture.SupportCPUHotplug() {
 		domainVCPUTopologyForHotplug(vmi, domain)
-	}
-
-	kvmPath := "/dev/kvm"
-	if _, err := os.Stat(kvmPath); errors.Is(err, os.ErrNotExist) {
-		if c.AllowEmulation {
-			logger := log.DefaultLogger()
-			logger.Infof("Hardware emulation device '%s' not present. Using software emulation.", kvmPath)
-			domain.Spec.Type = "qemu"
-		} else {
-			return fmt.Errorf("hardware emulation device '%s' not present", kvmPath)
-		}
-	} else if err != nil {
-		return err
 	}
 
 	domain.Spec.SysInfo = &api.SysInfo{}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1062,11 +1062,23 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		}
 	}
 
+	// Check KVM device availability
+	const kvmPath = "/dev/kvm"
+	kvmAvailable := true
+	if _, err := os.Stat(kvmPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			kvmAvailable = false
+		} else {
+			return nil, fmt.Errorf("failed to stat KVM device %s: %w", kvmPath, err)
+		}
+	}
+
 	// Map the VirtualMachineInstance to the Domain
 	c := &converter.ConverterContext{
 		Architecture:          arch.NewConverter(runtime.GOARCH),
 		VirtualMachine:        vmi,
 		AllowEmulation:        allowEmulation,
+		KvmAvailable:          kvmAvailable,
 		CPUSet:                podCPUSet,
 		IsBlockPVC:            isBlockPVCMap,
 		IsBlockDV:             isBlockDVMap,


### PR DESCRIPTION
Extract KVM device checking and emulation fallback logic from converter.go
into a new HypervisorDomainConfigurator under the compute
package. This improves code organization by following the new pattern
of using domain-specific configurators.

Add KvmAvailable field to ConverterContext to pass KVM availability
from manager.go instead of checking filesystem in converter.

Move the related unit tests to hypervisor_tests.go, extend them, and
make them independent of the existence of /dev/kvm device. True unit
tests must be environment-independent.

The refactoring maintains the same behavior while improving testability
and code organization.

Fixes: https://github.com/kubevirt/kubevirt/issues/13837

### Release note
```
NONE
```