### PR TITLE
Parallelize observability functional tests

### DIFF
--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/flags:go_default_library",
-        "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libkubevirt:go_default_library",


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Most monitoring tests ran Serial, including ones safe to parallelize.
#### After this PR:
In `vm_monitoring.go` we parallelized suites:
- VMI metrics
- VM status metrics
- VM snapshot metrics
- VM metrics based on the guest agent
- Metrics based on VMI connections
- VM dirty rate metrics

and kept disruptive suites Serial:
- Cluster VM metrics
- VM migration metrics
- VM alerts

In `monitoring.go` we parallelized suites:
- Kubevirt alert rules
- Migration Alerts

and kept disruptive suites Serial:
- System Alerts
- Deprecation Alerts
  
### Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Improves tests time by parallelizing non-disruptive suites (with 4 nodes it saves ~10 minutes). 
- Serializes cluster-wide/disruptive tests to avoid flakes and interference.

The following alternatives were considered:
- Marking individual Its as Serial, splitting by Describe kept intent clearer and safer.

### Special notes for your reviewer
- Replaced deprecated checks.SkipIfPrometheusRuleIsNotEnabled.
- Stabilized tests by removing shared state and deduplicating setup helpers.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```