### PR TITLE
e2e,network: Fix external connectivity flakes

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -557,10 +557,6 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 			It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
 				libnet.SkipWhenClusterNotSupportIpv4()
-				ipv4Address := "8.8.8.8"
-				if flags.IPV4ConnectivityCheckAddress != "" {
-					ipv4Address = flags.IPV4ConnectivityCheckAddress
-				}
 				dns := "google.com"
 				if flags.ConnectivityCheckDNS != "" {
 					dns = flags.ConnectivityCheckDNS
@@ -572,9 +568,10 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-				By("Checking ping (IPv4)")
-				Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
-				Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
+				By("Checking external connectivity via TCP (HTTP)")
+				Eventually(func() error {
+					return console.RunCommand(vmi, fmt.Sprintf("nc -z %s 80 -w 5", dns), 10*time.Second)
+				}, 30*time.Second, 1*time.Second).Should(Succeed())
 			})
 
 			DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Sometimes we see that one of the 5 ping packets is failing.
The current expect will fail if so, since it expects
all the packets to success (due to -w usage).

The following changes are done:
1. Use `nc` instead ICMP, since some clouds like AWS block ICMP.
This way the test will be robust.
Moreover using a protocol based on TCP has buildin retry and is less prone
to filtering and lower Qos such as ICMP is.
2. Add eventually to mitigate random noise when testing external connectivity.
3. Remove the ping IP command, leave the DNS one.
Since using the URL involves connectivity anyhow.
Note: using the IP allowed providing specific DNS IP, but the test
always checked both, and the default IP was used anyhow, so it didn't
add special value. (it also helps clouds that don't support ICMP, see reason 1)

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

