### PR TITLE
Pipe: metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -2,6 +2,7 @@
 
 | Name | Kind | Type | Description |
 |------|------|------|-------------|
+| kubevirt_active_pipe_proxies | Metric | Gauge | The number of running proxied pipe connections. |
 | kubevirt_configuration_emulation_enabled | Metric | Gauge | Indicates whether the Software Emulation is enabled in the configuration. |
 | kubevirt_console_active_connections | Metric | Gauge | Amount of active Console connections, broken down by namespace and vmi name. |
 | kubevirt_info | Metric | Gauge | Version information. |

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -3,6 +3,7 @@
 | Name | Kind | Type | Description |
 |------|------|------|-------------|
 | kubevirt_active_pipe_proxies | Metric | Gauge | The number of running proxied pipe connections. |
+| kubevirt_active_pipes | Metric | Gauge | The number of running pipes. |
 | kubevirt_configuration_emulation_enabled | Metric | Gauge | Indicates whether the Software Emulation is enabled in the configuration. |
 | kubevirt_console_active_connections | Metric | Gauge | Amount of active Console connections, broken down by namespace and vmi name. |
 | kubevirt_info | Metric | Gauge | Version information. |

--- a/pkg/monitoring/metrics/virt-handler/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "guest_metrics.go",
         "machine_type.go",
         "metrics.go",
+        "pipe.go",
         "version_metrics.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler",

--- a/pkg/monitoring/metrics/virt-handler/metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/metrics.go
@@ -46,7 +46,7 @@ func SetupMetrics(
 		return err
 	}
 
-	if err := operatormetrics.RegisterMetrics(componentMetrics, versionMetrics, machineTypeMetrics, guestPanicMetrics); err != nil {
+	if err := operatormetrics.RegisterMetrics(componentMetrics, versionMetrics, machineTypeMetrics, guestPanicMetrics, pipeMetrics); err != nil {
 		return err
 	}
 	SetVersionInfo()

--- a/pkg/monitoring/metrics/virt-handler/pipe.go
+++ b/pkg/monitoring/metrics/virt-handler/pipe.go
@@ -23,12 +23,20 @@ import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 var (
 	pipeMetrics = []operatormetrics.Metric{
 		pipeActiveProxies,
+		activePipes,
 	}
 
 	pipeActiveProxies = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_active_pipe_proxies",
 			Help: "The number of running proxied pipe connections.",
+		},
+	)
+
+	activePipes = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_active_pipes",
+			Help: "The number of running pipes.",
 		},
 	)
 )
@@ -39,4 +47,12 @@ func IncPipeActiveProxies() {
 
 func DecPipeActiveProxies() {
 	pipeActiveProxies.Dec()
+}
+
+func IncActivePipes() {
+	activePipes.Inc()
+}
+
+func DecActivePipes() {
+	activePipes.Dec()
 }

--- a/pkg/monitoring/metrics/virt-handler/pipe.go
+++ b/pkg/monitoring/metrics/virt-handler/pipe.go
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package virthandler
+
+import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+
+var (
+	pipeMetrics = []operatormetrics.Metric{
+		pipeActiveProxies,
+	}
+
+	pipeActiveProxies = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_active_pipe_proxies",
+			Help: "The number of running proxied pipe connections.",
+		},
+	)
+)
+
+func IncPipeActiveProxies() {
+	pipeActiveProxies.Inc()
+}
+
+func DecPipeActiveProxies() {
+	pipeActiveProxies.Dec()
+}

--- a/pkg/virt-handler/launcher-clients/launcher-clients.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients.go
@@ -213,9 +213,7 @@ func handleDomainNotifyPipe(ctx context.Context, ln net.Listener, virtShareDir s
 
 	// Process new connections
 	// exit when stop encountered
-	go pipe.Pipe(ctx, fdChan, func(conn net.Conn) {
-		pipe.Proxy(logger, conn, pipe.NewConnectToNotifyFunc(virtShareDir))
-	})
+	go pipe.Pipe(ctx, fdChan, pipe.Proxy(logger, pipe.NewConnectToNotifyFunc(virtShareDir)))
 }
 
 func (l *launcherClientsManager) startDomainNotifyPipe(domainPipeStopChan chan struct{}, vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-handler/notify-server/pipe/BUILD.bazel
+++ b/pkg/virt-handler/notify-server/pipe/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/monitoring/metrics/virt-handler:go_default_library",
         "//pkg/safepath:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-handler/notify-server/pipe/pipe.go
+++ b/pkg/virt-handler/notify-server/pipe/pipe.go
@@ -88,6 +88,8 @@ type connectFunc func() (net.Conn, error)
 type proxyFunc func(net.Conn)
 
 func Pipe(ctx context.Context, pipeChan chan net.Conn, proxy proxyFunc) {
+	metrics.IncActivePipes()
+	defer metrics.DecActivePipes()
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/virt-handler/notify-server/pipe/pipe.go
+++ b/pkg/virt-handler/notify-server/pipe/pipe.go
@@ -38,6 +38,8 @@ import (
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
+
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler"
 )
 
 func NewConnectToNotifyFunc(virtShareDir string) connectFunc {
@@ -99,9 +101,17 @@ func Pipe(ctx context.Context, pipeChan chan net.Conn, proxy proxyFunc) {
 	}
 }
 
-// Proxy is blocking, it proxies pipe connection [pipeConn] to given connection [connect](ultimately to notify server)
+func Proxy(logger *log.FilteredLogger, connect connectFunc) proxyFunc {
+	return func(c net.Conn) {
+		metrics.IncPipeActiveProxies()
+		defer metrics.DecPipeActiveProxies()
+		proxy(logger, c, connect)
+	}
+}
+
+// proxy is blocking, it proxies pipe connection [pipeConn] to given connection [connect](ultimately to notify server)
 // pipeConn is closed on success or error
-func Proxy(logger *log.FilteredLogger, pipeConn net.Conn, connect connectFunc) {
+func proxy(logger *log.FilteredLogger, pipeConn net.Conn, connect connectFunc) {
 	defer pipeConn.Close()
 
 	// proxy the VMI domain-notify-pipe.sock to the virt-handler domain-notify.sock

--- a/pkg/virt-handler/notify-server/pipe/pipe_test.go
+++ b/pkg/virt-handler/notify-server/pipe/pipe_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Proxy", func() {
 
 		exit := make(chan struct{})
 		go func() {
-			Proxy(log.Log, pipeS, func() (net.Conn, error) { return notifyS, nil })
+			Proxy(log.Log, func() (net.Conn, error) { return notifyS, nil })(pipeS)
 			exit <- struct{}{}
 		}()
 

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -28,6 +28,7 @@ import (
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	metricsutil "github.com/rhobs/operator-observability-toolkit/pkg/testutil"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -395,6 +396,25 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 
 		Expect(in).To(BeTrue())
 		Expect(out).To(BeTrue())
+	})
+
+	It("should include pipe metrics", func() {
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
+
+		fetcher := metricsutil.NewMetricsFetcher("")
+		fetcher.AddNameFilter("kubevirt_active_pipe")
+
+		metrics, err := fetcher.LoadMetrics(metricsPayload)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected")
+
+		Expect(metrics).To(HaveKey(ContainSubstring("pipe_proxies")))
+		Expect(metrics).To(HaveKeyWithValue(
+			ContainSubstring("kubevirt_active_pipes"),
+			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Value": Equal(1),
+			}),
+		))
 	})
 }))
 


### PR DESCRIPTION
### What this PR does
Adds `kubevirt_active_pipe_proxies` metric
The metric reports number of running proxied pipe connections. 

**Usage**
Reports the number of active proxied connections through notify pipes. Each pipe can serve multiple proxy connections, so this value can exceed kubevirt_active_pipes. Together the two metrics give visibility into whether the notify infrastructure is set up (pipes) and whether data is actually flowing through it (proxies). A proxy count of zero on a node with active pipes suggests connections aren't being established. An unexpectedly high count may indicate rapid reconnections from a launcher. The metric is serves as only tool for visibility into proxied connections.

Adds `kubevirt_active_pipes` metric
The metric reports number of running pipes.

**Usage**
A pipe is expected to exist for every running VMI on a node. If kubevirt_active_pipes drifts from the expected VMI count (e.g., pipes accumulate without being cleaned up, or drop to zero while VMIs are running), that signals a leak or a broken teardown path. Without this metric, such issues are invisible until they manifest as resource exhaustion or missed domain notifications and other symptoms.


### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New "kubevirt_active_pipe_proxies" and "kubevirt_active_pipes" metrics
```

