### PR TITLE
Auto-quarantine `Live Migration across ... target migration`

### DIFF
--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -638,7 +638,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(Equal(virtv1.WaitingForSync))
 		},
 			Entry("[QUARANTINE] delete source migration", decorators.Quarantine, true),
-			Entry("delete target migration", false),
+			Entry("[QUARANTINE]delete target migration", decorators.Quarantine, false),
 		)
 
 		It("should properly propagate failure from target to source", func() {


### PR DESCRIPTION
`[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] Live Migration across namespaces with migration policy should be able to cancel a migration by deleting the migration resource delete target migration`
[🔎](https://search.ci.kubevirt.io/?search=%5C%5Brfe_id%3A393%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Asystem%5D%5C%5Bsig-compute%5D+Live+Migration+across+namespaces+with+migration+policy+should+be+able+to+cancel+a+migration+by+deleting+the+migration+resource+delete+target+migration&maxAge=336h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) **6%** over **336h** [pull-kubevirt-e2e-k8s-1.33-sig-storage](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.33-sig-storage):
Failures: [3h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15992/pull-kubevirt-e2e-k8s-1.33-sig-storage/1998288288992989184) [17h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16081/pull-kubevirt-e2e-k8s-1.33-sig-storage/1998078079200661504) [96h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.33-sig-storage/1996698487156117504) [96h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16265/pull-kubevirt-e2e-k8s-1.33-sig-storage/1996740100280553472) [96h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16265/pull-kubevirt-e2e-k8s-1.33-sig-storage/1996658330247892992) [264h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16131/pull-kubevirt-e2e-k8s-1.33-sig-storage/1994113054249324544) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16131/pull-kubevirt-e2e-k8s-1.33-sig-storage/1993935255802744832)

/sig storage


/kind flake
/priority critical-urgent

Tracker: https://github.com/kubevirt/kubevirt/issues/16314

```release-note
none
```