### PR TITLE
tests/framework/checks/skips.go: convert skips to fails - storage

### DIFF
--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -15,10 +15,9 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-// Deprecated: SkipTestIfNoFeatureGate should be converted to check & fail
-func SkipTestIfNoFeatureGate(featureGate string) {
+func FailTestIfNoFeatureGate(featureGate string) {
 	if !HasFeature(featureGate) {
-		ginkgo.Skip(fmt.Sprintf("the %v feature gate is not enabled.", featureGate))
+		ginkgo.Fail(fmt.Sprintf("the %v feature gate is not enabled.", featureGate))
 	}
 }
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -143,7 +143,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 
 	Context("[storage-req]PVC expansion", decorators.StorageReq, decorators.RequiresVolumeExpansion, func() {
 		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
-			checks.SkipTestIfNoFeatureGate(featuregate.ExpandDisksGate)
+			checks.FailTestIfNoFeatureGate(featuregate.ExpandDisksGate)
 			var sc string
 			exists := false
 			if volumeMode == k8sv1.PersistentVolumeBlock {
@@ -227,7 +227,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 		)
 
 		It("Check disk expansion accounts for actual usable size", func() {
-			checks.SkipTestIfNoFeatureGate(featuregate.ExpandDisksGate)
+			checks.FailTestIfNoFeatureGate(featuregate.ExpandDisksGate)
 
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -73,7 +73,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 		vmi = nil
-		checks.SkipTestIfNoFeatureGate(featuregate.VirtIOFSStorageVolumeGate)
+		checks.FailTestIfNoFeatureGate(featuregate.VirtIOFSStorageVolumeGate)
 	})
 
 	Context("VirtIO-FS with multiple PVCs", func() {


### PR DESCRIPTION
Convert `SkipTestIfNoFeatureGate` to `FailTestIfNoFeatureGate` in storage tests. If a required feature gate is not enabled, it's a test infrastructure configuration issue that should be fixed, not silently skipped.

### Release note
```release-note
none
```

