### PR TITLE
pkg/virt-controller/watch/vm: Skip restart condition on firmware UUID sync

### DIFF
--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6710,6 +6710,33 @@ var _ = Describe("VirtualMachine", func() {
 					Entry("with LiveUpdate rollout strategy", pointer.P(v1.VMRolloutStrategyLiveUpdate)),
 				)
 			})
+
+			DescribeTable("RestartRequired condition based on VM and VMI UUID comparison", func(uuid types.UID, matcher gomegatypes.GomegaMatcher) {
+				By("Creating a VM without firmware UUID")
+				vm.Spec.Template.Spec.Domain.Firmware = nil
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with the calculated legacy UUID")
+				vmi = SetupVMIFromVM(vm)
+				controller.vmiIndexer.Add(vmi)
+
+				By("Setting the UUID in VM spec")
+				vm.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{
+					UUID: uuid,
+				}
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(vm)
+
+				By("Executing the controller")
+				sanityExecute(vm)
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm, v1.VirtualMachineRestartRequired)).To(matcher)
+			},
+				Entry("should not raise RestartRequired when VM and VMI UUIDs match", CalculateLegacyUUID("testvmi"), BeFalse()),
+				Entry("should raise RestartRequired when VM and VMI UUIDs differ", types.UID("different-uuid-than-vmi"), BeTrue()),
+			)
 		})
 
 		clearExpectations := func(vm *v1.VirtualMachine) {


### PR DESCRIPTION
### What this PR does
When a VM don't have a spec.firmware.uuid, the firmware synchronizer (introduced in #14130) calculates a legacy (UUID based on hash on the VM's name) UUID and patches it into the VM spec.
However, this patch was being interpreted as a modification to a non–live-updatable field, which incorrectly triggered the RestartRequired condition on the VM.

In reality, the VMI is already running with the same UUID, so no restart is needed.

This PR updates the restart-required logic to ignore UUID changes when the VMI’s UUID and the VM’s UUID match. This prevents false-positive restart conditions caused solely by the synchronizer’s patch.

#### Before this PR:
Any change to the `firmware.uuid` field was treated as a non–live-updatable modification, always triggering a `RestartRequired` condition.

#### After this PR:
Before raising the `RestartRequired` condition, we now check whether the corresponding running VMI already uses the same UUID.
If the VMI’s UUID equals the VM’s UUID, the change is considered no-op, and no restart requirement is raised.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->
### Release note
```release-note
Prevent false restart-required conditions when the VM and corresponding VMI already share the same firmware UUID.
```

