### PR TITLE
Fix: Do not apply HyperV preferences when HypervPassthrough is enabled

### DIFF
--- a/pkg/instancetype/preference/apply/features.go
+++ b/pkg/instancetype/preference/apply/features.go
@@ -42,7 +42,9 @@ func applyFeaturePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpe
 		vmiSpec.Domain.Features.APIC = preferenceSpec.Features.PreferredApic.DeepCopy()
 	}
 
-	if preferenceSpec.Features.PreferredHyperv != nil {
+	if preferenceSpec.Features.PreferredHyperv != nil && (vmiSpec.Domain.Features.HypervPassthrough == nil ||
+		vmiSpec.Domain.Features.HypervPassthrough.Enabled == nil ||
+		!*vmiSpec.Domain.Features.HypervPassthrough.Enabled) {
 		applyHyperVFeaturePreferences(preferenceSpec, vmiSpec)
 	}
 

--- a/pkg/instancetype/preference/apply/features_test.go
+++ b/pkg/instancetype/preference/apply/features_test.go
@@ -110,4 +110,16 @@ var _ = Describe("Preference.Features", func() {
 		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
 		Expect(vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled).To(HaveValue(BeFalse()))
 	})
+
+	It("should not apply HyperV preferences when HypervPassthrough is enabled by the user", func() {
+		vmi.Spec.Domain.Features = &virtv1.Features{
+			HypervPassthrough: &virtv1.HyperVPassthrough{
+				Enabled: pointer.P(true),
+			},
+		}
+
+		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
+		Expect(vmi.Spec.Domain.Features.Hyperv).To(BeNil())
+		Expect(vmi.Spec.Domain.Features.HypervPassthrough.Enabled).To(HaveValue(BeTrue()))
+	})
 })


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When a VM uses HypervPassthrough, applying HyperV preferences from an instancetype preference populates the HyperV struct, causing the validation webhook to reject the VM with `Cannot explicitly set hyperV features if HypervPassthrough is being used`.

#### After this PR:

This change skips applying HyperV preferences when HypervPassthrough is enabled, since they are mutually exclusive features.

### Why we need it and why it was done in this way

So users can enable HypervPassthrough for debugging, etc. without removing/altering the selected instancetype preference.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Bug fix: Skip applying HyperV preferences when HypervPassthrough is enabled to prevent validation conflicts
```

