### PR TITLE
storage, cbt: avoid enabling CBT from domain when VMI CBT is disabled

### DIFF
--- a/pkg/storage/cbt/cbt.go
+++ b/pkg/storage/cbt/cbt.go
@@ -284,7 +284,7 @@ func IsCBTEligibleVolume(volume *v1.Volume) bool {
 }
 
 func SetChangedBlockTrackingOnVMIFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
-	if domain == nil || vmi.Status.ChangedBlockTracking == nil {
+	if domain == nil || vmi.Status.ChangedBlockTracking == nil || cbtStateDisabled(vmi.Status.ChangedBlockTracking) {
 		return
 	}
 

--- a/pkg/storage/cbt/cbt_test.go
+++ b/pkg/storage/cbt/cbt_test.go
@@ -507,6 +507,11 @@ var _ = Describe("CBT", func() {
 				domain := &api.Domain{Spec: api.DomainSpec{Devices: api.Devices{Disks: []api.Disk{diskWithDataStore("pvc1", true)}}}}
 				cbt.SetChangedBlockTrackingOnVMIFromDomain(vmi, domain)
 			}, v1.ChangedBlockTrackingUndefined),
+			Entry("VMI CBT status is disabled", func() {
+				vmi.Status.ChangedBlockTracking.State = v1.ChangedBlockTrackingDisabled
+				domain := &api.Domain{Spec: api.DomainSpec{Devices: api.Devices{Disks: []api.Disk{diskWithDataStore("pvc1", true)}}}}
+				cbt.SetChangedBlockTrackingOnVMIFromDomain(vmi, domain)
+			}, v1.ChangedBlockTrackingDisabled),
 		)
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Previously, SetChangedBlockTrackingOnVMIFromDomain only checked whether the VMI CBT status was nil, but not whether it was explicitly disabled or undefined. As a result, CBT could be enabled from the domain even when no CBT matcher was present.


#### After this PR:
This change ensures CBT is not enabled from the domain unless it is explicitly enabled on the VMI.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: ensure VMI CBT state remains disabled when the VM has no CBT matcher.
```

