### PR TITLE
WIP: launcher, converter:  Introduce NewCpuConfigurator

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -1,0 +1,69 @@
+package compute
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
+)
+
+type CpuConfigurator struct {
+	architecture       string
+	isHotplugSupported bool
+}
+
+func NewCpuConfigurator(architecture string, isHotplugSupported bool) CpuConfigurator {
+	return CpuConfigurator{
+		architecture:       architecture,
+		isHotplugSupported: isHotplugSupported,
+	}
+}
+
+func (c CpuConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+	// Set VM CPU cores
+	// CPU topology will be created everytime, because user can specify
+	// number of cores in vmi.Spec.Domain.Resources.Requests/Limits, not only
+	// in vmi.Spec.Domain.CPU
+	cpuTopology := vcpu.GetCPUTopology(vmi)
+	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
+	domain.Spec.CPU.Topology = cpuTopology
+	domain.Spec.VCPU = &api.VCPU{
+		Placement: "static",
+		CPUs:      cpuCount,
+	}
+	// set the maximum number of sockets here to allow hot-plug CPUs
+	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.isHotplugSupported {
+		domainVCPUTopologyForHotplug(vmi, domain)
+	}
+	return nil
+}
+
+func domainVCPUTopologyForHotplug(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+	cpuTopology := vcpu.GetCPUTopology(vmi)
+	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
+	// Always allow to hotplug to minimum of 1 socket
+	minEnabledCpuCount := cpuTopology.Cores * cpuTopology.Threads
+	// Total vCPU count
+	enabledCpuCount := cpuCount
+	cpuTopology.Sockets = vmi.Spec.Domain.CPU.MaxSockets
+	cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
+	VCPUs := &api.VCPUs{}
+	for id := uint32(0); id < cpuCount; id++ {
+		// Enable all requestd vCPUs
+		isEnabled := id < enabledCpuCount
+		// There should not be fewer vCPU than cores and threads within a single socket
+		isHotpluggable := id >= minEnabledCpuCount
+		vcpu := api.VCPUsVCPU{
+			ID:           id,
+			Enabled:      boolToYesNo(&isEnabled, true),
+			Hotpluggable: boolToYesNo(&isHotpluggable, false),
+		}
+		VCPUs.VCPU = append(VCPUs.VCPU, vcpu)
+	}
+
+	domain.Spec.VCPUs = VCPUs
+	domain.Spec.CPU.Topology = cpuTopology
+	domain.Spec.VCPU = &api.VCPU{
+		Placement: "static",
+		CPUs:      cpuCount,
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References

- Partially addresses #16117

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

