### PR TITLE
operator tests: stop testing older disk image in upgrade test

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -40,8 +40,6 @@ var KubeVirtInstallNamespace string
 var PrometheusNamespace string
 var PreviousReleaseTag = ""
 var PreviousReleaseRegistry = ""
-var PreviousUtilityRegistry = ""
-var PreviousUtilityTag = ""
 var ConfigFile = ""
 var SkipShasumCheck bool
 var SkipDualStackTests bool
@@ -81,8 +79,6 @@ func init() {
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
 	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "quay.io/kubevirt", "Set registry of the release to test updating from")
-	flag.StringVar(&PreviousUtilityRegistry, "previous-utility-container-registry", "", "Set registry of the utility containers to test updating from")
-	flag.StringVar(&PreviousUtilityTag, "previous-utility-container-tag", "", "Set tag of the utility containers to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
 	flag.StringVar(&OperatorManifestPath, "operator-manifest-path", "", "Set path to virt-operator manifest file")
@@ -108,13 +104,4 @@ func NormalizeFlags() {
 	if KubeVirtUtilityRepoPrefix == "" {
 		KubeVirtUtilityRepoPrefix = KubeVirtRepoPrefix
 	}
-
-	if PreviousUtilityRegistry == "" {
-		PreviousUtilityRegistry = PreviousReleaseRegistry
-	}
-
-	if PreviousUtilityTag == "" {
-		PreviousUtilityTag = PreviousReleaseTag
-	}
-
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
this commit is challenging the need to test an older
image as part of backwards compatiblity upgrade testing

if the intention was testing kubevirt regressing for a certain disk image,
I don't think we put any effort into ensuring the image changes between releases

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This results in a somewhat of an edge case in CI on 1.7 where cri-o reports the imageID as the local existing quay image:
```
"image": "registry:5000/kubevirt/alpine-container-disk-demo:devel",
"imageID": "quay.io/kubevirt/alpine-container-disk-demo@sha256:081ab0c41a37499672990f612488fe0cded25589b60593473604df5d758afe8b",
 ```
This messes up the containerdisk migration logic, we can no longer infer the source SHA.
Failure example:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16316/pull-kubevirt-e2e-k8s-1.34-sig-operator-1.7/1998645773176147968

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Maintenance: fix release branches potentially failing over identical remote images existing on nodes
```

