### PR TITLE
Update GuestFilesystemAlmostOutOfSpace alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1204,3 +1204,45 @@ tests:
               name: "vmi-multi-hotplug"
               namespace: "test-ns"
               volume_name: "ephemeral-vol-1, ephemeral-vol-2"
+
+  # GuestFilesystemAlmostOutOfSpace - Exclusions: fuse.* should be excluded
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="test-vm", namespace="test-ns", disk_name="vdb", mount_point="/mnt/sshfs", file_system_type="fuse.sshfs"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="test-vm", namespace="test-ns", disk_name="vdb", mount_point="/mnt/sshfs", file_system_type="fuse.sshfs"}'
+        values: "96 96 96 96 96 96 96 96 96 96"
+
+    alert_rule_test:
+      # at 3m: usage = 96% -> would normally alert, but excluded by regex fuse(\\..*)?
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+  # GuestFilesystemAlmostOutOfSpace - Exclusions: overlay should be excluded
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="test-vm", namespace="test-ns", disk_name="vdc", mount_point="/", file_system_type="overlay"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="test-vm", namespace="test-ns", disk_name="vdc", mount_point="/", file_system_type="overlay"}'
+        values: "96 96 96 96 96 96 96 96 96 96"
+
+    alert_rule_test:
+      # at 3m: usage = 96% -> would normally alert, but excluded by overlay filter
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+  # GuestFilesystemAlmostOutOfSpace - Exclusions: Windows "System Reserved" mount should be excluded
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="win-vm", namespace="test-ns", disk_name="sda1", mount_point="System Reserved", file_system_type="ntfs"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="win-vm", namespace="test-ns", disk_name="sda1", mount_point="System Reserved", file_system_type="ntfs"}'
+        values: "96 96 96 96 96 96 96 96 96 96"
+
+    alert_rule_test:
+      # at 3m: usage = 96% -> would normally alert, but excluded by mount_point filter
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The alert fired for a VM with CDFS filesystem.

#### After this PR:
Updated the GuestFilesystemAlmostOutOfSpace alerts
expression to exclude non relevant file system types. 
The list in based on the node_exporte exclude list.
Now the alert should fire only for relevant file system types.

### References
- Fixes #https://issues.redhat.com/browse/CNV-74774

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug in GuestFilesystemAlmostOutOfSpace, that fired for non relevant file system types.
```

