### PR TITLE
Improve boolean flag formatting to parse it correctly.

### DIFF
--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -79,9 +79,17 @@ func flagsToArray(flags map[string]string) []string {
 	sort.Strings(fnames)
 
 	for _, flag := range fnames {
-		farr = append(farr, fmt.Sprintf("--%s", strings.ToLower(flag)))
-		if flags[flag] != "" {
-			farr = append(farr, flags[flag])
+		flagName := strings.ToLower(flag)
+		val := strings.ToLower(flags[flag])
+
+		switch val {
+		case "":
+			farr = append(farr, fmt.Sprintf("--%s", flagName))
+		case "true", "false":
+			farr = append(farr, fmt.Sprintf("--%s=%s", flagName, val))
+		default:
+			farr = append(farr, fmt.Sprintf("--%s", flagName))
+			farr = append(farr, val)
 		}
 	}
 

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -205,19 +205,23 @@ var _ = Describe("Patches", func() {
 
 	Describe("Config controller flags", func() {
 		flags := map[string]string{
-			"flag-one":  "1",
-			"flag":      "3",
-			"bool-flag": "",
+			"flag-one":        "1",
+			"flag":            "3",
+			"bool-flag":       "",
+			"bool-flag-true":  "True",
+			"bool-flag-false": "false",
 		}
 		resource := "Deployment"
 
 		It("should return flags in the proper format", func() {
 			fa := flagsToArray(flags)
-			Expect(fa).To(HaveLen(5))
+			Expect(fa).To(HaveLen(7))
 
 			Expect(strings.Join(fa, " ")).To(ContainSubstring("--flag-one 1"))
 			Expect(strings.Join(fa, " ")).To(ContainSubstring("--flag 3"))
 			Expect(strings.Join(fa, " ")).To(ContainSubstring("--bool-flag"))
+			Expect(strings.Join(fa, " ")).To(ContainSubstring("--bool-flag-true=true"))
+			Expect(strings.Join(fa, " ")).To(ContainSubstring("--bool-flag-false=false"))
 		})
 
 		It("should return flags in sorted order", func() {
@@ -225,6 +229,8 @@ var _ = Describe("Patches", func() {
 				return flagsToArray(flags)
 			}).Should(HaveExactElements(
 				"--bool-flag",
+				"--bool-flag-false=false",
+				"--bool-flag-true=true",
 				"--flag",
 				"3",
 				"--flag-one",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- Fixes #16347 
#### Before this PR: 
The flagsToArray implementation emits boolean flags as separate arguments (e.g., --enable-node-labeller "false"), but pflag expects boolean flags to be set as --flag (for true) or --flag=false (with an equals sign) for false. Because of this, pflag ignores the "false" argument and always enables the flag when present, so disabling features like the node labeller this way doesn't work as intended

#### After this PR:
flagsToArray function is updated to set boolean flags as --flag=false or --flag=true, so that pflag parses the flag as expected.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve boolean flag formatting to parse it correctly.
```

