### PR TITLE
Parallelize monitoring tests

### DIFF
--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -51,7 +51,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring, func() {
+var _ = Describe("[sig-monitoring]Monitoring", decorators.SigMonitoring, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var prometheusRule *promv1.PrometheusRule
@@ -115,6 +115,15 @@ var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring,
 		})
 	})
 
+})
+
+var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring, func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		virtClient = kubevirt.Client()
+	})
+
 	Context("System Alerts", func() {
 		var originalKv *v1.KubeVirt
 
@@ -149,7 +158,7 @@ var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring,
 			vmi := libvmifact.NewCirros()
 			vmi.APIVersion = "v1alpha3"
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
-			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+			_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying the alert exists")


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Most monitoring tests ran Serial, including ones safe to parallelize.
#### After this PR:
In `vm_monitoring.go` we parallelized suites:
- VMI metrics
- VM status metrics
- VM snapshot metrics
- VM metrics based on the guest agent
- Metrics based on VMI connections
- VM dirty rate metrics

and kept disruptive suites Serial:
- Cluster VM metrics
- VM migration metrics
- VM alerts

In `monitoring.go` we parallelized suites:
- Kubevirt alert rules
- Migration Alerts

and kept disruptive suites Serial:
- System Alerts
- Deprecation Alerts
  
### Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Improves tests time by parallelizing non-disruptive suites (with 4 nodes it saves ~10 minutes). 
- Serializes cluster-wide/disruptive tests to avoid flakes and interference.

The following alternatives were considered:
- Marking individual Its as Serial, splitting by Describe kept intent clearer and safer.

### Special notes for your reviewer
- Replaced deprecated checks.SkipIfPrometheusRuleIsNotEnabled.
- Stabilized tests by removing shared state and deduplicating setup helpers.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```