### PR TITLE
Parallelize observability functional tests

### DIFF
--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -78,7 +78,7 @@ func WaitForMetricValueWithLabels(client kubecli.KubevirtClient, metric string, 
 			return -1
 		}
 		return i
-	}, 3*time.Minute, 1*time.Second).Should(Equal(expectedValue), "Metric %s with labels %v has value %f, not the expected %f", metric, labels, expectedValue, expectedValue)
+	}, 3*time.Minute, 1*time.Second).Should(Equal(expectedValue), "Metric %s with labels %v has incorrect value", metric, labels)
 }
 
 func WaitForMetricValueWithLabelsToBe(client kubecli.KubevirtClient, metric string, labels map[string]string, offset int, comparator string, expectedValue float64) {

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -47,7 +47,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring, func() {
+var _ = Describe("[sig-monitoring]Monitoring", decorators.SigMonitoring, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var prometheusRule *promv1.PrometheusRule
@@ -111,7 +111,7 @@ var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring,
 		})
 	})
 
-	Context("System Alerts", func() {
+	Context("System Alerts", Serial, func() {
 		It("KubeVirtNoAvailableNodesToRunVMs should be triggered when there are no available nodes in the cluster to run VMs", func() {
 			By("Getting all schedulable nodes")
 			nodes := libnode.GetAllSchedulableNodes(virtClient)
@@ -133,13 +133,13 @@ var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring,
 		})
 	})
 
-	Context("Deprecation Alerts", decorators.SigMonitoring, func() {
+	Context("Deprecation Alerts", func() {
 		It("KubeVirtDeprecatedAPIRequested should be triggered when a deprecated API is requested", func() {
 			By("Creating a VMI with deprecated API version")
 			vmi := libvmifact.NewCirros()
 			vmi.APIVersion = "v1alpha3"
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
-			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+			_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying the alert exists")
@@ -149,7 +149,6 @@ var _ = Describe("[sig-monitoring]Monitoring", Serial, decorators.SigMonitoring,
 			libmonitoring.WaitUntilAlertDoesNotExistWithCustomTime(virtClient, 15*time.Minute, "KubeVirtDeprecatedAPIRequested")
 		})
 	})
-
 })
 
 func checkRequiredAnnotations(rule promv1.Rule) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Most monitoring tests ran Serial, including ones safe to parallelize.
#### After this PR:
In `vm_monitoring.go` we parallelized suites:
- VM status metrics
- VM snapshot metrics
- VM metrics based on the guest agent
- Metrics based on VMI connections
- VM dirty rate metrics

and kept disruptive suites Serial:
- Cluster VM metrics
- VM migration metrics
- VM alerts

update to use shared vmi:
- VMI metrics

In `monitoring.go` we parallelized suites:
- Kubevirt alert rules
- Migration Alerts
- Deprecation Alerts

and kept disruptive suites Serial:
- System Alerts

### Fixes https://github.com/kubevirt/kubevirt/issues/14534
jira-ticket: https://issues.redhat.com/browse/CNV-72705

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Improves tests time by parallelizing non-disruptive suites (with 4 nodes it saves ~10 minutes). 
- Serializes cluster-wide/disruptive tests to avoid flakes and interference.

The following alternatives were considered:
- Marking individual Its as Serial, splitting by Describe kept intent clearer and safer.

### Special notes for your reviewer
- Replaced deprecated checks.SkipIfPrometheusRuleIsNotEnabled.
- Stabilized tests by removing shared state and deduplicating setup helpers.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```