### PR TITLE
[Release-1.4] prevent cross-vendor migrations

### DIFF
--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -620,6 +620,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi.Status.RuntimeUser = 0
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -638,6 +639,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -674,6 +676,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -712,6 +715,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -772,6 +776,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -796,6 +801,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -863,6 +869,7 @@ var _ = Describe("Migration watcher", func() {
 
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -1698,6 +1705,7 @@ var _ = Describe("Migration watcher", func() {
 				virtv1.MigrationNameLabel: migration.Name,
 			}
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -1961,6 +1969,47 @@ var _ = Describe("Migration watcher", func() {
 		})
 	})
 
+	Context("CPU vendor label constraints", func() {
+		const nodeName = "testNode"
+		const intelVendorLabel = virtv1.CPUModelVendorLabel + "Intel"
+		const amdVendorLabel = virtv1.CPUModelVendorLabel + "AMD"
+
+		DescribeTable("should add CPU vendor label from source node", func(vendorLabel string) {
+			vmi := newVirtualMachine("testvmi", virtv1.Running)
+			addNodeNameToVMI(vmi, nodeName)
+			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
+
+			node := newNode(nodeName)
+			if vendorLabel != "" {
+				node.Labels = map[string]string{vendorLabel: "true"}
+			}
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			addPod(newSourcePodForVirtualMachine(vmi))
+			addNode(node)
+
+			controller.Execute()
+
+			testutils.ExpectEvent(recorder, virtcontroller.SuccessfulCreatePodReason)
+			pods, err := kubeClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s,%s=%s", virtv1.MigrationJobLabel, string(migration.UID), virtv1.CreatedByLabel, string(vmi.UID)),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods.Items).To(HaveLen(1))
+
+			if vendorLabel != "" {
+				Expect(pods.Items[0].Spec.NodeSelector).To(HaveKeyWithValue(vendorLabel, "true"))
+			} else {
+				Expect(pods.Items[0].Spec.NodeSelector).NotTo(HaveKey(HavePrefix(virtv1.CPUModelVendorLabel)))
+			}
+		},
+			Entry("Intel vendor", intelVendorLabel),
+			Entry("AMD vendor", amdVendorLabel),
+			Entry("no vendor label", ""),
+		)
+	})
+
 	Context("Migration abortion before hand-off to virt-handler", func() {
 		var vmi *virtv1.VirtualMachineInstance
 		var migration *virtv1.VirtualMachineInstanceMigration
@@ -2006,6 +2055,7 @@ var _ = Describe("Migration watcher", func() {
 			}
 			pendingMigration.CreationTimestamp = metav1.NewTime(failedMigration.CreationTimestamp.Add(time.Second * 1))
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(pendingMigration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -2034,6 +2084,7 @@ var _ = Describe("Migration watcher", func() {
 			}
 			pendingMigration.CreationTimestamp = metav1.NewTime(failedMigration.CreationTimestamp.Add(time.Second * 1))
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(pendingMigration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -2064,6 +2115,7 @@ var _ = Describe("Migration watcher", func() {
 			successfulMigration.CreationTimestamp = metav1.NewTime(failedMigration.CreationTimestamp.Add(time.Second * 1))
 			pendingMigration.CreationTimestamp = metav1.NewTime(successfulMigration.CreationTimestamp.Add(time.Second * 1))
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(pendingMigration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -2087,6 +2139,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi = newVirtualMachine("testvmi", virtv1.Running)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			sourcePod := newSourcePodForVirtualMachine(vmi)
@@ -2107,6 +2160,7 @@ var _ = Describe("Migration watcher", func() {
 				migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 				setAnnotation(virtv1.EvacuationMigrationAnnotation, migration)
 
+				addNode(newNode(vmi.Status.NodeName))
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
 				sourcePod := newSourcePodForVirtualMachine(vmi)
@@ -2176,6 +2230,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
@@ -2197,6 +2252,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 
+			addNode(newNode(vmi.Status.NodeName))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -160,41 +160,18 @@ var _ = DescribeInfra("Node-labeller", func() {
 
 		It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", func() {
 			for _, node := range nodesWithKVM {
-				Expect(err).ToNot(HaveOccurred())
-				cpuModelLabelPresent := false
-				cpuFeatureLabelPresent := false
-				hyperVLabelPresent := false
-				hostCpuModelPresent := false
-				hostCpuRequiredFeaturesPresent := false
-				for key := range node.Labels {
-					if strings.Contains(key, v1.CPUModelLabel) {
-						cpuModelLabelPresent = true
-					}
-					if strings.Contains(key, v1.CPUFeatureLabel) {
-						cpuFeatureLabelPresent = true
-					}
-					if strings.Contains(key, v1.HypervLabel) {
-						hyperVLabelPresent = true
-					}
-					if strings.Contains(key, v1.HostModelCPULabel) {
-						hostCpuModelPresent = true
-					}
-					if strings.Contains(key, v1.HostModelRequiredFeaturesLabel) {
-						hostCpuRequiredFeaturesPresent = true
-					}
-
-					if cpuModelLabelPresent && cpuFeatureLabelPresent && hyperVLabelPresent && hostCpuModelPresent &&
-						hostCpuRequiredFeaturesPresent {
-						break
-					}
-				}
-
 				errorMessageTemplate := "node " + node.Name + " does not contain %s label"
-				Expect(cpuModelLabelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "cpu"))
-				Expect(cpuFeatureLabelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "feature"))
-				Expect(hyperVLabelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "hyperV"))
-				Expect(hostCpuModelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu model"))
-				Expect(hostCpuRequiredFeaturesPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu required featuers"))
+				Expect(node.Labels).To(HaveKey(HavePrefix(v1.CPUModelLabel)), fmt.Sprintf(errorMessageTemplate, "cpu"))
+				Expect(node.Labels).To(HaveKey(HavePrefix(v1.CPUFeatureLabel)), fmt.Sprintf(errorMessageTemplate, "feature"))
+				Expect(node.Labels).To(HaveKey(HavePrefix(v1.HypervLabel)), fmt.Sprintf(errorMessageTemplate, "hyperV"))
+				Expect(node.Labels).To(HaveKey(HavePrefix(v1.HostModelCPULabel)), fmt.Sprintf(errorMessageTemplate, "host cpu model"))
+				Expect(node.Labels).To(HaveKey(HavePrefix(v1.HostModelRequiredFeaturesLabel)),
+					fmt.Sprintf(errorMessageTemplate, "host cpu required features"))
+				if node.Labels[k8sv1.LabelArchStable] == "amd64" {
+					Expect(node.Labels).To(HaveKey(HavePrefix(v1.CPUModelVendorLabel)), fmt.Sprintf(errorMessageTemplate, "vendor"))
+				} else {
+					Expect(node.Labels).ToNot(HaveKey(HavePrefix(v1.CPUModelVendorLabel)))
+				}
 			}
 		})
 


### PR DESCRIPTION
manual backport of https://github.com/kubevirt/kubevirt/pull/16348

There where conflicts in the migration_tests since the sanityExecute was not yet introduced, and some tests required adding the node to the cached store.

### Jira Ticket
```
https://issues.redhat.com/browse/CNV-74567
```

### Release note
```release-note
NONE
```

