### PR TITLE
Don't try to parse strategic patches as json

### DIFF
--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -511,7 +511,7 @@ func getDesiredApiReplicas(clientset kubecli.KubevirtClient) (replicas int32, er
 
 func replicasAlreadyPatched(patches []v1.CustomizeComponentsPatch, deploymentName string) bool {
 	for _, patch := range patches {
-		if patch.ResourceName != deploymentName {
+		if patch.ResourceName != deploymentName || patch.Type != v1.JSONPatchType {
 			continue
 		}
 		decodedPatch, err := jsonpatch.DecodePatch([]byte(patch.Patch))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

If you configure kubevirt with strategic patches for the virt-api deployment, the `replicasAlreadyPatched` function will try to deserialize them as JSON patches, fail, and log a warning every few seconds:

```
{"component":"virt-operator","level":"warning","msg":"json: cannot unmarshal object into Go value of type jsonpatch.Patch","pos":"apps.go:519","timestamp":"2025-12-16T15:30:09.647701Z"}
{"component":"virt-operator","level":"warning","msg":"json: cannot unmarshal object into Go value of type jsonpatch.Patch","pos":"apps.go:519","timestamp":"2025-12-16T15:30:09.647727Z"}
{"component":"virt-operator","level":"warning","msg":"json: cannot unmarshal object into Go value of type jsonpatch.Patch","pos":"apps.go:519","timestamp":"2025-12-16T15:30:09.647745Z"}
```

#### After this PR:

The function now skips patches that are not of the JSON patch type. Alternatively, the function could be updated to handle strategic patches to the deployment replica count, but it seems like that's probably not needed in practice.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't warn about failing to deserialize non-JSON patches as JSON patches.
```

