### PR TITLE
e2e, vmi_lifecycle: fix test_id:1622 to not rely on libvirt error logs

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -185,7 +185,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Eventually(logs,
 				2*time.Second,
 				500*time.Millisecond).
-				Should(ContainSubstring(`"subcomponent":"libvirt"`))
+				Should(ContainSubstring("Connected to libvirt daemon"))
 		})
 
 		DescribeTable("log libvirtd debug logs should be", func(vmiLabels, vmiAnnotations map[string]string, expectDebugLogs bool) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Updates the test "[test_id:1622] should log libvirtd logs" to avoid relying on libvirt log output that is not emitted during a normal startup.
Previously, the test expected "subcomponent":"libvirt" to appear in virt-launcher logs. With libvirt 11.x, no libvirt logs are produced during a clean startup unless logging or debug options are explicitly enabled, causing the test to fail even though libvirt starts successfully.
This PR modifies the test to verify that libvirt has started by checking for the "Connected to libvirt daemon" log entry, which is consistently logged on successful libvirt initialization.

#### Before this PR:
- The test asserted the presence of "subcomponent":"libvirt" in virt-launcher logs.
- With libvirt 11.x and default logging, no libvirt logs are emitted during a normal startup.
- As a result, the test failed despite libvirt starting correctly.

#### After this PR:
- The test verifies successful libvirt startup by asserting the "Connected to libvirt daemon" log entry.
- This avoids relying on libvirt log output that is not guaranteed to appear without enabling logging/debug explicitly.

### References
- Related CI failures observed in `pull-kubevirt-e2e-k8s-1.34-sig-compute`
- PR #15906 (libvirt 10.x → 11.x upgrade)
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
This failure was observed on PR #15906, which upgrades libvirt from 10.x to 11.x.  
The test `[test_id:1622]` was failing because it relied on libvirt error logs that are no longer emitted during normal startup in libvirt 11.x. The change preserves the original test intent, ensuring libvirt is running while avoiding reliance on incidental error conditions.

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- This PR only adjusts test validation logic; no functional behavior of KubeVirt is changed.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

