### PR TITLE
Fix Guestless VMI failure by adding KernelBoot on s390x

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -350,6 +350,12 @@ oci_push(
     repository = "quay.io/kubevirt/fedora-realtime-container-disk",
 )
 
+oci_push(
+    name = "push-s390x-guestless-kernel",
+    image = "//containerimages:s390x-guestless-kernel",
+    repository = "quay.io/kubevirt/s390x-guestless-kernel",
+)
+
 # testing images
 oci_push(
     name = "push-disks-images-provider",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -386,6 +386,12 @@ oci_pull(
 )
 
 oci_pull(
+    name = "s390x-guestless-kernel",
+    digest = "sha256:3bf6fc355fc9718c088c4c881b2d35a073ea274f6b16dc42236ef5e29db2215d",
+    image = "quay.io/kubevirt/s390x-guestless-kernel",
+)
+
+oci_pull(
     name = "alpine-ext-kernel-boot-demo-container-base",
     digest = "sha256:de4bc8de772ff7570e6dda871ea9cdd502feeeff1973f16f84bfbd60ff8f4149",
     image = "quay.io/kubevirt/alpine-ext-kernel-boot-demo",

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -130,3 +130,9 @@ oci_image(
     }),
     visibility = ["//visibility:public"],
 )
+
+oci_image(
+    name = "s390x-guestless-kernel",
+    base = "@s390x-guestless-kernel",
+    visibility = ["//visibility:public"],
+)

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -41,6 +41,13 @@ default_targets="
     libguestfs-tools
 "
 
+# Add additional images for s390x only
+if [[ "${ARCHITECTURE}" == "s390x" || "${ARCHITECTURE}" == "crossbuild-s390x" ]]; then
+    default_targets+="
+        s390x-guestless-kernel
+    "
+fi
+
 # Add additional images for non-s390x architectures only
 if [[ "${ARCHITECTURE}" != "s390x" && "${ARCHITECTURE}" != "crossbuild-s390x" ]]; then
     default_targets+="

--- a/pkg/libvmi/firmware.go
+++ b/pkg/libvmi/firmware.go
@@ -62,6 +62,23 @@ func WithKernelBootContainer(imageName string) Option {
 	}
 }
 
+// WithKernelBoot configures a VMI to boot from a kernel container with full boot parameters.
+func WithKernelBoot(image, kernelPath, initrdPath, kernelArgs string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.Firmware == nil {
+			vmi.Spec.Domain.Firmware = &v1.Firmware{}
+		}
+		vmi.Spec.Domain.Firmware.KernelBoot = &v1.KernelBoot{
+			KernelArgs: kernelArgs,
+			Container: &v1.KernelBootContainer{
+				Image:      image,
+				KernelPath: kernelPath,
+				InitrdPath: initrdPath,
+			},
+		}
+	}
+}
+
 func WithKernelBootContainerImagePullSecret(imagePullSecret string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Spec.Domain.Firmware == nil {

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -37,6 +37,7 @@ const (
 	ContainerDiskEmpty                ContainerDisk = "empty"
 	ContainerDiskFedoraRealtime       ContainerDisk = "fedora-realtime"
 	KernelBoot                        ContainerDisk = "alpine-ext-kernel-boot-demo"
+	KernelBootS390xGuestless          ContainerDisk = "s390x-guestless-kernel"
 )
 
 const (
@@ -72,6 +73,8 @@ func ContainerDiskFromRegistryFor(registry string, name ContainerDisk) string {
 		return fmt.Sprintf("%s/%s-container-disk:%s", registry, name, flags.KubeVirtUtilityVersionTag)
 	case KernelBoot:
 		return fmt.Sprintf("%s/alpine-ext-kernel-boot-demo:%s", registry, flags.KubeVirtUtilityVersionTag)
+	case KernelBootS390xGuestless:
+		return fmt.Sprintf("%s/s390x-guestless-kernel:%s", registry, flags.KubeVirtUtilityVersionTag)
 	}
 
 	panic(fmt.Sprintf("Unsupported registry disk %s", name))

--- a/tests/libvmifact/architecture.go
+++ b/tests/libvmifact/architecture.go
@@ -28,3 +28,7 @@ func RegisterArchitecture(arch string) {
 func isARM64() bool {
 	return architecture == "arm64"
 }
+
+func isS390X() bool {
+	return architecture == "s390x"
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Tests using [NewGuestless()](https://github.com/kubevirt/kubevirt/blob/8e654da048f0363c110f72f859cfe4e2583a461a/tests/libvmifact/factory.go#L100-L105) failed on s390x, due to architecture specific requirements.
#### After this PR:
Performs KernelBoot from a specialised minimal guest image, when trying to bring up a Guestless VMI on s390x.
The kernel was built using the toolset from [KVM-unit-tests](https://www.linux-kvm.org/page/KVM-unit-tests) and the image pushed to [quay](https://quay.io/repository/tgriedel/kubevirt_s390x_guestless_loop?tab=tags).
[This kernel-code](https://gitlab.com/Davo9111/kvm-unit-tests/-/commit/7e24b00453425b6c5187516719e9b649f09a20a6) is basically just running a simple while loop.


### References
- Fixes #14489

### Why we need it and why it was done in this way
On s390x, virtual machines require an Initial Program Load (IPL) source to start; they cannot be launched completely "empty" or guestless like x86_64 VMs. Attempting to do so results in QEMU failing with `Could not find a suitable boot device.`

The following alternatives were considered:
Simply using Alpine here was also tested successfully, but would come with significantly larger time & resource usage.

Links to places where a discussion took place:
[https://kubernetes.slack.com/archives/C0163DT0R8X/p1726468656344359](https://kubernetes.slack.com/archives/C0163DT0R8X/p1726468656344359)

### Special notes for your reviewer
Image:
https://quay.io/repository/kubevirt/s390x-guestless-kernel

Dockerfile PR on kubevirtci:
https://github.com/kubevirt/kubevirtci/pull/1589

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

