### PR TITLE
Handling pointer overflow caused by QGA reply

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Qemu agent poller", func() {
 			}
 			Expect(parseFilesystem(jsonInput)).To(Equal(expectedFilesystem))
 		})
-		It("should failed parse Filesystem with unconventional agent reply", func() {
+		It("should fail on malformed filesystem agent reply", func() {
 			jsonInput := `{dummy input}`
 
 			_, err := parseFilesystem(jsonInput)

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -22,7 +22,6 @@ package agentpoller
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -60,7 +59,8 @@ var _ = Describe("Qemu agent poller", func() {
 		It("should strip Agent response", func() {
 			jsonInput := `{"return":{"version":"4.1"}}`
 
-			response := stripAgentResponse(jsonInput)
+			response, err := stripAgentResponse(jsonInput)
+			Expect(err).To(BeNil())
 			expectedResponse := `{"version":"4.1"}`
 
 			Expect(response).To(Equal(expectedResponse))
@@ -102,5 +102,13 @@ var _ = Describe("Qemu agent poller", func() {
 			}
 			Expect(parseFilesystem(jsonInput)).To(Equal(expectedFilesystem))
 		})
+		It("should failed parse Filesystem with unconventional agent reply", func() {
+			jsonInput := `{dummy input}`
+
+			_, err := parseFilesystem(jsonInput)
+
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })
+

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -22,6 +22,7 @@ package agentpoller
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -60,7 +61,7 @@ var _ = Describe("Qemu agent poller", func() {
 			jsonInput := `{"return":{"version":"4.1"}}`
 
 			response, err := stripAgentResponse(jsonInput)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			expectedResponse := `{"version":"4.1"}`
 
 			Expect(response).To(Equal(expectedResponse))
@@ -111,4 +112,3 @@ var _ = Describe("Qemu agent poller", func() {
 		})
 	})
 })
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
If qga reply unconventional reply, launcher pod will crash due to pointer overflow.
#### After this PR:
Handling pointer overflows prevents the launcher pod from crashing.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


