### PR TITLE
launcher, converter: Make net configurator arch-independent

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1285,6 +1285,10 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	precond.MustNotBeNil(c)
 
 	architecture := c.Architecture.GetArchitecture()
+	virtioModel := virtio.InterpretTransitionalModelType(
+		vmi.Spec.Domain.Devices.UseVirtioTransitional,
+		architecture,
+	)
 
 	builder := NewDomainBuilder(
 		metadata.DomainConfigurator{},
@@ -1293,6 +1297,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			network.WithUseLaunchSecuritySEV(c.UseLaunchSecuritySEV),
 			network.WithUseLaunchSecurityPV(c.UseLaunchSecurityPV),
 			network.WithROMTuningSupport(c.Architecture.IsROMTuningSupported()),
+			network.WithVirtioModel(virtioModel),
 		),
 		compute.TPMDomainConfigurator{},
 		compute.VSOCKDomainConfigurator{},

--- a/pkg/virt-launcher/virtwrap/converter/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/network/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
-        "//pkg/virt-launcher/virtwrap/converter/virtio:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
@@ -21,7 +21,7 @@
   <devices>
     <interface type="ethernet">
       <source></source>
-      <model type="virtio-non-transitional"></model>
+      <model type="virtio"></model>
       <alias name="ua-default"></alias>
     </interface>
     <channel type="unix">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The network DomainConfigurator currently relies on the host architecture to determine the virtio device model [1].
Refactor the configurator to accept the virtio device model as an input parameter instead of calculating it internally.

Additionally, fix s390x unit test bug where "virtio-non-transitional" was incorrectly used. This model is unsupported on the s390x platform [2].
These tests were falsely passing because the `vmi.Spec.Architecture`
field was unset, causing the calls to `arch.NewConverter` to silently
default to AMD64 [3].

[1] https://libvirt.org/formatdomain.html#virtio-device-models
[2] https://github.com/kubevirt/kubevirt/blob/3d0364b3efe61d14c62d71590f131db550614db2/pkg/virt-launcher/virtwrap/converter/arch/s390x.go#L55
[3] https://github.com/kubevirt/kubevirt/blob/3d0364b3efe61d14c62d71590f131db550614db2/pkg/virt-launcher/virtwrap/converter/arch/converter.go#L55

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

