### PR TITLE
net, netstat: Limit the number if guest interfaces reported in VMI status

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -326,6 +326,9 @@ func ifacesStatusFromGuestAgent(
 	guestAgentInterfaces []api.InterfaceStatus,
 	vmiInterfacesSpecByName map[string]v1.Interface,
 ) []v1.VirtualMachineInstanceNetworkInterface {
+	const guestOnlyInterfaceLimit = 10
+	var guestOnlyInterfaceCount int
+
 	for _, guestAgentInterface := range guestAgentInterfaces {
 		if vmiIfaceStatus := netvmispec.LookupInterfaceStatusByMac(vmiIfacesStatus, guestAgentInterface.Mac); vmiIfaceStatus != nil {
 			vmiIfaceSpec := vmiInterfacesSpecByName[vmiIfaceStatus.Name]
@@ -341,6 +344,11 @@ func ifacesStatusFromGuestAgent(
 				vmiIfaceStatus.InfoSource = netvmispec.InfoSourceDomainAndGA
 			}
 		} else {
+			if guestOnlyInterfaceCount >= guestOnlyInterfaceLimit {
+				continue
+			}
+			guestOnlyInterfaceCount++
+
 			newVMIIfaceStatus := newVMIIfaceStatusFromGuestAgentData(guestAgentInterface)
 			newVMIIfaceStatus.InfoSource = netvmispec.InfoSourceGuestAgent
 			vmiIfacesStatus = append(vmiIfacesStatus, newVMIIfaceStatus)


### PR DESCRIPTION
The UpdateStatus cycle of VM controller in virt handler currently fetches all the guest interfaces from QEMU guest agent and adds them to interface status of the VMI.
If a VM has too many interfaces internal to the guest, example veth pairs, bridges etc, it can fill up the database, preventing further edits to the VMI.

This PR restricts the number of guest agent interfaces reported to 10. The interfaces present on the spec will not be restricted.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Limits the number of guest only interfaces reported on the VMI status to 10. This does not affect the interfaces specified on the spec.
```

