### PR TITLE
fix: cbt, backup: prevent stale status update when reusing backup names

### DIFF
--- a/pkg/storage/cbt/backup_test.go
+++ b/pkg/storage/cbt/backup_test.go
@@ -1414,7 +1414,7 @@ var _ = Describe("Backup Controller", func() {
 				CheckpointName: pointer.P("other-checkpoint"),
 			}
 
-			err := controller.updateSourceBackupInProgress(vmi, backupName)
+			err := controller.updateSourceBackupInProgress(vmi, backupName, metav1.Now())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("another backup"))
 			Expect(err.Error()).To(ContainSubstring("other-backup"))
@@ -1435,7 +1435,7 @@ var _ = Describe("Backup Controller", func() {
 					return vmi, nil
 				})
 
-			err := controller.updateSourceBackupInProgress(vmi, backupName)
+			err := controller.updateSourceBackupInProgress(vmi, backupName, metav1.Now())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(patched).To(BeTrue())
 		})
@@ -1452,7 +1452,7 @@ var _ = Describe("Backup Controller", func() {
 				Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Times(0)
 
-			err := controller.updateSourceBackupInProgress(vmi, backupName)
+			err := controller.updateSourceBackupInProgress(vmi, backupName, metav1.Now())
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2473,7 +2473,8 @@ func (c *VirtualMachineController) updateBackupStatus(vmi *v1.VirtualMachineInst
 	backupMetadata := domain.Spec.Metadata.KubeVirt.Backup
 	// Handle the case where a new backupStatus was initiated but
 	// the backupMetadata wasnt reinitialized yet
-	if vmi.Status.ChangedBlockTracking.BackupStatus.BackupName != backupMetadata.Name {
+	timestampMatch := backupMetadata.StartTimestamp.Equal(vmi.Status.ChangedBlockTracking.BackupStatus.StartTimestamp)
+	if vmi.Status.ChangedBlockTracking.BackupStatus.BackupName != backupMetadata.Name || !timestampMatch {
 		return
 	}
 	vmi.Status.ChangedBlockTracking.BackupStatus.Completed = backupMetadata.Completed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Previously, the controller identified backups solely by name. If a user deleted a Backup CR and immediately recreated it with the same name, the controller could match the new Backup CR with residual domain backup metadata from the previous instance. This resulted in the VMI status being populated with stale completion data.


#### After this PR:
This PR adds the Backup's CreationTimestamp to the VMI backup status initialization. The controller now verifies both the name and the timestamp, ensuring that status updates correspond to the specific backup instance currently running.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Prevent stale VMI backup status update when reusing backup names
```

