### PR TITLE
Enable semantic validation on KubeVirt CR creation

### DIFF
--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -23,11 +23,13 @@ import (
 	"context"
 	"fmt"
 
+
 	"kubevirt.io/client-go/log"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -50,13 +52,50 @@ type kubeVirtCreateAdmitter struct {
 // as it gets installed by virt-operator in its sync-loop, this means that this will only
 // check for creation of a new KubeVirt CR (rejecting it), no validation can be done here
 // as that is done in the 'kubevirt-update-validator.kubevirt.io' webhook
-
 func (k *kubeVirtCreateAdmitter) Admit(ctx context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	log.Log.Info("Trying to create KV")
 	if resp := webhooks.ValidateSchema(v1.KubeVirtGroupVersionKind, review.Request.Object.Raw); resp != nil {
 		return resp
 	}
-	//TODO: Do we want semantic validation
+
+	// Get new KubeVirt from admission response
+	newKV, _, err := getAdmissionReviewKubeVirt(review)
+	if err != nil {
+		return webhooks.ToAdmissionResponseError(err)
+	}
+
+	var results []metav1.StatusCause
+
+	results = append(results, validateCustomizeComponents(newKV.Spec.CustomizeComponents)...)
+	results = append(results, validateCertificates(newKV.Spec.CertificateRotationStrategy.SelfSigned)...)
+	results = append(results, validateGuestToRequestHeadroom(newKV.Spec.Configuration.AdditionalGuestMemoryOverheadRatio)...)
+
+	if newKV.Spec.Configuration.TLSConfiguration != nil {
+		results = append(results,
+			validateTLSConfiguration(newKV.Spec.Configuration.TLSConfiguration)...)
+	}
+
+	if newKV.Spec.Infra != nil && newKV.Spec.Infra.NodePlacement != nil {
+		results = append(results,
+			validateInfraPlacement(ctx, newKV.Namespace, newKV.Spec.Infra.NodePlacement, k.client)...)
+	}
+
+	if newKV.Spec.Workloads != nil && newKV.Spec.Workloads.NodePlacement != nil {
+		results = append(results,
+			validateWorkloadPlacement(ctx, newKV.Namespace, newKV.Spec.Workloads.NodePlacement, k.client)...)
+	}
+
+	results = append(results,
+		validateSeccompConfiguration(field.NewPath("spec").Child("configuration", "seccompConfiguration"), newKV.Spec.Configuration.SeccompConfiguration)...)
+
+	if newKV.Spec.Infra != nil {
+		results = append(results, validateInfraReplicas(newKV.Spec.Infra.Replicas)...)
+	}
+
+	// If any validation failed, return the errors
+	if len(results) > 0 {
+		return webhookutils.NewAdmissionResponse(results)
+	}
 
 	// Best effort
 	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(ctx, metav1.ListOptions{})
@@ -65,7 +104,35 @@ func (k *kubeVirtCreateAdmitter) Admit(ctx context.Context, review *admissionv1.
 	}
 	if len(list.Items) == 0 {
 		fmt.Println("Allowed to create KV")
-		return webhookutils.NewPassingAdmissionResponse()
+		response := webhookutils.NewPassingAdmissionResponse()
+		// warnings
+		// feature gates
+		featureGates := []string{}
+		if newKV.Spec.Configuration.DeveloperConfiguration != nil {
+			featureGates = newKV.Spec.Configuration.DeveloperConfiguration.FeatureGates
+		}
+		response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(featureGates)...)
+
+		// mdevs
+		const mdevWarningfmt = "%s is deprecated, use mediatedDeviceTypes"
+		if mdev := newKV.Spec.Configuration.MediatedDevicesConfiguration; mdev != nil {
+			f := field.NewPath("spec", "configuration", "mediatedDevicesConfiguration")
+			if mdev.MediatedDevicesTypes != nil {
+				f := f.Child("mediatedDevicesTypes")
+				response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, f.String()))
+			}
+
+			f = f.Child("nodeMediatedDeviceTypes")
+			for i, mdevType := range mdev.NodeMediatedDeviceTypes {
+				f := f.Index(i).Child("mediatedDevicesTypes")
+				if mdevType.MediatedDevicesTypes != nil {
+					response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, f.String()))
+				}
+			}
+		}
+
+		response.Warnings = append(response.Warnings, warnDeprecatedArchitectures(newKV.Spec.Configuration.ArchitectureConfiguration)...)
+		return response
 	}
 	return webhooks.ToAdmissionResponseError(fmt.Errorf("Kubevirt is already created"))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
`kubevirt-create-admitter` only did schema validation and check for existing CRs, not semantic validation on the spec fields (likke verifying replicas > 0). This allowed invalid KubeVirt CRs to be created. A TODO existed in the code noting this missing validation.

#### After this PR:
The `kubevirt-create-admitter` now includes the same semantic validation logic as the update admitter (`kubevirt-update-admitter`). This ensures that KubeVirt CRs are validated consistency at creation time, rejecting invalid configurations immediately.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
-->  
- Fixes #16401

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
We need this to prevent the creation of invalid KubeVirt configurations that could lead to broken deployments or issues that are only discovered later when attempting an update.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable semantic validation for KubeVirt CRs on creation. This ensures that invalid configurations (valid schema but invalid values like replicas: 0) are rejected immediately upon creation, matching the validation logic already present for updates.
```

