### PR TITLE
e2e, net, sriov: Fix memory hotplug + migration test (add MAC)

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -343,12 +343,15 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 					initialGuestMemory      = "1Gi"
 					updatedGuestMemory      = "3Gi"
 					sriovNetworkLogicalName = "sriov-network"
+					mac                     = "de:ad:00:00:be:af"
 				)
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithGuestMemory(initialGuestMemory),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(sriovNetworkLogicalName)),
 					libvmi.WithNetwork(libvmi.MultusNetwork(sriovNetworkLogicalName, sriovnet1)),
 				)
+
+				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = mac
 				vmi.Spec.Domain.Resources.Requests = nil
 
 				vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
@@ -396,6 +399,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 						MatchFields(IgnoreExtras, Fields{
 							"Name":       Equal(sriovNetworkLogicalName),
 							"InfoSource": ContainSubstring(vmispec.InfoSourceDomain),
+							"MAC":        Equal(mac),
 						}),
 					))
 			})


### PR DESCRIPTION
### What this PR does

The test is currently flaking.
It uses ConsitsOf instead of Contains, to analyze the status which is currently showing 2 interfaces instead of one.

The reason why the status includes two interfaces instead of one is as follows:

The virt-handler's logic responsible for reporting interface status of SR-IOV devices is comprised of two steps:
1. Info is collected from the domain spec, while the MAC address is taken from the vmi.spec.domain.interfaces[].mac field  (if exists) [1].
2. Info from guest agent enriches the existing status entries in case the MAC address reported by GA can be correlated with the MAC address reported in the status [2].

Since the MAC address is unspecified in the spec, it is also unspecified in the status and is therefore not correlated.
Since GA reporting is unrecognized, it is considered a guest only interface and is reported as an additional interface.
This is a known issue https://github.com/kubevirt/kubevirt/issues/16422.

In order to fix correlation, set explicit MAC address in the spec in order to mitigate # 1 above, and enable correlation in # 2.

The failure below [3] demonstrates how 2 interfaces were reported and how ConsitsOf was not satisfied with the results despite including the all the data that the gstruct matcher was asserting.

[1] https://github.com/kubevirt/kubevirt/blob/395bd0da05f8b8d39326eb1b90da90b574a16e2b/pkg/network/setup/netstat.go#L308

[2] https://github.com/kubevirt/kubevirt/blob/395bd0da05f8b8d39326eb1b90da90b574a16e2b/pkg/network/setup/netstat.go#L333

[3] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16391/pull-kubevirt-e2e-kind-sriov/2004191256049094656

```
 Expected
     <[]v1.VirtualMachineInstanceNetworkInterface | len:2, cap:2>: [
         {
             IP: "",
             MAC: "",
             Name: "sriov-network",
             IPs: nil,
             PodInterfaceName: "podafa4cdb1f64",
             InterfaceName: "",
             InfoSource: "domain, multus-status",
             QueueCount: 0,
             LinkState: "",
         },
         {
             IP: "",
             MAC: "86:4b:dc:31:e5:c8",
             Name: "",
             IPs: nil,
             PodInterfaceName: "",
             InterfaceName: "eth0",
             InfoSource: "guest-agent",
             QueueCount: 0,
             LinkState: "",
         },
     ]
 to consist of
     <[]*gstruct.FieldsMatcher | len:1, cap:1>: [
         {
             Fields: {
                 "Name": <*matchers.EqualMatcher | 0xc0073e61a0>{
                     Expected: <string>"sriov-network",
                 },
                 "InfoSource": <*matchers.ContainSubstringMatcher | 0xc004b126c0>{Substr: "domain", Args: nil},
             },
             IgnoreExtras: true,
             IgnoreMissing: false,
             failures: [
                 <*errors.NestedError | 0xc007a8d080>{
                     Path: ".Name",
                     Err: <*errors.errorString | 0xc007108820>{
                         s: "Expected\n    <string>: \nto equal\n    <string>: sriov-network",
                     },
                 },
                 <*errors.NestedError | 0xc007a8d0a0>{
                     Path: ".InfoSource",
                     Err: <*errors.errorString | 0xc007108920>{
                         s: "Expected\n    <string>: guest-agent\nto contain substring\n    <string>: domain",
                     },
                 },
             ],
         },
     ]
 the extra elements were
     <[]v1.VirtualMachineInstanceNetworkInterface | len:1, cap:1>: [
         {
             IP: "",
             MAC: "86:4b:dc:31:e5:c8",
             Name: "",
             IPs: nil,
             PodInterfaceName: "",
             InterfaceName: "eth0",
             InfoSource: "guest-agent",
             QueueCount: 0,
             LinkState: "",
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Fixes https://github.com/kubevirt/kubevirt/issues/16420
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

