### PR TITLE
api: Add omitempty to Filesystem.Virtiofs field

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15065,8 +15065,7 @@
    "v1.Filesystem": {
     "type": "object",
     "required": [
-     "name",
-     "virtiofs"
+     "name"
     ],
     "properties": {
      "name": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6306,7 +6306,6 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: object
                             required:
                             - name
-                            - virtiofs
                             type: object
                           type: array
                           x-kubernetes-list-type: atomic
@@ -12065,7 +12064,6 @@ var CRDsValidation map[string]string = map[string]string{
                         type: object
                     required:
                     - name
-                    - virtiofs
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic
@@ -15862,7 +15860,6 @@ var CRDsValidation map[string]string = map[string]string{
                         type: object
                     required:
                     - name
-                    - virtiofs
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic
@@ -18349,7 +18346,6 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: object
                             required:
                             - name
-                            - virtiofs
                             type: object
                           type: array
                           x-kubernetes-list-type: atomic
@@ -23341,7 +23337,6 @@ var CRDsValidation map[string]string = map[string]string{
                                         type: object
                                     required:
                                     - name
-                                    - virtiofs
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -28779,7 +28774,6 @@ var CRDsValidation map[string]string = map[string]string{
                                             type: object
                                         required:
                                         - name
-                                        - virtiofs
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -125,8 +125,7 @@ type ServiceAccountVolumeSource struct {
 
 // DownwardMetricsVolumeSource adds a very small disk to VMIs which contains a limited view of host and guest
 // metrics. The disk content is compatible with vhostmd (https://github.com/vhostmd/vhostmd) and vm-dump-metrics.
-type DownwardMetricsVolumeSource struct {
-}
+type DownwardMetricsVolumeSource struct{}
 
 // Represents a Sysprep volume source.
 type SysprepSource struct {
@@ -363,8 +362,7 @@ type Realtime struct {
 // NUMAGuestMappingPassthrough instructs kubevirt to model numa topology which is compatible with the CPU pinning on the guest.
 // This will result in a subset of the node numa topology being passed through, ensuring that virtual numa nodes and their memory
 // never cross boundaries coming from the node numa mapping.
-type NUMAGuestMappingPassthrough struct {
-}
+type NUMAGuestMappingPassthrough struct{}
 
 type NUMA struct {
 	// GuestMappingPassthrough will create an efficient guest topology based on host CPUs exclusively assigned to a pod.
@@ -505,7 +503,7 @@ type Devices struct {
 	// If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.
 	// +optional
 	NetworkInterfaceMultiQueue *bool `json:"networkInterfaceMultiqueue,omitempty"`
-	//Whether to attach a GPU device to the vmi.
+	// Whether to attach a GPU device to the vmi.
 	// +optional
 	// +listType=atomic
 	GPUs []GPU `json:"gpus,omitempty"`
@@ -520,7 +518,7 @@ type Devices struct {
 	// +optional
 	// +listType=atomic
 	Filesystems []Filesystem `json:"filesystems,omitempty"`
-	//Whether to attach a host device to the vmi.
+	// Whether to attach a host device to the vmi.
 	// +optional
 	// +listType=atomic
 	HostDevices []HostDevice `json:"hostDevices,omitempty"`
@@ -545,8 +543,7 @@ type Devices struct {
 // The struct is currently empty as there is no immediate request for
 // user-facing APIs. This structure simply turns on USB redirection of
 // UsbClientPassthroughMaxNumberOf devices.
-type ClientPassthroughDevices struct {
-}
+type ClientPassthroughDevices struct{}
 
 // Represents the upper limit allowed by QEMU + KubeVirt.
 const (
@@ -609,7 +606,7 @@ type Filesystem struct {
 	// Name is the device name
 	Name string `json:"name"`
 	// Virtiofs is supported
-	Virtiofs *FilesystemVirtiofs `json:"virtiofs"`
+	Virtiofs *FilesystemVirtiofs `json:"virtiofs,omitempty"`
 }
 
 type FilesystemVirtiofs struct{}
@@ -807,14 +804,11 @@ type SEVPolicy struct {
 	EncryptedState *bool `json:"encryptedState,omitempty"`
 }
 
-type SEVSNP struct {
-}
+type SEVSNP struct{}
 
-type SEVAttestation struct {
-}
+type SEVAttestation struct{}
 
-type TDX struct {
-}
+type TDX struct{}
 
 type LunTarget struct {
 	// Bus indicates the type of disk device to emulate.
@@ -1527,8 +1521,10 @@ type AccessCredentialSecretSource struct {
 	SecretName string `json:"secretName"`
 }
 
-type ConfigDriveSSHPublicKeyAccessCredentialPropagation struct{}
-type NoCloudSSHPublicKeyAccessCredentialPropagation struct{}
+type (
+	ConfigDriveSSHPublicKeyAccessCredentialPropagation struct{}
+	NoCloudSSHPublicKeyAccessCredentialPropagation     struct{}
+)
 
 // AuthorizedKeysFile represents a path within the guest
 // that ssh public keys should be propagated to
@@ -1679,8 +1675,7 @@ func (podNet *PodNetwork) UnmarshalJSON(data []byte) error {
 }
 
 // Rng represents the random device passed from host
-type Rng struct {
-}
+type Rng struct{}
 
 // Represents the multus cni network.
 type MultusNetwork struct {

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -821,10 +821,6 @@ func (ConfigDriveSSHPublicKeyAccessCredentialPropagation) SwaggerDoc() map[strin
 	return map[string]string{}
 }
 
-func (NoCloudSSHPublicKeyAccessCredentialPropagation) SwaggerDoc() map[string]string {
-	return map[string]string{}
-}
-
 func (AuthorizedKeysFile) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "AuthorizedKeysFile represents a path within the guest\nthat ssh public keys should be propagated to",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21250,7 +21250,7 @@ func schema_kubevirtio_api_core_v1_Filesystem(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"name", "virtiofs"},
+				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
## API: Add omitempty to Filesystem.Virtiofs field

### What this PR does
Marks the `Filesystem.Virtiofs` field as optional (`omitempty`) in the API. This allows users to omit the field when using alternative vhost-user-fs implementations without triggering validation errors from the mutating webhook (`virtualmachines-mutator.kubevirt.io`).

The container creation logic in `virtiofs.go` already checks for `nil` Virtiofs and will not create a `virtiofsd` container when it is `nil`.

#### Before this PR:
- The `virtiofs` field was a **required** field in the OpenAPI schema and CRD validation.
- Users providing their own vhost-user-fs device via a sidecar could not omit the field, causing the mutating webhook to reject the VM spec.

#### After this PR:
- The `virtiofs` field is now **optional**.
- The API correctly serializes the field when it is `nil`.
- The mutating webhook will accept VM specifications that omit this field, enabling the use case described in issue #14015.

### References
- Fixes #14015

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The change addresses a specific user need to integrate custom CSI drivers using the vhost-user-fs protocol without KubeVirt starting an unused `virtiofsd` container. The solution—adding the `omitempty` JSON struct tag—is the standard, minimal way to make a field optional in the Go API, which is then propagated correctly to all generated schemas and validations.

The following tradeoffs were made:
- **Simplicity over complexity**: A one-line change in the source API definition was chosen over more complex logic in the webhook or mutating admission controller.
- **Backward compatibility**: The change is fully backward compatible; existing VM specs that include the `virtiofs` field are unaffected.

The following alternatives were considered:
- Modifying the mutating webhook to accept `null` values for the field. This was rejected as it would be a workaround rather than fixing the root cause in the API definition.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
- The requirement and discussion are captured in the originating Issue #14015.

### Special notes for your reviewer
- The core change is the addition of `omitempty` on line 563 of `staging/src/kubevirt.io/api/core/v1/schema.go`.
- All other changed files (`swagger.json`, `*_generated.go`) were updated automatically by running `make generate`.
- The logic for container creation in `pkg/virt-launcher/virtwrap/converter/virtiofs.go` already contains the necessary guard: `if fs.Virtiofs == nil { continue }`, so no functional changes were required there.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `virtiofs` field in the `Filesystem` device specification is now optional (`omitempty`), allowing VM specifications to omit it when using alternative vhost-user-fs implementations.

