### PR TITLE
converter/arch: fix USB controller detection for empty input bus

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/arch/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/arch/BUILD.bazel
@@ -27,6 +27,8 @@ go_test(
     embed = [":go_default_library"],
     race = "on",
     deps = [
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
@@ -37,8 +37,8 @@ func (converterAMD64) ScsiController(model string, driver *api.ControllerDriver)
 }
 
 func (converterAMD64) IsUSBNeeded(vmi *v1.VirtualMachineInstance) bool {
-	for i := range vmi.Spec.Domain.Devices.Inputs {
-		if vmi.Spec.Domain.Devices.Inputs[i].Bus == "usb" {
+	for _, input := range vmi.Spec.Domain.Devices.Inputs {
+		if bus := input.Bus; bus == "usb" || bus == "" {
 			return true
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/converter/arch/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/converter_test.go
@@ -19,6 +19,9 @@ package arch
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
 var _ = Describe("Arch Converter", func() {
@@ -33,4 +36,13 @@ var _ = Describe("Arch Converter", func() {
 		Entry("s390x", "s390x", converterS390X{}),
 		Entry("unknown", "unknown", converterAMD64{}),
 	)
+
+	Context("IsUSBNeeded on AMD64", func() {
+		It("should require a USB controller on amd64 when an input device has an empty bus", func() {
+			vmi := libvmi.New()
+			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{}}
+			ac := NewConverter("amd64")
+			Expect(ac.IsUSBNeeded(vmi)).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
### What this PR does
convert_v1_Input_To_api_InputDevice used to mutate the VMI spec, which is wrong at this layer. This mutation created a dependency on the order in which it and converterAMD64.IsUSBNeeded are called.

Currently, InputDeviceDomainConfigurator runs before the USB controller setup, so empty bus is defaulted to USB before IsUSBNeeded is evaluated.
However, IsUSBNeeded only checks for explicit Bus == "usb" and doesn't account for empty bus which will be defaulted to USB.

Fix:
- Check for empty bus in IsUSBNeeded to make it work correctly regardless of when it's called relative to InputDeviceDomainConfigurator
- Refactor and rename convert_v1_Input_To_api_InputDevice to apiInputDeviceFromV1InputDevice that returns the api.Input value rather than mutating a pointer argument, and use a switch statement for clearer bus handling

[link](https://github.com/kubevirt/kubevirt/pull/1987/changes/d81f89d138234f1dcc305b403299bf3e905ce261#r256038968) to the discussion to default usb controller creation

#### Before this PR:
- InputDeviceDomainConfigurator runs before USB controller configuration.

- If an input device has an empty bus, it is implicitly defaulted to usb during domain configuration.

- IsUSBNeeded only checks for devices with Bus == "usb" and ignores devices with an empty bus.

- As a result, USB controller creation depends on the order in which configurators are invoked.

This implicit coupling makes the logic fragile and harder to reason about.
#### After this PR:
- IsUSBNeeded treats an empty bus as requiring USB, matching the effective defaulting behavior.

- USB controller creation no longer depends on whether InputDeviceDomainConfigurator has already run.

- The logic becomes order-independent and self-contained.

- Behavior is unchanged for users, but the implementation is more robust and predictable.

### References
Relates-To: #16306

### Release note
```release-note
none
```

