### PR TITLE
tests: remove redundant CPU model e2e tests

### DIFF
--- a/tests/compute/cpu.go
+++ b/tests/compute/cpu.go
@@ -22,8 +22,6 @@ package compute
 import (
 	"context"
 	"fmt"
-	"strings"
-	"unicode"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
@@ -238,101 +236,9 @@ var _ = Describe(SIG("CPU", func() {
 	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU spec", func() {
 		var nodes *k8sv1.NodeList
 
-		parseCPUNiceName := func(name string) string {
-			updatedCPUName := strings.Replace(name, "\n", "", -1)
-			if strings.Contains(updatedCPUName, ":") {
-				updatedCPUName = strings.Split(name, ":")[1]
-
-			}
-			updatedCPUName = strings.Replace(updatedCPUName, " ", "", 1)
-			updatedCPUName = strings.Replace(updatedCPUName, "(", "", -1)
-			updatedCPUName = strings.Replace(updatedCPUName, ")", "", -1)
-
-			updatedCPUName = strings.Split(updatedCPUName, "-")[0]
-			updatedCPUName = strings.Split(updatedCPUName, "_")[0]
-
-			for i, char := range updatedCPUName {
-				if unicode.IsUpper(char) && i != 0 {
-					updatedCPUName = strings.Split(updatedCPUName, string(char))[0]
-				}
-			}
-			return updatedCPUName
-		}
-
 		BeforeEach(func() {
 			nodes = libnode.GetAllSchedulableNodes(virtClient)
 			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model defined", func() {
-			It("[test_id:1678]should report defined CPU model", func() {
-				supportedCPUs := libnode.GetSupportedCPUModels(*nodes)
-				Expect(supportedCPUs).ToNot(BeEmpty())
-				cpuVmi := libvmifact.NewAlpine(libvmi.WithCPUModel(supportedCPUs[0]))
-
-				niceName := parseCPUNiceName(supportedCPUs[0])
-
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(cpuVmi)).Create(context.Background(), cpuVmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStart(cpuVmi)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(cpuVmi)).To(Succeed())
-
-				By("Checking the CPU model under the guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", niceName)},
-					&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
-				}, 10)).To(Succeed())
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model equals to passthrough", func() {
-			It("[test_id:1679]should report exactly the same model as node CPU", func() {
-				cpuVmi := libvmifact.NewAlpine(libvmi.WithCPUModel("host-passthrough"))
-
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(cpuVmi)).Create(context.Background(), cpuVmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStart(cpuVmi)
-
-				By("Checking the CPU model under the guest OS")
-				output := libpod.RunCommandOnVmiPod(cpuVmi, []string{"grep", "-m1", "model name", "/proc/cpuinfo"})
-
-				niceName := parseCPUNiceName(output)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(cpuVmi)).To(Succeed())
-
-				By("Checking the CPU model under the guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", niceName)},
-					&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
-				}, 10)).To(Succeed())
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model not defined", func() {
-			It("[test_id:1680]should report CPU model from libvirt capabilities", func() {
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), libvmifact.NewAlpine(), metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStart(cpuVmi)
-
-				output := libpod.RunCommandOnVmiPod(cpuVmi, []string{"grep", "-m1", "model name", "/proc/cpuinfo"})
-
-				niceName := parseCPUNiceName(output)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(cpuVmi)).To(Succeed())
-
-				By("Checking the CPU model under the guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", niceName)},
-					&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
-				}, 10)).To(Succeed())
-			})
 		})
 
 		Context("when CPU features defined", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
### What this PR does
This PR removes the CPU model e2e tests (test_id:1678, test_id:1679, test_id:1680).These tests verify the VMI spec to domain XML translation for CPU models, which is already fully covered by converter unit tests. Beyond that translation, the actual CPU model behavior is handled by libvirt, which KubeVirt trusts and does not need to validate through e2e tests.

#### Before this PR:
test_id:1678,1679,1680 are present in E2E tests.

#### After this PR:
test_id:1678,1679,1680 are removed  from E2E tests.

### References
Unit test coverage in `converter_test.go`:
- Custom CPU model (mode="custom", model set): [L845-L877](https://github.com/kubevirt/kubevirt/blob/7f90ec0c5da6fd40452ae93a1d50c63ddc76ecb8/pkg/virt-launcher/virtwrap/converter/converter_test.go#L845-L877)
- host-passthrough / host-model (mode set directly): [L1020-L1032](https://github.com/kubevirt/kubevirt/blob/7f90ec0c5da6fd40452ae93a1d50c63ddc76ecb8/pkg/virt-launcher/virtwrap/converter/converter_test.go#L1020-L1032)
- CPU spec with no model (defaults to host-model): [L1035-L1045](https://github.com/kubevirt/kubevirt/blob/7f90ec0c5da6fd40452ae93a1d50c63ddc76ecb8/pkg/virt-launcher/virtwrap/converter/converter_test.go#L1035-L1045)
- No CPU spec at all (defaults to host-model): [L1047-L1054](https://github.com/kubevirt/kubevirt/blob/7f90ec0c5da6fd40452ae93a1d50c63ddc76ecb8/pkg/virt-launcher/virtwrap/converter/converter_test.go#L1047-L1054)

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The e2e tests exercise the converter logic that translates CPU model settings from the VMI spec into domain XML. This logic is already covered by unit tests in the converter package. The remaining behaviour (applying the CPU model inside the guest) is libvirt's responsibility and not something KubeVirt needs to test.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
   None.

```

