### PR TITLE
`CONTRIBUTING.md` to mention VEPs instead of deprecated design proposals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ development community and users, so they should be communicated widely. Examples
 of changes:
 - New APIs
 - Architectural changes
-- Code refactors
+- Major code refactors
 - Complex features
 - API changes
 


### PR DESCRIPTION
### What this PR does

Updates CONTRIBUTING.md to mention VEPs.
This will replace the reference to deprecated "design proposals".

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

