### PR TITLE
Added a pod to check on the availability of libguestfs image

### DIFF
--- a/tests/virtctl/BUILD.bazel
+++ b/tests/virtctl/BUILD.bazel
@@ -58,7 +58,9 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:386": [
             "//tests/libvmops:go_default_library",

--- a/tests/virtctl/guestfs.go
+++ b/tests/virtctl/guestfs.go
@@ -26,10 +26,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/guestfs"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -39,6 +42,8 @@ import (
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
+
+const dummyPodName = "libguestfs-image-checker"
 
 var _ = Describe(SIG("[sig-storage]Guestfs", decorators.SigStorage, func() {
 	var (
@@ -53,6 +58,7 @@ var _ = Describe(SIG("[sig-storage]Guestfs", decorators.SigStorage, func() {
 	}
 
 	BeforeEach(func() {
+		CheckGuestfsImageAvailability()
 		guestfs.CreateAttacherFunc = fakeCreateAttacher
 		const randNameTail = 5
 		pvcClaim = "pvc-" + rand.String(randNameTail)
@@ -60,6 +66,7 @@ var _ = Describe(SIG("[sig-storage]Guestfs", decorators.SigStorage, func() {
 	})
 
 	AfterEach(func() {
+		CleanupGuestfsImageCheckPod()
 		guestfs.CreateAttacherFunc = guestfs.CreateAttacher
 		close(done)
 	})
@@ -178,4 +185,70 @@ func verifyCanRunOnFSPVC(podName, namespace string) {
 	Expect(stderr).To(BeEmpty())
 	Expect(stdout).To(BeEmpty())
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func CleanupGuestfsImageCheckPod() {
+	kubeClient := kubevirt.Client()
+	err := kubeClient.CoreV1().Pods(testsuite.GetTestNamespace(nil)).Delete(context.Background(), dummyPodName, metav1.DeleteOptions{})
+	if err != nil && k8serrors.IsNotFound(err) {
+		return
+	}
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// check if the libguestfs-tools image is available for test
+func CheckGuestfsImageAvailability() {
+	podYaml := ""
+	kubeClient := kubevirt.Client()
+	guestfsImage, err := guestfs.SetImage(kubeClient)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(guestfsImage).ToNot(BeEmpty())
+	namespace := testsuite.GetTestNamespace(nil)
+	pod := CreateDummyPod(guestfsImage, namespace)
+	_, err = kubeClient.CoreV1().Pods(testsuite.GetTestNamespace(nil)).Create(context.Background(), pod, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	Eventually(func(g Gomega) {
+		thePod, err := kubevirt.Client().CoreV1().Pods(namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		podBytes, err := yaml.Marshal(thePod)
+		g.Expect(err).ToNot(HaveOccurred())
+		podYaml = string(podBytes)
+		podYaml = fmt.Sprintf("[debug] failed pod yaml: \n%s\n---\n", podYaml)
+		g.Expect(thePod).To(matcher.HaveConditionTrue(corev1.ContainersReady), podYaml)
+	}, 2*time.Minute, 2*time.Second).Should(Succeed())
+}
+
+func CreateDummyPod(img, ns string) *corev1.Pod {
+	containerSecurityContext := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+	securityContext := &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dummyPodName,
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: securityContext,
+			Containers: []corev1.Container{
+				{
+					Name:            "testcontainer",
+					Image:           img,
+					Command:         []string{"sleep", "120"},
+					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: containerSecurityContext,
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	return pod
 }


### PR DESCRIPTION
If the guestfs test fails there is not enough information in the console log
to see what is exactly happened. One possible cause of failure is that the 
libguestfs-tools image is not available.
To help debugging a dummy pod is deployed before test to check the 
availability of the image. If the pod failed it will print out the whole pod
yaml to help debugging.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Not enough information to debugging when guestfs test fails
#### After this PR:
It gives more information about the checker pod
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

