### PR TITLE
tests: use localhost instead of ip when curling pod metrics

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -364,19 +364,14 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		Entry("[test_id:6226] by using IPv6", k8sv1.IPv6Protocol),
 	)
 
-	DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
+	It("[test_id:4141]should include the metrics for a running VM", func() {
 		By("Scraping the Prometheus endpoint")
 		Eventually(func() string {
 			out := libmonitoring.GetKubevirtVMMetrics(pod)
 			lines := libinfra.TakeMetricsWithPrefix(out, "kubevirt")
 			return strings.Join(lines, "\n")
 		}, 30*time.Second, 2*time.Second).Should(ContainSubstring("kubevirt"))
-	},
-		Entry("[test_id:4141] by using IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6227] by using IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 
 	It("should expose kubevirt_node_deprecated_machine_types metric", func() {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
@@ -395,9 +390,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		}
 	})
 
-	DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricName, operator string) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
+	DescribeTable("should include the storage metrics for a running VM", func(metricName, operator string) {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		By("Checking the collected metrics")
@@ -418,39 +411,23 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 	},
-		Entry("[test_id:4142] storage flush requests metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-		Entry("[test_id:6228] storage flush requests metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-		Entry("[test_id:4142] time spent on cache flushing metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_times_seconds_total", ">="),
-		Entry("[test_id:6229] time spent on cache flushing metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_times_seconds_total", ">="),
-		Entry("[test_id:4142] I/O read operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-		Entry("[test_id:6230] I/O read operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-		Entry("[test_id:4142] I/O write operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-		Entry("[test_id:6231] I/O write operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-		Entry("[test_id:4142] storage read operation time metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_times_seconds_total", ">="),
-		Entry("[test_id:6232] storage read operation time metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_times_seconds_total", ">="),
-		Entry("[test_id:4142] storage read traffic in bytes metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-		Entry("[test_id:6233] storage read traffic in bytes metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-		Entry("[test_id:4142] storage write operation time metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_times_seconds_total", ">="),
-		Entry("[test_id:6234] storage write operation time metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_times_seconds_total", ">="),
-		Entry("[test_id:4142] storage write traffic in bytes metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
-		Entry("[test_id:6235] storage write traffic in bytes metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+		Entry("[test_id:4142] storage flush requests metric",
+			"kubevirt_vmi_storage_flush_requests_total", ">="),
+		Entry("[test_id:4142] time spent on cache flushing metric",
+			"kubevirt_vmi_storage_flush_times_seconds_total", ">="),
+		Entry("[test_id:4142] I/O read operations metric", "kubevirt_vmi_storage_iops_read_total", ">="),
+		Entry("[test_id:4142] I/O write operations metric", "kubevirt_vmi_storage_iops_write_total", ">="),
+		Entry("[test_id:4142] storage read operation time metric",
+			"kubevirt_vmi_storage_read_times_seconds_total", ">="),
+		Entry("[test_id:4142] storage read traffic in bytes metric",
+			"kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+		Entry("[test_id:4142] storage write operation time metric",
+			"kubevirt_vmi_storage_write_times_seconds_total", ">="),
+		Entry("[test_id:4142] storage write traffic in bytes metric",
+			"kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
 	)
 
-	DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
+	DescribeTable("should include metrics for a running VM", func(metricSubstring, operator string) {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
@@ -466,21 +443,14 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 	},
-		Entry("[test_id:4143] network metrics by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_network_", ">="),
-		Entry("[test_id:6236] network metrics by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_network_", ">="),
-		Entry("[test_id:4144] memory metrics by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_memory", ">="),
-		Entry("[test_id:6237] memory metrics by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_memory", ">="),
-		Entry("[test_id:4553] vcpu wait by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-		Entry("[test_id:6238] vcpu wait by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-		Entry("[test_id:4554] vcpu seconds by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_seconds_total", ">="),
-		Entry("[test_id:6239] vcpu seconds by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_seconds_total", ">="),
-		Entry("[test_id:4556] vmi unused memory by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
-		Entry("[test_id:6240] vmi unused memory by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
+		Entry("[test_id:4143] network metrics", "kubevirt_vmi_network_", ">="),
+		Entry("[test_id:4144] memory metrics", "kubevirt_vmi_memory", ">="),
+		Entry("[test_id:4553] vcpu wait", "kubevirt_vmi_vcpu_wait", "=="),
+		Entry("[test_id:4554] vcpu seconds", "kubevirt_vmi_vcpu_seconds_total", ">="),
+		Entry("[test_id:4556] vmi unused memory", "kubevirt_vmi_memory_unused_bytes", ">="),
 	)
 
-	DescribeTable("[QUARANTINE]should include VMI infos for a running VM", decorators.Quarantine, func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
+	It("[QUARANTINE][test_id:4145]should include VMI infos for a running VM", decorators.Quarantine, func() {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
@@ -518,14 +488,9 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 				))
 			}
 		}
-	},
-		Entry("[test_id:4145] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6241] by IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 
-	DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
+	It("[test_id:4146]should include VMI phase metrics for all running VMs", func() {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
@@ -541,10 +506,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 				Expect(metricResult.Value).To(Equal(float64(len(preparedVMIs))))
 			}
 		}
-	},
-		Entry("[test_id:4146] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6242] by IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 
 	Context("VMI eviction blocker status", func() {
 		var controllerMetricIPs []string
@@ -586,9 +548,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		)
 	})
 
-	DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
+	It("[test_id:4147]should include kubernetes labels to VMI metrics", func() {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
@@ -611,15 +571,10 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 		Expect(containK8sLabel).To(BeTrue())
-	},
-		Entry("[test_id:4147] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6244] by IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 
 	// explicit test swap metrics as test_id:4144 doesn't catch if they are missing
-	DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
+	It("[test_id:4555]should include swap metrics", func() {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
@@ -644,10 +599,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 
 		Expect(in).To(BeTrue())
 		Expect(out).To(BeTrue())
-	},
-		Entry("[test_id:4555] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6245] by IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 }))
 
 func countReadyAndLeaderPods(pod *k8sv1.Pod, component string) (foundMetrics map[string]int, err error) {

--- a/tests/libmigration/BUILD.bazel
+++ b/tests/libmigration/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmonitoring:go_default_library",
-        "//tests/libnet:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -520,7 +520,6 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 		"kubevirt_vmi_migration_dirty_memory_rate_bytes",
 		"kubevirt_vmi_migration_memory_transfer_rate_bytes",
 	}
-	const family = k8sv1.IPv4Protocol
 
 	By("Finding the prometheus endpoint")
 	pod, err = libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)

--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -412,18 +412,24 @@ func getPrometheusAlerts(virtClient kubecli.KubevirtClient) promv1.PrometheusRul
 	return newRules
 }
 
-func GetKubevirtVMMetrics(pod *k8sv1.Pod, ip string) string {
+// Works whenever pod has curl
+func GetKubevirtVMMetrics(pod *k8sv1.Pod) string {
+	return GetKubevirtVMMetricsByIP(pod, "localhost")
+}
+
+// Deprecated: Use GetKubevirtVMMetrics or grab metrics indirectly through prometheus
+func GetKubevirtVMMetricsByIP(pod *k8sv1.Pod, ip string) string {
 	metricsURL := PrepareMetricsURL(ip, 8443)
-	stdout, _, err := execute.ExecuteCommandOnPodWithResults(
+	stdout, stderr, err := execute.ExecuteCommandOnPodWithResults(
 		pod,
-		"virt-handler",
+		pod.Spec.Containers[0].Name,
 		[]string{
 			"curl",
 			"-L",
 			"-k",
 			metricsURL,
 		})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", stdout, stderr)
 	return stdout
 }
 

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -68,7 +68,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmonitoring"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libstorage"
@@ -451,14 +450,13 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				metricsIPs = append(metricsIPs, ip.IP)
 			}
 			By("Waiting until the Migration Completes")
-			ip := libnet.GetIP(metricsIPs, k8sv1.IPv4Protocol)
 
 			By("Update volumes")
 			updateVMWithDV(vm, volName, destDV.Name)
 
 			threshold := resource.MustParse("500Mi")
 			Eventually(func() []string {
-				out := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+				out := libmonitoring.GetKubevirtVMMetrics(pod)
 				return libinfra.TakeMetricsWithPrefix(out, "kubevirt_vmi_migration_data_processed_bytes")
 			}, 100*time.Second, 1*time.Second).Should(
 				WithTransform(func(lines []string) []float64 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- we don't need the IP to succesfully curl the /metrics ep
- a bunch of tabled tests for ipv4/ipv6 seem like they're not needed

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

