### PR TITLE
[release-1.6] pkg/virt-controller/watch/vm: Skip restart condition on firmware UUID sync

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3025,6 +3025,16 @@ func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMa
 		lastSeenVM.Spec.Template.Spec.Networks = currentVM.Spec.Template.Spec.Networks
 	}
 
+	// Neutralize firmware UUID changes if the VMI's UUID matches the VM's UUID.
+	// This happens when the firmware synchronizer persists the UUID to a VM that didn't have one.
+	if vmi != nil && vmi.Spec.Domain.Firmware != nil && currentVM.Spec.Template.Spec.Domain.Firmware != nil &&
+		vmi.Spec.Domain.Firmware.UUID == currentVM.Spec.Template.Spec.Domain.Firmware.UUID {
+		if lastSeenVM.Spec.Template.Spec.Domain.Firmware == nil {
+			lastSeenVM.Spec.Template.Spec.Domain.Firmware = &virtv1.Firmware{}
+		}
+		lastSeenVM.Spec.Template.Spec.Domain.Firmware.UUID = currentVM.Spec.Template.Spec.Domain.Firmware.UUID
+	}
+
 	if !equality.Semantic.DeepEqual(lastSeenVM.Spec.Template.Spec, currentVM.Spec.Template.Spec) {
 		setRestartRequired(vm, "a non-live-updatable field was changed in the template spec")
 		return true


### PR DESCRIPTION
automatic backport is faling not on conflict but on missmatch of usage in unit-tests where in this release we are using
`controller.setupVMIFromVM` instead of the exported `SetupVMIFromVM(vm)` we
 had in release-1.7

### Release note
```release-note
Prevent false restart-required conditions when the VM and corresponding VMI already share the same firmware UUID.
```

