### PR TITLE
fix(hotplug): add toleration for unschedulable nodes

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -956,6 +956,12 @@ func (t *TemplateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 
 	tmpTolerations := make([]k8sv1.Toleration, len(ownerPod.Spec.Tolerations))
 	copy(tmpTolerations, ownerPod.Spec.Tolerations)
+	// Add toleration for unschedulable nodes to allow hotplug on cordoned nodes
+	tmpTolerations = append(tmpTolerations, k8sv1.Toleration{
+		Key:      "node.kubernetes.io/unschedulable",
+		Effect:   k8sv1.TaintEffectNoSchedule,
+		Operator: k8sv1.TolerationOpExists,
+	})
 
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1098,6 +1104,12 @@ func (t *TemplateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 
 	tmpTolerations := make([]k8sv1.Toleration, len(ownerPod.Spec.Tolerations))
 	copy(tmpTolerations, ownerPod.Spec.Tolerations)
+	// Add toleration for unschedulable nodes to allow hotplug on cordoned nodes
+	tmpTolerations = append(tmpTolerations, k8sv1.Toleration{
+		Key:      "node.kubernetes.io/unschedulable",
+		Effect:   k8sv1.TaintEffectNoSchedule,
+		Operator: k8sv1.TolerationOpExists,
+	})
 
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4477,7 +4477,12 @@ var _ = Describe("Template", func() {
 			pod, err := svc.RenderHotplugAttachmentPodTemplate([]*v1.Volume{}, ownerPod, vmi, claimMap)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(pod.Spec.Tolerations).To(BeEquivalentTo(vmi.Spec.Tolerations))
+			expectedTolerations := append(vmi.Spec.Tolerations, k8sv1.Toleration{
+				Key:      "node.kubernetes.io/unschedulable",
+				Effect:   k8sv1.TaintEffectNoSchedule,
+				Operator: k8sv1.TolerationOpExists,
+			})
+			Expect(pod.Spec.Tolerations).To(BeEquivalentTo(expectedTolerations))
 		})
 
 		It("should compute the correct tolerations when rendering hotplug attachment trigger pods", func() {
@@ -4490,7 +4495,12 @@ var _ = Describe("Template", func() {
 			pod, err := svc.RenderHotplugAttachmentTriggerPodTemplate(&v1.Volume{}, ownerPod, vmi, "test", true, false)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(pod.Spec.Tolerations).To(BeEquivalentTo(vmi.Spec.Tolerations))
+			expectedTolerations := append(vmi.Spec.Tolerations, k8sv1.Toleration{
+				Key:      "node.kubernetes.io/unschedulable",
+				Effect:   k8sv1.TaintEffectNoSchedule,
+				Operator: k8sv1.TolerationOpExists,
+			})
+			Expect(pod.Spec.Tolerations).To(BeEquivalentTo(expectedTolerations))
 		})
 
 		It("should compute the correct volumeDevice context when rendering hotplug attachment pods with the FS PersistentVolumeClaim", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Hot-plug volume attachment pods fail to schedule on cordoned nodes where VMs are still running. When an administrator cordons a node, the `node.kubernetes.io/unschedulable:NoSchedule` taint prevents hotplug attachment and trigger pods from being scheduled, even though the VM continues running on that node.

Error message:
```
Warning  FailedScheduling  0/3 nodes are available: 1 node(s) didn't match Pod's node affinity/selector, 2 node(s) were unschedulable.
```

#### After this PR:
Hot-plug volume operations succeed on cordoned nodes. Attachment and trigger pods include a toleration for `node.kubernetes.io/unschedulable:NoSchedule`, allowing them to be scheduled on the same node as the running VM.

### References
<!-- No specific issue referenced -->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Added toleration directly in pod template rendering functions to ensure all hotplug pods tolerate unschedulable nodes
- No configuration required - toleration is applied automatically

The following alternatives were considered:
- Adding toleration only to attachment pods (not trigger pods) - rejected because trigger pods also need to run on cordoned nodes
- Making this configurable - rejected because this is the expected behavior in all cases

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- Tests updated to verify the new toleration is present in both attachment and trigger pods
- The toleration is added in addition to tolerations copied from the virt-launcher pod

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Fix hotplug volume operations failing on cordoned nodes by adding toleration for node.kubernetes.io/unschedulable taint
```