### PR TITLE
tests: Replace HasCondition assertions with HaveCondition matchers

### DIFF
--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -5516,8 +5516,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
-					vmConditionController := virtcontroller.NewVirtualMachineConditionManager()
-					Expect(vmConditionController.HasCondition(vm, v1.VirtualMachineRestartRequired)).To(BeFalse(), "No RestartRequired condition should be set")
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired), "No RestartRequired condition should be set")
 
 					Expect(vmi.Spec.Domain.Memory.Guest.Cmp(*vm.Spec.Template.Spec.Domain.Memory.Guest)).To(Equal(0), "The VMI Guest should match VM's")
 
@@ -5650,8 +5649,7 @@ var _ = Describe("VirtualMachine", func() {
 					err := controller.handleMemoryHotplugRequest(vm, vmi)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmConditionController := virtcontroller.NewVirtualMachineConditionManager()
-					Expect(vmConditionController.HasCondition(vm, v1.VirtualMachineRestartRequired)).To(BeTrue())
+					Expect(vm).To(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
 				})
 
 				It("should set a restartRequired condition if VM does not support memory hotplug", func() {
@@ -6170,8 +6168,7 @@ var _ = Describe("VirtualMachine", func() {
 						RevisionName: updatedRevision.Name,
 					}
 					Expect(controller.addRestartRequiredIfNeeded(&originalVM.Spec, updatedVM, vmi)).To(BeFalse())
-					vmConditionController := virtcontroller.NewVirtualMachineConditionManager()
-					Expect(vmConditionController.HasCondition(updatedVM, v1.VirtualMachineRestartRequired)).To(BeFalse())
+					Expect(updatedVM).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
 				})
 				It("should add addRestartRequiredIfNeeded to VM if not live-updatable", func() {
 					updatedInstancetype := originalInstancetype.DeepCopy()
@@ -6195,8 +6192,7 @@ var _ = Describe("VirtualMachine", func() {
 					}
 
 					Expect(controller.addRestartRequiredIfNeeded(&originalVM.Spec, updatedVM, vmi)).To(BeTrue())
-					vmConditionController := virtcontroller.NewVirtualMachineConditionManager()
-					Expect(vmConditionController.HasCondition(updatedVM, v1.VirtualMachineRestartRequired)).To(BeTrue())
+					Expect(updatedVM).To(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
 				})
 			})
 		})
@@ -6497,8 +6493,7 @@ var _ = Describe("VirtualMachine", func() {
 					sanityExecute(vm)
 					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(Succeed())
-					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
-						v1.VirtualMachineRestartRequired)).To(BeFalse())
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
 				})
 
 				DescribeTable("should NOT appear for hotpluggable DataVolume regardless of rollout strategy", func(strategy *v1.VMRolloutStrategy) {
@@ -6540,8 +6535,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 
-					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
-						v1.VirtualMachineRestartRequired)).To(BeFalse())
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
 				},
 					Entry("with no rollout strategy", nil),
 					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
@@ -6589,8 +6583,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 
-					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
-						v1.VirtualMachineRestartRequired)).To(BeFalse())
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
 				},
 					Entry("with no rollout strategy", nil),
 					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
@@ -6636,8 +6629,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 
-					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
-						v1.VirtualMachineRestartRequired)).To(BeTrue())
+					Expect(vm).To(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
 				},
 					Entry("with no rollout strategy", nil),
 					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
@@ -6702,8 +6694,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 
-					Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm,
-						v1.VirtualMachineRestartRequired)).To(BeTrue())
+					Expect(vm).To(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
 				},
 					Entry("with no rollout strategy", nil),
 					Entry("with Stage rollout strategy", pointer.P(v1.VMRolloutStrategyStage)),
@@ -6732,10 +6723,10 @@ var _ = Describe("VirtualMachine", func() {
 				sanityExecute(vm)
 				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
-				Expect(virtcontroller.NewVirtualMachineConditionManager().HasCondition(vm, v1.VirtualMachineRestartRequired)).To(matcher)
+				Expect(vm).To(matcher)
 			},
-				Entry("should not raise RestartRequired when VM and VMI UUIDs match", CalculateLegacyUUID("testvmi"), BeFalse()),
-				Entry("should raise RestartRequired when VM and VMI UUIDs differ", types.UID("different-uuid-than-vmi"), BeTrue()),
+				Entry("should not raise RestartRequired when VM and VMI UUIDs match", CalculateLegacyUUID("testvmi"), matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired)),
+				Entry("should raise RestartRequired when VM and VMI UUIDs differ", types.UID("different-uuid-than-vmi"), matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired)),
 			)
 		})
 
@@ -7205,25 +7196,24 @@ var _ = Describe("VirtualMachine", func() {
 				Reason: reason,
 			}
 		}
-		DescribeTable("and UpdateVolumesStrategy set to Migration", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, expectedVolumeMigrationState *v1.VolumeMigrationState, expectCond bool) {
+		DescribeTable("and UpdateVolumesStrategy set to Migration", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, expectedVolumeMigrationState *v1.VolumeMigrationState, condMatcher gomegatypes.GomegaMatcher) {
 			vm.Spec.UpdateVolumesStrategy = pointer.P(v1.UpdateVolumesStrategyMigration)
 			syncVolumeMigration(vm, vmi)
 			Expect(vm.Status.VolumeUpdateState.VolumeMigrationState).To(Equal(expectedVolumeMigrationState))
-			Expect(virtcontroller.NewVirtualMachineConditionManager().HasConditionWithStatus(vm,
-				v1.VirtualMachineManualRecoveryRequired, k8sv1.ConditionTrue)).To(Equal(expectCond))
+			Expect(vm).To(condMatcher)
 		},
-			Entry("without any volume migration in progress", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{})))), libvmi.New(), nil, false),
+			Entry("without any volume migration in progress", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{})))), libvmi.New(), nil, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired)),
 			Entry("with volume migration in progress but no vmi", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(
 				libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{
 					MigratedVolumes: withMigVols(volName, "dv0", "dv1")}},
 				), libvmistatus.WithVMCondition(withVMCondVolumeMigInProgress(k8sv1.ConditionTrue, ""))),
 			)),
-				nil, nil, false),
+				nil, nil, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired)),
 			Entry("with recovered volumes", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv0")), libvmistatus.WithVMStatus(
 				libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(
 					&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{MigratedVolumes: withMigVols(volName, "dv0", "dv1")}},
 				)))),
-				libvmi.New(libvmi.WithDataVolume(volName, "dv0")), nil, false),
+				libvmi.New(libvmi.WithDataVolume(volName, "dv0")), nil, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired)),
 			Entry("with volumes still to be recovered", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")), libvmistatus.WithVMStatus(
 				libvmistatus.NewVMStatus(
 					libvmistatus.WithVMCondition(v1.VirtualMachineCondition{
@@ -7237,7 +7227,7 @@ var _ = Describe("VirtualMachine", func() {
 					)))),
 				libvmi.New(libvmi.WithDataVolume(volName, "dv0")), &v1.VolumeMigrationState{
 					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
-				}, true,
+				}, matcher.HaveConditionTrue(v1.VirtualMachineManualRecoveryRequired),
 			),
 			Entry("with volume change", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7250,7 +7240,7 @@ var _ = Describe("VirtualMachine", func() {
 						libvmistatus.New(libvmistatus.WithCondition(
 							withVMICondVolumeMigInProgress(k8sv1.ConditionTrue, "")))),
 				),
-				&v1.VolumeMigrationState{MigratedVolumes: withMigVols(volName, "dv0", "dv1")}, false,
+				&v1.VolumeMigrationState{MigratedVolumes: withMigVols(volName, "dv0", "dv1")}, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired),
 			),
 			Entry("with volume change cancellation", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7263,7 +7253,7 @@ var _ = Describe("VirtualMachine", func() {
 						libvmistatus.New(libvmistatus.WithCondition(
 							withVMICondVolumeMigInProgress(k8sv1.ConditionFalse, v1.VirtualMachineInstanceReasonVolumesChangeCancellation)))),
 				),
-				nil, false,
+				nil, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired),
 			),
 			Entry("with a failed volume migration", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7277,7 +7267,7 @@ var _ = Describe("VirtualMachine", func() {
 							withVMICondVolumeMigInProgress(k8sv1.ConditionFalse, "")))),
 				), &v1.VolumeMigrationState{
 					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
-				}, false,
+				}, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired),
 			),
 			Entry("with volume migration in progress and vmi disappeared", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7287,7 +7277,7 @@ var _ = Describe("VirtualMachine", func() {
 					))),
 				nil, &v1.VolumeMigrationState{
 					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
-				}, true,
+				}, matcher.HaveConditionTrue(v1.VirtualMachineManualRecoveryRequired),
 			),
 		)
 	})

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -127,6 +127,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -68,6 +68,7 @@ import (
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
 	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 )
 
 var _ = Describe("VirtualMachineInstance migration target", func() {
@@ -377,7 +378,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 
 		Expect(controller.hotplugMemory(vmi, client)).To(Succeed())
 
-		Expect(conditionManager.HasCondition(vmi, v1.VirtualMachineInstanceMemoryChange)).To(BeFalse())
+		Expect(vmi).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceMemoryChange))
 		Expect(v1.VirtualMachinePodMemoryRequestsLabel).ToNot(BeKeyOf(vmi.Labels))
 		Expect(vmi.Status.Memory.GuestRequested).To(Equal(vmi.Spec.Domain.Memory.Guest))
 		Expect(networkBindingPluginMemoryCalculator.calculatedMemoryOverhead).To(BeTrue())
@@ -412,7 +413,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 
 		Expect(controller.hotplugMemory(vmi, client)).ToNot(Succeed())
 
-		Expect(conditionManager.HasCondition(vmi, v1.VirtualMachineInstanceMemoryChange)).To(BeFalse())
+		Expect(vmi).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceMemoryChange))
 		Expect(v1.VirtualMachinePodMemoryRequestsLabel).ToNot(BeKeyOf(vmi.Labels))
 		Expect(vmi.Status.Memory.GuestRequested).ToNot(Equal(vmi.Spec.Domain.Memory.Guest))
 	})
@@ -451,7 +452,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 
 		Expect(controller.hotplugMemory(vmi, client)).ToNot(Succeed())
 
-		Expect(conditionManager.HasConditionWithStatusAndReason(vmi, v1.VirtualMachineInstanceMemoryChange, k8sv1.ConditionFalse, "Memory Hotplug Failed")).To(BeTrue())
+		Expect(vmi).To(matcher.HaveConditionFalseWithReason(v1.VirtualMachineInstanceMemoryChange, "Memory Hotplug Failed"))
 		Expect(v1.VirtualMachinePodMemoryRequestsLabel).ToNot(BeKeyOf(vmi.Labels))
 		Expect(vmi.Status.Memory.GuestRequested).ToNot(Equal(vmi.Spec.Domain.Memory.Guest))
 	})

--- a/tests/framework/matcher/conditions.go
+++ b/tests/framework/matcher/conditions.go
@@ -64,6 +64,15 @@ func HaveConditionTrueWithReason(conditionType interface{}, expectedReason strin
 	}
 }
 
+func HaveConditionFalseWithReason(conditionType interface{}, expectedReason string) types.GomegaMatcher {
+	return conditionMatcher{
+		expectedType:          conditionType,
+		expectedStatus:        k8sv1.ConditionFalse,
+		conditionCanBeMissing: false,
+		expectedReason:        expectedReason,
+	}
+}
+
 type conditionMatcher struct {
 	expectedType          interface{}
 	expectedStatus        k8sv1.ConditionStatus

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
-	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/libvmi/replicaset"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -447,14 +446,10 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(rs)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vmi.Status.Phase).To(Equal(v1.Running))
-		Expect(controller.NewVirtualMachineInstanceConditionManager().
-			HasConditionWithStatusAndReason(
-				vmi,
-				v1.VirtualMachineInstanceConditionType(k8sv1.PodReady),
-				k8sv1.ConditionFalse,
-				v1.PodTerminatingReason,
-			),
-		).To(BeTrue())
+		Expect(vmi).To(matcher.HaveConditionFalseWithReason(
+			v1.VirtualMachineInstanceConditionType(k8sv1.PodReady),
+			v1.PodTerminatingReason,
+		))
 		Expect(vmi.DeletionTimestamp).ToNot(BeNil())
 	})
 


### PR DESCRIPTION
### What this PR does

Replace uses of conditionManager.HasCondition helper methods with declarative HaveCondition Ginkgo matchers throughout the test suite. This improves test readability and consistency with the existing test framework.

Changes include:
- tests/storage/migration.go: Replace 5 HasCondition assertions with HaveConditionTrue and HaveConditionMissingOrFalse matchers
- pkg/virt-controller/watch/vm/vm_test.go: Replace 10+ HasCondition and HasConditionWithStatus assertions, updating DescribeTable to use matcher parameters
- pkg/virt-handler/migration-target_test.go: Replace HasCondition and HasConditionWithStatusAndReason assertions
- tests/replicaset_test.go: Replace HasConditionWithStatusAndReason assertion with HaveConditionFalseWithReason matcher
- tests/framework/matcher/conditions.go: Add new HaveConditionFalseWithReason matcher function

Note: pkg/controller/conditions_test.go intentionally retains direct HasCondition calls as it tests the conditionManager implementation itself.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

