### PR TITLE
network, SR-IOV: Sync macs from multus source

### DIFF
--- a/pkg/network/controllers/vmi.go
+++ b/pkg/network/controllers/vmi.go
@@ -112,6 +112,7 @@ func calculateSecondaryIfaceStatuses(
 
 	networkStatusesByPodIfaceName := multus.NetworkStatusesByPodIfaceName(networkStatuses)
 	podIfaceNamesByNetworkName := namescheme.CreateFromNetworkStatuses(vmi.Spec.Networks, networkStatuses)
+	specIfacesByName := vmispec.IndexInterfaceSpecByName(vmi.Spec.Domain.Devices.Interfaces)
 	for _, network := range vmispec.FilterMultusNonDefaultNetworks(vmi.Spec.Networks) {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)
 		podIfaceName, wasFound := podIfaceNamesByNetworkName[network.Name]
@@ -119,18 +120,25 @@ func calculateSecondaryIfaceStatuses(
 			return nil, fmt.Errorf("could not find the pod interface name for network [%s]", network.Name)
 		}
 
-		_, exists := networkStatusesByPodIfaceName[podIfaceName]
+		networkStatus, exists := networkStatusesByPodIfaceName[podIfaceName]
 		switch {
 		case exists && vmiIfaceStatus == nil:
-			interfaceStatuses = append(interfaceStatuses, v1.VirtualMachineInstanceNetworkInterface{
+			newIfaceStatus := v1.VirtualMachineInstanceNetworkInterface{
 				Name:             network.Name,
 				InfoSource:       vmispec.InfoSourceMultusStatus,
 				PodInterfaceName: podIfaceName,
-			})
+			}
+			if shouldUpdateMACAddress(specIfacesByName[network.Name]) && networkStatus.Mac != "" {
+				newIfaceStatus.MAC = networkStatus.Mac
+			}
+			interfaceStatuses = append(interfaceStatuses, newIfaceStatus)
 		case exists && vmiIfaceStatus != nil:
 			updatedIfaceStatus := *vmiIfaceStatus
 			updatedIfaceStatus.InfoSource = vmispec.AddInfoSource(updatedIfaceStatus.InfoSource, vmispec.InfoSourceMultusStatus)
 			updatedIfaceStatus.PodInterfaceName = podIfaceName
+			if shouldUpdateMACAddress(specIfacesByName[network.Name]) && networkStatus.Mac != "" && updatedIfaceStatus.MAC == "" {
+				updatedIfaceStatus.MAC = networkStatus.Mac
+			}
 			interfaceStatuses = append(interfaceStatuses, updatedIfaceStatus)
 		case !exists && vmiIfaceStatus != nil:
 			updatedIfaceStatus := *vmiIfaceStatus
@@ -158,4 +166,8 @@ func filterUnspecifiedSpecIfaces(
 	}
 
 	return unspecifiedIfaceStatuses
+}
+
+func shouldUpdateMACAddress(iface v1.Interface) bool {
+	return iface.SRIOV != nil
 }

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -113,6 +113,8 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 		return err
 	}
 
+	interfacesStatus = restoreSRIOVMACsFromPrevStatus(interfacesStatus, vmi.Status.Interfaces, vmiInterfacesSpecByName)
+
 	// Guest Agent information will add and conditionally override data gathered from the cache.
 	interfacesStatus = ifacesStatusFromGuestAgent(interfacesStatus, domain.Status.Interfaces, vmiInterfacesSpecByName)
 
@@ -123,7 +125,7 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 
 	interfacesStatus = ifacesStatusFromMultus(interfacesStatus, multusStatusNetworksByName, vmiInterfacesSpecByName)
 
-	interfacesStatus = restorePodIfaceNames(interfacesStatus, vmi.Status.Interfaces)
+	interfacesStatus = restoreControllerIfaceFields(interfacesStatus, vmi.Status.Interfaces)
 	vmi.Status.Interfaces = interfacesStatus
 
 	c.removeAbsentIfacesFromVolatileCache(vmi)
@@ -151,8 +153,31 @@ func restorePrimaryIfaceStatus(
 	})
 }
 
-// restorePodIfaceNames restores the PodInterfaceName based on the VMI controller's last report
-func restorePodIfaceNames(
+// restoreSRIOVMACsFromPrevStatus restores MAC addresses for SR-IOV interfaces from the previous VMI status.
+// The multus network-status MAC reflects the actual address on the VF, so it takes priority over the spec MAC.
+func restoreSRIOVMACsFromPrevStatus(
+	interfacesStatus []v1.VirtualMachineInstanceNetworkInterface,
+	prevIfaceStatuses []v1.VirtualMachineInstanceNetworkInterface,
+	vmiIfacesSpecByName map[string]v1.Interface,
+) []v1.VirtualMachineInstanceNetworkInterface {
+	prevIfaceStatusByName := netvmispec.IndexInterfaceStatusByName(prevIfaceStatuses, func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
+		return ifaceStatus.Name != ""
+	})
+
+	for i, ifaceStatus := range interfacesStatus {
+		iface, exists := vmiIfacesSpecByName[ifaceStatus.Name]
+		if exists && iface.SRIOV != nil {
+			if prevStatus, exists := prevIfaceStatusByName[ifaceStatus.Name]; exists && prevStatus.MAC != "" {
+				interfacesStatus[i].MAC = prevStatus.MAC
+			}
+		}
+	}
+
+	return interfacesStatus
+}
+
+// restoreControllerIfaceFields preserves interface status fields based on the VMI controller's last report
+func restoreControllerIfaceFields(
 	interfacesStatus []v1.VirtualMachineInstanceNetworkInterface,
 	prevIfaceStatuses []v1.VirtualMachineInstanceNetworkInterface,
 ) []v1.VirtualMachineInstanceNetworkInterface {
@@ -163,7 +188,11 @@ func restorePodIfaceNames(
 
 	for i, ifaceStatus := range interfacesStatus {
 		if ifaceStatusOriginatedFromSpec := ifaceStatus.Name != ""; ifaceStatusOriginatedFromSpec {
-			interfacesStatus[i].PodInterfaceName = prevIfaceStatusesFromSpecByName[ifaceStatus.Name].PodInterfaceName
+			prevStatus := prevIfaceStatusesFromSpecByName[ifaceStatus.Name]
+			interfacesStatus[i].PodInterfaceName = prevStatus.PodInterfaceName
+			if interfacesStatus[i].MAC == "" && prevStatus.MAC != "" {
+				interfacesStatus[i].MAC = prevStatus.MAC
+			}
 		}
 	}
 
@@ -307,20 +336,30 @@ func linkStateFromDomain(linkState *api.LinkState) string {
 	return linkState.State
 }
 
-func sriovIfacesStatusFromDomainHostDevices(hostDevices []api.HostDevice, vmiIfacesSpecByName map[string]v1.Interface) []v1.VirtualMachineInstanceNetworkInterface {
+func sriovIfacesStatusFromDomainHostDevices(
+	hostDevices []api.HostDevice,
+	vmiIfacesSpecByName map[string]v1.Interface,
+) []v1.VirtualMachineInstanceNetworkInterface {
 	var vmiStatusIfaces []v1.VirtualMachineInstanceNetworkInterface
 
 	for _, hostDevice := range filterHostDevicesByAlias(hostDevices, deviceinfo.SRIOVAliasPrefix) {
+		ifaceName := hostDevice.Alias.GetName()[len(deviceinfo.SRIOVAliasPrefix):]
 		vmiStatusIface := v1.VirtualMachineInstanceNetworkInterface{
-			Name:       hostDevice.Alias.GetName()[len(deviceinfo.SRIOVAliasPrefix):],
+			Name:       ifaceName,
 			InfoSource: netvmispec.InfoSourceDomain,
+			MAC:        resolveMACAddress(ifaceName, vmiIfacesSpecByName),
 		}
-		if iface, exists := vmiIfacesSpecByName[vmiStatusIface.Name]; exists {
-			vmiStatusIface.MAC = iface.MacAddress
-		}
+
 		vmiStatusIfaces = append(vmiStatusIfaces, vmiStatusIface)
 	}
 	return vmiStatusIfaces
+}
+
+func resolveMACAddress(ifaceName string, vmiIfacesSpecByName map[string]v1.Interface) string {
+	if iface, exists := vmiIfacesSpecByName[ifaceName]; exists && iface.MacAddress != "" {
+		return iface.MacAddress
+	}
+	return ""
 }
 
 func ifacesStatusFromGuestAgent(

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -28,6 +28,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netsriov "kubevirt.io/kubevirt/pkg/network/deviceinfo"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
@@ -677,6 +678,71 @@ var _ = Describe("netstat", func() {
 				LinkState:     linkStateUp,
 			},
 		}))
+	})
+
+	It("should report SR-IOV interface with MAC from multus network-status when not in VMI spec", func() {
+		const (
+			networkName = "sriov-network"
+			networkMAC  = "72:83:99:bb:13:c2"
+		)
+
+		setup.addSRIOVNetworkInterface(
+			libvmi.InterfaceDeviceWithSRIOVBinding(networkName),
+			*libvmi.MultusNetwork(networkName, "test.network"),
+		)
+
+		setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:       networkName,
+				MAC:        networkMAC,
+				InfoSource: netvmispec.InfoSourceMultusStatus,
+			},
+		}
+
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:       networkName,
+				MAC:        networkMAC,
+				InfoSource: netvmispec.NewInfoSource(netvmispec.InfoSourceDomain, netvmispec.InfoSourceMultusStatus),
+				QueueCount: netsetup.UnknownInterfaceQueueCount,
+			},
+		}), "the SR-IOV interface should be reported with MAC from multus status")
+	})
+
+	It("should prefer SR-IOV MAC from multus network-status over spec MAC", func() {
+		const (
+			networkName = "sriov-network"
+			specMAC     = "de:ad:be:ef:00:01"
+			multusMAC   = "72:83:99:bb:13:c2"
+		)
+
+		sriovIface := libvmi.InterfaceDeviceWithSRIOVBinding(networkName)
+		sriovIface.MacAddress = specMAC
+		setup.addSRIOVNetworkInterface(
+			sriovIface,
+			*libvmi.MultusNetwork(networkName, "test.network"),
+		)
+
+		setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:       networkName,
+				MAC:        multusMAC,
+				InfoSource: netvmispec.InfoSourceMultusStatus,
+			},
+		}
+
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:       networkName,
+				MAC:        multusMAC,
+				InfoSource: netvmispec.NewInfoSource(netvmispec.InfoSourceDomain, netvmispec.InfoSourceMultusStatus),
+				QueueCount: netsetup.UnknownInterfaceQueueCount,
+			},
+		}), "multus network-status MAC should take priority over spec MAC for SR-IOV")
 	})
 
 	When("the desired state (VMI spec) is not in sync with the state in the guest (guest-agent)", func() {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -196,6 +196,27 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			// there is little we can do beyond just checking two devices are present: PCI slots are different inside
 			// the guest, and DP doesn't pass information about vendor IDs of allocated devices into the pod, so
 			// it's hard to match them.
+
+			By("checking SR-IOV interface status and verifying no duplicate or ghost interfaces")
+			Eventually(func() ([]v1.VirtualMachineInstanceNetworkInterface, error) {
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return normalizeInterfaceStatuses(vmi.Status.Interfaces), nil
+			}).WithTimeout(time.Minute).WithPolling(time.Second).Should(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Name":             Equal("default"),
+					"InfoSource":       ContainSubstring(vmispec.InfoSourceDomain),
+					"PodInterfaceName": Not(BeEmpty()),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Name":             Equal(sriovnet1),
+					"MAC":              Not(BeEmpty()),
+					"InfoSource":       Equal(vmispec.NewInfoSource(vmispec.InfoSourceDomain, vmispec.InfoSourceGuestAgent, vmispec.InfoSourceMultusStatus)),
+					"PodInterfaceName": Not(BeEmpty()),
+				}),
+			), "expected exactly 2 interfaces without duplicates")
 		})
 
 		It("[test_id:1754]should create a virtual machine with sriov interface with all pci devices on the root bus", func() {
@@ -592,6 +613,17 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 	})
 }))
+
+func normalizeInterfaceStatuses(statuses []v1.VirtualMachineInstanceNetworkInterface) []v1.VirtualMachineInstanceNetworkInterface {
+	normalized := make([]v1.VirtualMachineInstanceNetworkInterface, len(statuses))
+	copy(normalized, statuses)
+	for i := range normalized {
+		normalized[i].InterfaceName = ""
+		normalized[i].IP = ""
+		normalized[i].IPs = nil
+	}
+	return normalized
+}
 
 func readSRIOVResourceName() string {
 	sriovResourceName := os.Getenv("SRIOV_RESOURCE_NAME")


### PR DESCRIPTION
### What this PR does
When a user creates an SR-IOV interface without specifying a MAC address, the MAC assigned by the CNI plugin never surfaces in `VMI.Status.Interfaces`. 
This happens because SR-IOV VFs use PCI passthrough and don't appear as network devices in the pod, so virt-handler cannot read the MAC from a pod interface or domain spec the way it does for other binding types.

Without the MAC in status, the guest agent cannot match its reported interface to the named SR-IOV entry (since matching is MAC-based), resulting in a duplicate "ghost" interface entry in the status (see #16422 ).

This PR populates SR-IOV interface MACs from the pod's `k8s.v1.cni.cncf.io/network-status` annotation (set by  Multus/CNI) into `VMI.Status.Interfaces`:                                                                           
- The VMI controller (`calculateSecondaryIfaceStatuses`) extracts the MAC from network-status for SR-IOV interfaces that don't have one set in the VMI spec.                                                                            
- virt-handler (`restoreControllerIfaceFields`) preserves the controller-set MAC across status recalculations.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SR-IOV: Sync macs from multus source
```

