### PR TITLE
[release-1.6] virtctl: add red warning when using CVE-crippled built-in ssh client

### DIFF
--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -131,7 +131,10 @@ func (o *SSH) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed(wrapLocalSSHFlag) {
+		const red = "\033[0;31m"
+		const none = "\033[0m"
 		cmd.PrintErrln("The --local-ssh flag is deprecated and now defaults to true.")
+		cmd.PrintErrln(red + "WARNING: The built-in ssh client is affected by multiple CVEs and should not be used!" + none)
 	}
 	if o.options.WrapLocalSSH {
 		clientArgs := o.buildSSHTarget(kind, namespace, name)


### PR DESCRIPTION
I know this is not how CVEs should be addressed, but the impact here is so minimal that I think it's enough.
Here, there would have to be a malicious SSH server in your own VM, which would allow it to crash your own call to `virtctl ssh`...
The alternative would be very invasive and could hurt the stability of the branch (more on that below).

### What this PR does
#### Before this PR:
Simple deprecation warning when using `--local-ssh=false`.

#### After this PR:
Red all-caps warning about the CVEs the feature suffers from (see https://github.com/kubevirt/kubevirt/pull/16194).

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following alternatives were considered:
There's a [PR](https://github.com/kubevirt/kubevirt/pull/16194) open to bump the crypto lib to a fixed version, which is normally the right thing to do, but it's incomplete and would require bumping the go version we use for building as well as the one we depend on, on top of all the other dependencies. This is probably too intrusive

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
