### PR TITLE
fix(instancetype): Propagate ResourceVersion from PatchStatus responses

### DIFF
--- a/pkg/instancetype/revision/patch.go
+++ b/pkg/instancetype/revision/patch.go
@@ -39,12 +39,17 @@ func (h *revisionHandler) patchVM(
 	if err != nil || len(revisionPatch) == 0 {
 		return err
 	}
-	if _, err := h.virtClient.VirtualMachine(vm.Namespace).PatchStatus(
+	patchedVM, err := h.virtClient.VirtualMachine(vm.Namespace).PatchStatus(
 		context.Background(), vm.Name, types.JSONPatchType, revisionPatch, metav1.PatchOptions{},
-	); err != nil {
+	)
+	if err != nil {
 		logger().Reason(err).Error("Failed to update VirtualMachine with instancetype and preference ControllerRevision references.")
 		return err
 	}
+	// Update the local vm ObjectMeta with the response to ensure ResourceVersion and other server-side fields are current
+	vm.ObjectMeta = patchedVM.ObjectMeta
+	vm.Status = patchedVM.Status
+
 	return nil
 }
 

--- a/pkg/instancetype/upgrade/BUILD.bazel
+++ b/pkg/instancetype/upgrade/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/instancetype/upgrade/handler.go
+++ b/pkg/instancetype/upgrade/handler.go
@@ -80,10 +80,13 @@ func (u *upgrader) Upgrade(vm *virtv1.VirtualMachine) error {
 		return err
 	}
 
-	if _, err := u.virtClient.VirtualMachine(vm.Namespace).PatchStatus(
-		context.Background(), vm.Name, types.JSONPatchType, patchPayload, metav1.PatchOptions{}); err != nil {
+	patchedVM, err := u.virtClient.VirtualMachine(vm.Namespace).PatchStatus(
+		context.Background(), vm.Name, types.JSONPatchType, patchPayload, metav1.PatchOptions{})
+	if err != nil {
 		return err
 	}
+	// Update the local vm ObjectMeta with the response to ensure ResourceVersion and other server-side fields are current
+	vm.ObjectMeta = patchedVM.ObjectMeta
 
 	if newInstancetypeCR != nil {
 		if err := u.virtClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3166,6 +3166,9 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 	if !equality.Semantic.DeepEqual(vm.Spec, syncedVM.Spec) {
 		return syncedVM, vmi, nil, nil
 	}
+	if !equality.Semantic.DeepEqual(vm.Status, syncedVM.Status) {
+		return syncedVM, vmi, nil, nil
+	}
 
 	vm.ObjectMeta = syncedVM.ObjectMeta
 	vm.Spec = syncedVM.Spec


### PR DESCRIPTION
### What this PR does
#### Before this PR:
When the instancetype controller's `Sync()` function called `PatchStatus` to update VM Status (via `Store()` or `Upgrade()`), the response from the API server was discarded. This meant server-side updates to the VM object's ObjectMeta (most critically the ResourceVersion, but also ManagedFields) were lost.

While Status content changes were preserved in the local `vm` object (since it's passed as a pointer), the local `vm.ObjectMeta.ResourceVersion` became stale and no longer matched the API server's value. This led to ResourceVersion conflicts when the main VM controller sync loop later attempted to call `UpdateStatus` (at vm.go:2401), causing reconciliation failures.

#### After this PR:
1. `patchVM()` and `Upgrade()` now capture the PatchStatus response and update `vm.ObjectMeta` with the current ResourceVersion and other server-side metadata
2. The VM sync loop now detects Status changes from the instancetype controller and returns early (similar to Spec changes), properly propagating the updated VM with current ResourceVersion
3. ResourceVersion conflicts are eliminated, preventing reconciliation failures

### References

Fixes: #16496

See #16497 for long-term architectural refactoring proposal

### Why we need it and why it was done in this way

**Problem:**
The instancetype controller violates the synchronizer interface pattern by making direct API calls (`PatchStatus`, `Update`, `UpdateStatus`). When these calls were made, the returned VM object containing the updated ResourceVersion was discarded, causing downstream conflicts.

**Why this approach:**
This PR implements a **short-term, backportable fix** that preserves the current architecture while fixing the immediate ResourceVersion conflict issue:

1. **Captures PatchStatus responses**: Minimal change to update `vm.ObjectMeta` with the response, ensuring ResourceVersion is current
2. **Adds Status change detection**: Mirrors the existing Spec change detection pattern to ensure proper propagation
3. **Backportable**: Changes are minimal, targeted, and suitable for stable releases

**Tradeoffs made:**
- Does NOT refactor the instancetype controller to remove direct API calls (longer-term fix tracked separately)
- Adds another check in the sync loop hot path (Status comparison), but necessary to prevent conflicts
- Maintains existing architectural inconsistencies between synchronizer implementations

**Alternatives considered:**
1. **Full architectural refactor** (rejected for this PR): Would remove all direct API calls from synchronizers and establish a consistent contract. This is the right long-term solution but too invasive for backporting. Tracked in #16497.
2. **Only fix PatchStatus without Status detection** (rejected): Would still allow stale ResourceVersion to propagate through the sync loop in edge cases.
3. **Return entire patchedVM instead of just ObjectMeta** (rejected): More invasive change; only ObjectMeta needs updating since Status is already modified via pointer.

### Special notes for your reviewer

1. **Testing**: Added a test in `upgrade_test.go` to verify ResourceVersion propagation. The patchVM() path is harder to test in isolation since it requires full instancetype setup, but it follows the exact same pattern as the Upgrade() test.

2. **Synchronizer inconsistencies**: This PR exposes that synchronizer implementations have inconsistent patterns:
   - Network synchronizer: Does NOT make direct VM API calls ✅
   - Firmware synchronizer: DOES make direct Patch() calls but handles it correctly
   - Instancetype synchronizer: DOES make direct API calls with inconsistent response handling (this PR fixes the inconsistency)

   A follow-up architectural refactoring should establish and enforce a consistent synchronizer contract (see #16497).

3. **Impact on expand flow**: The expand flow also makes direct `Update()` and `UpdateStatus()` calls but was not modified in this PR since it already returns the updated VM from those calls and doesn't go through the sync loop return path.

4. **Status comparison performance**: The added Status comparison at vm.go:3169 runs on every VM reconciliation. This is unavoidable to detect Status-only changes and prevent stale ResourceVersion propagation.

### Checklist

- [x] **Design**: No design document required - this is a targeted bug fix
- [x] **PR**: The PR description explains the problem, solution, and tradeoffs
- [x] **Code**: Changes follow existing patterns and are minimal
- [x] **Refactor**: Code is cleaner - fixes a bug and adds missing Status change detection
- [x] **Upgrade**: No impact on upgrade flows - this fixes existing behavior
- [x] **Testing**: Added test in `upgrade_test.go` to verify ResourceVersion propagation
- [ ] **Documentation**: No user-facing changes - internal bug fix
- [ ] **Community**: No announcement needed - bug fix in existing functionality

### Release note
```release-note
Fix ResourceVersion conflicts in VM reconciliation when instancetype controller modifies Status. The instancetype controller now properly propagates ResourceVersion from PatchStatus responses, preventing conflicts in subsequent UpdateStatus calls.
```