### PR TITLE
linter: Add tests/launchsecurity to linter paths 

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -76,6 +76,7 @@ tests/framework/kubevirt
 tests/framework/matcher/helper
 tests/infrastructure
 tests/instancetype
+tests/launchsecurity
 tests/libconfigmap
 tests/libdomain
 tests/libinstancetype

--- a/tests/launchsecurity/secure-execution.go
+++ b/tests/launchsecurity/secure-execution.go
@@ -45,72 +45,72 @@ import (
 
 var _ = Describe("[sig-compute]IBM Secure Execution",
 	decorators.SecureExecution, decorators.SigCompute, decorators.RequiresS390X, Serial, func() {
-	Context("Node Labels", func() {
-		It("Should have nodes with Secure Execution Label", func() {
-			virtclient := kubevirt.Client()
-			nodes := libnode.GetAllSchedulableNodes(virtclient)
-			hasNodeWithSELabel := false
-			for _, node := range nodes.Items {
-				if _, ok := node.Labels[kubevirtv1.SecureExecutionLabel]; ok {
-					hasNodeWithSELabel = true
-					break
+		Context("Node Labels", func() {
+			It("Should have nodes with Secure Execution Label", func() {
+				virtclient := kubevirt.Client()
+				nodes := libnode.GetAllSchedulableNodes(virtclient)
+				hasNodeWithSELabel := false
+				for _, node := range nodes.Items {
+					if _, ok := node.Labels[kubevirtv1.SecureExecutionLabel]; ok {
+						hasNodeWithSELabel = true
+						break
+					}
 				}
-			}
-			Expect(hasNodeWithSELabel).To(BeTrue())
+				Expect(hasNodeWithSELabel).To(BeTrue())
+			})
+		})
+		Context("Ensure cluster can run Secure Execution VMs", func() {
+			var vmi *kubevirtv1.VirtualMachineInstance
+
+			const commandTimeout = 10 * time.Second
+			BeforeEach(func() {
+				config.EnableFeatureGate(featuregate.SecureExecution)
+				By("Reading the hostkey from the 'secex-hostkey' configmap in the 'kubevirt-prow-jobs' namespace")
+				cm, err := kubevirt.Client().CoreV1().ConfigMaps("kubevirt-prow-jobs").Get(context.Background(), "secex-hostkey", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating a configmap containing the hostkey")
+				cm = libconfigmap.New(cm.Name, cm.Data)
+				cm, err = kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(cm)).Create(context.Background(), cm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi = libvmifact.NewFedora(
+					libvmi.WithConfigMapDisk(cm.Name, cm.Name),
+				)
+				// Enabling launchsecurity here won't prevent starting non-SE VMs
+				vmi.Spec.Domain.LaunchSecurity = &kubevirtv1.LaunchSecurity{}
+
+				By("Launching a non-SE VM to convert it to Secure Execution")
+				const secureExecutionStartupTimeout = 240
+				vmi = libvmops.RunVMIAndExpectLaunch(vmi, secureExecutionStartupTimeout)
+
+				By("Logging in to non-SE VM")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Mounting the secure execution hostkey iso")
+				Expect(console.RunCommand(vmi, "mount /dev/vdb /mnt/", commandTimeout)).To(Succeed())
+
+				By("Writing the kernel cmdline to a file")
+				Expect(console.RunCommand(vmi, "cat /proc/cmdline > /tmp/parmfile.txt", commandTimeout)).To(Succeed())
+
+				By("Creating the encrypted boot image")
+				genprotimgCmd := "genprotimg --no-verify -o /boot/sdboot -i /boot/vmlinuz-*.s390x " +
+					"-r /boot/initramfs-*.s390x.img -p /tmp/parmfile.txt -k /mnt/secex-hostkey.crt"
+				Expect(console.RunCommand(vmi, genprotimgCmd, commandTimeout)).To(Succeed())
+
+				By("Calling zipl to boot from the encrypted image")
+				Expect(console.RunCommand(vmi, "zipl -t /boot -i /boot/sdboot", commandTimeout)).To(Succeed())
+
+				By("Rebooting VM into Secure Execution mode")
+				Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).SoftReboot(context.Background(), vmi.Name)).To(Succeed())
+			})
+
+			It("Should launch a Secure Execution VM", func() {
+				By("Verifying that the VM is running in Secure Execution Mode")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+				output, err := console.RunCommandAndStoreOutput(vmi, "cat /sys/firmware/uv/prot_virt_guest", commandTimeout)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).To(Equal("1"))
+			})
 		})
 	})
-	Context("Ensure cluster can run Secure Execution VMs", func() {
-		var vmi *kubevirtv1.VirtualMachineInstance
-
-		const commandTimeout = 10 * time.Second
-		BeforeEach(func() {
-			config.EnableFeatureGate(featuregate.SecureExecution)
-			By("Reading the hostkey from the 'secex-hostkey' configmap in the 'kubevirt-prow-jobs' namespace")
-			cm, err := kubevirt.Client().CoreV1().ConfigMaps("kubevirt-prow-jobs").Get(context.Background(), "secex-hostkey", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Creating a configmap containing the hostkey")
-			cm = libconfigmap.New(cm.Name, cm.Data)
-			cm, err = kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(cm)).Create(context.Background(), cm, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi = libvmifact.NewFedora(
-				libvmi.WithConfigMapDisk(cm.Name, cm.Name),
-			)
-			// Enabling launchsecurity here won't prevent starting non-SE VMs
-			vmi.Spec.Domain.LaunchSecurity = &kubevirtv1.LaunchSecurity{}
-
-			By("Launching a non-SE VM to convert it to Secure Execution")
-			const secureExecutionStartupTimeout = 240
-			vmi = libvmops.RunVMIAndExpectLaunch(vmi, secureExecutionStartupTimeout)
-
-			By("Logging in to non-SE VM")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-			By("Mounting the secure execution hostkey iso")
-			Expect(console.RunCommand(vmi, "mount /dev/vdb /mnt/", commandTimeout)).To(Succeed())
-
-			By("Writing the kernel cmdline to a file")
-			Expect(console.RunCommand(vmi, "cat /proc/cmdline > /tmp/parmfile.txt", commandTimeout)).To(Succeed())
-
-			By("Creating the encrypted boot image")
-			genprotimgCmd := "genprotimg --no-verify -o /boot/sdboot -i /boot/vmlinuz-*.s390x " +
-				"-r /boot/initramfs-*.s390x.img -p /tmp/parmfile.txt -k /mnt/secex-hostkey.crt"
-			Expect(console.RunCommand(vmi, genprotimgCmd, commandTimeout)).To(Succeed())
-
-			By("Calling zipl to boot from the encrypted image")
-			Expect(console.RunCommand(vmi, "zipl -t /boot -i /boot/sdboot", commandTimeout)).To(Succeed())
-
-			By("Rebooting VM into Secure Execution mode")
-			Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).SoftReboot(context.Background(), vmi.Name)).To(Succeed())
-		})
-
-		It("Should launch a Secure Execution VM", func() {
-			By("Verifying that the VM is running in Secure Execution Mode")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
-			output, err := console.RunCommandAndStoreOutput(vmi, "cat /sys/firmware/uv/prot_virt_guest", commandTimeout)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(output).To(Equal("1"))
-		})
-	})
-})

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -52,7 +52,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 		diskSecret = "qwerty123"
 	)
 
-	newSEVFedora := func(withES bool, withSNP bool, opts ...libvmi.Option) *v1.VirtualMachineInstance {
+	newSEVFedora := func(withES, withSNP bool, opts ...libvmi.Option) *v1.VirtualMachineInstance {
 		const secureBoot = false
 		sevOptions := []libvmi.Option{
 			libvmi.WithUefi(secureBoot),
@@ -212,7 +212,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 		return uint(val)
 	}
 
-	prepareSession := func(virtClient kubecli.KubevirtClient, nodeName string, pdh string) (*v1.SEVSessionOptions, string, string) {
+	prepareSession := func(virtClient kubecli.KubevirtClient, nodeName, pdh string) (*v1.SEVSessionOptions, string, string) {
 		helperPod := libpod.RenderPrivilegedPod("sev-helper", []string{"sleep"}, []string{"infinity"})
 		helperPod.Spec.NodeName = nodeName
 
@@ -312,9 +312,8 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 	})
 
 	Context("lifecycle", func() {
-
 		DescribeTable("should start a SEV or SEV-ES VM",
-			func(withES bool, withSNP bool, sevstr string) {
+			func(withES, withSNP bool, sevstr string) {
 				vmi := newSEVFedora(withES, withSNP)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXHuge)
 

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -142,7 +142,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 		err = binary.Write(secret, binary.LittleEndian, uint32(uuidLen+sizeLen+len(diskSecret)+1))
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		// 40:40+len(diskSecret)+1
-		secret.Write([]byte(diskSecret))
+		secret.WriteString(diskSecret)
 		// write zeroes
 		secret.Write(make([]byte, l-secret.Len()))
 		ExpectWithOffset(1, secret.Len()).To(Equal(l))
@@ -156,7 +156,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ctr := cipher.NewCTR(aes, iv)
 		encryptedSecret := make([]byte, secret.Len())
-		cipher.Stream.XORKeyStream(ctr, encryptedSecret, secret.Bytes())
+		ctr.XORKeyStream(encryptedSecret, secret.Bytes())
 
 		// AMD SEV specification, section 6.6 LAUNCH_SECRET:
 		//   Header: FLAGS + IV + HMAC

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -222,7 +222,8 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 		helperPod.Spec.NodeName = nodeName
 
 		var err error
-		helperPod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(helperPod)).Create(context.Background(), helperPod, k8smetav1.CreateOptions{})
+		helperPod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(helperPod)).Create(
+			context.Background(), helperPod, k8smetav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			deleteErr := virtClient.CoreV1().Pods(helperPod.Namespace).Delete(context.Background(), helperPod.Name, k8smetav1.DeleteOptions{})
@@ -355,7 +356,8 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Expect(err).ToNot(HaveOccurred())
 
 			vmi := newSEVFedora(false, false, libvmi.WithSEVAttestation())
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
+			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(
+				context.Background(), vmi, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(matcher.ThisVMI(vmi), 60).Should(matcher.BeInPhase(v1.Scheduled))
 
@@ -418,7 +420,8 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			By("Unpausing the VirtualMachineInstance")
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(
+				matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 
 			By("Waiting for the VirtualMachineInstance to become ready")
 			libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -223,7 +223,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			err := virtClient.CoreV1().Pods(helperPod.Namespace).Delete(context.Background(), helperPod.Name, k8smetav1.DeleteOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		}()
-		EventuallyWithOffset(1, ThisPod(helperPod), 30).Should(BeInPhase(k8sv1.PodRunning))
+		EventuallyWithOffset(1, matcher.ThisPod(helperPod), 30).Should(matcher.BeInPhase(k8sv1.PodRunning))
 
 		execOnHelperPod := func(command string) (string, error) {
 			stdout, err := exec.ExecuteCommandOnPod(
@@ -351,7 +351,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			vmi := newSEVFedora(false, false, libvmi.WithSEVAttestation())
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisVMI(vmi), 60).Should(BeInPhase(v1.Scheduled))
+			Eventually(matcher.ThisVMI(vmi), 60).Should(matcher.BeInPhase(v1.Scheduled))
 
 			By("Querying virsh nodesevinfo")
 			nodeSevInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "nodesevinfo"})
@@ -366,12 +366,12 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Expect(sevPlatformInfo).To(Equal(expectedSEVPlatformInfo))
 
 			By("Setting up session parameters")
-			vmi, err = ThisVMI(vmi)()
+			vmi, err = matcher.ThisVMI(vmi)()
 			Expect(err).ToNot(HaveOccurred())
 			sevSessionOptions, tikBase64, tekBase64 := prepareSession(virtClient, vmi.Status.NodeName, sevPlatformInfo.PDH)
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).SEVSetupSession(context.Background(), vmi.Name, sevSessionOptions)
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisVMI(vmi), 60).Should(And(BeRunning(), HaveConditionTrue(v1.VirtualMachineInstancePaused)))
+			Eventually(matcher.ThisVMI(vmi), 60).Should(And(matcher.BeRunning(), matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused)))
 
 			By("Querying virsh domlaunchsecinfo 1")
 			domLaunchSecInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "domlaunchsecinfo", "1"})
@@ -411,7 +411,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			By("Unpausing the VirtualMachineInstance")
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisVMI(vmi), 30*time.Second, time.Second).Should(HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 
 			By("Waiting for the VirtualMachineInstance to become ready")
 			libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)


### PR DESCRIPTION
### What this PR does

Add tests/launchsecurity to linter paths and fix resulting linter issues

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

