### PR TITLE
logs: Fix Infof verbosity support

### DIFF
--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -218,7 +218,7 @@ func (l FilteredVerbosityLogger) Info(msg string) {
 }
 
 func (l FilteredVerbosityLogger) Infof(msg string, args ...interface{}) {
-	l.filteredLogger.log(2, "msg", fmt.Sprintf(msg, args...))
+	l.filteredLogger.Level(INFO).log(2, "msg", fmt.Sprintf(msg, args...))
 }
 
 func (l FilteredVerbosityLogger) Object(obj LoggableObject) *FilteredVerbosityLogger {

--- a/staging/src/kubevirt.io/client-go/log/log_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_test.go
@@ -451,3 +451,30 @@ func TestObjectContextLeakage(t *testing.T) {
 
 	tearDown()
 }
+
+func TestInfofVerbosity(t *testing.T) {
+	setUp()
+	log := MakeLogger(MockLogger{})
+	log.SetLogLevel(INFO)
+	log.SetVerbosityLevel(2)
+
+	logCalled = false
+	log.V(3).Infof("This should not be logged: verbosity %d", 3)
+	assert(t, !logCalled, "V(3).Infof() should not log when verbosity level is 2")
+
+	logCalled = false
+	log.V(2).Infof("This should be logged: verbosity %d", 2)
+	assert(t, logCalled, "V(2).Infof() should log when verbosity level is 2")
+
+	logEntry := logParams[len(logParams)-1].([]interface{})
+	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
+	assert(t, logEntry[1].(string) == LogLevelNames[INFO], "Logged line was not INFO level")
+
+	warningLog := log.Level(WARNING)
+	logCalled = false
+	logParams = make([]interface{}, 0)
+	warningLog.V(3).Infof("This should not be logged: verbosity %d", 3)
+	assert(t, !logCalled, "V(3).Infof() should not log when verbosity level is 2, even after Level(WARNING)")
+
+	tearDown()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
`Infof` didn't respect verbosity (while `Info` did).
Fix it by making sure Infof knows to respect INFO levels.

For example this line was printed even that default level is 2:
`log.Log.V(v3).Infof("Fetching guest info failed: %v", err)`

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

