### PR TITLE
IP matching for GuestAgent and masquerade to support IPv4 and dual-stack

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -132,7 +132,7 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 						if err != nil {
 							return err
 						}
-						return libnet.ValidateVMIandPodIPMatch(vmi, vmiPod)
+						return libnet.AssertAllPodIPsReportedOnVMI(vmi, vmiPod)
 					}, 5*time.Second, time.Second).Should(Succeed())
 				})
 			})


### PR DESCRIPTION
### What this PR does
This PR fixes a failure in the primary pod network status test for VMIs using masquerade binding with Guest Agent enabled.
Some guest os's (Fedora) automatically configure additional IP addresses (e.g. IPv6) inside the VM, even when the cluster is single-stack IPv4. This caused the test to incorrectly fail by enforcing a strict 1:1 match between Pod IPs and VMI-reported IPs. This PR uses `AssertAllPodIPsReportedOnVMI`, which verifies that every IP address in Pod.Status.PodIPs is present in vmi.Status.Interfaces[0].IPs.

### Before this PR:
Previously, tests compared Pod IPs and VMI interface IPs using strict equality-style checks. Strict comparison caused issues on setups with masquerade networking, where the VMI typically reports extra addresses (IPv6, masquerade-specific IPs). This made SIG-Network test brittle and prone to failures.

Tests failed with errors like:
```
VMI IPs = [10.129.2.11 fd10:0:2::2]
Pod IPs = [10.129.2.11]
```

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

