### PR TITLE
Add validation for pcihole64 domain xml

### DIFF
--- a/tests/compute/pcihole64.go
+++ b/tests/compute/pcihole64.go
@@ -55,6 +55,10 @@ var _ = Describe(SIG("64-Bit PCI hole", func() {
 
 		// Even if disabled, the 64-bit PCI hole can still be up to 2Gi in size under certain circumstances.
 		Expect(calculatePCIHole64Size(res[0].Output)).To(BeNumerically("<=", pciHole64MaxSize))
+        // Verify the annotation propagates the value to the domxml
+		domXML, err := libdomain.GetRunningVirtualMachineInstanceDomainXML(kubevirt.Client(), vmi)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(domXML).To(MatchRegexp(`<pcihole64\s+unit=["']KiB["']\s*>0</pcihole64>`))
 	})
 }))
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `DisablePCIHole64` annotation test would not verify the domain xml value

#### After this PR:
The `DisablePCIHole64` annotation test verifies the domain xml value 

### Why we need it and why it was done in this way
The domain xml validation ensures the annotation-to-XML conversion works correctly and catches converter regressions. Using a regex pattern on the running domain XML provides robust, end-to-end verification consistent with other tests in the codebase.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

