### PR TITLE
log: preserve object context after verbosity change

### DIFF
--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -222,7 +222,7 @@ func (l FilteredVerbosityLogger) Infof(msg string, args ...interface{}) {
 }
 
 func (l FilteredVerbosityLogger) Object(obj LoggableObject) *FilteredVerbosityLogger {
-	l.filteredLogger.Object(obj)
+	l.filteredLogger = *l.filteredLogger.Object(obj)
 	return &l
 }
 

--- a/staging/src/kubevirt.io/client-go/log/log_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_test.go
@@ -287,26 +287,6 @@ func TestCriticalMessage(t *testing.T) {
 	tearDown()
 }
 
-func TestObject(t *testing.T) {
-	setUp()
-	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(INFO)
-	vm := v1.VirtualMachineInstance{ObjectMeta: v12.ObjectMeta{Namespace: "test"}}
-	log.Object(&vm).Log("test", "message")
-	logEntry := logParams[0].([]interface{})
-	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == LogLevelNames[INFO], "Logged line was not of level infoLevel")
-	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
-	assert(t, logEntry[4].(string) == "pos", "Logged line was not pos")
-	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
-	assert(t, logEntry[7].(string) == "test", "Component was not logged")
-	assert(t, logEntry[8].(string) == "namespace", "Logged line did not contain object namespace")
-	assert(t, logEntry[10].(string) == "name", "Logged line did not contain object name")
-	assert(t, logEntry[12].(string) == "kind", "Logged line did not contain object kind")
-	assert(t, logEntry[14].(string) == "uid", "Logged line did not contain UUID")
-	tearDown()
-}
-
 func TestError(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
@@ -382,5 +362,92 @@ func TestErrWithMsgf(t *testing.T) {
 	assert(t, logEntry[9].(error).Error() == "testerror", "Logged line did not contain message header")
 	assert(t, logEntry[10].(string) == "msg", "Logged line did not contain message header")
 	assert(t, logEntry[11].(string) == "test", "Logged line did not contain message")
+	tearDown()
+}
+
+func TestObjectLogging(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(log *FilteredLogger)
+		logFunc   func(log *FilteredLogger, vm *v1.VirtualMachineInstance)
+	}{
+		{
+			name: "simple",
+			logFunc: func(log *FilteredLogger, vm *v1.VirtualMachineInstance) {
+				log.Object(vm).Log("test", "message")
+			},
+		},
+		{
+			name: "change verbosity",
+			configure: func(log *FilteredLogger) {
+				_ = log.SetVerbosityLevel(6)
+			},
+			logFunc: func(log *FilteredLogger, vm *v1.VirtualMachineInstance) {
+				log.Level(INFO).V(3).Object(vm).Log("test", "message")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setUp()
+			log := MakeLogger(MockLogger{})
+			log.SetLogLevel(INFO)
+			if tc.configure != nil {
+				tc.configure(log)
+			}
+
+			vm := v1.VirtualMachineInstance{ObjectMeta: v12.ObjectMeta{Namespace: "test"}}
+			tc.logFunc(log, &vm)
+
+			logEntry := logParams[0].([]interface{})
+			assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
+			assert(t, logEntry[1].(string) == LogLevelNames[INFO], "Logged line was not of level infoLevel")
+			assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
+			assert(t, logEntry[4].(string) == "pos", "Logged line was not pos")
+			assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
+			assert(t, logEntry[7].(string) == "test", "Component was not logged")
+			assert(t, logEntry[8].(string) == "namespace", "Logged line did not contain object namespace")
+			assert(t, logEntry[10].(string) == "name", "Logged line did not contain object name")
+			assert(t, logEntry[12].(string) == "kind", "Logged line did not contain object kind")
+			assert(t, logEntry[14].(string) == "uid", "Logged line did not contain UUID")
+			tearDown()
+		})
+	}
+}
+
+func TestObjectContextLeakage(t *testing.T) {
+	setUp()
+	log := MakeLogger(MockLogger{})
+	log.SetLogLevel(INFO)
+	if err := log.SetVerbosityLevel(0); err != nil {
+		t.Fatal(err)
+	}
+
+	vm := v1.VirtualMachineInstance{
+		ObjectMeta: v12.ObjectMeta{Name: "leak-test"},
+	}
+
+	// Simulate logging with verbosity in different orders.
+	for range 10 {
+		log.V(3).Object(&vm).Info("noop")
+		log.Object(&vm).V(3).Info("noop")
+	}
+
+	// Ensure the mock is empty before the check.
+	assert(t, !logCalled, "Expected no log output during loop")
+	assert(t, len(logParams) == 0, fmt.Sprintf("Expected no log params during loop, got %d entries", len(logParams)))
+
+	// Ensure object context did not leak into the base logger.
+	log.Error("post-check")
+	assert(t, logCalled, "Expected post-check log to reach logger")
+	assert(t, len(logParams) == 1, fmt.Sprintf("Expected 1 log entry, got %d", len(logParams)))
+	logEntry := logParams[0].([]interface{})
+	for _, item := range logEntry {
+		if s, ok := item.(string); ok {
+			assert(t, s != "leak-test", fmt.Sprintf("Unexpected object context on base logger: %v", logEntry))
+		}
+	}
+
 	tearDown()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Object context (namespace/name/kind/uid) could be lost when `FilteredVerbosityLogger.Object()` was used after changing verbosity, so logs missed object fields.

A few examples found in sources:
- `log.Log.V(4).Object(migration).Infof(...)`
- `c.logger.V(4).Object(vmi).Info(...)`

#### After this PR:
Object context is preserved across verbosity changes. Added unit tests for verbosity change path, and context leakage to ensure no memory/context leaks.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Fixes #15133
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Minimal change: reuse the returned logger from `FilteredLogger.Object()` to keep context, avoiding API changes.

The following alternatives were considered:
- In-place mutation of `FilteredLogger.Object()` or API changes, which are more invasive.

Links to places where the discussion took place:
- https://github.com/kubevirt/kubevirt/issues/15133
- https://github.com/kubevirt/kubevirt/pull/15266

### Special notes for your reviewer

Unit tests cover verbosity changes and verify that object context does not leak into the base logger.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed missing object context in client-go log output after changing verbosity.
```

