### PR TITLE
live-migration-source: fix qcow2 metadata overlay datastore resolution

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"k8s.io/apimachinery/pkg/types"
+	"libvirt.org/go/libvirtxml"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -160,5 +161,58 @@ var _ = Describe("Live migration source", func() {
 					localToMigrate: map[string]bool{vol: true},
 				})))
 		})
+	})
+
+	Context("getDiskPathFromSource", func() {
+		DescribeTable("path resolution",
+			func(source *libvirtxml.DomainDiskSource, expectedPath string, expectedErr bool) {
+				path, err := getDiskPathFromSource(source)
+				if expectedErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(path).To(Equal(expectedPath))
+				}
+			},
+			Entry("resolves block device path",
+				&libvirtxml.DomainDiskSource{Block: &libvirtxml.DomainDiskSourceBlock{Dev: "/dev/vda"}},
+				"/dev/vda", false),
+
+			Entry("resolves file path",
+				&libvirtxml.DomainDiskSource{File: &libvirtxml.DomainDiskSourceFile{File: "/test/disk.img"}},
+				"/test/disk.img", false),
+
+			Entry("resolves DataStore source path",
+				&libvirtxml.DomainDiskSource{
+					File: &libvirtxml.DomainDiskSourceFile{File: "/overlay/path"},
+					DataStore: &libvirtxml.DomainDiskDataStore{
+						Source: &libvirtxml.DomainDiskSource{
+							Block: &libvirtxml.DomainDiskSourceBlock{Dev: "/base/path"},
+						},
+					},
+				},
+				"/base/path", false),
+			Entry("returns error when DataStore source is nil",
+				&libvirtxml.DomainDiskSource{
+					File: &libvirtxml.DomainDiskSourceFile{File: "/overlay/path"},
+					DataStore: &libvirtxml.DomainDiskDataStore{
+						Source: nil,
+					},
+				},
+				"", true),
+			Entry("returns error when DataStore source has no path set",
+				&libvirtxml.DomainDiskSource{
+					File: &libvirtxml.DomainDiskSourceFile{File: "/overlay/path"},
+					DataStore: &libvirtxml.DomainDiskDataStore{
+						Source: &libvirtxml.DomainDiskSource{},
+					},
+				},
+				"", true),
+
+			Entry("returns error for nil source", nil, "", true),
+
+			Entry("returns error when no path is set in source",
+				&libvirtxml.DomainDiskSource{}, "", true),
+		)
 	})
 })


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Ditto https://github.com/kubevirt/kubevirt/pull/16419 but for libvirtxml, otherwise os.GetDiskInfo (which calls qemu-img info) would fail.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->
VEP tracking issue: https://github.com/kubevirt/enhancements/issues/25


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: live-migration with CBT no longer fails on virtual disk size evaluation errors.
```

