### PR TITLE
ctrl, template: Rm net dependant NET_BIND_SERVICE tests

### DIFF
--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4314,52 +4314,6 @@ var _ = Describe("Template", func() {
 			})
 		})
 
-		DescribeTable("should require NET_BIND_SERVICE", func(interfaceType string) {
-			vmi := api.NewMinimalVMI("fake-vmi")
-			switch interfaceType {
-			case "bridge":
-				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			case "masquerade":
-				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-			}
-
-			pod, err := svc.RenderLaunchManifest(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
-					Expect(container.SecurityContext.Capabilities.Add).To(ContainElement(k8sv1.Capability("NET_BIND_SERVICE")))
-					return
-				}
-			}
-			Expect(false).To(BeTrue())
-		},
-			Entry("when there is bridge interface", "bridge"),
-			Entry("when there is masquerade interface", "masquerade"),
-		)
-
-		It("should require capabilites which we set on virt-launcher binary", func() {
-			vmi := api.NewMinimalVMI("fake-vmi")
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name: "test",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					DeprecatedMacvtap: &v1.DeprecatedInterfaceMacvtap{},
-				},
-			}}
-
-			pod, err := svc.RenderLaunchManifest(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
-					Expect(container.SecurityContext.Capabilities.Add).To(
-						ContainElement(k8sv1.Capability("NET_BIND_SERVICE")))
-					return
-				}
-			}
-			Expect(false).To(BeTrue())
-		})
-
 		DescribeTable("should require the correct set of capabilites", func(
 			getVMI func() *v1.VirtualMachineInstance,
 			containerName string,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The `NET_BIND_SERVICE` capability is applied to virt-launcher pods' compute container regardless of whether they have network interfaces [1].

Remove the tests that imply a dependency between this capability and the presence of network interfaces.

[1] https://github.com/kubevirt/kubevirt/pull/7629

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

