### PR TITLE
virt-operator: lint and cleanup `pkg/virt-operator/webhooks/`

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -44,6 +44,7 @@ pkg/tpm
 pkg/util/ratelimiter
 pkg/virt-controller/leaderelectionconfig
 pkg/virt-controller/watch/common
+pkg/virt-operator/webhooks
 pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/configuration

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -56,7 +56,7 @@ func (k *kubeVirtCreateAdmitter) Admit(ctx context.Context, review *admissionv1.
 	if resp := webhooks.ValidateSchema(v1.KubeVirtGroupVersionKind, review.Request.Object.Raw); resp != nil {
 		return resp
 	}
-	//TODO: Do we want semantic validation
+	// TODO: Do we want semantic validation
 
 	// Best effort
 	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(ctx, metav1.ListOptions{})

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -67,5 +67,5 @@ func (k *kubeVirtCreateAdmitter) Admit(ctx context.Context, review *admissionv1.
 		fmt.Println("Allowed to create KV")
 		return webhookutils.NewPassingAdmissionResponse()
 	}
-	return webhooks.ToAdmissionResponseError(fmt.Errorf("Kubevirt is already created"))
+	return webhooks.ToAdmissionResponseError(fmt.Errorf("kubevirt is already created"))
 }

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -110,7 +110,9 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 
 	if !equality.Semantic.DeepEqual(currKV.Spec.Configuration.SeccompConfiguration, newKV.Spec.Configuration.SeccompConfiguration) {
 		results = append(results,
-			validateSeccompConfiguration(field.NewPath("spec").Child("configuration", "seccompConfiguration"), newKV.Spec.Configuration.SeccompConfiguration)...)
+			validateSeccompConfiguration(
+				field.NewPath("spec").Child("configuration", "seccompConfiguration"),
+				newKV.Spec.Configuration.SeccompConfiguration)...)
 	}
 
 	if newKV.Spec.Infra != nil {
@@ -214,8 +216,9 @@ func validateCertificates(certConfig *v1.KubeVirtSelfSignConfiguration) []metav1
 
 	if deprecatedAPI && currentAPI {
 		statuses = append(statuses, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueNotSupported,
-			Message: fmt.Sprintf("caRotateInterval, certRotateInterval and caOverlapInterval are deprecated and conflict with CertConfig defined rotation parameters"),
+			Type: metav1.CauseTypeFieldValueNotSupported,
+			Message: "caRotateInterval, certRotateInterval and caOverlapInterval are deprecated " +
+				"and conflict with CertConfig defined rotation parameters",
 		})
 	}
 
@@ -226,22 +229,25 @@ func validateCertificates(certConfig *v1.KubeVirtSelfSignConfiguration) []metav1
 
 	if caDuration.Duration < caRenewBefore.Duration {
 		statuses = append(statuses, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("CA RenewBefore cannot exceed Duration (spec.certificateRotationStrategy.selfSigned.ca.duration < spec.certificateRotationStrategy.selfSigned.ca.renewBefore)"),
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: "CA RenewBefore cannot exceed Duration " +
+				"(spec.certificateRotationStrategy.selfSigned.ca.duration < spec.certificateRotationStrategy.selfSigned.ca.renewBefore)",
 		})
 	}
 
 	if certDuration.Duration < certRenewBefore.Duration {
 		statuses = append(statuses, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Cert RenewBefore cannot exceed Duration (spec.certificateRotationStrategy.selfSigned.server.duration < spec.certificateRotationStrategy.selfSigned.server.renewBefore)"),
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: "Cert RenewBefore cannot exceed Duration " +
+				"(spec.certificateRotationStrategy.selfSigned.server.duration < spec.certificateRotationStrategy.selfSigned.server.renewBefore)",
 		})
 	}
 
 	if certDuration.Duration > caDuration.Duration {
 		statuses = append(statuses, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Certificate duration cannot exceed CA (spec.certificateRotationStrategy.selfSigned.server.duration > spec.certificateRotationStrategy.selfSigned.ca.duration)"),
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: "Certificate duration cannot exceed CA " +
+				"(spec.certificateRotationStrategy.selfSigned.server.duration > spec.certificateRotationStrategy.selfSigned.ca.duration)",
 		})
 	}
 
@@ -321,7 +327,9 @@ func validateSeccompConfiguration(fieldPath *field.Path, seccompConf *v1.Seccomp
 	return statuses
 }
 
-func validateWorkloadPlacement(ctx context.Context, namespace string, placementConfig *v1.NodePlacement, client kubernetes.Interface) []metav1.StatusCause {
+func validateWorkloadPlacement(
+	ctx context.Context, namespace string, placementConfig *v1.NodePlacement, client kubernetes.Interface,
+) []metav1.StatusCause {
 	statuses := []metav1.StatusCause{}
 
 	const (
@@ -374,7 +382,9 @@ func validateWorkloadPlacement(ctx context.Context, namespace string, placementC
 	return statuses
 }
 
-func validateInfraPlacement(ctx context.Context, namespace string, placementConfig *v1.NodePlacement, client kubernetes.Interface) []metav1.StatusCause {
+func validateInfraPlacement(
+	ctx context.Context, namespace string, placementConfig *v1.NodePlacement, client kubernetes.Interface,
+) []metav1.StatusCause {
 	statuses := []metav1.StatusCause{}
 
 	const (

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -267,7 +267,7 @@ func validateTLSConfiguration(tlsConfiguration *v1.TLSConfiguration) []metav1.St
 	}
 
 	if len(tlsConfiguration.Ciphers) > 0 {
-		var idByName = kvtls.CipherSuiteNameMap()
+		idByName := kvtls.CipherSuiteNameMap()
 		for index, cipher := range tlsConfiguration.Ciphers {
 			if _, exists := idByName[cipher]; !exists {
 				statuses = append(statuses, metav1.StatusCause{
@@ -365,7 +365,6 @@ func validateWorkloadPlacement(ctx context.Context, namespace string, placementC
 	}
 
 	_, err := client.AppsV1().DaemonSets(namespace).Create(ctx, mockDaemonSet, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
-
 	if err != nil {
 		statuses = append(statuses, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
@@ -420,7 +419,6 @@ func validateInfraPlacement(ctx context.Context, namespace string, placementConf
 	}
 
 	_, err := client.AppsV1().Deployments(namespace).Create(ctx, mockDeployment, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
-
 	if err != nil {
 		statuses = append(statuses, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -150,31 +150,31 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 	return response
 }
 
-func getAdmissionReviewKubeVirt(ar *admissionv1.AdmissionReview) (new *v1.KubeVirt, old *v1.KubeVirt, err error) {
+func getAdmissionReviewKubeVirt(ar *admissionv1.AdmissionReview) (newKV *v1.KubeVirt, oldKV *v1.KubeVirt, err error) {
 	if !webhookutils.ValidateRequestResource(ar.Request.Resource, KubeVirtGroupVersionResource.Group, KubeVirtGroupVersionResource.Resource) {
 		return nil, nil, fmt.Errorf("expect resource to be '%s'", KubeVirtGroupVersionResource)
 	}
 
 	raw := ar.Request.Object.Raw
-	newKV := v1.KubeVirt{}
+	newKV = &v1.KubeVirt{}
 
-	err = json.Unmarshal(raw, &newKV)
+	err = json.Unmarshal(raw, newKV)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	if ar.Request.Operation == admissionv1.Update {
 		raw := ar.Request.OldObject.Raw
-		oldKV := v1.KubeVirt{}
-		err = json.Unmarshal(raw, &oldKV)
+		oldKV = &v1.KubeVirt{}
+		err = json.Unmarshal(raw, oldKV)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		return &newKV, &oldKV, nil
+		return newKV, oldKV, nil
 	}
 
-	return &newKV, nil, nil
+	return newKV, nil, nil
 }
 
 func validateCustomizeComponents(customization v1.CustomizeComponents) []metav1.StatusCause {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -202,17 +202,17 @@ func validateCertificates(certConfig *v1.KubeVirtSelfSignConfiguration) []metav1
 		return statuses
 	}
 
-	deprecatedApi := false
+	deprecatedAPI := false
 	if certConfig.CARotateInterval != nil || certConfig.CertRotateInterval != nil || certConfig.CAOverlapInterval != nil {
-		deprecatedApi = true
+		deprecatedAPI = true
 	}
 
-	currentApi := false
+	currentAPI := false
 	if certConfig.CA != nil || certConfig.Server != nil {
-		currentApi = true
+		currentAPI = true
 	}
 
-	if deprecatedApi && currentApi {
+	if deprecatedAPI && currentAPI {
 		statuses = append(statuses, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueNotSupported,
 			Message: fmt.Sprintf("caRotateInterval, certRotateInterval and caOverlapInterval are deprecated and conflict with CertConfig defined rotation parameters"),
@@ -326,7 +326,7 @@ func validateWorkloadPlacement(ctx context.Context, namespace string, placementC
 		dsName    = "placement-validation-webhook"
 		mockLabel = "kubevirt.io/choose-me"
 		podName   = "placement-verification-pod"
-		mockUrl   = "test.only:latest"
+		mockURL   = "test.only:latest"
 	)
 
 	mockDaemonSet := &appsv1.DaemonSet{
@@ -350,7 +350,7 @@ func validateWorkloadPlacement(ctx context.Context, namespace string, placementC
 					Containers: []corev1.Container{
 						{
 							Name:  podName,
-							Image: mockUrl,
+							Image: mockURL,
 						},
 					},
 					// Inject placement fields here
@@ -380,7 +380,7 @@ func validateInfraPlacement(ctx context.Context, namespace string, placementConf
 		deploymentName = "placement-validation-webhook"
 		mockLabel      = "kubevirt.io/choose-me"
 		podName        = "placement-verification-pod"
-		mockUrl        = "test.only:latest"
+		mockURL        = "test.only:latest"
 	)
 
 	mockDeployment := &appsv1.Deployment{
@@ -405,7 +405,7 @@ func validateInfraPlacement(ctx context.Context, namespace string, placementConf
 					Containers: []corev1.Container{
 						{
 							Name:  podName,
-							Image: mockUrl,
+							Image: mockURL,
 						},
 					},
 					// Inject placement fields here

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -152,7 +152,7 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 	return response
 }
 
-func getAdmissionReviewKubeVirt(ar *admissionv1.AdmissionReview) (newKV *v1.KubeVirt, oldKV *v1.KubeVirt, err error) {
+func getAdmissionReviewKubeVirt(ar *admissionv1.AdmissionReview) (newKV, oldKV *v1.KubeVirt, err error) {
 	if !webhookutils.ValidateRequestResource(ar.Request.Resource, KubeVirtGroupVersionResource.Group, KubeVirtGroupVersionResource.Resource) {
 		return nil, nil, fmt.Errorf("expect resource to be '%s'", KubeVirtGroupVersionResource)
 	}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -204,15 +204,8 @@ func validateCertificates(certConfig *v1.KubeVirtSelfSignConfiguration) []metav1
 		return statuses
 	}
 
-	deprecatedAPI := false
-	if certConfig.CARotateInterval != nil || certConfig.CertRotateInterval != nil || certConfig.CAOverlapInterval != nil {
-		deprecatedAPI = true
-	}
-
-	currentAPI := false
-	if certConfig.CA != nil || certConfig.Server != nil {
-		currentAPI = true
-	}
+	deprecatedAPI := certConfig.CARotateInterval != nil || certConfig.CertRotateInterval != nil || certConfig.CAOverlapInterval != nil
+	currentAPI := certConfig.CA != nil || certConfig.Server != nil
 
 	if deprecatedAPI && currentAPI {
 		statuses = append(statuses, metav1.StatusCause{
@@ -480,6 +473,7 @@ func warnDeprecatedFeatureGates(featureGates []string) (warnings []string) {
 }
 
 func warnDeprecatedArchitectures(archConfiguration *v1.ArchConfiguration) []string {
+	//nolint:staticcheck // SA1019: we need to check deprecated field to warn users
 	if archConfiguration != nil && archConfiguration.Ppc64le != nil {
 		return []string{"spec.configuration.architectureConfiguration.ppc64le is deprecated and no longer supported."}
 	}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -111,7 +111,6 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 	if !equality.Semantic.DeepEqual(currKV.Spec.Configuration.SeccompConfiguration, newKV.Spec.Configuration.SeccompConfiguration) {
 		results = append(results,
 			validateSeccompConfiguration(field.NewPath("spec").Child("configuration", "seccompConfiguration"), newKV.Spec.Configuration.SeccompConfiguration)...)
-
 	}
 
 	if newKV.Spec.Infra != nil {
@@ -230,7 +229,6 @@ func validateCertificates(certConfig *v1.KubeVirtSelfSignConfiguration) []metav1
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("CA RenewBefore cannot exceed Duration (spec.certificateRotationStrategy.selfSigned.ca.duration < spec.certificateRotationStrategy.selfSigned.ca.renewBefore)"),
 		})
-
 	}
 
 	if certDuration.Duration < certRenewBefore.Duration {
@@ -319,7 +317,6 @@ func validateSeccompConfiguration(field *field.Path, seccompConf *v1.SeccompConf
 	}
 
 	return statuses
-
 }
 
 func validateWorkloadPlacement(ctx context.Context, namespace string, placementConfig *v1.NodePlacement, client kubernetes.Interface) []metav1.StatusCause {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -562,10 +562,14 @@ func validateRoleAggregationStrategy(config *v1.KubeVirtConfiguration) []metav1.
 		return nil
 	}
 
+	msg := fmt.Sprintf(
+		"RoleAggregationStrategy cannot be set to Manual without enabling the %s feature gate",
+		featuregate.OptOutRoleAggregation,
+	)
 	return []metav1.StatusCause{{
 		Type:    metav1.CauseTypeFieldValueInvalid,
 		Field:   "spec.configuration.roleAggregationStrategy",
-		Message: fmt.Sprintf("RoleAggregationStrategy cannot be set to Manual without enabling the %s feature gate", featuregate.OptOutRoleAggregation),
+		Message: msg,
 	}}
 }
 

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -284,29 +284,31 @@ func validateTLSConfiguration(tlsConfiguration *v1.TLSConfiguration) []metav1.St
 	return statuses
 }
 
-func validateSeccompConfiguration(field *field.Path, seccompConf *v1.SeccompConfiguration) []metav1.StatusCause {
+func validateSeccompConfiguration(fieldPath *field.Path, seccompConf *v1.SeccompConfiguration) []metav1.StatusCause {
 	statuses := []metav1.StatusCause{}
 	if seccompConf == nil || seccompConf.VirtualMachineInstanceProfile == nil {
 		return statuses
 	}
 
 	customProfile := seccompConf.VirtualMachineInstanceProfile.CustomProfile
-	customProfileField := field.Child("virtualMachineInstanceProfile").Child("customProfile")
+	customProfileField := fieldPath.Child("virtualMachineInstanceProfile").Child("customProfile")
 
 	if customProfile != nil {
 		if customProfile.LocalhostProfile != nil && customProfile.RuntimeDefaultProfile {
 			localhostProfileField := customProfileField.Child("localhostProfile")
 			runtimeDefaultProfileField := customProfileField.Child("runtimeDefaultProfile")
-			statuses = append(statuses, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Field:   localhostProfileField.String(),
-				Message: fmt.Sprintf("%s cannot be set when %s is set", localhostProfileField.String(), runtimeDefaultProfileField.String()),
-			})
-			statuses = append(statuses, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Field:   runtimeDefaultProfileField.String(),
-				Message: fmt.Sprintf("%s cannot be set when %s is set", runtimeDefaultProfileField.String(), localhostProfileField.String()),
-			})
+			statuses = append(statuses,
+				metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Field:   localhostProfileField.String(),
+					Message: fmt.Sprintf("%s cannot be set when %s is set", localhostProfileField.String(), runtimeDefaultProfileField.String()),
+				},
+				metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Field:   runtimeDefaultProfileField.String(),
+					Message: fmt.Sprintf("%s cannot be set when %s is set", runtimeDefaultProfileField.String(), localhostProfileField.String()),
+				},
+			)
 		}
 	} else {
 		statuses = append(statuses, metav1.StatusCause{
@@ -519,7 +521,7 @@ func validateFeatureGates(devConfig *v1.DeveloperConfiguration) (causes []metav1
 		if slices.Contains(disabledFGs, enabledFG) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeForbidden,
-				Message: fmt.Sprintf(`feature gate "%s" exists on both "FeatureGates" and "DisabledFeatureGates"`, enabledFG),
+				Message: fmt.Sprintf("feature gate %q exists on both \"FeatureGates\" and \"DisabledFeatureGates\"", enabledFG),
 				Field:   field.NewPath("spec", "configuration", "developerConfiguration", "featureGates").String(),
 			})
 		}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -75,6 +75,14 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 		return resp
 	}
 
+	results := admitter.validateKubeVirtSpec(ctx, newKV, currKV)
+	response := validating_webhooks.NewAdmissionResponse(results)
+	response.Warnings = generateKubeVirtWarnings(newKV, currKV)
+
+	return response
+}
+
+func (admitter *KubeVirtUpdateAdmitter) validateKubeVirtSpec(ctx context.Context, newKV, currKV *v1.KubeVirt) []metav1.StatusCause {
 	var results []metav1.StatusCause
 
 	results = append(results, validateCustomizeComponents(newKV.Spec.CustomizeComponents)...)
@@ -123,33 +131,46 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 		results = append(results, validateFeatureGates(newKV.Spec.Configuration.DeveloperConfiguration)...)
 	}
 
-	response := validating_webhooks.NewAdmissionResponse(results)
+	return results
+}
+
+func generateKubeVirtWarnings(newKV, currKV *v1.KubeVirt) []string {
+	var warnings []string
 
 	if featureGatesChanged(&currKV.Spec, &newKV.Spec) {
 		featureGates := newKV.Spec.Configuration.DeveloperConfiguration.FeatureGates
-		response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(featureGates)...)
+		warnings = append(warnings, warnDeprecatedFeatureGates(featureGates)...)
 	}
 
+	warnings = append(warnings, warnDeprecatedMediatedDevices(newKV.Spec.Configuration.MediatedDevicesConfiguration)...)
+	warnings = append(warnings, warnDeprecatedArchitectures(newKV.Spec.Configuration.ArchitectureConfiguration)...)
+
+	return warnings
+}
+
+func warnDeprecatedMediatedDevices(mdev *v1.MediatedDevicesConfiguration) []string {
+	if mdev == nil {
+		return nil
+	}
+
+	var warnings []string
 	const mdevWarningfmt = "%s is deprecated, use mediatedDeviceTypes"
-	if mdev := newKV.Spec.Configuration.MediatedDevicesConfiguration; mdev != nil {
-		f := field.NewPath("spec", "configuration", "mediatedDevicesConfiguration")
-		if mdev.MediatedDevicesTypes != nil {
-			fChild := f.Child("mediatedDevicesTypes")
-			response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, fChild.String()))
-		}
+	f := field.NewPath("spec", "configuration", "mediatedDevicesConfiguration")
 
-		f = f.Child("nodeMediatedDeviceTypes")
-		for i, mdevType := range mdev.NodeMediatedDeviceTypes {
-			fChild := f.Index(i).Child("mediatedDevicesTypes")
-			if mdevType.MediatedDevicesTypes != nil {
-				response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, fChild.String()))
-			}
+	if mdev.MediatedDevicesTypes != nil {
+		fChild := f.Child("mediatedDevicesTypes")
+		warnings = append(warnings, fmt.Sprintf(mdevWarningfmt, fChild.String()))
+	}
+
+	f = f.Child("nodeMediatedDeviceTypes")
+	for i, mdevType := range mdev.NodeMediatedDeviceTypes {
+		fChild := f.Index(i).Child("mediatedDevicesTypes")
+		if mdevType.MediatedDevicesTypes != nil {
+			warnings = append(warnings, fmt.Sprintf(mdevWarningfmt, fChild.String()))
 		}
 	}
 
-	response.Warnings = append(response.Warnings, warnDeprecatedArchitectures(newKV.Spec.Configuration.ArchitectureConfiguration)...)
-
-	return response
+	return warnings
 }
 
 func getAdmissionReviewKubeVirt(ar *admissionv1.AdmissionReview) (newKV, oldKV *v1.KubeVirt, err error) {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -132,15 +132,15 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 	if mdev := newKV.Spec.Configuration.MediatedDevicesConfiguration; mdev != nil {
 		f := field.NewPath("spec", "configuration", "mediatedDevicesConfiguration")
 		if mdev.MediatedDevicesTypes != nil {
-			f := f.Child("mediatedDevicesTypes")
-			response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, f.String()))
+			fChild := f.Child("mediatedDevicesTypes")
+			response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, fChild.String()))
 		}
 
 		f = f.Child("nodeMediatedDeviceTypes")
 		for i, mdevType := range mdev.NodeMediatedDeviceTypes {
-			f := f.Index(i).Child("mediatedDevicesTypes")
+			fChild := f.Index(i).Child("mediatedDevicesTypes")
 			if mdevType.MediatedDevicesTypes != nil {
-				response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, f.String()))
+				response.Warnings = append(response.Warnings, fmt.Sprintf(mdevWarningfmt, fChild.String()))
 			}
 		}
 	}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -523,7 +523,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				Expect(response.Result.Details.Causes).To(HaveLen(len(expectedConflictingGates)))
 				for _, gate := range expectedConflictingGates {
 					Expect(response.Result.Details.Causes).To(ContainElement(And(
-						HaveField("Message", fmt.Sprintf(`feature gate "%s" exists on both "FeatureGates" and "DisabledFeatureGates"`, gate)),
+						HaveField("Message", fmt.Sprintf("feature gate %q exists on both \"FeatureGates\" and \"DisabledFeatureGates\"", gate)),
 						HaveField("Type", metav1.CauseTypeForbidden),
 						HaveField("Field", field.NewPath("spec", "configuration", "developerConfiguration", "featureGates").String()),
 					)), `Expected to find conflict for gate: %s`, gate)

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -397,7 +397,8 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
 				Expect(response.Warnings).To(ContainElement(
-					"spec.configuration.mediatedDevicesConfiguration.nodeMediatedDeviceTypes[0].mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
+					"spec.configuration.mediatedDevicesConfiguration.nodeMediatedDeviceTypes[0]." +
+						"mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
 			} else {
 				Expect(response.Warnings).To(BeEmpty())
 			}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -462,6 +462,8 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			Entry("with MacvtapGate", featuregate.MacvtapGate, featuregate.MacvtapDiscontinueMessage),
 			Entry("with ExperimentalVirtiofsSupport", featuregate.VirtIOFSGate, featuregate.VirtioFsFeatureGateDiscontinueMessage),
 			Entry("with DisableMediatedDevicesHandling", featuregate.DisableMediatedDevicesHandling, "DisableMDEVConfiguration has been deprecated since v1.8.0"),
+			Entry("with DockerSELinuxMCSWorkaround", featuregate.DockerSELinuxMCSWorkaround, "DockerSELinuxMCSWorkaround has been deprecated since v1.4."),
+			Entry("with MultiArchitecture", featuregate.MultiArchitecture, "MultiArchitecture has been deprecated since v1.8.0"),
 		)
 
 		DescribeTable("should raise warning when archConfig is set for ppc64le", func(shouldWarn bool, archConfig *v1.ArchConfiguration) {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -230,7 +230,10 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 					LocalhostProfile:      pointer.P("somethingNotImportant"),
 				},
 			},
-		}, []string{vmProfileField.Child("customProfile", "runtimeDefaultProfile").String(), vmProfileField.Child("customProfile", "localhostProfile").String()}),
+		}, []string{
+			vmProfileField.Child("customProfile", "runtimeDefaultProfile").String(),
+			vmProfileField.Child("customProfile", "localhostProfile").String(),
+		}),
 	)
 
 	DescribeTable("test validateCustomizeComponents", func(cc v1.CustomizeComponents, expectedCauses int) {
@@ -358,7 +361,8 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			Expect(response).NotTo(BeNil())
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
-				Expect(response.Warnings).To(ContainElement("spec.configuration.mediatedDevicesConfiguration.mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
+				Expect(response.Warnings).To(ContainElement(
+				"spec.configuration.mediatedDevicesConfiguration.mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
 			} else {
 				Expect(response.Warnings).To(BeEmpty())
 			}
@@ -392,7 +396,8 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			Expect(response).NotTo(BeNil())
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
-				Expect(response.Warnings).To(ContainElement("spec.configuration.mediatedDevicesConfiguration.nodeMediatedDeviceTypes[0].mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
+				Expect(response.Warnings).To(ContainElement(
+				"spec.configuration.mediatedDevicesConfiguration.nodeMediatedDeviceTypes[0].mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
 			} else {
 				Expect(response.Warnings).To(BeEmpty())
 			}
@@ -452,18 +457,27 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				},
 			}))
 		},
-			Entry("with LiveMigration", featuregate.LiveMigrationGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.LiveMigrationGate, featuregate.GA)),
-			Entry("with SRIOVLiveMigration", featuregate.SRIOVLiveMigrationGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.SRIOVLiveMigrationGate, featuregate.GA)),
-			Entry("with NonRoot", featuregate.NonRoot, fmt.Sprintf(featuregate.WarningPattern, featuregate.NonRoot, featuregate.GA)),
-			Entry("with PSA", featuregate.PSA, fmt.Sprintf(featuregate.WarningPattern, featuregate.PSA, featuregate.GA)),
-			Entry("with CPUNodeDiscoveryGate", featuregate.CPUNodeDiscoveryGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.CPUNodeDiscoveryGate, featuregate.GA)),
-			Entry("with HotplugNICs", featuregate.HotplugNetworkIfacesGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.HotplugNetworkIfacesGate, featuregate.GA)),
+			Entry("with LiveMigration", featuregate.LiveMigrationGate,
+			fmt.Sprintf(featuregate.WarningPattern, featuregate.LiveMigrationGate, featuregate.GA)),
+			Entry("with SRIOVLiveMigration", featuregate.SRIOVLiveMigrationGate,
+			fmt.Sprintf(featuregate.WarningPattern, featuregate.SRIOVLiveMigrationGate, featuregate.GA)),
+			Entry("with NonRoot", featuregate.NonRoot,
+			fmt.Sprintf(featuregate.WarningPattern, featuregate.NonRoot, featuregate.GA)),
+			Entry("with PSA", featuregate.PSA,
+			fmt.Sprintf(featuregate.WarningPattern, featuregate.PSA, featuregate.GA)),
+			Entry("with CPUNodeDiscoveryGate", featuregate.CPUNodeDiscoveryGate,
+			fmt.Sprintf(featuregate.WarningPattern, featuregate.CPUNodeDiscoveryGate, featuregate.GA)),
+			Entry("with HotplugNICs", featuregate.HotplugNetworkIfacesGate,
+			fmt.Sprintf(featuregate.WarningPattern, featuregate.HotplugNetworkIfacesGate, featuregate.GA)),
 			Entry("with Passt", featuregate.PasstGate, featuregate.PasstDiscontinueMessage),
 			Entry("with MacvtapGate", featuregate.MacvtapGate, featuregate.MacvtapDiscontinueMessage),
 			Entry("with ExperimentalVirtiofsSupport", featuregate.VirtIOFSGate, featuregate.VirtioFsFeatureGateDiscontinueMessage),
-			Entry("with DisableMediatedDevicesHandling", featuregate.DisableMediatedDevicesHandling, "DisableMDEVConfiguration has been deprecated since v1.8.0"),
-			Entry("with DockerSELinuxMCSWorkaround", featuregate.DockerSELinuxMCSWorkaround, "DockerSELinuxMCSWorkaround has been deprecated since v1.4."),
-			Entry("with MultiArchitecture", featuregate.MultiArchitecture, "MultiArchitecture has been deprecated since v1.8.0"),
+			Entry("with DisableMediatedDevicesHandling", featuregate.DisableMediatedDevicesHandling,
+			"DisableMDEVConfiguration has been deprecated since v1.8.0"),
+			Entry("with DockerSELinuxMCSWorkaround", featuregate.DockerSELinuxMCSWorkaround,
+			"DockerSELinuxMCSWorkaround has been deprecated since v1.4."),
+			Entry("with MultiArchitecture", featuregate.MultiArchitecture,
+			"MultiArchitecture has been deprecated since v1.8.0"),
 		)
 
 		DescribeTable("should raise warning when archConfig is set for ppc64le", func(shouldWarn bool, archConfig *v1.ArchConfiguration) {
@@ -480,7 +494,8 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
-				Expect(response.Warnings).To(ContainElement("spec.configuration.architectureConfiguration.ppc64le is deprecated and no longer supported."))
+				Expect(response.Warnings).To(ContainElement(
+				"spec.configuration.architectureConfiguration.ppc64le is deprecated and no longer supported."))
 			} else {
 				Expect(response.Warnings).To(BeEmpty())
 			}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -362,7 +362,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
 				Expect(response.Warnings).To(ContainElement(
-				"spec.configuration.mediatedDevicesConfiguration.mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
+					"spec.configuration.mediatedDevicesConfiguration.mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
 			} else {
 				Expect(response.Warnings).To(BeEmpty())
 			}
@@ -397,7 +397,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
 				Expect(response.Warnings).To(ContainElement(
-				"spec.configuration.mediatedDevicesConfiguration.nodeMediatedDeviceTypes[0].mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
+					"spec.configuration.mediatedDevicesConfiguration.nodeMediatedDeviceTypes[0].mediatedDevicesTypes is deprecated, use mediatedDeviceTypes"))
 			} else {
 				Expect(response.Warnings).To(BeEmpty())
 			}
@@ -458,26 +458,26 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			}))
 		},
 			Entry("with LiveMigration", featuregate.LiveMigrationGate,
-			fmt.Sprintf(featuregate.WarningPattern, featuregate.LiveMigrationGate, featuregate.GA)),
+				fmt.Sprintf(featuregate.WarningPattern, featuregate.LiveMigrationGate, featuregate.GA)),
 			Entry("with SRIOVLiveMigration", featuregate.SRIOVLiveMigrationGate,
-			fmt.Sprintf(featuregate.WarningPattern, featuregate.SRIOVLiveMigrationGate, featuregate.GA)),
+				fmt.Sprintf(featuregate.WarningPattern, featuregate.SRIOVLiveMigrationGate, featuregate.GA)),
 			Entry("with NonRoot", featuregate.NonRoot,
-			fmt.Sprintf(featuregate.WarningPattern, featuregate.NonRoot, featuregate.GA)),
+				fmt.Sprintf(featuregate.WarningPattern, featuregate.NonRoot, featuregate.GA)),
 			Entry("with PSA", featuregate.PSA,
-			fmt.Sprintf(featuregate.WarningPattern, featuregate.PSA, featuregate.GA)),
+				fmt.Sprintf(featuregate.WarningPattern, featuregate.PSA, featuregate.GA)),
 			Entry("with CPUNodeDiscoveryGate", featuregate.CPUNodeDiscoveryGate,
-			fmt.Sprintf(featuregate.WarningPattern, featuregate.CPUNodeDiscoveryGate, featuregate.GA)),
+				fmt.Sprintf(featuregate.WarningPattern, featuregate.CPUNodeDiscoveryGate, featuregate.GA)),
 			Entry("with HotplugNICs", featuregate.HotplugNetworkIfacesGate,
-			fmt.Sprintf(featuregate.WarningPattern, featuregate.HotplugNetworkIfacesGate, featuregate.GA)),
+				fmt.Sprintf(featuregate.WarningPattern, featuregate.HotplugNetworkIfacesGate, featuregate.GA)),
 			Entry("with Passt", featuregate.PasstGate, featuregate.PasstDiscontinueMessage),
 			Entry("with MacvtapGate", featuregate.MacvtapGate, featuregate.MacvtapDiscontinueMessage),
 			Entry("with ExperimentalVirtiofsSupport", featuregate.VirtIOFSGate, featuregate.VirtioFsFeatureGateDiscontinueMessage),
 			Entry("with DisableMediatedDevicesHandling", featuregate.DisableMediatedDevicesHandling,
-			"DisableMDEVConfiguration has been deprecated since v1.8.0"),
+				"DisableMDEVConfiguration has been deprecated since v1.8.0"),
 			Entry("with DockerSELinuxMCSWorkaround", featuregate.DockerSELinuxMCSWorkaround,
-			"DockerSELinuxMCSWorkaround has been deprecated since v1.4."),
+				"DockerSELinuxMCSWorkaround has been deprecated since v1.4."),
 			Entry("with MultiArchitecture", featuregate.MultiArchitecture,
-			"MultiArchitecture has been deprecated since v1.8.0"),
+				"MultiArchitecture has been deprecated since v1.8.0"),
 		)
 
 		DescribeTable("should raise warning when archConfig is set for ppc64le", func(shouldWarn bool, archConfig *v1.ArchConfiguration) {
@@ -495,7 +495,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
 				Expect(response.Warnings).To(ContainElement(
-				"spec.configuration.architectureConfiguration.ppc64le is deprecated and no longer supported."))
+					"spec.configuration.architectureConfiguration.ppc64le is deprecated and no longer supported."))
 			} else {
 				Expect(response.Warnings).To(BeEmpty())
 			}

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -14,7 +14,8 @@ import (
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )
 
-const uninstallErrorMsg = "rejecting the uninstall request, since there are still %s present; either delete all KubeVirt related workloads or change the uninstall strategy before uninstalling KubeVirt"
+const uninstallErrorMsg = "rejecting the uninstall request, since there are still %s present; " +
+	"either delete all KubeVirt related workloads or change the uninstall strategy before uninstalling KubeVirt"
 
 var KubeVirtGroupVersionResource = metav1.GroupVersionResource{
 	Group:    v1.VirtualMachineInstanceGroupVersionKind.Group,

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -14,7 +14,7 @@ import (
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )
 
-const uninstallErrorMsg = "Rejecting the uninstall request, since there are still %s present. Either delete all KubeVirt related workloads or change the uninstall strategy before uninstalling KubeVirt."
+const uninstallErrorMsg = "rejecting the uninstall request, since there are still %s present; either delete all KubeVirt related workloads or change the uninstall strategy before uninstalling KubeVirt"
 
 var KubeVirtGroupVersionResource = metav1.GroupVersionResource{
 	Group:    v1.VirtualMachineInstanceGroupVersionKind.Group,

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -62,7 +62,6 @@ func (k *KubeVirtDeletionAdmitter) Admit(ctx context.Context, review *admissionv
 	}
 
 	vmis, err := k.client.VirtualMachineInstance(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 2})
-
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}
@@ -72,7 +71,6 @@ func (k *KubeVirtDeletionAdmitter) Admit(ctx context.Context, review *admissionv
 	}
 
 	vms, err := k.client.VirtualMachine(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 2})
-
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}
@@ -82,7 +80,6 @@ func (k *KubeVirtDeletionAdmitter) Admit(ctx context.Context, review *admissionv
 	}
 
 	vmirs, err := k.client.ReplicaSet(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 2})
-
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -41,7 +41,8 @@ func (k *KubeVirtDeletionAdmitter) Admit(ctx context.Context, review *admissionv
 			return webhookutils.ToAdmissionResponseError(err)
 		}
 	} else {
-		list, err := k.client.KubeVirt(review.Request.Namespace).List(ctx, metav1.ListOptions{})
+		var list *v1.KubeVirtList
+		list, err = k.client.KubeVirt(review.Request.Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}

--- a/pkg/virt-operator/webhooks/webhook_test.go
+++ b/pkg/virt-operator/webhooks/webhook_test.go
@@ -66,31 +66,48 @@ var _ = Describe("Webhook", func() {
 		})
 
 		It("should allow the deletion if no workload exists", func() {
-			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+			})
 			Expect(response.Allowed).To(BeTrue())
 		})
 
 		It("should deny the deletion if a VMI exists", func() {
-			_, err := fakeClient.KubevirtV1().VirtualMachineInstances(k8sv1.NamespaceDefault).Create(context.TODO(), &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "vmi"}}, metav1.CreateOptions{})
+			_, err := fakeClient.KubevirtV1().VirtualMachineInstances(k8sv1.NamespaceDefault).Create(
+				context.TODO(),
+				&v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "vmi"}},
+				metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+			})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
 		It("should deny the deletion if a VM exists", func() {
-			_, err := fakeClient.KubevirtV1().VirtualMachines(k8sv1.NamespaceDefault).Create(context.TODO(), &v1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: "vm"}}, metav1.CreateOptions{})
+			_, err := fakeClient.KubevirtV1().VirtualMachines(k8sv1.NamespaceDefault).Create(
+				context.TODO(),
+				&v1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: "vm"}},
+				metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+			})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
 		It("should deny the deletion if a VMIRS exists", func() {
-			_, err := fakeClient.KubevirtV1().VirtualMachineInstanceReplicaSets(k8sv1.NamespaceDefault).Create(context.TODO(), &v1.VirtualMachineInstanceReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "rs"}}, metav1.CreateOptions{})
+			_, err := fakeClient.KubevirtV1().VirtualMachineInstanceReplicaSets(k8sv1.NamespaceDefault).Create(
+				context.TODO(),
+				&v1.VirtualMachineInstanceReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "rs"}},
+				metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+			})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
@@ -99,7 +116,9 @@ var _ = Describe("Webhook", func() {
 				return true, &v1.VirtualMachineInstanceList{}, fmt.Errorf("whatever")
 			})
 
-			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+			})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
@@ -108,7 +127,9 @@ var _ = Describe("Webhook", func() {
 				return true, &v1.VirtualMachineList{}, fmt.Errorf("whatever")
 			})
 
-			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+			})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
@@ -117,31 +138,41 @@ var _ = Describe("Webhook", func() {
 				return true, &v1.VirtualMachineInstanceReplicaSetList{}, fmt.Errorf("whatever")
 			})
 
-			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+			})
 			Expect(response.Allowed).To(BeFalse())
 		})
 	})
 
 	It("should allow the deletion if the strategy is empty", func() {
-		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+		})
 		Expect(response.Allowed).To(BeTrue())
 	})
 
 	It("should allow the deletion if the strategy is set to RemoveWorkloads", func() {
 		setKV(fakeClient, v1.KubeVirtUninstallStrategyRemoveWorkloads, v1.KubeVirtPhaseDeployed)
-		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+		})
 		Expect(response.Allowed).To(BeTrue())
 	})
 
 	It("should allow the deletion of namespaces, where it gets an admission request without a resource name", func() {
 		setKV(fakeClient, v1.KubeVirtUninstallStrategyRemoveWorkloads, v1.KubeVirtPhaseDeployed)
-		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: ""}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: ""},
+		})
 		Expect(response.Allowed).To(BeTrue())
 	})
 
 	DescribeTable("should not check for workloads if kubevirt phase is", func(phase v1.KubeVirtPhase) {
 		setKV(fakeClient, v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist, phase)
-		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"},
+		})
 		Expect(response.Allowed).To(BeTrue())
 	},
 		Entry("unset", v1.KubeVirtPhase("")),
@@ -157,6 +188,7 @@ func setKV(fakeClient *kubevirtfake.Clientset, strategy v1.KubeVirtUninstallStra
 		patch.WithReplace("/status/phase", phase),
 	).GeneratePayload()
 	Expect(err).NotTo(HaveOccurred())
-	_, err = fakeClient.KubevirtV1().KubeVirts("test").Patch(context.TODO(), "kubevirt", types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	_, err = fakeClient.KubevirtV1().KubeVirts("test").Patch(
+		context.TODO(), "kubevirt", types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1388,7 +1388,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 			By("Creating another KubeVirt object")
 			_, err = virtClient.KubeVirt(newKv.Namespace).Create(context.Background(), newKv, metav1.CreateOptions{})
-			Expect(err).To(MatchError(ContainSubstring("Kubevirt is already created")))
+			Expect(err).To(MatchError(ContainSubstring("kubevirt is already created")))
 		})
 
 		It("[test_id:4612]should create non-namespaces resources without owner references", func() {


### PR DESCRIPTION
/sig control-plane
/kind cleanup
/area opereator
/wg code-quality

### What this PR does
#### Before this PR:
- The `pkg/virt-operator/webhooks/` directory was not included in the linter paths, allowing code quality issues to accumulate
- Two deprecated feature gates (`DockerSELinuxMCSWorkaround` and `MultiArchitecture`) were missing test coverage for deprecation warnings
- Multiple linting violations existed in the webhooks code:
  - Whitespace issues (unnecessary trailing newlines)
  - Naming convention violations (Api/Url instead of API/URL)
  - Error string formatting issues (capitalization and punctuation)
  - Variable shadowing issues
  - Import package shadowing
  - Code formatting inconsistencies
  - Lines exceeding 140 characters
  - Inefficient code patterns (consecutive appends, redundant conditionals)

#### After this PR:
- `pkg/virt-operator/webhooks/` is now linted as part of CI, preventing future quality regressions
- All deprecated feature gates have comprehensive test coverage
- All Linting issues addressed

### References
<!-- No specific issue being fixed, this is proactive code quality improvement -->

### Why we need it and why it was done in this way
**Why we need it:**
- The virt-operator webhooks are critical admission control components that validate KubeVirt CR updates
- Without linting, code quality issues can accumulate and lead to bugs
- Missing test coverage for deprecated features could allow regressions in user warnings

**Implementation approach:**
The following tradeoffs were made:
- Fixed issues in separate commits grouped by linting failure type for easier review and potential selective revert

The following alternatives were considered:
- Could have used `//nolint` directives instead of fixing issues - rejected because that defeats the purpose of enabling linting


### Special notes for your reviewer
- All changes are non-functional except for adding test coverage for deprecated feature gates
- Each commit is focused on a specific type of linting issue (whitespace, naming, shadowing, line length, etc.)
- The nolint comment for `Ppc64le` is intentional - we need to check the deprecated field to warn users about its deprecation


### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required (no impact - all changes are non-functional)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test (added tests for deprecated feature gates)
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required (not required - internal code quality improvement)

### Release note
```release-note
NONE
```