### PR TITLE
Promote MigrationPriorityQueue feature gate to Beta

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -149,6 +149,7 @@ const (
 	// over user-initiated ones (e.g., hot plug operations).
 	// Owner: sig-compute / @fossedihelm
 	// Alpha: v1.7.0
+	// Beta: v1.8.0
 	//
 	MigrationPriorityQueue = "MigrationPriorityQueue"
 )
@@ -186,5 +187,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: UtilityVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PasstIPStackMigration, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IncrementalBackupGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: Beta})
 }

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -123,6 +123,7 @@ func AdjustKubeVirtResource() {
 		featuregate.PanicDevicesGate,
 		featuregate.VideoConfig,
 		featuregate.UtilityVolumesGate,
+		featuregate.MigrationPriorityQueue,
 	)
 	kv.Spec.Configuration.ChangedBlockTrackingLabelSelectors = &v1.ChangedBlockTrackingSelectors{
 		VirtualMachineLabelSelector: &metav1.LabelSelector{


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `MigrationPriorityQueue` feature gate was in Alpha state and had to be explicitly enabled for testing and usage.

#### After this PR:
The `MigrationPriorityQueue` feature gate is promoted to Beta status (v1.8.0) and is enabled by default in the test suite, making it available for broader testing and adoption.

### References
<!-- If there's a tracking issue, add it here with:
- Fixes #<issue_number>
-->
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/62

### Why we need it and why it was done in this way
The MigrationPriorityQueue feature has been stable in Alpha and has matured sufficiently to warrant promotion to Beta. This allows migration operations to prioritize system-initiated migrations over user-initiated ones (e.g., hot plug operations), improving cluster stability and resource management.


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
The MigrationPriorityQueue feature gate has been promoted from Alpha to Beta.
```