### PR TITLE
virt-handler: requeue VMI when old launcher remains responsive during UID mismatch

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -373,6 +373,9 @@ func (c *VirtualMachineController) execute(key string) error {
 			// Make sure we re-enqueue the key to ensure this new VMI is processed
 			// after the stale domain is removed
 			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*5)
+		} else {
+			c.logger.Object(vmi).V(3).Infof("Old launcher for VMI %s is still responsive, waiting for domain cleanup before processing new VMI %s", oldVMI.UID, vmi.UID)
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*5)
 		}
 
 		return nil


### PR DESCRIPTION
## Problem Summary

During **VirtualMachineInstance (VMI) delete → recreate cycles**, `virt-handler` can enter a state where a newly created VMI is **never processed** and remains stuck indefinitely.

This occurs when:

* A VMI is deleted
* A new VMI with the **same name** is created before the old domain is fully cleaned up
* The old `virt-launcher` client is still **responsive**, but cleanup has not yet completed

In this scenario, `virt-handler` detects a **UID mismatch** between the existing domain and the new VMI, but incorrectly drops the workqueue item instead of retrying, resulting in a **silent, permanent stall**.

---

## Impact

**What breaks**

* New VMIs never start after quick delete/recreate cycles
* VMIs remain stuck in early lifecycle phases indefinitely
* No errors or events explain the failure

**Who is affected**

* CI/CD pipelines performing rapid VM turnover
* Auto-recovery systems restarting VMs
* Node maintenance operations (drain/cordon/reboot)
* Cluster administrators managing VM workloads

**Why this is production-critical**

* The failure is **silent**
* Requires **manual intervention** (force-deleting old launcher pods)
* Triggered by **common operational behavior**

---

##  Steps to Reproduce (Realistic)

1. Create a VMI with a slow shutdown:

   ```yaml
   terminationGracePeriodSeconds: 60
   ```
2. Start the VMI and wait until it is running
3. Delete the VMI without waiting:

   ```bash
   kubectl delete vmi test-vm --wait=false
   ```
4. Immediately recreate a VMI with the same name
5. Observe that the new VMI remains stuck indefinitely

This can also occur during:

* Controller restarts
* Node reboots
* Network delays during VM shutdown

---

##  Root Cause

When a UID mismatch is detected, `virt-handler` checks the state of the old launcher client:

* If the client is **uninitialized** → requeue ✅
* If the client is **expired** → cleanup and requeue ✅
* If the client is **responsive but cleanup is still in progress** → **returns nil without requeue ❌**

Returning `nil` causes the controller workqueue to **forget the VMI key**, and since no further events occur, the VMI is never retried.

```go
// Old behavior (simplified)
if expired {
    c.queue.AddAfter(key, 5*time.Second)
}
return nil // workqueue.Forget(key)
```

This assumes that a responsive launcher guarantees timely cleanup, which is **not a valid assumption** during slow shutdowns.

---

## Fix Overview

This change ensures that **all UID-mismatch cases result in a requeue**, including when the old launcher client is still responsive but the domain has not yet been removed.

```go
} else {
    // Old launcher still responsive; retry until cleanup completes
    c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*5)
}
```

The fix is **additive and minimal**, preserving existing behavior while preventing the workqueue item from being dropped.

---

##  Result After Fix

* VM delete/recreate cycles complete reliably
* VMIs are retried until the old domain is cleaned up
* No more silent, indefinite hangs
* Controller behavior aligns with standard Kubernetes retry semantics

---

##  Risk Assessment

* **Low risk**
* No changes to successful or normal execution paths
* Only handles a previously unhandled edge case
* Does not alter lifecycle logic, only ensures retry

```release-note
Fixes a virt-handler issue where VMIs could get stuck indefinitely during
delete/recreate cycles if the old launcher remained responsive.
```
