### PR TITLE
launcher, converter: Extract serial controller configuration logic

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -41,6 +41,7 @@ type ControllersDomainConfigurator struct {
 	autoThreads               uint
 	controllerDriver          *api.ControllerDriver
 	supportPCIHole64Disabling bool
+	virtioSerialModel         string
 }
 
 type controllersOption func(*ControllersDomainConfigurator)
@@ -65,6 +66,15 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 
 	if c.supportPCIHole64Disabling && shouldDisablePCIHole64(vmi) {
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newPCIControllerWithHole64Disabled())
+	}
+
+	if vmi.Spec.Domain.Devices.AutoattachSerialConsole == nil || *vmi.Spec.Domain.Devices.AutoattachSerialConsole {
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
+			Type:   "virtio-serial",
+			Index:  "0",
+			Model:  c.virtioSerialModel,
+			Driver: c.controllerDriver,
+		})
 	}
 
 	return nil
@@ -97,6 +107,12 @@ func ControllersWithControllerDriver(controllerDriver *api.ControllerDriver) con
 func ControllersWithSupportPCIHole64Disabling(support bool) controllersOption {
 	return func(c *ControllersDomainConfigurator) {
 		c.supportPCIHole64Disabling = support
+	}
+}
+
+func ControllersWithVirtioSerialModel(model string) controllersOption {
+	return func(c *ControllersDomainConfigurator) {
+		c.virtioSerialModel = model
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -68,13 +68,8 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newPCIControllerWithHole64Disabled())
 	}
 
-	if vmi.Spec.Domain.Devices.AutoattachSerialConsole == nil || *vmi.Spec.Domain.Devices.AutoattachSerialConsole {
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
-			Type:   "virtio-serial",
-			Index:  "0",
-			Model:  c.virtioSerialModel,
-			Driver: c.controllerDriver,
-		})
+	if requiresVirtioSerialController(vmi) {
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newVirtioSerialController(c.virtioSerialModel, c.controllerDriver))
 	}
 
 	return nil
@@ -151,11 +146,24 @@ func newPCIControllerWithHole64Disabled() api.Controller {
 	}
 }
 
+func newVirtioSerialController(model string, controllerDriver *api.ControllerDriver) api.Controller {
+	return api.Controller{
+		Type:   "virtio-serial",
+		Index:  "0",
+		Model:  model,
+		Driver: controllerDriver,
+	}
+}
+
 func shouldDisablePCIHole64(vmi *v1.VirtualMachineInstance) bool {
 	if val, ok := vmi.Annotations[v1.DisablePCIHole64]; ok {
 		return strings.EqualFold(val, "true")
 	}
 	return false
+}
+
+func requiresVirtioSerialController(vmi *v1.VirtualMachineInstance) bool {
+	return vmi.Spec.Domain.Devices.AutoattachSerialConsole == nil || *vmi.Spec.Domain.Devices.AutoattachSerialConsole
 }
 
 func requiresSCSIController(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -232,6 +232,42 @@ var _ = Describe("Controllers Domain Configurator", func() {
 				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 	)
+
+	DescribeTable("should configure virtio-serial controller based on serial console setting", func(vmiOpts []libvmi.Option, expectedControllers []api.Controller) {
+		var domain api.Domain
+
+		// withHotplugDisabled() is applied to all entries to prevent the SCSI controller
+		// from being added (hotplug enabled triggers SCSI), keeping the test focused on the
+		// virtio-serial controller only.
+		vmi := libvmi.New(append([]libvmi.Option{withHotplugDisabled()}, vmiOpts...)...)
+
+		configurator := compute.NewControllersDomainConfigurator(
+			compute.ControllersWithUSBNeeded(!usbNeeded),
+			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
+			compute.ControllersWithControllerDriver(nil),
+		)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithControllers(expectedControllers)))
+	},
+		Entry("when serial console is enabled by default (nil)",
+			nil,
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+			}),
+		Entry("when serial console is explicitly enabled",
+			[]libvmi.Option{withSerialConsole()},
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+			}),
+		Entry("when serial console is disabled",
+			[]libvmi.Option{libvmi.WithoutSerialConsole()},
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+			}),
+	)
 })
 
 func newDomainWithControllers(controllers []api.Controller) api.Domain {
@@ -247,5 +283,12 @@ func newDomainWithControllers(controllers []api.Controller) api.Domain {
 func withHotplugDisabled() libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Devices.DisableHotplug = true
+	}
+}
+
+func withSerialConsole() libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		enabled := true
+		vmi.Spec.Domain.Devices.AutoattachSerialConsole = &enabled
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			compute.ControllersWithSCSIModel("test-model"),
 			compute.ControllersWithSCSIIOThreads(uint(autoThreads)),
 			compute.ControllersWithControllerDriver(nil),
+			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
 		).Configure(vmi, &domain)).To(Succeed())
 
 		expectedDomain := api.Domain{
@@ -62,6 +63,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			0,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when USB is needed and disk hotplug is disabled",
 			libvmi.New(withHotplugDisabled()),
@@ -69,6 +71,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			0,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "qemu-xhci"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when USB is NOT needed and disk hotplug is enabled",
 			libvmi.New(),
@@ -77,6 +80,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when USB is needed and disk hotplug is enabled",
 			libvmi.New(),
@@ -85,6 +89,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "qemu-xhci"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk and disk hotplug is disabled",
 			libvmi.New(withHotplugDisabled(), libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
@@ -93,6 +98,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk and disk hotplug is enabled",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
@@ -101,6 +107,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk and USB is needed",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
@@ -109,6 +116,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "qemu-xhci"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and Virtio disk, VMI has 4 shared IO threads",
 			libvmi.New(
@@ -120,6 +128,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{Queues: pointer.P[uint](1), IOThread: pointer.P[uint](2)}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and Virtio disks, VMI has 2 shared IO threads, should roll over controller thread",
 			libvmi.New(
@@ -132,6 +141,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1)}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has multiple SCSI disks with dedicatedIOThread, VMI has 4 shared IO threads",
 			libvmi.New(
@@ -143,6 +153,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1)}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and VMI has no IOThreads",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
@@ -151,6 +162,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk without dedicatedIOThread and VMI has IOThreads",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
@@ -159,6 +171,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 	)
 
@@ -171,6 +184,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			compute.ControllersWithSCSIIOThreads(0),
 			compute.ControllersWithControllerDriver(nil),
 			compute.ControllersWithSupportPCIHole64Disabling(supportPCIHole64Disabling),
+			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
 		)
 		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
@@ -182,6 +196,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when arch does not support PCIHole64 disabling, annotation set",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
@@ -189,6 +204,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when arch supports PCIHole64 disabling, annotation not set",
 			libvmi.New(),
@@ -196,6 +212,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when arch supports PCIHole64 disabling, annotation set to false",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "false")),
@@ -203,6 +220,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when arch supports PCIHole64 disabling and annotation is true",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
@@ -211,6 +229,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
 				{Type: "pci", Index: "0", Model: "pcie-root", PCIHole64: &api.PCIHole64{Value: 0, Unit: "KiB"}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 	)
 })

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1071,6 +1071,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			compute.ControllersWithSCSIIOThreads(uint(autoThreads)),
 			compute.ControllersWithControllerDriver(controllerDriver),
 			compute.ControllersWithSupportPCIHole64Disabling(c.Architecture.SupportPCIHole64Disabling()),
+			compute.ControllersWithVirtioSerialModel(virtioModel),
 		),
 		compute.NewQemuCmdDomainConfigurator(c.Architecture.ShouldVerboseLogsBeEnabled()),
 		compute.NewCPUDomainConfigurator(c.Architecture.SupportCPUHotplug(), c.Architecture.RequiresMPXCPUValidation()),
@@ -1228,16 +1229,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 				}
 			}
 		}
-	}
-
-	if vmi.Spec.Domain.Devices.AutoattachSerialConsole == nil || *vmi.Spec.Domain.Devices.AutoattachSerialConsole {
-		// Add mandatory console device
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
-			Type:   "virtio-serial",
-			Index:  "0",
-			Model:  virtio.InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture()),
-			Driver: controllerDriver,
-		})
 	}
 
 	if val := vmi.Annotations[v1.PlacePCIDevicesOnRootComplex]; val == "true" {


### PR DESCRIPTION
### What this PR does
This PR extract the logic responsible of configuration the Console virtio-serial controller, to the `ControllersDomainConfigurator` as a follow-up to https://github.com/kubevirt/kubevirt/pull/16306

### References

- Partially addresses https://github.com/kubevirt/kubevirt/issues/16117

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

### Release note
```release-note
none
```

