### PR TITLE
launcher, converter, ctrls: Extract pci controller configuration logic

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -21,6 +21,7 @@ package compute
 
 import (
 	"slices"
+	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -35,10 +36,11 @@ const (
 )
 
 type ControllersDomainConfigurator struct {
-	isUSBNeeded      bool
-	scsiModel        string
-	autoThreads      uint
-	controllerDriver *api.ControllerDriver
+	isUSBNeeded               bool
+	scsiModel                 string
+	autoThreads               uint
+	controllerDriver          *api.ControllerDriver
+	supportPCIHole64Disabling bool
 }
 
 type controllersOption func(*ControllersDomainConfigurator)
@@ -59,6 +61,10 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 	if requiresSCSIController(vmi) {
 		scsiControllerDriver := assignSCSIControllerIOThread(vmi, uint(c.autoThreads), c.controllerDriver.DeepCopy())
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newSCSIController(c.scsiModel, scsiControllerDriver))
+	}
+
+	if c.supportPCIHole64Disabling && shouldDisablePCIHole64(vmi) {
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newPCIControllerWithHole64Disabled())
 	}
 
 	return nil
@@ -88,6 +94,12 @@ func ControllersWithControllerDriver(controllerDriver *api.ControllerDriver) con
 	}
 }
 
+func ControllersWithSupportPCIHole64Disabling(support bool) controllersOption {
+	return func(c *ControllersDomainConfigurator) {
+		c.supportPCIHole64Disabling = support
+	}
+}
+
 func newUSBController(usbNeeded bool) api.Controller {
 	usbControllerModel := "none"
 
@@ -109,6 +121,25 @@ func newSCSIController(controllerModel string, controllerDriver *api.ControllerD
 		Model:  controllerModel,
 		Driver: controllerDriver,
 	}
+}
+
+func newPCIControllerWithHole64Disabled() api.Controller {
+	return api.Controller{
+		Type:  "pci",
+		Index: "0",
+		Model: "pcie-root",
+		PCIHole64: &api.PCIHole64{
+			Value: 0,
+			Unit:  "KiB",
+		},
+	}
+}
+
+func shouldDisablePCIHole64(vmi *v1.VirtualMachineInstance) bool {
+	if val, ok := vmi.Annotations[v1.DisablePCIHole64]; ok {
+		return strings.EqualFold(val, "true")
+	}
+	return false
 }
 
 func requiresSCSIController(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -33,7 +33,8 @@ import (
 var _ = Describe("Controllers Domain Configurator", func() {
 
 	const (
-		usbNeeded = true
+		usbNeeded                   = true
+		pciHole64DisablingSupported = true
 	)
 
 	DescribeTable("should configure USB and SCSI controllers", func(vmi *v1.VirtualMachineInstance, isUSBNeeded bool, autoThreads int, expectedControllers []api.Controller) {
@@ -160,7 +161,69 @@ var _ = Describe("Controllers Domain Configurator", func() {
 				{Type: "scsi", Index: "0", Model: "test-model"},
 			}),
 	)
+
+	DescribeTable("should configure PCI controller based on arch support and annotation", func(vmi *v1.VirtualMachineInstance, supportPCIHole64Disabling bool, expectedControllers []api.Controller) {
+		var domain api.Domain
+
+		configurator := compute.NewControllersDomainConfigurator(
+			compute.ControllersWithUSBNeeded(!usbNeeded),
+			compute.ControllersWithSCSIModel("test-model"),
+			compute.ControllersWithSCSIIOThreads(0),
+			compute.ControllersWithControllerDriver(nil),
+			compute.ControllersWithSupportPCIHole64Disabling(supportPCIHole64Disabling),
+		)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithControllers(expectedControllers)))
+	},
+		Entry("when arch does not support PCIHole64 disabling, annotation not set",
+			libvmi.New(),
+			!pciHole64DisablingSupported,
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model"},
+			}),
+		Entry("when arch does not support PCIHole64 disabling, annotation set",
+			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
+			!pciHole64DisablingSupported,
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model"},
+			}),
+		Entry("when arch supports PCIHole64 disabling, annotation not set",
+			libvmi.New(),
+			pciHole64DisablingSupported,
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model"},
+			}),
+		Entry("when arch supports PCIHole64 disabling, annotation set to false",
+			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "false")),
+			pciHole64DisablingSupported,
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model"},
+			}),
+		Entry("when arch supports PCIHole64 disabling and annotation is true",
+			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
+			pciHole64DisablingSupported,
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "pci", Index: "0", Model: "pcie-root", PCIHole64: &api.PCIHole64{Value: 0, Unit: "KiB"}},
+			}),
+	)
 })
+
+func newDomainWithControllers(controllers []api.Controller) api.Domain {
+	return api.Domain{
+		Spec: api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: controllers,
+			},
+		},
+	}
+}
 
 func withHotplugDisabled() libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1070,6 +1070,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			compute.ControllersWithSCSIModel(scsiControllerModel),
 			compute.ControllersWithSCSIIOThreads(uint(autoThreads)),
 			compute.ControllersWithControllerDriver(controllerDriver),
+			compute.ControllersWithSupportPCIHole64Disabling(c.Architecture.SupportPCIHole64Disabling()),
 		),
 		compute.NewQemuCmdDomainConfigurator(c.Architecture.ShouldVerboseLogsBeEnabled()),
 		compute.NewCPUDomainConfigurator(c.Architecture.SupportCPUHotplug(), c.Architecture.RequiresMPXCPUValidation()),
@@ -1208,20 +1209,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
-	if c.Architecture.SupportPCIHole64Disabling() && shouldDisablePCIHole64(vmi) {
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers,
-			api.Controller{
-				Type:  "pci",
-				Index: "0",
-				Model: "pcie-root",
-				PCIHole64: &api.PCIHole64{
-					Value: 0,
-					Unit:  "KiB",
-				},
-			},
-		)
-	}
-
 	if vmi.Spec.Domain.CPU != nil {
 		// Adjust guest vcpu config. Currently will handle vCPUs to pCPUs pinning
 		if vmi.IsCPUDedicated() {
@@ -1274,13 +1261,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	return nil
-}
-
-func shouldDisablePCIHole64(vmi *v1.VirtualMachineInstance) bool {
-	if val, ok := vmi.Annotations[v1.DisablePCIHole64]; ok {
-		return strings.EqualFold(val, "true")
-	}
-	return false
 }
 
 func getPrefixFromBus(bus v1.DiskBus) string {


### PR DESCRIPTION
### What this PR does

This PR extract the logic responsible of configuration the PCI64 controller, to the `ControllersDomainConfigurator` as a follow-up to https://github.com/kubevirt/kubevirt/pull/16306

### References

- Partially addresses https://github.com/kubevirt/kubevirt/issues/16117

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

### Release note
```release-note
none
```

