### PR TITLE
VEP 171: Add rebootPolicy to VMI

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14929,6 +14929,10 @@
       "description": "Memory allow specifying the VMI memory features.",
       "$ref": "#/definitions/v1.Memory"
      },
+     "rebootPolicy": {
+      "description": "RebootPolicy specifies how the guest should behave on reboot. Reboot (default): The guest is allowed to reboot silently. Terminate: The VMI will be terminated on guest reboot, allowing higher level controllers (such as the VM controller) to recreate the VMI with any updated configuration such as boot order changes.",
+      "type": "string"
+     },
      "resources": {
       "description": "Resources describes the Compute Resources required by this vmi.",
       "default": {},

--- a/pkg/libvmi/vm.go
+++ b/pkg/libvmi/vm.go
@@ -87,6 +87,12 @@ func WithRunStrategy(strategy v1.VirtualMachineRunStrategy) VMOption {
 	}
 }
 
+func WithRebootPolicy(policy v1.RebootPolicy) VMOption {
+	return func(vm *v1.VirtualMachine) {
+		vm.Spec.Template.Spec.Domain.RebootPolicy = &policy
+	}
+}
+
 func WithDataVolumeTemplate(datavolume *cdiv1.DataVolume) VMOption {
 	return func(vm *v1.VirtualMachine) {
 		vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates,

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -216,3 +216,7 @@ func (config *ClusterConfig) PodSecondaryInterfaceNamingUpgradeEnabled() bool {
 func (config *ClusterConfig) ShouldDisableNADResourceInjection() bool {
 	return config.isFeatureGateEnabled(featuregate.DisableNADResourceInjection)
 }
+
+func (config *ClusterConfig) RebootPolicyEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.RebootPolicy)
+}

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -177,6 +177,14 @@ const (
 	// Owner: SIG network
 	// Beta: v1.8.0
 	DisableNADResourceInjection = "DisableNADResourceInjection"
+
+	// Owner: sig-compute / @MarSik
+	// Alpha: v1.8.0
+	//
+	// RebootPolicy enables setting the RebootPolicy field on VMI's DomainSpec
+	// which allows terminating the VMI on guest reboot instead of silently rebooting,
+	// enabling the VM controller to recreate the VMI with updated configuration.
+	RebootPolicy = "RebootPolicy"
 )
 
 func init() {
@@ -216,4 +224,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: DisableNADResourceInjection, State: Beta})
+	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Alpha})
 }

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -219,7 +219,11 @@ type DomainSpec struct {
 	NUMATune       *NUMATune       `xml:"numatune"`
 	IOThreads      *IOThreads      `xml:"iothreads,omitempty"`
 	LaunchSecurity *LaunchSecurity `xml:"launchSecurity,omitempty"`
+	OnReboot       string          `xml:"on_reboot,omitempty"`
 }
+
+const DomainOnRebootDestroy = "destroy"
+const DomainOnRebootRestart = "restart"
 
 type CPUTune struct {
 	VCPUPin     []CPUTuneVCPUPin     `xml:"vcpupin"`

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1269,6 +1269,17 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
+	// In case the RebootPolicy is not set, we rely on libvirt default behavior
+	// that is to reboot the guest silently.
+	if vmi.Spec.Domain.RebootPolicy != nil {
+		switch *vmi.Spec.Domain.RebootPolicy {
+		case v1.RebootPolicyTerminate:
+			domain.Spec.OnReboot = api.DomainOnRebootDestroy
+		case v1.RebootPolicyReboot:
+			domain.Spec.OnReboot = api.DomainOnRebootRestart
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7187,6 +7187,17 @@ var CRDsValidation map[string]string = map[string]string{
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
+                    rebootPolicy:
+                      description: |-
+                        RebootPolicy specifies how the guest should behave on reboot.
+                        Reboot (default): The guest is allowed to reboot silently.
+                        Terminate: The VMI will be terminated on guest reboot, allowing
+                        higher level controllers (such as the VM controller) to recreate
+                        the VMI with any updated configuration such as boot order changes.
+                      enum:
+                      - Reboot
+                      - Terminate
+                      type: string
                     resources:
                       description: Resources describes the Compute Resources required
                         by this vmi.
@@ -13052,6 +13063,17 @@ var CRDsValidation map[string]string = map[string]string{
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
               type: object
+            rebootPolicy:
+              description: |-
+                RebootPolicy specifies how the guest should behave on reboot.
+                Reboot (default): The guest is allowed to reboot silently.
+                Terminate: The VMI will be terminated on guest reboot, allowing
+                higher level controllers (such as the VM controller) to recreate
+                the VMI with any updated configuration such as boot order changes.
+              enum:
+              - Reboot
+              - Terminate
+              type: string
             resources:
               description: Resources describes the Compute Resources required by this
                 vmi.
@@ -16892,6 +16914,17 @@ var CRDsValidation map[string]string = map[string]string{
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
               type: object
+            rebootPolicy:
+              description: |-
+                RebootPolicy specifies how the guest should behave on reboot.
+                Reboot (default): The guest is allowed to reboot silently.
+                Terminate: The VMI will be terminated on guest reboot, allowing
+                higher level controllers (such as the VM controller) to recreate
+                the VMI with any updated configuration such as boot order changes.
+              enum:
+              - Reboot
+              - Terminate
+              type: string
             resources:
               description: Resources describes the Compute Resources required by this
                 vmi.
@@ -19416,6 +19449,17 @@ var CRDsValidation map[string]string = map[string]string{
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
+                    rebootPolicy:
+                      description: |-
+                        RebootPolicy specifies how the guest should behave on reboot.
+                        Reboot (default): The guest is allowed to reboot silently.
+                        Terminate: The VMI will be terminated on guest reboot, allowing
+                        higher level controllers (such as the VM controller) to recreate
+                        the VMI with any updated configuration such as boot order changes.
+                      enum:
+                      - Reboot
+                      - Terminate
+                      type: string
                     resources:
                       description: Resources describes the Compute Resources required
                         by this vmi.
@@ -24453,6 +24497,17 @@ var CRDsValidation map[string]string = map[string]string{
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
+                            rebootPolicy:
+                              description: |-
+                                RebootPolicy specifies how the guest should behave on reboot.
+                                Reboot (default): The guest is allowed to reboot silently.
+                                Terminate: The VMI will be terminated on guest reboot, allowing
+                                higher level controllers (such as the VM controller) to recreate
+                                the VMI with any updated configuration such as boot order changes.
+                              enum:
+                              - Reboot
+                              - Terminate
+                              type: string
                             resources:
                               description: Resources describes the Compute Resources
                                 required by this vmi.
@@ -29945,6 +30000,17 @@ var CRDsValidation map[string]string = map[string]string{
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
+                                rebootPolicy:
+                                  description: |-
+                                    RebootPolicy specifies how the guest should behave on reboot.
+                                    Reboot (default): The guest is allowed to reboot silently.
+                                    Terminate: The VMI will be terminated on guest reboot, allowing
+                                    higher level controllers (such as the VM controller) to recreate
+                                    the VMI with any updated configuration such as boot order changes.
+                                  enum:
+                                  - Reboot
+                                  - Terminate
+                                  type: string
                                 resources:
                                   description: Resources describes the Compute Resources
                                     required by this vmi.

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -458,7 +458,8 @@
             },
             "snp": {},
             "tdx": {}
-          }
+          },
+          "rebootPolicy": "rebootPolicyValue"
         },
         "nodeSelector": {
           "nodeSelectorKey": "nodeSelectorValue"

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -630,6 +630,7 @@ spec:
           hugepages:
             pageSize: pageSizeValue
           maxGuest: "0"
+        rebootPolicy: rebootPolicyValue
         resources:
           limits:
             limitsKey: "0"

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -398,7 +398,8 @@
         },
         "snp": {},
         "tdx": {}
-      }
+      },
+      "rebootPolicy": "rebootPolicyValue"
     },
     "nodeSelector": {
       "nodeSelectorKey": "nodeSelectorValue"

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -434,6 +434,7 @@ spec:
       hugepages:
         pageSize: pageSizeValue
       maxGuest: "0"
+    rebootPolicy: rebootPolicyValue
     resources:
       limits:
         limitsKey: "0"

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -1571,6 +1571,11 @@ func (in *DomainSpec) DeepCopyInto(out *DomainSpec) {
 		*out = new(LaunchSecurity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RebootPolicy != nil {
+		in, out := &in.RebootPolicy, &out.RebootPolicy
+		*out = new(RebootPolicy)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -57,6 +57,18 @@ const (
 	Pvpanic PanicDeviceModel = "pvpanic"
 )
 
+// RebootPolicy specifies how the domain should behave when a guest reboot is triggered.
+// +kubebuilder:validation:Enum=Reboot;Terminate
+type RebootPolicy string
+
+const (
+	// RebootPolicyReboot allows the guest to silently reboot without notifying KubeVirt (default behavior).
+	RebootPolicyReboot RebootPolicy = "Reboot"
+	// RebootPolicyTerminate terminates the VMI on guest reboot, allowing the VMI to be recreated
+	// by the controllers (e.g., to pick up new configuration from VM).
+	RebootPolicyTerminate RebootPolicy = "Terminate"
+)
+
 /*
  ATTENTION: Rerun code generators when comments on structs or fields are modified.
 */
@@ -221,6 +233,13 @@ type DomainSpec struct {
 	// Launch Security setting of the vmi.
 	// +optional
 	LaunchSecurity *LaunchSecurity `json:"launchSecurity,omitempty"`
+	// RebootPolicy specifies how the guest should behave on reboot.
+	// Reboot (default): The guest is allowed to reboot silently.
+	// Terminate: The VMI will be terminated on guest reboot, allowing
+	// higher level controllers (such as the VM controller) to recreate
+	// the VMI with any updated configuration such as boot order changes.
+	// +optional
+	RebootPolicy *RebootPolicy `json:"rebootPolicy,omitempty"`
 }
 
 // Chassis specifies the chassis info passed to the domain.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -96,6 +96,7 @@ func (DomainSpec) SwaggerDoc() map[string]string {
 		"ioThreads":       "IOThreads specifies the IOThreads options.\n+optional",
 		"chassis":         "Chassis specifies the chassis info passed to the domain.\n+optional",
 		"launchSecurity":  "Launch Security setting of the vmi.\n+optional",
+		"rebootPolicy":    "RebootPolicy specifies how the guest should behave on reboot.\nReboot (default): The guest is allowed to reboot silently.\nTerminate: The VMI will be terminated on guest reboot, allowing\nhigher level controllers (such as the VM controller) to recreate\nthe VMI with any updated configuration such as boot order changes.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20876,6 +20876,13 @@ func schema_kubevirtio_api_core_v1_DomainSpec(ref common.ReferenceCallback) comm
 							Ref:         ref("kubevirt.io/api/core/v1.LaunchSecurity"),
 						},
 					},
+					"rebootPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RebootPolicy specifies how the guest should behave on reboot. Reboot (default): The guest is allowed to reboot silently. Terminate: The VMI will be terminated on guest reboot, allowing higher level controllers (such as the VM controller) to recreate the VMI with any updated configuration such as boot order changes.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"devices"},
 			},

--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -119,6 +119,82 @@ var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 		Entry("with unresponsive empty-disk VMI", libvmifact.NewGuestless),
 	)
 
+	Context("with reboot policy", func() {
+		It("should recreate VMI on guest reboot with runStrategy Always", decorators.RebootPolicy, func() {
+			By("Creating a VM with runStrategy Always and rebootPolicy Terminate")
+			vm := libvmi.NewVirtualMachine(libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork())),
+				libvmi.WithRebootPolicy(v1.RebootPolicyTerminate),
+				libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			)
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+
+			By("Waiting for VMI to be running")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeRunning())
+
+			By("Waiting for guest agent to be connected")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("Getting the current VMI UID")
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			oldUID := vmi.UID
+
+			By("Triggering a soft reboot via guest agent")
+			err = virtClient.VirtualMachineInstance(vm.Namespace).SoftReboot(context.Background(), vm.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for the VMI to be recreated with a new UID")
+			Eventually(matcher.ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(matcher.BeRestarted(oldUID))
+
+			By("Verifying the new VMI is running")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeRunning())
+		})
+
+		DescribeTable("should not-recreate VMI on guest reboot", decorators.RebootPolicy, func(runStrategy v1.VirtualMachineRunStrategy) {
+			By("Creating a VM with runStrategy " + string(runStrategy) + " and rebootPolicy Terminate")
+			vm := libvmi.NewVirtualMachine(libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork())),
+				libvmi.WithRebootPolicy(v1.RebootPolicyTerminate),
+				libvmi.WithRunStrategy(runStrategy),
+			)
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			if runStrategy == v1.RunStrategyManual {
+				By("Starting the VM")
+				err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+
+			By("Waiting for VMI to be running")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeRunning())
+
+			By("Waiting for guest agent to be connected")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("Triggering a soft reboot via guest agent")
+			err = virtClient.VirtualMachineInstance(vm.Namespace).SoftReboot(context.Background(), vm.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for the VMI to be destroyed on guest reboot")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(120 * time.Second).WithPolling(time.Second).Should(matcher.HaveSucceeded())
+		},
+			Entry("with RunStrategy Once", v1.RunStrategyOnce),
+			Entry("with RunStrategy RerunOnFailure", v1.RunStrategyRerunOnFailure),
+			Entry("with RunStrategy Manual", v1.RunStrategyManual),
+		)
+	})
+
 	Context("with paused vmi", func() {
 		It("[test_id:4598][test_id:3060]should signal paused/unpaused state with condition", decorators.Conformance, func() {
 			vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine(

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -72,6 +72,7 @@ var (
 	GuestAgentProbes                     = Label("guest-agent-probes")
 	Passt                                = Label("passt")
 	ImageVolume                          = Label("ImageVolume")
+	RebootPolicy                         = Label("RebootPolicy")
 
 	/* Storage classes */
 

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -124,6 +124,7 @@ func AdjustKubeVirtResource() {
 		featuregate.VideoConfig,
 		featuregate.UtilityVolumesGate,
 		featuregate.MigrationPriorityQueue,
+		featuregate.RebootPolicy,
 	)
 	kv.Spec.Configuration.ChangedBlockTrackingLabelSelectors = &v1.ChangedBlockTrackingSelectors{
 		VirtualMachineLabelSelector: &metav1.LabelSelector{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This introduces a new VMI.spec.domain.rebootPolicy toggle to control the behavior on guest initiated reboot.

#### Before this PR:

Nothing happens visibly, qemu reboots internally and the VMI stays up.

#### After this PR:

As per VEP 0171 the VMI terminates on guest reboot when rebootPolicy is set to Terminate.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/171

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A VMI.spec.domain.rebootPolicy field can be used to control the method the domain uses to handle reboots originating from inside the VM. Either the hypervisor processes the reboot silently behind the scenes (default) or the user can opt-in to a more visible behavior, where the hypervisor terminates the domain and lets kubevirt to handle the restart according to the runStrategy rules.
```

