### PR TITLE
Align VMBackupTracker CRD rbacs to be the same as VMBackup CRD

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1043,6 +1043,7 @@ spec:
           - backup.kubevirt.io
           resources:
           - virtualmachinebackups
+          - virtualmachinebackuptrackers
           verbs:
           - get
           - delete
@@ -1052,18 +1053,6 @@ spec:
           - list
           - watch
           - deletecollection
-        - apiGroups:
-          - backup.kubevirt.io
-          resources:
-          - virtualmachinebackuptrackers
-          - virtualmachinebackuptrackers/status
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
         - apiGroups:
           - export.kubevirt.io
           resources:
@@ -1226,6 +1215,7 @@ spec:
           - backup.kubevirt.io
           resources:
           - virtualmachinebackups
+          - virtualmachinebackuptrackers
           verbs:
           - get
           - delete
@@ -1352,6 +1342,7 @@ spec:
           - backup.kubevirt.io
           resources:
           - virtualmachinebackups
+          - virtualmachinebackuptrackers
           verbs:
           - get
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -1071,6 +1071,7 @@ rules:
   - backup.kubevirt.io
   resources:
   - virtualmachinebackups
+  - virtualmachinebackuptrackers
   verbs:
   - get
   - delete
@@ -1080,18 +1081,6 @@ rules:
   - list
   - watch
   - deletecollection
-- apiGroups:
-  - backup.kubevirt.io
-  resources:
-  - virtualmachinebackuptrackers
-  - virtualmachinebackuptrackers/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
 - apiGroups:
   - export.kubevirt.io
   resources:
@@ -1254,6 +1243,7 @@ rules:
   - backup.kubevirt.io
   resources:
   - virtualmachinebackups
+  - virtualmachinebackuptrackers
   verbs:
   - get
   - delete
@@ -1380,6 +1370,7 @@ rules:
   - backup.kubevirt.io
   resources:
   - virtualmachinebackups
+  - virtualmachinebackuptrackers
   verbs:
   - get
   - list

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -322,21 +322,10 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					apiVMBackups,
+					apiVMBackupTrackers,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
-				},
-			},
-			{
-				APIGroups: []string{
-					backup.GroupName,
-				},
-				Resources: []string{
-					apiVMBackupTrackers,
-					apiVMBackupTrackers + "/status",
-				},
-				Verbs: []string{
-					"get", "list", "watch", "create", "update", "patch",
 				},
 			},
 			{
@@ -542,6 +531,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					apiVMBackups,
+					apiVMBackupTrackers,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch",
@@ -747,6 +737,7 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					apiVMBackups,
+					apiVMBackupTrackers,
 				},
 				Verbs: []string{
 					"get", "list", "watch",


### PR DESCRIPTION
Make sure no missing permissions for vmbackuptracker CRD

jira-ticket: https://issues.redhat.com/browse/CNV-76369

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

