### PR TITLE
go.work: Add replace rule to avoid checksum errors by k8s.io indirects

### DIFF
--- a/go.work
+++ b/go.work
@@ -53,3 +53,6 @@ replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.2
 replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.2
 
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b
+
+// TODO: remove once the project upgrade k8s dependencies to v0.35 and go 1.25
+replace github.com/envoyproxy/go-control-plane/envoy => github.com/envoyproxy/go-control-plane/envoy v1.32.4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1380,6 +1380,7 @@ sigs.k8s.io/yaml
 # k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.2
 # k8s.io/sample-controller => k8s.io/sample-controller v0.34.2
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b
+# github.com/envoyproxy/go-control-plane/envoy => github.com/envoyproxy/go-control-plane/envoy v1.32.4
 # github.com/nxadm/tail => github.com/nxadm/tail v0.0.0-20211216163028-4472660a31a6
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
GoLand the IDE fails to index the project due to the following error:
```
verifying github.com/envoyproxy/go-control-plane/envoy@v1.32.3/go.mod: checksum mismatch
	downloaded: h1:c955gQjaXHsMxMjHjEZ7nwIzMJYxXpN+sJIGufsSbg4=
	/home/omergi/workspace/github.com/kubevirt/go.sum:     h1:F6hWupPfh75TBXGKA++MCT/CZHFq5r9/uwt/kQYkZfE=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.
```

According to 'go mod graph' the mentioned module is used indirectly by various 'k8s.io' modules, for example:
```
  k8s.io/apiextensions-apiserver@v0.34.2 google.golang.org/grpc@v1.72.1
  ...
  k8s.io/apiserver@v0.34.2 google.golang.org/grpc@v1.72.1
  ...
  google.golang.org/grpc@v1.72.1 github.com/envoyproxy/go-control-plane@v0.13.4
  github.com/envoyproxy/go-control-plane@v0.13.4 github.com/envoyproxy/go-control-plane/envoy@v1.32.3
  github.com/envoyproxy/go-control-plane/envoy@v1.32.3
```

Upgrading 'k8s.io' stack to newer patch version doesn't solve the issue. Upgrading 'k8s.io' stack to newer minor version require upgrading the project Go version, both has significant impact on the project.

To unblock working with GoLand IDE for the shot term, add replace rule to ensure the mentioned module version is not used.

Once the project use 'k8s.io' stack v0.35 and go1.25 the change can be removed.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

