### PR TITLE
Promote VideoConfig feature gate from Beta to GA

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -234,7 +234,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validatePersistentReservation(field, spec, config)...)
 	causes = append(causes, validateDownwardMetrics(field, spec, config)...)
 	causes = append(causes, validateFilesystemsWithVirtIOFSEnabled(field, spec, config)...)
-	causes = append(causes, validateVideoConfig(field, spec, config)...)
+	causes = append(causes, validateVideoConfig(field, spec)...)
 	causes = append(causes, validatePanicDevices(field, spec, config)...)
 	causes = append(causes, validateRebootPolicy(field, spec, config)...)
 	causes = append(causes, validateReservedOverheadMemlock(field, spec, config)...)
@@ -2049,19 +2049,10 @@ func validateCPUHotplug(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpe
 	return causes
 }
 
-func validateVideoConfig(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+func validateVideoConfig(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	if spec.Domain.Devices.Video == nil {
-		return causes
-	}
-
-	if !config.VideoConfigEnabled() {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Video configuration is specified but the %s feature gate is not enabled", featuregate.VideoConfig),
-			Field:   field.Child("video").String(),
-		})
 		return causes
 	}
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3761,24 +3761,12 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	Context("with VideoConfig", func() {
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
-			enableFeatureGates(featuregate.VideoConfig)
 			vmi = libvmi.New(libvmi.WithArchitecture(runtime.GOARCH), libvmi.WithVideo(v1.VirtIO))
 		})
 
-		It("should accept video configuration with feature gate enabled", func() {
+		It("should accept video configuration", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty(), "should accept video configuration with valid setup")
-		})
-
-		It("should reject when the feature gate is disabled", func() {
-			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.VideoConfig}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(causes[0].Message).To(Equal(fmt.Sprintf("Video configuration is specified but the %s feature gate is not enabled", featuregate.VideoConfig)))
-			Expect(causes[0].Field).To(Equal("fake.video"))
 		})
 
 		It("should reject when autoattachGraphicsDevice is set to false", func() {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -131,10 +131,6 @@ func (config *ClusterConfig) LibvirtHooksServerAndClientEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.LibvirtHooksServerAndClient)
 }
 
-func (config *ClusterConfig) VideoConfigEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.VideoConfig)
-}
-
 func (config *ClusterConfig) NodeRestrictionEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.NodeRestrictionGate)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -131,14 +131,6 @@ const (
 	// SecureExecution introduces secure execution of VMs on IBM Z architecture
 	SecureExecution = "SecureExecution"
 
-	// VideoConfig enables VM owners to specify a video device type (e.g., virtio, vga, bochs, ramfb) via the `Video` field, overriding default settings.
-	// Requires `autoattachGraphicsDevice` to be true or unset. Alpha feature, defaults unchanged.
-	// Owner: @dasionov
-	// Alpha: v1.6.0
-	// Beta: v1.7.0
-	//
-	VideoConfig = "VideoConfig"
-
 	// Beta: v1.8.0
 	//
 	// PasstBinding enables the use of passt core network binding
@@ -257,7 +249,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: DeclarativeHotplugVolumesGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ObjectGraph, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: Beta})
-	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: UtilityVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: ConfigurableHypervisor, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PasstBinding, State: Beta})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -121,6 +121,14 @@ const (
 	// GA: v1.8.0
 	VirtIOFSConfigVolumesGate = "EnableVirtioFsConfigVolumes"
 
+	// VideoConfig enables VM owners to specify a video device type (e.g., virtio, vga, bochs, ramfb) via the `Video` field, overriding default settings.
+	// Requires `autoattachGraphicsDevice` to be true or unset.
+	// Owner: @dasionov
+	// Alpha: v1.6.0
+	// Beta: v1.7.0
+	// GA: v1.9.0
+	VideoConfig = "VideoConfig"
+
 	// Owner: sig-compute
 	// Alpha: v1.0.0
 	// Deprecated: v1.8.0
@@ -203,5 +211,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: PanicDevicesGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: LiveUpdateNADRef, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: HotplugVolumesGate, State: Deprecated, Message: "HotplugVolumes has been deprecated since v1.9.0 and has been replaced by DeclarativeHotplugVolumes"})
-
+	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: GA})
 }


### PR DESCRIPTION
### What this PR does
Graduate the VideoConfig feature gate to General Availability (GA). The feature allows VM owners to specify a video device type (e.g., virtio, vga, bochs, ramfb) via the Video field.

#### Before this PR:
- `VideoConfig` feature gate must be explicitly enabled to use the `spec.domain.devices.video` field
- Rejected with admission error if feature gate is not enabled

#### After this PR:
- `VideoConfig` is always enabled (GA) — no feature gate configuration needed
- Users can specify video device types (`virtio`, `vga`, `bochs`, `ramfb`, `cirrus`) directly

### References

closes: https://github.com/kubevirt/enhancements/issues/35

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

### Release note
```release-note
Promote `VideoConfig` FG to General Availability
```

