### PR TITLE
add /dev/vhost-vsock to device rule in cgroup util used by hotpluggable disk

### DIFF
--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -47,6 +47,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/safepath"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
 
@@ -174,6 +175,18 @@ func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, isolationRes isol
 			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
 		} else if deviceRule != nil {
 			log.Log.V(loggingVerbosity).Infof("device rule for volume rng: %v", deviceRule)
+			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
+		}
+	}
+	if util.IsAutoAttachVSOCK(vmi) {
+		path, err := safepath.JoinNoFollow(mountRoot, "/dev/vhost-vsock")
+		if err != nil {
+			return nil, err
+		}
+		if deviceRule, err := newAllowedDeviceRule(path); err != nil {
+			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
+		} else if deviceRule != nil {
+			log.Log.V(loggingVerbosity).Infof("device rule for volume vsock: %v", deviceRule)
 			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
We (in Microsoft) are actively using a VSOCK and hotpluggable disk. Both were working fine in Kubevirt 1.5. However, after we upgrade it to Kubevirt 1.6, virt-launcher is in NotReady state with this error message:

```
{"component":"virt-launcher","level":"error","msg":"unsupported configuration: unable to open vhost-vsock device","pos":"qemuProcessOpenVhostVsock:6915","subcomponent":"libvirt","thread":"35","timestamp":"2026-01-16T17:15:56.812000Z"}
```

It does not happen when we only enable autoattachVSOCK:true or hotpluggable:true in volumes. This is only happening when we set `autoattachVSOCK:true` and `hotpluggable:true` in volumes at the same time under Kubevirt 1.6+ (1.7 and 1.8alpha as well).

#### After this PR:
With this PR, we can set both autoattachVSOCK:true and hotpluggable:true in volumes. virt-launcher is now in running state although both were set to true at the same time.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made: N/A

The following alternatives were considered: Currently, we put this logic to [generateDeviceRulesForVMI](https://github.com/kubevirt/kubevirt/blob/v1.6.3/pkg/virt-handler/cgroup/util.go#L112) function considering the VMI manifests. However, we can set it to [GenerateDefaultDeviceRules](https://github.com/kubevirt/kubevirt/blob/v1.6.3/pkg/virt-handler/cgroup/util.go#L187) function to /dev/vhost-vsock registered by default when mounting hotplug volume under Kubevirt 1.6+

Links to places where the discussion took place: This is initial report.

<!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This is observed from 1.6. So, can we also cherrypick this patch to 1.6, 1.7, and 1.8 too?
Thanks!

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix block volume hotplug breaking autoattachVSOCK
```

