### PR TITLE
fix: update bump-distroless.sh script to get digest of correct base image

### DIFF
--- a/hack/bump-distroless.sh
+++ b/hack/bump-distroless.sh
@@ -6,9 +6,9 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-DISTROLESS_AMD64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-amd64 | jq '.Digest' -r)
-DISTROLESS_ARM64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-arm64 | jq '.Digest' -r)
-DISTROLESS_S390X_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-s390x | jq '.Digest' -r)
+DISTROLESS_AMD64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base-debian12:latest-amd64 | jq '.Digest' -r)
+DISTROLESS_ARM64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base-debian12:latest-arm64 | jq '.Digest' -r)
+DISTROLESS_S390X_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base-debian12:latest-s390x | jq '.Digest' -r)
 
 # buildozer returns a non-zero exit code (3) if the commands were a success but did not change the file.
 # To make the command idempotent, first set the digest to a kind-of-unique number to work around this behaviour.


### PR DESCRIPTION
### What this PR does

The base image used is gcr.io/distroless/base-debian12[1] - update the bump script to ensure that the right digest is pulled and bumped.

[1] https://github.com/brianmcarey/kubevirt/blob/f97902d496ff1e9e8a6a06b56ee8af993d82352b/WORKSPACE#L346

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

