### PR TITLE
Graduate ExpandDisk Feature Gate

### DIFF
--- a/docs/disk-expansion.md
+++ b/docs/disk-expansion.md
@@ -2,18 +2,8 @@
 
 For some storage methods, Kubernetes may support expanding storage in-use (allowVolumeExpansion feature).
 KubeVirt can respond to it by making the additional storage available for the virtual machines.
-This feature is currently off by default, and requires enabling a feature gate.
-To enable it, add the ExpandDisks feature gate in the kubevirt object:
+This feature is currently on by default.
 
-kubectl edit kubevirt -n kubevirt kubevirt
-```yaml
-spec:
-  configuration:
-    developerConfiguration:
-      featureGates:
-      - ExpandDisks
-```
-
-Enabling this feature does two things:
+This feature does two things:
 - Notify the virtual machine about size changes
 - If the disk is a Filesystem PVC, the matching file is expanded to the remaining size (while reserving some space for file system overhead).

--- a/pkg/handler-launcher-com/cmd/v1/cmd.pb.go
+++ b/pkg/handler-launcher-com/cmd/v1/cmd.pb.go
@@ -367,6 +367,7 @@ func (m *DiskInfo) GetVirtualSize() uint64 {
 }
 
 type ClusterConfig struct {
+	// Deprecated
 	ExpandDisksEnabled        bool `protobuf:"varint,1,opt,name=ExpandDisksEnabled" json:"ExpandDisksEnabled,omitempty"`
 	FreePageReportingDisabled bool `protobuf:"varint,2,opt,name=FreePageReportingDisabled" json:"FreePageReportingDisabled,omitempty"`
 	BochsDisplayForEFIGuests  bool `protobuf:"varint,3,opt,name=BochsDisplayForEFIGuests" json:"BochsDisplayForEFIGuests,omitempty"`

--- a/pkg/handler-launcher-com/cmd/v1/cmd.proto
+++ b/pkg/handler-launcher-com/cmd/v1/cmd.proto
@@ -98,6 +98,7 @@ message DiskInfo {
 }
 
 message ClusterConfig{
+  // Deprecated
   bool ExpandDisksEnabled = 1;
   bool FreePageReportingDisabled = 2;
   bool BochsDisplayForEFIGuests = 3;

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -202,7 +202,6 @@ func fuzzKubeVirtConfig(seed int64) *virtconfig.ClusterConfig {
 		func(dc *v1.DeveloperConfiguration, c randfill.Continue) {
 			c.FillNoCustom(dc)
 			featureGates := []string{
-				featuregate.ExpandDisksGate,
 				featuregate.CPUManager,
 				featuregate.NUMAFeatureGate,
 				featuregate.IgnitionGate,

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -45,10 +45,6 @@ func (config *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
 	return false
 }
 
-func (config *ClusterConfig) ExpandDisksEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.ExpandDisksGate)
-}
-
 func (config *ClusterConfig) CPUManagerEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.CPUManager)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -20,7 +20,6 @@
 package featuregate
 
 const (
-	ExpandDisksGate       = "ExpandDisks"
 	CPUManager            = "CPUManager"
 	IgnitionGate          = "ExperimentalIgnitionSupport"
 	HypervStrictCheckGate = "HypervStrictCheck"
@@ -152,7 +151,6 @@ const (
 
 func init() {
 	RegisterFeatureGate(FeatureGate{Name: ImageVolume, State: Beta})
-	RegisterFeatureGate(FeatureGate{Name: ExpandDisksGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CPUManager, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IgnitionGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: HypervStrictCheckGate, State: Alpha})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -120,6 +120,13 @@ const (
 	// DisableMediatedDevicesHandling disables the handling of mediated
 	// devices, its creation and deletion
 	DisableMediatedDevicesHandling = "DisableMDEVConfiguration"
+
+	// Owner: sig-storage
+	// Alpha: v0.48.0
+	// GA: v1.8.0
+	//
+	// ExpandDisksGate allows for expanding the storage available for in-use virtual machines.
+	ExpandDisksGate = "ExpandDisks"
 )
 
 func init() {
@@ -154,4 +161,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MultiArchitecture, State: Deprecated, Message: "MultiArchitecture has been deprecated since v1.8.0"})
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSConfigVolumesGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: DisableMediatedDevicesHandling, State: Deprecated, Message: "DisableMDEVConfiguration has been deprecated since v1.8.0"})
+	RegisterFeatureGate(FeatureGate{Name: ExpandDisksGate, State: GA})
 }

--- a/pkg/virt-handler/options.go
+++ b/pkg/virt-handler/options.go
@@ -60,9 +60,7 @@ func virtualMachineOptions(
 		if clusterConfig.VGADisplayForEFIGuestsEnabled() {
 			bochsDisplay = false
 		}
-		options.ExpandDisksEnabled = clusterConfig.ExpandDisksEnabled()
 		options.ClusterConfig = &cmdv1.ClusterConfig{
-			ExpandDisksEnabled:        clusterConfig.ExpandDisksEnabled(),
 			FreePageReportingDisabled: clusterConfig.IsFreePageReportingDisabled(),
 			BochsDisplayForEFIGuests:  bochsDisplay,
 			SerialConsoleLogDisabled:  clusterConfig.IsSerialConsoleLogDisabled(),

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -743,7 +743,6 @@ type Disk struct {
 	BlockIO            *BlockIO      `xml:"blockio,omitempty"`
 	FilesystemOverhead *v1.Percent   `xml:"filesystemOverhead,omitempty"`
 	Capacity           *int64        `xml:"capacity,omitempty"`
-	ExpandDisksEnabled bool          `xml:"expandDisksEnabled,omitempty"`
 	Shareable          *Shareable    `xml:"shareable,omitempty"`
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -107,7 +107,6 @@ type ConverterContext struct {
 	EphemeraldiskCreator            ephemeraldisk.EphemeralDiskCreatorInterface
 	VolumesDiscardIgnore            []string
 	Topology                        *cmdv1.Topology
-	ExpandDisksEnabled              bool
 	UseLaunchSecuritySEV            bool // For AMD SEV/ES/SNP
 	UseLaunchSecurityTDX            bool // For Intel TDX
 	UseLaunchSecurityPV             bool // For IBM SE(s390-pv)
@@ -200,7 +199,6 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 		if ok && volumeStatus.PersistentVolumeClaimInfo != nil {
 			disk.FilesystemOverhead = volumeStatus.PersistentVolumeClaimInfo.FilesystemOverhead
 			disk.Capacity = storagetypes.GetDiskCapacity(volumeStatus.PersistentVolumeClaimInfo)
-			disk.ExpandDisksEnabled = c.ExpandDisksEnabled
 		}
 	}
 	if numQueues != nil && disk.Target.Bus == v1.DiskBusVirtio {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -927,9 +927,6 @@ func getUsableDiskSize(path string) (int64, error) {
 }
 
 func shouldExpandOffline(disk api.Disk) bool {
-	if !disk.ExpandDisksEnabled {
-		return false
-	}
 	if disk.Source.Dev != "" {
 		// Block devices don't need to be expanded
 		return false
@@ -1060,7 +1057,6 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	}
 
 	if options != nil {
-		c.ExpandDisksEnabled = options.ExpandDisksEnabled
 		if options.VirtualMachineSMBios != nil {
 			c.SMBios = options.VirtualMachineSMBios
 		}
@@ -1072,7 +1068,6 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		c.VolumesDiscardIgnore = options.PreallocatedVolumes
 
 		if options.GetClusterConfig() != nil {
-			c.ExpandDisksEnabled = options.GetClusterConfig().GetExpandDisksEnabled()
 			c.FreePageReporting = isFreePageReportingEnabled(options.GetClusterConfig().GetFreePageReportingDisabled(), vmi)
 			c.BochsForEFIGuests = options.GetClusterConfig().GetBochsDisplayForEFIGuests()
 			c.SerialConsoleLog = isSerialConsoleLogEnabled(options.GetClusterConfig().GetSerialConsoleLogDisabled(), vmi)
@@ -1593,10 +1588,6 @@ func isBlockDeviceVolumeFunc(volumeName string) (bool, error) {
 }
 
 func shouldExpandOnline(dom cli.VirDomain, disk api.Disk) bool {
-	if !disk.ExpandDisksEnabled {
-		log.DefaultLogger().V(3).Infof("Not expanding disks, ExpandDisks featuregate disabled")
-		return false
-	}
 	blockInfo, err := dom.GetBlockInfo(getSourceFile(disk), 0)
 	if err != nil {
 		log.DefaultLogger().Reason(err).Error("Failed to get block info")

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -56,13 +56,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/os/disk"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libstorage"
@@ -125,7 +123,6 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 
 	Context("[storage-req]PVC expansion", decorators.StorageReq, decorators.RequiresVolumeExpansion, func() {
 		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
-			checks.FailTestIfNoFeatureGate(featuregate.ExpandDisksGate)
 			var sc string
 			exists := false
 			if volumeMode == k8sv1.PersistentVolumeBlock {
@@ -209,7 +206,6 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 		)
 
 		It("Check disk expansion accounts for actual usable size", func() {
-			checks.FailTestIfNoFeatureGate(featuregate.ExpandDisksGate)
 
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -112,7 +112,6 @@ func AdjustKubeVirtResource() {
 		featuregate.HostDiskGate,
 		featuregate.VirtIOFSStorageVolumeGate,
 		featuregate.DownwardMetricsFeatureGate,
-		featuregate.ExpandDisksGate,
 		featuregate.WorkloadEncryptionSEV,
 		featuregate.VMExportGate,
 		featuregate.KubevirtSeccompProfile,

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -52,7 +52,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	hw_utils "kubevirt.io/kubevirt/pkg/util/hardware"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -2325,7 +2324,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			if testingPciFunctions {
 				assignDisksToFunctions(startIndex, vmi)
 			} else {
-				kvconfig.DisableFeatureGate(featuregate.ExpandDisksGate)
 				assignDisksToSlots(startIndex, vmi)
 			}
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})


### PR DESCRIPTION
This is apart of an ongoing effort to graduate stable features from the list of feature gates. https://issues.redhat.com/browse/CNV-46952

Graduates the `ExpandDisk` feature gate to GA and removes the associated checks on said FG.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Graduate ExpandDisk Feature Gate
```

