### PR TITLE
virt-controller/watch/vm: Clear RestartRequired when no restart is needed

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -2962,8 +2962,8 @@ func setRestartRequired(vm *virtv1.VirtualMachine, message string) {
 	})
 }
 
-// addRestartRequiredIfNeeded adds the restartRequired condition to the VM if any non-live-updatable field was changed
-func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+// syncRestartRequired adds or removes the RestartRequired condition from the VM based on whether any non-live-updatable field was changed
+func (c *Controller) syncRestartRequired(lastSeenVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
 	if lastSeenVMSpec == nil {
 		return false
 	}
@@ -3027,6 +3027,14 @@ func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMa
 	if !equality.Semantic.DeepEqual(lastSeenVM.Spec.Template.Spec, currentVM.Spec.Template.Spec) {
 		setRestartRequired(vm, "a non-live-updatable field was changed in the template spec")
 		return true
+	}
+
+	// If no restart is needed, remove any existing RestartRequired condition.
+	// This handles cases where a previous condition was set but is no longer valid,
+	// such as when the firmware UUID synchronizer persisted a UUID that matches the VMI's UUID.
+	vmConditionManager := controller.NewVirtualMachineConditionManager()
+	if vmConditionManager.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
+		vmConditionManager.RemoveCondition(vm, virtv1.VirtualMachineRestartRequired)
 	}
 
 	return false
@@ -3193,7 +3201,7 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 		return vm, vmi, syncErr, nil
 	}
 
-	restartRequired := c.addRestartRequiredIfNeeded(startVMSpec, vm, vmi)
+	restartRequired := c.syncRestartRequired(startVMSpec, vm, vmi)
 
 	// Must check satisfiedExpectations again here because a VMI can be created or
 	// deleted in the startStop function which impacts how we process


### PR DESCRIPTION
### What this PR does

Clears the `RestartRequired` condition when `addRestartRequiredIfNeeded` determines that specs match (after neutralizing live-updatable fields).

also rename `addRestartRequiredIfNeeded` -> `syncRestartRequired`

### Background

The firmware UUID synchronizer automatically persists the firmware UUID to VMs that didn't have one specified. Since firmware UUID is a non-live-updatable field, this change triggered the `RestartRequired` condition.

A fix was added to neutralize the firmware UUID comparison when the VMI's UUID matches the VM's UUID This prevents **setting** the condition on new sync cycles.

### The Problem

The `RestartRequired` condition is only cleared in two places:
1. `startVMI` - when a new VMI is created (i.e., VM restart)
2. When VMI is stopped/deleted

For VMs that already had the `RestartRequired` condition raised **before** the neutralization fix was deployed, the condition remains indefinitely because:
- The neutralization only prevents setting **new** conditions
- Existing conditions are never cleared while the VM keeps running

This blocks hotplug operations for CPU, memory, and volumes.

### The Fix

After `addRestartRequiredIfNeeded` determines no restart is needed (returns `false`), we now also remove any existing `RestartRequired` condition.

fixes https://github.com/kubevirt/kubevirt/pull/16719

### Release note
```release-note
none
```

