### PR TITLE
[virt-operator]: respect Go reference semantics in NewEnvVarMap

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -3395,7 +3395,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// TODO: Refactor
 			envVars := util.NewEnvVarMap(config.GetExtraEnv())
 			envVarManager := util.DefaultEnvVarManager
-			for _, envVar := range *envVars {
+			for _, envVar := range envVars {
 				envVarManager.Setenv(envVar.Name, envVar.Value)
 			}
 			deploymentConfigJson, err := config.GetJson()

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -153,7 +153,7 @@ func NewExportProxyService(namespace string) *corev1.Service {
 	}
 }
 
-func newPodTemplateSpec(podName, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) *corev1.PodTemplateSpec {
+func newPodTemplateSpec(podName, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars []corev1.EnvVar) *corev1.PodTemplateSpec {
 	podTemplateSpec := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -194,8 +194,8 @@ func newPodTemplateSpec(podName, productName, productVersion, productComponent, 
 		podTemplateSpec.ObjectMeta.Labels[virtv1.AppComponentLabel] = productComponent
 	}
 
-	if envVars != nil && len(*envVars) != 0 {
-		podTemplateSpec.Spec.Containers[0].Env = *envVars
+	if len(envVars) != 0 {
+		podTemplateSpec.Spec.Containers[0].Env = envVars
 	}
 
 	return podTemplateSpec
@@ -239,7 +239,7 @@ func attachCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath 
 	spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, secretVolumeMount)
 }
 
-func newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) *appsv1.Deployment {
+func newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, imagePullSecrets []corev1.LocalObjectReference, podAffinity *corev1.Affinity, envVars []corev1.EnvVar) *appsv1.Deployment {
 	if image == "" {
 		image = fmt.Sprintf("%s/%s%s", repository, imageName, AddVersionSeparatorPrefix(version))
 	}
@@ -738,7 +738,7 @@ func NewSynchronizationControllerDeployment(config *operatorutil.KubeVirtDeploym
 	imageName := fmt.Sprintf("%s%s", config.GetImagePrefix(), deploymentName)
 
 	env := operatorutil.NewEnvVarMap(config.GetExtraEnv())
-	*env = append(*env, corev1.EnvVar{
+	env = append(env, corev1.EnvVar{
 		Name: "MY_POD_IP",
 		ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -322,7 +322,7 @@ var _ = Describe("Install Strategy", func() {
 		// Mimic generateInstallStrategyJob
 		// TODO: Refactor
 		envVars := util.NewEnvVarMap(config.GetExtraEnv())
-		for _, envVar := range *envVars {
+		for _, envVar := range envVars {
 			envVarManager.Setenv(envVar.Name, envVar.Value)
 		}
 		deploymentConfigJson, err := config.GetJson()

--- a/pkg/virt-operator/strategy_job.go
+++ b/pkg/virt-operator/strategy_job.go
@@ -113,7 +113,7 @@ func (c *KubeVirtController) generateInstallStrategyJob(infraPlacement *v1.Compo
 	placement.InjectPlacementMetadata(infraPlacement, &job.Spec.Template.Spec, placement.RequireControlPlanePreferNonWorker)
 	env := job.Spec.Template.Spec.Containers[0].Env
 	extraEnv := util.NewEnvVarMap(config.GetExtraEnv())
-	job.Spec.Template.Spec.Containers[0].Env = append(env, *extraEnv...)
+	job.Spec.Template.Spec.Containers[0].Env = append(env, extraEnv...)
 
 	return job, nil
 }

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -636,14 +636,14 @@ func (c *KubeVirtDeploymentConfig) GetJson() (string, error) {
 	return string(json), nil
 }
 
-func NewEnvVarMap(envMap map[string]string) *[]k8sv1.EnvVar {
+func NewEnvVarMap(envMap map[string]string) []k8sv1.EnvVar {
 	env := []k8sv1.EnvVar{}
 
 	for k, v := range envMap {
 		env = append(env, k8sv1.EnvVar{Name: k, Value: v})
 	}
 
-	return &env
+	return env
 }
 
 func IsValidLabel(label string) bool {

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Operator Config", func() {
 				{Name: key2, Value: val2},
 			}
 
-			Expect(*envObjects).To(ConsistOf(expected))
+			Expect(envObjects).To(ConsistOf(expected))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>
Assisted-By: Claude <noreply@anthropic.com>

### What this PR does

Change NewEnvVarMap to return []k8sv1.EnvVar instead of *[]k8sv1.EnvVar. 
Returning a pointer to a slice is not idiomatic Go since slices are already reference types with pointer semantics.

 This change also updates:
 * Function signatures that accept the env var slice parameter
 * All call sites to work with the slice directly
 * Unit tests to match the new signature


#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

