### PR TITLE
vmsnapshot: report volumes being deleted

### DIFF
--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -59,6 +59,7 @@ var (
 	ErrVolumeDoesntExist  = errors.New("volume doesnt exist")
 	ErrVolumeNotBound     = errors.New("volume not bound")
 	ErrVolumeNotPopulated = errors.New("volume not populated")
+	ErrVolumeBeingDeleted = errors.New("volume is being deleted")
 )
 
 type snapshotSource interface {
@@ -157,7 +158,7 @@ func (s *vmSnapshotSource) Lock() (bool, error) {
 	err = s.verifyVolumes(pvcNames.List())
 	if err != nil {
 		switch errors.Unwrap(err) {
-		case ErrVolumeDoesntExist, ErrVolumeNotBound, ErrVolumeNotPopulated:
+		case ErrVolumeDoesntExist, ErrVolumeNotBound, ErrVolumeNotPopulated, ErrVolumeBeingDeleted:
 			s.state.lockMsg += fmt.Sprintf(" source %s/%s %s", s.vm.Namespace, s.vm.Name, err.Error())
 			log.Log.Error(s.state.lockMsg)
 			return false, nil
@@ -259,6 +260,9 @@ func (s *vmSnapshotSource) verifyVolumes(pvcNames []string) error {
 		}
 
 		pvc := obj.(*corev1.PersistentVolumeClaim).DeepCopy()
+		if pvc.DeletionTimestamp != nil {
+			return fmt.Errorf("%w: %s", ErrVolumeBeingDeleted, pvcName)
+		}
 		if pvc.Status.Phase != corev1.ClaimBound {
 			return fmt.Errorf("%w: %s", ErrVolumeNotBound, pvcName)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
CDI 1.64 included https://github.com/kubevirt/containerized-data-importer/pull/3912
which will make us report the volume is merely "not populated", when in fact,
it is being deleted and it is pointless to progress further to snapshotting.

Report volumes being deleted and circumvent the entire thing,
alongside a conversion of the corresponding e2e test to a unit test.
This is because the new permutation alongside https://github.com/kubevirt/kubevirt/blob/5322c71a87ee41bd01a611d269645d3035da9f02/pkg/storage/snapshot/snapshot_test.go#L1216 is now fully covering all.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: vmsnapshot: report volumes being deleted
```

