### PR TITLE
Fix ServiceMonitor disabled during KubeVirt upgrades

### DIFF
--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	secv1 "github.com/openshift/api/security/v1"
@@ -337,18 +338,55 @@ func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, 
 }
 
 func getMonitorNamespace(clientset k8coresv1.CoreV1Interface, potentionalMonitorNamespaces []string, monitorServiceAccount string) (namespace string, err error) {
-	for _, ns := range potentionalMonitorNamespaces {
-		if nsExists, err := isNamespaceExist(clientset, ns); nsExists {
-			// the monitoring service account must be in the monitoring namespace otherwise
-			// we won't be able to create roleBinding for prometheus operator pods
-			if saExists, err := isServiceAccountExist(clientset, ns, monitorServiceAccount); saExists {
-				return ns, nil
-			} else if err != nil {
-				return "", err
-			}
-		} else if err != nil {
-			return "", err
+	// Use retry logic with reasonable defaults to handle race conditions during upgrades
+	return getMonitorNamespaceWithRetry(clientset, potentionalMonitorNamespaces, monitorServiceAccount, 3, 1*time.Second)
+}
+
+// getMonitorNamespaceWithRetry attempts to find the monitoring namespace with retry logic
+// to handle race conditions during upgrades when ServiceAccounts might be temporarily unavailable
+func getMonitorNamespaceWithRetry(clientset k8coresv1.CoreV1Interface, potentionalMonitorNamespaces []string, monitorServiceAccount string, maxRetries int, initialBackoff time.Duration) (namespace string, err error) {
+	backoff := initialBackoff
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			log.Log.Infof("Retry attempt %d/%d to find monitoring ServiceAccount %s, waiting %v", attempt, maxRetries, monitorServiceAccount, backoff)
+			time.Sleep(backoff)
+			backoff *= 2 // Exponential backoff
 		}
+
+		for _, ns := range potentionalMonitorNamespaces {
+			nsExists, err := isNamespaceExist(clientset, ns)
+			if err != nil && !errors.IsNotFound(err) {
+				// Non-NotFound errors should be returned immediately
+				return "", fmt.Errorf("error checking if namespace %s exists: %v", ns, err)
+			}
+
+			if nsExists {
+				// the monitoring service account must be in the monitoring namespace otherwise
+				// we won't be able to create roleBinding for prometheus operator pods
+				saExists, err := isServiceAccountExist(clientset, ns, monitorServiceAccount)
+				if err != nil && !errors.IsNotFound(err) {
+					// Non-NotFound errors should be returned immediately
+					return "", fmt.Errorf("error checking if ServiceAccount %s exists in namespace %s: %v", monitorServiceAccount, ns, err)
+				}
+
+				if saExists {
+					if attempt > 0 {
+						log.Log.Infof("Successfully found monitoring ServiceAccount %s in namespace %s after %d attempts", monitorServiceAccount, ns, attempt)
+					}
+					return ns, nil
+				}
+
+				lastErr = fmt.Errorf("ServiceAccount %s not found in namespace %s", monitorServiceAccount, ns)
+			}
+		}
+	}
+
+	// All retries exhausted
+	if lastErr != nil {
+		log.Log.Warningf("Failed to find monitoring ServiceAccount %s after %d attempts in namespaces %v: %v", 
+			monitorServiceAccount, maxRetries+1, potentionalMonitorNamespaces, lastErr)
 	}
 	return "", nil
 }
@@ -504,12 +542,27 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	rbaclist = append(rbaclist, rbac.GetAllSynchronizationController(config.GetNamespace())...)
 
 	monitorServiceAccount := config.GetMonitorServiceAccountName()
+	// Check if ServiceMonitorNamespace is explicitly configured in KubeVirt CR
+	// This takes precedence to ensure monitoring isn't accidentally disabled during upgrades
+	explicitServiceMonitorNs := config.GetServiceMonitorNamespace()
 	isServiceAccountFound := monitorNamespace != ""
-
-	if isServiceAccountFound {
-		serviceMonitorNamespace := config.GetServiceMonitorNamespace()
+	
+	// If ServiceMonitorNamespace is explicitly configured, always create monitoring resources
+	// even if we couldn't verify the ServiceAccount (it might be a temporary timing issue)
+	if explicitServiceMonitorNs != "" || isServiceAccountFound {
+		serviceMonitorNamespace := explicitServiceMonitorNs
 		if serviceMonitorNamespace == "" {
 			serviceMonitorNamespace = monitorNamespace
+		}
+
+		// If we have an explicit config but couldn't find the ServiceAccount, warn but proceed
+		if explicitServiceMonitorNs != "" && !isServiceAccountFound {
+			log.Log.Warningf("ServiceMonitorNamespace is explicitly configured as %s, but ServiceAccount %s was not found in monitoring namespaces %v. Creating ServiceMonitor anyway to avoid disabling monitoring during upgrades. If this is incorrect, monitoring may not work until the ServiceAccount is created.",
+				explicitServiceMonitorNs, monitorServiceAccount, config.GetPotentialMonitorNamespaces())
+			// Use the first potential namespace as fallback for RBAC
+			if len(config.GetPotentialMonitorNamespaces()) > 0 {
+				monitorNamespace = config.GetPotentialMonitorNamespaces()[0]
+			}
 		}
 
 		rbaclist = append(rbaclist, rbac.GetAllServiceMonitor(config.GetNamespace(), monitorNamespace, monitorServiceAccount)...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Fixes ServiceMonitor being disabled during KubeVirt upgrades by adding retry logic and explicit configuration support.

#### Before this PR:

- Install strategy job fails to detect monitoring ServiceAccount during upgrades due to timing issues
- ServiceMonitor is omitted from the generated ConfigMap permanently
- VM metrics stop being scraped after upgrade with no recovery mechanism

#### After this PR:

- Retry logic with exponential backoff (3 attempts) when detecting monitoring ServiceAccount
- Explicit `serviceMonitorNamespace` configuration in KubeVirt CR is honored
- ServiceMonitor/PrometheusRule are created even if SA detection temporarily fails
- Test validates retry behavior works correctly

### References

Fixes #16593

### Why we need it and why it was done in this way

**The Problem:** During KubeVirt upgrades, the install-strategy job generates a new ConfigMap. If the monitoring ServiceAccount doesn't exist at that exact moment, ServiceMonitor is omitted. Without retry logic, this omission persists until manual intervention.

**Why this approach:**
- **Retry with backoff** handles temporary ServiceAccount unavailability during cluster upgrades
- **Explicit configuration support** gives users control and prevents accidental monitoring disable
- **Minimal changes** - only 2 files modified, backward compatible
- **Well-tested** - includes test coverage for retry behavior

The tradeoffs:
- Added small delay (retry backoff) during install strategy generation, negligible impact
- Slightly more complex logic, but localized to monitoring detection only
- No breaking changes to existing configurations


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed ServiceMonitor being disabled during KubeVirt upgrades by adding retry logic when detecting the monitoring ServiceAccount.
```

