### PR TITLE
virtwrap, agent-poller: replace GetFilesystems with libvirt-go equivalent

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/agent-poller/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/testing:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -39,22 +39,6 @@ func stripAgentStringResponse(agentReply string) string {
 	return result[1]
 }
 
-// Filesystem disk of the host
-type FSDisk struct {
-	Serial  string `json:"serial,omitempty"`
-	BusType string `json:"bus-type"`
-}
-
-// Filesystem of the host
-type Filesystem struct {
-	Name       string   `json:"name"`
-	Mountpoint string   `json:"mountpoint"`
-	Type       string   `json:"type"`
-	UsedBytes  int      `json:"used-bytes,omitempty"`
-	TotalBytes int      `json:"total-bytes,omitempty"`
-	Disk       []FSDisk `json:"disk,omitempty"`
-}
-
 // AgentInfo from the guest VM serves the purpose
 // of checking the GA presence and version compatibility
 type AgentInfo struct {
@@ -72,44 +56,6 @@ func ParseFSFreezeStatus(agentReply string) (api.FSFreeze, error) {
 	return api.FSFreeze{
 		Status: response,
 	}, nil
-}
-
-// parseFilesystem from the agent response
-func parseFilesystem(agentReply string) ([]api.Filesystem, error) {
-	result := []Filesystem{}
-	response := stripAgentResponse(agentReply)
-
-	err := json.Unmarshal([]byte(response), &result)
-	if err != nil {
-		return []api.Filesystem{}, err
-	}
-
-	convertedResult := []api.Filesystem{}
-
-	for _, fs := range result {
-		convertedResult = append(convertedResult, api.Filesystem{
-			Name:       fs.Name,
-			Mountpoint: fs.Mountpoint,
-			Type:       fs.Type,
-			TotalBytes: fs.TotalBytes,
-			UsedBytes:  fs.UsedBytes,
-			Disk:       parseFSDisks(fs.Disk),
-		})
-	}
-
-	return convertedResult, nil
-}
-
-func parseFSDisks(fsDisks []FSDisk) []api.FSDisk {
-	disks := []api.FSDisk{}
-	for _, fsDisk := range fsDisks {
-		disks = append(disks, api.FSDisk{
-			Serial:  fsDisk.Serial,
-			BusType: fsDisk.BusType,
-		})
-	}
-
-	return disks
 }
 
 // parseAgent gets the agent version from response

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -65,42 +65,5 @@ var _ = Describe("Qemu agent poller", func() {
 
 			Expect(response).To(Equal(expectedResponse))
 		})
-
-		It("should parse Filesystem", func() {
-			jsonInput := `{
-                "return":[
-                    {
-                        "name":"main",
-                        "mountpoint":"/",
-                        "type":"ext",
-                        "total-bytes":99999,
-                        "used-bytes":33333,
-                        "disk":[
-                            {
-                                "serial":"testserial-1234",
-                                "bus-type":"scsi"
-                            }
-                        ]
-                    }
-                ]
-            }`
-
-			expectedFilesystem := []api.Filesystem{
-				{
-					Name:       "main",
-					Mountpoint: "/",
-					Type:       "ext",
-					TotalBytes: 99999,
-					UsedBytes:  33333,
-					Disk: []api.FSDisk{
-						{
-							Serial:  "testserial-1234",
-							BusType: "scsi",
-						},
-					},
-				},
-			}
-			Expect(parseFilesystem(jsonInput)).To(Equal(expectedFilesystem))
-		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2457,7 +2457,7 @@ var _ = Describe("Manager", func() {
 				LoginTime: 0,
 			},
 		})
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(libvirt.DOMAIN_GUEST_INFO_FILESYSTEM, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2519,7 +2519,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes GetFilesystems", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(libvirt.DOMAIN_GUEST_INFO_FILESYSTEM, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2546,7 +2546,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes generateCloudInitEmptyISO and succeeds", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(libvirt.DOMAIN_GUEST_INFO_FILESYSTEM, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",
@@ -2592,7 +2592,7 @@ var _ = Describe("Manager", func() {
 
 	It("executes generateCloudInitEmptyISO and fails", func() {
 		agentStore := agentpoller.NewAsyncAgentStore()
-		agentStore.Store(agentpoller.GetFilesystem, []api.Filesystem{
+		agentStore.Store(libvirt.DOMAIN_GUEST_INFO_FILESYSTEM, []api.Filesystem{
 			{
 				Name:       "test",
 				Mountpoint: "/mnt/whatever",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
As of libvirt 11.2[1] DOMAIN_GUEST_INFO_DISKS retrieves the disk bus type which was the missing piece of information that would enable us to use the libvirt domain call instead of QGA.

[1] https://gitlab.com/libvirt/libvirt-go-module/-/commit/17ddbf262b6001bf488958c04d1998a05833e079

#### After this PR:
Since KubeVirt now uses libvirt 11.9 and has the correct version of libvirt-go, this PR does that transition.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

