### PR TITLE
virt-api: ensure CRD to be stored only when field and group matches

### DIFF
--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -88,11 +88,27 @@ func RemoveDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
 func AddDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
 	crdInformer.GetStore().Add(&extv1.CustomResourceDefinition{
 		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "cdi.kubevirt.io",
 			Names: extv1.CustomResourceDefinitionNames{
 				Kind: "DataVolume",
 			},
 		},
 	})
+}
+
+func AddDataSourceAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Add(&extv1.CustomResourceDefinition{
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "cdi.kubevirt.io",
+			Names: extv1.CustomResourceDefinitionNames{
+				Kind: "DataSource",
+			},
+		},
+	})
+}
+
+func RemoveDataSourceAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Replace(nil, "")
 }
 
 func GetFakeKubeVirtClusterConfig(kubeVirtStore cache.Store) *KVv1.KubeVirt {
@@ -117,6 +133,7 @@ func AddServiceMonitorAPI(crdInformer cache.SharedIndexInformer) {
 			Name: "service-monitors.monitoring.coreos.com",
 		},
 		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "monitoring.coreos.com",
 			Names: extv1.CustomResourceDefinitionNames{
 				Kind: "ServiceMonitor",
 			},
@@ -134,6 +151,7 @@ func AddPrometheusRuleAPI(crdInformer cache.SharedIndexInformer) {
 			Name: "prometheusrules.monitoring.coreos.com",
 		},
 		Spec: extv1.CustomResourceDefinitionSpec{
+			Group: "monitoring.coreos.com",
 			Names: extv1.CustomResourceDefinitionNames{
 				Kind: "PrometheusRule",
 			},

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -39,8 +39,10 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -39,6 +39,8 @@ import (
 
 const (
 	NodeDrainTaintDefaultKey = "kubevirt.io/drain"
+	CdiGroupName             = "cdi.kubevirt.io"
+	MonitoringGroupName      = "monitoring.coreos.com"
 )
 
 type ConfigModifiedFn func()
@@ -119,19 +121,19 @@ func (c *ClusterConfig) configUpdated(_, _ interface{}) {
 }
 
 func isDataVolumeCrd(crd *extv1.CustomResourceDefinition) bool {
-	return crd.Spec.Names.Kind == "DataVolume"
+	return crd.Spec.Names.Kind == "DataVolume" && crd.Spec.Group == CdiGroupName
 }
 
 func isDataSourceCrd(crd *extv1.CustomResourceDefinition) bool {
-	return crd.Spec.Names.Kind == "DataSource"
+	return crd.Spec.Names.Kind == "DataSource" && crd.Spec.Group == CdiGroupName
 }
 
 func isServiceMonitor(crd *extv1.CustomResourceDefinition) bool {
-	return crd.Spec.Names.Kind == "ServiceMonitor"
+	return crd.Spec.Names.Kind == "ServiceMonitor" && crd.Spec.Group == MonitoringGroupName
 }
 
 func isPrometheusRules(crd *extv1.CustomResourceDefinition) bool {
-	return crd.Spec.Names.Kind == "PrometheusRule"
+	return crd.Spec.Names.Kind == "PrometheusRule" && crd.Spec.Group == MonitoringGroupName
 }
 
 func (c *ClusterConfig) crdAddedDeleted(obj interface{}) {


### PR DESCRIPTION

### What this PR does
This PR strengthens the validation logic for CRDs in virt-api.Before: isDataSourceCrd only validated the CRD by its **Kind** (e.g., DataSource), leading virt-api to incorrectly detect unrelated CRDs with the same **Kind**, causing reconciliation loops or panics.

#### Before this PR:
`isDataSourceCrd` logic only validates yaml file only by its value.(e.g. `Datasource`), 
which caused virt-api to detect non-relevant CRD as datasource and panicked.

#### After this PR:
Validation now includes the API Group field, ensuring that only CRDs from the expected origin (cdi.kubevirt.io) are processed

### References
resolves: #16553 

### Why we need it and why it was done in this way
This fix is essential to prevent virt-api from colliding with other third-party CRDs that might share the same $Kind$ name but belong to different API groups.

The following tradeoffs were made:

I had to modify some tests mocker to include API group, as existing logics now enforce to have specific group name.
now any CRD from other group api`s will be ignored.(if i missed something let me know, this is what i concerned the most).

The following alternatives were considered:

I've considered putting validation logics more earlier, but As it is difficalt to detect every group we are accepting, 
I decided to modify as little as possible, as precise as possible. 

Using more broader filtering such as 
`If contains("kubevirt")`
For any past/future compatibility.

### Special notes for your reviewer

As this is my first PR for this project, though i've put my best-effort to follow the convention, there can be some 
mis-followed code. 
So i'm marking this as Draft, let me know if you have some changes me to apply. 

And i also wondered if it would be better adding more test scenarios for detection logics of prometheuse and Datavolume.
i thought it could be redundant. 
  
### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Bug-fix: Correctly detect CDI and Prometheus crds, preventing to misinterpret with different objects.
```

