### PR TITLE
add s390x support for the alpine-with-test-tooling image.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -369,7 +369,13 @@ oci_pull(
 
 oci_pull(
     name = "alpine_with_test_tooling",
-    digest = "sha256:882450d4a0141d29422d049390cae59176c1a9ddf75bd9f3ecdd5a9081c7d95b",
+    digest = "sha256:8c8e8bb6cd81c75e492c678abb3e5f186d52eba2174ebabc328316250acfea58",
+    image = "quay.io/kubevirtci/alpine-with-test-tooling-container-disk",
+)
+
+oci_pull(
+    name = "alpine_with_test_tooling_s390x",
+    digest = "sha256:1a52903133c00507607e8a82308a34923e89288d852762b9f4d5da227767e965",
     image = "quay.io/kubevirtci/alpine-with-test-tooling-container-disk",
 )
 

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -104,7 +104,7 @@ oci_image(
     name = "alpine-with-test-tooling",
     base = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": "@alpine_with_test_tooling",
-        "@io_bazel_rules_go//go/platform:linux_s390x": "@alpine_with_test_tooling",
+        "@io_bazel_rules_go//go/platform:linux_s390x": "@alpine_with_test_tooling_s390x",
         "//conditions:default": "@alpine_with_test_tooling",
     }),
     visibility = ["//visibility:public"],

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -28,6 +28,7 @@ other_images_default="
     //cmd/sidecars:sidecar-shim-image
     //cmd/libguestfs:libguestfs-tools-image
     //containerimages:alpine-container-disk-image
+    //containerimages:alpine-with-test-tooling
     //containerimages:fedora-with-test-tooling
     //images/disks-images-provider:disks-images-provider-image
     //images/vm-killer:vm-killer-image
@@ -45,7 +46,6 @@ other_images_x86_64_aarch64="
     //containerimages:cirros-custom-container-disk-image
     //containerimages:virtio-container-disk-image
     //containerimages:alpine-ext-kernel-boot-demo-container
-    //containerimages:alpine-with-test-tooling
     //containerimages:fedora-realtime
     //images/winrmcli:winrmcli-image
     //tests:conformance_image

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -34,6 +34,7 @@ default_targets="
     virt-exportproxy
     virt-synchronization-controller
     alpine-container-disk-demo
+    alpine-with-test-tooling-container-disk
     fedora-with-test-tooling-container-disk
     vm-killer
     sidecar-shim
@@ -53,7 +54,6 @@ if [[ "${ARCHITECTURE}" != "s390x" && "${ARCHITECTURE}" != "crossbuild-s390x" ]]
         cirros-custom-container-disk-demo
         virtio-container-disk
         alpine-ext-kernel-boot-demo
-        alpine-with-test-tooling-container-disk
         fedora-realtime-container-disk
         winrmcli
         network-slirp-binding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Support for alpine-test-tooling on s390x was recently added to kubevirtCI, The Related PR: https://github.com/kubevirt/kubevirtci/pull/1587. and the publish job now builds and pushes s390x alpine-test-tooling images to quay.io/kubevirtci. https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/2014613023984979968/build-log.txt
This PR introduces the required changes in the KubeVirt repository to enable usage of these images on s390x, allowing relevant tests and workflows to run consistently across architectures.
#### Before this PR:
alpine-with-test-tooling image is not supported for  s390x.

#### After this PR:
alpine-with-test-tooling image is supported  for s390x.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```

