### PR TITLE
feat(virt-operator): Allow overriding virt-template images

### DIFF
--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -497,8 +497,7 @@ func NewControllerDeployment(config *operatorutil.KubeVirtDeploymentConfig, prod
 }
 
 // Used for manifest generation only
-func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosity, kubeVirtVersionEnv, runbookURLTemplate, virtApiImageEnv, virtControllerImageEnv, virtHandlerImageEnv, virtLauncherImageEnv, virtExportProxyImageEnv, virtExportServerImageEnv, virtSynchronizationControllerImageEnv, gsImage, prHelperImage, sidecarShimImage,
-	image string, pullPolicy corev1.PullPolicy) *appsv1.Deployment {
+func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosity, kubeVirtVersionEnv, runbookURLTemplate, virtApiImageEnv, virtControllerImageEnv, virtHandlerImageEnv, virtLauncherImageEnv, virtExportProxyImageEnv, virtExportServerImageEnv, virtSynchronizationControllerImageEnv, virtTemplateApiserverImage, virtTemplateControllerImage, gsImage, prHelperImage, sidecarShimImage, image string, pullPolicy corev1.PullPolicy) *appsv1.Deployment {
 
 	const kubernetesOSLinux = "linux"
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, corev1.LabelHostname, metav1.LabelSelectorOpIn, []string{VirtOperatorName})
@@ -647,7 +646,8 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 
 	envVars := generateVirtOperatorEnvVars(
 		runbookURLTemplate, virtApiImageEnv, virtControllerImageEnv, virtHandlerImageEnv, virtLauncherImageEnv, virtExportProxyImageEnv,
-		virtExportServerImageEnv, virtSynchronizationControllerImageEnv, gsImage, prHelperImage, sidecarShimImage, kubeVirtVersionEnv,
+		virtExportServerImageEnv, virtSynchronizationControllerImageEnv, virtTemplateApiserverImage, virtTemplateControllerImage, gsImage,
+		prHelperImage, sidecarShimImage, kubeVirtVersionEnv,
 	)
 
 	if envVars != nil {
@@ -864,7 +864,8 @@ func NewPodDisruptionBudgetForDeployment(deployment *appsv1.Deployment) *policyv
 }
 
 func generateVirtOperatorEnvVars(runbookURLTemplate, virtApiImageEnv, virtControllerImageEnv, virtHandlerImageEnv, virtLauncherImageEnv, virtExportProxyImageEnv,
-	virtExportServerImageEnv, virtSynchronizationControllerImageEnv, gsImage, prHelperImage, sidecarShimImage, kubeVirtVersionEnv string) (envVars []corev1.EnvVar) {
+	virtExportServerImageEnv, virtSynchronizationControllerImageEnv, virtTemplateApiserverImage, virtTemplateControllerImage, gsImage, prHelperImage,
+	sidecarShimImage, kubeVirtVersionEnv string) (envVars []corev1.EnvVar) {
 
 	addEnvVar := func(envVarName, envVarValue string) {
 		envVars = append(envVars, corev1.EnvVar{
@@ -899,6 +900,14 @@ func generateVirtOperatorEnvVars(runbookURLTemplate, virtApiImageEnv, virtContro
 
 	if virtSynchronizationControllerImageEnv != "" {
 		addEnvVar(operatorutil.VirtSynchronizationControllerImageEnvName, virtSynchronizationControllerImageEnv)
+	}
+
+	if virtTemplateApiserverImage != "" {
+		addEnvVar(operatorutil.VirtTemplateApiserverImageEnvName, virtTemplateApiserverImage)
+	}
+
+	if virtTemplateControllerImage != "" {
+		addEnvVar(operatorutil.VirtTemplateControllerImageEnvName, virtTemplateControllerImage)
 	}
 
 	if gsImage != "" {

--- a/pkg/virt-operator/resource/generate/csv/csv.go
+++ b/pkg/virt-operator/resource/generate/csv/csv.go
@@ -60,6 +60,8 @@ type NewClusterServiceVersionData struct {
 	VirtExportProxyImage               string
 	VirtExportServerImage              string
 	VirtSynchronizationControllerImage string
+	VirtTemplateApiserverImage         string
+	VirtTemplateControllerImage        string
 	GsImage                            string
 	PrHelperImage                      string
 	SidecarShimImage                   string
@@ -166,6 +168,8 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 		data.VirtExportProxyImage,
 		data.VirtExportServerImage,
 		data.VirtSynchronizationControllerImage,
+		data.VirtTemplateApiserverImage,
+		data.VirtTemplateControllerImage,
 		data.GsImage,
 		data.PrHelperImage,
 		data.SidecarShimImage,

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -55,6 +55,8 @@ const (
 	GsImageEnvName                            = "GS_IMAGE"
 	PrHelperImageEnvName                      = "PR_HELPER_IMAGE"
 	SidecarShimImageEnvName                   = "SIDECAR_SHIM_IMAGE"
+	VirtTemplateApiserverImageEnvName         = "VIRT_TEMPLATE_APISERVER_IMAGE"
+	VirtTemplateControllerImageEnvName        = "VIRT_TEMPLATE_CONTROLLER_IMAGE"
 	RunbookURLTemplate                        = "RUNBOOK_URL_TEMPLATE"
 
 	KubeVirtVersionEnvName = "KUBEVIRT_VERSION"
@@ -124,6 +126,8 @@ type ComponentImages struct {
 	VirtExportProxyImage               string `json:"virtExportProxyImage,omitempty" optional:"true"`
 	VirtExportServerImage              string `json:"virtExportServerImage,omitempty" optional:"true"`
 	VirtSynchronizationControllerImage string `json:"virtSynchronizationControllerImage,omitempty" optional:"true"`
+	VirtTemplateApiserverImage         string `json:"virtTemplateApiserverImage,omitempty" optional:"true"`
+	VirtTemplateControllerImage        string `json:"virtTemplateControllerImage,omitempty" optional:"true"`
 	GsImage                            string `json:"GsImage,omitempty" optional:"true"`
 	PrHelperImage                      string `json:"PrHelperImage,omitempty" optional:"true"`
 	SidecarShimImage                   string `json:"SidecarShimImage,omitempty" optional:"true"`
@@ -290,11 +294,13 @@ func getConfig(providedRegistry, providedTag, namespace string, additionalProper
 	exportProxyImage := envVarManager.Getenv(VirtExportProxyImageEnvName)
 	exportServerImage := envVarManager.Getenv(VirtExportServerImageEnvName)
 	synchronizationControllerImage := envVarManager.Getenv(VirtSynchronizationControllerImageEnvName)
+	virtTemplateApiserverImage := envVarManager.Getenv(VirtTemplateApiserverImageEnvName)
+	virtTemplateControllerImage := envVarManager.Getenv(VirtTemplateControllerImageEnvName)
 	GsImage := envVarManager.Getenv(GsImageEnvName)
 	PrHelperImage := envVarManager.Getenv(PrHelperImageEnvName)
 	SidecarShimImage := envVarManager.Getenv(SidecarShimImageEnvName)
 
-	return newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, GsImage, PrHelperImage, SidecarShimImage, additionalProperties, passthroughEnv)
+	return newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, GsImage, PrHelperImage, SidecarShimImage, additionalProperties, passthroughEnv)
 }
 
 func VerifyEnv() error {
@@ -328,7 +334,7 @@ func GetPassthroughEnvWithEnvVarManager(envVarManager EnvVarManager) map[string]
 	return passthroughEnv
 }
 
-func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, gsImage, prHelperImage, sidecarShimImage string, kvSpec, passthroughEnv map[string]string) *KubeVirtDeploymentConfig {
+func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, gsImage, prHelperImage, sidecarShimImage string, kvSpec, passthroughEnv map[string]string) *KubeVirtDeploymentConfig {
 	c := &KubeVirtDeploymentConfig{
 		Registry:        registry,
 		ImagePrefix:     imagePrefix,
@@ -342,6 +348,8 @@ func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorI
 			VirtExportProxyImage:               exportProxyImage,
 			VirtExportServerImage:              exportServerImage,
 			VirtSynchronizationControllerImage: synchronizationControllerImage,
+			VirtTemplateApiserverImage:         virtTemplateApiserverImage,
+			VirtTemplateControllerImage:        virtTemplateControllerImage,
 			GsImage:                            gsImage,
 			PrHelperImage:                      prHelperImage,
 			SidecarShimImage:                   sidecarShimImage,

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -222,6 +222,8 @@ var _ = Describe("Operator Config", func() {
 			launcherImage := setCustomImageForComponent("virt-launcher")
 			exportProxyImage := setCustomImageForComponent("virt-exportproxy")
 			exportServerImage := setCustomImageForComponent("virt-exportserver")
+			virtTemplateApiserverImage := setCustomImageForComponent("virt-template-apiserver")
+			virtTemplateControllerImage := setCustomImageForComponent("virt-template-controller")
 			gsImage := setCustomImageForComponent("gs")
 
 			err := VerifyEnv()
@@ -239,6 +241,8 @@ var _ = Describe("Operator Config", func() {
 			Expect(parsedConfig.VirtLauncherImage).To(Equal(launcherImage), errMsg)
 			Expect(parsedConfig.VirtExportProxyImage).To(Equal(exportProxyImage), errMsg)
 			Expect(parsedConfig.VirtExportServerImage).To(Equal(exportServerImage), errMsg)
+			Expect(parsedConfig.VirtTemplateApiserverImage).To(Equal(virtTemplateApiserverImage), errMsg)
+			Expect(parsedConfig.VirtTemplateControllerImage).To(Equal(virtTemplateControllerImage), errMsg)
 			Expect(parsedConfig.GsImage).To(Equal(gsImage), errMsg)
 		})
 

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -77,6 +77,8 @@ type templateData struct {
 	VirtExportProxyImage               string
 	VirtExportServerImage              string
 	VirtSynchronizationControllerImage string
+	VirtTemplateApiserverImage         string
+	VirtTemplateControllerImage        string
 	GsImage                            string
 	PrHelperImage                      string
 	SidecarShimImage                   string
@@ -112,6 +114,8 @@ func main() {
 	virtExportProxyImage := flag.String("virt-export-proxy-image", "", "custom image for virt-export-proxy. "+customImageExample)
 	virtExportServerImage := flag.String("virt-export-server-image", "", "custom image for virt-export-server. "+customImageExample)
 	virtSynchronizationControllerImage := flag.String("virt-synchronization-controller-image", "", "custom image for virt-synchronization-controller. "+customImageExample)
+	virtTemplateApiserverImage := flag.String("virt-template-apiserver-image", "", "custom image for virt-template-apiserver. "+customImageExample)
+	virtTemplateControllerImage := flag.String("virt-template-controller-image", "", "custom image for virt-template-controller. "+customImageExample)
 	gsImage := flag.String("gs-image", "", "custom image for gs. "+customImageExample)
 	prHelperImage := flag.String("pr-helper-image", "", "custom image for pr-helper. "+customImageExample)
 	sidecarShimImage := flag.String("sidecar-shim-image", "", "custom image for sidecar-shim. "+customImageExample)
@@ -163,6 +167,8 @@ func main() {
 		data.VirtExportProxyImage = *virtExportProxyImage
 		data.VirtExportServerImage = *virtExportServerImage
 		data.VirtSynchronizationControllerImage = *virtSynchronizationControllerImage
+		data.VirtTemplateApiserverImage = *virtTemplateApiserverImage
+		data.VirtTemplateControllerImage = *virtTemplateControllerImage
 		data.GsImage = *gsImage
 		data.PrHelperImage = *prHelperImage
 		data.SidecarShimImage = *sidecarShimImage
@@ -200,6 +206,8 @@ func main() {
 		data.VirtExportProxyImage = "{{.VirtExportProxyImage}}"
 		data.VirtExportServerImage = "{{.VirtExportServerImage}}"
 		data.VirtSynchronizationControllerImage = "{{.VirtSynchronizationControllerImage}}"
+		data.VirtTemplateApiserverImage = "{{.VirtTemplateApiserverImage}}"
+		data.VirtTemplateControllerImage = "{{.VirtTemplateControllerImage}}"
 		data.GsImage = "{{.GsImage}}"
 		data.PrHelperImage = "{{.PrHelperImage}}"
 		data.SidecarShimImage = "{{.SidecarShimImage}}"
@@ -270,6 +278,8 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		data.VirtExportProxyImage,
 		data.VirtExportServerImage,
 		data.VirtSynchronizationControllerImage,
+		data.VirtTemplateApiserverImage,
+		data.VirtTemplateControllerImage,
 		data.GsImage,
 		data.PrHelperImage,
 		data.SidecarShimImage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Allow overriding the images of virt-template-apiserver and
virt-template-controller from the KubeVirtDeploymentConfig. Also allow
overriding them from the virt-operator CSV.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/76

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

/hold
Requires https://github.com/kubevirt/kubevirt/pull/16655

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

