### PR TITLE
[release-1.5] Use ByMigrationUIDIndex informer in VMI stats collector

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -81,8 +81,9 @@ const (
 )
 
 const (
-	ByVMINameIndex  = "byVMIName"
-	UnfinishedIndex = "unfinished"
+	ByVMINameIndex      = "byVMIName"
+	ByMigrationUIDIndex = "byMigrationUID"
+	UnfinishedIndex     = "unfinished"
 )
 
 var unexpectedObjectError = errors.New("unexpected object")
@@ -524,6 +525,13 @@ func GetVirtualMachineInstanceMigrationInformerIndexers() cache.Indexers {
 				return nil, nil
 			}
 			return []string{fmt.Sprintf("%s/%s", migration.Namespace, migration.Spec.VMIName)}, nil
+		},
+		ByMigrationUIDIndex: func(obj interface{}) ([]string, error) {
+			migration, ok := obj.(*kubev1.VirtualMachineInstanceMigration)
+			if !ok {
+				return nil, nil
+			}
+			return []string{string(migration.UID)}, nil
 		},
 		UnfinishedIndex: func(obj interface{}) ([]string, error) {
 			migration, ok := obj.(*kubev1.VirtualMachineInstanceMigration)

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -385,7 +385,7 @@ func collectVMIMigrationTime(vmi *k6tv1.VirtualMachineInstance) []operatormetric
 		return cr
 	}
 
-	migrationName = getMigrationNameFromMigrationUID(vmi.Namespace, vmi.Status.MigrationState.MigrationUID)
+	migrationName = getMigrationNameFromMigrationUID(vmi.Status.MigrationState.MigrationUID)
 
 	if vmi.Status.MigrationState.StartTimestamp != nil {
 		cr = append(cr, operatormetrics.CollectorResult{
@@ -420,22 +420,13 @@ func calculateMigrationStatus(migrationState *k6tv1.VirtualMachineInstanceMigrat
 	return "succeeded"
 }
 
-func getMigrationNameFromMigrationUID(namespace string, migrationUID types.UID) string {
-	objs, err := vmiMigrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
-	if err != nil {
+func getMigrationNameFromMigrationUID(migrationUID types.UID) string {
+	objs, err := vmiMigrationInformer.GetIndexer().ByIndex(controller.ByMigrationUIDIndex, string(migrationUID))
+	if err != nil || len(objs) == 0 {
 		return none
 	}
 
-	for _, obj := range objs {
-		curMigration := obj.(*k6tv1.VirtualMachineInstanceMigration)
-		if curMigration.UID != migrationUID {
-			continue
-		}
-
-		return curMigration.Name
-	}
-
-	return none
+	return objs[0].(*k6tv1.VirtualMachineInstanceMigration).Name
 }
 
 func CollectVmisVnicInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -32,6 +32,7 @@ import (
 	k6tv1 "kubevirt.io/api/core/v1"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
@@ -708,7 +709,7 @@ func setupTestCollector() {
 	})
 
 	// VMI Migration informer
-	vmiMigrationInformer, _ = testutils.NewFakeInformerFor(&k6tv1.VirtualMachineInstanceMigration{})
+	vmiMigrationInformer, _ = testutils.NewFakeInformerWithIndexersFor(&k6tv1.VirtualMachineInstanceMigration{}, virtcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 
 	_ = vmiMigrationInformer.GetStore().Add(&k6tv1.VirtualMachineInstanceMigration{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/15860

jira-ticket: https://issues.redhat.com/browse/CNV-77322

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

