### PR TITLE
[dequarantine] e2e, net: Wait for network ready after passt migration

### DIFF
--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "mac.go",
         "netattachdef.go",
         "ping.go",
+        "route.go",
         "skips.go",
         "validation.go",
         "vmibuilder.go",

--- a/tests/libnet/route.go
+++ b/tests/libnet/route.go
@@ -1,0 +1,139 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libnet
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	k8sv1 "k8s.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/tests/console"
+)
+
+type Route struct {
+	Dst     string `json:"dst,omitempty"`
+	Gateway string `json:"gateway,omitempty"`
+	Dev     string `json:"dev,omitempty"`
+}
+
+type Neighbor struct {
+	Dst   string   `json:"dst,omitempty"`
+	Dev   string   `json:"dev,omitempty"`
+	State []string `json:"state,omitempty"`
+}
+
+const defaultRoute = "default"
+
+func HasDefaultRoute(vmi *v1.VirtualMachineInstance, ipFamily k8sv1.IPFamily, timeout time.Duration) bool {
+	if ipFamily == k8sv1.IPv6Protocol {
+		return hasDefaultRouteIPv6AndNeigh(vmi, timeout)
+	}
+	return hasDefaultRouteIPv4(vmi, timeout)
+}
+
+func hasDefaultRouteIPv4(vmi *v1.VirtualMachineInstance, timeout time.Duration) bool {
+	routes, err := queryDefaultRoutes(vmi, k8sv1.IPv4Protocol, timeout)
+	if err != nil {
+		return false
+	}
+
+	for _, route := range routes {
+		if (route.Dst == defaultRoute) && route.Gateway != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDefaultRouteIPv6AndNeigh(vmi *v1.VirtualMachineInstance, timeout time.Duration) bool {
+	routes, err := queryDefaultRoutes(vmi, k8sv1.IPv6Protocol, timeout)
+	if err != nil {
+		return false
+	}
+
+	for _, route := range routes {
+		if (route.Dst == defaultRoute) && route.Gateway != "" {
+			return hasNeighbor(vmi, route.Gateway, timeout)
+		}
+	}
+	return false
+}
+
+func hasNeighbor(vmi *v1.VirtualMachineInstance, dest string, timeout time.Duration) bool {
+	neighbors, err := queryNeighbors(vmi, timeout)
+	if err != nil {
+		return false
+	}
+	for _, neigh := range neighbors {
+		if neigh.Dst == dest && isValidNeighborState(neigh.State) {
+			return true
+		}
+	}
+	return false
+}
+
+func queryDefaultRoutes(vmi *v1.VirtualMachineInstance, ipFamily k8sv1.IPFamily, timeout time.Duration) ([]Route, error) {
+	const routeCmd = "ip -json %s route show default"
+	var ipFamilyArg string
+
+	if ipFamily == k8sv1.IPv6Protocol {
+		ipFamilyArg = "-6"
+	} else {
+		ipFamilyArg = "-4"
+	}
+
+	output, err := console.RunCommandAndStoreOutput(vmi, fmt.Sprintf(routeCmd, ipFamilyArg), timeout)
+	if err != nil {
+		return nil, err
+	}
+	var routes []Route
+	if err := json.Unmarshal([]byte(output), &routes); err != nil {
+		return nil, err
+	}
+	return routes, nil
+}
+
+func queryNeighbors(vmi *v1.VirtualMachineInstance, timeout time.Duration) ([]Neighbor, error) {
+	const neighCmd = "ip -6 -json neigh show"
+	output, err := console.RunCommandAndStoreOutput(vmi, neighCmd, timeout)
+	if err != nil {
+		return nil, err
+	}
+	var neighbors []Neighbor
+	if err := json.Unmarshal([]byte(output), &neighbors); err != nil {
+		return nil, err
+	}
+	return neighbors, nil
+}
+
+func isValidNeighborState(states []string) bool {
+	for _, state := range states {
+		state = strings.ToUpper(state)
+		switch state {
+		case "REACHABLE", "STALE", "DELAY", "PROBE", "PERMANENT":
+			return true
+		}
+	}
+	return false
+}

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -319,13 +319,13 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", Seria
 			Eventually(func() bool {
 				return libnet.HasDefaultRoute(migrateVMI, ipFamily, defaultRouteTimeout*time.Second)
 			}, 60*time.Second).Should(BeTrue(), "default route or neighbor not found indicating failure to configure network after migration")
-			
+
 			By("Verify the VMIs can ping each other after migration")
 			Expect(libnet.PingFromVMConsole(migrateVMI, anotherVmiIP)).To(Succeed())
 			Expect(libnet.PingFromVMConsole(anotherVMI, migrateVmiAfterMigIP)).To(Succeed())
 		},
 			Entry("[IPv4]", k8sv1.IPv4Protocol),
-			Entry("[IPv6]", k8sv1.IPv6Protocol, decorators.Quarantine),
+			Entry("[IPv6]", k8sv1.IPv6Protocol),
 		)
 	})
 }),

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -314,6 +314,12 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", Seria
 				return migrateVmiAfterMigIP
 			}, 30*time.Second).ShouldNot(Equal(migrateVmiBeforeMigIP), "the VMI status should get a new IP after migration")
 
+			By("Wait for guest network to be ready after migration")
+			const defaultRouteTimeout = 20
+			Eventually(func() bool {
+				return libnet.HasDefaultRoute(migrateVMI, ipFamily, defaultRouteTimeout*time.Second)
+			}, 60*time.Second).Should(BeTrue(), "default route or neighbor not found indicating failure to configure network after migration")
+			
 			By("Verify the VMIs can ping each other after migration")
 			Expect(libnet.PingFromVMConsole(migrateVMI, anotherVmiIP)).To(Succeed())
 			Expect(libnet.PingFromVMConsole(anotherVMI, migrateVmiAfterMigIP)).To(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
After VM live migration with passt binding, the guest's IPv6 network
stack needs time to reconfigure via NDP. The ping test was running
before the guest had a valid default route and reachable gateway,
causing "Network is unreachable" errors.
Wait up to 2 minutes for the guest network to be ready before running ping tests after migration.

The first commit was researched and authored by Cursor AI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes  https://redhat.atlassian.net/browse/CNV-84068

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
