### PR TITLE
tests: add storage capability discovery from CDI StorageProfile

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -59,6 +59,7 @@ var DNSServiceNamespace = ""
 
 var MigrationNetworkNIC = "eth1"
 var MigrationNetworkName string
+var StorageClass string
 
 func init() {
 	kubecli.Init()
@@ -93,6 +94,7 @@ func init() {
 	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
 	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
 	flag.StringVar(&MigrationNetworkName, "migration-network-name", "", "name of the NetworkAttachmentDefinition CR to be used for dedicated migration network tests")
+	flag.StringVar(&StorageClass, "storage-class", os.Getenv("KUBEVIRT_STORAGE_CLASS"), "Storage class to discover capabilities from via CDI StorageProfile")
 }
 
 func NormalizeFlags() {

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -98,6 +98,14 @@ func SynchronizedBeforeTestSetup() []byte {
 	libstorage.Config, err = libstorage.LoadConfig()
 	Expect(err).ToNot(HaveOccurred())
 
+	if flags.StorageClass != "" {
+		virtClient := kubevirt.Client()
+		err = libstorage.DiscoverStorageCapabilitiesFromSC(virtClient, flags.StorageClass)
+		if err != nil {
+			fmt.Printf("Failed to discover storage capabilities from %s: %v, using JSON config\n", flags.StorageClass, err)
+		}
+	}
+
 	if flags.KubeVirtInstallNamespace == "" {
 		detectInstallNamespace()
 	}


### PR DESCRIPTION
Add the ability to discover and configure storage test capabilities from a CDI StorageProfile. This eliminates the need to manually configure the JSON test configuration file, reducing setup complexity and potential for misconfiguration.

when KUBEVIRT_STORAGE_CLASS environment variable (or --storage-class flag) is set, the test framework queries the specified StorageProfile and populates the configuration based on the storage class capabilities (RWO/RWX, Filesystem/Block, snapshot support, CSI)

Usage:
```
export KUBEVIRT_STORAGE_CLASS=my-storage-class
make functest
```

Or:
` make functest FUNC_TEST_ARGS="--storage-class=my-storage-class"`

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Users manually configured tests/default-config.json with storage capabilities. Misconfiguration led to confusing test failures that appeared to be misconfiguration issues.

#### After this PR:
Users can set KUBEVIRT_STORAGE_CLASS=<storage-class-name> and capabilities are discovered from the CDI StorageProfile. Tests skip appropriately when capabilities are unavailable.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

