### PR TITLE
hostdevice: Add support for IOMMU companion devices

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool.go
@@ -85,7 +85,8 @@ func (p *AddressPool) Pop(resource string) (string, error) {
 
 // PopAll drains all remaining addresses for a resource, returning them as a slice.
 // This is useful for getting IOMMU companion devices that share the same resource.
-func (p *AddressPool) PopAll(resource string) ([]string, error) {
+// Returns an empty slice if no addresses remain (exhaustion is expected and non-fatal).
+func (p *AddressPool) PopAll(resource string) []string {
 	var addresses []string
 	for {
 		addr, err := p.Pop(resource)
@@ -94,7 +95,7 @@ func (p *AddressPool) PopAll(resource string) ([]string, error) {
 		}
 		addresses = append(addresses, addr)
 	}
-	return addresses, nil
+	return addresses
 }
 
 func filterOutAddress(addrs []string, addr string) []string {
@@ -122,7 +123,6 @@ func (p *BestEffortAddressPool) Pop(resource string) (string, error) {
 	return address, nil
 }
 
-func (p *BestEffortAddressPool) PopAll(resource string) ([]string, error) {
-	addresses, _ := p.pool.PopAll(resource)
-	return addresses, nil
+func (p *BestEffortAddressPool) PopAll(resource string) []string {
+	return p.pool.PopAll(resource)
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool.go
@@ -83,6 +83,20 @@ func (p *AddressPool) Pop(resource string) (string, error) {
 	return "", fmt.Errorf("no more addresses to allocate for resource %s", resource)
 }
 
+// PopAll drains all remaining addresses for a resource, returning them as a slice.
+// This is useful for getting IOMMU companion devices that share the same resource.
+func (p *AddressPool) PopAll(resource string) ([]string, error) {
+	var addresses []string
+	for {
+		addr, err := p.Pop(resource)
+		if err != nil {
+			break
+		}
+		addresses = append(addresses, addr)
+	}
+	return addresses, nil
+}
+
 func filterOutAddress(addrs []string, addr string) []string {
 	var res []string
 	for _, a := range addrs {
@@ -106,4 +120,9 @@ func NewBestEffortAddressPool(pool AddressPooler) *BestEffortAddressPool {
 func (p *BestEffortAddressPool) Pop(resource string) (string, error) {
 	address, _ := p.pool.Pop(resource)
 	return address, nil
+}
+
+func (p *BestEffortAddressPool) PopAll(resource string) ([]string, error) {
+	addresses, _ := p.pool.PopAll(resource)
+	return addresses, nil
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool_test.go
@@ -104,8 +104,7 @@ func expectPoolPopFailure(pool *hostdevice.AddressPool, resource string) {
 var _ = Describe("Address Pool PopAll", func() {
 	It("returns empty slice when no resource in env", func() {
 		pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
-		addresses, err := pool.PopAll(resource0)
-		Expect(err).NotTo(HaveOccurred())
+		addresses := pool.PopAll(resource0)
 		Expect(addresses).To(BeEmpty())
 	})
 
@@ -113,8 +112,7 @@ var _ = Describe("Address Pool PopAll", func() {
 		env := []envData{newResourceEnv(resourcePrefix, resource0)}
 		withEnvironmentContext(env, func() {
 			pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
-			addresses, err := pool.PopAll(resource0)
-			Expect(err).NotTo(HaveOccurred())
+			addresses := pool.PopAll(resource0)
 			Expect(addresses).To(BeEmpty())
 		})
 	})
@@ -123,8 +121,7 @@ var _ = Describe("Address Pool PopAll", func() {
 		env := []envData{newResourceEnv(resourcePrefix, resource0, pciAddresses0, pciAddresses1)}
 		withEnvironmentContext(env, func() {
 			pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
-			addresses, err := pool.PopAll(resource0)
-			Expect(err).NotTo(HaveOccurred())
+			addresses := pool.PopAll(resource0)
 			Expect(addresses).To(Equal([]string{pciAddresses0, pciAddresses1}))
 		})
 	})
@@ -136,8 +133,7 @@ var _ = Describe("Address Pool PopAll", func() {
 			// Pop one address first
 			Expect(pool.Pop(resource0)).To(Equal(pciAddresses0))
 			// PopAll should return only the remaining address
-			addresses, err := pool.PopAll(resource0)
-			Expect(err).NotTo(HaveOccurred())
+			addresses := pool.PopAll(resource0)
 			Expect(addresses).To(Equal([]string{pciAddresses1}))
 		})
 	})
@@ -147,12 +143,10 @@ var _ = Describe("Address Pool PopAll", func() {
 		withEnvironmentContext(env, func() {
 			pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
 			// First PopAll drains all addresses
-			addresses, err := pool.PopAll(resource0)
-			Expect(err).NotTo(HaveOccurred())
+			addresses := pool.PopAll(resource0)
 			Expect(addresses).To(Equal([]string{pciAddresses0, pciAddresses1}))
 			// Second PopAll should return empty
-			addresses, err = pool.PopAll(resource0)
-			Expect(err).NotTo(HaveOccurred())
+			addresses = pool.PopAll(resource0)
 			Expect(addresses).To(BeEmpty())
 		})
 	})
@@ -162,8 +156,7 @@ var _ = Describe("BestEffort Address Pool PopAll", func() {
 	It("returns empty slice when no resource in env", func() {
 		innerPool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
 		pool := hostdevice.NewBestEffortAddressPool(innerPool)
-		addresses, err := pool.PopAll(resource0)
-		Expect(err).NotTo(HaveOccurred())
+		addresses := pool.PopAll(resource0)
 		Expect(addresses).To(BeEmpty())
 	})
 
@@ -172,8 +165,7 @@ var _ = Describe("BestEffort Address Pool PopAll", func() {
 		withEnvironmentContext(env, func() {
 			innerPool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
 			pool := hostdevice.NewBestEffortAddressPool(innerPool)
-			addresses, err := pool.PopAll(resource0)
-			Expect(err).NotTo(HaveOccurred())
+			addresses := pool.PopAll(resource0)
 			Expect(addresses).To(Equal([]string{pciAddresses0, pciAddresses1}))
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool_test.go
@@ -100,3 +100,81 @@ func expectPoolPopFailure(pool *hostdevice.AddressPool, resource string) {
 	ExpectWithOffset(1, err).To(HaveOccurred())
 	ExpectWithOffset(1, address).To(BeEmpty())
 }
+
+var _ = Describe("Address Pool PopAll", func() {
+	It("returns empty slice when no resource in env", func() {
+		pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
+		addresses, err := pool.PopAll(resource0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addresses).To(BeEmpty())
+	})
+
+	It("returns empty slice when no addresses for resource", func() {
+		env := []envData{newResourceEnv(resourcePrefix, resource0)}
+		withEnvironmentContext(env, func() {
+			pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
+			addresses, err := pool.PopAll(resource0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(addresses).To(BeEmpty())
+		})
+	})
+
+	It("returns all addresses from a resource", func() {
+		env := []envData{newResourceEnv(resourcePrefix, resource0, pciAddresses0, pciAddresses1)}
+		withEnvironmentContext(env, func() {
+			pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
+			addresses, err := pool.PopAll(resource0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(addresses).To(Equal([]string{pciAddresses0, pciAddresses1}))
+		})
+	})
+
+	It("returns remaining addresses after some have been popped", func() {
+		env := []envData{newResourceEnv(resourcePrefix, resource0, pciAddresses0, pciAddresses1)}
+		withEnvironmentContext(env, func() {
+			pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
+			// Pop one address first
+			Expect(pool.Pop(resource0)).To(Equal(pciAddresses0))
+			// PopAll should return only the remaining address
+			addresses, err := pool.PopAll(resource0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(addresses).To(Equal([]string{pciAddresses1}))
+		})
+	})
+
+	It("drains the pool so subsequent PopAll returns empty", func() {
+		env := []envData{newResourceEnv(resourcePrefix, resource0, pciAddresses0, pciAddresses1)}
+		withEnvironmentContext(env, func() {
+			pool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
+			// First PopAll drains all addresses
+			addresses, err := pool.PopAll(resource0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(addresses).To(Equal([]string{pciAddresses0, pciAddresses1}))
+			// Second PopAll should return empty
+			addresses, err = pool.PopAll(resource0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(addresses).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("BestEffort Address Pool PopAll", func() {
+	It("returns empty slice when no resource in env", func() {
+		innerPool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
+		pool := hostdevice.NewBestEffortAddressPool(innerPool)
+		addresses, err := pool.PopAll(resource0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addresses).To(BeEmpty())
+	})
+
+	It("returns all addresses from a resource", func() {
+		env := []envData{newResourceEnv(resourcePrefix, resource0, pciAddresses0, pciAddresses1)}
+		withEnvironmentContext(env, func() {
+			innerPool := hostdevice.NewAddressPool(resourcePrefix, []string{resource0})
+			pool := hostdevice.NewBestEffortAddressPool(innerPool)
+			addresses, err := pool.PopAll(resource0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(addresses).To(Equal([]string{pciAddresses0, pciAddresses1}))
+		})
+	})
+})

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
@@ -122,3 +122,15 @@ func (p *stubAddressPool) Pop(resource string) (string, error) {
 
 	return address, nil
 }
+
+func (p *stubAddressPool) PopAll(resource string) ([]string, error) {
+	var addresses []string
+	for {
+		addr, err := p.Pop(resource)
+		if err != nil {
+			break
+		}
+		addresses = append(addresses, addr)
+	}
+	return addresses, nil
+}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
@@ -123,7 +123,7 @@ func (p *stubAddressPool) Pop(resource string) (string, error) {
 	return address, nil
 }
 
-func (p *stubAddressPool) PopAll(resource string) ([]string, error) {
+func (p *stubAddressPool) PopAll(resource string) []string {
 	var addresses []string
 	for {
 		addr, err := p.Pop(resource)
@@ -132,5 +132,5 @@ func (p *stubAddressPool) PopAll(resource string) ([]string, error) {
 		}
 		addresses = append(addresses, addr)
 	}
-	return addresses, nil
+	return addresses
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
@@ -21,6 +21,7 @@ package gpu
 
 import (
 	"fmt"
+	"sort"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -108,16 +109,18 @@ func validateCreationOfDevicePluginsDevices(gpus []v1.GPU, pciHostDevices, mdevH
 	return nil
 }
 
-// extractUniqueResources returns a deduplicated list of resource names from the GPU specs
+// extractUniqueResources returns a deduplicated, sorted list of resource names from the GPU specs.
+// The result is sorted to ensure deterministic ordering for alias generation and device ordering.
 func extractUniqueResources(gpus []v1.GPU) []string {
 	resourceSet := make(map[string]struct{})
 	for _, gpu := range gpus {
 		resourceSet[gpu.DeviceName] = struct{}{}
 	}
 
-	var resources []string
+	resources := make([]string, 0, len(resourceSet))
 	for resource := range resourceSet {
 		resources = append(resources, resource)
 	}
+	sort.Strings(resources)
 	return resources
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
@@ -55,9 +55,20 @@ func CreateHostDevicesFromPools(vmiGPUs []v1.GPU, pciAddressPool, mdevAddressPoo
 
 	hostDevices := append(pciHostDevices, mdevHostDevices...)
 
-	if err := validateCreationOfDevicePluginsDevices(vmiGPUs, hostDevices); err != nil {
+	if err := validateCreationOfDevicePluginsDevices(vmiGPUs, pciHostDevices, mdevHostDevices); err != nil {
 		return nil, fmt.Errorf(failedCreateGPUHostDeviceFmt, err)
 	}
+
+	// Create host devices for remaining IOMMU companion devices.
+	// When GPUs have multiple devices in their IOMMU group (e.g., GPU + audio controller),
+	// the device plugin provides all addresses but we only consumed one per requested GPU above.
+	// We need to passthrough all remaining devices in the IOMMU groups for proper operation.
+	resources := extractUniqueResources(vmiGPUs)
+	iommuCompanionDevices, err := hostdevice.CreatePCIHostDevicesFromRemainingAddresses(AliasPrefix, resources, pciPool)
+	if err != nil {
+		return nil, fmt.Errorf(failedCreateGPUHostDeviceFmt, err)
+	}
+	hostDevices = append(hostDevices, iommuCompanionDevices...)
 
 	return hostDevices, nil
 }
@@ -79,7 +90,8 @@ func createHostDevicesMetadata(vmiGPUs []v1.GPU) []hostdevice.HostDeviceMetaData
 // On validation failure, an error is returned.
 // The validation assumes that the assignment of a device to a specified GPU is correct,
 // therefore a simple quantity check is sufficient.
-func validateCreationOfDevicePluginsDevices(gpus []v1.GPU, hostDevices []api.HostDevice) error {
+// Note: This validates the primary GPU devices only, not IOMMU companion devices.
+func validateCreationOfDevicePluginsDevices(gpus []v1.GPU, pciHostDevices, mdevHostDevices []api.HostDevice) error {
 	var gpusWithDP []v1.GPU
 	for _, gpu := range gpus {
 		if !drautil.IsGPUDRA(gpu) {
@@ -87,10 +99,25 @@ func validateCreationOfDevicePluginsDevices(gpus []v1.GPU, hostDevices []api.Hos
 		}
 	}
 
-	if len(gpusWithDP) > 0 && len(gpusWithDP) != len(hostDevices) {
+	primaryHostDevices := append(pciHostDevices, mdevHostDevices...)
+	if len(gpusWithDP) > 0 && len(gpusWithDP) != len(primaryHostDevices) {
 		return fmt.Errorf(
-			"the number of device plugin GPU/s do not match the number of devices:\nGPU: %v\nDevice: %v", gpusWithDP, hostDevices,
+			"the number of device plugin GPU/s do not match the number of devices:\nGPU: %v\nDevice: %v", gpusWithDP, primaryHostDevices,
 		)
 	}
 	return nil
+}
+
+// extractUniqueResources returns a deduplicated list of resource names from the GPU specs
+func extractUniqueResources(gpus []v1.GPU) []string {
+	resourceSet := make(map[string]struct{})
+	for _, gpu := range gpus {
+		resourceSet[gpu.DeviceName] = struct{}{}
+	}
+
+	var resources []string
+	for resource := range resourceSet {
+		resources = append(resources, resource)
+	}
+	return resources
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
@@ -214,3 +214,148 @@ func (p *stubAddressPool) Pop(resource string) (string, error) {
 
 	return address, nil
 }
+
+func (p *stubAddressPool) PopAll(resource string) ([]string, error) {
+	var addresses []string
+	for {
+		addr, err := p.Pop(resource)
+		if err != nil {
+			break
+		}
+		addresses = append(addresses, addr)
+	}
+	return addresses, nil
+}
+
+var _ = Describe("GPU IOMMU Companion Devices", func() {
+	const (
+		gpuPCIAddress2 = "0000:81:01.2"
+		gpuPCIAddress3 = "0000:81:01.3"
+	)
+
+	var vmi *v1.VirtualMachineInstance
+
+	BeforeEach(func() {
+		vmi = &v1.VirtualMachineInstance{}
+	})
+
+	It("creates IOMMU companion devices for remaining addresses in pool", func() {
+		// GPU with one requested device but two PCI addresses in pool (GPU + audio controller)
+		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+			{DeviceName: gpuResource0, Name: gpuName0},
+		}
+		pciPool := newAddressPoolStub()
+		// First address is for the GPU, second is for the IOMMU companion (e.g., audio controller)
+		pciPool.AddResource(gpuResource0, gpuPCIAddress0, gpuPCIAddress1)
+		mdevPool := newAddressPoolStub()
+
+		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Should have 2 devices: 1 primary GPU + 1 IOMMU companion
+		Expect(hostDevices).To(HaveLen(2))
+
+		// First device should be the primary GPU
+		Expect(hostDevices[0].Alias.GetName()).To(Equal(gpu.AliasPrefix + gpuName0))
+
+		// Second device should be the IOMMU companion
+		Expect(hostDevices[1].Alias.GetName()).To(ContainSubstring("iommu-companion"))
+		Expect(hostDevices[1].Type).To(Equal(api.HostDevicePCI))
+		Expect(hostDevices[1].Managed).To(Equal("no"))
+	})
+
+	It("creates multiple IOMMU companion devices when pool has many addresses", func() {
+		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+			{DeviceName: gpuResource0, Name: gpuName0},
+		}
+		pciPool := newAddressPoolStub()
+		// GPU with 3 additional IOMMU group members
+		pciPool.AddResource(gpuResource0, gpuPCIAddress0, gpuPCIAddress1, gpuPCIAddress2, gpuPCIAddress3)
+		mdevPool := newAddressPoolStub()
+
+		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Should have 4 devices: 1 primary GPU + 3 IOMMU companions
+		Expect(hostDevices).To(HaveLen(4))
+
+		// First device should be the primary GPU
+		Expect(hostDevices[0].Alias.GetName()).To(Equal(gpu.AliasPrefix + gpuName0))
+
+		// Remaining devices should be IOMMU companions
+		for i := 1; i < len(hostDevices); i++ {
+			Expect(hostDevices[i].Alias.GetName()).To(ContainSubstring("iommu-companion"))
+		}
+	})
+
+	It("creates no IOMMU companion devices when pool is exactly exhausted", func() {
+		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+			{DeviceName: gpuResource0, Name: gpuName0},
+		}
+		pciPool := newAddressPoolStub()
+		// Exactly one address for one GPU
+		pciPool.AddResource(gpuResource0, gpuPCIAddress0)
+		mdevPool := newAddressPoolStub()
+
+		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Should have 1 device: just the primary GPU
+		Expect(hostDevices).To(HaveLen(1))
+		Expect(hostDevices[0].Alias.GetName()).To(Equal(gpu.AliasPrefix + gpuName0))
+	})
+
+	It("handles IOMMU companion devices with multiple GPUs from same resource", func() {
+		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+			{DeviceName: gpuResource0, Name: gpuName0},
+			{DeviceName: gpuResource0, Name: gpuName1},
+		}
+		pciPool := newAddressPoolStub()
+		// 2 primary GPUs + 2 IOMMU companions
+		pciPool.AddResource(gpuResource0, gpuPCIAddress0, gpuPCIAddress1, gpuPCIAddress2, gpuPCIAddress3)
+		mdevPool := newAddressPoolStub()
+
+		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Should have 4 devices: 2 primary GPUs + 2 IOMMU companions
+		Expect(hostDevices).To(HaveLen(4))
+
+		// First two devices should be the primary GPUs
+		Expect(hostDevices[0].Alias.GetName()).To(Equal(gpu.AliasPrefix + gpuName0))
+		Expect(hostDevices[1].Alias.GetName()).To(Equal(gpu.AliasPrefix + gpuName1))
+
+		// Last two should be IOMMU companions
+		Expect(hostDevices[2].Alias.GetName()).To(ContainSubstring("iommu-companion"))
+		Expect(hostDevices[3].Alias.GetName()).To(ContainSubstring("iommu-companion"))
+	})
+
+	It("does not include MDEV addresses in IOMMU companion devices", func() {
+		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+			{DeviceName: gpuResource0, Name: gpuName0},
+			{DeviceName: gpuResource1, Name: gpuName1},
+		}
+		pciPool := newAddressPoolStub()
+		pciPool.AddResource(gpuResource0, gpuPCIAddress0, gpuPCIAddress1) // GPU + companion
+		mdevPool := newAddressPoolStub()
+		mdevPool.AddResource(gpuResource1, gpuMDEVAddress1) // Just MDEV, no companion
+
+		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Should have 3 devices: 1 PCI GPU + 1 IOMMU companion + 1 MDEV
+		Expect(hostDevices).To(HaveLen(3))
+
+		// IOMMU companion should only come from PCI pool
+		companionCount := 0
+		for _, device := range hostDevices {
+			if device.Alias != nil && device.Type == api.HostDevicePCI {
+				if device.Alias.GetName() != gpu.AliasPrefix+gpuName0 {
+					companionCount++
+					Expect(device.Alias.GetName()).To(ContainSubstring("iommu-companion"))
+				}
+			}
+		}
+		Expect(companionCount).To(Equal(1))
+	})
+})

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -48,7 +48,8 @@ type AddressPooler interface {
 	Pop(key string) (value string, err error)
 	// PopAll drains all remaining addresses for a resource.
 	// Used to get IOMMU companion devices that share the same resource.
-	PopAll(key string) (values []string, err error)
+	// Returns an empty slice if no addresses remain (exhaustion is expected and non-fatal).
+	PopAll(key string) []string
 }
 
 func CreatePCIHostDevices(hostDevicesData []HostDeviceMetaData, pciAddrPool AddressPooler) ([]api.HostDevice, error) {
@@ -132,10 +133,7 @@ func CreatePCIHostDevicesFromRemainingAddresses(aliasPrefix string, resources []
 	var hostDevices []api.HostDevice
 
 	for _, resource := range resources {
-		addresses, err := pciAddrPool.PopAll(resource)
-		if err != nil {
-			continue
-		}
+		addresses := pciAddrPool.PopAll(resource)
 
 		for i, address := range addresses {
 			if address == "" {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -309,7 +309,7 @@ func (p *stubAddressPool) Pop(resource string) (string, error) {
 	return address, nil
 }
 
-func (p *stubAddressPool) PopAll(resource string) ([]string, error) {
+func (p *stubAddressPool) PopAll(resource string) []string {
 	var addresses []string
 	for {
 		addr, err := p.Pop(resource)
@@ -318,7 +318,7 @@ func (p *stubAddressPool) PopAll(resource string) ([]string, error) {
 		}
 		addresses = append(addresses, addr)
 	}
-	return addresses, nil
+	return addresses
 }
 
 var _ = Describe("CreatePCIHostDevicesFromRemainingAddresses", func() {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool_netstatus.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool_netstatus.go
@@ -73,3 +73,13 @@ func (p *PCIAddressWithNetworkStatusPool) Pop(networkName string) (string, error
 	delete(p.networkPCIMap, networkName)
 	return pciAddress, nil
 }
+
+// PopAll drains all remaining addresses for a network. For SR-IOV, each network
+// has at most one PCI address, so this returns at most one address.
+func (p *PCIAddressWithNetworkStatusPool) PopAll(networkName string) ([]string, error) {
+	addr, err := p.Pop(networkName)
+	if err != nil {
+		return nil, nil
+	}
+	return []string{addr}, nil
+}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool_netstatus.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool_netstatus.go
@@ -76,10 +76,11 @@ func (p *PCIAddressWithNetworkStatusPool) Pop(networkName string) (string, error
 
 // PopAll drains all remaining addresses for a network. For SR-IOV, each network
 // has at most one PCI address, so this returns at most one address.
-func (p *PCIAddressWithNetworkStatusPool) PopAll(networkName string) ([]string, error) {
+// Returns an empty slice if no address remains (exhaustion is expected and non-fatal).
+func (p *PCIAddressWithNetworkStatusPool) PopAll(networkName string) []string {
 	addr, err := p.Pop(networkName)
 	if err != nil {
-		return nil, nil
+		return nil
 	}
-	return []string{addr}, nil
+	return []string{addr}
 }


### PR DESCRIPTION
When GPUs have multiple devices in their IOMMU group (e.g., GPU + audio controller), the device plugin provides all PCI addresses but previously only one address was consumed per requested GPU. This change ensures all remaining devices in the IOMMU groups are passed through for proper operation.

Changes:
- Add PopAll method to AddressPooler interface to drain remaining addresses
- Add CreatePCIHostDevicesFromRemainingAddresses to create host devices for IOMMU companion devices
- Update GPU host device creation to include companion devices
- Add comprehensive unit tests for new functionality

### What this PR does

#### Before this PR:
 When requesting multiple GPUs where some GPUs have multiple devices in their IOMMU group (e.g., RTX 4090/5090 with VGA + audio controller), KubeVirt incorrectly mapped devices to GPUs. For example, when requesting 2 GPUs where the first GPU has 2 IOMMU group members, KubeVirt would treat the audio controller of the first GPU as the second GPU, instead of passing through the actual second GPU device.

#### After this PR:
All devices in the GPU's IOMMU group are automatically passed through to the VM. After allocating the primary GPU device, the code drains any remaining PCI addresses from the device plugin's pool and creates additional host devices for these IOMMU companion devices.

### References

- Fixes #13925

### Why we need it and why it was done in this way

Some GPU models (notably RTX 4090 and RTX 5090) have multiple devices in their IOMMU group - typically a VGA controller and an audio controller. VFIO requires all devices in an IOMMU group to be bound to the vfio-pci driver and passed through together for proper isolation and functionality.

The device plugin already provides all PCI addresses for the IOMMU group, but KubeVirt was only consuming one address per requested GPU. This PR adds logic to drain all remaining addresses from the pool after primary device allocation.

**The following tradeoffs were made:**
- IOMMU companion devices use a separate alias naming scheme (`iommu-companion-<resource>-<index>`) to distinguish them from primary GPU devices
- The validation logic was updated to only count primary devices, not companions, when verifying device plugin allocations

**The following alternatives were considered:**
- Using `externalResourceProvider: false` - This works but causes multiple VMs to use the same GPU, which is not the desired behavior
