### PR TITLE
fix: Write the "done" file before exit to notify sonobuoy about completion.

### DIFF
--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -13,15 +13,17 @@ const resultsDir = "/tmp/sonobuoy/results"
 
 func main() {
 	err := execute()
-	if err != nil {
-		fmt.Printf("Failed to execute conformance suite: %v\n", err)
+	const writeFilePerms = 0o666
+	writeErr := os.WriteFile(fmt.Sprintf("%s/done", resultsDir), []byte(strings.Join([]string{resultsDir}, "\n")), writeFilePerms)
+	if writeErr != nil {
+		fmt.Printf("Failed to notify sonobuoy that I am done: %v\n", writeErr)
+		if err != nil {
+			fmt.Printf("Additionally, conformance suite failed: %v\n", err)
+		}
 		os.Exit(1)
 	}
-
-	const writeFilePerms = 0o666
-	err = os.WriteFile(fmt.Sprintf("%s/done", resultsDir), []byte(strings.Join([]string{resultsDir}, "\n")), writeFilePerms)
 	if err != nil {
-		fmt.Printf("Failed to notify sonobuoy that I am done: %v\n", err)
+		fmt.Printf("Failed to execute conformance suite: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### What this PR does
This fix addresses the issue of not notifying sonobuoy about test completion by writing "done" file in results directory where there are one or more failures.

#### Before this PR:
Conformance test suit was exiting without writing done file when one or more tests fail and due to that sonobuoy couldn't recognize the test completion.  Sonobuoy treated it as an error in suit execution and was skipping parsing of test results properly.

#### After this PR:
Even if one or more tests fails, sonobuoy parses and prints the result summary.

It fixes https://github.com/kubevirt/kubevirt/issues/16673

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

