### PR TITLE
virt-operator: lint and cleanup `pkg/virt-operator/util/`

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -44,6 +44,7 @@ pkg/tpm
 pkg/util/ratelimiter
 pkg/virt-controller/leaderelectionconfig
 pkg/virt-controller/watch/common
+pkg/virt-operator/util
 pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/configuration

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -4189,7 +4189,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			for _, envVar := range envVars {
 				envVarManager.Setenv(envVar.Name, envVar.Value)
 			}
-			deploymentConfigJson, err := config.GetJson()
+			deploymentConfigJson, err := config.GetJSON()
 			Expect(err).ToNot(HaveOccurred())
 			envVarManager.Setenv(util.TargetDeploymentConfig, deploymentConfigJson)
 

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -403,7 +403,7 @@ var _ = Describe("Install Strategy", func() {
 		for _, envVar := range envVars {
 			envVarManager.Setenv(envVar.Name, envVar.Value)
 		}
-		deploymentConfigJson, err := config.GetJson()
+		deploymentConfigJson, err := config.GetJSON()
 		Expect(err).ToNot(HaveOccurred())
 		envVarManager.Setenv(util.TargetDeploymentConfig, deploymentConfigJson)
 

--- a/pkg/virt-operator/strategy_job.go
+++ b/pkg/virt-operator/strategy_job.go
@@ -24,7 +24,7 @@ func (c *KubeVirtController) generateInstallStrategyJob(infraPlacement *v1.Compo
 	if operatorImage == "" {
 		operatorImage = fmt.Sprintf("%s/%s%s%s", config.GetImageRegistry(), config.GetImagePrefix(), VirtOperator, components.AddVersionSeparatorPrefix(config.GetOperatorVersion()))
 	}
-	deploymentConfigJson, err := config.GetJson()
+	deploymentConfigJson, err := config.GetJSON()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -86,7 +86,8 @@ func UpdateConditionsAvailable(kv *virtv1.KubeVirt) {
 }
 
 func UpdateConditionsFailedExists(kv *virtv1.KubeVirt) {
-	updateCondition(kv, virtv1.KubeVirtConditionSynchronized, k8sv1.ConditionFalse, ConditionReasonDeploymentFailedExisting, "There is an active KubeVirt deployment")
+	updateCondition(kv, virtv1.KubeVirtConditionSynchronized, k8sv1.ConditionFalse,
+		ConditionReasonDeploymentFailedExisting, "There is an active KubeVirt deployment")
 	// don' t set any other conditions here, so HCO just ignores this KubeVirt CR
 }
 
@@ -108,10 +109,17 @@ func UpdateConditionsDeleting(kv *virtv1.KubeVirt) {
 }
 
 func UpdateConditionsDeletionFailed(kv *virtv1.KubeVirt, err error) {
-	updateCondition(kv, virtv1.KubeVirtConditionSynchronized, k8sv1.ConditionFalse, ConditionReasonDeletionFailedError, fmt.Sprintf("An error occurred during deletion: %v", err))
+	msg := fmt.Sprintf("An error occurred during deletion: %v", err)
+	updateCondition(kv, virtv1.KubeVirtConditionSynchronized, k8sv1.ConditionFalse,
+		ConditionReasonDeletionFailedError, msg)
 }
 
-func updateCondition(kv *virtv1.KubeVirt, conditionType virtv1.KubeVirtConditionType, status k8sv1.ConditionStatus, reason, message string) {
+func updateCondition(
+	kv *virtv1.KubeVirt,
+	conditionType virtv1.KubeVirtConditionType,
+	status k8sv1.ConditionStatus,
+	reason, message string,
+) {
 	condition, isNew := getCondition(kv, conditionType)
 	condition.Status = status
 	condition.Reason = reason

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -102,7 +102,7 @@ func UpdateConditionsFailedError(kv *virtv1.KubeVirt, err error) {
 func UpdateConditionsDeleting(kv *virtv1.KubeVirt) {
 	removeCondition(kv, virtv1.KubeVirtConditionCreated)
 	removeCondition(kv, virtv1.KubeVirtConditionSynchronized)
-	msg := fmt.Sprintf("Deletion was triggered")
+	msg := "Deletion was triggered"
 	updateCondition(kv, virtv1.KubeVirtConditionAvailable, k8sv1.ConditionFalse, ConditionReasonDeleting, msg)
 	updateCondition(kv, virtv1.KubeVirtConditionProgressing, k8sv1.ConditionFalse, ConditionReasonDeleting, msg)
 	updateCondition(kv, virtv1.KubeVirtConditionDegraded, k8sv1.ConditionTrue, ConditionReasonDeleting, msg)

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -111,7 +111,7 @@ func UpdateConditionsDeletionFailed(kv *virtv1.KubeVirt, err error) {
 	updateCondition(kv, virtv1.KubeVirtConditionSynchronized, k8sv1.ConditionFalse, ConditionReasonDeletionFailedError, fmt.Sprintf("An error occurred during deletion: %v", err))
 }
 
-func updateCondition(kv *virtv1.KubeVirt, conditionType virtv1.KubeVirtConditionType, status k8sv1.ConditionStatus, reason string, message string) {
+func updateCondition(kv *virtv1.KubeVirt, conditionType virtv1.KubeVirtConditionType, status k8sv1.ConditionStatus, reason, message string) {
 	condition, isNew := getCondition(kv, conditionType)
 	condition.Status = status
 	condition.Reason = reason
@@ -155,7 +155,7 @@ func removeCondition(kv *virtv1.KubeVirt, conditionType virtv1.KubeVirtCondition
 	}
 }
 
-func SetConditionTimestamps(kvOrig *virtv1.KubeVirt, kvUpdated *virtv1.KubeVirt) {
+func SetConditionTimestamps(kvOrig, kvUpdated *virtv1.KubeVirt) {
 	now := metav1.Time{
 		Time: time.Now(),
 	}

--- a/pkg/virt-operator/util/client_test.go
+++ b/pkg/virt-operator/util/client_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var _ = Describe("Operator Client", func() {
-
 	Describe("Conditions and Finalizers", func() {
 		getKubeVirtWithCreatedConditionAndRandomFinalizer := func() *v1.KubeVirt {
 			return &v1.KubeVirt{
@@ -63,7 +62,6 @@ var _ = Describe("Operator Client", func() {
 		})
 
 		Describe("Updating a condition", func() {
-
 			Context("When it doesn't exist yet", func() {
 				It("Should add the condition", func() {
 					updateCondition(kv, v1.KubeVirtConditionAvailable, k8sv1.ConditionTrue, "NewReason", "new message")
@@ -89,11 +87,9 @@ var _ = Describe("Operator Client", func() {
 					Expect(condition1.Message).To(Equal("new message"), "should update condition message")
 				})
 			})
-
 		})
 
 		Describe("Removing a condition", func() {
-
 			Context("When it doesn't exist", func() {
 				It("Should not change existing conditions", func() {
 					removeCondition(kv, v1.KubeVirtConditionAvailable)
@@ -112,7 +108,6 @@ var _ = Describe("Operator Client", func() {
 					Expect(kv.Status.Conditions).To(BeEmpty(), "should have no condition")
 				})
 			})
-
 		})
 
 		Describe("Adding a finalizer", func() {
@@ -224,6 +219,5 @@ var _ = Describe("Operator Client", func() {
 				})
 			})
 		})
-
 	})
 })

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -272,7 +272,6 @@ func getImagePrefix(parsedImage [][]string) string {
 func getImageRegistry(parsedImage [][]string) string {
 	if len(parsedImage) == 1 {
 		return parsedImage[0][1]
-
 	}
 	return ""
 }
@@ -280,7 +279,6 @@ func getImageRegistry(parsedImage [][]string) string {
 func getTag(parsedImage [][]string, kubeVirtVersion string) string {
 	if len(parsedImage) != 1 {
 		return kubeVirtVersion
-
 	}
 	version := parsedImage[0][3]
 	if version == "" {
@@ -295,7 +293,6 @@ func getTag(parsedImage [][]string, kubeVirtVersion string) string {
 }
 
 func getConfig(providedRegistry, providedTag, namespace string, additionalProperties map[string]string, envVarManager EnvVarManager) *KubeVirtDeploymentConfig {
-
 	// get registry and tag/shasum from operator image
 	imageString := GetOperatorImageWithEnvVarManager(envVarManager)
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
@@ -602,7 +599,6 @@ func (c *KubeVirtDeploymentConfig) GetSynchronizationPort() int32 {
 		} else {
 			return int32(port)
 		}
-
 	}
 	return DefaultSynchronizationPort
 }
@@ -748,10 +744,10 @@ func IsValidLabel(label string) bool {
 	return r.Match([]byte(label))
 }
 
-func DigestFromImageName(name string) (digest string) {
+func DigestFromImageName(name string) string {
 	if name != "" && strings.LastIndex(name, "@sha256:") != -1 {
-		digest = strings.Split(name, "@sha256:")[1]
+		return strings.Split(name, "@sha256:")[1]
 	}
 
-	return
+	return ""
 }

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -203,7 +203,12 @@ func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVa
 		additionalProperties[AdditionalPropertiesExternalNetResourceInjection] = ""
 	}
 
-	hypervisor := virtconfig.GetHypervisorFromKvConfig(&kv.Spec.Configuration, isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.ConfigurableHypervisor))
+	configurableHypervisor := isFeatureGateEnabledInKvConfig(
+		&kv.Spec.Configuration, featuregate.ConfigurableHypervisor,
+	)
+	hypervisor := virtconfig.GetHypervisorFromKvConfig(
+		&kv.Spec.Configuration, configurableHypervisor,
+	)
 	additionalProperties[AdditionalPropertiesHypervisorName] = hypervisor.Name
 
 	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.VMStatsCollector) {
@@ -292,7 +297,11 @@ func getTag(parsedImage [][]string, kubeVirtVersion string) string {
 	}
 }
 
-func getConfig(providedRegistry, providedTag, namespace string, additionalProperties map[string]string, envVarManager EnvVarManager) *KubeVirtDeploymentConfig {
+func getConfig(
+	providedRegistry, providedTag, namespace string,
+	additionalProperties map[string]string,
+	envVarManager EnvVarManager,
+) *KubeVirtDeploymentConfig {
 	// get registry and tag/shasum from operator image
 	imageString := GetOperatorImageWithEnvVarManager(envVarManager)
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
@@ -340,7 +349,14 @@ func getConfig(providedRegistry, providedTag, namespace string, additionalProper
 	PrHelperImage := envVarManager.Getenv(PrHelperImageEnvName)
 	SidecarShimImage := envVarManager.Getenv(SidecarShimImageEnvName)
 
-	return newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, GsImage, PrHelperImage, SidecarShimImage, additionalProperties, passthroughEnv)
+	return newDeploymentConfigWithTag(
+		registry, imagePrefix, tag, namespace,
+		operatorImage, apiImage, controllerImage, handlerImage, launcherImage,
+		exportProxyImage, exportServerImage, synchronizationControllerImage,
+		virtTemplateApiserverImage, virtTemplateControllerImage,
+		GsImage, PrHelperImage, SidecarShimImage,
+		additionalProperties, passthroughEnv,
+	)
 }
 
 func VerifyEnv() error {
@@ -374,7 +390,14 @@ func GetPassthroughEnvWithEnvVarManager(envVarManager EnvVarManager) map[string]
 	return passthroughEnv
 }
 
-func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, gsImage, prHelperImage, sidecarShimImage string, kvSpec, passthroughEnv map[string]string) *KubeVirtDeploymentConfig {
+func newDeploymentConfigWithTag(
+	registry, imagePrefix, tag, namespace string,
+	operatorImage, apiImage, controllerImage, handlerImage, launcherImage string,
+	exportProxyImage, exportServerImage, synchronizationControllerImage string,
+	virtTemplateApiserverImage, virtTemplateControllerImage string,
+	gsImage, prHelperImage, sidecarShimImage string,
+	kvSpec, passthroughEnv map[string]string,
+) *KubeVirtDeploymentConfig {
 	c := &KubeVirtDeploymentConfig{
 		Registry:        registry,
 		ImagePrefix:     imagePrefix,

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -43,11 +43,12 @@ import (
 )
 
 const (
-	// Name of env var containing the operator's image name
-	// Deprecated. Use VirtOperatorImageEnvName instead
-	OldOperatorImageEnvName                   = "OPERATOR_IMAGE"
-	VirtOperatorImageEnvName                  = "VIRT_OPERATOR_IMAGE"
-	VirtApiImageEnvName                       = "VIRT_API_IMAGE"
+	// Name of env var containing the operator's image name.
+	//
+	// Deprecated: Use VirtOperatorImageEnvName instead.
+	OldOperatorImageEnvName = "OPERATOR_IMAGE"
+	VirtOperatorImageEnvName = "VIRT_OPERATOR_IMAGE"
+	VirtApiImageEnvName = "VIRT_API_IMAGE" //nolint:staticcheck,revive
 	VirtControllerImageEnvName                = "VIRT_CONTROLLER_IMAGE"
 	VirtHandlerImageEnvName                   = "VIRT_HANDLER_IMAGE"
 	VirtLauncherImageEnvName                  = "VIRT_LAUNCHER_IMAGE"
@@ -62,9 +63,9 @@ const (
 	RunbookURLTemplate                        = "RUNBOOK_URL_TEMPLATE"
 
 	KubeVirtVersionEnvName = "KUBEVIRT_VERSION"
-	// Deprecated, use TargetDeploymentConfig instead
+	// Deprecated: Use TargetDeploymentConfig instead.
 	TargetInstallNamespace = "TARGET_INSTALL_NAMESPACE"
-	// Deprecated, use TargetDeploymentConfig instead
+	// Deprecated: Use TargetDeploymentConfig instead.
 	TargetImagePullPolicy = "TARGET_IMAGE_PULL_POLICY"
 	// JSON containing all relevant deployment properties, replaces TargetInstallNamespace and TargetImagePullPolicy
 	TargetDeploymentConfig = "TARGET_DEPLOYMENT_CONFIG"
@@ -132,8 +133,8 @@ var DefaultMonitorNamespaces = []string{
 }
 
 type ComponentImages struct {
-	VirtOperatorImage                  string `json:"virtOperatorImage,omitempty" optional:"true"`
-	VirtApiImage                       string `json:"virtApiImage,omitempty" optional:"true"`
+	VirtOperatorImage string `json:"virtOperatorImage,omitempty" optional:"true"`
+	VirtApiImage      string `json:"virtApiImage,omitempty" optional:"true"` //nolint:staticcheck,revive
 	VirtControllerImage                string `json:"virtControllerImage,omitempty" optional:"true"`
 	VirtHandlerImage                   string `json:"virtHandlerImage,omitempty" optional:"true"`
 	VirtLauncherImage                  string `json:"virtLauncherImage,omitempty" optional:"true"`
@@ -437,6 +438,7 @@ func (c *KubeVirtDeploymentConfig) GetOperatorVersion() string {
 	return c.KubeVirtVersion
 }
 
+//nolint:staticcheck,revive
 func (c *KubeVirtDeploymentConfig) GetApiVersion() string {
 	if digest := DigestFromImageName(c.VirtApiImage); digest != "" {
 		return digest
@@ -521,19 +523,17 @@ func (c *KubeVirtDeploymentConfig) SetTargetDeploymentConfig(kv *v1.KubeVirt) er
 	kv.Status.TargetKubeVirtVersion = c.GetKubeVirtVersion()
 	kv.Status.TargetKubeVirtRegistry = c.GetImageRegistry()
 	kv.Status.TargetDeploymentID = c.GetDeploymentID()
-	json, err := c.GetJson()
-	kv.Status.TargetDeploymentConfig = json
+	configJSON, err := c.GetJSON()
+	kv.Status.TargetDeploymentConfig = configJSON
 	return err
 }
 
 func SetDefaultArchitecture(kv *v1.KubeVirt) {
 	if kv.Spec.Configuration.ArchitectureConfiguration != nil && kv.Spec.Configuration.ArchitectureConfiguration.DefaultArchitecture != "" {
 		kv.Status.DefaultArchitecture = kv.Spec.Configuration.ArchitectureConfiguration.DefaultArchitecture
-	} else {
+	} else if kv.Status.DefaultArchitecture == "" {
 		// only set default architecture in status in the event that it has not been already set previously
-		if kv.Status.DefaultArchitecture == "" {
-			kv.Status.DefaultArchitecture = runtime.GOARCH
-		}
+		kv.Status.DefaultArchitecture = runtime.GOARCH
 	}
 }
 
@@ -541,8 +541,8 @@ func (c *KubeVirtDeploymentConfig) SetObservedDeploymentConfig(kv *v1.KubeVirt) 
 	kv.Status.ObservedKubeVirtVersion = c.GetKubeVirtVersion()
 	kv.Status.ObservedKubeVirtRegistry = c.GetImageRegistry()
 	kv.Status.ObservedDeploymentID = c.GetDeploymentID()
-	json, err := c.GetJson()
-	kv.Status.ObservedDeploymentConfig = json
+	configJSON, err := c.GetJSON()
+	kv.Status.ObservedDeploymentConfig = configJSON
 	return err
 }
 
@@ -706,7 +706,7 @@ func fieldsToString(v reflect.Value) string {
 		fieldName := v.Type().Field(i).Name
 		result += fieldName
 		field := v.Field(i)
-		switch field.Type().Kind() {
+		switch field.Type().Kind() { //nolint:exhaustive
 		case reflect.Map:
 			keys := field.MapKeys()
 			nameKeys := make(map[string]reflect.Value, len(keys))
@@ -741,12 +741,20 @@ func (c *KubeVirtDeploymentConfig) GetDeploymentID() string {
 	return c.ID
 }
 
-func (c *KubeVirtDeploymentConfig) GetJson() (string, error) {
-	json, err := json.Marshal(c)
+// GetJSON returns the JSON representation of the deployment config.
+func (c *KubeVirtDeploymentConfig) GetJSON() (string, error) {
+	data, err := json.Marshal(c)
 	if err != nil {
 		return "", err
 	}
-	return string(json), nil
+	return string(data), nil
+}
+
+// GetJson returns the JSON representation of the deployment config.
+//
+// Deprecated: Use GetJSON instead.
+func (c *KubeVirtDeploymentConfig) GetJson() (string, error) { //nolint:staticcheck,revive
+	return c.GetJSON()
 }
 
 func NewEnvVarMap(envMap map[string]string) []k8sv1.EnvVar {
@@ -763,8 +771,8 @@ func IsValidLabel(label string) bool {
 	// First and last character must be alphanumeric
 	// middle chars can be alphanumeric, or dot hyphen or dash
 	// entire string must not exceed 63 chars
-	r := regexp.MustCompile(`^([a-z0-9A-Z]([a-z0-9A-Z\-\_\.]{0,61}[a-z0-9A-Z])?)?$`)
-	return r.Match([]byte(label))
+	r := regexp.MustCompile(`^([a-z0-9A-Z]([a-z0-9A-Z\-_.]{0,61}[a-z0-9A-Z])?)?$`)
+	return r.MatchString(label)
 }
 
 func DigestFromImageName(name string) string {

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -25,9 +25,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"regexp"
-	"math"
 	"runtime"
 	"slices"
 	"sort"
@@ -47,9 +47,9 @@ const (
 	// Name of env var containing the operator's image name.
 	//
 	// Deprecated: Use VirtOperatorImageEnvName instead.
-	OldOperatorImageEnvName = "OPERATOR_IMAGE"
-	VirtOperatorImageEnvName = "VIRT_OPERATOR_IMAGE"
-	VirtApiImageEnvName = "VIRT_API_IMAGE" //nolint:staticcheck,revive
+	OldOperatorImageEnvName                   = "OPERATOR_IMAGE"
+	VirtOperatorImageEnvName                  = "VIRT_OPERATOR_IMAGE"
+	VirtApiImageEnvName                       = "VIRT_API_IMAGE" //nolint:staticcheck,revive
 	VirtControllerImageEnvName                = "VIRT_CONTROLLER_IMAGE"
 	VirtHandlerImageEnvName                   = "VIRT_HANDLER_IMAGE"
 	VirtLauncherImageEnvName                  = "VIRT_LAUNCHER_IMAGE"
@@ -124,6 +124,9 @@ const (
 	// #nosec 101, the variable is not holding any credential
 	// Prefix for env vars that will be passed along
 	PassthroughEnvPrefix = "KV_IO_EXTRA_ENV_"
+
+	// defaultVersionTag is the fallback version tag when no version is provided
+	defaultVersionTag = "latest"
 )
 
 // DefaultMonitorNamespaces holds a set of well known prometheus-operator namespaces.
@@ -134,8 +137,8 @@ var DefaultMonitorNamespaces = []string{
 }
 
 type ComponentImages struct {
-	VirtOperatorImage string `json:"virtOperatorImage,omitempty" optional:"true"`
-	VirtApiImage      string `json:"virtApiImage,omitempty" optional:"true"` //nolint:staticcheck,revive
+	VirtOperatorImage                  string `json:"virtOperatorImage,omitempty" optional:"true"`
+	VirtApiImage                       string `json:"virtApiImage,omitempty" optional:"true"` //nolint:staticcheck,revive
 	VirtControllerImage                string `json:"virtControllerImage,omitempty" optional:"true"`
 	VirtHandlerImage                   string `json:"virtHandlerImage,omitempty" optional:"true"`
 	VirtLauncherImage                  string `json:"virtLauncherImage,omitempty" optional:"true"`
@@ -289,7 +292,7 @@ func getTag(parsedImage [][]string, kubeVirtVersion string) string {
 	}
 	version := parsedImage[0][3]
 	if version == "" {
-		return "latest"
+		return defaultVersionTag
 	} else if strings.HasPrefix(version, ":") {
 		return strings.TrimPrefix(version, ":")
 	} else {
@@ -310,7 +313,7 @@ func getConfig(
 	parsedImage := imageRegEx.FindAllStringSubmatch(imageString, 1)
 	kubeVirtVersion := envVarManager.Getenv(KubeVirtVersionEnvName)
 	if kubeVirtVersion == "" {
-		kubeVirtVersion = "latest"
+		kubeVirtVersion = defaultVersionTag
 	}
 
 	imagePrefix, useStoredImagePrefix := additionalProperties[ImagePrefixKey]

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"math"
 	"runtime"
 	"slices"
 	"sort"
@@ -619,8 +620,10 @@ func (c *KubeVirtDeploymentConfig) GetSynchronizationPort() int32 {
 		port, err := strconv.Atoi(value)
 		if err != nil {
 			log.Log.Errorf("Unable to convert %s to integer", value)
+		} else if port < 0 || port > math.MaxInt32 {
+			log.Log.Errorf("Port value %d is out of valid range", port)
 		} else {
-			return int32(port)
+			return int32(port) //#nosec G109 -- bounds checked above
 		}
 	}
 	return DefaultSynchronizationPort

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -25,7 +25,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -623,8 +622,8 @@ func (c *KubeVirtDeploymentConfig) GetSynchronizationPort() int32 {
 		port, err := strconv.Atoi(value)
 		if err != nil {
 			log.Log.Errorf("Unable to convert %s to integer", value)
-		} else if port < 0 || port > math.MaxInt32 {
-			log.Log.Errorf("Port value %d is out of valid range", port)
+		} else if port < 0 || port > 65535 {
+			log.Log.Errorf("Port value %d is out of valid range (0-65535), using default", port)
 		} else {
 			return int32(port) //#nosec G109 -- bounds checked above
 		}
@@ -756,13 +755,6 @@ func (c *KubeVirtDeploymentConfig) GetJSON() (string, error) {
 	return string(data), nil
 }
 
-// GetJson returns the JSON representation of the deployment config.
-//
-// Deprecated: Use GetJSON instead.
-func (c *KubeVirtDeploymentConfig) GetJson() (string, error) { //nolint:staticcheck,revive
-	return c.GetJSON()
-}
-
 func NewEnvVarMap(envMap map[string]string) []k8sv1.EnvVar {
 	env := []k8sv1.EnvVar{}
 
@@ -773,17 +765,17 @@ func NewEnvVarMap(envMap map[string]string) []k8sv1.EnvVar {
 	return env
 }
 
+var validLabelRegexp = regexp.MustCompile(
+	`^([a-z0-9A-Z]([a-z0-9A-Z\-_.]{0,61}[a-z0-9A-Z])?)?$`,
+)
+
 func IsValidLabel(label string) bool {
-	// First and last character must be alphanumeric
-	// middle chars can be alphanumeric, or dot hyphen or dash
-	// entire string must not exceed 63 chars
-	r := regexp.MustCompile(`^([a-z0-9A-Z]([a-z0-9A-Z\-_.]{0,61}[a-z0-9A-Z])?)?$`)
-	return r.MatchString(label)
+	return validLabelRegexp.MatchString(label)
 }
 
 func DigestFromImageName(name string) string {
-	if name != "" && strings.LastIndex(name, "@sha256:") != -1 {
-		return strings.Split(name, "@sha256:")[1]
+	if idx := strings.LastIndex(name, "@sha256:"); idx != -1 {
+		return name[idx+len("@sha256:"):]
 	}
 
 	return ""

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -171,7 +171,9 @@ var _ = Describe("Operator Config", func() {
 			Entry("VirtLauncherImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtLauncherImage = img }),
 			Entry("VirtExportProxyImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtExportProxyImage = img }),
 			Entry("VirtExportServerImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtExportServerImage = img }),
-			Entry("VirtSynchronizationControllerImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtSynchronizationControllerImage = img }),
+			Entry("VirtSynchronizationControllerImage", func(c *KubeVirtDeploymentConfig, img string) {
+				c.VirtSynchronizationControllerImage = img
+			}),
 			Entry("GsImage", func(c *KubeVirtDeploymentConfig, img string) { c.GsImage = img }),
 			Entry("PrHelperImage", func(c *KubeVirtDeploymentConfig, img string) { c.PrHelperImage = img }),
 			Entry("SidecarShimImage", func(c *KubeVirtDeploymentConfig, img string) { c.SidecarShimImage = img }),

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 var _ = Describe("Operator Config", func() {
-
 	var envVarManager EnvVarManager
 
 	BeforeEach(func() {
@@ -69,7 +68,6 @@ var _ = Describe("Operator Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(envMap).To(Equal(map[string]string{realKey: val}))
-
 		})
 	})
 
@@ -93,7 +91,6 @@ var _ = Describe("Operator Config", func() {
 	})
 
 	Describe("creating config ID", func() {
-
 		var idMissing, idEmpty, idFilled string
 
 		BeforeEach(func() {
@@ -179,7 +176,6 @@ var _ = Describe("Operator Config", func() {
 			Entry("PrHelperImage", func(c *KubeVirtDeploymentConfig, img string) { c.PrHelperImage = img }),
 			Entry("SidecarShimImage", func(c *KubeVirtDeploymentConfig, img string) { c.SidecarShimImage = img }),
 		)
-
 	})
 
 	Context("Product Names and Versions", func() {
@@ -202,7 +198,6 @@ var _ = Describe("Operator Config", func() {
 	})
 
 	Context("custom component images", func() {
-
 		var definedEnvVars []string
 
 		setCustomImageForComponent := func(component string) string {
@@ -387,7 +382,6 @@ var _ = Describe("Operator Config", func() {
 
 			kubevirtVersion := parsedConfig.GetKubeVirtVersion()
 			Expect(kubevirtVersion).To(Equal(input.version))
-
 		},
 			Entry("virt-operator image tag when both KUBEVIRT_VERSION is set and virt-operator provided with tag",
 				&testInput{

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Operator Config", func() {
 		DescribeTable("should ", func(input testInput) {
 			envManager := EnvVarManagerMock{}
 			for k, v := range input.envVars {
-				envManager.Setenv(k, v)
+				Expect(envManager.Setenv(k, v)).To(Succeed())
 			}
 			config := GetTargetConfigFromKVWithEnvVarManager(
 				input.kv,

--- a/pkg/virt-operator/util/readycheck.go
+++ b/pkg/virt-operator/util/readycheck.go
@@ -41,7 +41,7 @@ func DaemonsetIsReady(kv *v1.KubeVirt, daemonset *appsv1.DaemonSet, stores Store
 
 	if daemonset.Status.DesiredNumberScheduled == 0 ||
 		daemonset.Status.DesiredNumberScheduled != daemonset.Status.NumberReady {
-		log.Log.V(4).Infof("DaemonSet %v not ready yet", daemonset.Name)
+		log.Log.V(4).Infof("DaemonSet %v not ready yet", daemonset.Name) //nolint:mnd
 		return false
 	}
 
@@ -89,7 +89,7 @@ func DeploymentIsReady(kv *v1.KubeVirt, deployment *appsv1.Deployment, stores St
 	}
 
 	if deployment.Status.Replicas == 0 || deployment.Status.ReadyReplicas == 0 {
-		log.Log.V(4).Infof("Deployment %v not ready yet", deployment.Name)
+		log.Log.V(4).Infof("Deployment %v not ready yet", deployment.Name) //nolint:mnd
 		return false
 	}
 

--- a/pkg/virt-operator/util/readycheck.go
+++ b/pkg/virt-operator/util/readycheck.go
@@ -30,7 +30,6 @@ import (
 )
 
 func DaemonsetIsReady(kv *v1.KubeVirt, daemonset *appsv1.DaemonSet, stores Stores) bool {
-
 	// ensure we're looking at the latest daemonset from cache
 	obj, exists, _ := stores.DaemonSetCache.Get(daemonset)
 	if exists {
@@ -42,7 +41,6 @@ func DaemonsetIsReady(kv *v1.KubeVirt, daemonset *appsv1.DaemonSet, stores Store
 
 	if daemonset.Status.DesiredNumberScheduled == 0 ||
 		daemonset.Status.DesiredNumberScheduled != daemonset.Status.NumberReady {
-
 		log.Log.V(4).Infof("DaemonSet %v not ready yet", daemonset.Name)
 		return false
 	}

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -66,6 +66,10 @@ type Stores struct {
 	ClusterPreference                     cache.Store
 }
 
+// AllEmpty returns true if all stores are empty.
+// The cyclomatic complexity is high because it checks each store field, but the logic is straightforward.
+//
+//nolint:gocyclo
 func (s *Stores) AllEmpty() bool {
 	return IsStoreEmpty(s.ServiceAccountCache) &&
 		IsStoreEmpty(s.ClusterRoleCache) &&
@@ -225,6 +229,10 @@ func (e *Expectations) ResetExpectations(key string) {
 	e.ValidatingAdmissionPolicy.SetExpectations(key, 0, 0)
 }
 
+// SatisfiedExpectations returns true if all expectations are satisfied for the given key.
+// The cyclomatic complexity is high because it checks each expectation field, but the logic is straightforward.
+//
+//nolint:gocyclo
 func (e *Expectations) SatisfiedExpectations(key string) bool {
 	return e.ServiceAccount.SatisfiedExpectations(key) &&
 		e.ClusterRole.SatisfiedExpectations(key) &&


### PR DESCRIPTION
/sig control-plane
/kind cleanup
/area operator
/wg code-quality

### What this PR does
#### Before this PR:

The `pkg/virt-operator/util` package was not included in the linter paths and contained various code style, static analysis, and security issues.

#### After this PR:

The `pkg/virt-operator/util` package is now included in `lint-paths.txt` and all linter warnings have been addressed through a series of targeted commits:

- Formatting fixes (blank lines, line length)
- Static analysis improvements (using `MatchString` instead of `Match`, simplifying named returns)
- Unchecked error handling in tests
- Security fix for integer overflow in port conversion (G109)
- Complexity warnings addressed with documentation and `nolint` directives
- Magic number warnings suppressed where appropriate
- Extracted `defaultVersionTag` constant for the `"latest"` string

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.

- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

- Some functions like `AllEmpty()` and `SatisfiedExpectations()` have high cyclomatic complexity due to checking many fields, but the logic is straightforward. Rather than refactoring these into more complex patterns, `nolint:gocyclo` directives were added with explanatory comments.
- The deprecated `GetJson()` method was kept for backward compatibility but now wraps the new `GetJSON()` method following Go naming conventions.
- Magic number warnings for log verbosity levels (`V(4)`) were suppressed with `nolint:mnd` rather than extracting constants, as the verbosity level is self-documenting in context.

The following alternatives were considered:

- Refactoring `AllEmpty()` and `SatisfiedExpectations()` into loop-based patterns, but this would reduce readability and require interface changes.
- Removing the deprecated `GetJson()` method entirely, but this could break existing callers.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Each commit addresses a specific category of linter warnings, making review easier:

1. `style: fix formatting issues` - Removes unnecessary blank lines
2. `style: fix line length issues` - Breaks long lines for readability
3. `refactor: fix static analysis issues` - Improves code patterns (e.g., `MatchString`, simplified returns)
4. `fix: handle unchecked errors` - Adds `Expect()` calls for error checks in tests
5. `fix: address security issues` - Adds bounds checking for int32 port conversion
6. `refactor: address complexity warnings` - Documents complex but straightforward functions
7. `style: suppress magic number warnings` - Adds `nolint:mnd` for log verbosity
8. `style: extract version tag constant` - Creates `defaultVersionTag` constant
9. `chore: add pkg/virt-operator/util to lint-paths.txt` - Enables linting for the package

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```