### PR TITLE
conformance: Always write done file to signal completion to Sonobuoy

### DIFF
--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -4,7 +4,7 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tools/... //tests/framework/... //tests/vmlogchecker/..."}
+WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tools/... //tests/framework/... //tests/vmlogchecker/... //tests/conformance/..."}
 rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 
 if [ "${CI}" == "true" ]; then

--- a/tests/conformance/BUILD.bazel
+++ b/tests/conformance/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//tests/conformance:def.bzl", "containertag_x_def")
 
 go_library(
@@ -14,4 +14,18 @@ go_binary(
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
     x_defs = containertag_x_def(),
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "conformance_suite_test.go",
+        "conformance_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )

--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -12,18 +12,23 @@ var containerTag = ""
 const resultsDir = "/tmp/sonobuoy/results"
 
 func main() {
-	err := execute()
-	const writeFilePerms = 0o666
-	writeErr := os.WriteFile(fmt.Sprintf("%s/done", resultsDir), []byte(strings.Join([]string{resultsDir}, "\n")), writeFilePerms)
-	if writeErr != nil {
-		fmt.Printf("Failed to notify sonobuoy that I am done: %v\n", writeErr)
-		if err != nil {
-			fmt.Printf("Additionally, conformance suite failed: %v\n", err)
-		}
-		os.Exit(1)
-	}
-	if err != nil {
+	os.Exit(run())
+}
+
+func run() (exitCode int) {
+	defer writeDoneFile()
+
+	if err := execute(); err != nil {
 		fmt.Printf("Failed to execute conformance suite: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func writeDoneFile() {
+	const writeFilePerms = 0o666
+	if err := os.WriteFile(fmt.Sprintf("%s/done", resultsDir), []byte(strings.Join([]string{resultsDir}, "\n")), writeFilePerms); err != nil {
+		fmt.Printf("Failed to notify sonobuoy that I am done: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -2,14 +2,18 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 )
 
-var containerTag = ""
-
-const resultsDir = "/tmp/sonobuoy/results"
+var (
+	containerTag           = ""
+	resultsDir             = "/tmp/sonobuoy/results"
+	executeFunc            = execute
+	output       io.Writer = os.Stdout
+)
 
 func main() {
 	os.Exit(run())
@@ -18,8 +22,8 @@ func main() {
 func run() (exitCode int) {
 	defer writeDoneFile()
 
-	if err := execute(); err != nil {
-		fmt.Printf("Failed to execute conformance suite: %v\n", err)
+	if err := executeFunc(); err != nil {
+		fmt.Fprintf(output, "Failed to execute conformance suite: %v\n", err)
 		return 1
 	}
 	return 0
@@ -28,7 +32,7 @@ func run() (exitCode int) {
 func writeDoneFile() {
 	const writeFilePerms = 0o666
 	if err := os.WriteFile(fmt.Sprintf("%s/done", resultsDir), []byte(strings.Join([]string{resultsDir}, "\n")), writeFilePerms); err != nil {
-		fmt.Printf("Failed to notify sonobuoy that I am done: %v\n", err)
+		fmt.Fprintf(output, "Failed to notify sonobuoy that I am done: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/tests/conformance/conformance_suite_test.go
+++ b/tests/conformance/conformance_suite_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestConformance(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Conformance", func() {
+	var (
+		tmpDir              string
+		originalResultsDir  string
+		originalExecuteFunc func() error
+		originalOutput      io.Writer
+	)
+
+	BeforeEach(func() {
+		tmpDir = GinkgoT().TempDir()
+		originalResultsDir = resultsDir
+		originalExecuteFunc = executeFunc
+		originalOutput = output
+		resultsDir = tmpDir
+		output = io.Discard
+	})
+
+	AfterEach(func() {
+		resultsDir = originalResultsDir
+		executeFunc = originalExecuteFunc
+		output = originalOutput
+	})
+
+	Describe("writeDoneFile", func() {
+		It("should create done file with results dir path", func() {
+			writeDoneFile()
+
+			content, err := os.ReadFile(filepath.Join(tmpDir, "done"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(Equal(tmpDir))
+		})
+	})
+
+	Describe("run", func() {
+		It("should return 0 on success and create done file", func() {
+			executeFunc = func() error { return nil }
+
+			exitCode := run()
+
+			Expect(exitCode).To(Equal(0))
+			Expect(filepath.Join(tmpDir, "done")).To(BeAnExistingFile())
+		})
+
+		It("should return 1 on failure and create done file", func() {
+			executeFunc = func() error { return errors.New("test failure") }
+
+			exitCode := run()
+
+			Expect(exitCode).To(Equal(1))
+			Expect(filepath.Join(tmpDir, "done")).To(BeAnExistingFile())
+		})
+
+		It("should create done file even on panic", func() {
+			executeFunc = func() error { panic("test panic") }
+
+			Expect(func() { run() }).To(Panic())
+			Expect(filepath.Join(tmpDir, "done")).To(BeAnExistingFile())
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
According to Sonobuoy's plugin contract, the done file must always be written to signal completion,
regardless of whether tests passed or failed. 
The actual test results are in the junit.xml file.

This fix ensures the done file is written even when tests panic.

Beside that Added Unit tests to cover the cases.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

