### PR TITLE
kubevirtci: Add fake SR-IOV vGPU kernel module for testing

### DIFF
--- a/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/.gitignore
+++ b/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/.gitignore
@@ -1,0 +1,16 @@
+# Build artifacts
+*.o
+*.ko
+*.mod
+*.mod.c
+*.mod.o
+modules.order
+Module.symvers
+.*.cmd
+.tmp_versions/
+
+# Editor files
+*~
+*.swp
+.vscode/
+.idea/

--- a/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/Makefile
+++ b/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/Makefile
@@ -1,0 +1,62 @@
+# Makefile for fake-sriov-vgpu kernel module
+#
+# Build against running kernel:
+#   make
+#
+# Build against specific kernel:
+#   make KDIR=/path/to/kernel/build
+#
+# Install to custom location:
+#   make INSTALL_MOD_PATH=/path install
+#
+# Clean:
+#   make clean
+
+MODULE_NAME := fake-sriov-vgpu
+obj-m := $(MODULE_NAME).o
+
+# Kernel build directory
+KDIR ?= /lib/modules/$(shell uname -r)/build
+
+# Current directory
+PWD := $(shell pwd)
+
+# Default target
+all: modules
+
+modules:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	rm -f *.o *.ko *.mod.c *.mod.o *.order *.symvers .*.cmd
+
+install: modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+	depmod -a
+
+# Load module
+load: modules
+	@echo "Loading $(MODULE_NAME) module..."
+	-rmmod $(MODULE_NAME) 2>/dev/null || true
+	insmod $(MODULE_NAME).ko
+	@echo "Module loaded. Check dmesg for details."
+
+# Unload module
+unload:
+	@echo "Unloading $(MODULE_NAME) module..."
+	-rmmod $(MODULE_NAME) 2>/dev/null || true
+	@echo "Module unloaded."
+
+# Show status
+status:
+	@echo "=== Module Status ==="
+	@lsmod | grep $(MODULE_NAME) || echo "Module not loaded"
+	@echo ""
+	@echo "=== Control Interface ==="
+	@ls -la /sys/class/fake-sriov-vgpu/control/ 2>/dev/null || echo "Not available"
+	@echo ""
+	@echo "=== Created VFs ==="
+	@cat /sys/class/fake-sriov-vgpu/control/list 2>/dev/null || echo "None"
+
+.PHONY: all modules clean install load unload status

--- a/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/README.md
+++ b/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/README.md
@@ -1,0 +1,176 @@
+# Fake SR-IOV vGPU Kernel Module
+
+This kernel module creates fake PCI devices that appear in `/sys/bus/pci/devices/` to simulate NVIDIA SR-IOV Virtual Functions (VFs) with vGPU profiles assigned. It is designed to test KubeVirt's vGPU VF discovery (PR #16710) **without requiring real GPU hardware**.
+
+## Purpose
+
+PR #16710 adds support for discovering NVIDIA vGPU SR-IOV Virtual Functions that:
+- Don't have the `vfio-pci` driver bound yet
+- Have vGPU profiles assigned (detected via `nvidia/current_vgpu_type` sysfs file)
+- Are not Physical Functions (no `virtfn*` subdirectories)
+
+This module creates a **real virtual PCI bus** and registers fake devices on it, making them visible to standard PCI device discovery mechanisms including KubeVirt's virt-handler.
+
+## Quick Start
+
+### 1. Build the Module
+
+```bash
+cd kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu
+
+# Build using container (ensures kernel version match)
+docker run --rm \
+  -v $(pwd):/src:Z \
+  quay.io/kubevirtci/bootstrap:v20251218-e7a7fc9 \
+  bash -c 'dnf install -y kernel-devel kernel-headers >/dev/null 2>&1 && cd /src && make KDIR=/usr/src/kernels/$(ls /usr/src/kernels/ | head -1) modules'
+```
+
+### 2. Setup Fake VFs (requires sudo)
+
+```bash
+sudo ./setup-fake-sriov.sh setup
+
+# Output shows:
+# - Module loaded
+# - 4 VF devices created
+# - Devices appear in /sys/bus/pci/devices/0001:00:XX.X
+```
+
+### 3. Verify PCI Devices
+
+```bash
+# List fake PCI devices (domain 0001)
+ls -la /sys/bus/pci/devices/0001:*
+
+# Check device attributes
+cat /sys/bus/pci/devices/0001:00:00.0/vendor    # 0x10de (NVIDIA)
+cat /sys/bus/pci/devices/0001:00:00.0/device    # 0x1eb8 (Tesla T4)
+cat /sys/bus/pci/devices/0001:00:00.0/nvidia/current_vgpu_type  # 256
+```
+
+### 4. Cleanup
+
+```bash
+sudo ./setup-fake-sriov.sh cleanup
+```
+
+## How It Works
+
+The module creates a **virtual PCI bus** at domain `0001` and registers fake PCI devices on it:
+
+1. **Virtual PCI Bus**: Created using `pci_create_root_bus()` with fake I/O and memory resources
+2. **Fake PCI Devices**: Registered using `pci_scan_single_device()` and `pci_bus_add_device()`
+3. **Config Space**: Each device has a PCI config space that reports NVIDIA Tesla T4 IDs
+4. **nvidia/ sysfs**: Each device has `nvidia/current_vgpu_type` attribute for vGPU profile detection
+
+### Device Structure
+
+```
+/sys/bus/pci/devices/0001:00:00.0/
+├── vendor              # 0x10de (NVIDIA)
+├── device              # 0x1eb8 (Tesla T4)
+├── class               # 0x030000 (Display controller)
+├── subsystem_vendor    # 0x10de
+├── subsystem_device    # 0x12a2
+└── nvidia/
+    └── current_vgpu_type  # vGPU profile (0 = none, non-zero = assigned)
+```
+
+## Testing PR #16710
+
+### KubeVirt Configuration
+
+Add the fake devices to the permitted host devices:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    permittedHostDevices:
+      pciHostDevices:
+      - pciVendorSelector: "10de:1eb8"
+        resourceName: "nvidia.com/VGPU_T4"
+```
+
+### Test Scenarios
+
+| Scenario | VF Config | Expected Result |
+|----------|-----------|-----------------|
+| VF with vGPU profile | `vgpu_type=256` | **Discovered** (new PR #16710 behavior) |
+| VF without vGPU profile | `vgpu_type=0` | Skipped (no profile assigned) |
+
+### Manual VF Management
+
+```bash
+# Create a VF with vGPU profile (slot 5, func 0, vgpu_type 256)
+sudo ./setup-fake-sriov.sh create-vf 5 0 256
+
+# Create a VF without vGPU profile (should be skipped by discovery)
+sudo ./setup-fake-sriov.sh create-vf 6 0 0
+
+# Remove a VF
+sudo ./setup-fake-sriov.sh remove-vf 5 0
+
+# Update vGPU type on existing device
+echo 512 > /sys/bus/pci/devices/0001:00:00.0/nvidia/current_vgpu_type
+```
+
+## Requirements
+
+- Linux kernel 5.10 or later
+- Linux kernel headers (matching your running kernel)
+- Build tools: `make`, `gcc`
+- Root privileges for loading the module
+
+## Troubleshooting
+
+### Module fails to load with "Invalid module format"
+
+Kernel version mismatch. Rebuild the module for your running kernel:
+
+```bash
+uname -r  # Check your kernel version
+make clean && make
+```
+
+### Module crashes during load
+
+Check dmesg for errors. The module may need architecture-specific adjustments for your kernel.
+
+### VFs not being discovered by KubeVirt
+
+1. Check that the `permittedHostDevices` CR includes the NVIDIA T4 PCI ID (`10de:1eb8`)
+2. Verify the VF has a vGPU profile: `cat /sys/bus/pci/devices/0001:00:00.0/nvidia/current_vgpu_type`
+3. The value must be non-zero for the new PR #16710 logic to discover it
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FAKE_SRIOV_VFS` | 4 | Number of VF devices to create |
+| `FAKE_SRIOV_VGPU_TYPE` | 256 | vGPU type value (0 = no profile) |
+
+## License
+
+### Kernel Module Files (GPL-2.0-only)
+
+| File | License | Notes |
+|------|---------|-------|
+| `fake-sriov-vgpu.c` | GPL-2.0-only | Kernel module source |
+| `compat.h` | GPL-2.0-only | Compatibility header |
+| `Makefile` | GPL-2.0-only | Build configuration |
+| `dkms.conf` | GPL-2.0-only | DKMS configuration |
+
+### Infrastructure Files (Apache-2.0)
+
+| File | License | Notes |
+|------|---------|-------|
+| `setup-fake-sriov.sh` | Apache-2.0 | KubeVirt test infrastructure |
+| `README.md` | Apache-2.0 | Documentation |
+
+## References
+
+- [KubeVirt PR #16710](https://github.com/kubevirt/kubevirt/pull/16710) - vGPU SR-IOV support
+- [NVIDIA vGPU Documentation](https://docs.nvidia.com/grid/)
+- [Linux PCI Driver API](https://docs.kernel.org/PCI/pci.html)

--- a/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/compat.h
+++ b/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/compat.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Kernel compatibility header for fake-sriov-vgpu module
+ *
+ * This header provides compatibility shims for different kernel versions.
+ */
+
+#ifndef _FAKE_SRIOV_VGPU_COMPAT_H
+#define _FAKE_SRIOV_VGPU_COMPAT_H
+
+#include <linux/version.h>
+
+/*
+ * Minimum supported kernel version
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
+#error "This module requires kernel 5.10 or later"
+#endif
+
+/*
+ * class_create() signature changed in 6.4
+ * Before 6.4: class_create(owner, name)
+ * After 6.4: class_create(name)
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+#define COMPAT_CLASS_CREATE(name) class_create(name)
+#else
+#define COMPAT_CLASS_CREATE(name) class_create(THIS_MODULE, name)
+#endif
+
+/*
+ * strscpy was introduced in 4.3, but some older distributions
+ * may not have it. Use strlcpy fallback if needed.
+ */
+#ifndef strscpy
+#define strscpy(dest, src, size) strlcpy(dest, src, size)
+#endif
+
+#endif /* _FAKE_SRIOV_VGPU_COMPAT_H */

--- a/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/dkms.conf
+++ b/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/dkms.conf
@@ -1,0 +1,18 @@
+# DKMS configuration for fake-sriov-vgpu
+#
+# Install with DKMS:
+#   sudo cp -r fake-sriov-vgpu /usr/src/fake-sriov-vgpu-1.0
+#   sudo dkms add -m fake-sriov-vgpu -v 1.0
+#   sudo dkms build -m fake-sriov-vgpu -v 1.0
+#   sudo dkms install -m fake-sriov-vgpu -v 1.0
+#
+# Remove:
+#   sudo dkms remove -m fake-sriov-vgpu -v 1.0 --all
+
+PACKAGE_NAME="fake-sriov-vgpu"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="fake-sriov-vgpu"
+DEST_MODULE_LOCATION[0]="/extra"
+
+AUTOINSTALL="yes"

--- a/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/fake-sriov-vgpu.c
+++ b/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/fake-sriov-vgpu.c
@@ -1,0 +1,642 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Fake SR-IOV vGPU PCI device driver for KubeVirt testing
+ *
+ * This module creates fake PCI devices that appear in /sys/bus/pci/devices/
+ * to simulate NVIDIA SR-IOV Virtual Functions with vGPU profiles assigned.
+ *
+ * It creates a virtual PCI bus and registers fake devices on it, making them
+ * visible to the standard PCI device discovery mechanisms.
+ *
+ * Copyright the KubeVirt Authors.
+ */
+
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/pci.h>
+#include <linux/list.h>
+#include <linux/mutex.h>
+#include <linux/version.h>
+#include <linux/device.h>
+#include <linux/ioport.h>
+
+#include "compat.h"
+
+/* Fake resources for our virtual PCI bus */
+static struct resource fake_pci_mem = {
+	.name	= "fake-sriov-vgpu PCI mem",
+	.start	= 0x80000000,
+	.end	= 0x8fffffff,
+	.flags	= IORESOURCE_MEM,
+};
+
+static struct resource fake_pci_io = {
+	.name	= "fake-sriov-vgpu PCI I/O",
+	.start	= 0x1000,
+	.end	= 0x1fff,
+	.flags	= IORESOURCE_IO,
+};
+
+#define VERSION_STRING  "1.0"
+#define DRIVER_AUTHOR   "KubeVirt Fake SR-IOV vGPU Driver"
+
+#define FAKE_SRIOV_NAME         "fake-sriov-vgpu"
+
+/* NVIDIA PCI IDs - Tesla T4 */
+#define NVIDIA_VENDOR_ID        0x10de
+#define NVIDIA_T4_DEVICE_ID     0x1eb8
+#define NVIDIA_T4_SUBSYS_ID     0x12a2
+
+/* Our fake PCI domain/segment */
+#define FAKE_PCI_DOMAIN         0x0001  /* Use domain 1 to avoid conflicts */
+#define FAKE_PCI_BUS            0x00
+
+/* Maximum number of fake VFs */
+#define MAX_FAKE_VFS            32
+
+/* PCI config space size */
+#define PCI_CONFIG_SPACE_SIZE   256
+
+MODULE_DESCRIPTION("Fake SR-IOV vGPU PCI driver for KubeVirt testing");
+MODULE_LICENSE("GPL v2");
+MODULE_VERSION(VERSION_STRING);
+MODULE_AUTHOR(DRIVER_AUTHOR);
+
+/* Per-VF device state */
+struct fake_vf_state {
+	struct list_head list;
+	struct pci_dev *pdev;
+	u8 config_space[PCI_CONFIG_SPACE_SIZE];
+	u32 vgpu_type;
+	int slot;
+	int func;
+	struct kobject *nvidia_kobj;
+};
+
+/* Global state */
+static struct {
+	struct pci_bus *bus;
+	struct pci_host_bridge *bridge;
+	struct list_head vf_list;
+	struct mutex lock;
+	int vf_count;
+	struct class *ctrl_class;
+	struct device *ctrl_dev;
+} fake_sriov;
+
+/* Forward declarations */
+static void destroy_fake_vf(struct fake_vf_state *vf);
+
+/*
+ * PCI config space operations for our fake bus
+ */
+static struct fake_vf_state *find_vf_by_devfn(unsigned int devfn)
+{
+	struct fake_vf_state *vf;
+	int slot = PCI_SLOT(devfn);
+	int func = PCI_FUNC(devfn);
+
+	list_for_each_entry(vf, &fake_sriov.vf_list, list) {
+		if (vf->slot == slot && vf->func == func)
+			return vf;
+	}
+	return NULL;
+}
+
+static int fake_pci_read(struct pci_bus *bus, unsigned int devfn,
+			 int where, int size, u32 *val)
+{
+	struct fake_vf_state *vf;
+
+	if (where >= PCI_CONFIG_SPACE_SIZE)
+		return PCIBIOS_BAD_REGISTER_NUMBER;
+
+	vf = find_vf_by_devfn(devfn);
+	if (!vf) {
+		*val = ~0;
+		return PCIBIOS_DEVICE_NOT_FOUND;
+	}
+
+	switch (size) {
+	case 1:
+		*val = vf->config_space[where];
+		break;
+	case 2:
+		*val = *(u16 *)&vf->config_space[where];
+		break;
+	case 4:
+		*val = *(u32 *)&vf->config_space[where];
+		break;
+	default:
+		return PCIBIOS_BAD_REGISTER_NUMBER;
+	}
+
+	return PCIBIOS_SUCCESSFUL;
+}
+
+static int fake_pci_write(struct pci_bus *bus, unsigned int devfn,
+			  int where, int size, u32 val)
+{
+	struct fake_vf_state *vf;
+
+	if (where >= PCI_CONFIG_SPACE_SIZE)
+		return PCIBIOS_BAD_REGISTER_NUMBER;
+
+	vf = find_vf_by_devfn(devfn);
+	if (!vf)
+		return PCIBIOS_DEVICE_NOT_FOUND;
+
+	switch (size) {
+	case 1:
+		vf->config_space[where] = val & 0xff;
+		break;
+	case 2:
+		*(u16 *)&vf->config_space[where] = val & 0xffff;
+		break;
+	case 4:
+		*(u32 *)&vf->config_space[where] = val;
+		break;
+	default:
+		return PCIBIOS_BAD_REGISTER_NUMBER;
+	}
+
+	return PCIBIOS_SUCCESSFUL;
+}
+
+static struct pci_ops fake_pci_ops = {
+	.read = fake_pci_read,
+	.write = fake_pci_write,
+};
+
+/*
+ * Initialize PCI config space to look like NVIDIA Tesla T4 VF
+ */
+static void init_config_space(struct fake_vf_state *vf)
+{
+	u8 *cfg = vf->config_space;
+
+	memset(cfg, 0, PCI_CONFIG_SPACE_SIZE);
+
+	/* Vendor and Device ID */
+	*(u16 *)&cfg[PCI_VENDOR_ID] = NVIDIA_VENDOR_ID;
+	*(u16 *)&cfg[PCI_DEVICE_ID] = NVIDIA_T4_DEVICE_ID;
+
+	/* Command: Memory space enable */
+	*(u16 *)&cfg[PCI_COMMAND] = PCI_COMMAND_MEMORY;
+
+	/* Status: Capabilities list */
+	*(u16 *)&cfg[PCI_STATUS] = PCI_STATUS_CAP_LIST;
+
+	/* Revision */
+	cfg[PCI_REVISION_ID] = 0xa1;
+
+	/* Class: Display controller / VGA compatible */
+	cfg[PCI_CLASS_PROG] = 0x00;
+	*(u16 *)&cfg[PCI_CLASS_DEVICE] = 0x0300;  /* VGA compatible */
+
+	/* Header type: Normal */
+	cfg[PCI_HEADER_TYPE] = PCI_HEADER_TYPE_NORMAL;
+
+	/* Subsystem IDs */
+	*(u16 *)&cfg[PCI_SUBSYSTEM_VENDOR_ID] = NVIDIA_VENDOR_ID;
+	*(u16 *)&cfg[PCI_SUBSYSTEM_ID] = NVIDIA_T4_SUBSYS_ID;
+
+	/* BAR0: Memory, 64-bit, prefetchable (minimal - just for structure) */
+	*(u32 *)&cfg[PCI_BASE_ADDRESS_0] = PCI_BASE_ADDRESS_MEM_TYPE_64 |
+					   PCI_BASE_ADDRESS_MEM_PREFETCH;
+
+	/* Capabilities pointer */
+	cfg[PCI_CAPABILITY_LIST] = 0x60;
+
+	/* Interrupt pin */
+	cfg[PCI_INTERRUPT_PIN] = 0x01;
+
+	/* Power Management capability at 0x60 */
+	cfg[0x60] = PCI_CAP_ID_PM;
+	cfg[0x61] = 0x00;  /* End of caps */
+	*(u16 *)&cfg[0x62] = 0x0003;  /* PM capabilities */
+}
+
+/*
+ * nvidia/current_vgpu_type sysfs attribute
+ */
+static ssize_t current_vgpu_type_show(struct kobject *kobj,
+				      struct kobj_attribute *attr, char *buf)
+{
+	struct fake_vf_state *vf;
+
+	mutex_lock(&fake_sriov.lock);
+	list_for_each_entry(vf, &fake_sriov.vf_list, list) {
+		if (vf->nvidia_kobj == kobj) {
+			mutex_unlock(&fake_sriov.lock);
+			return sprintf(buf, "%u\n", vf->vgpu_type);
+		}
+	}
+	mutex_unlock(&fake_sriov.lock);
+	return -ENODEV;
+}
+
+static ssize_t current_vgpu_type_store(struct kobject *kobj,
+				       struct kobj_attribute *attr,
+				       const char *buf, size_t count)
+{
+	struct fake_vf_state *vf;
+	u32 type;
+	int ret;
+
+	ret = kstrtou32(buf, 0, &type);
+	if (ret)
+		return ret;
+
+	mutex_lock(&fake_sriov.lock);
+	list_for_each_entry(vf, &fake_sriov.vf_list, list) {
+		if (vf->nvidia_kobj == kobj) {
+			vf->vgpu_type = type;
+			mutex_unlock(&fake_sriov.lock);
+			return count;
+		}
+	}
+	mutex_unlock(&fake_sriov.lock);
+	return -ENODEV;
+}
+
+static struct kobj_attribute vgpu_type_attr =
+	__ATTR(current_vgpu_type, 0644, current_vgpu_type_show, current_vgpu_type_store);
+
+static struct attribute *nvidia_attrs[] = {
+	&vgpu_type_attr.attr,
+	NULL,
+};
+
+static const struct attribute_group nvidia_attr_group = {
+	.attrs = nvidia_attrs,
+};
+
+/*
+ * Create a fake VF PCI device
+ */
+static struct fake_vf_state *create_fake_vf(int slot, int func, u32 vgpu_type)
+{
+	struct fake_vf_state *vf;
+	struct pci_dev *pdev;
+	unsigned int devfn;
+	int ret;
+
+	if (fake_sriov.vf_count >= MAX_FAKE_VFS) {
+		pr_err("fake_sriov_vgpu: maximum VF count reached\n");
+		return ERR_PTR(-ENOSPC);
+	}
+
+	/* Check slot/func not already used */
+	devfn = PCI_DEVFN(slot, func);
+	if (find_vf_by_devfn(devfn)) {
+		pr_err("fake_sriov_vgpu: slot %d func %d already exists\n", slot, func);
+		return ERR_PTR(-EEXIST);
+	}
+
+	vf = kzalloc(sizeof(*vf), GFP_KERNEL);
+	if (!vf)
+		return ERR_PTR(-ENOMEM);
+
+	vf->slot = slot;
+	vf->func = func;
+	vf->vgpu_type = vgpu_type;
+
+	/* Initialize config space */
+	init_config_space(vf);
+
+	/* Add to list first so config space reads work during scan */
+	list_add_tail(&vf->list, &fake_sriov.vf_list);
+	fake_sriov.vf_count++;
+
+	/* Scan the device - this creates the pci_dev and adds it to sysfs */
+	pdev = pci_scan_single_device(fake_sriov.bus, devfn);
+	if (!pdev) {
+		pr_err("fake_sriov_vgpu: failed to scan device %02x:%02x.%d\n",
+		       FAKE_PCI_BUS, slot, func);
+		ret = -ENODEV;
+		goto err_list;
+	}
+
+	vf->pdev = pdev;
+
+	/* Add the device to the bus */
+	pci_bus_add_device(pdev);
+
+	/* Create nvidia/ subdirectory with current_vgpu_type */
+	vf->nvidia_kobj = kobject_create_and_add("nvidia", &pdev->dev.kobj);
+	if (!vf->nvidia_kobj) {
+		pr_err("fake_sriov_vgpu: failed to create nvidia kobj\n");
+		ret = -ENOMEM;
+		goto err_pdev;
+	}
+
+	ret = sysfs_create_group(vf->nvidia_kobj, &nvidia_attr_group);
+	if (ret) {
+		pr_err("fake_sriov_vgpu: failed to create nvidia attrs: %d\n", ret);
+		goto err_nvidia_kobj;
+	}
+
+	pr_info("fake_sriov_vgpu: created VF %04x:%02x:%02x.%d (vgpu_type=%u)\n",
+		FAKE_PCI_DOMAIN, FAKE_PCI_BUS, slot, func, vgpu_type);
+
+	return vf;
+
+err_nvidia_kobj:
+	kobject_put(vf->nvidia_kobj);
+err_pdev:
+	pci_stop_and_remove_bus_device(pdev);
+err_list:
+	list_del(&vf->list);
+	fake_sriov.vf_count--;
+	kfree(vf);
+	return ERR_PTR(ret);
+}
+
+static void destroy_fake_vf(struct fake_vf_state *vf)
+{
+	pr_info("fake_sriov_vgpu: destroying VF %04x:%02x:%02x.%d\n",
+		FAKE_PCI_DOMAIN, FAKE_PCI_BUS, vf->slot, vf->func);
+
+	sysfs_remove_group(vf->nvidia_kobj, &nvidia_attr_group);
+	kobject_put(vf->nvidia_kobj);
+
+	if (vf->pdev)
+		pci_stop_and_remove_bus_device(vf->pdev);
+
+	list_del(&vf->list);
+	fake_sriov.vf_count--;
+	kfree(vf);
+}
+
+/*
+ * Control interface sysfs attributes
+ */
+
+/* Create: echo "slot func vgpu_type" > create */
+static ssize_t create_store(struct device *dev,
+			    struct device_attribute *attr,
+			    const char *buf, size_t count)
+{
+	int slot, func;
+	u32 vgpu_type = 256;
+	struct fake_vf_state *vf;
+	int ret;
+
+	ret = sscanf(buf, "%d %d %u", &slot, &func, &vgpu_type);
+	if (ret < 2) {
+		pr_err("fake_sriov_vgpu: usage: echo 'slot func [vgpu_type]' > create\n");
+		return -EINVAL;
+	}
+
+	if (slot < 0 || slot > 31 || func < 0 || func > 7) {
+		pr_err("fake_sriov_vgpu: invalid slot/func\n");
+		return -EINVAL;
+	}
+
+	mutex_lock(&fake_sriov.lock);
+	vf = create_fake_vf(slot, func, vgpu_type);
+	mutex_unlock(&fake_sriov.lock);
+
+	if (IS_ERR(vf))
+		return PTR_ERR(vf);
+
+	return count;
+}
+static DEVICE_ATTR_WO(create);
+
+/* Remove: echo "slot func" > remove */
+static ssize_t remove_store(struct device *dev,
+			    struct device_attribute *attr,
+			    const char *buf, size_t count)
+{
+	int slot, func;
+	struct fake_vf_state *vf;
+	unsigned int devfn;
+	int ret;
+
+	ret = sscanf(buf, "%d %d", &slot, &func);
+	if (ret != 2) {
+		pr_err("fake_sriov_vgpu: usage: echo 'slot func' > remove\n");
+		return -EINVAL;
+	}
+
+	devfn = PCI_DEVFN(slot, func);
+
+	mutex_lock(&fake_sriov.lock);
+	vf = find_vf_by_devfn(devfn);
+	if (!vf) {
+		mutex_unlock(&fake_sriov.lock);
+		pr_err("fake_sriov_vgpu: VF slot %d func %d not found\n", slot, func);
+		return -ENOENT;
+	}
+	destroy_fake_vf(vf);
+	mutex_unlock(&fake_sriov.lock);
+
+	return count;
+}
+static DEVICE_ATTR_WO(remove);
+
+/* List all VFs */
+static ssize_t list_show(struct device *dev,
+			 struct device_attribute *attr, char *buf)
+{
+	struct fake_vf_state *vf;
+	ssize_t len = 0;
+
+	mutex_lock(&fake_sriov.lock);
+	list_for_each_entry(vf, &fake_sriov.vf_list, list) {
+		len += scnprintf(buf + len, PAGE_SIZE - len,
+				 "%04x:%02x:%02x.%d vgpu_type=%u\n",
+				 FAKE_PCI_DOMAIN, FAKE_PCI_BUS,
+				 vf->slot, vf->func, vf->vgpu_type);
+		if (len >= PAGE_SIZE - 1)
+			break;
+	}
+	mutex_unlock(&fake_sriov.lock);
+
+	if (len == 0)
+		len = scnprintf(buf, PAGE_SIZE, "(no VFs created)\n");
+
+	return len;
+}
+static DEVICE_ATTR_RO(list);
+
+/* Clear all VFs */
+static ssize_t clear_store(struct device *dev,
+			   struct device_attribute *attr,
+			   const char *buf, size_t count)
+{
+	struct fake_vf_state *vf, *tmp;
+
+	mutex_lock(&fake_sriov.lock);
+	list_for_each_entry_safe(vf, tmp, &fake_sriov.vf_list, list) {
+		destroy_fake_vf(vf);
+	}
+	mutex_unlock(&fake_sriov.lock);
+
+	pr_info("fake_sriov_vgpu: all VFs cleared\n");
+	return count;
+}
+static DEVICE_ATTR_WO(clear);
+
+static struct attribute *ctrl_dev_attrs[] = {
+	&dev_attr_create.attr,
+	&dev_attr_remove.attr,
+	&dev_attr_list.attr,
+	&dev_attr_clear.attr,
+	NULL,
+};
+
+static const struct attribute_group ctrl_dev_attr_group = {
+	.attrs = ctrl_dev_attrs,
+};
+
+static const struct attribute_group *ctrl_dev_attr_groups[] = {
+	&ctrl_dev_attr_group,
+	NULL,
+};
+
+static void ctrl_device_release(struct device *dev)
+{
+	pr_debug("fake_sriov_vgpu: control device released\n");
+}
+
+/* Sysdata structure for our fake bus */
+static struct {
+	int domain;
+} fake_sysdata = {
+	.domain = FAKE_PCI_DOMAIN,
+};
+
+/*
+ * Create the virtual PCI bus
+ */
+static int create_fake_pci_bus(void)
+{
+	struct pci_host_bridge *bridge;
+	struct pci_bus *bus;
+	LIST_HEAD(resources);
+
+	/* Add resource windows */
+	pci_add_resource(&resources, &fake_pci_io);
+	pci_add_resource(&resources, &fake_pci_mem);
+
+	/* Create root bus directly - simpler than host bridge for virtual devices */
+	bus = pci_create_root_bus(NULL, FAKE_PCI_BUS, &fake_pci_ops,
+				  &fake_sysdata, &resources);
+	if (!bus) {
+		pr_err("fake_sriov_vgpu: failed to create root bus\n");
+		pci_free_resource_list(&resources);
+		return -ENOMEM;
+	}
+
+	fake_sriov.bus = bus;
+	
+	/* Get the bridge from the bus */
+	bridge = to_pci_host_bridge(bus->bridge);
+	fake_sriov.bridge = bridge;
+
+	pr_info("fake_sriov_vgpu: created PCI bus %04x:%02x\n",
+		pci_domain_nr(fake_sriov.bus), FAKE_PCI_BUS);
+
+	return 0;
+}
+
+static void destroy_fake_pci_bus(void)
+{
+	if (fake_sriov.bridge) {
+		pci_remove_root_bus(fake_sriov.bus);
+		fake_sriov.bus = NULL;
+		fake_sriov.bridge = NULL;
+	}
+}
+
+static int __init fake_sriov_init(void)
+{
+	int ret;
+
+	pr_info("fake_sriov_vgpu: initializing\n");
+
+	INIT_LIST_HEAD(&fake_sriov.vf_list);
+	mutex_init(&fake_sriov.lock);
+	fake_sriov.vf_count = 0;
+
+	/* Create control class and device */
+	fake_sriov.ctrl_class = COMPAT_CLASS_CREATE(FAKE_SRIOV_NAME);
+	if (IS_ERR(fake_sriov.ctrl_class)) {
+		ret = PTR_ERR(fake_sriov.ctrl_class);
+		pr_err("fake_sriov_vgpu: failed to create class: %d\n", ret);
+		goto err_class;
+	}
+
+	fake_sriov.ctrl_dev = kzalloc(sizeof(*fake_sriov.ctrl_dev), GFP_KERNEL);
+	if (!fake_sriov.ctrl_dev) {
+		ret = -ENOMEM;
+		goto err_ctrl_alloc;
+	}
+
+	device_initialize(fake_sriov.ctrl_dev);
+	fake_sriov.ctrl_dev->class = fake_sriov.ctrl_class;
+	fake_sriov.ctrl_dev->release = ctrl_device_release;
+	fake_sriov.ctrl_dev->groups = ctrl_dev_attr_groups;
+	dev_set_name(fake_sriov.ctrl_dev, "control");
+
+	ret = device_add(fake_sriov.ctrl_dev);
+	if (ret) {
+		pr_err("fake_sriov_vgpu: failed to add control device: %d\n", ret);
+		goto err_ctrl_add;
+	}
+
+	/* Create the virtual PCI bus */
+	ret = create_fake_pci_bus();
+	if (ret)
+		goto err_bus;
+
+	pr_info("fake_sriov_vgpu: ready\n");
+	pr_info("fake_sriov_vgpu: control at /sys/class/%s/control/\n", FAKE_SRIOV_NAME);
+	pr_info("fake_sriov_vgpu: create VF: echo 'slot func [vgpu_type]' > create\n");
+	pr_info("fake_sriov_vgpu: devices appear in /sys/bus/pci/devices/\n");
+
+	return 0;
+
+err_bus:
+	device_del(fake_sriov.ctrl_dev);
+err_ctrl_add:
+	put_device(fake_sriov.ctrl_dev);
+err_ctrl_alloc:
+	class_destroy(fake_sriov.ctrl_class);
+err_class:
+	mutex_destroy(&fake_sriov.lock);
+	return ret;
+}
+
+static void __exit fake_sriov_exit(void)
+{
+	struct fake_vf_state *vf, *tmp;
+
+	pr_info("fake_sriov_vgpu: cleaning up\n");
+
+	/* Remove all VFs */
+	mutex_lock(&fake_sriov.lock);
+	list_for_each_entry_safe(vf, tmp, &fake_sriov.vf_list, list) {
+		destroy_fake_vf(vf);
+	}
+	mutex_unlock(&fake_sriov.lock);
+
+	/* Remove PCI bus */
+	destroy_fake_pci_bus();
+
+	/* Remove control interface */
+	device_del(fake_sriov.ctrl_dev);
+	put_device(fake_sriov.ctrl_dev);
+	class_destroy(fake_sriov.ctrl_class);
+	mutex_destroy(&fake_sriov.lock);
+
+	pr_info("fake_sriov_vgpu: unloaded\n");
+}
+
+module_init(fake_sriov_init)
+module_exit(fake_sriov_exit)

--- a/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/setup-fake-sriov.sh
+++ b/kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu/setup-fake-sriov.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+# Setup fake-sriov-vgpu module for testing NVIDIA SR-IOV vGPU VF discovery
+#
+# This module creates real PCI devices in /sys/bus/pci/devices/ by
+# registering a virtual PCI bus.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_PATH="${SCRIPT_DIR}/fake-sriov-vgpu.ko"
+MODULE_NAME="fake_sriov_vgpu"
+
+# Default configuration
+NUM_VFS=${FAKE_SRIOV_VFS:-4}
+VGPU_TYPE=${FAKE_SRIOV_VGPU_TYPE:-256}  # Non-zero means vGPU profile assigned
+
+# Control interface path
+CTRL_PATH="/sys/class/fake-sriov-vgpu/control"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        log_error "This script must be run as root"
+        exit 1
+    fi
+}
+
+check_module_exists() {
+    if [[ ! -f "$MODULE_PATH" ]]; then
+        log_error "Module not found at $MODULE_PATH"
+        log_info "Please build the module first:"
+        log_info "  cd ${SCRIPT_DIR} && make"
+        exit 1
+    fi
+}
+
+load_module() {
+    log_info "Loading fake-sriov-vgpu module..."
+    
+    # Unload if already loaded
+    if lsmod | grep -q "$MODULE_NAME"; then
+        log_info "Module already loaded, removing first..."
+        echo 1 > "$CTRL_PATH/clear" 2>/dev/null || true
+        rmmod $MODULE_NAME 2>/dev/null || true
+        sleep 1
+    fi
+    
+    # Load the module
+    insmod "$MODULE_PATH"
+    
+    if lsmod | grep -q "$MODULE_NAME"; then
+        log_info "Module loaded successfully"
+    else
+        log_error "Failed to load module"
+        dmesg | tail -20
+        exit 1
+    fi
+    
+    # Wait for sysfs
+    sleep 1
+}
+
+create_vfs() {
+    log_info "Creating $NUM_VFS fake VF devices..."
+    
+    if [[ ! -f "$CTRL_PATH/create" ]]; then
+        log_error "Control interface not found at $CTRL_PATH"
+        exit 1
+    fi
+    
+    local created=0
+    for ((i=0; i<NUM_VFS; i++)); do
+        local slot=$((i % 32))
+        local func=$((i / 32))
+        
+        # Create VF: slot func vgpu_type
+        if echo "${slot} ${func} ${VGPU_TYPE}" > "$CTRL_PATH/create" 2>/dev/null; then
+            log_info "Created VF: slot=$slot func=$func (vgpu_type=$VGPU_TYPE)"
+            created=$((created + 1))
+        else
+            log_warn "Failed to create VF slot=$slot func=$func"
+            dmesg | tail -5
+        fi
+    done
+    
+    log_info "Created $created VF devices"
+    
+    if [[ $created -eq 0 ]]; then
+        log_error "Failed to create any VF devices"
+        exit 1
+    fi
+}
+
+show_status() {
+    echo ""
+    log_info "=== Fake SR-IOV vGPU Status ==="
+    echo ""
+    
+    echo "Loaded modules:"
+    lsmod | grep "$MODULE_NAME" || echo "  Module not loaded"
+    echo ""
+    
+    echo "Created VFs:"
+    if [[ -f "$CTRL_PATH/list" ]]; then
+        cat "$CTRL_PATH/list"
+    else
+        echo "  Control interface not available"
+    fi
+    echo ""
+    
+    echo "PCI devices (fake domain 0001):"
+    ls -la /sys/bus/pci/devices/ 2>/dev/null | grep "0001:" || echo "  None"
+    echo ""
+    
+    # Show first VF details
+    local first_vf=$(ls -d /sys/bus/pci/devices/0001:* 2>/dev/null | head -1)
+    if [[ -n "$first_vf" && -d "$first_vf" ]]; then
+        echo "Example VF: $first_vf"
+        echo "  vendor: $(cat "$first_vf/vendor" 2>/dev/null)"
+        echo "  device: $(cat "$first_vf/device" 2>/dev/null)"
+        if [[ -f "$first_vf/nvidia/current_vgpu_type" ]]; then
+            echo "  nvidia/current_vgpu_type: $(cat "$first_vf/nvidia/current_vgpu_type" 2>/dev/null)"
+        fi
+    fi
+}
+
+cleanup() {
+    log_info "Cleaning up fake SR-IOV vGPU..."
+    
+    # Clear VFs
+    if [[ -f "$CTRL_PATH/clear" ]]; then
+        echo 1 > "$CTRL_PATH/clear" 2>/dev/null || true
+    fi
+    
+    # Unload module
+    if lsmod | grep -q "$MODULE_NAME"; then
+        rmmod $MODULE_NAME 2>/dev/null || true
+        log_info "Module unloaded"
+    fi
+}
+
+usage() {
+    echo "Usage: $0 [setup|cleanup|status|create-vf|remove-vf]"
+    echo ""
+    echo "Commands:"
+    echo "  setup       Load module and create VFs (default)"
+    echo "  cleanup     Clear VFs and unload module"
+    echo "  status      Show current status"
+    echo "  create-vf   Create a single VF: $0 create-vf SLOT FUNC [vgpu_type]"
+    echo "  remove-vf   Remove a single VF: $0 remove-vf SLOT FUNC"
+    echo ""
+    echo "Environment variables:"
+    echo "  FAKE_SRIOV_VFS         Number of VFs to create (default: 4)"
+    echo "  FAKE_SRIOV_VGPU_TYPE   vGPU type value (default: 256, 0=no profile)"
+    echo ""
+    echo "Examples:"
+    echo "  # Setup with defaults (4 VFs with vGPU type 256)"
+    echo "  sudo $0 setup"
+    echo ""
+    echo "  # Setup with 8 VFs"
+    echo "  sudo FAKE_SRIOV_VFS=8 $0 setup"
+    echo ""
+    echo "  # Create a VF without vGPU profile"
+    echo "  sudo $0 create-vf 5 0 0"
+    echo ""
+    echo "  # Check the PCI devices"
+    echo "  ls /sys/bus/pci/devices/0001:*"
+}
+
+# Main
+case "${1:-setup}" in
+    setup)
+        check_root
+        check_module_exists
+        load_module
+        create_vfs
+        show_status
+        ;;
+    cleanup)
+        check_root
+        cleanup
+        ;;
+    status)
+        show_status
+        ;;
+    create-vf)
+        check_root
+        if [[ -z "$2" || -z "$3" ]]; then
+            log_error "Usage: $0 create-vf SLOT FUNC [vgpu_type]"
+            exit 1
+        fi
+        slot="$2"
+        func="$3"
+        vgpu_type="${4:-256}"
+        echo "${slot} ${func} ${vgpu_type}" > "$CTRL_PATH/create"
+        log_info "Created VF: slot=$slot func=$func vgpu_type=$vgpu_type"
+        ;;
+    remove-vf)
+        check_root
+        if [[ -z "$2" || -z "$3" ]]; then
+            log_error "Usage: $0 remove-vf SLOT FUNC"
+            exit 1
+        fi
+        slot="$2"
+        func="$3"
+        echo "${slot} ${func}" > "$CTRL_PATH/remove"
+        log_info "Removed VF: slot=$slot func=$func"
+        ;;
+    -h|--help)
+        usage
+        ;;
+    *)
+        log_error "Unknown command: $1"
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add a kernel module that creates fake PCI devices in /sys/bus/pci/devices/ to simulate NVIDIA SR-IOV Virtual Functions with vGPU profiles assigned.

This enables testing of PR #16710's vGPU VF discovery logic without requiring real GPU hardware. The module:
Note: didn't test e2d, just device creation.

- Creates a virtual PCI bus at domain 0001
- Registers fake PCI devices with NVIDIA Tesla T4 vendor/device IDs
- Provides nvidia/current_vgpu_type sysfs attribute for vGPU profile detection
- Devices appear as real PCI devices visible to virt-handler

Usage:
  cd kubevirtci/cluster-up/cluster/kind-1.33-vgpu/fake-sriov-vgpu make  # or use container build sudo ./setup-fake-sriov.sh setup

Devices will appear at /sys/bus/pci/devices/0001:00:XX.X with:
- vendor: 0x10de (NVIDIA)
- device: 0x1eb8 (Tesla T4)
- nvidia/current_vgpu_type: configurable vGPU profile

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

