### PR TITLE
virt-handler: Fix entry duplication in vmiMountTargetRecord

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -244,6 +244,21 @@ var _ = Describe("HotplugVolume", func() {
 			_, err = os.Stat(filepath.Join(tempDir, "test"))
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("writePathToMountRecord should not duplicate existing entry", func() {
+			duplicatePath := record.MountTargetEntries[0].TargetFile
+			originalLength := len(record.MountTargetEntries)
+			originalBytes, err := os.ReadFile(filepath.Join(tempDir, string(vmi.UID)))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = m.writePathToMountRecord(duplicatePath, vmi, record)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(record.MountTargetEntries).To(HaveLen(originalLength))
+
+			updatedBytes, err := os.ReadFile(filepath.Join(tempDir, string(vmi.UID)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedBytes).To(Equal(originalBytes))
+		})
 	})
 
 	Context("block devices", func() {


### PR DESCRIPTION
### What this PR does
This PR fixes the issue when in certain circumstances a per-VMI mount target record file grows unbounded because `writePathToMountRecord()` appends a new `vmiMountTargetEntry` without deduplicating by `TargetFile`.
#### Before this PR:
When virt-handler resolves an incorrect hotplug volume mountpoint on the node (see #16520), it may repeatedly append duplicate entries to the per-VMI mount target record. The file grows unbounded because `writePathToMountRecord()` appends a new `vmiMountTargetEntry` without deduplicating by `TargetFile`. This is amplified by reconcile retries: every sync failure that re-enqueues the VM adds another duplicate entry for the same (incorrectly resolved) target path.
See #16532.
#### After this PR:
Now `writePathToMountRecord()` calls `appendPathToMountRecord()` that verifies whether there's already an entry with the same `TargetFile` in the `vmiMountTargetRecord` record before calling `append()`.
### References
- Fixes #16532.
- Partially addresses #16520.

### Why we need it and why it was done in this way
The per-VMI mount target record drives hotplug cleanup. When virt-handler repeatedly resolves the same (potentially incorrect) target path across retries, `writePathToMountRecord()` could append duplicate `TargetFile` entries and the record file could grow unbounded. This PR makes the operation idempotent by deduplicating on `TargetFile` before appending.

**The following tradeoffs were made:**
Deduplication is done in-memory (simple, low risk) and keeps the existing record format/ordering (“first entry wins”).

**Links to places where the discussion took place:** #16532, #16520.

### Special notes for your reviewer
Included a unit test ensuring `writePathToMountRecord()` is idempotent for an already-recorded path.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A design document is not required, this is a targeted bug fix
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: Included a unit test ensuring `writePathToMountRecord()` is idempotent for an already-recorded path
- [x] Documentation: A user-guide update is not required
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Fix virt-handler hotplug mount target record growth by preventing duplicate TargetFile entries.
```

