### PR TITLE
virt-handler: Unmount() now does best-effort volume cleanup

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -729,10 +729,22 @@ func (m *volumeMounter) Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cg
 		newRecord := vmiMountTargetRecord{
 			MountTargetEntries: make([]vmiMountTargetEntry, 0),
 		}
+		var errs []error
+		logErrAndKeepMount := func(path string, format string, args ...any) {
+			err := fmt.Errorf(format, args...)
+			log.Log.Object(vmi).Error(err.Error())
+			newRecord.appendPath(path)
+			errs = append(errs, err)
+		}
 		for _, entry := range record.MountTargetEntries {
 			fd, err := safepath.NewFileNoFollow(entry.TargetFile)
 			if err != nil {
-				return err
+				if errors.Is(err, os.ErrNotExist) {
+					log.Log.Object(vmi).Infof("Volume %v is not mounted anymore, continuing", entry.TargetFile)
+				} else {
+					logErrAndKeepMount(entry.TargetFile, "Unable to unmount volume at path %s: %v", entry.TargetFile, err)
+				}
+				continue
 			}
 			fd.Close()
 			diskPath := fd.Path()
@@ -740,13 +752,16 @@ func (m *volumeMounter) Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cg
 
 			if _, ok := currentHotplugPaths[diskPathAbs]; !ok {
 				if blockDevice, err := isBlockDevice(diskPath); err != nil {
-					return err
+					logErrAndKeepMount(diskPathAbs, "Unable to unmount volume at path %s: %v", diskPath, err)
+					continue
 				} else if blockDevice {
 					if err := m.unmountBlockHotplugVolumes(diskPath, cgroupManager); err != nil {
-						return err
+						logErrAndKeepMount(diskPathAbs, "Unable to remove block device at path %s: %v", diskPath, err)
+						continue
 					}
 				} else if err := m.unmountFileSystemHotplugVolumes(diskPath); err != nil {
-					return err
+					logErrAndKeepMount(diskPathAbs, "Unable to unmount filesystem volume at path %s: %v", diskPath, err)
+					continue
 				}
 				log.Log.Object(vmi).V(3).Infof("Unmounted hotplug volume path %s", diskPath)
 			} else {
@@ -760,6 +775,9 @@ func (m *volumeMounter) Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cg
 		}
 		if err != nil {
 			return err
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("failed to cleanup hotplug mounts for VMI %s: %w", vmi.Name, errors.Join(errs...))
 		}
 	}
 	return nil

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -947,6 +947,58 @@ var _ = Describe("HotplugVolume", func() {
 			Expect(err).To(HaveOccurred(), "block device volume still exists %s", blockVolume)
 		})
 
+		It("Unmount, if failed, should continue for other volumes", func() {
+			badPath, err := newFile(targetPodPath, "badvolume.img")
+			Expect(err).ToNot(HaveOccurred())
+			goodPath, err := newFile(targetPodPath, "goodvolume.img")
+			Expect(err).ToNot(HaveOccurred())
+			badPathAbs := unsafepath.UnsafeAbsolute(badPath.Raw())
+			goodPathAbs := unsafepath.UnsafeAbsolute(goodPath.Raw())
+
+			record := &vmiMountTargetRecord{
+				MountTargetEntries: []vmiMountTargetEntry{
+					{TargetFile: badPathAbs},
+					{TargetFile: goodPathAbs},
+				},
+			}
+			Expect(m.setMountTargetRecord(vmi, record)).To(Succeed())
+
+			// Inject block probe failure
+			DeferCleanup(func() {
+				isBlockDevice = orgIsBlockDevice
+			})
+			isBlockDevice = func(path *safepath.Path) (bool, error) {
+				if unsafepath.UnsafeAbsolute(path.Raw()) == badPathAbs {
+					return false, fmt.Errorf("block probe error")
+				}
+				return false, nil
+			}
+
+			isMounted = func(path *safepath.Path) (bool, error) {
+				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(goodPathAbs))
+				return true, nil
+			}
+			unmountCommand = func(diskPath *safepath.Path) ([]byte, error) {
+				Expect(unsafepath.UnsafeAbsolute(diskPath.Raw())).To(Equal(goodPathAbs))
+				return []byte("Success"), nil
+			}
+
+			err = m.Unmount(vmi, cgroupManagerMock)
+			Expect(err).To(HaveOccurred())
+
+			_, err = os.Stat(goodPathAbs)
+			Expect(err).To(HaveOccurred(), "filesystem volume file still exists %s", goodPathAbs)
+			_, err = os.Stat(badPathAbs)
+			Expect(err).ToNot(HaveOccurred(), "failed volume should remain %s", badPathAbs)
+
+			bytes, err := os.ReadFile(filepath.Join(tempDir, string(vmi.UID)))
+			Expect(err).ToNot(HaveOccurred())
+			updated := &vmiMountTargetRecord{}
+			Expect(json.Unmarshal(bytes, updated)).To(Succeed())
+			Expect(updated.MountTargetEntries).To(HaveLen(1))
+			Expect(updated.MountTargetEntries[0].TargetFile).To(Equal(badPathAbs))
+		})
+
 		It("Should not do anything if vmi has no hotplug volumes", func() {
 			volumeStatuses := make([]v1.VolumeStatus, 0)
 			volumeStatuses = append(volumeStatuses, v1.VolumeStatus{


### PR DESCRIPTION
### What this PR does
Improves hotplug filesystem volume unmount robustness in `virt-handler` by continuing cleanup on per-path failures and reporting an aggregate error at the end.
#### Before this PR:
`Unmount()` returned early on the first error, which could prevent cleanup of remaining hotplug paths and didn’t preserve a reduced “still mounted / failed” record for retry.
#### After this PR:
`Unmount()` attempts to process all recorded hotplug paths, keeps failed paths in a new record for retry, and reports a summarized error only after finishing the loop.
### References
- Fixes #16537
### Why we need it and why it was done in this way
**The following tradeoffs were made:**
- Pros: Best-effort cleanup makes progress even when one mount path is stuck (busy, missing, transient). This reduces “one bad entry blocks everything” behavior during reconcile retries.
- Cons: A single failing path no longer stops the function immediately; instead you get an aggregated failure signal and must rely on logs/record persistence to see which path(s) failed.
### Checklist
- [x] Design: A design document is not required, this is a targeted bug fix
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: Included a unit test ensuring `Unmount()` now attempts all unmount-ready paths instead of returning early on 1st failure
- [x] Documentation: A user-guide update is not required
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
### Release note
```release-note
Improve Unmount() cleanup by processing all entries and preserving failed paths for retry.
```

