### PR TITLE
fix: support vfio-ap model for s390x mdev devices in dra

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -1283,9 +1283,9 @@ type GraphicsListen struct {
 }
 
 type Address struct {
-	Type       string `xml:"type,attr"`
+	Type       string `xml:"type,attr,omitempty"`
 	Domain     string `xml:"domain,attr,omitempty"`
-	Bus        string `xml:"bus,attr"`
+	Bus        string `xml:"bus,attr,omitempty"`
 	Slot       string `xml:"slot,attr,omitempty"`
 	Function   string `xml:"function,attr,omitempty"`
 	Controller string `xml:"controller,attr,omitempty"`

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
@@ -22,8 +22,6 @@ package dra
 import (
 	"fmt"
 
-	k8sv1 "k8s.io/api/core/v1"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
@@ -49,7 +47,7 @@ func CreateDRAHostDevices(vmi *v1.VirtualMachineInstance, basePath string) ([]ap
 			continue
 		}
 
-		hostDevice, err := createHostDeviceForHostDevice(hd, basePath, vmi.Spec.ResourceClaims)
+		hostDevice, err := createHostDeviceForHostDevice(hd, basePath, vmi.Spec)
 		if err != nil {
 			return nil, fmt.Errorf(failedCreateGenericHostDevicesFmt, err)
 		}
@@ -65,19 +63,24 @@ func CreateDRAHostDevices(vmi *v1.VirtualMachineInstance, basePath string) ([]ap
 	return hostDevices, nil
 }
 
-func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, resourceClaims []k8sv1.PodResourceClaim) (*api.HostDevice, error) {
+func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, vmiSpecs v1.VirtualMachineInstanceSpec) (*api.HostDevice, error) {
 	if hd.ClaimRequest == nil || hd.ClaimRequest.ClaimName == nil || hd.ClaimRequest.RequestName == nil {
 		return nil, fmt.Errorf("HostDevice %s has incomplete ClaimRequest", hd.Name)
 	}
 
 	claimName := *hd.ClaimRequest.ClaimName
 	requestName := *hd.ClaimRequest.RequestName
+	resourceClaims := vmiSpecs.ResourceClaims
 
 	// Check mdevUUID first: a device with both pciBusID and mdevUUID is a
 	// mediated (vGPU) device whose parent happens to expose pciBusID. Treating
 	// it as PCI passthrough would be incorrect.
 	if mdevUUID, err := drautil.GetMDevUUIDForClaim(basePath, resourceClaims, claimName, requestName); err == nil {
 		log.Log.V(2).Infof("Adding DRA MDEV HostDevice for %s", hd.Name)
+		model := "vfio-pci"
+		if vmiSpecs.Architecture == "s390x" {
+			model = "vfio-ap"
+		}
 		return &api.HostDevice{
 			Alias: api.NewUserDefinedAlias(DRAHostDeviceAliasPrefix + hd.Name),
 			Source: api.HostDeviceSource{
@@ -87,7 +90,7 @@ func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, resourceCl
 			},
 			Type:  api.HostDeviceMDev,
 			Mode:  "subsystem",
-			Model: "vfio-pci",
+			Model: model,
 		}, nil
 	}
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev_test.go
@@ -163,6 +163,68 @@ var _ = Describe("CreateDRAHostDevices", func() {
 			Expect(dev.Type).To(Equal(api.HostDeviceMDev))
 			Expect(dev.Alias.GetName()).To(Equal(DRAHostDeviceAliasPrefix + "vhd1"))
 			Expect(dev.Source.Address.UUID).To(Equal(uuid))
+			Expect(dev.Source.Address.Type).To(Equal(""))
+			Expect(dev.Source.Address.Bus).To(Equal(""))
+			Expect(dev.Mode).To(Equal("subsystem"))
+			Expect(dev.Model).To(Equal("vfio-pci"))
+		})
+	})
+
+	Context("when the VMI has an MDEV host device allocated through DRA (s390x)", func() {
+		It("should create an MDEV HostDevice", func() {
+			uuid := "abcd1234-1111-2222-3333-444455556666"
+
+			createMetadataFile("claim1", "req1", "mdev.example.com", &metadata.DeviceMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceMetadata",
+					APIVersion: "v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "claim1",
+				},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Driver: "mdev.example.com",
+						Pool:   "mdev-pool",
+						Name:   "device1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.MDevUUIDAttribute: {StringValue: &uuid},
+						},
+					}},
+				}},
+			})
+
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vmi"},
+				Spec: v1.VirtualMachineInstanceSpec{
+					ResourceClaims: []k8sv1.PodResourceClaim{{
+						Name:              "claim1",
+						ResourceClaimName: ptr.To("claim1"),
+					}},
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							HostDevices: []v1.HostDevice{{
+								Name:         "vhd1",
+								ClaimRequest: &v1.ClaimRequest{ClaimName: ptr.To("claim1"), RequestName: ptr.To("req1")},
+							}},
+						},
+					},
+					Architecture: "s390x",
+				},
+			}
+
+			hostDevs, err := CreateDRAHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevs).To(HaveLen(1))
+			dev := hostDevs[0]
+			Expect(dev.Type).To(Equal(api.HostDeviceMDev))
+			Expect(dev.Alias.GetName()).To(Equal(DRAHostDeviceAliasPrefix + "vhd1"))
+			Expect(dev.Source.Address.UUID).To(Equal(uuid))
+			Expect(dev.Source.Address.Type).To(Equal(""))
+			Expect(dev.Source.Address.Bus).To(Equal(""))
+			Expect(dev.Mode).To(Equal("subsystem"))
+			Expect(dev.Model).To(Equal("vfio-ap"))
 		})
 	})
 


### PR DESCRIPTION
On s390x architecture, mediated devices should use the vfio-ap model instead of vfio-pci.

Furthermore the type and bus must values in the xml schema must be optional because of libvirt restrictions.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

