### PR TITLE
[release-1.6] vm controller: Clear RestartRequired when no restart is needed

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -2973,8 +2973,8 @@ func setRestartRequired(vm *virtv1.VirtualMachine, message string) {
 	})
 }
 
-// addRestartRequiredIfNeeded adds the restartRequired condition to the VM if any non-live-updatable field was changed
-func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+// syncRestartRequired adds or removes the RestartRequired condition from the VM based on whether any non-live-updatable field was changed
+func (c *Controller) syncRestartRequired(lastSeenVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
 	if lastSeenVMSpec == nil {
 		return false
 	}
@@ -3038,6 +3038,14 @@ func (c *Controller) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMa
 	if !equality.Semantic.DeepEqual(lastSeenVM.Spec.Template.Spec, currentVM.Spec.Template.Spec) {
 		setRestartRequired(vm, "a non-live-updatable field was changed in the template spec")
 		return true
+	}
+
+	// If no restart is needed, remove any existing RestartRequired condition.
+	// This handles cases where a previous condition was set but is no longer valid,
+	// such as when the firmware UUID synchronizer persisted a UUID that matches the VMI's UUID.
+	vmConditionManager := controller.NewVirtualMachineConditionManager()
+	if vmConditionManager.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
+		vmConditionManager.RemoveCondition(vm, virtv1.VirtualMachineRestartRequired)
 	}
 
 	return false
@@ -3191,7 +3199,7 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 		return vm, vmi, syncErr, nil
 	}
 
-	restartRequired := c.addRestartRequiredIfNeeded(startVMSpec, vm, vmi)
+	restartRequired := c.syncRestartRequired(startVMSpec, vm, vmi)
 
 	// Must check satisfiedExpectations again here because a VMI can be created or
 	// deleted in the startStop function which impacts how we process

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -5647,7 +5647,7 @@ var _ = Describe("VirtualMachine", func() {
 					})
 				})
 
-				It("should not add addRestartRequiredIfNeeded to VM if live-updatable", func() {
+				It("should not add RestartRequired condition to VM if live-updatable", func() {
 					updatedInstancetype := originalInstancetype.DeepCopy()
 					updatedInstancetype.Generation = originalInstancetype.Generation + 1
 					updatedInstancetype.Spec.CPU.Guest = uint32(2)
@@ -5664,11 +5664,10 @@ var _ = Describe("VirtualMachine", func() {
 						Kind:         instancetypeapi.SingularResourceName,
 						RevisionName: updatedRevision.Name,
 					}
-					Expect(controller.addRestartRequiredIfNeeded(&originalVM.Spec, updatedVM, vmi)).To(BeFalse())
-					vmConditionController := virtcontroller.NewVirtualMachineConditionManager()
-					Expect(vmConditionController.HasCondition(updatedVM, v1.VirtualMachineRestartRequired)).To(BeFalse())
+					Expect(controller.syncRestartRequired(&originalVM.Spec, updatedVM, vmi)).To(BeFalse())
+					Expect(updatedVM).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
 				})
-				It("should add addRestartRequiredIfNeeded to VM if not live-updatable", func() {
+				It("should add RestartRequired condition to VM if not live-updatable", func() {
 					updatedInstancetype := originalInstancetype.DeepCopy()
 					updatedInstancetype.Generation = originalInstancetype.Generation + 1
 					updatedInstancetype.Spec.CPU.Guest = uint32(2)
@@ -5689,9 +5688,8 @@ var _ = Describe("VirtualMachine", func() {
 						RevisionName: updatedRevision.Name,
 					}
 
-					Expect(controller.addRestartRequiredIfNeeded(&originalVM.Spec, updatedVM, vmi)).To(BeTrue())
-					vmConditionController := virtcontroller.NewVirtualMachineConditionManager()
-					Expect(vmConditionController.HasCondition(updatedVM, v1.VirtualMachineRestartRequired)).To(BeTrue())
+					Expect(controller.syncRestartRequired(&originalVM.Spec, updatedVM, vmi)).To(BeTrue())
+					Expect(updatedVM).To(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
 				})
 			})
 		})
@@ -6232,6 +6230,31 @@ var _ = Describe("VirtualMachine", func() {
 				Entry("should not raise RestartRequired when VM and VMI UUIDs match", CalculateLegacyUUID("testvmi"), BeFalse()),
 				Entry("should raise RestartRequired when VM and VMI UUIDs differ", types.UID("different-uuid-than-vmi"), BeTrue()),
 			)
+
+			It("should clear existing RestartRequired condition when VM and VMI specs match", func() {
+				By("Creating a VM with an existing RestartRequired condition")
+				vm.Status.Conditions = append(vm.Status.Conditions, v1.VirtualMachineCondition{
+					Type:   v1.VirtualMachineRestartRequired,
+					Status: k8sv1.ConditionTrue,
+				})
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with matching spec")
+				vmi = controller.setupVMIFromVM(vm)
+				controller.vmiIndexer.Add(vmi)
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(vm)
+
+				By("Executing the controller")
+				sanityExecute(vm)
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+
+				By("Verifying the RestartRequired condition was removed")
+				Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+			})
 		})
 
 		clearExpectations := func(vm *v1.VirtualMachine) {


### PR DESCRIPTION
### What this PR does
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/16606

automated cherry-pick didnot fail, but build had an error because the usage of `controller.setupVMIFromVM` is different in other releases 

### References
- closes #16719 

### Release note
```release-note
none
```