### PR TITLE
[release-1.7] vmsnapshot: report volumes being deleted

### DIFF
--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -59,6 +59,7 @@ var (
 	ErrVolumeDoesntExist  = errors.New("volume doesnt exist")
 	ErrVolumeNotBound     = errors.New("volume not bound")
 	ErrVolumeNotPopulated = errors.New("volume not populated")
+	ErrVolumeBeingDeleted = errors.New("volume is being deleted")
 )
 
 type snapshotSource interface {
@@ -157,7 +158,7 @@ func (s *vmSnapshotSource) Lock() (bool, error) {
 	err = s.verifyVolumes(pvcNames.List())
 	if err != nil {
 		switch errors.Unwrap(err) {
-		case ErrVolumeDoesntExist, ErrVolumeNotBound, ErrVolumeNotPopulated:
+		case ErrVolumeDoesntExist, ErrVolumeNotBound, ErrVolumeNotPopulated, ErrVolumeBeingDeleted:
 			s.state.lockMsg += fmt.Sprintf(" source %s/%s %s", s.vm.Namespace, s.vm.Name, err.Error())
 			log.Log.Error(s.state.lockMsg)
 			return false, nil
@@ -259,6 +260,9 @@ func (s *vmSnapshotSource) verifyVolumes(pvcNames []string) error {
 		}
 
 		pvc := obj.(*corev1.PersistentVolumeClaim).DeepCopy()
+		if pvc.DeletionTimestamp != nil {
+			return fmt.Errorf("%w: %s", ErrVolumeBeingDeleted, pvcName)
+		}
 		if pvc.Status.Phase != corev1.ClaimBound {
 			return fmt.Errorf("%w: %s", ErrVolumeNotBound, pvcName)
 		}

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1097,58 +1097,6 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 			})
 		})
 
-		It("vmsnapshot should update error if vmsnapshotcontent is unready to use and error", func() {
-			vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, snapshotStorageClass)
-			vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
-
-			for _, dvt := range vm.Spec.DataVolumeTemplates {
-				waitDataVolumePopulated(vm.Namespace, dvt.Name)
-			}
-			// Delete DV and wait pvc get deletionTimestamp
-			// when pvc is deleting snapshot is not possible
-			volumeName := vm.Spec.DataVolumeTemplates[0].Name
-			By("Deleting Data volume")
-			err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Delete(context.Background(), volumeName, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(func() *metav1.Time {
-				pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), volumeName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return pvc.DeletionTimestamp
-			}, 30*time.Second, time.Second).ShouldNot(BeNil())
-
-			By("Creating VMSnapshot")
-			snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
-
-			_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func() *snapshotv1.VirtualMachineSnapshotStatus {
-				snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return snapshot.Status
-			}, time.Minute, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-				"Conditions": ContainElements(
-					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Type":   Equal(snapshotv1.ConditionReady),
-						"Status": Equal(corev1.ConditionFalse),
-						"Reason": Equal("Not ready")}),
-					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Type":   Equal(snapshotv1.ConditionProgressing),
-						"Status": Equal(corev1.ConditionFalse),
-						"Reason": Equal("In error state")}),
-				),
-				"Phase": Equal(snapshotv1.InProgress),
-				"Error": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-					"Message": gstruct.PointTo(ContainSubstring("Failed to create snapshot content with error")),
-				})),
-				"CreationTime": BeNil(),
-			})))
-		})
-
 		It("snapshot create before source wait for volume bound, then continues and succeeds", func() {
 			wffc := libstorage.IsStorageClassBindingModeWaitForFirstConsumer(snapshotStorageClass)
 			// Stand alone dv


### PR DESCRIPTION
CDI 1.64 included https://github.com/kubevirt/containerized-data-importer/pull/3912 which will make us report the volume is merely "not populated", when in fact, it is being deleted and it is pointless to progress further.

Report volumes being deleted and circumvent the entire thing, alongside a conversion of the corresponding e2e test to a unit test.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/16621

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: vmsnapshot: report volumes being deleted
```

