### PR TITLE
virt-operator: refine canary flow to fully support out of band changes

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1637,7 +1637,12 @@ func (k *KubeVirtTestData) makeHandlerReady() {
 			handlerNew := handler.DeepCopy()
 			handlerNew.Status.DesiredNumberScheduled = 1
 			handlerNew.Status.NumberReady = 1
+			handlerNew.Status.NumberAvailable = 1
 			handlerNew.Status.UpdatedNumberScheduled = 1
+			maxUnavailable := intstr.FromInt(1)
+			handlerNew.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
+				MaxUnavailable: &maxUnavailable,
+			}
 			k.controller.stores.DaemonSetCache.Update(handlerNew)
 			key, err := kubecontroller.KeyFunc(handlerNew)
 			Expect(err).To(Not(HaveOccurred()))
@@ -2223,8 +2228,8 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.controller.Execute()
 
-			// add one for the namespace, one for the export proxy route
-			Expect(kvTestData.totalPatches).To(Equal(numGenerations + 2))
+			// add one for the namespace
+			Expect(kvTestData.totalPatches).To(Equal(numGenerations + 1))
 
 			// all these resources should be tracked by there generation so everyone that has been added should now be patched
 			// since they where the `lastGeneration` was set to -1 on the KubeVirt CR
@@ -2930,7 +2935,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.resourceChanges["deployments"][Patched]).To(Equal(1))          // virt-operator patched, virt-api unpatched
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(1)) // 1 of 2 PDBs patched
 			Expect(kvTestData.resourceChanges["namespace"][Patched]).To(Equal(0))            // namespace unpatched
-			Expect(kvTestData.resourceChanges["daemonsets"][Patched]).To(Equal(0))           // namespace unpatched
+			Expect(kvTestData.resourceChanges["daemonsets"][Patched]).To(Equal(0))           // daemonset unpatched
 		})
 
 		Context("virt-api replica count", func() {

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -35,14 +35,19 @@ var (
 	daemonSetFastMaxUnavailable    = intstr.FromString("10%")
 )
 
-type CanaryUpgradeStatus string
+// canaryUpgradeStatus represents the current phase of a DaemonSet canary
+// upgrade within processCanaryUpgrade. The phases progress as:
+// started -> canary -> increasing -> waiting -> successful
+// Any phase can transition to failed on error.
+type canaryUpgradeStatus string
 
 const (
-	CanaryUpgradeStatusStarted                 CanaryUpgradeStatus = "started"
-	CanaryUpgradeStatusUpgradingDaemonSet      CanaryUpgradeStatus = "upgrading daemonset"
-	CanaryUpgradeStatusWaitingDaemonSetRollout CanaryUpgradeStatus = "waiting for daemonset rollout"
-	CanaryUpgradeStatusSuccessful              CanaryUpgradeStatus = "successful"
-	CanaryUpgradeStatusFailed                  CanaryUpgradeStatus = "failed"
+	started    canaryUpgradeStatus = "started"    // spec patched with MaxUnavailable=1, initial canary pod rolling out
+	canary     canaryUpgradeStatus = "canary"     // waiting for the single canary pod to become ready
+	increasing canaryUpgradeStatus = "increasing" // canary healthy, MaxUnavailable raised to 10% for full rollout
+	waiting    canaryUpgradeStatus = "waiting"    // full rollout in progress, waiting for all pods to become ready
+	successful canaryUpgradeStatus = "successful" // all pods ready, MaxUnavailable reverted to default
+	failed     canaryUpgradeStatus = "failed"
 )
 
 func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.Deployment, error) {
@@ -126,7 +131,8 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 	}
 
 	ops, err := patch.New(getPatchWithObjectMetaAndSpec([]patch.PatchOption{
-		patch.WithTest("/metadata/generation", cachedDeployment.ObjectMeta.Generation)},
+		patch.WithTest("/metadata/generation", cachedDeployment.ObjectMeta.Generation),
+	},
 		&deployment.ObjectMeta, deployment.Spec)...).GeneratePayload()
 	if err != nil {
 		return nil, err
@@ -154,7 +160,8 @@ func setMaxUnavailable(daemonSet *appsv1.DaemonSet, maxUnavailable intstr.IntOrS
 func generateDaemonSetPatch(oldDs, newDs *appsv1.DaemonSet) ([]byte, error) {
 	return patch.New(
 		getPatchWithObjectMetaAndSpec([]patch.PatchOption{
-			patch.WithTest("/metadata/generation", oldDs.ObjectMeta.Generation)},
+			patch.WithTest("/metadata/generation", oldDs.ObjectMeta.Generation),
+		},
 			&newDs.ObjectMeta, newDs.Spec)...).GeneratePayload()
 }
 
@@ -209,10 +216,8 @@ func daemonHasDefaultRolloutStrategy(daemonSet *appsv1.DaemonSet) bool {
 	return getMaxUnavailable(daemonSet) == daemonSetDefaultMaxUnavailable.IntValue()
 }
 
-func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonSet, forceUpdate bool) (bool, error, CanaryUpgradeStatus) {
+func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonSet, objectChanged bool) (bool, error, canaryUpgradeStatus) {
 	var updatedAndReadyPods int32
-	var status CanaryUpgradeStatus
-	done := false
 
 	if hasTLS(cachedDaemonSet) && !hasTLS(newDS) {
 		insertTLS(newDS)
@@ -223,91 +228,85 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 	}
 	log := log.Log.With("resource", fmt.Sprintf("ds/%s", cachedDaemonSet.Name))
 
-	isDaemonSetUpdated := util.DaemonSetIsUpToDate(r.kv, cachedDaemonSet) && !forceUpdate
 	desiredReadyPods := cachedDaemonSet.Status.DesiredNumberScheduled
-	if isDaemonSetUpdated {
-		updatedAndReadyPods = r.howManyUpdatedAndReadyPods(cachedDaemonSet)
-	}
+	updatedAndReadyPods = r.howManyUpdatedAndReadyPods(cachedDaemonSet)
 
 	switch {
+	case objectChanged:
+		// start canary upgrade
+		setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
+		newDS, err := r.patchDaemonSet(cachedDaemonSet, newDS)
+		if err != nil {
+			return false, fmt.Errorf("unable to start canary upgrade for daemonset %+v: %v", newDS, err), failed
+		}
+		log.V(2).Infof("daemonSet %v started upgrade", newDS.GetName())
+		// Do not call SetGeneration here. The generation mismatch ensures
+		// subsequent reconciles re-enter processCanaryUpgrade so the
+		// canary can progress through Increasing and Successful.
+		return false, nil, started
 	case updatedAndReadyPods == 0:
-		if !isDaemonSetUpdated {
-			// start canary upgrade
-			setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
-			_, err := r.patchDaemonSet(cachedDaemonSet, newDS)
-			if err != nil {
-				log.V(2).Infof("failed to start canary upgrade for daemonset %s: %+v", newDS.Name, newDS)
-				return false, fmt.Errorf("unable to start canary upgrade for daemonset %s: %v", newDS.Name, err), CanaryUpgradeStatusFailed
-			}
-			log.V(2).Infof("daemonSet %v started upgrade", newDS.GetName())
-		} else {
-			// check for a crashed canary pod
-			canaryPods := r.getCanaryPods(cachedDaemonSet)
-			for _, canary := range canaryPods {
-				if canary != nil && util.PodIsCrashLooping(canary) {
-					r.recorder.Eventf(cachedDaemonSet, corev1.EventTypeWarning, failedUpdateDaemonSetReason, "daemonSet %v rollout failed", cachedDaemonSet.Name)
-					return false, fmt.Errorf("daemonSet %s rollout failed", cachedDaemonSet.Name), CanaryUpgradeStatusFailed
-				}
+		// check for a crashed canary pod
+		canaryPods := r.getCanaryPods(cachedDaemonSet)
+		for _, canary := range canaryPods {
+			if canary != nil && util.PodIsCrashLooping(canary) {
+				r.recorder.Eventf(cachedDaemonSet, corev1.EventTypeWarning, failedUpdateDaemonSetReason, "daemonSet %v rollout failed", cachedDaemonSet.Name)
+				return false, fmt.Errorf("daemonSet %s rollout failed", cachedDaemonSet.Name), failed
 			}
 		}
-		done, status = false, CanaryUpgradeStatusStarted
+		return false, nil, canary
 	case updatedAndReadyPods > 0 && updatedAndReadyPods < desiredReadyPods:
 		if daemonHasDefaultRolloutStrategy(cachedDaemonSet) {
 			// canary was ok, start real rollout
 			setMaxUnavailable(newDS, daemonSetFastMaxUnavailable)
 			// start rollout again
-			_, err := r.patchDaemonSet(cachedDaemonSet, newDS)
-			if err != nil {
-				log.V(2).Infof("failed to update daemonset %s: %+v", newDS.Name, newDS)
-				return false, fmt.Errorf("unable to update daemonset %s: %v", newDS.Name, err), CanaryUpgradeStatusFailed
-			}
-			log.V(2).Infof("daemonSet %v updated", newDS.GetName())
-			status = CanaryUpgradeStatusUpgradingDaemonSet
-		} else {
-			log.V(4).Infof("waiting for all pods of daemonSet %v to be ready", newDS.GetName())
-			status = CanaryUpgradeStatusWaitingDaemonSetRollout
-		}
-		done = false
-	case updatedAndReadyPods > 0 && updatedAndReadyPods == desiredReadyPods:
-
-		// rollout has completed and all virt-handlers are ready
-		if !daemonHasDefaultRolloutStrategy(cachedDaemonSet) {
-			// revert maxUnavailable to default value
-			setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
 			var err error
 			newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
 			if err != nil {
-				return false, err, CanaryUpgradeStatusFailed
+				return false, fmt.Errorf("unable to update daemonset %+v: %v", newDS, err), failed
 			}
-			log.V(2).Infof("daemonSet %v updated back to default", newDS.GetName())
+			log.V(2).Infof("daemonSet %v updated", newDS.GetName())
 			SetGeneration(&r.kv.Status.Generations, newDS)
-			return false, nil, CanaryUpgradeStatusWaitingDaemonSetRollout
+			return false, nil, increasing
 		}
-
+		log.V(4).Infof("waiting for all pods of daemonSet %v to be ready", newDS.GetName())
+		return false, nil, waiting
+	case updatedAndReadyPods > 0 && updatedAndReadyPods == desiredReadyPods:
+		var err error
 		if supportsTLS(cachedDaemonSet) {
 			if !hasTLS(cachedDaemonSet) {
 				insertTLS(newDS)
-				_, err := r.patchDaemonSet(cachedDaemonSet, newDS)
-				log.V(2).Infof("daemonSet %v updated to default CN TLS", newDS.GetName())
+				newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
+				if err != nil {
+					return false, err, failed
+				}
 				SetGeneration(&r.kv.Status.Generations, newDS)
-				return false, err, CanaryUpgradeStatusWaitingDaemonSetRollout
+				return false, nil, waiting
 			}
 			if hasCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName) {
 				unattachCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName)
-				var err error
-				cachedDaemonSet, err = r.patchDaemonSet(cachedDaemonSet, newDS)
+				newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
 				if err != nil {
-					return false, err, CanaryUpgradeStatusFailed
+					return false, err, failed
 				}
-				log.V(2).Infof("daemonSet %v updated to secure certificates", newDS.GetName())
+				SetGeneration(&r.kv.Status.Generations, newDS)
+				return false, nil, waiting
 			}
 		}
-
-		SetGeneration(&r.kv.Status.Generations, cachedDaemonSet)
+		// rollout has completed and all virt-handlers are ready revert
+		// maxUnavailable to default value
+		setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
+		newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
+		if err != nil {
+			return false, err, failed
+		}
+		SetGeneration(&r.kv.Status.Generations, newDS)
 		log.V(2).Infof("daemonSet %v is ready", newDS.GetName())
-		done, status = true, CanaryUpgradeStatusSuccessful
+		return true, nil, successful
+	default:
+		err := fmt.Errorf("unexpected canary upgrade state: updatedAndReadyPods=%d, desiredReadyPods=%d", updatedAndReadyPods, desiredReadyPods)
+		log.Errorf("%s", err)
+		return false, err, failed
 	}
-	return done, nil, status
 }
 
 func supportsTLS(daemonSet *appsv1.DaemonSet) bool {
@@ -409,13 +408,16 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 	}
 
 	cachedDaemonSet = obj.(*appsv1.DaemonSet)
-	modified := resourcemerge.BoolPtr(false)
 	existingCopy := cachedDaemonSet.DeepCopy()
-	expectedGeneration := GetExpectedGeneration(daemonSet, kv.Status.Generations)
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, daemonSet.ObjectMeta)
-	// there was no change to metadata, the generation was right
-	if !*modified && existingCopy.GetGeneration() == expectedGeneration {
+	objectMetaModified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureObjectMeta(objectMetaModified, &existingCopy.ObjectMeta, daemonSet.ObjectMeta)
+
+	specChanged := !util.DaemonSetIsUpToDate(r.kv, cachedDaemonSet) || *objectMetaModified
+	generationUnknown := existingCopy.GetGeneration() != GetExpectedGeneration(daemonSet, kv.Status.Generations)
+	ongoingRollout := !daemonHasDefaultRolloutStrategy(cachedDaemonSet)
+
+	if !specChanged && !ongoingRollout && !generationUnknown {
 		log.Log.V(4).Infof("daemonset %v is up-to-date", daemonSet.GetName())
 		return true, nil
 	}
@@ -428,7 +430,12 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 	// start the rollout of the new virt-handler again
 	// wait for all nodes to complete the rollout
 	// set maxUnavailable back to 1
-	done, err, _ := r.processCanaryUpgrade(cachedDaemonSet, daemonSet, *modified)
+	//
+	// Only pass specChanged as objectChanged to processCanaryUpgrade so
+	// that an unknown generation alone does not restart the canary from
+	// scratch. The generation will be re-recorded when the canary
+	// completes.
+	done, err, _ := r.processCanaryUpgrade(cachedDaemonSet, daemonSet, specChanged)
 	return done, err
 }
 

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -441,6 +441,91 @@ var _ = Describe("Apply Apps", func() {
 				}
 			}
 
+			It("should not restart canary when generation is unknown but spec is up-to-date", func() {
+				addCustomTargetDeployment(kv, daemonSet)
+				markHandlerReady(daemonSet)
+
+				r := &Reconciler{
+					clientset:    clientset,
+					kv:           kv,
+					expectations: expectations,
+					stores:       stores,
+					recorder:     record.NewFakeRecorder(100),
+				}
+
+				// Simulate a DS that is up-to-date (annotations match KV target)
+				currentDs := daemonSet.DeepCopy()
+				addCustomTargetDeployment(kv, currentDs)
+				currentDs.Status = daemonSet.Status
+				currentDs.Spec.Template.Spec.Containers[0].Args = append(currentDs.Spec.Template.Spec.Containers[0].Args,
+					"--migration-cn-types",
+				)
+				unattachCertificateSecret(&currentDs.Spec.Template.Spec, components.VirtHandlerCertSecretName)
+
+				mockDSCacheStore.get = daemonSet
+				SetGeneration(&kv.Status.Generations, currentDs)
+
+				_, err := r.clientset.AppsV1().DaemonSets(currentDs.Namespace).Create(context.TODO(), currentDs, v12.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				// objectChanged=false simulates generationUnknown without specChanged
+				_, err, status := r.processCanaryUpgrade(currentDs, daemonSet, false)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(status).To(Equal(successful))
+			})
+
+			It("should continue rollout without restarting canary when generation is unknown during ongoing rollout", func() {
+				addCustomTargetDeployment(kv, daemonSet)
+
+				// Prepare the desired DS with all metadata that syncDaemonSet would inject
+				imageTag, imageRegistry, id := getTargetVersionRegistryID(kv)
+				desiredDs := daemonSet.DeepCopy()
+				injectOperatorMetadata(kv, &desiredDs.ObjectMeta, imageTag, imageRegistry, id, true)
+				injectOperatorMetadata(kv, &desiredDs.Spec.Template.ObjectMeta, imageTag, imageRegistry, id, false)
+				placement.InjectPlacementMetadata(kv.Spec.Workloads, &desiredDs.Spec.Template.Spec, placement.AnyNode)
+
+				// Use the fully-prepared desired DS as the cached DS with ongoing rollout
+				cachedDs := desiredDs.DeepCopy()
+				cachedDs.Generation = 2
+				// Simulate a multi-node cluster with 1 of 2 pods updated
+				cachedDs.Status.DesiredNumberScheduled = 2
+				cachedDs.Status.NumberReady = 1
+				maxUnavailable := intstr.FromString("10%")
+				cachedDs.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &maxUnavailable,
+				}
+				mockDSCacheStore.get = cachedDs
+				// Record generation 1 so that the cached generation 2 is "unknown"
+				SetGeneration(&kv.Status.Generations, daemonSet)
+
+				markHandlerCanaryReady(daemonSet)
+
+				r := &Reconciler{
+					clientset:    clientset,
+					kv:           kv,
+					expectations: expectations,
+					stores:       stores,
+					recorder:     record.NewFakeRecorder(100),
+				}
+
+				_, err := r.clientset.AppsV1().DaemonSets(cachedDs.Namespace).Create(context.TODO(), cachedDs, v12.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				done, err := r.syncDaemonSet(daemonSet)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(done).To(BeFalse())
+
+				// Verify rollout continued at 10% (not restarted at MaxUnavailable=1)
+				patchedDs, err := r.clientset.AppsV1().DaemonSets(cachedDs.Namespace).Get(context.TODO(), cachedDs.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				rollingUpdate := patchedDs.Spec.UpdateStrategy.RollingUpdate
+				Expect(rollingUpdate).ToNot(BeNil())
+				Expect(rollingUpdate.MaxUnavailable).ToNot(BeNil())
+				Expect(rollingUpdate.MaxUnavailable.String()).ToNot(Equal("1"))
+			})
+
 			It("should start canary upgrade if updating virt-handler", func() {
 				mockDSCacheStore.get = daemonSet
 				SetGeneration(&kv.Status.Generations, daemonSet)
@@ -496,10 +581,11 @@ var _ = Describe("Apply Apps", func() {
 			DescribeTable("process canary upgrade",
 				func(dsBuild daemonSetBuilder,
 					dsCheck daemonSetPatchChecker,
-					expectedStatus CanaryUpgradeStatus,
+					expectedStatus canaryUpgradeStatus,
 					expectedDone bool,
 					expectingError bool,
-					expectingPatch bool) {
+					expectingPatch bool,
+					objectChanged bool) {
 
 					r := &Reconciler{
 						clientset:    clientset,
@@ -516,7 +602,8 @@ var _ = Describe("Apply Apps", func() {
 					_, err := r.clientset.AppsV1().DaemonSets(currentDs.Namespace).Create(context.TODO(), currentDs, v12.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					done, err, status := r.processCanaryUpgrade(currentDs, newDs, false)
+					Expect(!util.DaemonSetIsUpToDate(kv, currentDs)).To(Equal(objectChanged))
+					done, err, status := r.processCanaryUpgrade(currentDs, newDs, objectChanged)
 
 					patched := false
 					for _, action := range dsClient.Fake.Actions() {
@@ -552,7 +639,7 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable).ToNot(BeNil())
 						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
 					},
-					CanaryUpgradeStatusStarted, false, false, true,
+					started, false, false, true, true,
 				),
 				Entry("should wait for canary pod to be created",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
@@ -563,7 +650,7 @@ var _ = Describe("Apply Apps", func() {
 						return currentDs, newDs
 					},
 					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {},
-					CanaryUpgradeStatusStarted, false, false, false,
+					canary, false, false, false, false,
 				),
 				Entry("should wait for canary pod to be ready",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
@@ -574,7 +661,7 @@ var _ = Describe("Apply Apps", func() {
 						return currentDs, newDs
 					},
 					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {},
-					CanaryUpgradeStatusStarted, false, false, false,
+					canary, false, false, false, false,
 				),
 				Entry("should restart daemonset rollout with MaxUnavailable 10%",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
@@ -594,7 +681,7 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable).ToNot(BeNil())
 						Expect(rollingUpdate.MaxUnavailable.String()).To(Equal("10%"))
 					},
-					CanaryUpgradeStatusUpgradingDaemonSet, false, false, true,
+					increasing, false, false, true, false,
 				),
 				Entry("should report an error when canary pod fails",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
@@ -605,7 +692,7 @@ var _ = Describe("Apply Apps", func() {
 						return currentDs, newDs
 					},
 					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {},
-					CanaryUpgradeStatusFailed, false, true, false,
+					failed, false, true, false, false,
 				),
 				Entry("should wait for new daemonset rollout",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
@@ -620,7 +707,7 @@ var _ = Describe("Apply Apps", func() {
 						return currentDs, newDs
 					},
 					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {},
-					CanaryUpgradeStatusWaitingDaemonSetRollout, false, false, false,
+					waiting, false, false, false, false,
 				),
 				Entry("should complete rollout",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
@@ -629,6 +716,7 @@ var _ = Describe("Apply Apps", func() {
 						addCustomTargetDeployment(kv, newDs)
 						addCustomTargetDeployment(kv, currentDs)
 						markHandlerReady(daemonSet)
+						currentDs.Status = daemonSet.Status
 						currentDs.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
 							MaxUnavailable: &maxUnavailable,
 						}
@@ -645,7 +733,7 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable).ToNot(BeNil())
 						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
 					},
-					CanaryUpgradeStatusSuccessful, true, false, false,
+					successful, true, false, true, false,
 				),
 
 				Entry("should unattach secret before complete rollout",
@@ -672,7 +760,7 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
 						hasCertificateSecret(&daemonSet.Spec.Template.Spec, components.VirtHandlerCertSecretName)
 					},
-					CanaryUpgradeStatusSuccessful, true, false, true,
+					waiting, false, false, true, false,
 				),
 				Entry("should switch to tls rollout",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
@@ -684,6 +772,7 @@ var _ = Describe("Apply Apps", func() {
 						addCustomTargetDeployment(kv, newDs)
 						addCustomTargetDeployment(kv, currentDs)
 						markHandlerReady(daemonSet)
+						currentDs.Status = daemonSet.Status
 
 						return currentDs, newDs
 					},
@@ -695,7 +784,7 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
 						Expect(daemonSet.Spec.Template.Spec.Containers[0].Args).To(ContainElements("--migration-cn-types", "migration"))
 					},
-					CanaryUpgradeStatusWaitingDaemonSetRollout, false, false, true,
+					waiting, false, false, true, false,
 				),
 			)
 		})


### PR DESCRIPTION
### What this PR does
This commit aims to ensure that any out of band changes start a full canary rollout as any version upgrade would.

Previously out of band changes would race the operator reconcile loop and could be seen as later stages of a canary upgrade. This could result in changes being ignored and the new generation of the object being marked as known by the operator.

This commit aims to avoid that by always patching objects with an unknown generation while also always storing the generation of an object as it is patched during a canary flow.

This is hopefully small enough to be backported with future changes looking to extract, lint and refine this implementation further.

### References

- Fixes #16561 

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

