### PR TITLE
Onboarding kube-burner tests

### DIFF
--- a/automation/perfscale-test.sh
+++ b/automation/perfscale-test.sh
@@ -91,4 +91,10 @@ if [[ (${PERFAUDIT} == "true" || ${PERFAUDIT} == "True") && ${KUBEVIRT_PROVIDER}
   _prometheus_port_forward_pid=$1
 fi
 
-./hack/perfscale-tests.sh
+if [[ "${PERFSCALE_KUBE_BURNER}" == "true" ]]; then
+  echo "running kube-burner perfscale tests"
+  ./hack/perfscale-kube-burner-test.sh
+else
+  echo "building and running in house perfscale tests"
+  ./hack/perfscale-tests.sh
+fi

--- a/hack/perfscale-kube-burner-test.sh
+++ b/hack/perfscale-kube-burner-test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2026 The KubeVirt Authors.
+
+set -e
+
+export PROMETHEUS_PORT=${PROMETHEUS_PORT:-30007}
+export PROMETHEUS_URL=${PROMETHEUS_URL:-http://127.0.0.1}
+
+echo 'Preparing directory for artifacts'
+mkdir -p $ARTIFACTS
+
+KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-v2.2.2}
+OS=$(uname -s)
+HARDWARE=$(uname -m)
+EXTRA_FLAGS=${EXTRA_FLAGS:-}
+KUBE_DIR=${KUBE_DIR:-/tmp}
+
+# in kubevirt CI/CD the node we run the job is on a different cluster, so time is not synced across all nodes
+# as a workaround, we collect the timestamps by making a prometheus query, so we can use the exact time that prometheus is using
+function get_timestamp() {
+    curr_timestamp=$(curl -fs --data-urlencode 'query=container_cpu_usage_seconds_total{pod!="",container="prometheus"}' "http://${PROMETHEUS_URL}:${PROMETHEUS_PORT}/api/v1/query" | jq -r '.data.result[0] | .value[0]')
+    date -u +%Y-%m-%dT%TZ -d @$curr_timestamp
+}
+
+download_binary() {
+    REPO_URL="https://github.com/kube-burner/kube-burner"
+    LATEST_TAG=$(curl -s "https://api.github.com/repos/kube-burner/kube-burner/releases/latest" | jq -r '.tag_name')
+    TAG_OPTION=$(if [ "$KUBE_BURNER_VERSION" == "latest" ]; then echo "${LATEST_TAG#v}"; else echo "${KUBE_BURNER_VERSION#v}"; fi)
+    KUBE_BURNER_URL="https://github.com/kube-burner/kube-burner/releases/download/v${TAG_OPTION}/kube-burner-V${TAG_OPTION}-${OS}-${HARDWARE}.tar.gz"
+    curl --fail --retry 8 --retry-all-errors -sS -L "${KUBE_BURNER_URL}" | tar -xzC "${KUBE_DIR}/" kube-burner
+}
+
+function perftest() {
+    SKIP_INDEXING=${SKIP_INDEXING:-false} JOB_ITERATIONS=${JOB_ITERATIONS:-1} GC=${GC:-false} GC_METRICS=${GC_METRICS:-false} METRICS_FOLDER=${METRICS_FOLDER:-"collected-metrics"} ${KUBE_DIR}/kube-burner init \
+        --config ${PERFSCALE_WORKLOAD} \
+        --log-level debug \
+        ${EXTRA_FLAGS:-}
+}
+
+function perfaudit() {
+    metrics_folder_name=$(find . -maxdepth 1 -type d -name 'collected-metric*' | head -n 1)
+    cp -r "${metrics_folder_name}" "${ARTIFACTS}/"
+}
+
+# run small test to verify the functionality
+download_binary
+time SKIP_INDEXING=true JOB_ITERATIONS=1 perftest
+echo "Sleeping 30 to let system cooldown after the test"
+sleep 30
+start_timestamp=$(get_timestamp)
+# run the test
+time GC=true perftest
+stop_timestamp=$(get_timestamp)
+
+# run audit tool to transform all kube-burner collected metrics into kubevirt perfscale format
+if [[ ${PERFAUDIT} == "true" || ${PERFAUDIT} == "True" ]]; then
+    perfaudit
+fi
+
+echo "start_timestamp= $start_timestamp"
+echo "stop_timestamp= $stop_timestamp"

--- a/tests/performance/manifests/kube-burner/kubevirt-density/kubevirt-density.yml
+++ b/tests/performance/manifests/kube-burner/kubevirt-density/kubevirt-density.yml
@@ -1,0 +1,51 @@
+{{- if ne (index . "SKIP_INDEXING") "true" }}
+metricsEndpoints:
+  # endpoints to collect metrics from
+  - endpoint: {{ .PROMETHEUS_ENDPOINT }}{{ with index . "PROMETHEUS_PORT" }}:{{ . }}{{ end }}
+    token: {{ .PROMETHEUS_TOKEN }}
+    metrics:
+      - tests/performance/manifests/kube-burner/metric-profiles/kubevirt-density.yml
+    indexer:
+      type: local
+      metricsDirectory: {{ .METRICS_FOLDER }}
+{{- end }}
+
+global:
+  # collect runtime measurements
+  gc: {{.GC}}
+  gcMetrics: {{.GC_METRICS}}
+  measurements:
+  - name: vmiLatency
+    thresholds:
+     - conditionType: VMIRunning
+       metric: P50
+       threshold: 45s
+     - conditionType: VMIRunning
+       metric: P95
+       threshold: 60s
+
+jobs:
+  # create the VMs
+  - name: kubevirt-density
+    jobType: create
+    jobIterations: {{ .JOB_ITERATIONS }}
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    namespacedIterations: false
+    namespace: kubevirt-density
+    verifyObjects: true
+    errorOnVerify: true
+    waitWhenFinished: true
+    cleanup: true
+    objects:
+    - objectTemplate: tests/performance/manifests/kube-burner/kubevirt-density/templates/vm-ephemeral.yml
+      replicas: 1
+      inputVars:
+        name: kubevirt-density
+        image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v0.48.1
+        OS: fedora27
+        cpuCores: 1
+        cpu: 100m
+        memory: 90Mi
+        createVMI: true
+

--- a/tests/performance/manifests/kube-burner/kubevirt-density/templates/vm-ephemeral.yml
+++ b/tests/performance/manifests/kube-burner/kubevirt-density/templates/vm-ephemeral.yml
@@ -1,0 +1,54 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt-vm: vm-{{.name}}-{{.Replica}}-{{.Iteration}}
+    kubevirt.io/os: {{.OS}}
+  name: {{.name}}-{{.Replica}}-{{.Iteration}}
+spec:
+  running: {{.createVMI}}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        kubevirt-vm: vm-{{.name}}-{{.Replica}}-{{.Iteration}}
+        kubevirt.io/os: {{.OS}}
+    spec:
+      domain:
+        cpu:
+          cores: {{.cpuCores}}
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          - disk:
+              bus: virtio
+            name: containerdisk
+          interfaces:
+          - masquerade: {}
+            model: virtio
+            name: default
+          networkInterfaceMultiqueue: true
+          rng: {}
+        resources:
+          requests:
+            cpu: {{.cpu}}
+            memory: {{.memory}}
+      networks:
+      - name: default
+        pod: {}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk
+      - containerDisk:
+          image:  {{.image}}
+          imagePullPolicy: IfNotPresent
+        name: containerdisk
+

--- a/tests/performance/manifests/kube-burner/metric-profiles/kubevirt-density.yml
+++ b/tests/performance/manifests/kube-burner/metric-profiles/kubevirt-density.yml
@@ -1,0 +1,122 @@
+# kubevirt vmi phase transition time from creation seconds bucket
+- query: histogram_quantile(0.99, rate(kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket{phase="Running"}[{{.elapsed}}]))
+  metricName: vmiCreationToRunningSecondsP99
+  instant: true
+
+- query: histogram_quantile(0.95, rate(kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket{phase="Running"}[{{.elapsed}}]))
+  metricName: vmiCreationToRunningSecondsP95
+  instant: true
+
+- query: histogram_quantile(0.50, rate(kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket{phase="Running"}[{{.elapsed}}]))
+  metricName: vmiCreationToRunningSecondsP50
+  instant: true
+
+- query: histogram_quantile(0.99, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Succeeded"}[{{.elapsed}}]))
+  metricName: vmiDeletionToSucceededSecondsP99
+  instant: true
+
+- query: histogram_quantile(0.95, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Succeeded"}[{{.elapsed}}]))
+  metricName: vmiDeletionToSucceededSecondsP95
+  instant: true
+
+- query: histogram_quantile(0.50, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Succeeded"}[{{.elapsed}}]))
+  metricName: vmiDeletionToSucceededSecondsP50
+  instant: true
+
+- query: histogram_quantile(0.99, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Failed"}[{{.elapsed}}]))
+  metricName: vmiDeletionToFailedSecondsP99
+  instant: true
+
+- query: histogram_quantile(0.95, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Failed"}[{{.elapsed}}]))
+  metricName: vmiDeletionToFailedSecondsP95
+  instant: true
+
+- query: histogram_quantile(0.50, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Failed"}[{{.elapsed}}]))
+  metricName: vmiDeletionToFailedSecondsP50
+  instant: true
+
+# Resource request counts by operation
+- query: sum by (resource, verb) (increase(kubevirt_rest_client_requests_total{pod=~"virt-controller.*|virt-handler.*|virt-operator.*|virt-api.*"}[{{ .elapsed }}]))
+  metricName: resourceRequestCountsByOperation
+  instant: true
+
+# VMI counts by phase
+- query: sum by (phase) (kubevirt_vmi_phase_count{})
+  metricName: phaseCount
+  instant: true
+
+# Container cpu usage
+- query: avg(rate(container_cpu_usage_seconds_total{namespace="kubevirt",pod=~"virt-api.*", container!="",container!="POD"}[{{ .elapsed }}]))
+  metricName: avgVirtAPICPUUsage
+  instant: true
+
+- query: max(rate(container_cpu_usage_seconds_total{namespace="kubevirt",pod=~"virt-controller.*", container!="",container!="POD"}[{{ .elapsed }}]))
+  metricName: avgVirtControllerCPUUsage
+  instant: true
+
+- query: avg((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[{{ .elapsed }}])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))
+  metricName: avgVirtHandlerCPUUsage
+  instant: true
+
+- query: min((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[{{ .elapsed }}])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))
+  metricName: minVirtHandlerCPUUsage
+  instant: true
+
+- query: max((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[{{ .elapsed }}])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))
+  metricName: maxVirtHandlerCPUUsage
+  instant: true
+
+# Container memory rss
+- query: avg(avg_over_time(container_memory_rss{pod=~"virt-api.*", container!="POD", container!=""}[{{ .elapsed }}]))/1024/1024
+  metricName: avgVirtAPIMemoryUsageInMB
+  instant: true
+
+- query: max(avg_over_time(container_memory_rss{pod=~"virt-controller.*", container!="POD", container!=""}[{{ .elapsed }}]))/1024/1024
+  metricName: avgVirtControllerMemoryUsageInMB
+  instant: true
+
+- query: avg(min_over_time(container_memory_rss{pod=~"virt-api.*", container!="POD", container!=""}[{{ .elapsed }}]))/1024/1024
+  metricName: minVirtAPIMemoryUsageInMB
+  instant: true
+
+- query: avg(max_over_time(container_memory_rss{pod=~"virt-api.*", container!="POD", container!=""}[{{ .elapsed }}]))/1024/1024
+  metricName: maxVirtAPIMemoryUsageInMB
+  instant: true
+
+- query: avg(max_over_time(container_memory_rss{pod=~"virt-api.*", container!="POD", container!=""}[{{ .elapsed }}]))/1024/1024
+  metricName: maxVirtAPIMemoryUsageInMB
+  instant: true
+
+- query: max(max_over_time(container_memory_rss{pod=~"virt-controller.*", container!="POD", container!=""}[{{ .elapsed }}]))/1024/1024
+  metricName: maxVirtControllerMemoryUsageInMB
+  instant: true
+
+- query: max(min_over_time(container_memory_rss{pod=~"virt-controller.*", container!="POD", container!=""}[{{ .elapsed }}]))/1024/1024
+  metricName: minVirtControllerMemoryUsageInMB
+  instant: true
+
+- query: avg(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[{{ .elapsed }}:]))/1024/1024
+  metricName: avgVirtHandlerMemoryUsageInMB
+  instant: true
+
+- query: min(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[{{ .elapsed }}:]))/1024/1024
+  metricName: minVirtHandlerMemoryUsageInMB
+  instant: true
+
+- query: max(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[{{ .elapsed }}:]))/1024/1024
+  metricName: maxVirtHandlerMemoryUsageInMB
+  instant: true
+
+# Virt controller workbench metrics
+- query: sum(rate(kubevirt_workqueue_adds_total{container="virt-controller"}[{{ .elapsed }}]))
+  metricName: virtControllerWorkqueueAddRate
+  instant: true
+
+- query: sum(rate(kubevirt_workqueue_depth{container="virt-controller"}[{{ .elapsed }}]))
+  metricName: virtControllerWorkqueueDepth
+  instant: true
+
+- query: histogram_quantile(0.99, sum(rate(kubevirt_workqueue_queue_duration_seconds_bucket{container="virt-controller"}[{{ .elapsed }}])) by (le))
+  metricName: virtControllerWorkqueueP99Latency
+  instant: true
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR: Doesn't tamper any of the existing functionality.

#### After this PR: This PR adds a performance test using kube-burner.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
Links to places where the discussion took place: sig-kubevirt community call on Feb 5th 2026, Relevant document: https://docs.google.com/document/d/1JOku910lO7KSttLuooJzjtqBo66U5_4B94jNRwZRqPk/edit?tab=t.0#heading=h.hl13cbd470v2

### Special notes for your reviewer
Adding kube-burner test compatibility as discussed here: https://docs.google.com/document/d/1d_b2o05FfBG37VwlC2Z1ZArnT9-_AEJoQTe7iKaQZ6I/edit?tab=t.0#heading=h.my0ur0q5ftg1 

* All the metrics will be captured into ${ARTIFACTS} directory. 
* Transformer scripts to convert kube-burner metrics into current perf-audit format will be written in the follow ups.
* Will add specific documentation after this PR goes through.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Testing
Dependent on this PR: https://github.com/kubevirt/project-infra/pull/4703 for testing this feature.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```