### PR TITLE
Skip GuestPing during filesystem freeze operations

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -609,6 +609,10 @@ func (l *LibvirtDomainManager) Exec(domainName, command string, args []string, t
 }
 
 func (l *LibvirtDomainManager) GuestPing(domainName string) error {
+	if l.storageManager.IsFreezeInProgress() {
+		log.Log.V(1).Infof("Skipping GuestPing for %s: freeze in progress", domainName)
+		return nil
+	}
 	pingCmd := `{"execute":"guest-ping"}`
 	_, err := l.virConn.QemuAgentCommand(pingCmd, domainName)
 	return err

--- a/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
+++ b/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
@@ -70,6 +70,9 @@ func (m *StorageManager) FreezeVMI(vmi *v1.VirtualMachineInstance, unfreezeTimeo
 	}
 	defer domain.Free()
 
+	m.freezeInProgress.Store(true)
+	defer m.freezeInProgress.Store(false)
+
 	if err := domain.FSFreeze(nil, 0); err != nil {
 		log.Log.Errorf("Failed to freeze vmi, %s", err.Error())
 		return err
@@ -137,4 +140,9 @@ func (m *StorageManager) getParsedFSStatus(domainName string) (string, error) {
 	}
 
 	return fsfreezeStatus.Status, nil
+}
+
+// IsFreezeInProgress returns true while a filesystem freeze operation is in progress.
+func (m *StorageManager) IsFreezeInProgress() bool {
+	return m.freezeInProgress.Load()
 }

--- a/pkg/virt-launcher/virtwrap/storage/manager.go
+++ b/pkg/virt-launcher/virtwrap/storage/manager.go
@@ -20,6 +20,8 @@
 package storage
 
 import (
+	"sync/atomic"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 )
@@ -34,6 +36,7 @@ type StorageManager struct {
 	metadataCache            *metadata.Cache
 	memoryDumpInProgress     chan struct{}
 	cancelSafetyUnfreezeChan chan struct{}
+	freezeInProgress         atomic.Bool
 }
 
 func NewStorageManager(connection cli.Connection, metadataCache *metadata.Cache) *StorageManager {


### PR DESCRIPTION
As a follow-up to #16653: When virt-launcher uses the guest agent (GA) for the readiness probe, the pod can be marked NotReady during a freeze if the freeze runs long enough. The GA can be unresponsive while the freezing is in progress, so the probe fails and the pod flips to not ready.


This change makes GuestPing return success whenever a freeze is in progress, so the readiness probe no longer fails during snapshot creation.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed readiness probe failures during snapshots by skipping guest agent ping while a freeze request is in progress
```

