### PR TITLE
virt-launcher, notify-client: always process libvirt events

### DIFF
--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -56,6 +56,8 @@ var _ = Describe("Notify", func() {
 		var eventChan chan watch.Event
 		var deleteNotificationSent chan watch.Event
 		var client *Notifier
+		var vmiStore cache.Store
+		var recorder *record.FakeRecorder
 
 		var mockLibvirt *testing.Libvirt
 		var e *eventCaller
@@ -71,10 +73,14 @@ var _ = Describe("Notify", func() {
 			stopped := false
 			shareDir, err := os.MkdirTemp("", "kubevirt-share")
 			Expect(err).ToNot(HaveOccurred())
+			recorder = record.NewFakeRecorder(10)
+			recorder.IncludeObject = true
+			vmiInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
+			vmiStore = vmiInformer.GetStore()
 			e = &eventCaller{}
 
 			go func() {
-				notifyserver.RunServer(shareDir, stop, eventChan, nil, nil)
+				notifyserver.RunServer(shareDir, stop, eventChan, recorder, vmiStore)
 			}()
 			// mimic pipe
 			notifyServer := filepath.Join(shareDir, "domain-notify.sock")
@@ -253,6 +259,86 @@ var _ = Describe("Notify", func() {
 				}
 				Expect(timedOut).To(BeFalse())
 			})
+
+		It("should consolidate I/O error status and Agent updates into a single watch event", func() {
+			faultDisk := []libvirt.DomainDiskError{
+				{
+					Disk:  "vda",
+					Error: libvirt.DOMAIN_DISK_ERROR_NO_SPACE,
+				},
+			}
+			domain := api.NewMinimalDomain("test")
+			domain.Status.Reason = api.ReasonPausedIOError
+			x, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockLibvirt := testing.NewLibvirt(ctrl)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(gomock.Any()).Return(mockLibvirt.VirtDomain, nil).AnyTimes()
+			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(libvirt.DOMAIN_PAUSED_IOERROR), nil)
+			mockLibvirt.DomainEXPECT().Free()
+			mockLibvirt.DomainEXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+			mockLibvirt.DomainEXPECT().GetDiskErrors(uint32(0)).Return(faultDisk, nil)
+
+			vmi := api2.NewMinimalVMI("test-vmi")
+			vmi.UID = "1234"
+			vmiStore.Add(vmi)
+
+			metadataCache := metadata.NewCache()
+			interfaceStatus := []api.InterfaceStatus{{Ip: "10.0.0.1", InterfaceName: "eth0"}}
+			e.eventCallback(mockLibvirt.VirtConnection, domain, libvirtEvent{}, client, deleteNotificationSent, interfaceStatus, nil, vmi, nil, metadataCache)
+
+			var event watch.Event
+			Eventually(eventChan, 2*time.Second).Should(Receive(&event))
+
+			newDomain, ok := event.Object.(*api.Domain)
+			Expect(ok).To(BeTrue())
+			Expect(newDomain.Status.Reason).To(Equal(api.ReasonPausedIOError))
+			Expect(newDomain.Status.Interfaces).To(HaveLen(1))
+			Expect(newDomain.Status.Interfaces[0].Ip).To(Equal("10.0.0.1"))
+		})
+
+		It("should process job completion event even if the domain is paused due to an I/O error", func() {
+			faultDisk := []libvirt.DomainDiskError{
+				{
+					Disk:  "vda",
+					Error: libvirt.DOMAIN_DISK_ERROR_NO_SPACE,
+				},
+			}
+			domain := api.NewMinimalDomain("test")
+			domain.Status.Reason = api.ReasonPausedIOError
+			x, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			domainJobInfo := libvirt.DomainJobInfo{
+				Type:      libvirt.DOMAIN_JOB_COMPLETED,
+				Operation: libvirt.DOMAIN_JOB_OPERATION_BACKUP,
+			}
+			ctrl := gomock.NewController(GinkgoT())
+			mockLibvirt := testing.NewLibvirt(ctrl)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(gomock.Any()).Return(mockLibvirt.VirtDomain, nil).AnyTimes()
+			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(libvirt.DOMAIN_PAUSED_IOERROR), nil)
+			mockLibvirt.DomainEXPECT().Free()
+			mockLibvirt.DomainEXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+			mockLibvirt.DomainEXPECT().GetDiskErrors(uint32(0)).Return(faultDisk, nil)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(1)).Return(&domainJobInfo, nil)
+
+			metadataCache := metadata.NewCache()
+			metadataCache.Backup.Store(api.BackupMetadata{})
+			libvirtEvent := libvirtEvent{
+				JobCompletedEvent: &libvirt.DomainEventJobCompleted{
+					Info: domainJobInfo,
+				},
+			}
+			vmi := api2.NewMinimalVMI("fake-vmi")
+			vmi.UID = "4321"
+			vmiStore.Add(vmi)
+
+			e.eventCallback(mockLibvirt.VirtConnection, domain, libvirtEvent, client, deleteNotificationSent, nil, nil, vmi, nil, metadataCache)
+			backupMeta, ok := metadataCache.Backup.Load()
+			Expect(ok).To(BeTrue())
+			Expect(backupMeta.Completed).To(BeTrue())
+		})
 	})
 
 	Describe("K8s Events", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Previously if the domain became paused due to an I/O error the switch case in eventCallback would not hit the default case and would therefore skip processing of incoming libvirt events until the domain was unpaused.

Certain libvirt events, most notably job failure, must be processed as they originate from the same underlying cause (i.e., I/O error).

#### After this PR:
Process libvirt events as they come regardless of domain state.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: domain job completion events would not be processed if the domain was paused due to an I/O error.
```

