### PR TITLE
Backend storage: Track backend storage PVC in VM status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19631,6 +19631,10 @@
       "type": "integer",
       "format": "int64"
      },
+     "persistentStateVolume": {
+      "description": "PersistentStateVolume tracks the backend storage PVC status containing persistent VM state (UEFI, TPM, CBT)",
+      "$ref": "#/definitions/v1.VolumeStatus"
+     },
      "preferenceRef": {
       "description": "PreferenceRef captures the state of any referenced preference from the VirtualMachine",
       "$ref": "#/definitions/v1.InstancetypeStatusRef"

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -756,6 +756,7 @@ func (vca *VirtControllerApp) initCommon() {
 	vca.migrationController, err = migration.NewController(
 		vca.templateService,
 		vca.vmiInformer,
+		vca.vmInformer,
 		vca.kvPodInformer,
 		vca.migrationInformer,
 		vca.nodeInformer,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -184,6 +184,7 @@ var _ = Describe("Application", func() {
 		)
 		app.migrationController, _ = migration.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
+			vmInformer,
 			podInformer,
 			migrationInformer,
 			nodeInformer,

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -237,6 +237,7 @@ var _ = Describe("Migration watcher", func() {
 		virtClientset = kubevirtfake.NewSimpleClientset()
 
 		vmiInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
+		vmInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachine{})
 		migrationInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstanceMigration{}, virtcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		resourceQuotaInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
@@ -254,6 +255,7 @@ var _ = Describe("Migration watcher", func() {
 		controller, _ = NewController(
 			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
+			vmInformer,
 			podInformer,
 			migrationInformer,
 			nodeInformer,

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -229,19 +229,7 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 }
 
 func (c *Controller) getOwnerVM(vmi *virtv1.VirtualMachineInstance) *virtv1.VirtualMachine {
-	controllerRef := v1.GetControllerOf(vmi)
-	if controllerRef == nil || controllerRef.Kind != virtv1.VirtualMachineGroupVersionKind.Kind {
-		return nil
-	}
-	obj, exists, _ := c.vmStore.GetByKey(controller.NamespacedKey(vmi.Namespace, controllerRef.Name))
-	if !exists {
-		return nil
-	}
-	ownerVM := obj.(*virtv1.VirtualMachine)
-	if controllerRef.UID == ownerVM.UID {
-		return ownerVM.DeepCopy()
-	}
-	return nil
+	return controller.GetOwnerVM(vmi, c.vmStore)
 }
 
 // updateStatus handles the VMI's lifecycle status updates.

--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -157,6 +157,15 @@ func (c *Controller) handleBackendStorage(vmi *virtv1.VirtualMachineInstance) (s
 			return "", common.NewSyncError(err, controller.FailedBackendStorageCreateReason)
 		}
 	}
+
+	vm := c.getOwnerVM(vmi)
+	if vm != nil {
+		// Add the backend storage PVC to the VM status
+		if err := c.backendStorage.UpdatePersistentStateVolume(vm, pvc); err != nil {
+			return "", common.NewSyncError(err, controller.FailedBackendStorageUpdateReason)
+		}
+	}
+
 	return pvc.Name, nil
 }
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8543,6 +8543,131 @@ var CRDsValidation map[string]string = map[string]string{
             started.
           format: int64
           type: integer
+        persistentStateVolume:
+          description: |-
+            PersistentStateVolume tracks the backend storage PVC status
+            containing persistent VM state (UEFI, TPM, CBT)
+          nullable: true
+          properties:
+            containerDiskVolume:
+              description: ContainerDiskVolume shows info about the containerdisk,
+                if the volume is a containerdisk
+              properties:
+                checksum:
+                  description: Checksum is the checksum of the rootdisk or kernel
+                    artifacts inside the containerdisk
+                  format: int32
+                  type: integer
+              type: object
+            hotplugVolume:
+              description: If the volume is hotplug, this will contain the hotplug
+                status.
+              properties:
+                attachPodName:
+                  description: AttachPodName is the name of the pod used to attach
+                    the volume to the node.
+                  type: string
+                attachPodUID:
+                  description: AttachPodUID is the UID of the pod used to attach the
+                    volume to the node.
+                  type: string
+              type: object
+            memoryDumpVolume:
+              description: If the volume is memorydump volume, this will contain the
+                memorydump info.
+              properties:
+                claimName:
+                  description: ClaimName is the name of the pvc the memory was dumped
+                    to
+                  type: string
+                endTimestamp:
+                  description: EndTimestamp is the time when the memory dump completed
+                  format: date-time
+                  type: string
+                startTimestamp:
+                  description: StartTimestamp is the time when the memory dump started
+                  format: date-time
+                  type: string
+                targetFileName:
+                  description: TargetFileName is the name of the memory dump output
+                  type: string
+              type: object
+            message:
+              description: Message is a detailed message about the current hotplug
+                volume phase
+              type: string
+            name:
+              description: Name is the name of the volume
+              type: string
+            persistentVolumeClaimInfo:
+              description: PersistentVolumeClaimInfo is information about the PVC
+                that handler requires during start flow
+              properties:
+                accessModes:
+                  description: |-
+                    AccessModes contains the desired access modes the volume should have.
+                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity represents the capacity set on the corresponding
+                    PVC status
+                  type: object
+                claimName:
+                  description: ClaimName is the name of the PVC
+                  type: string
+                filesystemOverhead:
+                  description: Percentage of filesystem's size to be reserved when
+                    resizing the PVC
+                  pattern: ^(0(?:\.\d{1,3})?|1)$
+                  type: string
+                preallocated:
+                  description: Preallocated indicates if the PVC's storage is preallocated
+                    or not
+                  type: boolean
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Requests represents the resources requested by the
+                    corresponding PVC spec
+                  type: object
+                volumeMode:
+                  description: |-
+                    VolumeMode defines what type of volume is required by the claim.
+                    Value of Filesystem is implied when not included in claim spec.
+                  type: string
+              type: object
+            phase:
+              description: Phase is the phase
+              type: string
+            reason:
+              description: Reason is a brief description of why we are in the current
+                hotplug volume phase
+              type: string
+            size:
+              description: Represents the size of the volume
+              format: int64
+              type: integer
+            target:
+              description: 'Target is the target name used when adding the volume
+                to the VM, eg: vda'
+              type: string
+          required:
+          - name
+          - target
+          type: object
         preferenceRef:
           description: PreferenceRef captures the state of any referenced preference
             from the VirtualMachine
@@ -31336,6 +31461,134 @@ var CRDsValidation map[string]string = map[string]string{
                         the vmi when started.
                       format: int64
                       type: integer
+                    persistentStateVolume:
+                      description: |-
+                        PersistentStateVolume tracks the backend storage PVC status
+                        containing persistent VM state (UEFI, TPM, CBT)
+                      nullable: true
+                      properties:
+                        containerDiskVolume:
+                          description: ContainerDiskVolume shows info about the containerdisk,
+                            if the volume is a containerdisk
+                          properties:
+                            checksum:
+                              description: Checksum is the checksum of the rootdisk
+                                or kernel artifacts inside the containerdisk
+                              format: int32
+                              type: integer
+                          type: object
+                        hotplugVolume:
+                          description: If the volume is hotplug, this will contain
+                            the hotplug status.
+                          properties:
+                            attachPodName:
+                              description: AttachPodName is the name of the pod used
+                                to attach the volume to the node.
+                              type: string
+                            attachPodUID:
+                              description: AttachPodUID is the UID of the pod used
+                                to attach the volume to the node.
+                              type: string
+                          type: object
+                        memoryDumpVolume:
+                          description: If the volume is memorydump volume, this will
+                            contain the memorydump info.
+                          properties:
+                            claimName:
+                              description: ClaimName is the name of the pvc the memory
+                                was dumped to
+                              type: string
+                            endTimestamp:
+                              description: EndTimestamp is the time when the memory
+                                dump completed
+                              format: date-time
+                              type: string
+                            startTimestamp:
+                              description: StartTimestamp is the time when the memory
+                                dump started
+                              format: date-time
+                              type: string
+                            targetFileName:
+                              description: TargetFileName is the name of the memory
+                                dump output
+                              type: string
+                          type: object
+                        message:
+                          description: Message is a detailed message about the current
+                            hotplug volume phase
+                          type: string
+                        name:
+                          description: Name is the name of the volume
+                          type: string
+                        persistentVolumeClaimInfo:
+                          description: PersistentVolumeClaimInfo is information about
+                            the PVC that handler requires during start flow
+                          properties:
+                            accessModes:
+                              description: |-
+                                AccessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            capacity:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Capacity represents the capacity set on
+                                the corresponding PVC status
+                              type: object
+                            claimName:
+                              description: ClaimName is the name of the PVC
+                              type: string
+                            filesystemOverhead:
+                              description: Percentage of filesystem's size to be reserved
+                                when resizing the PVC
+                              pattern: ^(0(?:\.\d{1,3})?|1)$
+                              type: string
+                            preallocated:
+                              description: Preallocated indicates if the PVC's storage
+                                is preallocated or not
+                              type: boolean
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests represents the resources requested
+                                by the corresponding PVC spec
+                              type: object
+                            volumeMode:
+                              description: |-
+                                VolumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                          type: object
+                        phase:
+                          description: Phase is the phase
+                          type: string
+                        reason:
+                          description: Reason is a brief description of why we are
+                            in the current hotplug volume phase
+                          type: string
+                        size:
+                          description: Represents the size of the volume
+                          format: int64
+                          type: integer
+                        target:
+                          description: 'Target is the target name used when adding
+                            the volume to the VM, eg: vda'
+                          type: string
+                      required:
+                      - name
+                      - target
+                      type: object
                     preferenceRef:
                       description: PreferenceRef captures the state of any referenced
                         preference from the VirtualMachine

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -1349,6 +1349,42 @@
         ]
       }
     },
+    "persistentStateVolume": {
+      "name": "nameValue",
+      "target": "targetValue",
+      "phase": "phaseValue",
+      "reason": "reasonValue",
+      "message": "messageValue",
+      "persistentVolumeClaimInfo": {
+        "claimName": "claimNameValue",
+        "accessModes": [
+          "accessModesValue"
+        ],
+        "volumeMode": "volumeModeValue",
+        "capacity": {
+          "capacityKey": "0"
+        },
+        "requests": {
+          "requestsKey": "0"
+        },
+        "preallocated": true,
+        "filesystemOverhead": "filesystemOverheadValue"
+      },
+      "hotplugVolume": {
+        "attachPodName": "attachPodNameValue",
+        "attachPodUID": "attachPodUIDValue"
+      },
+      "size": -4,
+      "memoryDumpVolume": {
+        "startTimestamp": "1986-01-01T01:01:01Z",
+        "endTimestamp": "1988-01-01T01:01:01Z",
+        "claimName": "claimNameValue",
+        "targetFileName": "targetFileNameValue"
+      },
+      "containerDiskVolume": {
+        "checksum": 4294967288
+      }
+    },
     "instancetypeRef": {
       "name": "nameValue",
       "kind": "kindValue",

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -841,6 +841,34 @@ status:
     remove: true
     startTimestamp: "1986-01-01T01:01:01Z"
   observedGeneration: -18
+  persistentStateVolume:
+    containerDiskVolume:
+      checksum: 4294967288
+    hotplugVolume:
+      attachPodName: attachPodNameValue
+      attachPodUID: attachPodUIDValue
+    memoryDumpVolume:
+      claimName: claimNameValue
+      endTimestamp: "1988-01-01T01:01:01Z"
+      startTimestamp: "1986-01-01T01:01:01Z"
+      targetFileName: targetFileNameValue
+    message: messageValue
+    name: nameValue
+    persistentVolumeClaimInfo:
+      accessModes:
+      - accessModesValue
+      capacity:
+        capacityKey: "0"
+      claimName: claimNameValue
+      filesystemOverhead: filesystemOverheadValue
+      preallocated: true
+      requests:
+        requestsKey: "0"
+      volumeMode: volumeModeValue
+    phase: phaseValue
+    reason: reasonValue
+    size: -4
+    target: targetValue
   preferenceRef:
     controllerRevisionRef:
       name: nameValue

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -6778,6 +6778,11 @@ func (in *VirtualMachineStatus) DeepCopyInto(out *VirtualMachineStatus) {
 		*out = new(ChangedBlockTrackingStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PersistentStateVolume != nil {
+		in, out := &in.PersistentStateVolume, &out.PersistentStateVolume
+		*out = new(VolumeStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.InstancetypeRef != nil {
 		in, out := &in.InstancetypeRef, &out.InstancetypeRef
 		*out = new(InstancetypeStatusRef)

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2128,6 +2128,12 @@ type VirtualMachineStatus struct {
 	// +optional
 	ChangedBlockTracking *ChangedBlockTrackingStatus `json:"changedBlockTracking,omitempty" optional:"true"`
 
+	// PersistentStateVolume tracks the backend storage PVC status
+	// containing persistent VM state (UEFI, TPM, CBT)
+	// +nullable
+	// +optional
+	PersistentStateVolume *VolumeStatus `json:"persistentStateVolume,omitempty" optional:"true"`
+
 	// InstancetypeRef captures the state of any referenced instance type from the VirtualMachine
 	//+nullable
 	//+optional

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -500,6 +500,7 @@ func (VirtualMachineStatus) SwaggerDoc() map[string]string {
 		"runStrategy":            "RunStrategy tracks the last recorded RunStrategy used by the VM.\nThis is needed to correctly process the next strategy (for now only the RerunOnFailure)",
 		"volumeUpdateState":      "VolumeUpdateState contains the information about the volumes set\nupdates related to the volumeUpdateStrategy",
 		"changedBlockTracking":   "ChangedBlockTracking represents the status of the changedBlockTracking\n+nullable\n+optional",
+		"persistentStateVolume":  "PersistentStateVolume tracks the backend storage PVC status\ncontaining persistent VM state (UEFI, TPM, CBT)\n+nullable\n+optional",
 		"instancetypeRef":        "InstancetypeRef captures the state of any referenced instance type from the VirtualMachine\n+nullable\n+optional",
 		"preferenceRef":          "PreferenceRef captures the state of any referenced preference from the VirtualMachine\n+nullable\n+optional",
 	}

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -29705,6 +29705,12 @@ func schema_kubevirtio_api_core_v1_VirtualMachineStatus(ref common.ReferenceCall
 							Ref:         ref("kubevirt.io/api/core/v1.ChangedBlockTrackingStatus"),
 						},
 					},
+					"persistentStateVolume": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PersistentStateVolume tracks the backend storage PVC status containing persistent VM state (UEFI, TPM, CBT)",
+							Ref:         ref("kubevirt.io/api/core/v1.VolumeStatus"),
+						},
+					},
 					"instancetypeRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "InstancetypeRef captures the state of any referenced instance type from the VirtualMachine",
@@ -29721,7 +29727,7 @@ func schema_kubevirtio_api_core_v1_VirtualMachineStatus(ref common.ReferenceCall
 			},
 		},
 		Dependencies: []string{
-			"kubevirt.io/api/core/v1.ChangedBlockTrackingStatus", "kubevirt.io/api/core/v1.InstancetypeStatusRef", "kubevirt.io/api/core/v1.VirtualMachineCondition", "kubevirt.io/api/core/v1.VirtualMachineMemoryDumpRequest", "kubevirt.io/api/core/v1.VirtualMachineStartFailure", "kubevirt.io/api/core/v1.VirtualMachineStateChangeRequest", "kubevirt.io/api/core/v1.VirtualMachineVolumeRequest", "kubevirt.io/api/core/v1.VolumeSnapshotStatus", "kubevirt.io/api/core/v1.VolumeUpdateState"},
+			"kubevirt.io/api/core/v1.ChangedBlockTrackingStatus", "kubevirt.io/api/core/v1.InstancetypeStatusRef", "kubevirt.io/api/core/v1.VirtualMachineCondition", "kubevirt.io/api/core/v1.VirtualMachineMemoryDumpRequest", "kubevirt.io/api/core/v1.VirtualMachineStartFailure", "kubevirt.io/api/core/v1.VirtualMachineStateChangeRequest", "kubevirt.io/api/core/v1.VirtualMachineVolumeRequest", "kubevirt.io/api/core/v1.VolumeSnapshotStatus", "kubevirt.io/api/core/v1.VolumeStatus", "kubevirt.io/api/core/v1.VolumeUpdateState"},
 	}
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR adds a `PersistentStateVolume` field to VirtualMachineStatus to track the current backend storage PVC.

This provides visibility into which PVC is actively storing the VM's persistent state, which is especially useful considering this is a pvc created with a randomly generated name that can't be located anywhere if the VM is offline.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->


### Special notes for your reviewer

Not ready for review yet.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Track backend storage PVC in VM status
```

