### PR TITLE
Handle single-node cluster scenario in CPUManager feature check

### DIFF
--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
@@ -147,9 +148,15 @@ func AdjustKubeVirtResource() {
 	Expect(err).ToNot(HaveOccurred())
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
 	if checks.HasFeature(featuregate.CPUManager) {
-		// CPUManager is not enabled in the control-plane node(s)
+		// CPUManager is typically not enabled in the control-plane node(s)
 		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane"})
 		Expect(err).NotTo(HaveOccurred())
+		// This case could happen in the case of single node clusters (like OpenShift SNO)
+		if len(nodes.Items) == 0 {
+			log.Log.Info("No non-control-plane nodes found. This shouldn't happen unless this is a single-node cluster. Falling back to listing nodes labeled as `worker`.")
+			nodes, err = virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
+			Expect(err).NotTo(HaveOccurred())
+		}
 		waitForSchedulableNodesWithCPUManager(len(nodes.Items))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Running functional tests on OpenShift SNO would fail due to this code snippet:
```go
	if checks.HasFeature(featuregate.CPUManager) {
		// CPUManager is not enabled in the control-plane node(s)
		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane"})
		Expect(err).NotTo(HaveOccurred())
		waitForSchedulableNodesWithCPUManager(len(nodes.Items))
	}
```

The code assumes a worker node will never also be a control node, but this is exactly the case in SNO. This results in an error like this:
```
[SynchronizedBeforeSuite] [FAILED] [182.296 seconds]
[SynchronizedBeforeSuite] 
tests/tests_suite_test.go:105

  [FAILED] Timed out after 180.000s.
  There are pods in system which are not ready.                                                                                                                                                                                                                                       
  Expected                                                                                                                                                                                                                                                                            
      <[]string | len:1, cap:1>: [                                                                                                                                                                                                                                                    
          "virt-launcher-testvmi-gl6s7-69pd5",                                                                                                                                                                                                                                        
      ]                                                                                                                                                                                                                                                                               
  to be empty                                                                                                                                                                                                                                                                         
  In [SynchronizedBeforeSuite] at: tests/testsuite/fixture.go:438 @ 02/09/26 16:15:48.154
```

What happens is that inside fixture.go, `SynchronizedBeforeTestSetup` calls `AdjustKubeVirtResource` which first appends the CPUManager feature gate so long as `translateBuildArch() != "s390x"` (almost always). This results in the above snippet executing in nearly all functests.

Then when the snippet calls waitForSchedulableNodesWithCPUManager, then this function is defined as follows:
```go
	virtClient := kubevirt.Client()
	Eventually(func() bool {
		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true," + v1.CPUManager + "=true"})
		Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
		return len(nodes.Items) == n
	}, 360, 1*time.Second).Should(BeTrue())
```
The problem is that since inside a single node cluster, control-plane node is also a worker so even though `virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane"})` returned no nodes, `virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true," + v1.CPUManager + "=true"})` returns 1 node (since that single node does have CPUManager enabled). This results in `len(nodes.Items) == n` to resolve to `0 == 1` which is obviously false (unless this happens to execute before the node had the CPUManager label applied).

This causes the tests to timeout.

#### After this PR:

To allows single node clusters like OpenShift SNOs to run functional tests by checking for nodes labeled `node-role.kubernetes.io/worker` in the absence of `!node-role.kubernetes.io/control-plane`.

### Why we need it and why it was done in this way

The following alternatives were considered:
* Considered replacing `metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane"}` with `metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/worker"}`. But, apparently, according to Claude, Kind doesn't always label its nodes with "worker". And either way the safer option was to preserve existing behavior and handling this edge case when no nodes match.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

