### PR TITLE
arch/converter: Fix SMBIOS details missing on ARM64

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
@@ -42,8 +42,7 @@ func (converterARM64) SupportCPUHotplug() bool {
 }
 
 func (converterARM64) IsSMBiosNeeded() bool {
-	// ARM64 use UEFI boot by default, set SMBios is unnecessary.
-	return false
+	return true
 }
 
 func (converterARM64) TransitionalModelType(useVirtioTransitional bool) string {

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
@@ -3,6 +3,7 @@
   <memory unit="b">8388608</memory>
   <os>
     <type arch="aarch64" machine="virt">hvm</type>
+    <smbios mode="sysinfo"></smbios>
     <loader readonly="yes" secure="no" type="pflash"></loader>
     <nvram>/var/lib/libvirt/qemu/nvram/testvmi_VARS.fd</nvram>
   </os>

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2200,7 +2200,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 	})
 
-	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values", func() {
+	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values", decorators.WgArm64, func() {
 
 		It("[test_id:2751]test default SMBios", func() {
 			kv := libkubevirt.GetCurrentKv(virtClient)


### PR DESCRIPTION
### What this PR does

On aarch64, `IsSMBiosNeeded()` returned `false` under the incorrect assumption that UEFI boot makes the `<smbios mode='sysinfo'/>` directive unnecessary. This directive is required regardless of firmware type -- it tells libvirt to pass the sysinfo entries to QEMU. Without it, the guest sees default host SMBIOS values instead of the KubeVirt-configured data.

#### Before this PR

- ARM64 domain XML includes `<sysinfo type='smbios'>` with correct entries, but `<os>` is missing `<smbios mode='sysinfo'/>`, so libvirt never passes the data to QEMU.

#### After this PR

- `<smbios mode='sysinfo'/>` is added to `<os>` for ARM64, matching existing x86_64 behavior.

### Special notes for your reviewer

### Alternatives considered

- Removing `IsSMBiosNeeded()` from the `arch.Converter` interface entirely and enabling `<smbios mode='sysinfo'/>` unconditionally for all architectures.
  - This was not done because s390x also returns `false` and has the same unused `<sysinfo>` block, but SMBIOS support on s390x is unverified.
  - Changing s390x behavior without testing could break VMs.
   
  - This can be revisited if a s390x issue is reported.


### Release note
```release-note
Fixed SMBIOS system information not being visible inside ARM64 guest VMs
```

