### PR TITLE
fix(virt-operator): include ComponentImages in deployment ID hash

### DIFF
--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -125,6 +125,34 @@ var _ = Describe("Operator Config", func() {
 			Expect(idFilled).ToNot(Equal(idEmpty))
 		})
 
+		DescribeTable("should result in different ID when component images change", func(setImage func(*KubeVirtDeploymentConfig, string)) {
+			cfgA := &KubeVirtDeploymentConfig{}
+			cfgA.AdditionalProperties = make(map[string]string)
+			setImage(cfgA, "registry:5000/kubevirt/image:v1")
+			cfgA.generateInstallStrategyID()
+
+			cfgB := &KubeVirtDeploymentConfig{}
+			cfgB.AdditionalProperties = make(map[string]string)
+			setImage(cfgB, "registry:5000/kubevirt/image:v2")
+			cfgB.generateInstallStrategyID()
+
+			Expect(cfgA.ID).ToNot(BeEmpty())
+			Expect(cfgB.ID).ToNot(BeEmpty())
+			Expect(cfgA.ID).ToNot(Equal(cfgB.ID))
+		},
+			Entry("VirtOperatorImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtOperatorImage = img }),
+			Entry("VirtApiImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtApiImage = img }),
+			Entry("VirtControllerImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtControllerImage = img }),
+			Entry("VirtHandlerImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtHandlerImage = img }),
+			Entry("VirtLauncherImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtLauncherImage = img }),
+			Entry("VirtExportProxyImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtExportProxyImage = img }),
+			Entry("VirtExportServerImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtExportServerImage = img }),
+			Entry("VirtSynchronizationControllerImage", func(c *KubeVirtDeploymentConfig, img string) { c.VirtSynchronizationControllerImage = img }),
+			Entry("GsImage", func(c *KubeVirtDeploymentConfig, img string) { c.GsImage = img }),
+			Entry("PrHelperImage", func(c *KubeVirtDeploymentConfig, img string) { c.PrHelperImage = img }),
+			Entry("SidecarShimImage", func(c *KubeVirtDeploymentConfig, img string) { c.SidecarShimImage = img }),
+		)
+
 	})
 
 	Context("Product Names and Versions", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Updating `VIRT_LAUNCHER_IMAGE`, `VIRT_HANDLER_IMAGE`, or any other `VIRT_*_IMAGE` environment variable on the virt-operator deployment did not propagate to component deployments. The operator continued to report "All KubeVirt components ready" without updating virt-controller, virt-handler, or any other component.

This was caused by commit `e80193d263` ("Aggregate component images"), which moved the image fields from `KubeVirtDeploymentConfig` into an embedded `ComponentImages` struct. The `getStringFromFields()` function uses reflection to build a string for the deployment ID hash. It handled `reflect.Map` and assumed everything else was a `reflect.String`, but the embedded struct has `reflect.Struct` kind. Calling `reflect.Value.String()` on a struct returns a constant type-description string (`"<util.ComponentImages Value>"`) regardless of the actual field values, so all 11 image fields were excluded from the deployment ID hash.

Because the deployment ID never changed, the operator reused the existing install strategy ConfigMap with stale manifests and `syncDeployment()` detected no metadata diff, skipping the update entirely.

#### After this PR:

`getStringFromFields()` now handles `reflect.Struct` fields by iterating over the embedded struct's fields and including each field's name and value in the hash input. Changes to any `VIRT_*_IMAGE` env var now produce a new deployment ID, triggering a new install strategy job, new manifests, and a full reconciliation that updates the affected component deployments.

### References

Fixes: https://github.com/kubevirt/kubevirt/issues/16790

### Why we need it and why it was done in this way
The following tradeoffs were made:

The fix adds a `reflect.Struct` case to the existing `switch` in `getStringFromFields()`, iterating over the struct's fields and appending their names and string values. This mirrors how top-level string fields are already handled and is consistent with the function's reflection-based approach.

The following alternatives were considered:

Flattening `ComponentImages` back into `KubeVirtDeploymentConfig` was considered but would revert the refactoring from `e80193d263` that other code now depends on.

Links to places where the discussion took place:

### Special notes for your reviewer

Note that this changes the deployment ID for any installation that uses the code from `e80193d263`. On upgrade, the operator will detect a deployment ID mismatch and trigger a full reconciliation. This is the correct behavior — it will converge to the expected state — but reviewers should be aware it will cause a one-time re-sync.

### Checklist

- [x] Design: A design document was not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New unit test added to verify component image changes produce different deployment IDs
- [ ] Documentation: A user-guide update was not required
- [ ] Community: Announcement to kubevirt-dev was considered

### Release note
```release-note
Bug fix: VIRT_*_IMAGE environment variable overrides on the virt-operator deployment are now correctly propagated to component deployments (virt-controller, virt-handler, etc.). Previously, changing these env vars had no effect due to the image values being excluded from the install strategy deployment ID hash.
```