### PR TITLE
Fix newDeviceNamer to handle CDRom and LUN devices

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1301,10 +1301,18 @@ func newDeviceNamer(volumeStatuses []v1.VolumeStatus, disks []v1.Disk) map[strin
 	}
 
 	for _, disk := range disks {
-		if disk.Disk == nil {
+		var prefix string
+		switch {
+		case disk.Disk != nil:
+			prefix = getPrefixFromBus(disk.Disk.Bus)
+		case disk.LUN != nil:
+			prefix = getPrefixFromBus(disk.LUN.Bus)
+		case disk.CDRom != nil:
+			prefix = getPrefixFromBus(disk.CDRom.Bus)
+		default:
 			continue
 		}
-		prefix := getPrefixFromBus(disk.Disk.Bus)
+
 		if _, ok := prefixMap[prefix]; !ok {
 			prefixMap[prefix] = deviceNamer{
 				existingNameMap: make(map[string]string),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
CD ROM and LUN devices are not being tracked in the prefix map, which can cause naming conflicts when device targets are assigned during hotplug operations. 

For example, if I create a VM with a boot disk (sda), a data disk with hotpluggable: true (sdb), and two CD ROM devices for cloud-init, etc. (sdc and sdd), and then hotplug attach a new disk (sde) and hotplug detach the original data disk (sdb), this operation will succeed. However, because the CD ROM devices are not tracked in the prefix map, they are essentially rediscovered on each sync, so if I try to hotplug a new disk, the boot disk is tracked so it remains at sda, but the CD ROMs are rediscovered and are assigned to the newly available sdb and sdc, and the new disk will try to take sdd since it appears to be available. This will cause a libvirt error since sdd is already defined in the domain:

"Failed","message":"VMI synchronization failed: server error. command SyncVMI failed: \"LibvirtError(Code=55, Domain=10, Message='Requested operation is not valid: target sdd already exists'

#### After this PR:
This PR updates newDeviceNamer to correctly build prefix maps for CDRom and LUN disk device types in addition to standard Disk types.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made: N/A

The following alternatives were considered:
It's possible to work around the issue by arranging disks in the spec to keep all CD ROMs at the top to ensure they don't change position, but with this PR, I haven't been able to reproduce the issue and new disk take the appropriate targets as expected.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```