### PR TITLE
test: Add unit tests for isOwnedByClone

### DIFF
--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     srcs = [
         "clone_suite_test.go",
         "clone_test.go",
+        "util_test.go",
     ],
     embed = [":go_default_library"],
     race = "on",
@@ -64,6 +65,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/virt-controller/watch/clone/util.go
+++ b/pkg/virt-controller/watch/clone/util.go
@@ -149,7 +149,6 @@ func isOwnedByClone(obj metav1.Object) (isOwned bool, key string) {
 	}
 
 	return false, ""
-	// TODO: Unit test this?
 }
 
 func updateCondition(conditions []clone.Condition, c clone.Condition, includeReason bool) []clone.Condition {

--- a/pkg/virt-controller/watch/clone/util_test.go
+++ b/pkg/virt-controller/watch/clone/util_test.go
@@ -1,0 +1,115 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package clone
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	clone "kubevirt.io/api/clone/v1beta1"
+)
+
+var _ = Describe("Clone Utils", func() {
+
+	Context("isOwnedByClone", func() {
+		var (
+			testObj          *metav1.ObjectMeta
+			cloneKind        string
+			cloneAPIVersion  string
+			correctOwnerRef  metav1.OwnerReference
+			incorrectKindRef metav1.OwnerReference
+		)
+
+		BeforeEach(func() {
+			cloneKind = clone.VirtualMachineCloneKind.Kind
+			cloneAPIVersion = clone.VirtualMachineCloneKind.GroupVersion().String()
+
+			testObj = &metav1.ObjectMeta{
+				Name:      "test-object",
+				Namespace: "test-namespace",
+			}
+
+			correctOwnerRef = metav1.OwnerReference{
+				Kind:       cloneKind,
+				APIVersion: cloneAPIVersion,
+				Name:       "my-clone",
+				UID:        types.UID("12345"),
+			}
+
+			incorrectKindRef = metav1.OwnerReference{
+				Kind:       "VirtualMachine",
+				APIVersion: cloneAPIVersion,
+				Name:       "my-vm",
+				UID:        types.UID("67890"),
+			}
+		})
+
+		It("should return true and the key when object is owned by a valid Clone", func() {
+			testObj.OwnerReferences = []metav1.OwnerReference{correctOwnerRef}
+
+			isOwned, key := isOwnedByClone(testObj)
+
+			Expect(isOwned).To(BeTrue())
+			Expect(key).To(Equal("test-namespace/my-clone"))
+		})
+
+		It("should return false when object has no owners", func() {
+			testObj.OwnerReferences = []metav1.OwnerReference{}
+
+			isOwned, key := isOwnedByClone(testObj)
+
+			Expect(isOwned).To(BeFalse())
+			Expect(key).To(BeEmpty())
+		})
+
+		It("should return false when object is owned by something else (wrong Kind)", func() {
+			testObj.OwnerReferences = []metav1.OwnerReference{incorrectKindRef}
+
+			isOwned, key := isOwnedByClone(testObj)
+
+			Expect(isOwned).To(BeFalse())
+			Expect(key).To(BeEmpty())
+		})
+
+		It("should return false when key matches Kind but has wrong API Version", func() {
+			wrongVersionRef := correctOwnerRef
+			wrongVersionRef.APIVersion = "api.group/v1alpha0" // Intentionally wrong
+			testObj.OwnerReferences = []metav1.OwnerReference{wrongVersionRef}
+
+			isOwned, key := isOwnedByClone(testObj)
+
+			Expect(isOwned).To(BeFalse())
+			Expect(key).To(BeEmpty())
+		})
+
+		It("should return true if multiple owners exist and one is a valid Clone", func() {
+			// Mixed ownership: One VM and one Clone
+			testObj.OwnerReferences = []metav1.OwnerReference{incorrectKindRef, correctOwnerRef}
+
+			isOwned, key := isOwnedByClone(testObj)
+
+			Expect(isOwned).To(BeTrue())
+			Expect(key).To(Equal("test-namespace/my-clone"))
+		})
+	})
+})


### PR DESCRIPTION
This PR adds unit test coverage for the ``isOwnedByClone`` utility function as requested by the TODO in [util.go](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-controller/watch/clone/util.go).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

- Adds unit tests validating the behavior of ``isOwnedByClone``.
- Removes the outdated ``TODO: Unit test this?`` comment from [util.go](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-controller/watch/clone/util.go) as the test coverage is now implemented.

#### Before this PR:
- ``isOwnedByClone`` had no direct unit tests.
- A TODO comment indicated missing test coverage.

#### After this PR:
- ``isOwnedByClone`` is fully unit tested.
- The TODO comment has been removed.

### Testing
- Added unit tests for util.go.
- All existing tests pass.


### Why we need it and why it was done in this way
The isOwnedByClone helper is non trivial logic used in multiple code paths, but previously had no direct unit test coverage. Adding tests improves confidence in its behavior, protects against regressions, and aligns the codebase with testing best practices.

### Notes for reviewer
This PR is intentionally scoped to testing only. No functional or behavioral changes were made to production code.

<!-- optional -->

### Checklist

Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Testing: Added unit tests for isOwnedByClone



<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
### Release Note
```release-note
NONE
```

