### PR TITLE
tests: use vms with a long name

### DIFF
--- a/pkg/libvmi/vm.go
+++ b/pkg/libvmi/vm.go
@@ -81,6 +81,12 @@ func WithLabels(labels map[string]string) VMOption {
 	}
 }
 
+func WithVMName(name string) VMOption {
+	return func(vm *v1.VirtualMachine) {
+		vm.Name = name
+	}
+}
+
 func WithRunStrategy(strategy v1.VirtualMachineRunStrategy) VMOption {
 	return func(vm *v1.VirtualMachine) {
 		vm.Spec.RunStrategy = &strategy

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -50,7 +50,7 @@ func RegisterDefaultOption(opt Option) {
 // randName returns a random name for a virtual machine
 func randName() string {
 	const randomPostfixLen = 5
-	return "testvmi" + "-" + rand.String(randomPostfixLen)
+	return "testvmi" + "-" + rand.String(randomPostfixLen) + "-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 }
 
 func baseVmi(name string) *v1.VirtualMachineInstance {

--- a/tests/migration/recovery.go
+++ b/tests/migration/recovery.go
@@ -70,6 +70,7 @@ var _ = Describe("[sig-compute]Migration recovery", decorators.SigCompute, decor
 
 		By("Creating a VM with RWO backend-storage")
 		vmi := libvmifact.NewFedora(
+			libvmi.WithName("issue-16760"),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),

--- a/tests/objectgraph_test.go
+++ b/tests/objectgraph_test.go
@@ -98,6 +98,7 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 					libvmi.WithTPM(true),
 				),
 				libvmi.WithRunStrategy(v1.RunStrategyAlways),
+				libvmi.WithVMName("issue-16760"),
 			)
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -82,6 +82,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
 			libvmi.WithLabels(backup.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			libvmi.WithVMName("issue-16760"),
 		)
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
@@ -125,6 +126,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
 			libvmi.WithLabels(backup.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			libvmi.WithVMName("issue-16760"),
 		)
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
@@ -305,6 +307,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
 			libvmi.WithLabels(backup.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			libvmi.WithVMName("issue-16760"),
 		)
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
@@ -410,6 +413,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
 			libvmi.WithLabels(backup.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			libvmi.WithVMName("issue-16760"),
 		)
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))

--- a/tests/storage/cbt.go
+++ b/tests/storage/cbt.go
@@ -289,6 +289,7 @@ var _ = Describe(SIG("CBT", func() {
 		),
 			libvmi.WithLabels(cbt.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			libvmi.WithVMName("issue-16760"),
 		)
 		volumeName := vm.Spec.Template.Spec.Volumes[0].Name
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1243,7 +1243,7 @@ func volumeExpansionAllowed(sc string) bool {
 		*storageClass.AllowVolumeExpansion
 }
 
-func renderVMWithRegistryImportDataVolume(containerDisk cd.ContainerDisk, storageClass string) *v1.VirtualMachine {
+func renderVMWithRegistryImportDataVolume(containerDisk cd.ContainerDisk, storageClass string, opts ...libvmi.VMOption) *v1.VirtualMachine {
 	importUrl := cd.DataVolumeImportUrlForContainerDisk(containerDisk)
 	dv := libdv.NewDataVolume(
 		libdv.WithRegistryURLSource(importUrl),
@@ -1253,5 +1253,5 @@ func renderVMWithRegistryImportDataVolume(containerDisk cd.ContainerDisk, storag
 			libdv.StorageWithVolumeSize(cd.ContainerDiskSizeBySourceURL(importUrl)),
 		),
 	)
-	return libstorage.RenderVMWithDataVolumeTemplate(dv)
+	return libstorage.RenderVMWithDataVolumeTemplate(dv, opts...)
 }

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -235,7 +235,7 @@ var _ = Describe(SIG("Export", func() {
 
 	createExportTokenSecret := func(name, namespace string) *k8sv1.Secret {
 		var err error
-		secret := libsecret.New(fmt.Sprintf("export-token-%s", name), libsecret.DataString{"token": name})
+		secret := libsecret.New(fmt.Sprintf("export-token-%s", name[:min(len(name), 50)]), libsecret.DataString{"token": name})
 		token, err = virtClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return token

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1630,7 +1630,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			})
 
 			It("should restore an already cloned virtual machine", func() {
-				vm, vmi = createAndStartVM(renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass))
+				vm, vmi = createAndStartVM(renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithVMName("issue-16760")))
 
 				targetVMName := vm.Name + "-clone"
 				cloneVM(vm.Name, targetVMName)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1337,6 +1337,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 					libvmi.WithMemoryRequest("128Mi"),
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 					libvmi.WithPersistentVolumeClaim("snapshotablevolume", includedDataVolume.Name),
+					libvmi.WithName("issue-16760"),
 				)
 				vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
 				vm = libvmi.NewVirtualMachine(vmi)

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -71,7 +71,7 @@ var _ = Describe(SIG("[sig-storage]Memory dump", decorators.SigStorage, func() {
 
 		pvcName = "fs-pvc-" + rand.String(randNameTail)
 
-		vm = libvmi.NewVirtualMachine(libvmifact.NewCirros(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		vm = libvmi.NewVirtualMachine(libvmifact.NewCirros(), libvmi.WithRunStrategy(v1.RunStrategyAlways), libvmi.WithVMName("issue-16760"))
 		var err error
 		vm, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -116,6 +116,7 @@ var _ = Describe("[sig-compute]VM state", func() {
 		DescribeTable("should persist VM state of", decorators.RequiresTwoSchedulableNodes, func(withTPM, withEFI, shouldBeRWX bool, ops ...string) {
 			By("Creating a migratable Fedora VM with UEFI")
 			vmi := libvmifact.NewFedora(
+				libvmi.WithName("issue-16760"),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(cloudinit.CreateDefaultCloudInitNetworkData())),


### PR DESCRIPTION
Due to reports of regressions in that area (e.g https://github.com/kubevirt/kubevirt/issues/16760 ), let us test our functionality with full-length VMs. This PR makes all VM names long, except for the tests that expose a bug.

```release-note
NONE
```

