### PR TITLE
Add a warning message for Alpha and Beta feature gates

### DIFF
--- a/pkg/virt-config/featuregate/feature-gates.go
+++ b/pkg/virt-config/featuregate/feature-gates.go
@@ -44,8 +44,10 @@ const (
 	// Discontinued represents features that have been removed, with no option to enable them.
 	Discontinued State = "Discontinued"
 
-	WarningPattern = "feature gate %s is deprecated (feature state is %q), therefore it can be safely removed and is redundant. " +
+	WarningPatternDeprecated = "feature gate %s is deprecated (feature state is %q), therefore it can be safely removed and is redundant. " +
 		"For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md"
+
+	WarningPatternActive = "feature gate %s is active (feature state is %q)"
 )
 
 type FeatureGate struct {
@@ -62,8 +64,13 @@ var featureGates = map[string]FeatureGate{}
 // existing FG.
 // If an inactive feature-gate is missing a message, a default one is set.
 func RegisterFeatureGate(fg FeatureGate) {
-	if fg.State != Alpha && fg.State != Beta && fg.Message == "" {
-		fg.Message = fmt.Sprintf(WarningPattern, fg.Name, fg.State)
+	if fg.Message == "" {
+		switch fg.State {
+		case Alpha, Beta:
+			fg.Message = fmt.Sprintf(WarningPatternActive, fg.Name, fg.State)
+		default:
+			fg.Message = fmt.Sprintf(WarningPatternDeprecated, fg.Name, fg.State)
+		}
 	}
 	featureGates[fg.Name] = fg
 }

--- a/pkg/virt-config/featuregate/feature-gates_test.go
+++ b/pkg/virt-config/featuregate/feature-gates_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Feature Gate", func() {
 		Expect(featuregate.FeatureGateInfo(fg.Name)).To(Equal(&featuregate.FeatureGate{
 			Name:    fg.Name,
 			State:   fg.State,
-			Message: fmt.Sprintf(featuregate.WarningPattern, fg.Name, fg.State),
+			Message: fmt.Sprintf(featuregate.WarningPatternDeprecated, fg.Name, fg.State),
 		}))
 	})
 

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -122,7 +122,7 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 
 	if featureGatesChanged(&currKV.Spec, &newKV.Spec) {
 		featureGates := newKV.Spec.Configuration.DeveloperConfiguration.FeatureGates
-		response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(featureGates)...)
+		response.Warnings = append(response.Warnings, warnFeatureGates(featureGates)...)
 	}
 
 	const mdevWarningfmt = "%s is deprecated, use mediatedDeviceTypes"
@@ -455,11 +455,10 @@ func featureGatesChanged(currKVSpec, newKVSpec *v1.KubeVirtSpec) bool {
 		!slices.Equal(currDevConfig.DisabledFeatureGates, newDevConfig.DisabledFeatureGates)
 }
 
-func warnDeprecatedFeatureGates(featureGates []string) (warnings []string) {
+func warnFeatureGates(featureGates []string) (warnings []string) {
 	for _, featureGate := range featureGates {
-		deprectedFeature := featuregate.FeatureGateInfo(featureGate)
-		if deprectedFeature != nil {
-			warning := deprectedFeature.Message
+		if fg := featuregate.FeatureGateInfo(featureGate); fg != nil {
+			warning := fg.Message
 			warnings = append(warnings, warning)
 			log.Log.Warning(warning)
 		}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -366,7 +366,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			Entry("should not warn if configuration nil", warnNotExpected, nil),
 		)
 
-		DescribeTable("should raise warning when a deprecated feature-gate is enabled", func(featureGate, expectedWarning string) {
+		DescribeTable("should raise warning when a feature-gate is enabled", func(featureGate, expectedWarning string) {
 			kv := v1.KubeVirt{}
 			kvBytes, err := json.Marshal(kv)
 			Expect(err).ToNot(HaveOccurred())
@@ -391,12 +391,14 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				},
 			}))
 		},
-			Entry("with LiveMigration", featuregate.LiveMigrationGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.LiveMigrationGate, featuregate.GA)),
-			Entry("with SRIOVLiveMigration", featuregate.SRIOVLiveMigrationGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.SRIOVLiveMigrationGate, featuregate.GA)),
-			Entry("with NonRoot", featuregate.NonRoot, fmt.Sprintf(featuregate.WarningPattern, featuregate.NonRoot, featuregate.GA)),
-			Entry("with PSA", featuregate.PSA, fmt.Sprintf(featuregate.WarningPattern, featuregate.PSA, featuregate.GA)),
-			Entry("with CPUNodeDiscoveryGate", featuregate.CPUNodeDiscoveryGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.CPUNodeDiscoveryGate, featuregate.GA)),
-			Entry("with HotplugNICs", featuregate.HotplugNetworkIfacesGate, fmt.Sprintf(featuregate.WarningPattern, featuregate.HotplugNetworkIfacesGate, featuregate.GA)),
+			Entry("with CPUManager", featuregate.CPUManager, fmt.Sprintf(featuregate.WarningPatternActive, featuregate.CPUManager, featuregate.Alpha)),
+			Entry("with ImageVolume", featuregate.ImageVolume, fmt.Sprintf(featuregate.WarningPatternActive, featuregate.ImageVolume, featuregate.Beta)),
+			Entry("with LiveMigration", featuregate.LiveMigrationGate, fmt.Sprintf(featuregate.WarningPatternDeprecated, featuregate.LiveMigrationGate, featuregate.GA)),
+			Entry("with SRIOVLiveMigration", featuregate.SRIOVLiveMigrationGate, fmt.Sprintf(featuregate.WarningPatternDeprecated, featuregate.SRIOVLiveMigrationGate, featuregate.GA)),
+			Entry("with NonRoot", featuregate.NonRoot, fmt.Sprintf(featuregate.WarningPatternDeprecated, featuregate.NonRoot, featuregate.GA)),
+			Entry("with PSA", featuregate.PSA, fmt.Sprintf(featuregate.WarningPatternDeprecated, featuregate.PSA, featuregate.GA)),
+			Entry("with CPUNodeDiscoveryGate", featuregate.CPUNodeDiscoveryGate, fmt.Sprintf(featuregate.WarningPatternDeprecated, featuregate.CPUNodeDiscoveryGate, featuregate.GA)),
+			Entry("with HotplugNICs", featuregate.HotplugNetworkIfacesGate, fmt.Sprintf(featuregate.WarningPatternDeprecated, featuregate.HotplugNetworkIfacesGate, featuregate.GA)),
 			Entry("with Passt", featuregate.PasstGate, featuregate.PasstDiscontinueMessage),
 			Entry("with MacvtapGate", featuregate.MacvtapGate, featuregate.MacvtapDiscontinueMessage),
 			Entry("with ExperimentalVirtiofsSupport", featuregate.VirtIOFSGate, featuregate.VirtioFsFeatureGateDiscontinueMessage),


### PR DESCRIPTION
 This patch adds a non-empty Message for Alpha and Beta feature gates.
 Before this patch, Alpha and Beta feature gates had empty Message fields, so when
 we logged them in virt-operator, their warning messages would be empty
 and useless.
    
 Also fixes typos and updates function name to be more accurate.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
KubeVirt CR snippet:
```
  configuration:
    developerConfiguration:
      featureGates:
      - CPUManager
      - ImageVolume
      - NonRoot
```
CPUManager is Alpha, ImageVolume is Beta, and NonRoot is GA
#### Before this PR:
logs had empty messages for Alpha and Beta feature gates:
```
{"component":"virt-operator","level":"warning","msg":"","pos":"kubevirt-update-admitter.go:458","timestamp":"2026-02-03T20:01:48.461704Z"}
{"component":"virt-operator","level":"warning","msg":"","pos":"kubevirt-update-admitter.go:458","timestamp":"2026-02-03T20:01:48.461768Z"}
{"component":"virt-operator","level":"warning","msg":"feature gate NonRoot is deprecated (feature state is \"General Availability\"), therefore it can be safely removed and is redundant. For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md","pos":"kubevirt-update-admitter.go:458","timestamp":"2026-02-03T20:01:48.461795Z"}
```


#### After this PR:

```
{"component":"virt-operator","level":"warning","msg":"feature gate CPUManager is active (feature state is \"Alpha\")","pos":"kubevirt-update-admitter.go:458","timestamp":"2026-02-12T04:02:17.460297Z"}
{"component":"virt-operator","level":"warning","msg":"feature gate ImageVolume is active (feature state is \"Beta\")","pos":"kubevirt-update-admitter.go:458","timestamp":"2026-02-12T04:02:17.460337Z"}
{"component":"virt-operator","level":"warning","msg":"feature gate NonRoot is deprecated (feature state is \"General Availability\"), therefore it can be safely removed and is redundant. For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md","pos":"kubevirt-update-admitter.go:458","timestamp":"2026-02-12T04:02:17.460351Z"}
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://issues.redhat.com/browse/VIRTCNV-182

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

