### PR TITLE
migration: vm with a long name

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -325,7 +325,10 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 		})
 		Context("with a Alpine disk", func() {
 			It("[test_id:6969]should be successfully migrate with a tablet device", func() {
-				vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+				vmi := libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithName("migration-test-for-a-vmi-with-a-tablet-and-a-very-long-name"),
+					libnet.WithMasqueradeNetworking(),
+				)
 				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 					{
 						Name: "tablet0",


### PR DESCRIPTION
Due to a report of a regression in that area, try to migrate a VM with a 60 char long name. Migration is a long and fragile process, hence no specific test is added for this.

This is a manual backport of PR 16798
```release-note
NONE
```

