### PR TITLE
api, clone: Allow PrefixTargetName as VolumeNamePolicy

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9418,6 +9418,7 @@ var CRDsValidation map[string]string = map[string]string{
             the clone operation
           enum:
           - RandomizeNames
+          - PrefixTargetName
           type: string
       required:
       - source

--- a/staging/src/kubevirt.io/api/clone/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/types.go
@@ -97,7 +97,7 @@ type VirtualMachineCloneSpec struct {
 	Patches []string `json:"patches,omitempty"`
 	// VolumeNamePolicy defines how to handle volume naming during the clone operation
 	// +optional
-	// +kubebuilder:validation:Enum=RandomizeNames
+	// +kubebuilder:validation:Enum=RandomizeNames;PrefixTargetName
 	VolumeNamePolicy *VolumeNamePolicy `json:"volumeNamePolicy,omitempty"`
 }
 
@@ -108,6 +108,10 @@ const (
 	// VolumeNamePolicyRandomizeNames creates new volumes with randomized names for each cloned volume.
 	// This is the default and currently only supported policy.
 	VolumeNamePolicyRandomizeNames VolumeNamePolicy = "RandomizeNames"
+	// VolumeNamePolicyPrefixTargetName defines a VolumeNamePolicy which creates
+	// new PVCs with names prefixed by the target VM name: {targetVMName}-{volumeName}.
+	// This provides predictable naming while avoiding collisions when restoring to different targets.
+	VolumeNamePolicyPrefixTargetName VolumeNamePolicy = "PrefixTargetName"
 )
 
 // ToVolumeRestorePolicy converts a VolumeNamePolicy to the corresponding VolumeRestorePolicy
@@ -116,6 +120,8 @@ func (p VolumeNamePolicy) ToVolumeRestorePolicy() snapshotv1beta1.VolumeRestoreP
 	switch p {
 	case VolumeNamePolicyRandomizeNames:
 		return snapshotv1beta1.VolumeRestorePolicyRandomizeNames
+	case VolumeNamePolicyPrefixTargetName:
+		return snapshotv1beta1.VolumeRestorePolicyPrefixTargetName
 	default:
 		// Default to RandomizeNames for safety
 		return snapshotv1beta1.VolumeRestorePolicyRandomizeNames

--- a/staging/src/kubevirt.io/api/clone/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/types_swagger_generated.go
@@ -25,7 +25,7 @@ func (VirtualMachineCloneSpec) SwaggerDoc() map[string]string {
 		"newMacAddresses":   "NewMacAddresses manually sets that target interfaces' mac addresses. The key is the interface name and the\nvalue is the new mac address. If this field is not specified, a new MAC address will\nbe generated automatically, as for any interface that is not included in this map.\n+optional",
 		"newSMBiosSerial":   "NewSMBiosSerial manually sets that target's SMbios serial. If this field is not specified, a new serial will\nbe generated automatically.\n+optional",
 		"patches":           "Patches holds JSON patches to apply to target. Patches should fit the target's Kind.\nExample: '{\"op\": \"add\", \"path\": \"/spec/template/metadata/labels/example\", \"value\": \"new-label\"}'\n+optional\n+listType=atomic",
-		"volumeNamePolicy":  "VolumeNamePolicy defines how to handle volume naming during the clone operation\n+optional\n+kubebuilder:validation:Enum=RandomizeNames",
+		"volumeNamePolicy":  "VolumeNamePolicy defines how to handle volume naming during the clone operation\n+optional\n+kubebuilder:validation:Enum=RandomizeNames;PrefixTargetName",
 	}
 }
 


### PR DESCRIPTION
### What this PR does
VolumeNamePolicy was added to VirtualMachineClone by ed8107103a1191e06d5a62cd63f6a129f34a586d and wired down into the resulting VirtualMachineRestore as a VolumeRestorePolicy by dd42fb82b921cdfdeeff7d2c938a53d0b63c61b2. Initially this was limited to the existing RandomizeNames policy through a simple openapi validation.

PrefixTargetName was then added as a supported VolumeRestorePolicy for VirtualMachineRestore by a3306c855683642ead607a41d6616cf93f2f0b95.

This commit allows the use of PrefixTargetName as a VolumeNamePolicy by VirtualMachineClone that will map into a PrefixTargetName VolumeRestorePolicy used by the eventual VirtualMachineRestore.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`PrefixTargetName` is now allowed as a `VolumeNamePolicy` for `VirtualMachineClone`
```

