### PR TITLE
preferences: Add PreferredVideoType to DevicePreferences

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20802,6 +20802,10 @@
       "description": "PreferredUseVirtioTransitional optionally defines the preferred value of UseVirtioTransitional",
       "type": "boolean"
      },
+     "preferredVideoType": {
+      "description": "PreferredVideoType optionally defines the preferred type for Video devices.",
+      "type": "string"
+     },
      "preferredVirtualGPUOptions": {
       "description": "PreferredVirtualGPUOptions optionally defines the preferred value of VirtualGPUOptions",
       "$ref": "#/definitions/v1.VGPUOptions"

--- a/pkg/instancetype/preference/apply/device.go
+++ b/pkg/instancetype/preference/apply/device.go
@@ -88,6 +88,15 @@ func ApplyDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
 		vmiSpec.Domain.Devices.TPM = preferenceSpec.Devices.PreferredTPM.DeepCopy()
 	}
 
+	if preferenceSpec.Devices.PreferredVideoType != nil {
+		if vmiSpec.Domain.Devices.Video == nil {
+			vmiSpec.Domain.Devices.Video = &virtv1.VideoDevice{}
+		}
+		if vmiSpec.Domain.Devices.Video.Type == "" {
+			vmiSpec.Domain.Devices.Video.Type = *preferenceSpec.Devices.PreferredVideoType
+		}
+	}
+
 	ApplyAutoAttachPreferences(preferenceSpec, vmiSpec)
 	applyDiskPreferences(preferenceSpec, vmiSpec)
 	applyInterfacePreferences(preferenceSpec, vmiSpec)

--- a/pkg/instancetype/preference/apply/device_test.go
+++ b/pkg/instancetype/preference/apply/device_test.go
@@ -320,6 +320,42 @@ var _ = Describe("Preference.Devices", func() {
 		)
 	})
 
+	Context("PreferredVideoType", func() {
+		DescribeTable("should",
+			func(preferredVideoType *string, vmiVideo, expectedVideo *virtv1.VideoDevice) {
+				vmi.Spec.Domain.Devices.Video = vmiVideo
+				preferenceSpec.Devices.PreferredVideoType = preferredVideoType
+				Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
+				Expect(vmi.Spec.Domain.Devices.Video).To(Equal(expectedVideo))
+			},
+			Entry("only apply when video device type is empty within VMI spec",
+				pointer.P("virtio"),
+				&virtv1.VideoDevice{},
+				&virtv1.VideoDevice{Type: "virtio"},
+			),
+			Entry("not apply when video device type is already set within VMI spec",
+				pointer.P("virtio"),
+				&virtv1.VideoDevice{Type: "vga"},
+				&virtv1.VideoDevice{Type: "vga"},
+			),
+			Entry("create video device and apply when video device is not provided in the VMI spec",
+				pointer.P("virtio"),
+				nil,
+				&virtv1.VideoDevice{Type: "virtio"},
+			),
+			Entry("not apply when preferredVideoType is nil",
+				nil,
+				&virtv1.VideoDevice{},
+				&virtv1.VideoDevice{},
+			),
+			Entry("not apply when preferredVideoType is nil and video device is nil",
+				nil,
+				nil,
+				nil,
+			),
+		)
+	})
+
 	DescribeTable("PreferredAutoAttach should", func(preferenceValue, vmiValue *bool, match types.GomegaMatcher) {
 		type autoAttachField struct {
 			preference **bool

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -10071,6 +10071,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: PreferredUseVirtioTransitional optionally defines the preferred
                 value of UseVirtioTransitional
               type: boolean
+            preferredVideoType:
+              description: PreferredVideoType optionally defines the preferred type
+                for Video devices.
+              type: string
             preferredVirtualGPUOptions:
               description: PreferredVirtualGPUOptions optionally defines the preferred
                 value of VirtualGPUOptions
@@ -26062,6 +26066,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: PreferredUseVirtioTransitional optionally defines the preferred
                 value of UseVirtioTransitional
               type: boolean
+            preferredVideoType:
+              description: PreferredVideoType optionally defines the preferred type
+                for Video devices.
+              type: string
             preferredVirtualGPUOptions:
               description: PreferredVirtualGPUOptions optionally defines the preferred
                 value of VirtualGPUOptions

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
@@ -230,6 +230,11 @@ func (in *DevicePreferences) DeepCopyInto(out *DevicePreferences) {
 		*out = new(v1.PanicDeviceModel)
 		**out = **in
 	}
+	if in.PreferredVideoType != nil {
+		in, out := &in.PreferredVideoType, &out.PreferredVideoType
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -533,6 +533,11 @@ type DevicePreferences struct {
 	//
 	// +optional
 	PreferredPanicDeviceModel *v1.PanicDeviceModel `json:"preferredPanicDeviceModel,omitempty"`
+
+	// PreferredVideoType optionally defines the preferred type for Video devices.
+	//
+	// +optional
+	PreferredVideoType *string `json:"preferredVideoType,omitempty"`
 }
 
 // FeaturePreferences contains various optional defaults for Features.

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -164,6 +164,7 @@ func (DevicePreferences) SwaggerDoc() map[string]string {
 		"preferredTPM":                        "PreferredTPM optionally defines the preferred TPM device to be used.\n\n+optional",
 		"preferredInterfaceMasquerade":        "PreferredInterfaceMasquerade optionally defines the preferred masquerade configuration to use with each network interface.\n\n+optional",
 		"preferredPanicDeviceModel":           "PreferredPanicDeviceModel optionally defines the preferred panic device model to use with panic devices.\n\n+optional",
+		"preferredVideoType":                  "PreferredVideoType optionally defines the preferred type for Video devices.\n\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -31457,6 +31457,13 @@ func schema_kubevirtio_api_instancetype_v1beta1_DevicePreferences(ref common.Ref
 							Format:      "",
 						},
 					},
+					"preferredVideoType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PreferredVideoType optionally defines the preferred type for Video devices.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### What this PR does

Allow preference authors to specify a default video device type (e.g. virtio, vga, bochs, ramfb) via the preference system.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

