### PR TITLE
virtctl image-upload command need to handle auth error properly in retries

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -435,61 +435,104 @@ func ConstructUploadProxyPathAsync(uploadProxyURL, token string, insecure bool) 
 	return u.String(), nil
 }
 
-func (c *command) uploadData(token string, file *os.File) error {
+func (c *command) newUploadRequest(token string, reader io.Reader, length int64) (*http.Request, error) {
 	uploadURL, err := ConstructUploadProxyPathAsync(c.uploadProxyURL, token, c.insecure)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	req, err := http.NewRequest("POST", uploadURL, io.NopCloser(reader))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Content-Type", "application/octet-stream")
+	req.ContentLength = length
+	return req, nil
+}
 
+func (c *command) uploadData(initToken string, file *os.File) error {
 	fi, err := file.Stat()
 	if err != nil {
 		return err
 	}
 
-	bar := pb.New64(fi.Size())
+	length := fi.Size()
+
+	bar := pb.New64(length)
 	bar.SetTemplate(pb.Full)
 	bar.SetWriter(os.Stdout)
 	bar.Set(pb.Bytes, true)
+
 	reader := bar.NewProxyReader(file)
 
 	client := GetHTTPClientFn(c.insecure)
-	req, _ := http.NewRequest("POST", uploadURL, io.NopCloser(reader))
 
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/octet-stream")
-	req.ContentLength = fi.Size()
-
-	clientDo := func() error {
+	// clientDo returns http status code and error
+	// in case of an error, it may return the
+	// relevant http status code for further processing
+	clientDo := func(req *http.Request) (httpCode int, err error) {
 		if _, err := file.Seek(0, io.SeekStart); err != nil {
-			return err
+			return 0, err
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
-				return err
+				return resp.StatusCode, err
 			}
-			return fmt.Errorf("unexpected return value %d, %s", resp.StatusCode, string(body))
+			return resp.StatusCode, fmt.Errorf("unexpected return value %d, %s", resp.StatusCode, string(body))
 		}
-		return nil
+		return resp.StatusCode, nil
 	}
 
 	c.cmd.Println()
 	bar.Start()
 
 	retry := uint(0)
+	maxTokenRetries := c.uploadRetries/2 + 1
+
+	req, err := c.newUploadRequest(initToken, reader, length)
+	if err != nil {
+		return err
+	}
+
 	for retry < c.uploadRetries {
-		if err = clientDo(); err == nil {
-			break
-		}
-		retry++
-		if retry < c.uploadRetries {
+
+		if retry > 0 {
+			// reset the bar on each retry, either with the same request or
+			// with a new request if we had to refresh the token due to unauthorized error
 			bar.SetCurrent(0)
 			time.Sleep(time.Duration(retry*rand.UintN(50)) * time.Millisecond)
+		}
+
+		code, retryErr := clientDo(req)
+		if retryErr == nil {
+			break
+		}
+
+		err = retryErr
+
+		// don't count this against the retry limit
+		// only refresh the token maxTokenRetries times to avoid infinite loop in case of other errors
+		// fail fast if the unauthorized happens on the first time request without attempting to refresh the token
+		// as this may indicate simple auth error rather than an expired token
+		if code == http.StatusUnauthorized && maxTokenRetries > 0 && retry != 0 {
+			// Token may have expired, get a new one
+			token, tErr := c.getUploadToken()
+			if tErr != nil {
+				return fmt.Errorf("failed to get upload token: %w", tErr)
+			}
+			req, tErr = c.newUploadRequest(token, reader, length)
+			if tErr != nil {
+				return fmt.Errorf("failed to create new upload request with refreshed token: %w", tErr)
+			}
+			maxTokenRetries--
+		} else {
+			retry++
 		}
 	}
 
@@ -504,9 +547,11 @@ func (c *command) uploadData(token string, file *os.File) error {
 }
 
 func (c *command) getUploadToken() (string, error) {
+	// random unique name to avoid collision
+	name := "token-for-virtctl-" + fmt.Sprintf("%d", time.Now().UnixNano())
 	request := &uploadcdiv1.UploadTokenRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "token-for-virtctl",
+			Name: name,
 		},
 		Spec: uploadcdiv1.UploadTokenRequestSpec{
 			PvcName: c.name,


### PR DESCRIPTION
virtctl image-upload retries uploading on failures. However those retries uses the same token. If the each retry takes a long time the token may expires at some point and remaining retries will always fail with auth error (401). It should try refresh the token when it expires before next retry.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The virtctl image-upload command uses one token during the uploading and retry operations.
There is a risk of the token being expired causing any remaining retries to fail with 401 auth error.

#### After this PR:
Token will be refreshed on auth 401 error before next retry.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses #
-->
- Fixes #16811 
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the virtctl image-upload command token expiry issue by refreshing the token.
```

