### PR TITLE
tests: Assert unexpected virt-launcher errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tools/crd-validation-generator/crd-validation-generator
 tools/resource-generator/resource-generator
 tools/manifest-templator/manifest-templator
 tools/vms-generator/vms-generator
+tools/vmlog-checker/vmlog-checker
 **/bin
 bin/*
 .vagrant

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,12 @@ gofumpt:
 update-generated-api-testdata:
 	./hack/update-generated-api-testdata.sh
 
+vmlog-checker:
+	@echo "Building vmlog-checker..."
+	@CGO_ENABLED=0 go build -o tools/vmlog-checker/vmlog-checker tools/vmlog-checker/main.go
+	@echo "Built successfully: tools/vmlog-checker/vmlog-checker"
+	@echo "Usage: ./tools/vmlog-checker/vmlog-checker --log <file> [options]"
+
 .PHONY: \
 	build-verify \
 	conformance \
@@ -290,4 +296,5 @@ update-generated-api-testdata:
 	rpm-deps-cs9 \
 	rpm-deps-cs10 \
 	rpm-deps-all \
+	vmlog-checker \
 	$(NULL)

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -4,7 +4,7 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tools/... //tests/framework/..."}
+WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tools/... //tests/framework/... //tests/vmlogchecker/..."}
 rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 
 if [ "${CI}" == "true" ]; then

--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "kubernetes.go",
         "outputenricher.go",
+        "vmlog_reporter.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/reporter",
     visibility = ["//visibility:public"],
@@ -23,6 +24,7 @@ go_library(
         "//tests/libdomain:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/testsuite:go_default_library",
+        "//tests/vmlogchecker:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2/config:go_default_library",

--- a/tests/reporter/vmlog_reporter.go
+++ b/tests/reporter/vmlog_reporter.go
@@ -1,0 +1,142 @@
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/testsuite"
+	"kubevirt.io/kubevirt/tests/vmlogchecker"
+)
+
+const testAnnotationKey = "kubevirt.io/created-by-test"
+
+var failOnVMLogErrors = os.Getenv("FAIL_ON_VM_LOG_ERRORS") == "true"
+
+// CheckVMLogsAfterTest is intended to be called from a JustAfterEach block.
+func CheckVMLogsAfterTest(specReport types.SpecReport) {
+	if specReport.Failed() || specReport.State.Is(types.SpecStateSkipped) {
+		return
+	}
+
+	testName := specReport.FullText()
+	foundErrors := getVMILogErrors(testName)
+	if len(foundErrors) == 0 {
+		return
+	}
+
+	if failOnVMLogErrors {
+		ginkgo.Fail(fmt.Sprintf("VM logs contain unexpected errors:\n%s", strings.Join(foundErrors, "\n")))
+	} else {
+		saveVMLogErrors(testName, foundErrors)
+	}
+}
+
+func getVMILogErrors(testName string) []string {
+	virtCli := kubevirt.Client()
+
+	var foundErrors []string
+
+	for _, namespace := range testsuite.TestNamespaces {
+		vmis, err := virtCli.VirtualMachineInstance(namespace).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			log.DefaultLogger().Reason(err).Errorf("Failed to list VMIs in namespace %s", namespace)
+			continue
+		}
+
+		for _, vmi := range vmis.Items {
+			if vmi.Annotations == nil {
+				continue
+			}
+			createdBy, ok := vmi.Annotations[testAnnotationKey]
+			if !ok || createdBy != testName {
+				continue
+			}
+
+			labelSelector := fmt.Sprintf("%s=%s", virtv1.CreatedByLabel, string(vmi.GetUID()))
+			pods, err := virtCli.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: labelSelector,
+			})
+			if err != nil {
+				log.DefaultLogger().Reason(err).Errorf("Failed to list pods for VMI %s/%s", namespace, vmi.Name)
+				continue
+			}
+			if len(pods.Items) == 0 {
+				continue
+			}
+
+			for _, pod := range pods.Items {
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+
+				logsRaw, err := virtCli.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{
+					Container: "compute",
+				}).DoRaw(context.Background())
+				if err != nil {
+					log.DefaultLogger().Reason(err).Errorf("Failed to get logs for pod %s/%s", pod.Namespace, pod.Name)
+					continue
+				}
+
+				errors := findDisallowedErrors(string(logsRaw), vmi.Name)
+				foundErrors = append(foundErrors, errors...)
+			}
+		}
+	}
+
+	return foundErrors
+}
+
+func saveVMLogErrors(testName string, errors []string) {
+	artifactsDir := flags.ArtifactsDir
+	if artifactsDir == "" {
+		return
+	}
+
+	filename := filepath.Join(artifactsDir, fmt.Sprintf("vm-log-errors-%d.log", ginkgo.GinkgoParallelProcess()))
+
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Failed to open VM log errors file: %s", filename)
+		return
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "=== Test: %s ===\n", testName)
+	fmt.Fprintln(f, strings.Join(errors, "\n"))
+}
+
+func findDisallowedErrors(logs string, vmiName string) []string {
+	var disallowedErrors []string
+
+	for _, line := range strings.Split(logs, "\n") {
+		if !vmlogchecker.IsErrorLevel(line) {
+			continue
+		}
+
+		if vmlogchecker.ClassifyLogLine(line) == vmlogchecker.UnexpectedError {
+			disallowedErrors = append(disallowedErrors, formatErrorLine(vmiName, line))
+		}
+	}
+
+	return disallowedErrors
+}
+
+func formatErrorLine(vmiName string, line string) string {
+	if vmiName != "" {
+		return fmt.Sprintf("[%s] %s", vmiName, line)
+	}
+	return line
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -177,6 +177,16 @@ var _ = ReportBeforeSuite(func(report Report) {
 	k8sReporter.ConfigurePerSpecReporting(report)
 })
 
+// CRITICAL ORDER: These two JustAfterEach blocks must remain in this order!
+// 1. First JustAfterEach checks VM logs and may call ginkgo.Fail() to mark spec as failed.
+// 2. Second one collects logs based on failure status, hence it must run after the first block
+var _ = JustAfterEach(func() {
+	if flags.DeployFakeKWOKNodesFlag {
+		return
+	}
+	reporter.CheckVMLogsAfterTest(CurrentSpecReport())
+})
+
 var _ = JustAfterEach(func() {
 	if flags.DeployFakeKWOKNodesFlag {
 		return

--- a/tests/vmlogchecker/BUILD.bazel
+++ b/tests/vmlogchecker/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["checker.go"],
+    importpath = "kubevirt.io/kubevirt/tests/vmlogchecker",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "checker_test.go",
+        "vmlogchecker_suite_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/tests/vmlogchecker/checker.go
+++ b/tests/vmlogchecker/checker.go
@@ -1,0 +1,98 @@
+package vmlogchecker
+
+import (
+	"regexp"
+	"strings"
+)
+
+// SIGMask is a bitmask identifying which SIG areas are affected by an allowlist entry.
+// Entries may affect multiple SIGs; combine with |, e.g. SIGNetwork | SIGStorage.
+type SIGMask uint8
+
+const (
+	SIGCompute     SIGMask = 1 << iota // 0x01
+	SIGNetwork                         // 0x02
+	SIGOperator                        // 0x04
+	SIGPerformance                     // 0x08
+	SIGStorage                         // 0x10
+)
+
+// AllowlistEntry describes a known/expected error pattern in virt-launcher logs.
+// When adding a new entry, always use the last entry's ID + 1.
+// Never reuse an ID after deletion.
+type AllowlistEntry struct {
+	// ID is a stable unique identifier. Set to last entry's ID + 1 on insert.
+	ID int
+	// Regex is matched against the full log line.
+	Regex *regexp.Regexp
+	// SIGs is the bitmask of affected SIG areas for triage routing.
+	SIGs SIGMask
+}
+
+// VirtLauncherErrorAllowlist lists known error patterns that are expected and
+// should not fail tests. Add new entries at the end with ID = last ID + 1.
+var VirtLauncherErrorAllowlist = []AllowlistEntry{
+	// Example:
+	// {
+	// 	ID:               1,
+	// 	Regex:            regexp.MustCompile(`"level":"error","msg":"End of file while reading data: Input/output error","pos":"virNetSocketReadWire`),
+	// 	SIGs:             SIGCompute | SIGNetwork,
+	// },
+}
+
+// errorKeywordPatterns provides broad keyword-based error detection for the
+// CLI tool's --all-levels mode, which scans lines regardless of JSON level.
+// The e2e reporter pre-filters on "level":"error" via IsErrorLevel instead.
+var errorKeywordPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\berror\b`),
+	regexp.MustCompile(`\bfailed\b`),
+	regexp.MustCompile(`\bpanic\b`),
+	regexp.MustCompile(`\bfatal\b`),
+}
+
+type ErrorClassification int
+
+const (
+	NotAnError ErrorClassification = iota
+	AllowlistedError
+	UnexpectedError
+)
+
+// IsErrorLevel returns true if the log line contains a JSON "level":"error" field.
+// Use this to pre-filter lines before classification when only error-level lines matter.
+func IsErrorLevel(line string) bool {
+	return strings.Contains(line, `"level":"error"`)
+}
+
+func ClassifyLogLine(line string) ErrorClassification {
+	if line == "" || !containsErrorKeyword(line) {
+		return NotAnError
+	}
+
+	if matchAllowlist(line) != nil {
+		return AllowlistedError
+	}
+
+	return UnexpectedError
+}
+
+func containsErrorKeyword(line string) bool {
+	lineLower := strings.ToLower(line)
+	for _, pattern := range errorKeywordPatterns {
+		if pattern.MatchString(lineLower) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchAllowlist returns the first AllowlistEntry whose Regex matches the given
+// line, or nil if the line is not allowlisted.
+func matchAllowlist(errorLine string) *AllowlistEntry {
+	for i := range VirtLauncherErrorAllowlist {
+		if VirtLauncherErrorAllowlist[i].Regex.MatchString(errorLine) {
+			return &VirtLauncherErrorAllowlist[i]
+		}
+	}
+	return nil
+}

--- a/tests/vmlogchecker/checker_test.go
+++ b/tests/vmlogchecker/checker_test.go
@@ -1,0 +1,57 @@
+package vmlogchecker_test
+
+import (
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/tests/vmlogchecker"
+)
+
+var _ = Describe("ClassifyLogLine", func() {
+	It("should return NotAnError for empty lines", func() {
+		Expect(vmlogchecker.ClassifyLogLine("")).To(Equal(vmlogchecker.NotAnError))
+	})
+
+	DescribeTable("should return NotAnError when no error keyword is present",
+		func(line string) {
+			Expect(vmlogchecker.ClassifyLogLine(line)).To(Equal(vmlogchecker.NotAnError))
+		},
+		Entry("info level", `{"level":"info","msg":"Starting VM","pos":"manager.go:42"}`),
+		Entry("warning level", `{"level":"warning","msg":"Something happened"}`),
+		Entry("plain text", `plain text log with no keywords`),
+	)
+
+	DescribeTable("should return UnexpectedError for unrecognized errors",
+		func(line string) {
+			Expect(vmlogchecker.ClassifyLogLine(line)).To(Equal(vmlogchecker.UnexpectedError))
+		},
+		Entry("failed keyword", `{"level":"error","msg":"something totally unexpected failed"}`),
+		Entry("fatal keyword", `{"level":"error","msg":"fatal crash in component"}`),
+		Entry("panic keyword", `{"level":"error","msg":"panic in goroutine"}`),
+	)
+
+	It("should return AllowlistedError when line matches an allowlist pattern", func() {
+		original := vmlogchecker.VirtLauncherErrorAllowlist
+		vmlogchecker.VirtLauncherErrorAllowlist = []vmlogchecker.AllowlistEntry{
+			{ID: 1, Regex: regexp.MustCompile(`known error pattern`)},
+		}
+		defer func() { vmlogchecker.VirtLauncherErrorAllowlist = original }()
+
+		Expect(vmlogchecker.ClassifyLogLine(`{"level":"error","msg":"known error pattern occurred"}`)).To(Equal(vmlogchecker.AllowlistedError))
+	})
+})
+
+var _ = Describe("IsErrorLevel", func() {
+	DescribeTable("should detect error-level JSON log lines",
+		func(line string, expected bool) {
+			Expect(vmlogchecker.IsErrorLevel(line)).To(Equal(expected))
+		},
+		Entry("error level", `{"level":"error","msg":"something failed"}`, true),
+		Entry("info level", `{"level":"info","msg":"all good"}`, false),
+		Entry("warning level", `{"level":"warning","msg":"be careful"}`, false),
+		Entry("plain text", `just a plain line with no JSON`, false),
+		Entry("empty", ``, false),
+	)
+})

--- a/tests/vmlogchecker/vmlogchecker_suite_test.go
+++ b/tests/vmlogchecker/vmlogchecker_suite_test.go
@@ -1,0 +1,11 @@
+package vmlogchecker_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVmlogchecker(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/tools/vmlog-checker/README.md
+++ b/tools/vmlog-checker/README.md
@@ -1,0 +1,43 @@
+# VM Log Checker
+
+Analyze KubeVirt virt-launcher logs with color-coded error detection.
+
+## Building
+
+```bash
+make vmlog-checker
+```
+
+## Usage
+
+```bash
+# Basic usage
+./tools/vmlog-checker/vmlog-checker --log virt-launcher.log
+
+# With options
+./tools/vmlog-checker/vmlog-checker --log virt-launcher.log --no-color
+./tools/vmlog-checker/vmlog-checker --log virt-launcher.log --all-levels
+./tools/vmlog-checker/vmlog-checker --log virt-launcher.log --errors-only
+./tools/vmlog-checker/vmlog-checker --log virt-launcher.log --errors-only --no-color
+```
+
+## Options
+
+- `--log`: Log file to analyze (required)
+- `--no-color`: Disable colored output
+- `--all-levels`: Check all log levels (default: only ERROR level, matching test reporter)
+- `--errors-only`: Print only unexpected errors (lines that need attention)
+
+## Allowlist
+
+Edit `tests/vmlogchecker/checker.go` to add patterns:
+
+```go
+var VirtLauncherErrorAllowlist = []AllowlistEntry{
+    {
+        ID:    1,
+        Regex: regexp.MustCompile(`"level":"error","msg":"pattern here"`),
+        SIGs:  SIGCompute,
+    },
+}
+```

--- a/tools/vmlog-checker/main.go
+++ b/tools/vmlog-checker/main.go
@@ -1,0 +1,136 @@
+//go:build vmlogchecker
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"kubevirt.io/kubevirt/tests/vmlogchecker"
+)
+
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorPurple = "\033[35m"
+
+	exitCodeRuntimeError    = 1
+	exitCodeUnexpectedError = 2
+)
+
+var (
+	logger    = log.New(os.Stdout, "", 0)
+	errLogger = log.New(os.Stderr, "", 0)
+)
+
+func main() {
+	logFile := flag.String("log", "", "Log file to analyze (required)")
+	noColor := flag.Bool("no-color", false, "Disable colored output")
+	allLevels := flag.Bool("all-levels", false, "Check all log levels (default: only ERROR level, matching test reporter)")
+	errorsOnly := flag.Bool("errors-only", false, "Print only unexpected errors (lines that need attention)")
+	flag.Parse()
+
+	if *logFile == "" {
+		printUsage()
+		os.Exit(exitCodeRuntimeError)
+	}
+
+	file, err := os.Open(*logFile)
+	if err != nil {
+		errLogger.Fatalf("Error opening log file: %v", err)
+	}
+	defer file.Close()
+
+	totalLines, allowlistedCount, unexpectedCount, err := processLog(file, *allLevels, *errorsOnly, *noColor)
+	if err != nil {
+		errLogger.Fatalf("Error reading log file: %v", err)
+	}
+
+	printSummary(totalLines, allowlistedCount, unexpectedCount)
+
+	if unexpectedCount > 0 {
+		os.Exit(exitCodeUnexpectedError)
+	}
+}
+
+func processLog(file *os.File, allLevels, errorsOnly, noColor bool) (totalLines, allowlistedCount, unexpectedCount int, err error) {
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if !errorsOnly {
+				fmt.Println()
+			}
+			continue
+		}
+
+		totalLines++
+
+		if !allLevels && !vmlogchecker.IsErrorLevel(line) {
+			if !errorsOnly {
+				fmt.Println(line)
+			}
+			continue
+		}
+
+		switch vmlogchecker.ClassifyLogLine(line) {
+		case vmlogchecker.AllowlistedError:
+			allowlistedCount++
+			if !errorsOnly {
+				printColored(line, colorPurple, noColor)
+			}
+		case vmlogchecker.UnexpectedError:
+			unexpectedCount++
+			printColored(line, colorRed, noColor)
+		default:
+			if !errorsOnly {
+				fmt.Println(line)
+			}
+		}
+	}
+	return totalLines, allowlistedCount, unexpectedCount, scanner.Err()
+}
+
+func printColored(line, color string, noColor bool) {
+	if noColor {
+		fmt.Println(line)
+	} else {
+		fmt.Printf("%s%s%s\n", color, line, colorReset)
+	}
+}
+
+func printUsage() {
+	errLogger.Println("Error: --log flag is required")
+	errLogger.Printf("Usage: %s --log <logfile> [--no-color] [--all-levels] [--errors-only]", os.Args[0])
+	errLogger.Println("")
+	errLogger.Println("Options:")
+	errLogger.Println("  --log          Log file to analyze (required)")
+	errLogger.Println("  --no-color     Disable colored output")
+	errLogger.Println("  --all-levels   Check all log levels (default: only ERROR level)")
+	errLogger.Println("  --errors-only  Print only unexpected errors (lines that need attention)")
+	errLogger.Println("")
+	errLogger.Println("Output:")
+	errLogger.Println("  - Normal lines: default color")
+	errLogger.Printf("  - Allowlisted errors: %spurple%s (expected/known)", colorPurple, colorReset)
+	errLogger.Printf("  - Unexpected errors: %sred%s (NEED ATTENTION)", colorRed, colorReset)
+}
+
+func printSummary(totalLines, allowlistedCount, unexpectedCount int) {
+	logger.Println("")
+	logger.Println("═══════════════════════════════════════════════════════════")
+	logger.Println("  VM Log Analysis Summary")
+	logger.Println("═══════════════════════════════════════════════════════════")
+	logger.Printf("  Total lines:          %d", totalLines)
+	logger.Printf("  Allowlisted errors:   %d (expected)", allowlistedCount)
+
+	if unexpectedCount > 0 {
+		logger.Printf("  Unexpected errors:    %d NEEDS ATTENTION", unexpectedCount)
+	} else {
+		logger.Println("  Unexpected errors:    0")
+	}
+
+	logger.Println("═══════════════════════════════════════════════════════════")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Motivation:
Every error in virt-launcher logs represents a potential bug or issue in the system. 
Until now, passing tests could silently leave behind unexpected errors in VM logs, 
allowing bugs to slip through undetected.
This PR ensures we catch and prevent new issues from being introduced.

This PR adds automated VM log validation to the e2e test suite. 
When a test passes, we now validate that virt-launcher logs contain no unexpected errors,
if any are found, the test fails.

Allowlist-First Approach:
We start by allowlisting current known errors.
This establishes a baseline.
Follow-up efforts can validate each allowelisted error and fix them as needed. 
The purpose of this PR is to introduce the mechanism and prevent regression.

Note:
We can also introduce incremental approach, where each sig will update the list and enable the feature on it's lane.
We can also split the list into topics or even list per sig for easier maintenance.
If desired i can suggest a follow-up VEP for it.

Standalone Tool:
The validation logic is also available as a standalone binary (`vmlog-checker`) for local development and debugging.
Run it on logs to see categorized output with color-coding, or use `--errors-only` to see just the problems.
This makes it easy to test allowlist updates or investigate failures, since the known errors are already labeled.

Idea of @dankenigsberg 

```
tests/vmlogchecker/              ← LIB: classification logic + allowlist
├── vmlog_checker.go
└── vmlog_checker_test.go
        │
        ├──► tools/vmlog-checker/    ← STANDALONE CLI: offline log analysis
        │    └── main.go               developer tool
        │
        └──► tests/reporter/         ← E2E INTEGRATION: live test validation
             └── vmlog_reporter.go     checks virt-launcher logs after each test
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
* Please see https://github.com/kubevirt/kubevirt/pull/16815#issuecomment-3953226961
* It doesn't catch virt-launcher tear down unexpected errors, since it runs before it (same as reporter is).
* It checks only log level error, follow-up can research deeper to find what are the info / warning levels that have unexpected errors.
* The standalone log analyzer allows running it on all log levels (additional unexpected errors are likely,
since we don't filter them out in e2e). However the default is as the e2e reporter (error level only).
* Follow-up can print the unexpected errors also when test fails, it can ease debugging.
* Follow-up can warn about deprecation messages.
* At the end will test it once again e2e.
* "Self heal" POC - https://gist.github.com/oshoval/9611a0aeba2f424949c54d975f9fe78c

* replaces https://github.com/kubevirt/kubevirt/pull/16550 which was closed by mistake

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```