### PR TITLE
test(virt-controller): verify replicaset batch processing

### DIFF
--- a/pkg/virt-controller/watch/replicaset/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset/replicaset_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Replicaset", func() {
 			for x := 0; x < 10; x++ {
 				testutils.ExpectEvent(recorder, common.SuccessfulCreateVirtualMachineReason)
 			}
-			// TODO test for missing 5
+			Expect(testing.FilterActions(&virtClientset.Fake, "create", "virtualmachineinstances")).To(HaveLen(10))
 		})
 
 		It("should already create replacement VMIs once it discovers that a VMI is marked for deletion", func() {
@@ -272,7 +272,7 @@ var _ = Describe("Replicaset", func() {
 			for x := 0; x < 10; x++ {
 				testutils.ExpectEvent(recorder, common.SuccessfulDeleteVirtualMachineReason)
 			}
-			// TODO test for missing 5
+			Expect(testing.FilterActions(&virtClientset.Fake, "delete", "virtualmachineinstances")).To(HaveLen(10))
 		})
 
 		It("should not delete vmis which are already marked deleted", func() {


### PR DESCRIPTION
Implement missing test logic in [replicaset_test.go](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-controller/watch/replicaset/replicaset_test.go#L223) to verify that the controller correctly processes large scale up and scale down events in batches of 10.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The replicaset controller tests for batch scale-up and scale-down had ``// TODO test for missing 5`` placeholders. The tests verified that at least 10 actions happened, but did not strictly verify that the controller respected the batch limit of 10.

#### After this PR:
The tests now strictly verify the controller's safety "burst limit" mechanism:

1.**Scale up test (Request 15)**: Verifies that exactly 10 ``create`` calls are sent to the API server in a single sync loop, ensuring the controller throttles correctly.
2. **Scale down test (Delete 15)**: Verifies that exactly 10 ``delete`` calls are sent in a single sync loop.

### References
Addresses ``TODO`` in [replicaset_test.go](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-controller/watch/replicaset/replicaset_test.go#L223)
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The virt-controller implements a safety limit to prevent flooding the API server with massive amounts of concurrent requests. These tests ensure that this limit is strictly enforced (blocking operations beyond the batch size of 10) rather than allowing potential runaway behavior.


### Special notes for your reviewer
Test only change. No production code modified.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.


- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```