### PR TITLE
feat(vms): sync labels/annotations to pod using wildcard

### DIFF
--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -71,9 +71,7 @@ var (
 )
 
 var _ = Describe("VirtualMachine", func() {
-
 	Context("One valid VirtualMachine controller given", func() {
-
 		var controller *Controller
 		var recorder *record.FakeRecorder
 		var mockQueue *testutils.MockWorkQueue[string]
@@ -202,10 +200,9 @@ var _ = Describe("VirtualMachine", func() {
 				}
 				return false, nil, nil
 			})
-
 		}
 
-		shouldExpectDataVolumeCreationPriorityClass := func(uid types.UID, labels map[string]string, annotations map[string]string, priorityClassName string, idx *int) {
+		shouldExpectDataVolumeCreationPriorityClass := func(uid types.UID, labels, annotations map[string]string, priorityClassName string, idx *int) {
 			allAnnotations := map[string]string{
 				"cdi.kubevirt.io/allowClaimAdoption": "true",
 			}
@@ -225,7 +222,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 		}
 
-		shouldExpectDataVolumeCreation := func(uid types.UID, labels map[string]string, annotations map[string]string, idx *int) {
+		shouldExpectDataVolumeCreation := func(uid types.UID, labels, annotations map[string]string, idx *int) {
 			shouldExpectDataVolumeCreationPriorityClass(uid, labels, annotations, "", idx)
 		}
 
@@ -420,7 +417,6 @@ var _ = Describe("VirtualMachine", func() {
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 			Expect(vm.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusProvisioning))
-
 		})
 		Context("Disk un/hotplug", func() {
 			addVolumeReactor := func(virtFakeClient *fake.Clientset) {
@@ -441,7 +437,6 @@ var _ = Describe("VirtualMachine", func() {
 						Fail("unexpected action type on addvolume")
 						return false, nil, nil
 					}
-
 				})
 			}
 
@@ -463,7 +458,6 @@ var _ = Describe("VirtualMachine", func() {
 						Fail("unexpected action type on removevolume")
 						return false, nil, nil
 					}
-
 				})
 			}
 
@@ -492,12 +486,10 @@ var _ = Describe("VirtualMachine", func() {
 						Fail("unexpected action type on removevolume")
 						return false, nil, nil
 					}
-
 				})
 			}
 
 			DescribeTable("should hotplug a vm", func(isRunning bool) {
-
 				vm, vmi := watchtesting.DefaultVirtualMachine(isRunning)
 				vm.Status.Created = true
 				vm.Status.Ready = true
@@ -1201,7 +1193,6 @@ var _ = Describe("VirtualMachine", func() {
 		)
 
 		It("should start VMI once DataVolumes (not templates) are complete", func() {
-
 			vm, _ := watchtesting.DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
@@ -1475,7 +1466,6 @@ var _ = Describe("VirtualMachine", func() {
 		)
 
 		Context("crashloop backoff tests", func() {
-
 			It("should track start failures when VMIs fail without hitting running state", func() {
 				vm, vmi := watchtesting.DefaultVirtualMachine(true)
 				vmi.UID = "123"
@@ -1633,8 +1623,7 @@ var _ = Describe("VirtualMachine", func() {
 				Entry("once", v1.RunStrategyOnce),
 			)
 
-			DescribeTable("should calculated expected backoff delay", func(failCount, minExpectedDelay int, maxExpectedDelay int) {
-
+			DescribeTable("should calculated expected backoff delay", func(failCount, minExpectedDelay, maxExpectedDelay int) {
 				for i := 0; i < 1000; i++ {
 					delay := calculateStartBackoffTime(failCount, defaultMaxCrashLoopBackoffDelaySeconds)
 
@@ -1899,7 +1888,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			sanityExecute(vm)
 
-			//TODO expect update status is called
+			// TODO expect update status is called
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 			Expect(vm.Status.Created).To(BeFalse())
@@ -1929,7 +1918,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			sanityExecute(vm)
 
-			//TODO expect update status is called
+			// TODO expect update status is called
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 			Expect(vm.Status.Created).To(BeFalse())
@@ -1943,8 +1932,7 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		Context("VM generation tests", func() {
-
-			DescribeTable("should add the generation annotation onto the VMI", func(startingAnnotations map[string]string, endAnnotations map[string]string) {
+			DescribeTable("should add the generation annotation onto the VMI", func(startingAnnotations, endAnnotations map[string]string) {
 				_, vmi := watchtesting.DefaultVirtualMachine(true)
 				vmi.ObjectMeta.Annotations = startingAnnotations
 
@@ -1970,7 +1958,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				sanityExecute(vm)
 
-				//TODO expect update status is called
+				// TODO expect update status is called
 				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
 				Expect(vm.Status.Created).To(BeFalse())
@@ -2035,7 +2023,6 @@ var _ = Describe("VirtualMachine", func() {
 			)
 
 			DescribeTable("should parse generation from vm controller revision name", func(name string, desiredGeneration *int64) {
-
 				gen := parseGeneration(name, log.DefaultLogger())
 				if desiredGeneration == nil {
 					Expect(gen).To(BeNil())
@@ -2058,7 +2045,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, vmi = watchtesting.DefaultVirtualMachine(true)
 				})
 
-				DescribeTable("should conditionally bump the generation annotation on the vmi", func(initialAnnotations map[string]string, desiredAnnotations map[string]string, revisionVmSpec v1.VirtualMachineSpec, newVMSpec v1.VirtualMachineSpec, vmGeneration int64, desiredErr error, expectPatch bool) {
+				DescribeTable("should conditionally bump the generation annotation on the vmi", func(initialAnnotations, desiredAnnotations map[string]string, revisionVmSpec, newVMSpec v1.VirtualMachineSpec, vmGeneration int64, desiredErr error, expectPatch bool) {
 					// Spec and generation for the vmRevision and 'old' objects
 					vmi.ObjectMeta.Annotations = initialAnnotations
 					vm.Generation = 1
@@ -2093,7 +2080,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(vmi.Annotations).To(Equal(desiredAnnotations))
-
 				},
 					Entry(
 						"with generation and template staying the same",
@@ -2260,7 +2246,7 @@ var _ = Describe("VirtualMachine", func() {
 				)
 			})
 
-			DescribeTable("should sync the generation info", func(initialAnnotations map[string]string, desiredAnnotations map[string]string, revisionVmGeneration int64, vmGeneration int64, desiredErr error, expectPatch bool, desiredObservedGeneration int64, desiredDesiredGeneration int64) {
+			DescribeTable("should sync the generation info", func(initialAnnotations, desiredAnnotations map[string]string, revisionVmGeneration, vmGeneration int64, desiredErr error, expectPatch bool, desiredObservedGeneration, desiredDesiredGeneration int64) {
 				vm, vmi := watchtesting.DefaultVirtualMachine(true)
 				vmi.ObjectMeta.Annotations = initialAnnotations
 				vm.Generation = revisionVmGeneration
@@ -2515,7 +2501,7 @@ var _ = Describe("VirtualMachine", func() {
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 
-			//TODO expect update status is called
+			// TODO expect update status is called
 			Expect(vm.Status.Created).To(BeFalse())
 			Expect(vm.Status.Ready).To(BeFalse())
 			if runStrategy == v1.RunStrategyRerunOnFailure || runStrategy == v1.RunStrategyAlways {
@@ -2547,7 +2533,7 @@ var _ = Describe("VirtualMachine", func() {
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 
-			//TODO expect update status is called
+			// TODO expect update status is called
 			Expect(vm.Status.Created).To(BeFalse())
 			Expect(vm.Status.Ready).To(BeFalse())
 
@@ -2571,7 +2557,7 @@ var _ = Describe("VirtualMachine", func() {
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 
-			//TODO expect update status is called
+			// TODO expect update status is called
 			Expect(vm.Status.Created).To(BeTrue())
 			Expect(vm.Status.Ready).To(BeFalse())
 		})
@@ -2590,7 +2576,7 @@ var _ = Describe("VirtualMachine", func() {
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 
-			//TODO expect update status is called
+			// TODO expect update status is called
 			Expect(vm.Status.Created).To(BeTrue())
 			Expect(vm.Status.Ready).To(BeTrue())
 		})
@@ -2654,7 +2640,7 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		It("should add controller finalizer only once", func() {
-			//watchtesting.DefaultVirtualMachine already set finalizer
+			// watchtesting.DefaultVirtualMachine already set finalizer
 			vm, _ := watchtesting.DefaultVirtualMachine(false)
 			Expect(vm.Finalizers).To(HaveLen(1))
 			Expect(vm.Finalizers[0]).To(BeEquivalentTo(v1.VirtualMachineControllerFinalizer))
@@ -2663,7 +2649,7 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(err).To(Succeed())
 			addVirtualMachine(vm)
 
-			//TODO Expect only update status, not Patch on vmInterface
+			// TODO Expect only update status, not Patch on vmInterface
 			sanityExecute(vm)
 		})
 
@@ -2688,7 +2674,7 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		It("should remove controller finalizer once VirtualMachineInstance is gone", func() {
-			//watchtesting.DefaultVirtualMachine already set finalizer
+			// watchtesting.DefaultVirtualMachine already set finalizer
 			vm, _ := watchtesting.DefaultVirtualMachine(true)
 			vm.DeletionTimestamp = pointer.P(metav1.Now())
 
@@ -2719,7 +2705,6 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectVMIFinalizerRemoval()
 
 			sanityExecute(vm)
-
 		},
 
 			Entry("with run strategy Once", v1.RunStrategyOnce),
@@ -2920,7 +2905,6 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 				"Status": Equal(status),
 			}))
-
 		},
 			Entry("VMI Ready condition is True", watchtesting.MarkAsReady, k8sv1.ConditionTrue),
 			Entry("VMI Ready condition is False", watchtesting.MarkAsNonReady, k8sv1.ConditionFalse),
@@ -3054,7 +3038,6 @@ var _ = Describe("VirtualMachine", func() {
 
 			_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
-
 		})
 
 		It("should add paused condition", func() {
@@ -3083,7 +3066,6 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 				"Status": Equal(k8sv1.ConditionTrue),
 			}))
-
 		})
 
 		It("should remove paused condition", func() {
@@ -3213,9 +3195,11 @@ var _ = Describe("VirtualMachine", func() {
 		Context("dynamic annotations and labels", func() {
 			const selectedAnnotationKey = descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction
 			const customSyncAnnotation = "custom/annotation"
+			const customWildcardSyncAnnotation = "custom/ann*"
 			const customSyncLabel = "custom/label"
+			const customWildcardSyncLabel = "custom/lab*"
 			const ignoredKey = "anotherKey"
-			const intitialValue = "initialValue"
+			const initialValue = "initialValue"
 			const updatedValue = "updatedValue"
 			const anotherValue = "anotherValue"
 
@@ -3261,49 +3245,62 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vmi.ObjectMeta.Annotations).To(Equal(expectedVMIAnnotations))
 
 				Expect(kvtesting.FilterActions(&virtFakeClient.Fake, "patch", "virtualmachineinstances")).To(HaveLen(numExpectedPatches))
-
 			},
 				Entry("should copy selected annotations from VM.spec.template.metadata.annotations to VMI",
 					[]string{},
-					map[string]string{selectedAnnotationKey: intitialValue},
+					map[string]string{selectedAnnotationKey: initialValue},
 					map[string]string{selectedAnnotationKey: updatedValue},
 					map[string]string{selectedAnnotationKey: updatedValue},
 					1,
 				),
 				Entry("should remove selected annotations from VMI if missing in VM.spec.template.metadata.annotations",
 					[]string{},
-					map[string]string{selectedAnnotationKey: intitialValue, ignoredKey: anotherValue},
+					map[string]string{selectedAnnotationKey: initialValue, ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should do nothing if selected annotations are already equal",
 					[]string{},
-					map[string]string{selectedAnnotationKey: intitialValue, ignoredKey: anotherValue},
-					map[string]string{selectedAnnotationKey: intitialValue, ignoredKey: anotherValue},
-					map[string]string{selectedAnnotationKey: intitialValue, ignoredKey: anotherValue},
+					map[string]string{selectedAnnotationKey: initialValue, ignoredKey: anotherValue},
+					map[string]string{selectedAnnotationKey: initialValue, ignoredKey: anotherValue},
+					map[string]string{selectedAnnotationKey: initialValue, ignoredKey: anotherValue},
 					0,
 				),
 				Entry("should update only selected annotations",
 					[]string{},
-					map[string]string{selectedAnnotationKey: intitialValue, ignoredKey: anotherValue},
+					map[string]string{selectedAnnotationKey: initialValue, ignoredKey: anotherValue},
 					map[string]string{selectedAnnotationKey: updatedValue, ignoredKey: updatedValue},
 					map[string]string{selectedAnnotationKey: updatedValue, ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should ignore other annotations on VM.spec.template.metadata.annotations",
 					[]string{},
-					map[string]string{selectedAnnotationKey: intitialValue},
-					map[string]string{selectedAnnotationKey: intitialValue, ignoredKey: updatedValue},
-					map[string]string{selectedAnnotationKey: intitialValue},
+					map[string]string{selectedAnnotationKey: initialValue},
+					map[string]string{selectedAnnotationKey: initialValue, ignoredKey: updatedValue},
+					map[string]string{selectedAnnotationKey: initialValue},
 					0,
 				),
 				Entry("should copy selected custom additional annotations from VM.spec.template.metadata.annotations to VMI",
 					[]string{customSyncAnnotation},
-					map[string]string{selectedAnnotationKey: intitialValue},
-					map[string]string{selectedAnnotationKey: intitialValue, customSyncAnnotation: customSyncAnnotation},
-					map[string]string{selectedAnnotationKey: intitialValue, customSyncAnnotation: customSyncAnnotation},
+					map[string]string{selectedAnnotationKey: initialValue},
+					map[string]string{selectedAnnotationKey: initialValue, customSyncAnnotation: customSyncAnnotation},
+					map[string]string{selectedAnnotationKey: initialValue, customSyncAnnotation: customSyncAnnotation},
 					1,
+				),
+				Entry("should copy wildcard additional annotations from VM.spec.template.metadata.annotations to VMI",
+					[]string{customWildcardSyncAnnotation},
+					map[string]string{selectedAnnotationKey: initialValue},
+					map[string]string{selectedAnnotationKey: initialValue, customSyncAnnotation: customSyncAnnotation},
+					map[string]string{selectedAnnotationKey: initialValue, customSyncAnnotation: customSyncAnnotation},
+					1,
+				),
+				Entry("should ignore wildcard additional annotations when they match nothing",
+					[]string{customWildcardSyncAnnotation},
+					map[string]string{selectedAnnotationKey: initialValue},
+					map[string]string{selectedAnnotationKey: initialValue, ignoredKey: anotherValue},
+					map[string]string{selectedAnnotationKey: initialValue},
+					0,
 				),
 			)
 
@@ -3334,40 +3331,103 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vmi.ObjectMeta.Labels).To(Equal(expectedVMILabels))
 
 				Expect(kvtesting.FilterActions(&virtFakeClient.Fake, "patch", "virtualmachineinstances")).To(HaveLen(numExpectedPatches))
-
 			},
 				Entry("should copy selected custom labels from VM.spec.template.metadata.labels to VMI",
-					map[string]string{customSyncLabel: intitialValue},
+					map[string]string{customSyncLabel: initialValue},
 					map[string]string{customSyncLabel: updatedValue},
 					map[string]string{customSyncLabel: updatedValue},
 					1,
 				),
 				Entry("should remove selected custom labels from VMI if missing in VM.spec.template.metadata.labels",
-					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should do nothing if selected custom labels are already equal",
-					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
-					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
-					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
 					0,
 				),
 				Entry("should update only custom selected labels",
-					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
 					map[string]string{customSyncLabel: updatedValue, ignoredKey: updatedValue},
 					map[string]string{customSyncLabel: updatedValue, ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should ignore other labels on VM.spec.template.metadata.labels",
-					map[string]string{customSyncLabel: intitialValue},
-					map[string]string{customSyncLabel: intitialValue, ignoredKey: updatedValue},
-					map[string]string{customSyncLabel: intitialValue},
+					map[string]string{customSyncLabel: initialValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: updatedValue},
+					map[string]string{customSyncLabel: initialValue},
 					0,
 				),
 			)
 
+			DescribeTable("should sync wildcard dynamic labels from spec.template to vmi", func(labelsToSync []string, existingLabels, updatedVMLabels, expectedVMILabels map[string]string, numExpectedPatches int) {
+				controller.additionalLauncherLabelsSync = labelsToSync
+
+				vm, vmi := watchtesting.DefaultVirtualMachine(true)
+				vm.Spec.Template.ObjectMeta.Labels = existingLabels
+				vmi.ObjectMeta.Labels = existingLabels
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+
+				vm.Spec.Template.ObjectMeta.Labels = updatedVMLabels
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVirtualMachine(vm)
+				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(controller.vmiIndexer.Add(vmi)).To(Succeed())
+
+				sanityExecute(vm)
+
+				By("Expecting to see the updated VMI with the updated labels")
+				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi.ObjectMeta.Labels).To(Equal(expectedVMILabels))
+
+				Expect(kvtesting.FilterActions(&virtFakeClient.Fake, "patch", "virtualmachineinstances")).To(HaveLen(numExpectedPatches))
+			},
+				Entry("should copy selected custom labels from VM.spec.template.metadata.labels to VMI",
+					[]string{customWildcardSyncLabel},
+					map[string]string{customSyncLabel: initialValue},
+					map[string]string{customSyncLabel: updatedValue},
+					map[string]string{customSyncLabel: updatedValue},
+					1,
+				),
+				Entry("should remove selected custom labels from VMI if missing in VM.spec.template.metadata.labels",
+					[]string{customWildcardSyncLabel},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
+					map[string]string{ignoredKey: anotherValue},
+					map[string]string{ignoredKey: anotherValue},
+					1,
+				),
+				Entry("should do nothing if selected custom labels are already equal",
+					[]string{customWildcardSyncLabel},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
+					0,
+				),
+				Entry("should update only custom selected labels",
+					[]string{customWildcardSyncLabel},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: anotherValue},
+					map[string]string{customSyncLabel: updatedValue, ignoredKey: updatedValue},
+					map[string]string{customSyncLabel: updatedValue, ignoredKey: anotherValue},
+					1,
+				),
+				Entry("should ignore other labels on VM.spec.template.metadata.labels",
+					[]string{customWildcardSyncLabel},
+					map[string]string{customSyncLabel: initialValue},
+					map[string]string{customSyncLabel: initialValue, ignoredKey: updatedValue},
+					map[string]string{customSyncLabel: initialValue},
+					0,
+				),
+			)
 		})
 
 		Context("Changed Block Tracking", func() {
@@ -3851,17 +3911,14 @@ var _ = Describe("VirtualMachine", func() {
 
 				vmi := SetupVMIFromVM(vm)
 				Expect(vmi.Spec.Volumes).To(BeEmpty())
-
 			},
 				Entry("in phase Unmounting", v1.MemoryDumpUnmounting),
 				Entry("in phase Completed", v1.MemoryDumpCompleted),
 				Entry("in phase Dissociating", v1.MemoryDumpDissociating),
 			)
-
 		})
 
 		Context("VM printableStatus", func() {
-
 			It("Should set a Stopped status when running=false and VMI doesn't exist", func() {
 				vm, _ := watchtesting.DefaultVirtualMachine(false)
 
@@ -3909,7 +3966,6 @@ var _ = Describe("VirtualMachine", func() {
 					_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(MatchError(ContainSubstring("not found")))
 				}
-
 			},
 
 				Entry("in Succeeded state", v1.Succeeded, nil),
@@ -3956,7 +4012,7 @@ var _ = Describe("VirtualMachine", func() {
 				Entry("VMI is in Scheduled phase", v1.Scheduled),
 			)
 
-			DescribeTable("Should set a CrashLoop status when VMI is deleted and VM is in crash loop backoff", func(status v1.VirtualMachineStatus, runStrategy v1.VirtualMachineRunStrategy, hasVMI bool, expectCrashloop bool) {
+			DescribeTable("Should set a CrashLoop status when VMI is deleted and VM is in crash loop backoff", func(status v1.VirtualMachineStatus, runStrategy v1.VirtualMachineRunStrategy, hasVMI, expectCrashloop bool) {
 				vm, vmi := watchtesting.DefaultVirtualMachine(true)
 				vm.Spec.Running = nil
 				vm.Spec.RunStrategy = &runStrategy
@@ -4322,13 +4378,11 @@ var _ = Describe("VirtualMachine", func() {
 					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					Expect(vm.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusWaitingForVolumeBinding))
-
 				},
 
 					Entry("PersistentVolumeClaim is in Pending phase", k8sv1.ClaimPending),
 					Entry("PersistentVolumeClaim is in Lost phase", k8sv1.ClaimLost),
 				)
-
 			})
 
 			It("should set a Running status when VMI is running but not paused", func() {
@@ -4521,7 +4575,6 @@ var _ = Describe("VirtualMachine", func() {
 
 			DescribeTable("should set a failure status in accordance to VMI condition",
 				func(status v1.VirtualMachinePrintableStatus, cond v1.VirtualMachineInstanceCondition) {
-
 					vm, vmi := watchtesting.DefaultVirtualMachine(true)
 					vmi.Status.Phase = v1.Scheduling
 					vmi.Status.Conditions = append(vmi.Status.Conditions, cond)
@@ -4582,7 +4635,6 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		Context("Instancetype and Preferences", func() {
-
 			const resourceUID types.UID = "9160e5de-2540-476a-86d9-af0081aee68a"
 			const resourceGeneration int64 = 1
 
@@ -4805,9 +4857,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 
 			Context("preference", func() {
-				var (
-					clusterPreference *instancetypev1beta1.VirtualMachineClusterPreference
-				)
+				var clusterPreference *instancetypev1beta1.VirtualMachineClusterPreference
 
 				BeforeEach(func() {
 					clusterPreference = &instancetypev1beta1.VirtualMachineClusterPreference{
@@ -4840,7 +4890,6 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should apply preferences to default network interface", func() {
-
 					vm.Spec.Preference = &v1.PreferenceMatcher{
 						Name: preference.Name,
 						Kind: instancetypeapi.SingularPreferenceResourceName,
@@ -4869,7 +4918,6 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should apply preferredAutoattachPodInterface and skip adding default network interface", func() {
-
 					autoattachPodInterfacePreference := &instancetypev1beta1.VirtualMachinePreference{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       "autoattachPodInterfacePreference",
@@ -4916,7 +4964,6 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should apply preferences to default volume disk", func() {
-
 					vm.Spec.Preference = &v1.PreferenceMatcher{
 						Name: preference.Name,
 						Kind: instancetypeapi.SingularPreferenceResourceName,
@@ -4968,7 +5015,6 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should apply preferences to AutoattachInputDevice attached input device", func() {
-
 					vm.Spec.Preference = &v1.PreferenceMatcher{
 						Name: preference.Name,
 						Kind: instancetypeapi.SingularPreferenceResourceName,
@@ -4998,7 +5044,6 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should apply preferences to preferredAutoattachInputDevice attached input device", func() {
-
 					autoattachInputDevicePreference := &instancetypev1beta1.VirtualMachinePreference{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       "autoattachInputDevicePreference",
@@ -5044,7 +5089,6 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should apply preferredAutoattachInputDevice and skip adding default input device", func() {
-
 					autoattachInputDevicePreference := &instancetypev1beta1.VirtualMachinePreference{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       "preferredAutoattachInputDevicePreference",
@@ -5116,7 +5160,6 @@ var _ = Describe("VirtualMachine", func() {
 						"InterfaceBindingMethod": gstruct.MatchFields(gstruct.IgnoreExtras, field),
 					},
 				)))
-
 			},
 			Entry("as bridge", "bridge", gstruct.Fields{"Bridge": Not(BeNil())}),
 			Entry("as masquerade", "masquerade", gstruct.Fields{"Masquerade": Not(BeNil())}),
@@ -5244,7 +5287,6 @@ var _ = Describe("VirtualMachine", func() {
 				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal(presentVolumeName)}),
 				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal(missingVolumeName)}),
 			))
-
 		})
 
 		DescribeTable("AutoattachInputDevice should ", func(autoAttach *bool, existingInputDevices []v1.Input, matcher gomegatypes.GomegaMatcher) {
@@ -5261,7 +5303,6 @@ var _ = Describe("VirtualMachine", func() {
 			vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vmi.Spec.Domain.Devices.Inputs).To(matcher)
-
 		},
 			Entry("add default input device when enabled in VirtualMachine", pointer.P(true), []v1.Input{},
 				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
@@ -5968,7 +6009,6 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(vmi.Spec.Affinity).To(Not(BeNil()))
 					Expect(*vmi.Spec.Affinity).To(Equal(affinity))
 				})
-
 			})
 
 			Context("Volumes", func() {
@@ -5989,12 +6029,14 @@ var _ = Describe("VirtualMachine", func() {
 					})
 					vm, vmi := watchtesting.DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
-						Name: "vol1"})
+						Name: "vol1",
+					})
 					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 						Name: "vol3",
 						VolumeSource: v1.VolumeSource{
 							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "updated-vol3"}},
+								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "updated-vol3"},
+							},
 						},
 					})
 					vm.Spec.UpdateVolumesStrategy = pointer.P(v1.UpdateVolumesStrategyMigration)
@@ -6009,7 +6051,8 @@ var _ = Describe("VirtualMachine", func() {
 							Name: "vol3",
 							VolumeSource: v1.VolumeSource{
 								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "vol3"}},
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "vol3"},
+								},
 							},
 						},
 					)
@@ -6287,7 +6330,6 @@ var _ = Describe("VirtualMachine", func() {
 				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
 				Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue))
-
 			})
 
 			It("should appear when changing a non-live-updatable field", func() {
@@ -6340,7 +6382,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 
 			It("should appear when VM doesn't specify maxGuest and guest memory goes above cluster-wide maxGuest", func() {
-				var maxGuest = resource.MustParse("256Mi")
+				maxGuest := resource.MustParse("256Mi")
 
 				By("Creating a VM with guest memory set to the cluster maximum")
 				vm.Spec.Template.Spec.Domain.Memory.Guest = &maxGuest
@@ -6450,7 +6492,6 @@ var _ = Describe("VirtualMachine", func() {
 				BeforeEach(func() {
 					kv.Spec.Configuration.VMRolloutStrategy = pointer.P(stage)
 					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
-
 				})
 
 				addVolume := func() {
@@ -6464,7 +6505,8 @@ var _ = Describe("VirtualMachine", func() {
 						Name: "hotplug",
 						DiskDevice: v1.DiskDevice{
 							Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
-						}}
+						},
+					}
 					vm.Status.VolumeRequests = append(vm.Status.VolumeRequests, v1.VirtualMachineVolumeRequest{
 						AddVolumeOptions: &v1.AddVolumeOptions{
 							Name:         "hotplug",
@@ -6475,7 +6517,6 @@ var _ = Describe("VirtualMachine", func() {
 					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
 					Expect(err).To(Succeed())
 					addVirtualMachine(vm)
-
 				}
 
 				It("shouldn't appear with the stage rollout strategy and when a volume is added with a hotplug volume request", func() {
@@ -6756,14 +6797,13 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		clearExpectations := func(vm *v1.VirtualMachine) {
-			//Clear all expectations
+			// Clear all expectations
 			key, err := virtcontroller.KeyFunc(vm)
 			Expect(err).To(Not(HaveOccurred()))
 			controller.expectations.SetExpectations(key, 0, 0)
 		}
 
 		Context("RunStrategy", func() {
-
 			It("when starting a VM with RerunOnFailure the VM should get started", func() {
 				vm, _ := watchtesting.DefaultVirtualMachine(true)
 				vm.Spec.Running = nil
@@ -7124,7 +7164,8 @@ var _ = Describe("VirtualMachine", func() {
 							ClaimName: claimName,
 						},
 					},
-				}}
+				},
+			}
 		}
 		createDisk := func(name string) v1.Disk {
 			return v1.Disk{
@@ -7155,8 +7196,10 @@ var _ = Describe("VirtualMachine", func() {
 			Entry("for a removed pvc", []v1.Volume{createPVCVol("vol1", "test1", false)}, []v1.Volume{}, false),
 			Entry("for an updated hotpluggable pvc", []v1.Volume{createPVCVol("vol1", "test1", true)}, []v1.Volume{createPVCVol("vol1", "test2", true)}, true),
 			Entry("for an added hotpluggable pvc", []v1.Volume{}, []v1.Volume{createPVCVol("vol1", "test1", true)}, true),
-			Entry("for an added hotpluggable pvc as first volume", []v1.Volume{createPVCVol("vol2", "test2", false)}, []v1.Volume{createPVCVol("vol1", "test1", true),
-				createPVCVol("vol2", "test2", false)}, true),
+			Entry("for an added hotpluggable pvc as first volume", []v1.Volume{createPVCVol("vol2", "test2", false)}, []v1.Volume{
+				createPVCVol("vol1", "test1", true),
+				createPVCVol("vol2", "test2", false),
+			}, true),
 			Entry("for a replaced hotpluggable pvc", []v1.Volume{createPVCVol("vol1", "test1", true)}, []v1.Volume{createPVCVol("vol1", "test2", true)}, true),
 			Entry("for a removed hotpluggable pvc", []v1.Volume{createPVCVol("vol1", "test1", true)}, []v1.Volume{}, true),
 		)
@@ -7184,8 +7227,10 @@ var _ = Describe("VirtualMachine", func() {
 				[]v1.Disk{createDisk("vol1")}, []v1.Disk{createDisk("vol1")}, true),
 			Entry("for an added hotpluggable pvc", []v1.Volume{}, []v1.Volume{createPVCVol("vol1", "test1", true)},
 				[]v1.Disk{}, []v1.Disk{createDisk("vol1")}, true),
-			Entry("for an added hotpluggable pvc as first volume", []v1.Volume{createPVCVol("vol2", "test2", false)}, []v1.Volume{createPVCVol("vol1", "test1", true),
-				createPVCVol("vol2", "test2", false)}, []v1.Disk{createDisk("vol2")}, []v1.Disk{createDisk("vol1"), createDisk("vol2")}, true),
+			Entry("for an added hotpluggable pvc as first volume", []v1.Volume{createPVCVol("vol2", "test2", false)}, []v1.Volume{
+				createPVCVol("vol1", "test1", true),
+				createPVCVol("vol2", "test2", false),
+			}, []v1.Disk{createDisk("vol2")}, []v1.Disk{createDisk("vol1"), createDisk("vol2")}, true),
 			Entry("for a removed hotpluggable pvc", []v1.Volume{createPVCVol("vol1", "test1", true)}, []v1.Volume{},
 				[]v1.Disk{createDisk("vol1")}, []v1.Disk{}, true),
 			Entry("cd-rom eject", []v1.Volume{createPVCVol("vol1", "test1", false), createPVCVol("vol2", "test2", true)}, []v1.Volume{createPVCVol("vol1", "test1", false)},
@@ -7205,7 +7250,8 @@ var _ = Describe("VirtualMachine", func() {
 					VolumeName:         volName,
 					SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: src},
 					DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: dst},
-				}}
+				},
+			}
 		}
 		withVMCondVolumeMigInProgress := func(inProgress k8sv1.ConditionStatus, reason string) v1.VirtualMachineCondition {
 			return v1.VirtualMachineCondition{
@@ -7230,7 +7276,8 @@ var _ = Describe("VirtualMachine", func() {
 			Entry("without any volume migration in progress", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{})))), libvmi.New(), nil, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired)),
 			Entry("with volume migration in progress but no vmi", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(
 				libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{
-					MigratedVolumes: withMigVols(volName, "dv0", "dv1")}},
+					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
+				}},
 				), libvmistatus.WithVMCondition(withVMCondVolumeMigInProgress(k8sv1.ConditionTrue, ""))),
 			)),
 				nil, nil, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineManualRecoveryRequired)),

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -3302,6 +3302,13 @@ var _ = Describe("VirtualMachine", func() {
 					map[string]string{selectedAnnotationKey: initialValue},
 					0,
 				),
+				Entry("should remove wildcard-synced annotations from VMI if missing in VM.spec.template.metadata.annotations",
+					[]string{customWildcardSyncAnnotation},
+					map[string]string{selectedAnnotationKey: initialValue, customSyncAnnotation: customSyncAnnotation},
+					map[string]string{selectedAnnotationKey: initialValue},
+					map[string]string{selectedAnnotationKey: initialValue},
+					1,
+				),
 			)
 
 			DescribeTable("should sync selected dynamic labels from spec.template to vmi", func(existingLabels, updatedVMLabels, expectedVMILabels map[string]string, numExpectedPatches int) {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -687,8 +687,35 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToPod(vmi *virtv1.VirtualMac
 			podNewMap = map[string]string{}
 		}
 
-		changed := false
+		// keyMap contains the deduplicated keys that we need to sync between the VM and VMIs
+		// This includes keys containing wildcards (e.g., abc/*) in their expanded form (e.g., abc/123 and abc/456)
+		keyMap := map[string]struct{}{}
+
+		// Iterate over every configured key we are asked to sync
 		for _, key := range keys {
+			// If the key is a wildcard (it has a "*" at the very end), we need to
+			// find every key that matches that pattern in the VMI/Pod
+			if strings.HasSuffix(key, "*") {
+				prefix, _ := strings.CutSuffix(key, "*")
+				for vmiMapKey := range vmiMap {
+					if strings.HasPrefix(vmiMapKey, prefix) {
+						keyMap[vmiMapKey] = struct{}{}
+					}
+				}
+
+				for podMapKey := range podNewMap {
+					if strings.HasPrefix(podMapKey, prefix) {
+						keyMap[podMapKey] = struct{}{}
+					}
+				}
+			} else {
+				// Key is not a wildcard, store it as-is
+				keyMap[key] = struct{}{}
+			}
+		}
+
+		changed := false
+		for key := range keyMap {
 			vmiVal, vmiExists := vmiMap[key]
 			podVal, podExists := podNewMap[key]
 			if vmiExists == podExists && vmiVal == podVal {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -687,7 +687,7 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToPod(vmi *virtv1.VirtualMac
 			podNewMap = map[string]string{}
 		}
 
-		// keyMap contains the deduplicated keys that we need to sync between the VM and VMIs
+		// keyMap contains the deduplicated keys that we need to sync between the VMI and the Pod
 		// This includes keys containing wildcards (e.g., abc/*) in their expanded form (e.g., abc/123 and abc/456)
 		keyMap := map[string]struct{}{}
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -134,7 +134,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			ContainElement(
 				MatchFields(IgnoreExtras, Fields{
 					"Type":   BeEquivalentTo(virtv1.VirtualMachineInstanceDataVolumesReady),
-					"Status": BeEquivalentTo(expectedStatus)},
+					"Status": BeEquivalentTo(expectedStatus),
+				},
 				),
 			),
 		)
@@ -299,7 +300,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	}
 
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {
-
 		dvVolumeSource := virtv1.VolumeSource{
 			DataVolume: &virtv1.DataVolumeSource{
 				Name: "test1",
@@ -485,13 +485,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			},
 			Entry("fail if pod in failed state", k8sv1.PodFailed, nil, virtv1.Failed),
 			Entry("do nothing if pod succeed", k8sv1.PodSucceeded, nil, virtv1.Pending),
-			//The PodReasonUnschedulable is a transient condition. It can clear up if more resources are added to the cluster
+			// The PodReasonUnschedulable is a transient condition. It can clear up if more resources are added to the cluster
 			Entry("do nothing if pod Pending Unschedulable",
 				k8sv1.PodPending,
 				[]k8sv1.PodCondition{{
 					Type:   k8sv1.PodScheduled,
 					Status: k8sv1.ConditionFalse,
-					Reason: k8sv1.PodReasonUnschedulable}}, virtv1.Pending),
+					Reason: k8sv1.PodReasonUnschedulable,
+				}}, virtv1.Pending),
 		)
 
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
@@ -570,7 +571,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
 				expectMatchingPodCreation(vmi)
 			})
-
 		})
 
 		When("backend storage no RWX support", func() {
@@ -659,7 +659,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	})
 
 	Context("On valid VirtualMachineInstance given with PVC source, ownedRef of DataVolume", func() {
-
 		pvcVolumeSource := virtv1.VolumeSource{
 			PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 				ClaimName: "test1",
@@ -780,7 +779,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, kvcontroller.SuccessfulDeletePodReason)
 			expectPodDoesNotExist(pod.Namespace, pod.Name)
 			expectVMIDataVolumeReadyCondition(vmi.Namespace, vmi.Name, k8sv1.ConditionTrue)
-
 		})
 
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
@@ -820,7 +818,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
 			expectMatchingPodCreation(vmi)
 		})
-
 	})
 
 	Context("network annotations generation", func() {
@@ -880,7 +877,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 		})
 		It("should create empty status network interfaces patch, regardless of interfaces order", func() {
-
 			// Reverse the order of interfaces in the new VMI
 			newVMI.Status.Interfaces = slices.Clone(oldVMI.Status.Interfaces)
 			slices.Reverse(newVMI.Status.Interfaces)
@@ -891,7 +887,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(patch.IsEmpty()).To(BeTrue(), "Patch should be empty")
 		})
 		It("should create non empty status network interfaces patch", func() {
-
 			// Add a new interface to the new VMI
 			newVMI.Status.Interfaces = append(oldVMI.Status.Interfaces,
 				virtv1.VirtualMachineInstanceNetworkInterface{Name: "stubNetStatusUpdate3"},
@@ -1163,7 +1158,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		DescribeTable("should never proceed to creating the launcher pod if not all PVCs are there to determine if they are WFFC and/or an import is done",
 			func(syncReason string, volumeSource virtv1.VolumeSource) {
-
 				expectConditions := func(vmi *virtv1.VirtualMachineInstance) {
 					// PodScheduled and Synchronized (as well as Ready)
 					Expect(vmi.Status.Conditions).To(HaveLen(3), "there should be exactly 3 conditions")
@@ -2325,6 +2319,56 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						additionalLauncherLabelsSync: []string{"custom/label"},
 					},
 				),
+				Entry("when VMI and pod wildcard labels differ",
+					&testData{
+						vmiLabels: map[string]string{
+							"custom/label-1": "val1",
+							"custom/label-2": "val2",
+						},
+						podLabels: map[string]string{
+							"custom/label-1": "old-val",
+							"other/label":    "val",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+							"custom/label-1":         "val1",
+							"custom/label-2":         "val2",
+							"other/label":            "val",
+						},
+						expectedPatch:                true,
+						additionalLauncherLabelsSync: []string{"custom/label-*"},
+					},
+				),
+				Entry("when VMI and pod wildcard annotations differ",
+					&testData{
+						vmiAnnotations: map[string]string{
+							"custom/ann-1": "val1",
+							"custom/ann-2": "val2",
+						},
+						podAnnotations: map[string]string{
+							"custom/ann-1":                  "old-val",
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+							"custom/ann-1":                  "val1",
+							"custom/ann-2":                  "val2",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedPatch:                     true,
+						additionalLauncherAnnotationsSync: []string{"custom/ann-*"},
+					},
+				),
 			)
 		})
 
@@ -3120,7 +3164,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", virtv1.HotplugVolumeAttachedToNode, "Created hotplug attachment pod test-pod, for volume volume%d", kvcontroller.SuccessfulCreatePodReason, indexes...)
 		}
 
-		DescribeTable("updateVolumeStatus", func(oldStatus []virtv1.VolumeStatus, specVolumes []*virtv1.Volume, podIndexes []int, pvcIndexes []int, expectedStatus []virtv1.VolumeStatus, expectedEvents []string) {
+		DescribeTable("updateVolumeStatus", func(oldStatus []virtv1.VolumeStatus, specVolumes []*virtv1.Volume, podIndexes, pvcIndexes []int, expectedStatus []virtv1.VolumeStatus, expectedEvents []string) {
 			vmi := newPendingVirtualMachine("testvmi")
 			volumes := make([]virtv1.Volume, 0)
 			for _, volume := range specVolumes {
@@ -3328,10 +3372,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pvc := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
-					Name:      "test"},
+					Name:      "test",
+				},
 				Spec: k8sv1.PersistentVolumeClaimSpec{},
 			}
 
@@ -3715,18 +3761,22 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			existingPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "existing"},
+					Name:      "existing",
+				},
 			}
 			hpPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "hotplug"},
+					Name:      "hotplug",
+				},
 				Status: k8sv1.PersistentVolumeClaimStatus{
 					Phase: k8sv1.ClaimBound,
 				},
@@ -3817,18 +3867,22 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			existingPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "existing"},
+					Name:      "existing",
+				},
 			}
 			hpPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "hotplug"},
+					Name:      "hotplug",
+				},
 				Status: k8sv1.PersistentVolumeClaimStatus{
 					Phase: k8sv1.ClaimBound,
 				},
@@ -3865,7 +3919,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Target: "",
 					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
 						ClaimName:          "existing",
-						FilesystemOverhead: pointer.P(virtv1.Percent("0.055"))},
+						FilesystemOverhead: pointer.P(virtv1.Percent("0.055")),
+					},
 				},
 				{
 					Name:   "hotplug",
@@ -3982,7 +4037,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	})
 
 	Context("topology hints", func() {
-
 		getVmiWithInvTsc := func() *virtv1.VirtualMachineInstance {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
@@ -4057,13 +4111,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
 					})
 				})
-
 			})
-
 		})
 
 		Context("pod creation", func() {
-
 			It("does not need to happen if tsc requirement is of type RequiredForBoot", func() {
 				vmi := getVmiWithInvTsc()
 				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.RequiredForBoot))
@@ -4128,11 +4179,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			Expect(alc.calls).To(ConsistOf([]string{"Allocate", "Remove"}))
 		})
-
 	})
 
 	Context("Aggregating DataVolume conditions", func() {
-
 		dvVolumeSource1 := virtv1.VolumeSource{
 			DataVolume: &virtv1.DataVolumeSource{
 				Name: "test1",
@@ -4497,7 +4546,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	})
 })
 
-func newDv(namespace string, name string, phase cdiv1.DataVolumePhase) *cdiv1.DataVolume {
+func newDv(namespace, name string, phase cdiv1.DataVolumePhase) *cdiv1.DataVolume {
 	dv := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -4619,11 +4668,12 @@ func newDv(namespace string, name string, phase cdiv1.DataVolumePhase) *cdiv1.Da
 	return dv
 }
 
-func newPvc(namespace string, name string) *k8sv1.PersistentVolumeClaim {
+func newPvc(namespace, name string) *k8sv1.PersistentVolumeClaim {
 	return &k8sv1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
-			APIVersion: "v1"},
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -4631,11 +4681,12 @@ func newPvc(namespace string, name string) *k8sv1.PersistentVolumeClaim {
 	}
 }
 
-func newPvcWithOwner(namespace string, name string, ownerName string, isController *bool) *k8sv1.PersistentVolumeClaim {
+func newPvcWithOwner(namespace, name, ownerName string, isController *bool) *k8sv1.PersistentVolumeClaim {
 	return &k8sv1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
-			APIVersion: "v1"},
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -4785,7 +4836,6 @@ func addVolumeStatuses(vmi *virtv1.VirtualMachineInstance, volumeStatuses ...vir
 }
 
 func addActivePods(vmi *virtv1.VirtualMachineInstance, podUID types.UID, hostName string) *virtv1.VirtualMachineInstance {
-
 	if vmi.Status.ActivePods != nil {
 		vmi.Status.ActivePods[podUID] = hostName
 	} else {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Live reloading of labels/annotations on pods created by VMIs was done using static keys.

My usecase:
- My users can put labels on their VM to apply network policies to the VM
- Unless they reboot the VM, new labels are not enforced

This PR https://github.com/kubevirt/kubevirt/pull/14902 introduced the ability to provide a list of keys for labels/annotations that we wish to sync. This is a first step, but I can't know what label the users are gonna use.

This PR introduces wildcards in the label/annotations:
- mykey/* will match mykey/a or mykey/b
- * will match anything

Note: wildcards only work as a suffix, you can't write something like "my*key" and match "myabckey".

This allows for more flexibility.

#### After this PR:

Live reloading of labels/annotations on pods created by VMIs can be done using wildcards.

### Why we need it and why it was done in this way
The following tradeoffs were made:
None

The following alternatives were considered:
Hardcoding every key into the configuration of the virt-controller (impossible to scale).

### Special notes for your reviewer

The code is also linted by Kubevirt, which accounts for a lot of the changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

This release note is based on the release note of https://github.com/kubevirt/kubevirt/pull/14902 with the addition of wildcards

```release-note
The list of annotations and labels synced from VM.spec.template.metadata to VMI and then to virt-launcher pods can be extended using wildcards
```

