### PR TITLE
fix(tests): Skip hotplug metric tests for IPv6

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -592,6 +592,7 @@ fi
 # Single stack IPv6 cluster should skip tests that require dual stack cluster
 if [[ ${KUBEVIRT_SINGLE_STACK} == "true" ]]; then
   add_to_label_filter '(!requires-dual-stack-cluster)' '&&'
+  add_to_label_filter '(!requires-ipv4-cluster)' '&&'
 fi
 
 # If KUBEVIRT_QUARANTINE is not set, do not run quarantined tests. When it is

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -67,6 +67,7 @@ var (
 	RequiresTwoWorkerNodesWithCPUManager = Label("requires-two-worker-nodes-with-cpu-manager")
 	RequiresNodeWithCPUManager           = Label("requires-node-with-cpu-manager")
 	RequiresDualStackCluster             = Label("requires-dual-stack-cluster")
+	RequiresIPv4Cluster                  = Label("requires-ipv4-cluster")
 	RequiresHugepages2Mi                 = Label("requireHugepages2Mi")
 	RequiresHugepages1Gi                 = Label("requireHugepages1Gi")
 	GuestAgentProbes                     = Label("guest-agent-probes")

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -829,7 +829,7 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyNoVolumeAttached(vmi, "testvolume")
 		}
 
-		Context("Ephemeral Metrics", decorators.SigMonitoring, func() {
+		Context("Ephemeral Metrics", decorators.SigMonitoring, decorators.RequiresIPv4Cluster, func() {
 
 			var (
 				vm *v1.VirtualMachine
@@ -868,6 +868,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				if !isPrometheusDeployed() {
 					Skip("Prometheus not deployed")
 				}
+
 				kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
 				kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
 				ephemeralCount := 0.0
@@ -914,6 +915,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				if !isPrometheusDeployed() {
 					Skip("Prometheus not deployed")
 				}
+
 				kvconfig.EnableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
 				kvconfig.DisableFeatureGate(featuregate.HotplugVolumesGate)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

This specific hotplug test attempts to grab metrics and alerts from the Prometheus service however, it was discovered that the existing `libmonitoring.WaitForMetricValue()` function can only correctly resolve and connect to this endpoint using IPv4 addresses.

I believe running these tests exclusively in IPv4 environments is still sufficient since the core objective of the tests is to test the storage/hotplug logic that sets the metric, not the actual retrieval mechanism. Because of this, I am opting to skip these tests in clusters that are only configured for IPv6.


### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

