### PR TITLE
tests/infrastructure/prometheus: remove test_id:4146

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -485,24 +485,6 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		}
 	})
 
-	It("[test_id:4146]should include VMI phase metrics for all running VMs", func() {
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
-
-		fetcher := metricsutil.NewMetricsFetcher("")
-		fetcher.AddNameFilter("kubevirt_vmi_")
-		fetcher.AddLabelFilter("phase", "Running")
-
-		metrics, err := fetcher.LoadMetrics(metricsPayload)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Checking the collected metrics")
-		for _, results := range metrics {
-			for _, metricResult := range results {
-				Expect(metricResult.Value).To(Equal(float64(len(preparedVMIs))))
-			}
-		}
-	})
-
 	Context("VMI eviction blocker status", func() {
 		var controllerMetricIPs []string
 


### PR DESCRIPTION
### What this PR does

test_id:4146 was filtering virt-handler metrics by phase=Running, but no virt-handler metric carries a "phase" label. The phase label exists only on kubevirt_vmi_info emitted by virt-controller, so the test always got an empty result and passed vacuously.

~~Fix by scraping the virt-controller leader endpoint and filtering for kubevirt_vmi_info{phase=Running}, then asserting one entry per running VMI.~~

~~Also move test_id:4146 into a "virt-controller metrics" Context alongside the eviction blocker tests, keeping controllerMetricIPs scoped to tests that actually need them.~~

fix by removing the test, since it's covered by unit tests already at vmistats_collector.go

### References

- Fixes #16858 

### Release note
```release-note
none
```

