### PR TITLE
virt-operator: Validate cpuModel against cluster node labels

### DIFF
--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )
@@ -57,6 +58,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
     ],
 )


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Setting `spec.configuration.cpuModel` on the KubeVirt CR to any arbitrary string (e.g. `"Homer-Simpson"` or misspelled `"CascadelakeServer"`) was silently accepted with no validation. The invalid value propagated as the cluster-wide default CPU model for all new VMIs via `setDefaultCPUModel()` in `pkg/defaults/defaults.go`. This caused opaque scheduling failures because the node selector `cpu-model.node.kubevirt.io/<model>=true` would never match any node.

#### After this PR:

The KubeVirt update admission webhook now validates `spec.configuration.cpuModel` against CPU model labels advertised by cluster nodes. If the specified model is not supported by any node, the admission request is **rejected** with a clear error message:

```
the cpuModel "Homer-Simpson" is not supported by any node in the cluster
```

The following values are always accepted without querying nodes:
- Empty string (no override)
- `host-passthrough` (libvirt special mode)
- `host-model` (libvirt special mode)

### References

- Fixes #16854

### Why we need it and why it was done in this way

**Why:** Users setting an invalid `cpuModel` get no feedback at configuration time. The error only surfaces much later as opaque VM scheduling failures, making debugging difficult.

**Approach:** The validation is implemented in the existing `KubeVirtUpdateAdmitter.Admit()` function, following the same pattern as other validators (`validateTLSConfiguration`, `validateSeccompConfiguration`, etc.). The function queries cluster nodes for the `cpu-model.node.kubevirt.io/<model>=true` label to verify the model is actually supported.

The following tradeoffs were made:
- **Hard rejection vs warning:** This PR uses hard rejection (returns `StatusCause`) rather than an admission warning. This gives immediate, clear feedback to the user. If the cluster is expected to receive new node types with different CPU models, the user can set the cpuModel after those nodes join the cluster.
- **API error handling:** If the node list API call fails (e.g. transient network issue), the validation is skipped with a logged warning rather than blocking the update. This avoids rejecting legitimate configuration changes due to unrelated infrastructure issues.

The following alternatives were considered:
- **Warning-only approach:** Would allow invalid values through with a warning message. Rejected because the original issue specifically asks for either rejecting or providing meaningful errors, and a warning is easy to miss.
- **Static list of known CPU models:** Would not reflect the actual capabilities of the specific cluster. The node-label approach dynamically matches what's available.

### Special notes for your reviewer

- The `validateCPUModel` function is placed alongside existing validators in `kubevirt-update-admitter.go` and follows the same `[]metav1.StatusCause` return pattern.
- The function has a `client == nil` guard for safety, matching how the existing `deprecations` tests pass `nil` as the client in `NewKubeVirtUpdateAdmitter`.
- The `Limit: 1` on the node list query ensures we only check for existence, not enumerate all matching nodes.
- The BUILD.bazel change adds `k8s.io/client-go/kubernetes/fake` as a test dependency, required for the `k8sfake.NewSimpleClientset` used in tests.

### Changes made

**Files modified (3 files, +105 lines):**

| File | Change |
|------|--------|
| `pkg/virt-operator/webhooks/kubevirt-update-admitter.go` | Added `validateCPUModel()` function (+29 lines) and wired it into `Admit()` (+2 lines) |
| `pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go` | Added `validateCPUModel` test context with 7 test cases (+68 lines) and 3 new imports (+5 lines) |
| `pkg/virt-operator/webhooks/BUILD.bazel` | Added `k8s.io/client-go/kubernetes/fake` test dependency (+1 line) |

**`validateCPUModel` function logic:**
1. Returns `nil` immediately for empty string, `host-passthrough`, or `host-model` (no node query needed)
2. Returns `nil` if client is `nil` (safety guard)
3. Queries nodes with label selector `cpu-model.node.kubevirt.io/<model>=true` (limit 1)
4. On API error: logs warning, returns `nil` (does not block the update)
5. If no matching nodes found: returns `StatusCause` with `CauseTypeFieldValueInvalid` and field `spec.configuration.cpuModel`

### Tests added

7 unit tests in a new `validateCPUModel` context under the existing `Validating KubeVirtUpdate Admitter` suite:

| # | Test case | Input | Mock setup | Expected result |
|---|-----------|-------|------------|-----------------|
| 1 | `should accept valid values without querying nodes` | `""` (empty) | No `CoreV1()` expectation | No causes |
| 2 | `should accept valid values without querying nodes` | `host-passthrough` | No `CoreV1()` expectation | No causes |
| 3 | `should accept valid values without querying nodes` | `host-model` | No `CoreV1()` expectation | No causes |
| 4 | `should accept a CPU model that exists on cluster nodes` | `"Haswell"` | Fake node with label `cpu-model.node.kubevirt.io/Haswell=true` | No causes |
| 5 | `should reject a CPU model not supported by any node` | `"Homer-Simpson"` | Empty fake clientset (no nodes) | 1 cause: `CauseTypeFieldValueInvalid`, field `spec.configuration.cpuModel`, message contains `"Homer-Simpson"` |
| 6 | `should reject a misspelled CPU model` | `"CascadelakeServer"` | Fake node with label `Cascadelake-Server` (correct spelling) | 1 cause: message contains `"CascadelakeServer"` |
| 7 | `should not fail when client is nil` | `"SomeModel"` | `nil` client | No causes |

Tests use `gomock` (`kubecli.NewMockKubevirtClient`) with `k8sfake.NewSimpleClientset` wired via `mockClient.EXPECT().CoreV1().Return(kubeClient.CoreV1())`, following the same pattern used in `kubevirt-create-admitter_test.go` and `webhook_test.go`.

### Checklist

- [x] Design: A design document was not required (bug fix with straightforward validation addition)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Follows existing patterns in `kubevirt-update-admitter.go`, uses early returns, consistent style
- [x] Refactor: No unrelated changes, focused scope
- [x] Upgrade: No impact on upgrade flows — this is a new validation that only applies to future updates of the KubeVirt CR
- [x] Testing: Unit tests added covering: empty string, host-passthrough, host-model, valid model, invalid model, misspelled model, nil client
- [ ] Documentation: User-guide update not required (no new user-facing API — this validates an existing field)
- [ ] Community: Announcement not required (bug fix)

### Release note

```release-note
The KubeVirt update admission webhook now validates spec.configuration.cpuModel against CPU models supported by cluster nodes. Setting an unsupported CPU model is rejected with a clear error message instead of being silently accepted.
```
