### PR TITLE
WIP/DNM: VEP 140: user feedback

### DIFF
--- a/pkg/network/migration/evaluator.go
+++ b/pkg/network/migration/evaluator.go
@@ -70,8 +70,8 @@ func NewEvaluatorWithTimeProvider(timeProvider timeProviderFunc, clusterConfigur
 
 func (e Evaluator) Evaluate(vmi *v1.VirtualMachineInstance,
 	pod *k8scorev1.Pod,
-) k8scorev1.ConditionStatus {
-	result := shouldVMIBeMarkedForAutoMigration(
+) (mig k8scorev1.ConditionStatus, msg string) {
+	result, reason := shouldVMIBeMarkedForAutoMigration(
 		vmi,
 		pod,
 		e.clusterConfigurer.LiveUpdateNADRefEnabled(),
@@ -79,28 +79,28 @@ func (e Evaluator) Evaluate(vmi *v1.VirtualMachineInstance,
 
 	switch result {
 	case notRequired:
-		return k8scorev1.ConditionUnknown
+		return k8scorev1.ConditionUnknown, ""
 	case immediateMigration:
-		return k8scorev1.ConditionTrue
+		return k8scorev1.ConditionTrue, reason
 	case pendingMigration:
 		existingCondition := lookupMigrationRequiredCondition(vmi.Status.Conditions)
 		if existingCondition != nil &&
 			existingCondition.Status == k8scorev1.ConditionFalse &&
 			e.timeProvider().Sub(existingCondition.LastTransitionTime.Time) > DynamicNetworkControllerGracePeriod {
-			return k8scorev1.ConditionTrue
+			return k8scorev1.ConditionTrue, reason
 		}
 
-		return k8scorev1.ConditionFalse
+		return k8scorev1.ConditionFalse, ""
 	}
 
-	return k8scorev1.ConditionUnknown
+	return k8scorev1.ConditionUnknown, ""
 }
 
 func shouldVMIBeMarkedForAutoMigration(
 	vmi *v1.VirtualMachineInstance,
 	pod *k8scorev1.Pod,
 	isLiveUpdateNADRefEnabled bool,
-) migrationRequirementKind {
+) (mig migrationRequirementKind, msg string) {
 	ifaces := vmi.Spec.Domain.Devices.Interfaces
 	nets := vmi.Spec.Networks
 	ifaceStatuses := vmi.Status.Interfaces
@@ -119,11 +119,11 @@ func shouldVMIBeMarkedForAutoMigration(
 		ifaceStatus, ifaceStatusExists := ifaceStatusesByName[iface.Name]
 
 		if result := shouldMigrateOnIfaceHotplug(iface, ifaceStatusExists); result != notRequired {
-			return result
+			return result, "Live migration due to hotplug of Interface"
 		}
 
 		if result := shouldMigrateOnIfaceUnplug(iface, ifaceStatus, ifaceStatusExists); result != notRequired {
-			return result
+			return result, "Live migration due to hotunplug of Interface"
 		}
 
 		if !isLiveUpdateNADRefEnabled {
@@ -143,10 +143,10 @@ func shouldVMIBeMarkedForAutoMigration(
 		}
 
 		if !isNADNameEqual(net.Multus.NetworkName, podNetStatus.Name, namespace) {
-			return immediateMigration
+			return immediateMigration, "Live migration due to change in NAD reference"
 		}
 	}
-	return notRequired
+	return notRequired, ""
 }
 
 func shouldMigrateOnIfaceHotplug(iface v1.Interface, ifaceStatusExists bool) migrationRequirementKind {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -1156,7 +1156,7 @@ func (c *Controller) syncMigrationRequiredCondition(vmi *virtv1.VirtualMachineIn
 		return
 	}
 
-	result := c.netMigrationEvaluator.Evaluate(vmi, pod)
+	result, reason := c.netMigrationEvaluator.Evaluate(vmi, pod)
 
 	cm := controller.NewVirtualMachineInstanceConditionManager()
 	existingCondition := cm.GetCondition(vmi, virtv1.VirtualMachineInstanceMigrationRequired)
@@ -1173,7 +1173,7 @@ func (c *Controller) syncMigrationRequiredCondition(vmi *virtv1.VirtualMachineIn
 		return
 	}
 
-	cm.UpdateCondition(vmi, newMigrationRequiredCondition(result))
+	cm.UpdateCondition(vmi, newMigrationRequiredCondition(result, reason))
 
 	if result == k8sv1.ConditionTrue {
 		return
@@ -1186,7 +1186,7 @@ func (c *Controller) syncMigrationRequiredCondition(vmi *virtv1.VirtualMachineIn
 	c.Queue.AddAfter(key, pendingMigrationReEvalPeriod)
 }
 
-func newMigrationRequiredCondition(status k8sv1.ConditionStatus) *virtv1.VirtualMachineInstanceCondition {
+func newMigrationRequiredCondition(status k8sv1.ConditionStatus, message string) *virtv1.VirtualMachineInstanceCondition {
 	reason := virtv1.VirtualMachineInstanceReasonAutoMigrationDueToLiveUpdate
 	if status == k8sv1.ConditionFalse {
 		reason = virtv1.VirtualMachineInstanceReasonAutoMigrationPending
@@ -1198,6 +1198,6 @@ func newMigrationRequiredCondition(status k8sv1.ConditionStatus) *virtv1.Virtual
 		LastProbeTime:      v1.Time{},
 		LastTransitionTime: v1.Now(),
 		Reason:             reason,
-		Message:            "",
+		Message:            message,
 	}
 }

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -215,7 +215,7 @@ type migrationEvaluator interface {
 	//   * ConditionUnknown: No action needed; the VMI should not be marked for auto-migration.
 	//   * ConditionTrue: Mark the VMI for immediate migration.
 	//   * ConditionFalse: Mark the VMI for pending migration.
-	Evaluate(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) k8sv1.ConditionStatus
+	Evaluate(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) (k8sv1.ConditionStatus, string)
 }
 
 type Controller struct {

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -250,7 +250,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			stubStorageAnnotationsGenerator{},
 			stubNetStatusUpdate,
 			validateNetVMISpecStub(),
-			stubMigrationEvaluator{result: k8sv1.ConditionUnknown},
+			stubMigrationEvaluator{result: k8sv1.ConditionUnknown, reason: ""},
 			[]string{},
 			[]string{},
 		)
@@ -4648,7 +4648,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			},
 			Entry("should not set the condition when there is no condition and evaluator returns Unknown",
 				nil,
-				stubMigrationEvaluator{result: k8sv1.ConditionUnknown},
+				stubMigrationEvaluator{result: k8sv1.ConditionUnknown, reason: ""},
 				noConditionMatcher,
 			),
 			Entry("should set the condition to false when there is no condition and evaluator returns False",
@@ -4694,7 +4694,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Status: k8sv1.ConditionFalse,
 					Reason: virtv1.VirtualMachineInstanceReasonAutoMigrationPending,
 				},
-				stubMigrationEvaluator{result: k8sv1.ConditionUnknown},
+				stubMigrationEvaluator{result: k8sv1.ConditionUnknown, reason: ""},
 				noConditionMatcher,
 			),
 			Entry("should remove the condition when there is a True condition and evaluator returns Unknown",
@@ -4703,7 +4703,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Status: k8sv1.ConditionTrue,
 					Reason: virtv1.VirtualMachineInstanceReasonAutoMigrationDueToLiveUpdate,
 				},
-				stubMigrationEvaluator{result: k8sv1.ConditionUnknown},
+				stubMigrationEvaluator{result: k8sv1.ConditionUnknown, reason: ""},
 				noConditionMatcher,
 			),
 		)
@@ -5055,8 +5055,9 @@ func validateNetVMISpecStub(causes ...metav1.StatusCause) func(*k8sfield.Path, *
 
 type stubMigrationEvaluator struct {
 	result k8sv1.ConditionStatus
+	reason string
 }
 
-func (e stubMigrationEvaluator) Evaluate(_ *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) k8sv1.ConditionStatus {
-	return e.result
+func (e stubMigrationEvaluator) Evaluate(_ *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) (k8sv1.ConditionStatus, string) {
+	return e.result, e.reason
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

