### PR TITLE
Subtract non-schedulable nodes from kubevirt_allocatable_nodes

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -103,6 +103,7 @@
 | kubevirt_workqueue_retries_total | Metric | Counter | Total number of retries handled by workqueue |
 | kubevirt_workqueue_unfinished_work_seconds | Metric | Gauge | How many seconds of work have been in progress without being observed by work_duration. Large values indicate stuck threads. The number of stuck threads can be deduced by observing the rate at which this value increases. |
 | kubevirt_workqueue_work_duration_seconds | Metric | Histogram | How long in seconds processing an item from workqueue takes. |
+| cluster:kubevirt_non_schedulable_nodes:sum | Recording rule | Gauge | The number of non-schedulable nodes in the cluster. |
 | cluster:kubevirt_virt_controller_pods_running:count | Recording rule | Gauge | The number of virt-controller pods that are running. |
 | cluster:kubevirt_virt_operator_pods_running:count | Recording rule | Gauge | The number of virt-operator pods that are running. |
 | kubevirt_allocatable_nodes | Recording rule | Gauge | The number of allocatable nodes in the cluster. |

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -483,13 +483,13 @@ tests:
   # Some nodes without KVM resources
   - interval: 1m
     input_series:
-      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node1"}'
-        values: "110 110 110 110 110 110"
-      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node2 "}'
-        values: "0 0 0 0 0 0"
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="node1"}'
+        values: "110 110 110 110 110 110 110"
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="node2"}'
+        values: "0 0 0 0 0 0 0"
 
     alert_rule_test:
-      - eval_time: 5m
+      - eval_time: 6m
         alertname: LowKVMNodesCount
         exp_alerts:
           - exp_annotations:
@@ -505,13 +505,13 @@ tests:
   # All nodes without KVM resources
   - interval: 1m
     input_series:
-      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node1"}'
-        values: "0 0 0 0 0 0"
-      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node2 "}'
-        values: "0 0 0 0 0 0"
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="node1"}'
+        values: "0 0 0 0 0 0 0"
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="node2"}'
+        values: "0 0 0 0 0 0 0"
 
     alert_rule_test:
-      - eval_time: 5m
+      - eval_time: 6m
         alertname: LowKVMNodesCount
         exp_alerts:
           - exp_annotations:
@@ -527,9 +527,9 @@ tests:
   # Two nodes with KVM resources
   - interval: 1m
     input_series:
-      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node1"}'
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="node1"}'
         values: "110 110 110 110 110 110"
-      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node2 "}'
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="node2"}'
         values: "110 110 110 110 110 110"
 
     alert_rule_test:

--- a/pkg/monitoring/rules/recordingrules/nodes.go
+++ b/pkg/monitoring/rules/recordingrules/nodes.go
@@ -27,11 +27,19 @@ import (
 var nodesRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "cluster:kubevirt_non_schedulable_nodes:sum",
+			Help: "The number of non-schedulable nodes in the cluster.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum (count by (node) (kube_node_role{role=~'arbiter'})) or vector(0)"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "kubevirt_allocatable_nodes",
 			Help: "The number of allocatable nodes in the cluster.",
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString("count(count (kube_node_status_allocatable) by (node))"),
+		Expr:       intstr.FromString("count(count (kube_node_status_allocatable) by (node)) - cluster:kubevirt_non_schedulable_nodes:sum"),
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

The metric "kubevirt_allocatable_nodes" was tracking nodes like arbiter nodes in a Two Node + Arbiter cluster configuration. Arbiter nodes should not count towards kubevirt_allocatable_nodes as arbiter nodes are not designed to run user workloads.

#### After this PR:

Arbiter nodes are ignored from kubevirt_allocatable_nodes

### References

jira-ticket: https://issues.redhat.com/browse/CNV-79412

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Subtract non-schedulable nodes from kubevirt_allocatable_nodes
```

