### PR TITLE
hypervisor: Add package to linter coverage

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -7,6 +7,7 @@ cmd/virtctl
 cmd/virt-exportserver
 cmd/virt-operator
 pkg/controller/testing
+pkg/hypervisor
 pkg/instancetype
 pkg/libvmi
 pkg/network/admitter

--- a/pkg/hypervisor/kvm/launcherhypervisorresources.go
+++ b/pkg/hypervisor/kvm/launcherhypervisorresources.go
@@ -62,8 +62,6 @@ func (k *KvmLauncherHypervisorResources) GetHypervisorDevice() string {
 // The return value is overhead memory quantity
 //
 // Note: The overhead memory is a calculated estimation, the values are not to be assumed accurate.
-//
-//nolint:gocyclo // complexity is inherent to memory overhead calculation
 func (k *KvmLauncherHypervisorResources) GetMemoryOverhead(
 	vmi *v1.VirtualMachineInstance, cpuArch string, additionalOverheadRatio *string,
 ) resource.Quantity {

--- a/pkg/hypervisor/launcherhypervisorresources.go
+++ b/pkg/hypervisor/launcherhypervisorresources.go
@@ -35,8 +35,9 @@ type LauncherHypervisorResources interface {
 
 func NewLauncherHypervisorResources(hypervisor string) LauncherHypervisorResources {
 	switch hypervisor {
-	// Other hypervisors can be added here
-	default:
+	case kvm.KvmHypervisorDevice, "":
 		return kvm.NewKvmLauncherHypervisorResources()
+	default:
+		panic("unsupported hypervisor: " + hypervisor)
 	}
 }

--- a/pkg/hypervisor/launcherhypervisorresources_test.go
+++ b/pkg/hypervisor/launcherhypervisorresources_test.go
@@ -27,10 +27,18 @@ import (
 	"kubevirt.io/kubevirt/pkg/hypervisor/kvm"
 )
 
-var _ = DescribeTable("Test NewLauncherHypervisorResources", func(hypervisorType string, expectedType interface{}) {
-	renderer := NewLauncherHypervisorResources(hypervisorType)
-	Expect(renderer).To(BeAssignableToTypeOf(expectedType))
-},
-	Entry("should return KVM renderer for unknown hypervisor", "unknownHypervisor", (*kvm.KvmLauncherHypervisorResources)(nil)),
-	Entry("should return KVM renderer for KVM hypervisor", v1.KvmHypervisorName, (*kvm.KvmLauncherHypervisorResources)(nil)),
-)
+var _ = Describe("NewLauncherHypervisorResources", func() {
+	DescribeTable("should return correct hypervisor resources", func(hypervisorType string, expectedType interface{}) {
+		renderer := NewLauncherHypervisorResources(hypervisorType)
+		Expect(renderer).To(BeAssignableToTypeOf(expectedType))
+	},
+		Entry("should return KVM renderer for empty hypervisor", "", (*kvm.KvmLauncherHypervisorResources)(nil)),
+		Entry("should return KVM renderer for KVM hypervisor", v1.KvmHypervisorName, (*kvm.KvmLauncherHypervisorResources)(nil)),
+	)
+
+	It("should panic for unsupported hypervisor", func() {
+		Expect(func() {
+			NewLauncherHypervisorResources("unsupported")
+		}).To(Panic())
+	})
+})


### PR DESCRIPTION
### What this PR does

 Add pkg/hypervisor to linter coverage and resolve all linting
 issues including init function usage, cyclomatic complexity,
 line length, formatting, and misspellings.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

Add pkg/hypervisor to linter coverage and resolve all linting
issues including init function usage, cyclomatic complexity,
line length, formatting, and misspellings.

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

