### PR TITLE
Set topology hints decentralized live migration

### DIFF
--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -300,15 +300,13 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 			vmiCopy.Status.Phase = virtv1.Failed
 		} else if vmi.IsMigrationTarget() && !vmi.IsMigrationTargetNodeLabelSet() {
 			vmiCopy.Status.Phase = virtv1.WaitingForSync
+			if err := c.addTopologyHints(vmi, vmiCopy); err != nil {
+				return err
+			}
 		} else {
 			vmiCopy.Status.Phase = virtv1.Pending
-			if vmi.Status.TopologyHints == nil {
-				if topologyHints, tscRequirement, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil && tscRequirement == topology.RequiredForBoot {
-					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, controller.FailedGatherhingClusterTopologyHints, err.Error())
-					return common.NewSyncError(err, controller.FailedGatherhingClusterTopologyHints)
-				} else if topologyHints != nil {
-					vmiCopy.Status.TopologyHints = topologyHints
-				}
+			if err := c.addTopologyHints(vmi, vmiCopy); err != nil {
+				return err
 			}
 			if hasWffcDataVolume {
 				condition := virtv1.VirtualMachineInstanceCondition{
@@ -577,6 +575,18 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 		}
 	}
 
+	return nil
+}
+
+func (c *Controller) addTopologyHints(vmi *virtv1.VirtualMachineInstance, vmiCopy *virtv1.VirtualMachineInstance) error {
+	if vmi.Status.TopologyHints == nil {
+		if topologyHints, tscRequirement, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil && tscRequirement == topology.RequiredForBoot {
+			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, controller.FailedGatherhingClusterTopologyHints, err.Error())
+			return common.NewSyncError(err, controller.FailedGatherhingClusterTopologyHints)
+		} else if topologyHints != nil {
+			vmiCopy.Status.TopologyHints = topologyHints
+		}
+	}
 	return nil
 }
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -4093,6 +4093,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				expectMatchingPodCreation(vmi)
 			})
 		})
+
+		Context("decentralized live migration", func() {
+			It("should set the topology hints when the VMI is created", func() {
+				vmi := getVmiWithReenlightenment()
+				vmi.Annotations[virtv1.CreateMigrationTarget] = "true"
+				addVirtualMachine(vmi)
+				sanityExecute()
+				expectTopologyHintsDefined(vmi, BeTrue())
+				updatedVmi, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedVmi.Status.Phase).To(Equal(virtv1.WaitingForSync))
+			})
+		})
 	})
 
 	Context("auto attach VSOCK", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The topology hints were not set for decentralized live migration. This caused VMs to no lnoger be live migrateable after a decentralized live migration.

#### Before this PR:
After a decentralized live migration, a windows VM with reenlightment enabled was no longer able to live migrate, because it was missing the topologyHints in the status.

#### After this PR:
The topologyHints are properly set in the status allowing live migration after a decentralized live migration.

### References
- Fixes https://issues.redhat.com/browse/CNV-79979

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: VMs requiring enlightenment are now able to be live migrated after a decentralized live migration
```

