### PR TITLE
[release-1.4] netstat: Omit LLA when using masquerade binding

### DIFF
--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -476,6 +476,94 @@ var _ = Describe("netstat", func() {
 		}), "the SR-IOV interface should be reported in the status, associated to the network")
 	})
 
+	It("should not report link local addresses for masquerade binding when reported by guest-agent", func() {
+		const (
+			primaryNetworkName = "primary"
+
+			primaryGaIPv4    = "1.1.1.1"
+			primaryGaIPv6    = "fd20:244::8c4c"
+			primaryGaLLAIPv6 = "fe80::a00:27ff:fe8f:5d42"
+
+			primaryMAC     = "1C:CE:C0:01:BE:E7"
+			primaryPodIPv4 = "1.1.1.1"
+		)
+
+		Expect(
+			setup.addNetworkInterface(
+				newVMISpecIfaceWithMasqueradeBinding(primaryNetworkName),
+				newVMISpecPodNetwork(primaryNetworkName),
+				newDomainSpecIface(primaryNetworkName, primaryMAC),
+				primaryPodIPv4,
+			)).To(Succeed())
+
+		setup.addGuestAgentInterfaces(
+			newDomainStatusIface(
+				[]string{primaryGaIPv4, primaryGaIPv6, primaryGaLLAIPv6},
+				primaryMAC,
+				"eth0",
+			),
+		)
+
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:          primaryNetworkName,
+				InterfaceName: "eth0",
+				IP:            primaryPodIPv4,
+				IPs:           []string{primaryPodIPv4, primaryGaIPv6},
+				MAC:           primaryMAC,
+				InfoSource:    netvmispec.InfoSourceDomainAndGA,
+				QueueCount:    netsetup.DefaultInterfaceQueueCount,
+			},
+		}))
+	})
+
+	It("should report link local addresses for secondary iface using bridge binding w/o IPAM when reported by guest-agent", func() {
+		const (
+			secondaryNetworkName = "secondary"
+
+			secondaryGaIPv4    = "1.1.1.1"
+			secondaryGaIPv4LLA = "169.254.0.1"
+			secondaryGaIPv6    = "fd20:244::8c4c"
+			secondaryGaLLAIPv6 = "fe80::a00:27ff:fe8f:5d42"
+
+			secondaryMAC = "1C:CE:C0:01:BE:E7"
+		)
+
+		Expect(
+			setup.addNetworkInterface(
+				newVMISpecIfaceWithBridgeBinding(secondaryNetworkName),
+				newVMISpecMultusNetwork(secondaryNetworkName),
+				newDomainSpecIface(secondaryNetworkName, secondaryMAC),
+			)).To(Succeed())
+
+		// The IPv4 configuration reported here is illegal according to
+		// https://datatracker.ietf.org/doc/html/rfc3927#section-2.1
+		// but is used for testing the filtering logic
+		setup.addGuestAgentInterfaces(
+			newDomainStatusIface(
+				[]string{secondaryGaIPv4, secondaryGaIPv4LLA, secondaryGaIPv6, secondaryGaLLAIPv6},
+				secondaryMAC,
+				"eth0",
+			),
+		)
+
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
+			{
+				Name:          secondaryNetworkName,
+				InterfaceName: "eth0",
+				IP:            secondaryGaIPv4,
+				IPs:           []string{secondaryGaIPv4, secondaryGaIPv4LLA, secondaryGaIPv6, secondaryGaLLAIPv6},
+				MAC:           secondaryMAC,
+				InfoSource:    netvmispec.InfoSourceDomainAndGA,
+				QueueCount:    netsetup.DefaultInterfaceQueueCount,
+			},
+		}))
+	})
+
 	When("the desired state (VMI spec) is not in sync with the state in the guest (guest-agent)", func() {
 		const (
 			primaryNetworkName = "primary"
@@ -535,20 +623,50 @@ var _ = Describe("netstat", func() {
 		It("reports a new interface that appeared in the guest", func() {
 			const (
 				newGaIPv4    = "3.3.3.3"
+				newGaIPv4LLA = "169.254.0.1"
 				newGaIPv6    = "fd20:333::3333"
+				newGaIPv6LLA = "fe80::a00:27ff:fe8f:5d42"
 				newIfaceName = "eth3"
 			)
+
+			// The IPv4 configuration reported for the guest interface is illegal according to
+			// https://datatracker.ietf.org/doc/html/rfc3927#section-2.1
+			// but is used for testing the filtering logic
 			setup.addGuestAgentInterfaces(
 				newDomainStatusIface([]string{primaryGaIPv4, primaryGaIPv6}, primaryMAC, primaryIfaceName),
 				newDomainStatusIface([]string{secondaryGaIPv4, secondaryGaIPv6}, secondaryMAC, secondaryIfaceName),
-				newDomainStatusIface([]string{newGaIPv4, newGaIPv6}, newMAC1, newIfaceName),
+				newDomainStatusIface([]string{newGaIPv4, newGaIPv4LLA, newGaIPv6, newGaIPv6LLA}, newMAC1, newIfaceName),
 			)
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(ConsistOf([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secondaryNetworkName, "", []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface("", "", []string{newGaIPv4, newGaIPv6}, newMAC1, newIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
+				{
+					Name:          primaryNetworkName,
+					InterfaceName: primaryIfaceName,
+					IP:            primaryPodIPv4,
+					IPs:           []string{primaryPodIPv4, primaryPodIPv6},
+					MAC:           primaryMAC,
+					InfoSource:    netvmispec.InfoSourceDomainAndGA,
+					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+				},
+				{
+					Name:          secondaryNetworkName,
+					InterfaceName: secondaryIfaceName,
+					IP:            secondaryPodIPv4,
+					IPs:           []string{secondaryPodIPv4, secondaryPodIPv6},
+					MAC:           secondaryMAC,
+					InfoSource:    netvmispec.InfoSourceDomainAndGA,
+					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+				},
+				{
+					Name:          "",
+					InterfaceName: newIfaceName,
+					IP:            newGaIPv4,
+					IPs:           []string{newGaIPv4, newGaIPv4LLA, newGaIPv6, newGaIPv6LLA},
+					MAC:           newMAC1,
+					InfoSource:    netvmispec.InfoSourceGuestAgent,
+					QueueCount:    netsetup.UnknownInterfaceQueueCount,
+				},
 			}))
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/16242.
References to LinkState were removed, as it was introduced in v1.5.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

