### PR TITLE
Snapshot: Add PartialSnapshot indication for excluded volumes

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -72,11 +72,12 @@ const (
 
 // Indication messages
 var snapshotIndicationMessages = map[snapshotv1.Indication]string{
-	snapshotv1.VMSnapshotOnlineSnapshotIndication: "Snapshot taken while the VM was running. Consistency depends on guest-agent quiescing.",
-	snapshotv1.VMSnapshotGuestAgentIndication:     "Guest agent was active and attempted to quiesce the filesystem for application consistency.",
-	snapshotv1.VMSnapshotNoGuestAgentIndication:   "Guest agent was not available. Snapshot is crash-consistent and may not be application-consistent.",
-	snapshotv1.VMSnapshotQuiesceTimeoutIndication: "Guest agent quiesced the filesystem, but the freeze window timed out before completion. Snapshot is crash-consistent and may not be application-consistent.",
-	snapshotv1.VMSnapshotPausedIndication:         "Snapshot taken while the VM was paused. Snapshot is crash-consistent and may not be application-consistent.",
+	snapshotv1.VMSnapshotOnlineSnapshotIndication:  "Snapshot taken while the VM was running. Consistency depends on guest-agent quiescing.",
+	snapshotv1.VMSnapshotGuestAgentIndication:      "Guest agent was active and attempted to quiesce the filesystem for application consistency.",
+	snapshotv1.VMSnapshotNoGuestAgentIndication:    "Guest agent was not available. Snapshot is crash-consistent and may not be application-consistent.",
+	snapshotv1.VMSnapshotQuiesceTimeoutIndication:  "Guest agent quiesced the filesystem, but the freeze window timed out before completion. Snapshot is crash-consistent and may not be application-consistent.",
+	snapshotv1.VMSnapshotPausedIndication:          "Snapshot taken while the VM was paused. Snapshot is crash-consistent and may not be application-consistent.",
+	snapshotv1.VMSnapshotPartialSnapshotIndication: "Not all snapshotable volumes were included in the snapshot. Check status.snapshotVolumes for excluded volumes and VM VolumeSnapshotStatus for details.",
 }
 
 func VmSnapshotReady(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
@@ -901,6 +902,26 @@ func updateSnapshotSourceIndications(snapshot *snapshotv1.VirtualMachineSnapshot
 	}
 }
 
+func (ctrl *VMSnapshotController) addPartialSnapshotIndication(snapshot *snapshotv1.VirtualMachineSnapshot) {
+	for _, indication := range snapshot.Status.SourceIndications {
+		if indication.Indication == snapshotv1.VMSnapshotPartialSnapshotIndication {
+			return
+		}
+	}
+
+	partialSnapshotIndication := snapshotv1.SourceIndication{
+		Indication: snapshotv1.VMSnapshotPartialSnapshotIndication,
+		Message:    IndicationMessage(snapshotv1.VMSnapshotPartialSnapshotIndication),
+	}
+	snapshot.Status.SourceIndications = append(snapshot.Status.SourceIndications, partialSnapshotIndication)
+
+	// Keep deprecated field in sync without rebuilding the slice
+	indications := sets.New(snapshot.Status.Indications...)
+	if !indications.Has(snapshotv1.VMSnapshotPartialSnapshotIndication) {
+		snapshot.Status.Indications = append(snapshot.Status.Indications, snapshotv1.VMSnapshotPartialSnapshotIndication)
+	}
+}
+
 func (ctrl *VMSnapshotController) updateSnapshotSnapshotableVolumes(snapshot *snapshotv1.VirtualMachineSnapshot, content *snapshotv1.VirtualMachineSnapshotContent) error {
 	if content == nil {
 		return nil
@@ -921,17 +942,27 @@ func (ctrl *VMSnapshotController) updateSnapshotSnapshotableVolumes(snapshot *sn
 
 	var excludedVolumes []string
 	var includedVolumes []string
+	hasExcludedSnapshottableVolume := false
 	for _, volume := range volumes {
 		if _, ok := volumeBackups[volume.Name]; ok {
 			includedVolumes = append(includedVolumes, volume.Name)
 		} else {
 			excludedVolumes = append(excludedVolumes, volume.Name)
+			// Track if any excluded volume was snapshottable
+			if !hasExcludedSnapshottableVolume && ctrl.isVolumeSnapshottable(&volume) {
+				hasExcludedSnapshottableVolume = true
+			}
 		}
 	}
 	snapshot.Status.SnapshotVolumes = &snapshotv1.SnapshotVolumesLists{
 		IncludedVolumes: includedVolumes,
 		ExcludedVolumes: excludedVolumes,
 	}
+
+	if hasExcludedSnapshottableVolume {
+		ctrl.addPartialSnapshotIndication(snapshot)
+	}
+
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -77,11 +77,12 @@ type VirtualMachineSnapshotSpec struct {
 type Indication string
 
 const (
-	VMSnapshotOnlineSnapshotIndication Indication = "Online"
-	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
-	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
-	VMSnapshotQuiesceTimeoutIndication Indication = "QuiesceTimeout"
-	VMSnapshotPausedIndication         Indication = "Paused"
+	VMSnapshotOnlineSnapshotIndication  Indication = "Online"
+	VMSnapshotNoGuestAgentIndication    Indication = "NoGuestAgent"
+	VMSnapshotGuestAgentIndication      Indication = "GuestAgent"
+	VMSnapshotQuiesceTimeoutIndication  Indication = "QuiesceTimeout"
+	VMSnapshotPausedIndication          Indication = "Paused"
+	VMSnapshotPartialSnapshotIndication Indication = "PartialSnapshot"
 )
 
 // SourceIndication provides an indication of the source VM with its description message

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -78,11 +78,12 @@ type VirtualMachineSnapshotSpec struct {
 type Indication string
 
 const (
-	VMSnapshotOnlineSnapshotIndication Indication = "Online"
-	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
-	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
-	VMSnapshotQuiesceTimeoutIndication Indication = "QuiesceTimeout"
-	VMSnapshotPausedIndication         Indication = "Paused"
+	VMSnapshotOnlineSnapshotIndication  Indication = "Online"
+	VMSnapshotNoGuestAgentIndication    Indication = "NoGuestAgent"
+	VMSnapshotGuestAgentIndication      Indication = "GuestAgent"
+	VMSnapshotQuiesceTimeoutIndication  Indication = "QuiesceTimeout"
+	VMSnapshotPausedIndication          Indication = "Paused"
+	VMSnapshotPartialSnapshotIndication Indication = "PartialSnapshot"
 )
 
 // SourceIndication provides an indication of the source VM with its description message

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1317,6 +1317,12 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes[0]).Should(Equal("snapshotablevolume"))
 				Expect(snapshot.Status.SnapshotVolumes.ExcludedVolumes).Should(HaveLen(1))
 				Expect(snapshot.Status.SnapshotVolumes.ExcludedVolumes[0]).Should(Equal("notsnapshotablevolume"))
+
+				By("Verifying PartialSnapshot indication is set when snapshottable volume is excluded")
+				Expect(snapshot.Status.Indications).Should(ContainElement(snapshotv1.VMSnapshotPartialSnapshotIndication))
+				Expect(snapshot.Status.SourceIndications).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Indication": Equal(snapshotv1.VMSnapshotPartialSnapshotIndication),
+				})))
 			})
 
 			It("Should also include backend PVC in the snapshot", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR introduces a new PartialSnapshot indication to notify users when a VM snapshot doesn't include all snapshottable volumes. The indication is added to the snapshot status when volumes of snapshottable types (PVC, DataVolume, or MemoryDump) are excluded from the snapshot.

Non-snapshottable volumes being excluded do not trigger this indication.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Snapshot: Add PartialSnapshot indication for excluded volumes
```

