### PR TITLE
virtctl expose: Add ownerReference to created Services

### DIFF
--- a/pkg/virtctl/expose/BUILD.bazel
+++ b/pkg/virtctl/expose/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apimachinery:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/virtctl/clientconfig:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -14,6 +15,7 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
     ],
 )
@@ -40,6 +42,7 @@ go_test(
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],


### PR DESCRIPTION
### What this PR does

When using `virtctl expose` to create a Service for a VM, VMI, or VMIRS, the Service is now created with an ownerReference pointing to the exposed resource. This enables automatic garbage collection by Kubernetes when the owner is deleted, preventing resource leaks.

The ownerReference uses BlockOwnerDeletion=false for RBAC compatibility, following the established pattern from other virtctl commands.

### Testing
Covered using unit tests.

Verified also on a live cluster:

- Create VM:

```
$ cat <<EOF | kubectl apply -f -
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: test-vm
spec:
  running: true
  template:
    metadata:
      labels:
        kubevirt.io/vm: test-vm
    spec:
      domain:
        devices:
          disks:
          - name: containerdisk
            disk:
              bus: virtio
          interfaces:
          - name: default
            masquerade: {}
        resources:
          requests:
            memory: 64M
      networks:
      - name: default
        pod: {}
      volumes:
      - name: containerdisk
        containerDisk:
          image: quay.io/kubevirt/cirros-container-disk-demo:latest
EOF

virtualmachine.kubevirt.io/test-vm created
```

- Check VM:

```
$ kubectl get vms -A
NAMESPACE   NAME      AGE   STATUS     READY
default     test-vm   22s   Running   True
```

- Create service using expose:

```
$ virtctl expose vm test-vm --name=test-svc --port=22 --kubeconfig=./kubevirtci/_ci-configs/k8s-1.34/.kubeconfig 
Service test-svc successfully created for vm test-vm
```

- Check the service created and confirm the `ownerReferences` is there:

```
$ kubectl get svc test-svc -o yaml
selecting podman as container runtime
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2026-02-18T09:32:50Z"
  name: test-svc
  namespace: default
  ownerReferences:
  - apiVersion: kubevirt.io/v1
    blockOwnerDeletion: false
    controller: true
    kind: VirtualMachine
    name: test-vm
    uid: eff6aef7-29a8-480e-aaea-2f249e2f2dd5
  resourceVersion: "9221"
  uid: 3467e70f-ccf7-42d6-9f5a-4e822723fbcf
spec:
  clusterIP: fd10:96::a:4723
  clusterIPs:
  - fd10:96::a:4723
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv6
  ipFamilyPolicy: SingleStack
  ports:
  - port: 22
    protocol: TCP
    targetPort: 22
  selector:
    vmi.kubevirt.io/id: test-vm
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```

- Delete the VM:

```
$ kubectl delete vm test-vm
virtualmachine.kubevirt.io "test-vm" deleted from default namespace
```

- Check if the service exists:

```
$ kubectl get svc test-svc
Error from server (NotFound): services "test-svc" not found
```

### References

- Fixes: https://issues.redhat.com/browse/CNV-79964
  
### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
'virtctl expose' creates now services with an ownerReference pointing to the exposed resource. 
```

