### PR TITLE
bazel server: reload on network changes

### DIFF
--- a/hack/bazel-server.sh
+++ b/hack/bazel-server.sh
@@ -3,6 +3,21 @@ if [ "$KUBEVIRT_NO_BAZEL" = true ]; then
     sleep infinity
 else
     BAZEL_PID=$(bazel info | grep server_pid | cut -d " " -f 2)
+
+    # Shut down the bazel server on network changes
+    (
+        initial=$(cat /proc/net/route 2>/dev/null)
+        while kill -0 $BAZEL_PID 2>/dev/null; do
+            sleep 5
+            current=$(cat /proc/net/route 2>/dev/null)
+            if [ "$initial" != "$current" ]; then
+                echo "Network change detected, shutting down bazel server..."
+                bazel shutdown
+                break
+            fi
+        done
+    ) &
+
     while kill -0 $BAZEL_PID 2>/dev/null; do sleep 1; done
     # Might not be necessary, just to be sure that exec shutdowns always succeed
     # and are not killed by docker.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
the server container starting before network changes
can trigger all sorts of weird errors like
```
java.io.IOException: Error downloading [https://github.com/google/go-containerregistry/releases/download/v0.18.0/go-containerregistry_Linux_x86_64.tar.gz] to /root/.cache/bazel/_bazel_root/6f347497f91c9a385dcd9294645b76e0/external/oci_crane_linux_amd64/temp750214973604621885/go-containerregistry_Linux_x86_64.tar.gz: Unknown host: github.com
```
this could be a nice quality of life improvement for the dev environment

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Maintenance: make the bazel server container reload on network changes
```

