### PR TITLE
tests: move guest agent tests out of vmi_conf_tests

### DIFF
--- a/hack/lint-test-cleanup-label.sh
+++ b/hack/lint-test-cleanup-label.sh
@@ -21,10 +21,11 @@
 EXCLUDE_PATTERN="./decorators/decorators.go|\
 ./tests_suite_test.go|\
 ./tests/virtctl|\
-./tests/network"
+./tests/network|\
+./tests/compute/guest_agent.go"
 
 if grep -rl 'OncePerOrderedCleanup' ./tests --include=*.go |
     grep -Evq "$EXCLUDE_PATTERN"; then
-    echo "The use of OncePerOrderedCleanup label is currently limited to SIG-Network and virtctl tests only"
+    echo "The use of OncePerOrderedCleanup label is currently limited to a hand-picked list of paths"
     exit 1
 fi

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -236,16 +236,10 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			libwait.WaitForSuccessfulVMIStart(agentVMI)
 
 			By("VMI has the guest agent connected condition")
-			Eventually(func() []v1.VirtualMachineInstanceCondition {
-				freshVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-				return freshVMI.Status.Conditions
-			}, guestAgentConnectTimeout, 2*time.Second).Should(
-				ContainElement(
-					MatchFields(
-						IgnoreExtras,
-						Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
-				"Should have agent connected condition")
+			Eventually(matcher.ThisVMI(agentVMI)).
+				WithTimeout(guestAgentConnectTimeout).
+				WithPolling(2 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Logging in to the guest")
 			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
@@ -285,7 +279,9 @@ var _ = Describe(SIG("GuestAgent info", func() {
 					return false
 				}
 				return updatedVmi.Status.GuestOSInfo.Name != ""
-			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in vmi status")
+			}).WithTimeout(guestAgentConnectTimeout).
+				WithPolling(2*time.Second).
+				Should(BeTrue(), "Should have guest OS Info in vmi status")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
@@ -306,7 +302,9 @@ var _ = Describe(SIG("GuestAgent info", func() {
 					guestInfo.OS.Name != "" &&
 					len(guestInfo.FSInfo.Filesystems) > 0
 
-			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in subresource")
+			}).WithTimeout(guestAgentConnectTimeout).
+				WithPolling(2*time.Second).
+				Should(BeTrue(), "Should have guest OS Info in subresource")
 		})
 
 		It("[test_id:4629]should return user list", func() {
@@ -320,7 +318,9 @@ var _ = Describe(SIG("GuestAgent info", func() {
 
 				return len(userList.Items) > 0 && userList.Items[0].UserName == "fedora"
 
-			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have fedora users")
+			}).WithTimeout(guestAgentConnectTimeout).
+				WithPolling(2*time.Second).
+				Should(BeTrue(), "Should have fedora users")
 		})
 
 		It("[test_id:4630]should return filesystem list", func() {
@@ -335,7 +335,9 @@ var _ = Describe(SIG("GuestAgent info", func() {
 				return len(fsList.Items) > 0 && fsList.Items[0].DiskName != "" && fsList.Items[0].MountPoint != "" &&
 					len(fsList.Items[0].Disk) > 0 && fsList.Items[0].Disk[0].BusType != ""
 
-			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have some filesystem")
+			}).WithTimeout(guestAgentConnectTimeout).
+				WithPolling(2*time.Second).
+				Should(BeTrue(), "Should have some filesystem")
 		})
 	})
 
@@ -376,7 +378,9 @@ var _ = Describe(SIG("GuestAgent info", func() {
 					return err.Error()
 				}
 				return ""
-			}, guestAgentConnectTimeout, 2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
+			}).WithTimeout(guestAgentConnectTimeout).
+				WithPolling(2*time.Second).
+				Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
 		})
 	})
 

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -52,6 +52,11 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const (
+	guestAgentConnectTimeout = 4 * time.Minute
+	vmiStartTimeout          = 180
+)
+
 var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 	Context("Readiness Probe", func() {
 		const (
@@ -66,11 +71,11 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 				libnet.WithMasqueradeNetworking(),
 				withReadinessProbe(readinessProbe),
 			)
-			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, vmiStartTimeout)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi)).
-				WithTimeout(12 * time.Minute).
+				WithTimeout(guestAgentConnectTimeout).
 				WithPolling(2 * time.Second).
 				Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
@@ -85,7 +90,7 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 				libnet.WithMasqueradeNetworking(),
 				withReadinessProbe(readinessProbe),
 			)
-			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, vmiStartTimeout)
 
 			By("Checking that the VMI is consistently non-ready")
 			Consistently(matcher.ThisVMI(vmi)).
@@ -112,9 +117,9 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 
 		BeforeEach(func() {
 			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withReadinessProbe(createGuestAgentPingProbe(period, initialSeconds)))
-			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, vmiStartTimeout)
 			By("Waiting for agent to connect")
-			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+			Eventually(matcher.ThisVMI(vmi), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			Eventually(matcher.ThisVMI(vmi), 2*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
 			By("Disabling the guest-agent")
@@ -151,11 +156,11 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 		It("Should not fail the VMI", func() {
 			livenessProbe := createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a")
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withLivenessProbe(livenessProbe))
-			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, vmiStartTimeout)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi)).
-				WithTimeout(12 * time.Minute).
+				WithTimeout(guestAgentConnectTimeout).
 				WithPolling(2 * time.Second).
 				Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
@@ -172,7 +177,7 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 		It("Should fail the VMI with working Exec probe and invalid command", func() {
 			livenessProbe := createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1")
 			vmi := libvmifact.NewFedora(withLivenessProbe(livenessProbe))
-			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, vmiStartTimeout)
 
 			By("Checking that the VMI is in a final state after a while")
 			Eventually(func() bool {
@@ -195,11 +200,11 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 
 		BeforeEach(func() {
 			vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withLivenessProbe(createGuestAgentPingProbe(period, initialSeconds)))
-			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, vmiStartTimeout)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi)).
-				WithTimeout(12 * time.Minute).
+				WithTimeout(guestAgentConnectTimeout).
 				WithPolling(2 * time.Second).
 				Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -235,7 +240,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 				freshVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 				return freshVMI.Status.Conditions
-			}, 240*time.Second, 2*time.Second).Should(
+			}, guestAgentConnectTimeout, 2*time.Second).Should(
 				ContainElement(
 					MatchFields(
 						IgnoreExtras,
@@ -280,7 +285,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 					return false
 				}
 				return updatedVmi.Status.GuestOSInfo.Name != ""
-			}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in vmi status")
+			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in vmi status")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
@@ -301,7 +306,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 					guestInfo.OS.Name != "" &&
 					len(guestInfo.FSInfo.Filesystems) > 0
 
-			}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in subresource")
+			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in subresource")
 		})
 
 		It("[test_id:4629]should return user list", func() {
@@ -315,7 +320,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 
 				return len(userList.Items) > 0 && userList.Items[0].UserName == "fedora"
 
-			}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have fedora users")
+			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have fedora users")
 		})
 
 		It("[test_id:4630]should return filesystem list", func() {
@@ -330,7 +335,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 				return len(fsList.Items) > 0 && fsList.Items[0].DiskName != "" && fsList.Items[0].MountPoint != "" &&
 					len(fsList.Items[0].Disk) > 0 && fsList.Items[0].Disk[0].BusType != ""
 
-			}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have some filesystem")
+			}, guestAgentConnectTimeout, 2*time.Second).Should(BeTrue(), "Should have some filesystem")
 		})
 	})
 
@@ -347,7 +352,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			libwait.WaitForSuccessfulVMIStart(agentVMI)
 
 			By("Waiting for the guest agent to connect")
-			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Expecting the VirtualMachineInstance console")
 			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
@@ -356,7 +361,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			Expect(stopGuestAgent(agentVMI)).To(Succeed())
 
 			By("VMI has the guest agent connected condition")
-			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
+			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 		})
 
 		It("[test_id:4625]should remove condition when agent is off", func() {
@@ -371,7 +376,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 					return err.Error()
 				}
 				return ""
-			}, 240*time.Second, 2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
+			}, guestAgentConnectTimeout, 2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
 		})
 	})
 
@@ -396,7 +401,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 			libwait.WaitForSuccessfulVMIStart(agentVMI)
 
-			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
+			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
 		})
 
 		It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", func() {
@@ -412,7 +417,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			libwait.WaitForSuccessfulVMIStart(agentVMI)
 
 			By("VMI has the guest agent connected condition")
-			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("fetching the VMI after agent has connected")
 			Expect(matcher.ThisVMI(agentVMI)()).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceUnsupportedAgent))

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -254,9 +254,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 		})
 
 		It("[test_id:1677]VMI condition should signal agent presence", func() {
-			getOptions := metav1.GetOptions{}
-
-			freshVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, getOptions)
+			freshVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 			Expect(freshVMI.Status.Conditions).To(
 				ContainElement(
@@ -264,17 +262,15 @@ var _ = Describe(SIG("GuestAgent info", func() {
 						IgnoreExtras,
 						Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
 				"agent should already be connected")
-
 		})
 
 		It("[test_id:4626]should have guestosinfo in status when agent is present", func() {
-			getOptions := metav1.GetOptions{}
 			var updatedVmi *v1.VirtualMachineInstance
 			var err error
 
 			By("Expecting the Guest VM information")
 			Eventually(func() bool {
-				updatedVmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, getOptions)
+				updatedVmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
@@ -361,8 +357,6 @@ var _ = Describe(SIG("GuestAgent info", func() {
 
 			By("Terminating guest agent and waiting for it to disappear.")
 			Expect(stopGuestAgent(agentVMI)).To(Succeed())
-
-			By("VMI has the guest agent connected condition")
 			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 		})
 

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -214,21 +214,21 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 }))
 
 var _ = Describe(SIG("GuestAgent info", func() {
-	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent", func() {
-		prepareAgentVM := func() *v1.VirtualMachineInstance {
-			agentVMI := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
+	Context("with running guest agent", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var agentVMI *v1.VirtualMachineInstance
+
+		BeforeAll(func() {
+			agentVMI = libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 
 			By("Starting a VirtualMachineInstance")
-			agentVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
+			var err error
+			agentVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 			libwait.WaitForSuccessfulVMIStart(agentVMI)
 
-			getOptions := metav1.GetOptions{}
-			var freshVMI *v1.VirtualMachineInstance
-
 			By("VMI has the guest agent connected condition")
 			Eventually(func() []v1.VirtualMachineInstanceCondition {
-				freshVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, getOptions)
+				freshVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 				return freshVMI.Status.Conditions
 			}, 240*time.Second, 2*time.Second).Should(
@@ -238,11 +238,11 @@ var _ = Describe(SIG("GuestAgent info", func() {
 						Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
 				"Should have agent connected condition")
 
-			return agentVMI
-		}
+			By("Logging in to the guest")
+			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
+		})
 
 		It("[test_id:1677]VMI condition should signal agent presence", func() {
-			agentVMI := prepareAgentVM()
 			getOptions := metav1.GetOptions{}
 
 			freshVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, getOptions)
@@ -256,23 +256,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 
 		})
 
-		It("[test_id:4625]should remove condition when agent is off", func() {
-			agentVMI := prepareAgentVM()
-			By("Expecting the VirtualMachineInstance console")
-			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
-
-			By("Terminating guest agent and waiting for it to disappear.")
-			Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-				&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
-				&expect.BExp{R: ""},
-			}, 400)).To(Succeed())
-
-			By("VMI has the guest agent connected condition")
-			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
-		})
-
 		It("[test_id:4626]should have guestosinfo in status when agent is present", func() {
-			agentVMI := prepareAgentVM()
 			getOptions := metav1.GetOptions{}
 			var updatedVmi *v1.VirtualMachineInstance
 			var err error
@@ -291,8 +275,6 @@ var _ = Describe(SIG("GuestAgent info", func() {
 		})
 
 		It("[test_id:4627]should return the whole data when agent is present", func() {
-			agentVMI := prepareAgentVM()
-
 			By("Expecting the Guest VM information")
 			Eventually(func() bool {
 				guestInfo, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).GuestOsInfo(context.Background(), agentVMI.Name)
@@ -310,33 +292,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in subresource")
 		})
 
-		It("[test_id:4628]should not return the whole data when agent is not present", func() {
-			agentVMI := prepareAgentVM()
-
-			By("Expecting the VirtualMachineInstance console")
-			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
-
-			By("Terminating guest agent and waiting for it to disappear.")
-			Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-				&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
-				&expect.BExp{R: ""},
-			}, 400)).To(Succeed())
-
-			By("Expecting the Guest VM information")
-			Eventually(func() string {
-				_, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).GuestOsInfo(context.Background(), agentVMI.Name)
-				if err != nil {
-					return err.Error()
-				}
-				return ""
-			}, 240*time.Second, 2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
-		})
-
 		It("[test_id:4629]should return user list", func() {
-			agentVMI := prepareAgentVM()
-
-			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
-
 			By("Expecting the Guest VM information")
 			Eventually(func() bool {
 				userList, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).UserList(context.Background(), agentVMI.Name)
@@ -351,8 +307,6 @@ var _ = Describe(SIG("GuestAgent info", func() {
 		})
 
 		It("[test_id:4630]should return filesystem list", func() {
-			agentVMI := prepareAgentVM()
-
 			By("Expecting the Guest VM information")
 			Eventually(func() bool {
 				fsList, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).FilesystemList(context.Background(), agentVMI.Name)
@@ -365,6 +319,50 @@ var _ = Describe(SIG("GuestAgent info", func() {
 					len(fsList.Items[0].Disk) > 0 && fsList.Items[0].Disk[0].BusType != ""
 
 			}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have some filesystem")
+		})
+	})
+
+	Context("without running guest agent", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var agentVMI *v1.VirtualMachineInstance
+
+		BeforeAll(func() {
+			agentVMI = libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
+
+			By("Starting a VirtualMachineInstance")
+			var err error
+			agentVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+			libwait.WaitForSuccessfulVMIStart(agentVMI)
+
+			By("Waiting for the guest agent to connect")
+			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("Expecting the VirtualMachineInstance console")
+			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
+
+			By("Terminating guest agent and waiting for it to disappear.")
+			Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
+				&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
+				&expect.BExp{R: ""},
+			}, 400)).To(Succeed())
+
+			By("VMI has the guest agent connected condition")
+			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
+		})
+
+		It("[test_id:4625]should remove condition when agent is off", func() {
+			Expect(matcher.ThisVMI(agentVMI)()).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
+		})
+
+		It("[test_id:4628]should not return the whole data when agent is not present", func() {
+			By("Expecting the Guest VM information")
+			Eventually(func() string {
+				_, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).GuestOsInfo(context.Background(), agentVMI.Name)
+				if err != nil {
+					return err.Error()
+				}
+				return ""
+			}, 240*time.Second, 2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
 		})
 	})
 }))

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -353,10 +353,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
 
 			By("Terminating guest agent and waiting for it to disappear.")
-			Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-				&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
-				&expect.BExp{R: ""},
-			}, 400)).To(Succeed())
+			Expect(stopGuestAgent(agentVMI)).To(Succeed())
 
 			By("VMI has the guest agent connected condition")
 			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -37,11 +37,15 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libkubevirt"
+	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -374,6 +378,49 @@ var _ = Describe(SIG("GuestAgent info", func() {
 		})
 	})
 
+	Context("with cluster config changes", Serial, func() {
+		BeforeEach(func() {
+			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
+
+			config := kv.Spec.Configuration
+			config.SupportedGuestAgentVersions = []string{"X.*"}
+			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
+		})
+
+		It("[test_id:5267]VMI condition should signal unsupported agent presence", func() {
+			agentVMI := libvmifact.NewFedora(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithCloudInitNoCloud(
+					libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-shutdown")),
+				),
+			)
+			By("Starting a VirtualMachineInstance")
+			agentVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+			libwait.WaitForSuccessfulVMIStart(agentVMI)
+
+			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
+		})
+
+		It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", func() {
+			agentVMI := libvmifact.NewFedora(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithCloudInitNoCloud(
+					libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec,guest-set-password")),
+				),
+			)
+			By("Starting a VirtualMachineInstance")
+			agentVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+			libwait.WaitForSuccessfulVMIStart(agentVMI)
+
+			By("VMI has the guest agent connected condition")
+			Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("fetching the VMI after agent has connected")
+			Expect(matcher.ThisVMI(agentVMI)()).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceUnsupportedAgent))
+		})
+	})
 }))
 
 func createExecProbe(period, initialSeconds, timeoutSeconds int32, command ...string) *v1.Probe {

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -242,6 +242,14 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			Expect(console.LoginToFedora(agentVMI)).To(Succeed())
 		})
 
+		It("[test_id:1676]should have attached a guest agent channel by default", func() {
+			By("Verifying the guest agent virtio-serial port is visible inside the guest")
+			Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
+				&expect.BSnd{S: "cat /sys/class/virtio-ports/*/name 2>/dev/null | grep -c org.qemu.guest_agent.0\n"},
+				&expect.BExp{R: console.RetValue("1")},
+			}, 30)).To(Succeed(), "Guest agent virtio-serial port should be present in the guest")
+		})
+
 		It("[test_id:1677]VMI condition should signal agent presence", func() {
 			getOptions := metav1.GetOptions{}
 
@@ -365,6 +373,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			}, 240*time.Second, 2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
 		})
 	})
+
 }))
 
 func createExecProbe(period, initialSeconds, timeoutSeconds int32, command ...string) *v1.Probe {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -889,7 +889,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					freshVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, getOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 					return freshVMI.Status.Conditions
-				}, 240*time.Second, 2).Should(
+				}, 240*time.Second, 2*time.Second).Should(
 					ContainElement(
 						MatchFields(
 							IgnoreExtras,
@@ -943,7 +943,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}, 400)).To(Succeed())
 
 				By("VMI has the guest agent connected condition")
-				Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
+				Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 			})
 
 			Context("with cluster config changes", Serial, func() {
@@ -1003,7 +1003,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						return false
 					}
 					return updatedVmi.Status.GuestOSInfo.Name != ""
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in vmi status")
+				}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in vmi status")
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
@@ -1026,7 +1026,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						guestInfo.OS.Name != "" &&
 						len(guestInfo.FSInfo.Filesystems) > 0
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in subresource")
+				}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have guest OS Info in subresource")
 			})
 
 			It("[test_id:4628]should not return the whole data when agent is not present", func() {
@@ -1048,7 +1048,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						return err.Error()
 					}
 					return ""
-				}, 240*time.Second, 2).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
+				}, 240*time.Second, 2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
 			})
 
 			It("[test_id:4629]should return user list", func() {
@@ -1066,7 +1066,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 					return len(userList.Items) > 0 && userList.Items[0].UserName == "fedora"
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have fedora users")
+				}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have fedora users")
 			})
 
 			It("[test_id:4630]should return filesystem list", func() {
@@ -1083,7 +1083,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					return len(fsList.Items) > 0 && fsList.Items[0].DiskName != "" && fsList.Items[0].MountPoint != "" &&
 						len(fsList.Items[0].Disk) > 0 && fsList.Items[0].Disk[0].BusType != ""
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have some filesystem")
+				}, 240*time.Second, 2*time.Second).Should(BeTrue(), "Should have some filesystem")
 			})
 
 		})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -871,23 +871,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent", func() {
-			It("[test_id:1676]should have attached a guest agent channel by default", func() {
-				agentVMI := libvmifact.NewAlpine()
-				By("Starting a VirtualMachineInstance")
-				agentVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
-				libwait.WaitForSuccessfulVMIStart(agentVMI)
-
-				By("Logging in to the guest")
-				Expect(console.LoginToAlpine(agentVMI)).To(Succeed())
-
-				By("Verifying the guest agent virtio-serial port is visible inside the guest")
-				Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-					&expect.BSnd{S: "cat /sys/class/virtio-ports/*/name 2>/dev/null | grep -c org.qemu.guest_agent.0\n"},
-					&expect.BExp{R: console.RetValue("1")},
-				}, 30)).To(Succeed(), "Guest agent virtio-serial port should be present in the guest")
-			})
-
 			Context("with cluster config changes", Serial, func() {
 				BeforeEach(func() {
 					kv := libkubevirt.GetCurrentKv(virtClient)


### PR DESCRIPTION
This PR tidies up a bit the over-crowded vmi_configuration_test by moving guest-agent-related tests to compute/guest_agent.go.

When possible, it uses `OncePerOrderedCleanup` to save 6 expensive VM startups.

I am aware that some people in the community believe that ensuring randomization between tests is more important than reducing the test runtime and fragility. I believe that in the moved tests it is very clear that repeated preparation is superfluous and expensive relative to the value of the tests.

This PR significantly reduces the runtime of the affected tests. In a test run before it, they consumed 556s of CI resources
```
for t in test_id:1676 test_id:1677 test_id:4625 test_id:4626 test_id:4627 test_id:4628 test_id:4629 test_id:4630 test_id:5267 test_id:6958; do grep $t junit-sigcompute.xml ; done
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:1676]should have attached a guest agent channel by default" classname="KubeVirt Tests Suite" time="18.273216811"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:1677]VMI condition should signal agent presence" classname="KubeVirt Tests Suite" time="41.279574176"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:4625]should remove condition when agent is off" classname="KubeVirt Tests Suite" time="50.892042375"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:4626]should have guestosinfo in status when agent is present" classname="KubeVirt Tests Suite" time="40.25963206"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:4627]should return the whole data when agent is present" classname="KubeVirt Tests Suite" time="39.341429489"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:4628]should not return the whole data when agent is not present" classname="KubeVirt Tests Suite" time="48.010682751"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:4629]should return user list" classname="KubeVirt Tests Suite" time="50.839412356"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent [test_id:4630]should return filesystem list" classname="KubeVirt Tests Suite" time="42.304756888"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent with cluster config changes [test_id:5267]VMI condition should signal unsupported agent presence" classname="KubeVirt Tests Suite" time="113.63170994"></testcase>
      <testcase name="[sig-compute]Configurations VirtualMachineInstance definition [rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent with cluster config changes [test_id:6958]VMI condition should not signal unsupported agent presence for optional commands" classname="KubeVirt Tests Suite" time="111.527916995"></testcase>
```
After this PR, these tests consume only 125s
```
$ for t in test_id:1676 test_id:1677 test_id:4625 test_id:4626 test_id:4627 test_id:4628 test_id:4629 test_id:4630 test_id:5267 test_id:6958; do grep $t junit.functest.xml ; done 
      <testcase name="[sig-compute] GuestAgent info with running guest agent [test_id:1676]should have attached a guest agent channel by default" classname="KubeVirt Tests Suite" time="41.897606024"></testcase>
      <testcase name="[sig-compute] GuestAgent info with running guest agent [test_id:1677]VMI condition should signal agent presence" classname="KubeVirt Tests Suite" time="0.006747648"></testcase>
      <testcase name="[sig-compute] GuestAgent info without running guest agent [test_id:4625]should remove condition when agent is off" classname="KubeVirt Tests Suite" time="42.412931989"></testcase>
      <testcase name="[sig-compute] GuestAgent info with running guest agent [test_id:4626]should have guestosinfo in status when agent is present" classname="KubeVirt Tests Suite" time="0.005624794"></testcase>
      <testcase name="[sig-compute] GuestAgent info with running guest agent [test_id:4627]should return the whole data when agent is present" classname="KubeVirt Tests Suite" time="0.022811759"></testcase>
      <testcase name="[sig-compute] GuestAgent info without running guest agent [test_id:4628]should not return the whole data when agent is not present" classname="KubeVirt Tests Suite" time="14.463144467"></testcase>
      <testcase name="[sig-compute] GuestAgent info with running guest agent [test_id:4629]should return user list" classname="KubeVirt Tests Suite" time="2.077427455"></testcase>
      <testcase name="[sig-compute] GuestAgent info with running guest agent [test_id:4630]should return filesystem list" classname="KubeVirt Tests Suite" time="24.400553179"></testcase>
      <testcase name="[sig-compute] GuestAgent info with cluster config changes [test_id:5267]VMI condition should signal unsupported agent presence" classname="KubeVirt Tests Suite" time="0">
      <testcase name="[sig-compute] GuestAgent info with cluster config changes [test_id:6958]VMI condition should not signal unsupported agent presence for optional commands" classname="KubeVirt Tests Suite" time="0">

```

The average execution of  sig compute with this PR was 1h32m26s ± 5s

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16889/pull-kubevirt-e2e-k8s-1.35-sig-compute/2028127919615774720 1h32m31s
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16889/pull-kubevirt-e2e-k8s-1.35-sig-compute/2025910961591816192 1h32m22s
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16889/pull-kubevirt-e2e-k8s-1.35-sig-compute/2024861102201901056 1h32m26s

While successful executions of
https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-computefg
took (5605+5678+6139+61410+5575+5387)/6/60 = 1h35m54s ± 5m13s . The variance is big, but the average makes sense: it's 2m30s longer to start more VMs.

/kind cleanup

```release-note
NONE
```

