### PR TITLE
vGPU: SRIOV support

### DIFF
--- a/pkg/virt-handler/device-manager/BUILD.bazel
+++ b/pkg/virt-handler/device-manager/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "generic_device.go",
         "mediated_device.go",
         "mediated_devices_types.go",
+        "nvidia.go",
         "pci_device.go",
         "socket_device.go",
         "usb_device.go",

--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -24,6 +24,7 @@ package device_manager
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -43,14 +44,16 @@ import (
 )
 
 type DeviceHandler interface {
-	GetDeviceIOMMUGroup(basepath string, pciAddress string) (string, error)
-	GetDeviceDriver(basepath string, pciAddress string) (string, error)
-	GetDeviceNumaNode(basepath string, pciAddress string) (numaNode int)
-	GetDevicePCIID(basepath string, pciAddress string) (string, error)
+	GetDeviceIOMMUGroup(basepath, pciAddress string) (string, error)
+	GetDeviceDriver(basepath, pciAddress string) (string, error)
+	GetDeviceNumaNode(basepath, pciAddress string) (numaNode int)
+	GetDevicePCIID(basepath, pciAddress string) (string, error)
 	GetMdevParentPCIAddr(mdevUUID string) (string, error)
 	CreateMDEVType(mdevType string, parentID string) error
 	RemoveMDEVType(mdevUUID string) error
 	ReadMDEVAvailableInstances(mdevType string, parentID string) (int, error)
+	HasVGPUProfile(basepath, pciAddress string) bool
+	IsPhysicalFunction(basepath, pciAddress string) bool
 }
 
 type DeviceUtilsHandler struct{}
@@ -194,6 +197,38 @@ func (h *DeviceUtilsHandler) ReadMDEVAvailableInstances(mdevType string, parentI
 	}
 
 	return i, nil
+}
+
+// Returns true if the device has a vGPU profile assigned (current_vgpu_type != 0).
+func (h *DeviceUtilsHandler) HasVGPUProfile(basepath, pciAddress string) bool {
+	vgpuTypePath := filepath.Join(basepath, pciAddress, "nvidia", "current_vgpu_type")
+	data, err := os.ReadFile(vgpuTypePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("%s has no gpu profile", pciAddress)
+		return false
+	}
+
+	vgpuType := strings.TrimSpace(string(data))
+	return vgpuType != "" && vgpuType != "0"
+}
+
+// IsPhysicalFunction checks if a PCI device is an SR-IOV Physical Function by
+// looking for sriov_totalvfs subdirectories in its sysfs path. Only Physical Functions
+// have these subdirectories representing their associated Virtual Functions.
+func (h *DeviceUtilsHandler) IsPhysicalFunction(basepath, pciAddress string) bool {
+	fpath := filepath.Join(basepath, pciAddress, "sriov_totalvfs")
+
+	_, err := os.Stat(fpath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("%s is not physical function", pciAddress)
+	}
+	return err == nil
 }
 
 func waitForGRPCServer(socketPath string, timeout time.Duration) error {

--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -109,7 +109,12 @@ var _ = Describe("Device Controller", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockPCI = NewMockDeviceHandler(ctrl)
 		mockPCI.EXPECT().GetDevicePCIID(gomock.Any(), gomock.Any()).Return("1234:5678", nil).AnyTimes()
+
+		oldHandler := handler
 		handler = mockPCI
+		DeferCleanup(func() {
+			handler = oldHandler
+		})
 
 		fakeConfigMap, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 			PermittedHostDevices: &v1.PermittedHostDevices{

--- a/pkg/virt-handler/device-manager/generated_mock_common.go
+++ b/pkg/virt-handler/device-manager/generated_mock_common.go
@@ -127,6 +127,34 @@ func (mr *MockDeviceHandlerMockRecorder) GetMdevParentPCIAddr(mdevUUID any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMdevParentPCIAddr", reflect.TypeOf((*MockDeviceHandler)(nil).GetMdevParentPCIAddr), mdevUUID)
 }
 
+// HasVGPUProfile mocks base method.
+func (m *MockDeviceHandler) HasVGPUProfile(basepath, pciAddress string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasVGPUProfile", basepath, pciAddress)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasVGPUProfile indicates an expected call of HasVGPUProfile.
+func (mr *MockDeviceHandlerMockRecorder) HasVGPUProfile(basepath, pciAddress any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasVGPUProfile", reflect.TypeOf((*MockDeviceHandler)(nil).HasVGPUProfile), basepath, pciAddress)
+}
+
+// IsPhysicalFunction mocks base method.
+func (m *MockDeviceHandler) IsPhysicalFunction(basepath, pciAddress string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPhysicalFunction", basepath, pciAddress)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPhysicalFunction indicates an expected call of IsPhysicalFunction.
+func (mr *MockDeviceHandlerMockRecorder) IsPhysicalFunction(basepath, pciAddress any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPhysicalFunction", reflect.TypeOf((*MockDeviceHandler)(nil).IsPhysicalFunction), basepath, pciAddress)
+}
+
 // ReadMDEVAvailableInstances mocks base method.
 func (m *MockDeviceHandler) ReadMDEVAvailableInstances(mdevType, parentID string) (int, error) {
 	m.ctrl.T.Helper()

--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -127,7 +127,11 @@ var _ = Describe("Mediated Device", func() {
 			By("mocking PCI and MDEV functions to simulate an mdev an its parent PCI device")
 			ctrl = gomock.NewController(GinkgoT())
 			mockPCI = NewMockDeviceHandler(ctrl)
+			oldHandler := handler
 			handler = mockPCI
+			DeferCleanup(func() {
+				handler = oldHandler
+			})
 			// Force pre-defined returned values and ensure the function only get called exacly once each on 0000:00:00.0
 			mockPCI.EXPECT().GetMdevParentPCIAddr(fakeMdevUUID).Return(fakeAddress, nil).Times(1)
 			mockPCI.EXPECT().GetDeviceIOMMUGroup(mdevBasePath, fakeMdevUUID).Return(fakeIommuGroup, nil).Times(1)

--- a/pkg/virt-handler/device-manager/mediated_devices_types.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types.go
@@ -141,7 +141,7 @@ func (m *MDEVTypesManager) discoverConfigurableMDEVTypes(desiredTypesMap map[str
 		}
 
 		// The name usually contain spaces which should be replaced with _
-		typeNameStr := strings.Replace(string(rawName), " ", "_", -1)
+		typeNameStr := strings.ReplaceAll(string(rawName), " ", "_")
 		typeNameStr = strings.TrimSpace(typeNameStr)
 
 		// get this type's ID
@@ -246,7 +246,7 @@ func createMdevTypes(mdevType string, parentID string) error {
 func shouldRemoveMDEV(mdevUUID string, desiredTypesMap map[string]struct{}) bool {
 
 	if rawName, err := os.ReadFile(filepath.Join(mdevBasePath, mdevUUID, "mdev_type/name")); err == nil {
-		typeNameStr := strings.Replace(string(rawName), " ", "_", -1)
+		typeNameStr := strings.ReplaceAll(string(rawName), " ", "_")
 		typeNameStr = strings.TrimSpace(typeNameStr)
 		if _, exist := desiredTypesMap[typeNameStr]; exist {
 			return false
@@ -260,7 +260,7 @@ func shouldRemoveMDEV(mdevUUID string, desiredTypesMap map[string]struct{}) bool
 	rawName := []byte(filepath.Base(originFile))
 
 	// The name usually contain spaces which should be replaced with _
-	typeNameStr := strings.Replace(string(rawName), " ", "_", -1)
+	typeNameStr := strings.ReplaceAll(string(rawName), " ", "_")
 	typeNameStr = strings.TrimSpace(typeNameStr)
 	if _, exist := desiredTypesMap[typeNameStr]; exist {
 		return false

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -150,7 +150,12 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 		fakeNodeInformer, _ := testutils.NewFakeInformerFor(&kubev1.Node{})
 		fakeNodeStore = fakeNodeInformer.GetStore()
 		mockMDEV := NewMockDeviceHandler(gomock.NewController(GinkgoT()))
+
+		oldHandler := handler
 		handler = mockMDEV
+		DeferCleanup(func() {
+			handler = oldHandler
+		})
 		configuredMdevTypesOnCards = make(map[string]map[string]struct{})
 
 		mockMDEV.EXPECT().CreateMDEVType(gomock.Any(), gomock.Any()).DoAndReturn(func(mdevType string, parentID string) error {

--- a/pkg/virt-handler/device-manager/nvidia.go
+++ b/pkg/virt-handler/device-manager/nvidia.go
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package device_manager
+
+import "kubevirt.io/client-go/log"
+
+func shouldPermitNvidia(driver, pciBasePath, pciAddress, pciID string) bool {
+	if driver != "nvidia" {
+		return false
+	}
+	if handler.IsPhysicalFunction(pciBasePath, pciAddress) {
+		log.DefaultLogger().Infof("Skipping non-vfio-pci Physical Function %s (%s)", pciAddress, pciID)
+		return false
+	}
+
+	if !handler.HasVGPUProfile(pciBasePath, pciAddress) {
+		log.DefaultLogger().Infof("Skipping non-vfio-pci device without vGPU profile %s (%s, driver: %s)",
+			pciAddress, pciID, driver)
+		return false
+	}
+
+	log.DefaultLogger().Infof("Found vGPU-capable VF %s (%s, driver: %s)", pciAddress, pciID, driver)
+	return true
+}

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -267,8 +267,17 @@ func discoverPermittedHostPCIDevices(supportedPCIDeviceMap map[string]string) ma
 		if resourceName, supported := supportedPCIDeviceMap[pciID]; supported {
 			// check device driver
 			driver, err := handler.GetDeviceDriver(pciBasePath, info.Name())
-			if err != nil || driver != "vfio-pci" {
+			if err != nil {
+				log.DefaultLogger().Reason(err).Errorf("failed to get driver for device: %s", info.Name())
 				return nil
+			}
+
+			// For devices without vfio-pci driver, check if they're NVIDIA vGPU VFs
+			if driver != "vfio-pci" {
+				if !shouldPermitNonVFIOPCI(driver, pciBasePath, info.Name(), pciID) {
+					log.DefaultLogger().V(9).Infof("Not supported driver %s, pci %s", driver, pciID)
+					return nil
+				}
 			}
 
 			pcidev := &PCIDevice{
@@ -283,11 +292,18 @@ func discoverPermittedHostPCIDevices(supportedPCIDeviceMap map[string]string) ma
 			pcidev.driver = driver
 			pcidev.numaNode = handler.GetDeviceNumaNode(pciBasePath, info.Name())
 			pciDevicesMap[resourceName] = append(pciDevicesMap[resourceName], pcidev)
+		} else {
+			log.DefaultLogger().V(9).Infof("Not supported %s", pciID)
 		}
 		return nil
-	})
+	},
+	)
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("failed to discover host devices")
 	}
 	return pciDevicesMap
+}
+
+func shouldPermitNonVFIOPCI(driver, pciBasePath, pciAddress, pciID string) bool {
+	return shouldPermitNvidia(driver, pciBasePath, pciAddress, pciID)
 }

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -63,7 +63,11 @@ var _ = Describe("PCI Device", func() {
 
 		By("mocking PCI functions to simulate a vfio-pci device at " + fakeAddress)
 		mockPCI := NewMockDeviceHandler(gomock.NewController(GinkgoT()))
+		oldHandler := handler
 		handler = mockPCI
+		DeferCleanup(func() {
+			handler = oldHandler
+		})
 		// Force pre-defined returned values and ensure the function only get called exacly once each on 0000:00:00.0
 		mockPCI.EXPECT().GetDeviceIOMMUGroup(pciBasePath, fakeAddress).Return(fakeIommuGroup, nil).Times(1)
 		mockPCI.EXPECT().GetDeviceDriver(pciBasePath, fakeAddress).Return(fakeDriver, nil).Times(1)

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
@@ -35,6 +35,7 @@ const (
 	DefaultDisplayOn             = true
 )
 
+// TODO: Pass in also medata so metada can be constructed also in tests, include if display is possible
 func CreateHostDevices(vmiGPUs []v1.GPU) ([]api.HostDevice, error) {
 	return CreateHostDevicesFromPools(vmiGPUs, NewPCIAddressPool(vmiGPUs), NewMDEVAddressPool(vmiGPUs))
 }


### PR DESCRIPTION
### What this PR does
Starting with newer generation of NVIDIA cards (Ampere and newer) the hw is shipped with SRIOV support. Some Kernels maintain  mdev support for this cards, while others don't. This PR enables the later Kernels where the SRIOV capability is used to slice the gpu into multiple VF(Virtual Functions) and particular profile(same as mdev) is assigned for each/some (note some vfs might not have any profile. Note2 the PF cannot be passed). 
The last quirk here is that the VFs are still bind to nvidia driver rather the vfio-pci. 

Now what this PR does is following:
Extend our PCI driver to accept nvidia driver, recognize if PCI device is PF, and recognize if particular VF is assigned with profile. In these conditions the PCI can be advertised and consumed by the virt-launcher. 

Now I know I wrote last quirk already so I say "really last quirk" is that these VFs can support display and ramfb options but this PR left this out, intentionally. The support for display and ramfb for PCI will be implemented in later patch.

### Special notes for your reviewer
E2E tests are missing as we don't have a capable HW in our CI for now. I have tested these changes against supported HW.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt's PCI device plugin now supports passing of pre-setup VF (vGPU)
```

