### PR TITLE
Build Scripts for custom QEMU and Libvirt RPMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ manifests/**/*.tmp
 _ci-configs/
 .history
 hack/builder/manifests/
+hack/custom-rpms/generated/
 *~
 .bazeldnf/
 user.bazelrc

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,9 @@ cluster-deploy: cluster-clean
 cluster-sync:
 	./hack/cluster-sync.sh
 
+custom-rpms:
+	./hack/custom-rpms.sh
+
 builder-build:
 	./hack/builder/build.sh
 

--- a/docs/custom-rpms.md
+++ b/docs/custom-rpms.md
@@ -1,6 +1,91 @@
 # Build custom libvirt rpms from source code to KubeVirt builds
 
-This setup illustrates how to build and integrate custom libvirt rpms in KubeVirt. This can be particularly useful if you need to test a fix in libvirt for KubeVirt.
+This setup illustrates how to build and integrate custom libvirt and qemu rpms in KubeVirt. This can be particularly useful if you need to test a fix in libvirt or qemu for KubeVirt.
+
+# Quick start
+Set the required environment variables and run `make custom-rpms`
+
+## Required environment variables
+The build script by default builds both QEMU and libvirt from source. 
+If you wish to only build one or the other you can set one of the following environment variables;
+- QEMU_ONLY=1 
+- LIBVIRT_ONLY=1
+
+If QEMU build is enabled (LIBVIRT_ONLY not set), you must export the following environment variables
+- QEMU_DIR: The path to the QEMU source directory to be built (can be a git repo or extracted tarball)
+- QEMU_KVM_DIR: The path to the CentOS stream source directory providing rpmbuild spec and dependencies
+  - See the CentOS stream [qemu-kvm repo](https://gitlab.com/redhat/centos-stream/rpms/qemu-kvm). You should check out the specification corresponding to the currently used version of CentOS stream for the build chain (CentOS 9 Stream, branch name 'c9s')
+
+If libvirt build is enabled (QEMU_ONLY not set), you must export the following environment variables
+- LIBVIRT_DIR: The path to the libvirt source directory to be built (can be a git repo or extracted tarball)
+
+### A note on versions
+Currently all local builds (cluster-up/cluster-sync) are based on CentOS Stream 9 images.
+Accordingly, the RPM build containers are based on the same to avoid version issues where possible.
+Should this change in the future the RPM build images, package names for built RPMs, and qemu-kvm spec branch would need to change.
+The qemu-kvm branch 'c9s' is currently a good baseline for your builds.
+Picking compatible versions of qemu and libvirt to compile is left to the user.
+
+# Confirming the build
+The simplest way to check that custom libvirt/qemu RPMs were integrated in kubevirt images is to set unique version numbers for each.
+This can be done for qemu by modifying the **VERSION** file in the repository root, and for libvirt by modifying the **meson.build** project/version variable.
+
+**Example: change default versions 10.1.0 and 12.1.0 to 10.1.99 and 12.1.99**
+
+#### `qemu/VERSION`
+```diff
+-10.1.0
++10.1.99
+```
+
+#### `libvirt/meson.build`
+```diff
+project(
+  'libvirt', 'c',
+- version: '12.1.0',
++ version: '12.1.99',
+  license: 'LGPLv2+',
+  meson_version: '>= 0.57.0',
+  ...
+```
+
+**WARNING: Libvirt builds by default require a clean git repo, so you must either commit your changes or override this requirement. QEMU does not have this requirement**
+
+With uniqe versions set, run `make custom-rpms`, `make cluster-up` and `make cluster-sync` to build a local cluster with the new RPMs.
+
+Next deploy, any VM or VM instance to the cluster (vmi-alpine-efi.yaml used for example)
+```
+./kubevirtci/cluster-up/kubectl.sh apply -f examples/vmi-alpine-efi.yaml
+```
+Run the `virsh version` command in virt-launcher pods "compute" container (this is the container that kicks off QEMU through libvirt, and the primary image that consumes libvirt/QEMU RPMs).
+The "special" label is specified by **vmi-alpine-efi.yaml**, alternatively find the pod name with another method
+#### Example:
+```
+./kubevirtci/cluster-up/kubectl.sh exec $(./kubevirtci/cluster-up/kubectl.sh get pods -l special=vmi-alpine-efi -o name) -c compute -i -t -- virsh version --daemon
+```
+#### Output:
+```
+Compiled against library: libvirt 12.1.99
+Using library: libvirt 12.1.99
+Using API: QEMU 12.1.99
+Running hypervisor: QEMU 10.1.99
+Running against daemon: 12.1.99
+```
+
+This confirms that the used versions match our special source versions.
+
+### Another note on versions
+The "package" versions of the RPM's are set by the corresponding spec file (qemu-kvm.spec and libvirt.spec) and don't necessarily match the executable version that is set in the example.
+You can also increment the RPM package versions through the spec files, which may be necessary in rare circumstances to ensure your built package gets selected over the official packages.
+
+# Manual build
+This section attempts to document the build process performed by the scripts in as much detail as possible for troubleshooting/maintainence purposes.
+
+## Container base
+The **hack/custom-rpms/Dockerfile** file provides a base image with build dependencies for both qemu and libvirt installed.
+It is based on the same CentOS 9 Stream image used by the kubevirt builder: `quay.io/centos/centos:stream9`.
+This matches the version of packages expected by kubevirt by default (see [BASESYSTEM](#BASESYSTEM-anchor)).
+If you are using a different basesystem for kubevirt builds, or the default version changes, the RPM base image will need to change as well
 
 ## Build libvirt and the rpms
 
@@ -13,7 +98,7 @@ $ docker volume create rpms
   * Start build environment for libvirt source code. This setup uses the [container images](https://gitlab.com/libvirt/libvirt/container_registry) used by the libvirt CI. This setup is just an example for reference, and this can be achieved in many ways.
 Start container inside the libvirt directory with your changes and enter in the build container
 ```bash
-$ docker run -td -w /libvirt-src --security-opt label=disable --name libvirt-build -v $(pwd):/libvirt-src -v rpms:/root/rpmbuild/RPMS registry.gitlab.com/libvirt/libvirt/ci-centos-stream-8
+$ docker run -td -w /libvirt-src --security-opt label=disable --name libvirt-build -v $(pwd):/libvirt-src -v rpms:/root/rpmbuild/RPMS registry.gitlab.com/libvirt/libvirt/ci-centos-stream-9
 # Exec in the container
 $ docker exec -ti libvirt-build bash
 ```
@@ -33,8 +118,22 @@ $ rpmbuild -ta    /libvirt-src/build/meson-dist/libvirt-*.tar.xz
 $ createrepo -v  /root/rpmbuild/RPMS/x86_64
 ```
 
-## Start the http server for the rpms
+The next concern is getting your source into the container while not confounding file ownership.
+The scripts mirror the approach used by `hack/dockerized` by using rsync to copy source into the container before build and rsync the build artifacts out after.
+There are other ways to solve, but keep in mind that by default libvirt will run git commands during build.
+These commands will fail with error "dubious file permissions" if the source code is owned by the user while the "build" folder is owned by root, which is the default if simply using volume mounts.
+You may opt to disable the git command part of the libvirt build and simply run those commands ahead of time, or choose another option to deal with docker user ownership in/out of the container.
 
+The **hack/custom-rpms** folder contains build scripts for qemu and libvirt, and the dockerfile defining the base build image. 
+Each build script will additionally get rsync-ed into the build container as necessary to build the respective RPM.
+The build scripts and dockerfile are documented through comments in the files themselves.
+
+The `dockerized` function defined in the **hack/custom-rpms.sh** build script is based on **hack/dockerized**, stripped down and tailored to the requirements of rpm builds.
+It is responsible for starting a build container and rsync server container for transferring files, transferring, building, and copying build artifacts (including a version metadata file required for the `make rpm-deps` step) out of the container.
+
+## Start the http server for the rpms
+All built rpms will land in a named docker container (rpms), that was mounted into each build container.
+This volume can then be mounted into a httpd container to serve as a RPM server for `make rpm-deps`
 If you want to use other publicly available rpms or a private repository that is reachable from the KubeVirt build container, you can skip this section and substitute the custom repository.
 The http server container allows to expose locally the rpms to the KubeVirt build server. It is reachable by the IP address from the KubeVirt build container.
   * Start the http server with the `rpms` volume where we created the rpms in the previous step (otherwise pass the directory that contains the rpms)
@@ -47,7 +146,8 @@ $ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' rp
 172.17.0.4
 ```
 ## Add the custom repository to KubeVirt
-
+The build script retreives the httpd server IP automatically and generates a modified version of **hack/custom-rpms/custom-repo.yaml**.
+This file must be saved in a kubevirt directory that isn't ignored by the **hack/dockerized** rsync copy process so that it is copied into the builder container.
   * Create `custom-repo.yaml` pointing to the local http server:
 ```yaml
 repositories:
@@ -57,11 +157,77 @@ repositories:
   gpgcheck: 0
   repo_gpgcheck: 0
 ```
-  * Update the rpms in KubeVirt repository.
-  * If you only want to update a single architecture, set `SINGLE_ARCH="x86_64"`.
-  * It is sometimes necessary to change `basesystem` when using custom rpms packages. This can be achieved by setting `BASESYSTEM=xyz` env variable.
-  * If you want to change version of some packages you can set env variables. See [`hack/rpm-deps.sh`](/hack/rpm-deps.sh) script for all variables that can be changed.
-```bash
-$ make CUSTOM_REPO=custom-repo.yaml LIBVIRT_VERSION=0:7.2.0-1.el8 rpm-deps
-```
+The custom repo will be specified to the `make rpm-deps` command.
 Afterwards, the `WORKSPACE` and `rpm/BUILD.bazel` are automatically updated and KubeVirt can be built with the custom rpms.
+
+
+## The `make rpm-deps` command
+TLDR: we need to set the LIBVIRT_VERSION/QEMU_VERSION variable to match that of the version we are building from source, and the SINGLE_ARCH variable to match what architecture we are building for (likely host arch). We *do not* need to set the BASESYSTEM variable, but the default value (centos-stream-release) implies what image version we should use for our dockerized build of libvirt
+
+This command updates the **WORKSPACE** file and **rpms/BUILD.bazel** file according to pre-defined rules, and the currently used rpm repositories.
+Inspection of the script shows that it uses several environment variables that can specify custom RPM versions to be used by the kubevirt build system.
+The LIBVIRT_VERSION and QEMU_VERSION variables are the ones that are critical to running custom RPMs for libvirt and qemu respectively.
+- LIBVIRT_VERSION
+- QEMU_VERSION
+- SEABIOS_VERSION
+- EDK2_VERSION
+- LIBGUESTFS_VERSION
+- GUESTFSTOOLS_VERSION
+- PASST_VERSION
+- VIRTIOFSD_VERSION
+- SWTPM_VERSION
+
+Additionally, two more environment variables are used:
+- **SINGLE_ARCH**: This variable will restrict which rpm specifications will be updated in the **WORKSPACE** and **rpms/BUILD.bazel** file.
+This is required to be set in our situation, as otherwise the make command will attempt to update package requirements of other architectures (arm64 and s390x) to the version that we specify in LIBVIRT_VERSION, which will not exist in our self-hosted package repository, and likely not exist in the upstream repositories.
+- **BASESYSTEM** <a id="BASESYSTEM-anchor"></a>: This will become the `--basesystem` argument to the `bazeldnf rpmtree` command, which resolves rpm trees into an individualized rpm list with precise versioning (see [bazeldnf docs](https://github.com/brianmcarey/bazeldnf) for the currently used fork of bazeldnf).
+The default for this value in kubevirt build scripts is "centos-stream-release," which at the time of writing corresponds to CentOS Stream 9.
+This is a reasonable value as the kubevirt builder is *currently* based on CentOS Stream 9 (see **hack/builder/Dockerfile** for the base version being used).
+The **custom-rpms.md** docs mention that it is sometimes necessary to change this value, but changing the value is not necessary if using the standard kubevirt builder, and what values are valid to set for this is outside the scope of this document.
+
+### Getting the correct LIBVIRT_VERSION
+The build script automatically gets the libvirt version using the `meson introspect` within the build container and outputting the version value to **libvirt/build/version.txt**.
+It gets the qemu version by grepping the qemu-kvm.spec rpmbuild specfile used to build the package.
+The qemu approach doesn't work for libvirt, as libvirt.spec uses a variable to retrieve the meson package version.
+The libvirt approach doesn't work for qemu, as the qemu source version is completely independent from the RPM package version.
+
+#### Manual version setting
+The libvirt version of the compiled code can be found manually in **libvirt/meson.build** as shown:
+```
+project(
+  'libvirt', 'c',
+  version: '12.1.0',    # libvirt-version-number
+  license: 'LGPLv2+',
+  meson_version: '>= 0.57.0',
+  default_options: [
+    'buildtype=debugoptimized',
+    'b_pie=true',
+    'c_std=gnu99',
+    'warning_level=2',
+  ],
+)
+```
+The format of the LIBVIRT_VERSION/QEMU_VERSION environment variable is "<epoch>:<version-number>-<release>.el<centos-stream-version>", for example:
+- Given the libvirt version shown (12.1.0) and using centos-stream-9 to build the rpms, you would have LIBVIRT_VERSION=0:12.1.0-1.el9 (Epoch is currently hardcoded to 0, Release to 1. See libvirt.spec if that changes).
+- This ***does not*** exactly match the format of the built rpm file names (i.e. libvirt-devel-12.1.0-1.el9.x86_64.rpm)
+
+The QEMU version is found in **qemu-kvm/qemu-kvm.spec**
+```
+Summary: QEMU is a machine emulator and virtualizer
+Name: qemu-kvm
+Version: 10.1.0
+Release: 12%{?rcrel}%{?dist}%{?cc_suffix}
+# Epoch because we pushed a qemu-1.0 package. AIUI this can't ever be dropped
+# Epoch 15 used for RHEL 8
+# Epoch 17 used for RHEL 9 (due to release versioning offset in RHEL 8.5)
+Epoch: 17
+License: GPLv2 and GPLv2+ and CC-BY
+URL: http://www.qemu.org/
+ExclusiveArch: x86_64 %{power64} aarch64 s390x
+```
+
+Release will by default collapse to just "12.el<centos-stream-version>" in this case, unless you explicitly set the rcrel version for a release candidate. Epoch and Version are self explanatory.
+
+You may override the automatically populated value of LIBVIRT_VERSION/QEMU_VERSION by exporting the environment variable in the correct format
+
+With the correct environment variables set, we can successfully run the `make rpm-deps` command. Running a `git diff` in the kubevirt source folder will show the updated packages being referenced. You may also see some non-libvirt packages that changed that are simply newer versions available on the remote. All libvirt dependencies should show a *url* field that references the rpm http server that is being run in docker.

--- a/hack/custom-rpms.sh
+++ b/hack/custom-rpms.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Builds QEMU and libvirt RPMs from local source directories
+# See docs/custom-rpms.md for usage
+
+set +x
+
+source $(dirname "$0")/common.sh
+
+KUBEVIRT_CRI=$(determine_cri_bin)
+fail_if_cri_bin_missing
+SCRIPT_DIR=${KUBEVIRT_DIR}/hack/custom-rpms
+
+dockerized() {
+  if [[ -z "$SRCS" ]]; then
+    echo "The required variable 'SRCS' is not defined."
+    exit 1
+  fi
+
+  default_BUILDER_IMAGE="rpm-build-image"
+
+  BUILDER_IMAGE=${BUILDER_IMAGE:-"${default_BUILDER_IMAGE}"}
+
+  RPM_BUILD_VOL=${RPM_BUILD_VOL:-custom-rpms}
+
+  # Create the persistent container volume
+  if [ -z "$($KUBEVIRT_CRI volume list | grep ${RPM_BUILD_VOL})" ]; then
+      $KUBEVIRT_CRI volume create ${RPM_BUILD_VOL}
+  fi
+
+  selinux_bind_options=",z"
+  # Using Podman and MacOS and 'z' bind option may not work correctly.
+  # See: https://github.com/containers/podman/issues/13631
+  if [[ $KUBEVIRT_CRI = podman* ]] && [[ "$(uname -s)" == "Darwin" ]]; then
+      selinux_bind_options=""
+  fi
+
+  # Make sure that the output directory exists on both sides
+  if [[ ! -z "$OUT_DIR" ]]; then
+      OUT_DIR_SRC=$(echo "$OUT_DIR" | cut -d ":" -f 1)
+      OUT_DIR_DST=$(echo "$OUT_DIR" | cut -d ":" -f 2)
+      $KUBEVIRT_CRI run -v "${RPM_BUILD_VOL}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --rm ${BUILDER_IMAGE} mkdir -p /root/${OUT_DIR_SRC}
+      mkdir -p ${OUT_DIR_DST}
+  fi
+
+  # Start an rsyncd instance and make sure it gets stopped after the script exits
+  RSYNC_CID=$($KUBEVIRT_CRI run -d -v "${RPM_BUILD_VOL}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --cap-add SYS_CHROOT --expose 873 -P ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+
+  function finish() {
+      $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
+      $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
+  }
+  trap finish RETURN
+
+  RSYNCD_PORT=$($KUBEVIRT_CRI port $RSYNC_CID 873 | cut -d':' -f2)
+
+  rsynch_fail_count=0
+
+  while ! rsync ${KUBEVIRT_DIR}/${RSYNCTEMP} "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/${RSYNCTEMP}" &>/dev/null; do
+      if [[ "$rsynch_fail_count" -eq 0 ]]; then
+          printf "Waiting for rsyncd to be ready"
+          sleep .1
+      elif [[ "$rsynch_fail_count" -lt 30 ]]; then
+          printf "."
+          sleep 1
+      else
+          printf "failed"
+          exit 1
+      fi
+      rsynch_fail_count=$((rsynch_fail_count + 1))
+  done
+
+  printf "\n"
+
+  rsynch_fail_count=0
+
+  _rsync() {
+      # Preserve permissions, but change ownership to destination
+      rsync -rlpt "$@"
+  }
+
+  IFS="," read -r -a sources <<< "$SRCS"
+
+  for item in "${sources[@]}"; do
+      if [[ ! -z "$item" ]]; then
+          # Copy source into the persistent container volume
+          _rsync \
+              --delete \
+              $item \
+              "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/"
+      fi
+  done
+
+  volumes="${EXTRA_VOLS}"
+
+  # Add build volume mount (directory root for source in the container)
+  volumes="$volumes -v ${RPM_BUILD_VOL}:/build:rw${selinux_bind_options}"
+
+  # append .docker secrets directory as volume
+  mkdir -p "${HOME}/.docker/secrets"
+  volumes="$volumes -v ${HOME}/.docker/secrets:/root/.docker/secrets:ro${selinux_bind_options}"
+
+  # Use a bind-mount to expose docker/podman auth file to the container
+  if [[ $KUBEVIRT_CRI = podman* ]] && [[ -f "${XDG_RUNTIME_DIR}/containers/auth.json" ]]; then
+      volumes="$volumes --mount type=bind,source=${XDG_RUNTIME_DIR}/containers/auth.json,target=/root/.docker/config.json,readonly"
+  elif [[ -f "${HOME}/.docker/config.json" && "$(cat ${HOME}/.docker/config.json | jq 'has("credHelpers")')" != "true" ]]; then
+      volumes="$volumes --mount type=bind,source=${HOME}/.docker/config.json,target=/root/.docker/config.json,readonly"
+  fi
+
+  # add custom docker certs, if needed
+  if [ -n "$DOCKER_CA_CERT_FILE" ] && [ -f "$DOCKER_CA_CERT_FILE" ]; then
+      volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro${selinux_bind_options}"
+  fi
+
+  BUILD_CID=$($KUBEVIRT_CRI run -dit ${volumes} -w /build ${BUILDER_IMAGE})
+  function finish() {
+      $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
+      $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
+      $KUBEVIRT_CRI stop --time 1 ${BUILD_CID} >/dev/null 2>&1
+      $KUBEVIRT_CRI rm -f ${BUILD_CID} >/dev/null 2>&1
+  }
+
+  function copy_out() {
+      if [[ ! -z "$OUT_DIR" ]]; then
+          echo "Copying output to ${OUT_DIR_DST}"
+          _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/${OUT_DIR_SRC}/" ${OUT_DIR_DST}
+      fi
+  }
+
+  # Run the command
+  test -t 1 && USE_TTY="-t"
+  if ! $KUBEVIRT_CRI exec ${CONTAINER_ENV} ${USE_TTY} ${BUILD_CID} $1; then
+      # Copy the build output out of the container, make sure that _out exactly matches the build result
+      copy_out
+      exit 1
+  fi
+
+  copy_out
+}
+
+(
+  # Shutdown the old rpm server before building (ignore failures)
+  ${KUBEVIRT_CRI} kill rpms-http-server &> /dev/null
+  ${KUBEVIRT_CRI} rm -f rpms-http-server &> /dev/null
+
+  set -e
+
+  # Pulled from custom-rpms.md (creates a shared docker volume for built RPMs)
+  ${KUBEVIRT_CRI} volume create rpms
+  # Build the CentOS Stream 9 image with some extra dependencies
+  ${KUBEVIRT_CRI} build -t rpm-build-image -f ${SCRIPT_DIR}/Dockerfile . 
+  # Mount the rpm volume to the default build output directory for libvirt RPMs
+  EXTRA_VOLS="-v rpms:/root/rpmbuild/RPMS"
+
+  RPM_VERSION_STRING=""
+
+  if [[ -z "$LIBVIRT_ONLY" ]]; then
+    if [[ -z "$QEMU_DIR" ]]; then
+        echo "The variable 'QEMU_DIR' is not defined."
+        echo "Defined the value with the QEMU source directory or disable QEMU builds with `export LIBVIRT_ONLY=1`"
+        exit 1
+    fi
+
+    if [[ -z "$QEMU_KVM_DIR" ]]; then
+        echo "The variable 'QEMU_KVM_DIR' is not defined."
+        echo "Define the value with the qemu-kvm source directory or disable QEMU builds with `export LIBVIRT_ONLY=1`"
+        exit 1
+    fi
+    # This directory will capture the version file from the containerized RPM build
+    OUT_DIR="output:${QEMU_DIR}/build"
+
+    SRCS="${QEMU_DIR},${QEMU_KVM_DIR},${SCRIPT_DIR}/build-qemu.bash"
+    # Pass the container-side path to the script (it will be rsynced to the cwd in the container)
+    dockerized ./build-qemu.bash
+
+    # Get the qemu version number from build data (Format is "EPOCH:VERSION-RELEASE")
+    RPM_VERSION_STRING="${RPM_VERSION_STRING} QEMU_VERSION=${QEMU_VERSION:-$(cat ${QEMU_DIR}/build/version.txt).el9}"
+  fi
+
+  if [[ -z "$QEMU_ONLY" ]]; then
+    if [[ -z "$LIBVIRT_DIR" ]]; then
+        echo "The variable 'LIBVIRT_DIR' is not defined."
+        echo "Define the value with the libvirt source directory or disable libvirt builds with `export QEMU_ONLY=1`"
+        exit 1
+    fi
+
+    OUT_DIR="libvirt/build:${LIBVIRT_DIR}/build"
+
+    SRCS="${LIBVIRT_DIR},${SCRIPT_DIR}/build-libvirt.bash"
+
+    # Pass the container-side path to the script (it will be rsynced to the cwd in the container)
+    dockerized ./build-libvirt.bash
+
+    # Get the libvirt version number from meson introspection data (Format is "EPOCH:VERSION-RELEASE")
+    RPM_VERSION_STRING="${RPM_VERSION_STRING} LIBVIRT_VERSION=${LIBVIRT_VERSION:-0:$(cat ${LIBVIRT_DIR}/build/version.txt)-1.el9}"
+  fi
+
+
+  # Mount the same rpm volume to an httpd container, and output it's IP to the "${KUBEVIRT_DIR}/hack/custom-rpms/generated/custom-repo.yaml" file
+  # This file MUST be in the kubevirt source directory in a non-ignored location (see rsync commands in ${KUBEVIRT_DIR}/hack/dockerized), 
+  # otherwise it will not be copied into the build container.
+  ${KUBEVIRT_CRI} run -dit --name rpms-http-server -p 80 -v rpms:/usr/local/apache2/htdocs/ httpd:latest
+  DOCKER_URL=$(${KUBEVIRT_CRI} inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' rpms-http-server)
+  mkdir -p ${KUBEVIRT_DIR}/hack/custom-rpms/generated
+  sed "s|DOCKER_URL|$DOCKER_URL|g" ${SCRIPT_DIR}/custom-repo.yaml > ${KUBEVIRT_DIR}/hack/custom-rpms/generated/custom-repo.yaml 
+
+  # Run the `make rpm-deps` command, adding our rpm host as a repo and setting other args as described in the building-libvirt doc 
+  pushd ${KUBEVIRT_DIR}
+  make CUSTOM_REPO=hack/custom-rpms/generated/custom-repo.yaml ${RPM_VERSION_STRING} SINGLE_ARCH="x86_64" rpm-deps
+  popd
+)

--- a/hack/custom-rpms.sh
+++ b/hack/custom-rpms.sh
@@ -11,130 +11,134 @@ fail_if_cri_bin_missing
 SCRIPT_DIR=${KUBEVIRT_DIR}/hack/custom-rpms
 
 dockerized() {
-  if [[ -z "$SRCS" ]]; then
-    echo "The required variable 'SRCS' is not defined."
-    exit 1
-  fi
+    (
+        if [[ -z "$SRCS" ]]; then
+            echo "The required variable 'SRCS' is not defined."
+            exit 1
+        fi
 
-  default_BUILDER_IMAGE="rpm-build-image"
+        default_BUILDER_IMAGE="rpm-build-image"
 
-  BUILDER_IMAGE=${BUILDER_IMAGE:-"${default_BUILDER_IMAGE}"}
+        BUILDER_IMAGE=${BUILDER_IMAGE:-"${default_BUILDER_IMAGE}"}
 
-  RPM_BUILD_VOL=${RPM_BUILD_VOL:-custom-rpms}
+        RPM_BUILD_VOL=${RPM_BUILD_VOL:-custom-rpms}
 
-  # Create the persistent container volume
-  if [ -z "$($KUBEVIRT_CRI volume list | grep ${RPM_BUILD_VOL})" ]; then
-      $KUBEVIRT_CRI volume create ${RPM_BUILD_VOL}
-  fi
+        # Create the persistent container volume
+        if [ -z "$($KUBEVIRT_CRI volume list | grep ${RPM_BUILD_VOL})" ]; then
+            $KUBEVIRT_CRI volume create ${RPM_BUILD_VOL}
+        fi
 
-  selinux_bind_options=",z"
-  # Using Podman and MacOS and 'z' bind option may not work correctly.
-  # See: https://github.com/containers/podman/issues/13631
-  if [[ $KUBEVIRT_CRI = podman* ]] && [[ "$(uname -s)" == "Darwin" ]]; then
-      selinux_bind_options=""
-  fi
+        selinux_bind_options=",z"
+        # Using Podman and MacOS and 'z' bind option may not work correctly.
+        # See: https://github.com/containers/podman/issues/13631
+        if [[ $KUBEVIRT_CRI = podman* ]] && [[ "$(uname -s)" == "Darwin" ]]; then
+            selinux_bind_options=""
+        fi
 
-  # Make sure that the output directory exists on both sides
-  if [[ ! -z "$OUT_DIR" ]]; then
-      OUT_DIR_SRC=$(echo "$OUT_DIR" | cut -d ":" -f 1)
-      OUT_DIR_DST=$(echo "$OUT_DIR" | cut -d ":" -f 2)
-      $KUBEVIRT_CRI run -v "${RPM_BUILD_VOL}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --rm ${BUILDER_IMAGE} mkdir -p /root/${OUT_DIR_SRC}
-      mkdir -p ${OUT_DIR_DST}
-  fi
+        # Make sure that the output directory exists on both sides
+        if [[ ! -z "$OUT_DIR" ]]; then
+            OUT_DIR_SRC=$(echo "$OUT_DIR" | cut -d ":" -f 1)
+            OUT_DIR_DST=$(echo "$OUT_DIR" | cut -d ":" -f 2)
+            $KUBEVIRT_CRI run -v "${RPM_BUILD_VOL}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --rm ${BUILDER_IMAGE} mkdir -p /root/${OUT_DIR_SRC}
+            mkdir -p ${OUT_DIR_DST}
+        fi
 
-  # Start an rsyncd instance and make sure it gets stopped after the script exits
-  RSYNC_CID=$($KUBEVIRT_CRI run -d -v "${RPM_BUILD_VOL}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --cap-add SYS_CHROOT --expose 873 -P ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+        # Start an rsyncd instance and make sure it gets stopped after the script exits
+        RSYNC_CID=$($KUBEVIRT_CRI run -d -v "${RPM_BUILD_VOL}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --cap-add SYS_CHROOT --expose 873 -P ${BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
-  function finish() {
-      $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
-      $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
-  }
-  trap finish RETURN
+        function finish() {
+            $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
+            $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
+        }
+        # trap finish EXIT
 
-  RSYNCD_PORT=$($KUBEVIRT_CRI port $RSYNC_CID 873 | cut -d':' -f2)
+        RSYNCD_PORT=$($KUBEVIRT_CRI port $RSYNC_CID 873 | cut -d':' -f2)
 
-  rsynch_fail_count=0
+        rsynch_fail_count=0
 
-  while ! rsync ${KUBEVIRT_DIR}/${RSYNCTEMP} "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/${RSYNCTEMP}" &>/dev/null; do
-      if [[ "$rsynch_fail_count" -eq 0 ]]; then
-          printf "Waiting for rsyncd to be ready"
-          sleep .1
-      elif [[ "$rsynch_fail_count" -lt 30 ]]; then
-          printf "."
-          sleep 1
-      else
-          printf "failed"
-          exit 1
-      fi
-      rsynch_fail_count=$((rsynch_fail_count + 1))
-  done
+        while ! rsync ${KUBEVIRT_DIR}/${RSYNCTEMP} "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/${RSYNCTEMP}" &>/dev/null; do
+            if [[ "$rsynch_fail_count" -eq 0 ]]; then
+                printf "Waiting for rsyncd to be ready"
+                sleep .1
+            elif [[ "$rsynch_fail_count" -lt 30 ]]; then
+                printf "."
+                sleep 1
+            else
+                printf "failed"
+                exit 1
+            fi
+            rsynch_fail_count=$((rsynch_fail_count + 1))
+        done
 
-  printf "\n"
+        printf "\n"
 
-  rsynch_fail_count=0
+        rsynch_fail_count=0
 
-  _rsync() {
-      # Preserve permissions, but change ownership to destination
-      rsync -rlpt "$@"
-  }
+        _rsync() {
+            # Preserve permissions, but change ownership to destination
+            rsync -rlpt "$@"
+        }
 
-  IFS="," read -r -a sources <<< "$SRCS"
+        IFS="," read -r -a sources <<< "$SRCS"
 
-  for item in "${sources[@]}"; do
-      if [[ ! -z "$item" ]]; then
-          # Copy source into the persistent container volume
-          _rsync \
-              --delete \
-              $item \
-              "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/"
-      fi
-  done
+        for item in "${sources[@]}"; do
+            if [[ ! -z "$item" ]]; then
+                # Copy source into the persistent container volume
+                _rsync \
+                    --delete \
+                    $item \
+                    "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/"
+            fi
+        done
 
-  volumes="${EXTRA_VOLS}"
+        volumes="${EXTRA_VOLS}"
 
-  # Add build volume mount (directory root for source in the container)
-  volumes="$volumes -v ${RPM_BUILD_VOL}:/build:rw${selinux_bind_options}"
+        # Add build volume mount (directory root for source in the container)
+        volumes="$volumes -v ${RPM_BUILD_VOL}:/build:rw${selinux_bind_options}"
 
-  # append .docker secrets directory as volume
-  mkdir -p "${HOME}/.docker/secrets"
-  volumes="$volumes -v ${HOME}/.docker/secrets:/root/.docker/secrets:ro${selinux_bind_options}"
+        # append .docker secrets directory as volume
+        mkdir -p "${HOME}/.docker/secrets"
+        volumes="$volumes -v ${HOME}/.docker/secrets:/root/.docker/secrets:ro${selinux_bind_options}"
 
-  # Use a bind-mount to expose docker/podman auth file to the container
-  if [[ $KUBEVIRT_CRI = podman* ]] && [[ -f "${XDG_RUNTIME_DIR}/containers/auth.json" ]]; then
-      volumes="$volumes --mount type=bind,source=${XDG_RUNTIME_DIR}/containers/auth.json,target=/root/.docker/config.json,readonly"
-  elif [[ -f "${HOME}/.docker/config.json" && "$(cat ${HOME}/.docker/config.json | jq 'has("credHelpers")')" != "true" ]]; then
-      volumes="$volumes --mount type=bind,source=${HOME}/.docker/config.json,target=/root/.docker/config.json,readonly"
-  fi
+        # Use a bind-mount to expose docker/podman auth file to the container
+        if [[ $KUBEVIRT_CRI = podman* ]] && [[ -f "${XDG_RUNTIME_DIR}/containers/auth.json" ]]; then
+            volumes="$volumes --mount type=bind,source=${XDG_RUNTIME_DIR}/containers/auth.json,target=/root/.docker/config.json,readonly"
+        elif [[ -f "${HOME}/.docker/config.json" && "$(cat ${HOME}/.docker/config.json | jq 'has("credHelpers")')" != "true" ]]; then
+            volumes="$volumes --mount type=bind,source=${HOME}/.docker/config.json,target=/root/.docker/config.json,readonly"
+        fi
 
-  # add custom docker certs, if needed
-  if [ -n "$DOCKER_CA_CERT_FILE" ] && [ -f "$DOCKER_CA_CERT_FILE" ]; then
-      volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro${selinux_bind_options}"
-  fi
+        # add custom docker certs, if needed
+        if [ -n "$DOCKER_CA_CERT_FILE" ] && [ -f "$DOCKER_CA_CERT_FILE" ]; then
+            volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro${selinux_bind_options}"
+        fi
 
-  BUILD_CID=$($KUBEVIRT_CRI run -dit ${volumes} -w /build ${BUILDER_IMAGE})
-  function finish() {
-      $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
-      $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
-      $KUBEVIRT_CRI stop --time 1 ${BUILD_CID} >/dev/null 2>&1
-      $KUBEVIRT_CRI rm -f ${BUILD_CID} >/dev/null 2>&1
-  }
+        BUILD_CID=$($KUBEVIRT_CRI run -dit ${volumes} -w /build ${BUILDER_IMAGE})
+        function finish() {
+            $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
+            $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
+            $KUBEVIRT_CRI stop --time 1 ${BUILD_CID} >/dev/null 2>&1
+            $KUBEVIRT_CRI rm -f ${BUILD_CID} >/dev/null 2>&1
+        }
 
-  function copy_out() {
-      if [[ ! -z "$OUT_DIR" ]]; then
-          echo "Copying output to ${OUT_DIR_DST}"
-          _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/${OUT_DIR_SRC}/" ${OUT_DIR_DST}
-      fi
-  }
+        function copy_out() {
+            if [[ ! -z "$OUT_DIR" ]]; then
+                echo "Copying output to ${OUT_DIR_DST}"
+                _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/${OUT_DIR_SRC}/" ${OUT_DIR_DST}
+            fi
+        }
 
-  # Run the command
-  test -t 1 && USE_TTY="-t"
-  if ! $KUBEVIRT_CRI exec ${CONTAINER_ENV} ${USE_TTY} ${BUILD_CID} $1; then
-      # Copy the build output out of the container, make sure that _out exactly matches the build result
-      copy_out
-      exit 1
-  fi
+        # Run the command
+        test -t 1 && USE_TTY="-t"
+        if ! $KUBEVIRT_CRI exec ${CONTAINER_ENV} ${USE_TTY} ${BUILD_CID} $1; then
+            # Copy the build output out of the container, make sure that _out exactly matches the build result
+            copy_out
+            exit 1
+        fi
 
-  copy_out
+        copy_out
+    )
+
+    return $?
 }
 
 (
@@ -168,9 +172,9 @@ dockerized() {
     # This directory will capture the version file from the containerized RPM build
     OUT_DIR="output:${QEMU_DIR}/build"
 
-    SRCS="${QEMU_DIR},${QEMU_KVM_DIR},${SCRIPT_DIR}/build-qemu.bash"
+    SRCS="${QEMU_DIR},${QEMU_KVM_DIR},${SCRIPT_DIR}/build-qemu.sh"
     # Pass the container-side path to the script (it will be rsynced to the cwd in the container)
-    dockerized ./build-qemu.bash
+    dockerized ./build-qemu.sh
 
     # Get the qemu version number from build data (Format is "EPOCH:VERSION-RELEASE")
     RPM_VERSION_STRING="${RPM_VERSION_STRING} QEMU_VERSION=${QEMU_VERSION:-$(cat ${QEMU_DIR}/build/version.txt).el9}"
@@ -185,10 +189,10 @@ dockerized() {
 
     OUT_DIR="libvirt/build:${LIBVIRT_DIR}/build"
 
-    SRCS="${LIBVIRT_DIR},${SCRIPT_DIR}/build-libvirt.bash"
+    SRCS="${LIBVIRT_DIR},${SCRIPT_DIR}/build-libvirt.sh"
 
     # Pass the container-side path to the script (it will be rsynced to the cwd in the container)
-    dockerized ./build-libvirt.bash
+    dockerized ./build-libvirt.sh
 
     # Get the libvirt version number from meson introspection data (Format is "EPOCH:VERSION-RELEASE")
     RPM_VERSION_STRING="${RPM_VERSION_STRING} LIBVIRT_VERSION=${LIBVIRT_VERSION:-0:$(cat ${LIBVIRT_DIR}/build/version.txt)-1.el9}"

--- a/hack/custom-rpms/Dockerfile
+++ b/hack/custom-rpms/Dockerfile
@@ -1,0 +1,25 @@
+FROM quay.io/centos/centos:stream9
+
+RUN dnf config-manager --set-enabled crb
+RUN dnf update -y && dnf builddep -y libvirt qemu-kvm
+
+RUN dnf install -y \
+    rsync \
+    createrepo_c \
+    jq \
+    libpmem-devel \
+    libepoxy-devel \
+    mesa-libgbm-devel \
+    libdrm-devel \
+    rpmdevtools \
+    rpm-build
+
+# Basic rsync config file that configures the module "build" at path "/root"
+RUN cat <<EOF > /etc/rsyncd.conf
+read only = no
+uid = root
+gid = root
+[build] 
+    path = /root
+    comment = Libvirt/QEMU source
+EOF

--- a/hack/custom-rpms/Dockerfile
+++ b/hack/custom-rpms/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/centos/centos:stream9
+FROM registry.gitlab.com/libvirt/libvirt/ci-centos-stream-9
 
-RUN dnf config-manager --set-enabled crb
+# RUN dnf config-manager --set-enabled crb
 RUN dnf update -y && dnf builddep -y libvirt qemu-kvm
 
 RUN dnf install -y \

--- a/hack/custom-rpms/build-libvirt.sh
+++ b/hack/custom-rpms/build-libvirt.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Compile and create the rpms, used by hack/custom-rpms.bash
+# THIS SCRIPT IS NOT DESIGNED TO BE CALLED DIRECTLY
+
+# Libvirt source is copied into the container at /build/libvirt
+# Container is started with CWD /build
+# Contents of /build/libvirt/build is copied back out of container after build, so should contain any build artifacts needed on the host
+set -e
+cd libvirt
+git status &> /dev/null     # For some reason the git repo is marked as dirty when it isn't, running status fixes it!?
+meson setup build -Dsystem=true -Ddriver_qemu=enabled       # Options recommended by libvirt build docs
+ninja -C build dist                                         
+rpmbuild -ta    /build/libvirt/build/meson-dist/libvirt-*.tar.xz  
+# Create repomd.xml
+createrepo_c -v --general-compress-type gz /root/rpmbuild/RPMS/x86_64   # Force the compress type. bazeldnf doesn't support zstd at time of writing
+# Write the libvirt build version to file
+meson introspect build --projectinfo | jq -r ".version" > /build/libvirt/build/version.txt

--- a/hack/custom-rpms/build-qemu.sh
+++ b/hack/custom-rpms/build-qemu.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Compile and create the rpms, used by hack/custom-rpms.bash
+# THIS SCRIPT IS NOT DESIGNED TO BE CALLED DIRECTLY
+
+# QEMU source is copied into the container at /build/qemu
+# Container is started with CWD /build
+# Contents of /build/output is copied back out of container after build, so should contain any build artifacts needed on the host
+
+set -e
+
+get_qemu_kvm_version_info() {
+    # Extract the version and epoch info from qemu-kvm.spec
+    SPEC_FILE=$1
+    VERSION=$(grep -oP "Version:\s+\\K(.*)" ${SPEC_FILE})
+    EPOCH=$(grep -oP "Epoch:\s+\\K(.*)" ${SPEC_FILE})
+    RELEASE=$(grep -oP "Release:\s+\\K(\d+)" ${SPEC_FILE})
+
+    echo "$EPOCH:$VERSION-$RELEASE" > /build/output/version.txt
+} 
+
+get_qemu_kvm_version_info /build/qemu-kvm/qemu-kvm.spec
+
+QEMU_NAME="qemu-${VERSION}"
+
+# Copy all sources needed by rpmbuild into /root/rpmbuild/SOURCES and the spec file into /root/rpmbuild/SPECS
+# QEMU source must be in a tar archive by the name of qemu-${VERSION}.tar.xz where VERSION matches the version field specified in the qemu-kvm.spec file
+# The tar must also extract to a folder of the exact same name (qemu-${VERSION})
+rpmdev-setuptree
+rm -rf ${QEMU_NAME}
+mv qemu ${QEMU_NAME}
+tar --exclude build -cf /build/${QEMU_NAME}.tar.xz ${QEMU_NAME}
+cp /build/qemu-*.tar.xz /root/rpmbuild/SOURCES
+cp /build/qemu-kvm/* /root/rpmbuild/SOURCES
+cp /build/qemu-kvm/qemu-kvm.spec /root/rpmbuild/SPECS
+
+# Run the RPM build and build a repo
+cd /root/rpmbuild/SPECS
+rpmbuild -ba qemu-kvm.spec --nocheck --define '_smp_mflags -j12'    # nocheck because QEMU tests take forever
+createrepo_c -v --general-compress-type gz /root/rpmbuild/RPMS/x86_64   # Force the compress type. bazeldnf doesn't support zstd at time of writing

--- a/hack/custom-rpms/custom-repo.yaml
+++ b/hack/custom-rpms/custom-repo.yaml
@@ -1,0 +1,6 @@
+repositories:
+- arch: x86_64
+  baseurl: http://DOCKER_URL:80/x86_64/ # The IP corresponding to the rpms-http-server container
+  name: custom-build
+  gpgcheck: 0
+  repo_gpgcheck: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The custom-rpms.md document partially documented how to build custom libvirt rpms only. Some references in the document were out of date
#### After this PR:
Scripts and make target "custom-rpms" is added to build QEMU and libvirt custom rpms from a local source repository. The custom-rpms.md document is updated to match

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

The hack/custom-rpms folder contains a dockerfile and scripts that will be copied into the build container.
The dockerfile is built locally by the make target.

Alternatively, this image definition could be added to the kubevirtci project and pushed to quay.io with the other build images.
I don't think it fits as well here.

The image could also be merged into the default builder, which would require adding the following dependencies:

```
RUN dnf builddep -y libvirt qemu-kvm

RUN dnf install -y \
    createrepo_c \
    libpmem-devel \
    libepoxy-devel \
    mesa-libgbm-devel \
    libdrm-devel \
    rpmdevtools \
    rpm-build
```

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

