### PR TITLE
tests: convert container disk bogus path E2E test to unit test

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -184,6 +184,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	},
 		Entry("when path is not absolute", "a/b/c", "spec.volumes[0].containerDisk must be an absolute path to a file without relative components"),
 		Entry("when path contains relative components", "/a/b/c/../d", "spec.volumes[0].containerDisk must be an absolute path to a file without relative components"),
+		Entry("when path starts with relative components", "../test", "spec.volumes[0].containerDisk must be an absolute path to a file without relative components"),
 		Entry("when path is root", "/", "spec.volumes[0].containerDisk must not point to root"),
 	)
 

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -205,21 +205,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			})
 		})
 	})
-	Describe("Bogus container disk path", func() {
-		Context("that points to outside of the volume", func() {
-			//TODO this could be unit test
-			It("should be rejected on VMI creation", func() {
-				vmi := libvmifact.NewAlpine()
-				vmi.Spec.Volumes[0].ContainerDisk.Path = "../test"
-				By("Starting the VirtualMachineInstance")
-				_, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("admission webhook"))
-				Expect(err.Error()).To(ContainSubstring("denied the request"))
-				Expect(err.Error()).To(ContainSubstring("must be an absolute path to a file without relative components"))
-			})
-		})
-	})
 
 	Describe("Simulate an upgrade from a version where ImageVolume was disabled to a version where it is enabled", Serial, decorators.ImageVolume, decorators.NoFlakeCheck, func() {
 		BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The validation that a `ContainerDisk` path does not contain relative paths (like `../test`) was being verified by a slow E2E test in [tests/container_disk_test.go](http://github.com/kubevirt/kubevirt/blob/main/tests/container_disk_test.go#L210). A `//TODO` comment correctly identified that this webhook admission validation should be a unit test.

#### After this PR:
The slow E2E test has been removed. A direct unit test replicating the `../test` relative path check has been added to the validating webhook admission tests ([vmi-create-admitter_test.go](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go)). 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
Testing admission webhook validation through E2E tests is expensive and unnecessary when the validation logic can be effortlessly covered by existing webhook unit tests. Converting it reduces the flake/runtime burden on the CI without sacrificing coverage.

The following tradeoffs were made:
This PR slightly trades E2E coverage for Unit test coverage. However, the E2E nature was testing the admission hook implicitly, which is an antipattern. 


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Resolves the TODO left in [tests/container_disk_test.go](https://github.com/kubevirt/kubevirt/blob/main/tests/container_disk_test.go#L210).

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
