### PR TITLE
tests/reporter: migrate from deprecated v1 Endpoints to EndpointSlices

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -973,13 +973,13 @@ func (r *KubernetesReporter) logAPIServices(virtCli kubecli.KubevirtClient) {
 }
 
 func (r *KubernetesReporter) logEndpoints(virtCli kubecli.KubevirtClient) {
-	endpoints, err := virtCli.CoreV1().Endpoints(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	endpointSlices, err := virtCli.DiscoveryV1().EndpointSlices(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		printError("failed to fetch endpointss: %v", err)
+		printError("failed to fetch endpoint slices: %v", err)
 		return
 	}
 
-	r.logObjects(endpoints, "endpoints")
+	r.logObjects(endpointSlices, "endpointslices")
 }
 
 func (r *KubernetesReporter) logConfigMaps(virtCli kubecli.KubevirtClient) {


### PR DESCRIPTION
### What this PR does

Replace `CoreV1().Endpoints()` with `DiscoveryV1().EndpointSlices()` in the test reporter log collector to silence the 
"v1 Endpoints is deprecated in v1.33+" warning emitted on every spec.

### Release note
```release-note
none
```

