### PR TITLE
tests/infra/Prometheus: Share VM setup across Prometheus Endpoints tests

### DIFF
--- a/hack/lint-test-cleanup-label.sh
+++ b/hack/lint-test-cleanup-label.sh
@@ -23,7 +23,8 @@ EXCLUDE_PATTERN="./decorators/decorators.go|\
 ./tests/virtctl|\
 ./tests/network|\
 ./tests/compute/guest_agent.go|\
-./tests/vnc_test.go"
+./tests/vnc_test.go|\
+./tests/infrastructure/prometheus.go"
 
 if grep -rl 'OncePerOrderedCleanup' ./tests --include=*.go |
     grep -Evq "$EXCLUDE_PATTERN"; then

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -163,7 +163,7 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 	})
 })
 
-var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", func() {
+var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", Ordered, decorators.OncePerOrderedCleanup, func() { //nolint:lll
 	var (
 		virtClient       kubecli.KubevirtClient
 		preparedVMIs     []*v1.VirtualMachineInstance
@@ -209,7 +209,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		return nodeName
 	}
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		var err error
 		virtClient = kubevirt.Client()
 
@@ -229,12 +229,6 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		for _, ip := range pod.Status.PodIPs {
 			handlerMetricIPs = append(handlerMetricIPs, ip.IP)
 		}
-	})
-
-	AfterEach(func() {
-		preparedVMIs = []*v1.VirtualMachineInstance{}
-		pod = nil
-		handlerMetricIPs = []string{}
 	})
 
 	It("[test_id:4136] should find one leading virt-controller and two ready", func() {


### PR DESCRIPTION
### What this PR does

Convert the "Prometheus Endpoints" Describe to an Ordered container with `OncePerOrderedCleanup` so that the two Alpine VMIs and virt-handler pod lookup are created once (`BeforeAll`) instead of per-test.
All specs in this block only read metrics and never mutate the VMIs, making them safe to share.

### Why

The `BeforeEach` was spinning up 2 VMIs before every single spec (~27 specs = ~54 VMI boot cycles).
Since every test only scrapes metrics from the relevant virt-handler, this was pure waste.

### Impact

|  | Before | After |
|--------|--------|-------|
| VMI boot cycles | 54 | 2 |
| Block runtime | ~20 min | ~3 min |

Before ([Random sample of sig-compute-serial prow job](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16632/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026534862629900288)): each test ~50s, dominated by VMI creation.

After ([this PR](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16914/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2025896170630418432)): setup cost paid once, individual tests run in 0-12s.

### Release note
```release-note
none
```
