### PR TITLE
[VEP 106] virt-config: Rename the DisableNADResourceInjection FG

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -213,8 +213,8 @@ func (config *ClusterConfig) PodSecondaryInterfaceNamingUpgradeEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.PodSecondaryInterfaceNamingUpgrade)
 }
 
-func (config *ClusterConfig) ShouldDisableNADResourceInjection() bool {
-	return config.isFeatureGateEnabled(featuregate.DisableNADResourceInjection)
+func (config *ClusterConfig) ExternalNetResourceInjectionEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.ExternalNetResourceInjection)
 }
 
 func (config *ClusterConfig) RebootPolicyEnabled() bool {

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -172,11 +172,11 @@ const (
 	// Beta: v1.8
 	PodSecondaryInterfaceNamingUpgrade = "PodSecondaryInterfaceNamingUpgrade"
 
-	// DisableNADResourceInjection disables the VMI controller query of NetworkAttachmentDefinition objects and
+	// ExternalNetResourceInjection disables the VMI controller query of NetworkAttachmentDefinition objects and
 	// the deployment of related RBAC rules by virt-operator.
 	// Owner: SIG network
 	// Beta: v1.8.0
-	DisableNADResourceInjection = "DisableNADResourceInjection"
+	ExternalNetResourceInjection = "ExternalNetResourceInjection"
 
 	// Owner: sig-compute / @MarSik
 	// Alpha: v1.8.0
@@ -228,7 +228,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: IncrementalBackupGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: Beta})
-	RegisterFeatureGate(FeatureGate{Name: DisableNADResourceInjection, State: Beta})
+	RegisterFeatureGate(FeatureGate{Name: ExternalNetResourceInjection, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: Template, State: Alpha})
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -362,7 +362,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	var networkToResourceMap map[string]string
-	if !t.clusterConfig.ShouldDisableNADResourceInjection() {
+	if !t.clusterConfig.ExternalNetResourceInjectionEnabled() {
 		var err error
 		networkToResourceMap, err = multus.NetworkToResource(t.virtClient, vmi)
 		if err != nil {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -5950,9 +5950,9 @@ var _ = Describe("Template", func() {
 	})
 
 	Context("NAD query disablement", func() {
-		It("Should not query NAD when DisableNADResourceInjection is enabled", func() {
+		It("Should not query NAD when ExternalNetResourceInjection is enabled", func() {
 			config, kvStore, svc = configFactory(defaultArch)
-			enableFeatureGate(featuregate.DisableNADResourceInjection)
+			enableFeatureGate(featuregate.ExternalNetResourceInjection)
 
 			svc = NewTemplateService("kubevirt/virt-launcher",
 				240,

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -512,7 +512,7 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	rbaclist := make([]runtime.Object, 0)
 	rbaclist = append(rbaclist, rbac.GetAllCluster()...)
 	rbaclist = append(rbaclist, rbac.GetAllApiServer(config.GetNamespace())...)
-	rbaclist = append(rbaclist, rbac.GetAllController(config.GetNamespace(), !config.ShouldDisableNADResourceInjection())...)
+	rbaclist = append(rbaclist, rbac.GetAllController(config.GetNamespace(), !config.ExternalNetResourceInjectionEnabled())...)
 	rbaclist = append(rbaclist, rbac.GetAllHandler(config.GetNamespace())...)
 	rbaclist = append(rbaclist, rbac.GetAllExportProxy(config.GetNamespace())...)
 	rbaclist = append(rbaclist, rbac.GetAllSynchronizationController(config.GetNamespace())...)

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -95,7 +95,7 @@ const (
 	AdditionalPropertiesHypervisorName = "HypervisorName"
 
 	// lookup key in AdditionalProperties
-	AdditionalPropertiesDisableNADResourceInjection = "DisableNADResourceInjection"
+	AdditionalPropertiesExternalNetResourceInjection = "ExternalNetResourceInjection"
 
 	// lookup key in AdditionalProperties
 	AdditionalPropertiesSynchronizationPort       = "SynchronizationPort"
@@ -185,8 +185,8 @@ func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVa
 		}
 	}
 
-	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.DisableNADResourceInjection) {
-		additionalProperties[AdditionalPropertiesDisableNADResourceInjection] = ""
+	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.ExternalNetResourceInjection) {
+		additionalProperties[AdditionalPropertiesExternalNetResourceInjection] = ""
 	}
 
 	hypervisor := virtconfig.GetHypervisorFromKvConfig(&kv.Spec.Configuration, isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.ConfigurableHypervisor))
@@ -548,8 +548,8 @@ func (c *KubeVirtDeploymentConfig) VirtTemplateDeploymentEnabled() bool {
 	return enabled
 }
 
-func (c *KubeVirtDeploymentConfig) ShouldDisableNADResourceInjection() bool {
-	_, enabled := c.AdditionalProperties[AdditionalPropertiesDisableNADResourceInjection]
+func (c *KubeVirtDeploymentConfig) ExternalNetResourceInjectionEnabled() bool {
+	_, enabled := c.AdditionalProperties[AdditionalPropertiesExternalNetResourceInjection]
 	return enabled
 }
 

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -98,7 +98,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
 			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
 
-		config.EnableFeatureGate(featuregate.DisableNADResourceInjection)
+		config.EnableFeatureGate(featuregate.ExternalNetResourceInjection)
 	})
 
 	Context("VMI connected to single SRIOV network", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does:
Following amendment of VEP 106 [1]
rename ShouldDisableNADResourceInjection FG
to ExternalNetResourceInjection.

[1] https://github.com/kubevirt/enhancements/pull/213



#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/106

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
PR starts from [config: Rename NAD FG](https://github.com/kubevirt/kubevirt/pull/16921/changes/d14e3a58d32ae2f28708be218405df7d1dac428b)
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

