### PR TITLE
tests: add some missing applyStorageProfile label to test PVCs

### DIFF
--- a/tests/objectgraph_test.go
+++ b/tests/objectgraph_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -64,20 +63,9 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 
 		BeforeEach(func() {
 			By("Creating a PVC")
-			pvc = &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-pvc-",
-					Namespace:    testsuite.GetTestNamespace(nil),
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("1Gi"),
-						},
-					},
-				},
-			}
+			sc, exists := libstorage.GetRWOFileSystemStorageClass()
+			Expect(exists).To(BeTrue())
+			pvc = libstorage.NewPVC("test-pvc", "1Gi", sc, libstorage.WithStorageProfile())
 			var err error
 			pvc, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Create(context.Background(), pvc, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -155,7 +143,7 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 
 		It("should detect hotplugged disks in the object graph", func() {
 			By("Hotplugging a disk")
-			hotplugPVC := libstorage.NewPVC("hotplug-pvc", "1Gi", "")
+			hotplugPVC := libstorage.NewPVC("hotplug-pvc", "1Gi", "", libstorage.WithStorageProfile())
 			hotplugPVC, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Create(context.Background(), hotplugPVC, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1941,7 +1941,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 
 			It("standalone PVC should have no owner with volumeOwnershipPolicyNone", func() {
 				pvcName := "standalone-pvc"
-				pvc := libstorage.NewPVC(pvcName, "2Gi", snapshotStorageClass)
+				pvc := libstorage.NewPVC(pvcName, "2Gi", snapshotStorageClass, libstorage.WithStorageProfile())
 				pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Create(context.Background(), pvc, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Some tests create PVCs without the applyStorageProfile label, causing them to fail against CSI provisioners that enforce a minimum PVC size.
Also add a nil guard for options in libstorage.NewPVC

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

