### PR TITLE
fix(virtctl): support TigerVNC 1.16.0+ path on macOS

### DIFF
--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -49,7 +49,9 @@ const (
 	//#### Tiger VNC ####
 	//# https://github.com/TigerVNC/tigervnc/releases
 	// Compatible with multiple Tiger VNC versions
-	MACOS_TIGER_VNC_PATTERN = `/Applications/TigerVNC Viewer *.app/Contents/MacOS/TigerVNC Viewer`
+	MACOS_TIGER_VNC_LEGACY_PATTERN = `/Applications/TigerVNC Viewer *.app/Contents/MacOS/TigerVNC Viewer`
+	// Tiger VNC 1.16.0+ changed the default app name
+	MACOS_TIGER_VNC_PATTERN = `/Applications/TigerVNC.app/Contents/MacOS/vncviewer`
 
 	//#### Chicken VNC ####
 	//# https://sourceforge.net/projects/chicken/
@@ -260,7 +262,11 @@ func getUserSpecifiedVnc(ctx context.Context, osType, vncType, vncPath string, p
 func getAutoDetectedVnc(osType string, port int) (string, []string, error) {
 	switch osType {
 	case "darwin":
-		if matches, err := filepath.Glob(MACOS_TIGER_VNC_PATTERN); err == nil && len(matches) > 0 {
+		if _, err := os.Stat(MACOS_TIGER_VNC_PATTERN); err == nil {
+			return MACOS_TIGER_VNC_PATTERN, tigerVncArgs(port), nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", nil, err
+		} else if matches, err := filepath.Glob(MACOS_TIGER_VNC_LEGACY_PATTERN); err == nil && len(matches) > 0 {
 			return matches[len(matches)-1], tigerVncArgs(port), nil
 		} else if err == filepath.ErrBadPattern {
 			return "", nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
TigerVNC 1.16.0 changed its default installation path on macOS from `/Applications/TigerVNC Viewer *.app/...` to `/Applications/TigerVNC.app/...`. This caused `virtctl vnc` to fail to auto-detect the viewer. 

This PR adds the new deterministic path (`/Applications/TigerVNC.app/Contents/MacOS/vncviewer`) and checks it using `os.Stat` before falling back to the legacy wildcard pattern, ensuring both new and old installations of TigerVNC are supported without breaking backward compatibility.

**Which issue(s) this PR fixes**:
Fixes #16755

**Special notes for the reviewer**:
Used `os.Stat` for the new path since it does not contain wildcards, avoiding the overhead of `filepath.Glob`.

**Release note**:
```release-note
Fixed an issue where `virtctl vnc` failed to auto-detect TigerVNC 1.16.0 and newer on macOS due to an application path change.