### PR TITLE
Add capacity parameter to EphemeralVolumeSource for disk resizing

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15013,6 +15013,10 @@
    "v1.EphemeralVolumeSource": {
     "type": "object",
     "properties": {
+     "capacity": {
+      "description": "Capacity specifies the virtual size of the ephemeral disk overlay. If set, the qcow2 overlay will be created with this virtual size, allowing the guest to see a larger disk than the backing PVC. The overlay is sparse and only consumes space for written data. If omitted, the overlay defaults to the size of the backing PVC.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+     },
      "persistentVolumeClaim": {
       "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
       "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaimVolumeSource"

--- a/pkg/ephemeral-disk/BUILD.bazel
+++ b/pkg/ephemeral-disk/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )
 
@@ -28,5 +29,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )

--- a/pkg/ephemeral-disk/ephemeral-disk.go
+++ b/pkg/ephemeral-disk/ephemeral-disk.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "kubevirt.io/api/core/v1"
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
@@ -50,7 +51,7 @@ type ephemeralDiskCreator struct {
 	mountBaseDir    string
 	pvcBaseDir      string
 	blockDevBaseDir string
-	discCreateFunc  func(backingFile string, backingFormat string, imagePath string) ([]byte, error)
+	discCreateFunc  func(backingFile string, backingFormat string, imagePath string, capacity *resource.Quantity) ([]byte, error)
 }
 
 func NewEphemeralDiskCreator(mountBaseDir string) *ephemeralDiskCreator {
@@ -107,7 +108,11 @@ func (c *ephemeralDiskCreator) CreateBackedImageForVolume(volume v1.Volume, back
 		return err
 	}
 
-	output, err := c.discCreateFunc(backingFile, backingFormat, imagePath)
+	var capacity *resource.Quantity
+	if volume.VolumeSource.Ephemeral != nil {
+		capacity = volume.VolumeSource.Ephemeral.Capacity
+	}
+	output, err := c.discCreateFunc(backingFile, backingFormat, imagePath, capacity)
 
 	// Cleanup of previous images isn't really necessary as they're all on EmptyDir.
 	if err != nil {
@@ -140,17 +145,20 @@ func (c *ephemeralDiskCreator) CreateEphemeralImages(vmi *v1.VirtualMachineInsta
 	return nil
 }
 
-func createBackingDisk(backingFile string, backingFormat string, imagePath string) ([]byte, error) {
-	// #nosec No risk for attacker injection. Parameters are predefined strings
-	cmd := exec.Command("qemu-img",
+func createBackingDisk(backingFile string, backingFormat string, imagePath string, capacity *resource.Quantity) ([]byte, error) {
+	args := []string{
 		"create",
-		"-f",
-		"qcow2",
-		"-b",
-		backingFile,
-		"-F",
-		backingFormat,
+		"-f", "qcow2",
+		"-b", backingFile,
+		"-F", backingFormat,
 		imagePath,
-	)
+	}
+	if capacity != nil {
+		// Use decimal string representation to avoid int64 overflow for large capacities.
+		// qemu-img accepts decimal byte values as the size argument.
+		args = append(args, capacity.AsDec().String())
+	}
+	// #nosec No risk for attacker injection. Parameters are predefined strings or validated numeric values from resource.Quantity
+	cmd := exec.Command("qemu-img", args...)
 	return cmd.CombinedOutput()
 }

--- a/pkg/ephemeral-disk/ephemeral-disk.go
+++ b/pkg/ephemeral-disk/ephemeral-disk.go
@@ -153,7 +153,7 @@ func createBackingDisk(backingFile string, backingFormat string, imagePath strin
 		"-F", backingFormat,
 		imagePath,
 	}
-	if capacity != nil {
+	if capacity != nil && !capacity.IsZero() {
 		// Use decimal string representation to avoid int64 overflow for large capacities.
 		// qemu-img accepts decimal byte values as the size argument.
 		args = append(args, capacity.AsDec().String())

--- a/pkg/ephemeral-disk/ephemeral-disk_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -171,10 +172,69 @@ var _ = Describe("ContainerDisk", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+
+		Context("With ephemeral volume specifying capacity", func() {
+			It("Should create ephemeral image and pass capacity to disk creator", func() {
+				By("Creating a VirtualMachineInstance with ephemeral volume and capacity")
+				capacity := resource.MustParse("100Gi")
+				vmi := libvmi.New(
+					libvmi.WithEphemeralPersistentVolumeClaimWithCapacity("fake-disk", "fake-pvc", capacity),
+				)
+
+				By("Creating a backing image for the PVC")
+				Expect(createBackingImageForPVC("fake-disk", false)).To(Succeed())
+
+				By("Tracking capacity passed to disk creator")
+				var capturedCapacity *resource.Quantity
+				creator.discCreateFunc = func(backingFile string, backingFormat string, imagePath string, cap *resource.Quantity) ([]byte, error) {
+					capturedCapacity = cap
+					return fakeCreateBackingDisk(backingFile, backingFormat, imagePath, cap)
+				}
+
+				By("Creating ephemeral images")
+				err := creator.CreateEphemeralImages(vmi, &api.Domain{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying capacity was passed")
+				Expect(capturedCapacity).NotTo(BeNil())
+				Expect(capturedCapacity.Cmp(capacity)).To(Equal(0))
+
+				By("Verifying the overlay was created")
+				_, err = os.Stat(filepath.Join(creator.mountBaseDir, "fake-disk", "disk.qcow2"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Should pass nil capacity when not specified", func() {
+				By("Creating a VirtualMachineInstance without capacity")
+				vmi := libvmi.New(
+					libvmi.WithEphemeralPersistentVolumeClaim("fake-disk", "fake-pvc"),
+				)
+
+				By("Creating a backing image for the PVC")
+				Expect(createBackingImageForPVC("fake-disk", false)).To(Succeed())
+
+				By("Tracking capacity passed to disk creator")
+				var capturedCapacity *resource.Quantity
+				wasCalled := false
+				creator.discCreateFunc = func(backingFile string, backingFormat string, imagePath string, cap *resource.Quantity) ([]byte, error) {
+					capturedCapacity = cap
+					wasCalled = true
+					return fakeCreateBackingDisk(backingFile, backingFormat, imagePath, cap)
+				}
+
+				By("Creating ephemeral images")
+				err := creator.CreateEphemeralImages(vmi, &api.Domain{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying nil capacity was passed")
+				Expect(wasCalled).To(BeTrue())
+				Expect(capturedCapacity).To(BeNil())
+			})
+		})
 	})
 })
 
-func fakeCreateBackingDisk(backingFile string, backingFormat string, imagePath string) ([]byte, error) {
+func fakeCreateBackingDisk(backingFile string, backingFormat string, imagePath string, capacity *resource.Quantity) ([]byte, error) {
 	if backingFormat != "raw" {
 		return nil, fmt.Errorf("wrong backing format")
 	}

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -78,7 +78,16 @@ func WithHotplugPersistentVolumeClaim(diskName, pvcName string, diskOpts ...Disk
 func WithEphemeralPersistentVolumeClaim(diskName, pvcName string, diskOpts ...DiskOption) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDisk(vmi, newDisk(diskName, v1.DiskBusSATA, diskOpts...))
-		addVolume(vmi, newEphemeralPersistentVolumeClaimVolume(diskName, pvcName))
+		addVolume(vmi, newEphemeralPersistentVolumeClaimVolume(diskName, pvcName, nil))
+	}
+}
+
+// WithEphemeralPersistentVolumeClaimWithCapacity specifies an Ephemeral.PersistentVolumeClaim with a custom disk capacity.
+// The capacity sets the virtual size of the qcow2 overlay, allowing the guest to see a larger disk than the backing PVC.
+func WithEphemeralPersistentVolumeClaimWithCapacity(diskName, pvcName string, capacity resource.Quantity, diskOpts ...DiskOption) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDisk(vmi, newDisk(diskName, v1.DiskBusSATA, diskOpts...))
+		addVolume(vmi, newEphemeralPersistentVolumeClaimVolume(diskName, pvcName, &capacity))
 	}
 }
 
@@ -351,7 +360,7 @@ func newPersistentVolumeClaimVolume(name, claimName string, hotpluggable bool) v
 	}
 }
 
-func newEphemeralPersistentVolumeClaimVolume(name, claimName string) v1.Volume {
+func newEphemeralPersistentVolumeClaimVolume(name, claimName string, capacity *resource.Quantity) v1.Volume {
 	return v1.Volume{
 		Name: name,
 		VolumeSource: v1.VolumeSource{
@@ -359,6 +368,7 @@ func newEphemeralPersistentVolumeClaimVolume(name, claimName string) v1.Volume {
 				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
 					ClaimName: claimName,
 				},
+				Capacity: capacity,
 			},
 		},
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1648,6 +1648,15 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 		}
 		if volume.Ephemeral != nil {
 			volumeSourceSetCount++
+			if volume.Ephemeral.Capacity != nil {
+				if volume.Ephemeral.Capacity.CmpInt64(0) <= 0 {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: "capacity must be a positive value",
+						Field:   field.Index(idx).Child("ephemeral", "capacity").String(),
+					})
+				}
+			}
 		}
 		if volume.EmptyDisk != nil {
 			volumeSourceSetCount++

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1649,10 +1649,10 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 		if volume.Ephemeral != nil {
 			volumeSourceSetCount++
 			if volume.Ephemeral.Capacity != nil {
-				if volume.Ephemeral.Capacity.CmpInt64(0) <= 0 {
+				if volume.Ephemeral.Capacity.CmpInt64(0) < 0 {
 					causes = append(causes, metav1.StatusCause{
 						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: "capacity must be a positive value",
+						Message: "capacity must not be negative",
 						Field:   field.Index(idx).Child("ephemeral", "capacity").String(),
 					})
 				}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2242,7 +2242,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes[0].Message).To(ContainSubstring("fake must have max one memory dump volume set"))
 		})
 
-		It("should reject ephemeral volume with zero capacity", func() {
+		It("should accept ephemeral volume with zero capacity", func() {
 			capacity := resource.MustParse("0")
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name: "testdisk",
@@ -2260,8 +2260,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(ContainSubstring("capacity"))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject ephemeral volume with negative capacity", func() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8252,6 +8252,18 @@ var CRDsValidation map[string]string = map[string]string{
                           specified source and provides copy-on-write image on top
                           of it.
                         properties:
+                          capacity:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Capacity specifies the virtual size of the ephemeral disk overlay.
+                              If set, the qcow2 overlay will be created with this virtual size,
+                              allowing the guest to see a larger disk than the backing PVC.
+                              The overlay is sparse and only consumes space for written data.
+                              If omitted, the overlay defaults to the size of the backing PVC.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           persistentVolumeClaim:
                             description: |-
                               PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.
@@ -14155,6 +14167,18 @@ var CRDsValidation map[string]string = map[string]string{
                 description: Ephemeral is a special volume source that "wraps" specified
                   source and provides copy-on-write image on top of it.
                 properties:
+                  capacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      Capacity specifies the virtual size of the ephemeral disk overlay.
+                      If set, the qcow2 overlay will be created with this virtual size,
+                      allowing the guest to see a larger disk than the backing PVC.
+                      The overlay is sparse and only consumes space for written data.
+                      If omitted, the overlay defaults to the size of the backing PVC.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   persistentVolumeClaim:
                     description: |-
                       PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.
@@ -20590,6 +20614,18 @@ var CRDsValidation map[string]string = map[string]string{
                           specified source and provides copy-on-write image on top
                           of it.
                         properties:
+                          capacity:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Capacity specifies the virtual size of the ephemeral disk overlay.
+                              If set, the qcow2 overlay will be created with this virtual size,
+                              allowing the guest to see a larger disk than the backing PVC.
+                              The overlay is sparse and only consumes space for written data.
+                              If omitted, the overlay defaults to the size of the backing PVC.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                           persistentVolumeClaim:
                             description: |-
                               PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.
@@ -25686,6 +25722,18 @@ var CRDsValidation map[string]string = map[string]string{
                                   that "wraps" specified source and provides copy-on-write
                                   image on top of it.
                                 properties:
+                                  capacity:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Capacity specifies the virtual size of the ephemeral disk overlay.
+                                      If set, the qcow2 overlay will be created with this virtual size,
+                                      allowing the guest to see a larger disk than the backing PVC.
+                                      The overlay is sparse and only consumes space for written data.
+                                      If omitted, the overlay defaults to the size of the backing PVC.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   persistentVolumeClaim:
                                     description: |-
                                       PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.
@@ -31238,6 +31286,18 @@ var CRDsValidation map[string]string = map[string]string{
                                       that "wraps" specified source and provides copy-on-write
                                       image on top of it.
                                     properties:
+                                      capacity:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          Capacity specifies the virtual size of the ephemeral disk overlay.
+                                          If set, the qcow2 overlay will be created with this virtual size,
+                                          allowing the guest to see a larger disk than the backing PVC.
+                                          The overlay is sparse and only consumes space for written data.
+                                          If omitted, the overlay defaults to the size of the backing PVC.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                       persistentVolumeClaim:
                                         description: |-
                                           PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -792,7 +792,8 @@
               "persistentVolumeClaim": {
                 "claimName": "claimNameValue",
                 "readOnly": true
-              }
+              },
+              "capacity": "0"
             },
             "emptyDisk": {
               "capacity": "0"

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -780,6 +780,7 @@ spec:
         emptyDisk:
           capacity: "0"
         ephemeral:
+          capacity: "0"
           persistentVolumeClaim:
             claimName: claimNameValue
             readOnly: true

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -732,7 +732,8 @@
           "persistentVolumeClaim": {
             "claimName": "claimNameValue",
             "readOnly": true
-          }
+          },
+          "capacity": "0"
         },
         "emptyDisk": {
           "capacity": "0"

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -583,6 +583,7 @@ spec:
     emptyDisk:
       capacity: "0"
     ephemeral:
+      capacity: "0"
       persistentVolumeClaim:
         claimName: claimNameValue
         readOnly: true

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -1716,6 +1716,11 @@ func (in *EphemeralVolumeSource) DeepCopyInto(out *EphemeralVolumeSource) {
 		*out = new(corev1.PersistentVolumeClaimVolumeSource)
 		**out = **in
 	}
+	if in.Capacity != nil {
+		in, out := &in.Capacity, &out.Capacity
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -1011,6 +1011,13 @@ type EphemeralVolumeSource struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 	// +optional
 	PersistentVolumeClaim *v1.PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
+	// Capacity specifies the virtual size of the ephemeral disk overlay.
+	// If set, the qcow2 overlay will be created with this virtual size,
+	// allowing the guest to see a larger disk than the backing PVC.
+	// The overlay is sparse and only consumes space for written data.
+	// If omitted, the overlay defaults to the size of the backing PVC.
+	// +optional
+	Capacity *resource.Quantity `json:"capacity,omitempty"`
 }
 
 // EmptyDisk represents a temporary disk which shares the vmis lifecycle.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -527,6 +527,7 @@ func (MemoryDumpVolumeSource) SwaggerDoc() map[string]string {
 func (EphemeralVolumeSource) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"persistentVolumeClaim": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.\nDirectly attached to the vmi via qemu.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims\n+optional",
+		"capacity":              "Capacity specifies the virtual size of the ephemeral disk overlay.\nIf set, the qcow2 overlay will be created with this virtual size,\nallowing the guest to see a larger disk than the backing PVC.\nThe overlay is sparse and only consumes space for written data.\nIf omitted, the overlay defaults to the size of the backing PVC.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21042,11 +21042,17 @@ func schema_kubevirtio_api_core_v1_EphemeralVolumeSource(ref common.ReferenceCal
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource"),
 						},
 					},
+					"capacity": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Capacity specifies the virtual size of the ephemeral disk overlay. If set, the qcow2 overlay will be created with this virtual size, allowing the guest to see a larger disk than the backing PVC. The overlay is sparse and only consumes space for written data. If omitted, the overlay defaults to the size of the backing PVC.",
+							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource"},
+			"k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
 	}
 }
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -466,6 +466,34 @@ var _ = Describe(SIG("Storage", func() {
 			})
 		})
 
+		Context("With ephemeral PVC and capacity override", func() {
+			It("should present the guest with a disk of the specified capacity", func() {
+				capacity := resource.MustParse("2Gi")
+				vmi = libvmi.New(
+					libvmi.WithMemoryRequest("256Mi"),
+					libvmi.WithEphemeralPersistentVolumeClaimWithCapacity("disk0", diskAlpineHostPath, capacity),
+				)
+
+				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsLarge)
+
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+				var diskDevice string
+				Eventually(func() string {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					diskDevice = libstorage.LookupVolumeTargetPath(vmi, "disk0")
+					return diskDevice
+				}, 30*time.Second, time.Second).ShouldNot(BeEmpty())
+
+				By("Checking that the disk has a capacity of 2Gi")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("blockdev --getsize64 %s\n", diskDevice)},
+					&expect.BExp{R: "2147483648"}, // 2Gi in bytes
+				}, 10)).To(Succeed())
+			})
+		})
+
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With VirtualMachineInstance with two PVCs", func() {
 			BeforeEach(func() {
 				// Setup second PVC to use in this context


### PR DESCRIPTION
## Summary

Add an optional `Capacity` field to `EphemeralVolumeSource` that specifies the virtual size of the qcow2 overlay disk. This enables creating ephemeral disks larger than the backing PVC without requiring VirtualMachineSnapshot/Clone workflows.

Fixes: https://github.com/kubevirt/kubevirt/issues/16633

## Changes

- **API:** Add `Capacity *resource.Quantity` to `EphemeralVolumeSource` (optional, backward compatible)
- **ephemeral-disk:** Pass capacity as size argument to `qemu-img create` when specified, using `AsDec().String()` to avoid int64 overflow for large capacities
- **validation:** Reject non-positive capacity values at admission
- **libvmi:** Add `WithEphemeralPersistentVolumeClaimWithCapacity` helper
- **tests:** Unit tests for capacity passthrough, admission validation tests, and e2e test verifying guest sees the correct disk size
- **generated:** Updated swagger, openapi, deepcopy, CRD validations

## How it works

qcow2 overlays natively support a virtual size larger than their backing file. When `capacity` is set, `qemu-img create -f qcow2 -b <backing> -F <format> <overlay> <capacity_bytes>` creates a sparse overlay that the guest sees as the specified size. Cloud-init `growpart`/`resize_rootfs` handles filesystem expansion.

## Use case

Creating VMs with custom disk sizes from a shared golden image PVC. Instead of the current flow (golden PVC → snapshot → clone → PVC resize), this simplifies to: golden PVC + ephemeral volume with capacity.

```release-note
Added optional `capacity` field to `EphemeralVolumeSource` allowing users to specify a virtual disk size larger than the backing PVC for ephemeral disks
```

/sig storage