### PR TITLE
Converter, context: Remove unused field "Secrets"

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -784,15 +784,8 @@ var _ = Describe("Converter", func() {
 
 		BeforeEach(func() {
 			c = &convertertypes.ConverterContext{
-				Architecture:   archconverter.NewConverter(runtime.GOARCH),
-				VirtualMachine: vmi,
-				Secrets: map[string]*k8sv1.Secret{
-					"mysecret": {
-						Data: map[string][]byte{
-							"node.session.auth.username": []byte("admin"),
-						},
-					},
-				},
+				Architecture:                    archconverter.NewConverter(runtime.GOARCH),
+				VirtualMachine:                  vmi,
 				AllowEmulation:                  true,
 				HypervisorDeviceAvailable:       true,
 				IsBlockPVC:                      isBlockPVCMap,
@@ -2036,13 +2029,6 @@ var _ = Describe("Converter", func() {
 			c = &convertertypes.ConverterContext{
 				Architecture:   archconverter.NewConverter(runtime.GOARCH),
 				VirtualMachine: vmi,
-				Secrets: map[string]*k8sv1.Secret{
-					"mysecret": {
-						Data: map[string][]byte{
-							"node.session.auth.username": []byte("admin"),
-						},
-					},
-				},
 				AllowEmulation: true,
 				SMBios:         TestSmbios,
 				DomainAttachmentByInterfaceName: map[string]string{

--- a/pkg/virt-launcher/virtwrap/converter/types/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/types/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/arch:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/converter/types/converter-context.go
+++ b/pkg/virt-launcher/virtwrap/converter/types/converter-context.go
@@ -20,7 +20,6 @@
 package types
 
 import (
-	k8sv1 "k8s.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
@@ -41,7 +40,6 @@ type ConverterContext struct {
 	Architecture                    arch.Converter
 	AllowEmulation                  bool
 	HypervisorDeviceAvailable       bool
-	Secrets                         map[string]*k8sv1.Secret
 	VirtualMachine                  *v1.VirtualMachineInstance
 	CPUSet                          []int
 	IsBlockPVC                      map[string]bool


### PR DESCRIPTION
### What this PR does
1. Removes `Secrets` field, the is not being used anymore.

### Why we need it and why it was done in this way

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

