### PR TITLE
linter: Add linter to pkg/monitoring/metrics

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -10,6 +10,7 @@ pkg/controller/testing
 pkg/instancetype
 pkg/libvmi
 pkg/monitoring/metrics/virt-api
+pkg/monitoring/metrics/virt-handler
 pkg/monitoring/metrics/virt-operator
 pkg/monitoring/rules
 pkg/network/admitter

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -9,10 +9,7 @@ cmd/virt-operator
 pkg/controller/testing
 pkg/instancetype
 pkg/libvmi
-pkg/monitoring/metrics/virt-api
-pkg/monitoring/metrics/virt-controller
-pkg/monitoring/metrics/virt-handler
-pkg/monitoring/metrics/virt-operator
+pkg/monitoring/metrics
 pkg/monitoring/rules
 pkg/network/admitter
 pkg/network/controllers

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -9,6 +9,7 @@ cmd/virt-operator
 pkg/controller/testing
 pkg/instancetype
 pkg/libvmi
+pkg/monitoring/metrics/virt-api
 pkg/monitoring/rules
 pkg/network/admitter
 pkg/network/controllers

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -10,6 +10,7 @@ pkg/controller/testing
 pkg/instancetype
 pkg/libvmi
 pkg/monitoring/metrics/virt-api
+pkg/monitoring/metrics/virt-controller
 pkg/monitoring/metrics/virt-handler
 pkg/monitoring/metrics/virt-operator
 pkg/monitoring/rules

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -10,6 +10,7 @@ pkg/controller/testing
 pkg/instancetype
 pkg/libvmi
 pkg/monitoring/metrics/virt-api
+pkg/monitoring/metrics/virt-operator
 pkg/monitoring/rules
 pkg/network/admitter
 pkg/network/controllers

--- a/pkg/monitoring/metrics/common/client/client_test.go
+++ b/pkg/monitoring/metrics/common/client/client_test.go
@@ -35,41 +35,86 @@ var _ = BeforeSuite(func() {
 
 var _ = Describe("URL Parsing", func() {
 	Context("with resource and operation", func() {
-		DescribeTable("accurately parse resource and operation", func(urlStr, queryStr, method, expectedResource, expectedOperation string) {
+		DescribeTable("accurately parse resource and operation",
+			func(urlStr, queryStr, method, expectedResource, expectedOperation string) {
+				request := &http.Request{
+					Method: method,
+					URL: &url.URL{
+						Path:     urlStr,
+						RawQuery: queryStr,
+					},
+				}
 
-			request := &http.Request{
-				Method: method,
-				URL: &url.URL{
-					Path:     urlStr,
-					RawQuery: queryStr,
-				},
-			}
+				resource, operation := parseURLResourceOperation(request)
+				Expect(resource).To(Equal(expectedResource))
+				Expect(operation).To(Equal(expectedOperation))
+			},
 
-			resource, operation := parseURLResourceOperation(request)
-			Expect(resource).To(Equal(expectedResource))
-			Expect(operation).To(Equal(expectedOperation))
+			Entry("should handle an empty URL and method",
+				"", "", " ", "none", "none"),
 
-		},
-			Entry("should handle an empty URL and method", "", "", " ", "none", "none"),
-			Entry("should handle an empty URL", "", "", "GET", "none", "none"),
-			Entry("should handle an empty Method", "/api/v1/watch/namespaces/kubevirt/pods", "", "", "none", "none"),
-			Entry("should handle watching namespaced resource", "/api/v1/watch/namespaces/kubevirt/pods", "", "GET", "pods", "WATCH"),
-			Entry("should handle watching globally scoped resource", "/api/v1/watch/pods", "", "GET", "pods", "WATCH"),
-			Entry("should handle list of namespaced resources", "/api/v1/namespaces/kubevirt/pods", "", "GET", "pods", "LIST"),
-			Entry("should handle list of namespaced resources with a fieldSelector as a query", "/api/v1/namespaces/kubevirt/pods", "fieldSelector=value", "GET", "pods", "LIST"),
-			Entry("should handle list of namespaced resources with watch query", "/api/v1/namespaces/kubevirt/pods", "fieldSelector=value&watch=true", "GET", "pods", "WATCH"),
-			Entry("should handle get of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "GET", "pods", "GET"),
-			Entry("should handle get of namespaced resources with a query", "/api/v1/namespaces/kubevirt/pods/my-pod", "label=value", "GET", "pods", "GET"),
-			Entry("should handle list of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances", "", "GET", "virtualmachineinstances", "LIST"),
-			Entry("should handle get of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi", "", "GET", "virtualmachineinstances", "GET"),
-			Entry("should handle list of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts", "", "GET", "kubevirts", "LIST"),
-			Entry("should handle get of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts/my-kv", "", "GET", "kubevirts", "GET"),
-			Entry("should handle UPDATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "PUT", "pods", "UPDATE"),
-			Entry("should handle PATCH of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "PATCH", "pods", "PATCH"),
-			Entry("should handle CREATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "POST", "pods", "CREATE"),
-			Entry("should handle DELETE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "DELETE", "pods", "DELETE"),
-			Entry("should handle UPDATE to status subresource", "/api/v1/namespaces/kubevirt/pods/my-pod/status", "", "PUT", "pods", "UPDATE"),
-			Entry("should handle UPDATE to custom subresource", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi/some-subresource", "", "PUT", "virtualmachineinstances", "UPDATE"),
+			Entry("should handle an empty URL",
+				"", "", "GET", "none", "none"),
+
+			Entry("should handle an empty Method",
+				"/api/v1/watch/namespaces/kubevirt/pods", "", "", "none", "none"),
+
+			Entry("should handle watching namespaced resource",
+				"/api/v1/watch/namespaces/kubevirt/pods", "", "GET", "pods", "WATCH"),
+
+			Entry("should handle watching globally scoped resource",
+				"/api/v1/watch/pods", "", "GET", "pods", "WATCH"),
+
+			Entry("should handle list of namespaced resources",
+				"/api/v1/namespaces/kubevirt/pods", "", "GET", "pods", "LIST"),
+
+			Entry("should handle list of namespaced resources with a fieldSelector",
+				"/api/v1/namespaces/kubevirt/pods", "fieldSelector=value",
+				"GET", "pods", "LIST"),
+
+			Entry("should handle list of namespaced resources with watch query",
+				"/api/v1/namespaces/kubevirt/pods",
+				"fieldSelector=value&watch=true", "GET", "pods", "WATCH"),
+
+			Entry("should handle get of namespaced resources",
+				"/api/v1/namespaces/kubevirt/pods/my-pod", "", "GET", "pods", "GET"),
+
+			Entry("should handle get of namespaced resources with a query",
+				"/api/v1/namespaces/kubevirt/pods/my-pod", "label=value",
+				"GET", "pods", "GET"),
+
+			Entry("should handle list of custom namespaced resources",
+				"/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances",
+				"", "GET", "virtualmachineinstances", "LIST"),
+
+			Entry("should handle get of custom namespaced resources",
+				"/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi",
+				"", "GET", "virtualmachineinstances", "GET"),
+
+			Entry("should handle list of custom globally scoped resources",
+				"/apis/kubevirt.io/v1/kubevirts", "", "GET", "kubevirts", "LIST"),
+
+			Entry("should handle get of custom globally scoped resources",
+				"/apis/kubevirt.io/v1/kubevirts/my-kv", "", "GET", "kubevirts", "GET"),
+
+			Entry("should handle UPDATE of namespaced resources",
+				"/api/v1/namespaces/kubevirt/pods/my-pod", "", "PUT", "pods", "UPDATE"),
+
+			Entry("should handle PATCH of namespaced resources",
+				"/api/v1/namespaces/kubevirt/pods/my-pod", "", "PATCH", "pods", "PATCH"),
+
+			Entry("should handle CREATE of namespaced resources",
+				"/api/v1/namespaces/kubevirt/pods/my-pod", "", "POST", "pods", "CREATE"),
+
+			Entry("should handle DELETE of namespaced resources",
+				"/api/v1/namespaces/kubevirt/pods/my-pod", "", "DELETE", "pods", "DELETE"),
+
+			Entry("should handle UPDATE to status subresource",
+				"/api/v1/namespaces/kubevirt/pods/my-pod/status", "", "PUT", "pods", "UPDATE"),
+
+			Entry("should handle UPDATE to custom subresource",
+				"/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi/some-subresource",
+				"", "PUT", "virtualmachineinstances", "UPDATE"),
 		)
 	})
 })

--- a/pkg/monitoring/metrics/common/client/rest_metrics.go
+++ b/pkg/monitoring/metrics/common/client/rest_metrics.go
@@ -23,6 +23,12 @@ import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 )
 
+const (
+	rateLimiterBucketStart  = 0.001
+	rateLimiterBucketFactor = 2
+	rateLimiterBucketCount  = 10
+)
+
 var (
 	restMetrics = []operatormetrics.Metric{
 		requestLatency,
@@ -54,7 +60,7 @@ var (
 			Help: "Client side rate limiter latency in seconds. Broken down by verb and URL.",
 		},
 		prometheus.HistogramOpts{
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+			Buckets: prometheus.ExponentialBuckets(rateLimiterBucketStart, rateLimiterBucketFactor, rateLimiterBucketCount),
 		},
 		[]string{"verb", "url"},
 	)

--- a/pkg/monitoring/metrics/common/client/rt_wrapper.go
+++ b/pkg/monitoring/metrics/common/client/rt_wrapper.go
@@ -25,7 +25,19 @@ import (
 	"strings"
 )
 
-const defaultNone = "none"
+const (
+	defaultNone = "none"
+
+	verbGet    = "GET"
+	verbPut    = "PUT"
+	verbPatch  = "PATCH"
+	verbPost   = "POST"
+	verbDelete = "DELETE"
+	verbWatch  = "WATCH"
+	verbList   = "LIST"
+	verbUpdate = "UPDATE"
+	verbCreate = "CREATE"
+)
 
 type rtWrapper struct {
 	origRoundTripper http.RoundTripper
@@ -73,16 +85,16 @@ func parseURLResourceOperation(request *http.Request) (resource, verb string) {
 
 func getVerbFromHTTPVerb(u url.URL, methodOrVerb string) (verb string) {
 	switch methodOrVerb {
-	case "GET":
+	case verbGet:
 		verb = determineGetVerb(u)
-	case "PUT":
-		verb = "UPDATE"
-	case "PATCH":
-		verb = "PATCH"
-	case "POST":
-		verb = "CREATE"
-	case "DELETE":
-		verb = "DELETE"
+	case verbPut:
+		verb = verbUpdate
+	case verbPatch:
+		verb = verbPatch
+	case verbPost:
+		verb = verbCreate
+	case verbDelete:
+		verb = verbDelete
 	default:
 		verb = methodOrVerb
 	}
@@ -92,16 +104,16 @@ func getVerbFromHTTPVerb(u url.URL, methodOrVerb string) (verb string) {
 
 func determineGetVerb(u url.URL) string {
 	if strings.Contains(u.Path, "/watch/") || u.Query().Get("watch") == "true" {
-		return "WATCH"
+		return verbWatch
 	}
 
 	if resource := findResource(u); resource == "" {
-		return "none"
+		return defaultNone
 	} else if strings.HasSuffix(u.Path, resource) {
-		return "LIST"
+		return verbList
 	}
 
-	return "GET"
+	return verbGet
 }
 
 func findResource(u url.URL) (resource string) {

--- a/pkg/monitoring/metrics/common/labels/labels_config.go
+++ b/pkg/monitoring/metrics/common/labels/labels_config.go
@@ -102,7 +102,7 @@ func (c *configImpl) startWatcherWithClient(client kubecli.KubevirtClient) error
 }
 
 func (c *configImpl) attachHandlersToInformer(informer cache.SharedIndexInformer) {
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			cm, ok := obj.(*k8sv1.ConfigMap)
 			if !ok {
@@ -123,6 +123,9 @@ func (c *configImpl) attachHandlersToInformer(informer cache.SharedIndexInformer
 			c.resetToDefaults()
 		},
 	})
+	if err != nil {
+		log.Log.Warningf("vm-labels: failed to add event handler: %v", err)
+	}
 }
 
 func (c *configImpl) ShouldReport(label string) bool {

--- a/pkg/monitoring/metrics/common/workqueue/metrics.go
+++ b/pkg/monitoring/metrics/common/workqueue/metrics.go
@@ -24,6 +24,12 @@ import (
 	k8sworkqueue "k8s.io/client-go/util/workqueue"
 )
 
+const (
+	workqueueBucketStart  = 10e-9
+	workqueueBucketFactor = 10
+	workqueueBucketCount  = 10
+)
+
 var (
 	workqueueMetrics = []operatormetrics.Metric{
 		depth,
@@ -57,7 +63,7 @@ var (
 			Help: "How long an item stays in workqueue before being requested.",
 		},
 		prometheus.HistogramOpts{
-			Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+			Buckets: prometheus.ExponentialBuckets(workqueueBucketStart, workqueueBucketFactor, workqueueBucketCount),
 		},
 		[]string{"name"},
 	)
@@ -68,7 +74,7 @@ var (
 			Help: "How long in seconds processing an item from workqueue takes.",
 		},
 		prometheus.HistogramOpts{
-			Buckets: prometheus.ExponentialBuckets(10e-9, 10, 10),
+			Buckets: prometheus.ExponentialBuckets(workqueueBucketStart, workqueueBucketFactor, workqueueBucketCount),
 		},
 		[]string{"name"},
 	)
@@ -103,7 +109,7 @@ var (
 
 type Provider struct{}
 
-func init() {
+func init() { //nolint:gochecknoinits // Force KubeVirt workqueue metrics to be registered before default k8s workqueue metrics
 	k8sworkqueue.SetProvider(Provider{})
 }
 

--- a/pkg/monitoring/metrics/testing/metric_matcher.go
+++ b/pkg/monitoring/metrics/testing/metric_matcher.go
@@ -74,7 +74,7 @@ func (matcher *MetricMatcher) Match(actual interface{}) (success bool, err error
 
 	nameToMatch := matcher.Metric.GetOpts().Name
 	if matcher.Metric.GetType() == operatormetrics.HistogramType || matcher.Metric.GetType() == operatormetrics.HistogramVecType {
-		nameToMatch = nameToMatch + prometheusHistogramBucketSuffix
+		nameToMatch += prometheusHistogramBucketSuffix
 	}
 
 	if actualName != nameToMatch {

--- a/pkg/monitoring/metrics/virt-api/connection_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/connection_metrics.go
@@ -16,7 +16,7 @@
  * Copyright The KubeVirt Authors.
  */
 
-package virt_api
+package virtapi
 
 import (
 	"time"

--- a/pkg/monitoring/metrics/virt-api/metrics.go
+++ b/pkg/monitoring/metrics/virt-api/metrics.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_api
+package virtapi
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"

--- a/pkg/monitoring/metrics/virt-api/vm_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/vm_metrics.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_api
+package virtapi
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"

--- a/pkg/monitoring/metrics/virt-controller/component_metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/component_metrics.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	ioprometheusclient "github.com/prometheus/client_model/go"

--- a/pkg/monitoring/metrics/virt-controller/leader_metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/leader_metrics.go
@@ -16,7 +16,7 @@
  * Copyright The KubeVirt Authors.
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	ioprometheusclient "github.com/prometheus/client_model/go"
@@ -31,7 +31,8 @@ var (
 	outdatedVirtualMachineInstanceWorkloads = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_number_of_outdated",
-			Help: "Indication for the total number of VirtualMachineInstance workloads that are not running within the most up-to-date version of the virt-launcher environment.",
+			Help: "Indication for the total number of VirtualMachineInstance workloads " +
+				"that are not running within the most up-to-date version of the virt-launcher environment.",
 		},
 	)
 )

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"fmt"
@@ -36,6 +36,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/workqueue"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+)
+
+const (
+	logVerbosityDebug = 4
 )
 
 type vmApplyHandler interface {
@@ -168,7 +172,7 @@ func PhaseTransitionTimeBuckets() []float64 {
 	}
 }
 
-func getTransitionTimeSeconds(oldTime *metav1.Time, newTime *metav1.Time) (float64, error) {
+func getTransitionTimeSeconds(oldTime, newTime *metav1.Time) (float64, error) {
 	if newTime == nil || oldTime == nil {
 		// no phase transition timestamp found
 		return 0.0, fmt.Errorf("missing phase transition timestamp, newTime: %v, oldTime: %v", newTime, oldTime)

--- a/pkg/monitoring/metrics/virt-controller/migration_metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/migration_metrics.go
@@ -16,7 +16,7 @@
  * Copyright The KubeVirt Authors.
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -56,21 +56,24 @@ var (
 func CreateVMIMigrationHandler(informer cache.SharedIndexInformer) error {
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldVMIMigration, newVMIMigration interface{}) {
-			updateVMIMigrationPhaseTransitionTimeFromCreationTime(oldVMIMigration.(*v1.VirtualMachineInstanceMigration), newVMIMigration.(*v1.VirtualMachineInstanceMigration))
+			updateVMIMigrationPhaseTransitionTimeFromCreationTime(
+				oldVMIMigration.(*v1.VirtualMachineInstanceMigration),
+				newVMIMigration.(*v1.VirtualMachineInstanceMigration),
+			)
 		},
 	})
 
 	return err
 }
 
-func updateVMIMigrationPhaseTransitionTimeFromCreationTime(oldVMIMigration *v1.VirtualMachineInstanceMigration, newVMIMigration *v1.VirtualMachineInstanceMigration) {
+func updateVMIMigrationPhaseTransitionTimeFromCreationTime(oldVMIMigration, newVMIMigration *v1.VirtualMachineInstanceMigration) {
 	if oldVMIMigration == nil || oldVMIMigration.Status.Phase == newVMIMigration.Status.Phase {
 		return
 	}
 
 	diffSeconds, err := getVMIMigrationTransitionTimeSeconds(newVMIMigration)
 	if err != nil {
-		log.Log.V(4).Infof(migrationTransTimeErrFmt, err)
+		log.Log.V(logVerbosityDebug).Infof(migrationTransTimeErrFmt, err)
 		return
 	}
 

--- a/pkg/monitoring/metrics/virt-controller/migration_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-controller/migration_metrics_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"time"
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("VMI migration phase transition time histogram", func() {
 	Context("Transition Time calculations", func() {
-		DescribeTable("time diff calculations", func(expectedVal float64, curPhase v1.VirtualMachineInstanceMigrationPhase, oldPhase v1.VirtualMachineInstanceMigrationPhase) {
+		DescribeTable("time diff calculations", func(expectedVal float64, curPhase, oldPhase v1.VirtualMachineInstanceMigrationPhase) {
 			var oldMigration *v1.VirtualMachineInstanceMigration
 
 			migration := createVMIMigrationSForPhaseTransitionTime(curPhase, expectedVal*1000)
@@ -44,7 +44,6 @@ var _ = Describe("VMI migration phase transition time histogram", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(diffSeconds).To(Equal(expectedVal))
-
 		},
 			Entry("Time between succeeded and scheduled", 5.0, v1.MigrationSucceeded, v1.MigrationScheduled),
 			Entry("Time between succeeded and scheduled using fraction of a second", .5, v1.MigrationSucceeded, v1.MigrationScheduled),
@@ -55,7 +54,9 @@ var _ = Describe("VMI migration phase transition time histogram", func() {
 	})
 })
 
-func createVMIMigrationSForPhaseTransitionTime(phase v1.VirtualMachineInstanceMigrationPhase, offset float64) *v1.VirtualMachineInstanceMigration {
+func createVMIMigrationSForPhaseTransitionTime(
+	phase v1.VirtualMachineInstanceMigrationPhase, offset float64,
+) *v1.VirtualMachineInstanceMigration {
 	now := metav1.NewTime(time.Now())
 	old := metav1.NewTime(now.Time.Add(-time.Duration(int64(offset)) * time.Millisecond))
 	creation := metav1.NewTime(old.Time.Add(-time.Duration(int64(offset)) * time.Millisecond))
@@ -71,10 +72,13 @@ func createVMIMigrationSForPhaseTransitionTime(phase v1.VirtualMachineInstanceMi
 		},
 	}
 
-	migration.Status.PhaseTransitionTimestamps = append(migration.Status.PhaseTransitionTimestamps, v1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
-		Phase:                    phase,
-		PhaseTransitionTimestamp: old,
-	})
+	migration.Status.PhaseTransitionTimestamps = append(
+		migration.Status.PhaseTransitionTimestamps,
+		v1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
+			Phase:                    phase,
+			PhaseTransitionTimestamp: old,
+		},
+	)
 
 	return migration
 }

--- a/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
@@ -108,12 +108,19 @@ func reportMigrationStats(vmims []*k6tv1.VirtualMachineInstanceMigration) []oper
 			schedulingCount++
 		case k6tv1.MigrationPhaseUnset:
 			unsetCount++
-		case k6tv1.MigrationRunning, k6tv1.MigrationScheduled, k6tv1.MigrationPreparingTarget, k6tv1.MigrationTargetReady:
+		case k6tv1.MigrationRunning, k6tv1.MigrationScheduled, k6tv1.MigrationPreparingTarget,
+			k6tv1.MigrationTargetReady, k6tv1.MigrationWaitingForSync, k6tv1.MigrationSynchronizing:
 			runningCount++
 		case k6tv1.MigrationSucceeded:
-			cr = append(cr, operatormetrics.CollectorResult{Metric: succeededMigration, Value: 1, Labels: []string{vmim.Spec.VMIName, vmim.Name, vmim.Namespace}})
-		default:
-			cr = append(cr, operatormetrics.CollectorResult{Metric: failedMigration, Value: 1, Labels: []string{vmim.Spec.VMIName, vmim.Name, vmim.Namespace}})
+			cr = append(cr, operatormetrics.CollectorResult{
+				Metric: succeededMigration, Value: 1,
+				Labels: []string{vmim.Spec.VMIName, vmim.Name, vmim.Namespace},
+			})
+		case k6tv1.MigrationFailed:
+			cr = append(cr, operatormetrics.CollectorResult{
+				Metric: failedMigration, Value: 1,
+				Labels: []string{vmim.Spec.VMIName, vmim.Name, vmim.Namespace},
+			})
 		}
 	}
 

--- a/pkg/monitoring/metrics/virt-controller/migrationstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/migrationstats_collector_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"strings"
@@ -49,26 +49,27 @@ var _ = Describe("Migration Stats Collector", func() {
 		}
 	})
 
-	DescribeTable("should set correct metric for each phase", func(phase k6tv1.VirtualMachineInstanceMigrationPhase, metric operatormetrics.Metric) {
-		vmims := []*k6tv1.VirtualMachineInstanceMigration{
-			getVMIM(phase),
-		}
-
-		cr := reportMigrationStats(vmims)
-
-		containsMetric := false
-
-		for _, result := range cr {
-			if strings.Contains(result.Metric.GetOpts().Name, metric.GetOpts().Name) {
-				containsMetric = true
-				Expect(result.Value).To(Equal(1.0))
-			} else {
-				Expect(result.Value).To(BeZero())
+	DescribeTable("should set correct metric for each phase",
+		func(phase k6tv1.VirtualMachineInstanceMigrationPhase, metric operatormetrics.Metric) {
+			vmims := []*k6tv1.VirtualMachineInstanceMigration{
+				getVMIM(phase),
 			}
-		}
 
-		Expect(containsMetric).To(BeTrue())
-	},
+			cr := reportMigrationStats(vmims)
+
+			containsMetric := false
+
+			for _, result := range cr {
+				if strings.Contains(result.Metric.GetOpts().Name, metric.GetOpts().Name) {
+					containsMetric = true
+					Expect(result.Value).To(Equal(1.0))
+				} else {
+					Expect(result.Value).To(BeZero())
+				}
+			}
+
+			Expect(containsMetric).To(BeTrue())
+		},
 		Entry("Failed migration", k6tv1.MigrationFailed, failedMigration),
 		Entry("Pending migration", k6tv1.MigrationPending, pendingMigrations),
 		Entry("Running migration", k6tv1.MigrationRunning, runningMigrations),

--- a/pkg/monitoring/metrics/virt-controller/perfscale_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-controller/perfscale_metrics_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"time"
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("VMI phase transition time histogram", func() {
 	Context("Transition Time calculations", func() {
-		DescribeTable("time diff calculations", func(expectedVal float64, curPhase v1.VirtualMachineInstancePhase, oldPhase v1.VirtualMachineInstancePhase) {
+		DescribeTable("time diff calculations", func(expectedVal float64, curPhase, oldPhase v1.VirtualMachineInstancePhase) {
 			var oldVMI *v1.VirtualMachineInstance
 
 			vmi := createVMISForPhaseTransitionTime(curPhase, oldPhase, expectedVal*1000, true)
@@ -44,7 +44,6 @@ var _ = Describe("VMI phase transition time histogram", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(diffSeconds).To(Equal(expectedVal))
-
 		},
 			Entry("Time between running and scheduled", 5.0, v1.Running, v1.Scheduled),
 			Entry("Time between running and scheduled using fraction of a second", .5, v1.Running, v1.Scheduled),
@@ -55,7 +54,7 @@ var _ = Describe("VMI phase transition time histogram", func() {
 	})
 
 	Context("Time since Create/Delete calculations", func() {
-		DescribeTable("time diff calculations", func(expectedVal float64, curPhase v1.VirtualMachineInstancePhase, oldPhase v1.VirtualMachineInstancePhase, creation bool) {
+		DescribeTable("time diff calculations", func(expectedVal float64, curPhase, oldPhase v1.VirtualMachineInstancePhase, creation bool) {
 			var oldVMI *v1.VirtualMachineInstance
 
 			vmi := createVMISForPhaseTransitionTime(curPhase, oldPhase, expectedVal*1000, true)
@@ -85,7 +84,11 @@ var _ = Describe("VMI phase transition time histogram", func() {
 	})
 })
 
-func createVMISForPhaseTransitionTime(phase v1.VirtualMachineInstancePhase, oldPhase v1.VirtualMachineInstancePhase, offset float64, hasTransitionTime bool) *v1.VirtualMachineInstance {
+func createVMISForPhaseTransitionTime(
+	phase, oldPhase v1.VirtualMachineInstancePhase,
+	offset float64,
+	hasTransitionTime bool,
+) *v1.VirtualMachineInstance {
 	now := metav1.NewTime(time.Now())
 	old := metav1.NewTime(now.Time.Add(-time.Duration(int64(offset)) * time.Millisecond))
 	creation := metav1.NewTime(old.Time.Add(-time.Duration(int64(offset)) * time.Millisecond))
@@ -114,7 +117,6 @@ func createVMISForPhaseTransitionTime(phase v1.VirtualMachineInstancePhase, oldP
 			Phase:                    oldPhase,
 			PhaseTransitionTimestamp: old,
 		})
-
 	}
 
 	return vmi

--- a/pkg/monitoring/metrics/virt-controller/virt_controller_suite_test.go
+++ b/pkg/monitoring/metrics/virt-controller/virt_controller_suite_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller_test
+package virtcontroller_test
 
 import (
 	"testing"

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"strconv"
@@ -41,8 +41,9 @@ import (
 )
 
 const (
-	none  = "" // Empty values will be ignored by operator-observability and label will not be created
-	other = "<other>"
+	none      = "" // Empty values will be ignored by operator-observability and label will not be created
+	other     = "<other>"
+	modelNone = "<none>"
 
 	annotationPrefix        = "vm.kubevirt.io/"
 	instancetypeVendorLabel = "instancetype.kubevirt.io/vendor"
@@ -152,7 +153,7 @@ var (
 func vmiStatsCollectorCallback() []operatormetrics.CollectorResult {
 	cachedObjs := stores.VMI.List()
 	if len(cachedObjs) == 0 {
-		log.Log.V(4).Infof("No VMIs detected")
+		log.Log.V(logVerbosityDebug).Infof("No VMIs detected")
 		return []operatormetrics.CollectorResult{}
 	}
 
@@ -169,8 +170,7 @@ func reportVmisStats(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.Col
 	var crs []operatormetrics.CollectorResult
 
 	for _, vmi := range vmis {
-		crs = append(crs, collectVMIInfo(vmi))
-		crs = append(crs, getEvictionBlocker(vmi))
+		crs = append(crs, collectVMIInfo(vmi), getEvictionBlocker(vmi))
 		crs = append(crs, collectVMIInterfacesInfo(vmi)...)
 		crs = append(crs, collectVMIMigrationTime(vmi)...)
 		crs = append(crs, CollectVmisVnicInfo(vmi)...)
@@ -191,7 +191,8 @@ func collectVMILauncherMemoryOverhead(vmi *k6tv1.VirtualMachineInstance) operato
 	} else {
 		// TODO: Remove this fallback once VmiMemoryOverheadReport feature gate is GA
 		// and we are sure that all VMIs include the MemoryOverhead status field
-		// Create the hypervisor resources calculator based on the cluster configuration, as the overhead calculation may differ between different hypervisors
+		// Create the hypervisor resources calculator based on the cluster configuration, as the overhead calculation may differ between
+		// different hypervisors
 		launcherHypervisorResources := hypervisor.NewLauncherHypervisorResources(clusterConfig.GetHypervisor().Name)
 		memoryOverhead := services.CalculateMemoryOverhead(clusterConfig, netresources.MemoryCalculator{}, vmi, launcherHypervisorResources)
 		memoryOverheadValue = memoryOverhead.Value()
@@ -251,7 +252,6 @@ func getSystemInfoFromAnnotations(annotations map[string]string) (os, workload, 
 }
 
 func getGuestOSInfo(vmi *k6tv1.VirtualMachineInstance) (kernelRelease, guestOSMachineArch, name, versionID string) {
-
 	if vmi.Status.GuestOSInfo == (k6tv1.VirtualMachineInstanceGuestOSInfo{}) {
 		return
 	}
@@ -379,7 +379,6 @@ func isVMEvictable(vmi *k6tv1.VirtualMachineInstance) bool {
 		if vmiIsMigratableCond == nil || vmiIsMigratableCond.Status == k8sv1.ConditionFalse {
 			return false
 		}
-
 	}
 	return true
 }
@@ -401,7 +400,10 @@ func collectVMIInterfacesInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetri
 	return crs
 }
 
-func collectVMIInterfaceInfo(vmi *k6tv1.VirtualMachineInstance, iface k6tv1.VirtualMachineInstanceNetworkInterface) *operatormetrics.CollectorResult {
+func collectVMIInterfaceInfo(
+	vmi *k6tv1.VirtualMachineInstance,
+	iface k6tv1.VirtualMachineInstanceNetworkInterface,
+) *operatormetrics.CollectorResult {
 	interfaceType := "ExternalInterface"
 
 	if iface.IP == "" {
@@ -444,7 +446,8 @@ func collectVMIMigrationTime(vmi *k6tv1.VirtualMachineInstance) []operatormetric
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmiMigrationEndTime,
 			Value:  float64(vmi.Status.MigrationState.EndTimestamp.Time.Unix()),
-			Labels: []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, migrationName,
+			Labels: []string{
+				vmi.Status.NodeName, vmi.Namespace, vmi.Name, migrationName,
 				calculateMigrationStatus(vmi.Status.MigrationState),
 			},
 		})
@@ -481,7 +484,7 @@ func CollectVmisVnicInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.Co
 	networks := vmi.Spec.Networks
 
 	for _, iface := range interfaces {
-		model := "<none>"
+		model := modelNone
 		if iface.Model != "" {
 			model = iface.Model
 		}

--- a/pkg/monitoring/metrics/virt-controller/vmsnapshot.go
+++ b/pkg/monitoring/metrics/virt-controller/vmsnapshot.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller
+package virtcontroller
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
@@ -28,10 +28,10 @@ import (
 
 var (
 	vmSnapshotMetrics = []operatormetrics.Metric{
-		VmSnapshotSucceededTimestamp,
+		VMSnapshotSucceededTimestamp,
 	}
 
-	VmSnapshotSucceededTimestamp = operatormetrics.NewGaugeVec(
+	VMSnapshotSucceededTimestamp = operatormetrics.NewGaugeVec(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmsnapshot_succeeded_timestamp_seconds",
 			Help: "Returns the timestamp of successful virtual machine snapshot.",
@@ -42,7 +42,7 @@ var (
 
 func HandleSucceededVMSnapshot(snapshot *snapshotv1.VirtualMachineSnapshot) {
 	if snapshot.Status.Phase == snapshotv1.Succeeded {
-		VmSnapshotSucceededTimestamp.WithLabelValues(
+		VMSnapshotSucceededTimestamp.WithLabelValues(
 			snapshot.Spec.Source.Name,
 			snapshot.Name,
 			snapshot.Namespace,
@@ -50,9 +50,9 @@ func HandleSucceededVMSnapshot(snapshot *snapshotv1.VirtualMachineSnapshot) {
 	}
 }
 
-func GetVmSnapshotSucceededTimestamp(vm, snapshot, namespace string) (float64, error) {
+func GetVMSnapshotSucceededTimestamp(vm, snapshot, namespace string) (float64, error) {
 	dto := &io_prometheus_client.Metric{}
-	if err := VmSnapshotSucceededTimestamp.WithLabelValues(vm, snapshot, namespace).Write(dto); err != nil {
+	if err := VMSnapshotSucceededTimestamp.WithLabelValues(vm, snapshot, namespace).Write(dto); err != nil {
 		return 0, err
 	}
 	return *dto.Gauge.Value, nil

--- a/pkg/monitoring/metrics/virt-controller/vmsnapshot_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmsnapshot_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_controller_test
+package virtcontroller_test
 
 import (
 	"time"
@@ -59,7 +59,7 @@ var _ = Describe("VMSnapshot Metrics Collector", func() {
 
 			metrics.HandleSucceededVMSnapshot(vmSnapshot)
 
-			metricTime, err := metrics.GetVmSnapshotSucceededTimestamp("vm-name", "snapshot-name", "namespace")
+			metricTime, err := metrics.GetVMSnapshotSucceededTimestamp("vm-name", "snapshot-name", "namespace")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(metricTime).NotTo(BeNil())
 

--- a/pkg/monitoring/metrics/virt-handler/collector/collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/collector/collector_test.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("Collector", func() {
 	var vmis []*k6tv1.VirtualMachineInstance
 
-	var newCollector = func(retries int) Collector {
+	newCollector := func(retries int) Collector {
 		fakeMapper := func(vmi []*k6tv1.VirtualMachineInstance) vmiSocketMap {
 			m := vmiSocketMap{}
 			for _, vmi := range vmi {
@@ -99,7 +99,6 @@ var _ = Describe("Collector", func() {
 			Expect(skipped).To(HaveLen(1))
 			Expect(skipped[0]).To(Equal("a"))
 			Expect(completed).To(BeTrue())
-
 		})
 
 		It("should resume scraping when unblocks", func() {

--- a/pkg/monitoring/metrics/virt-handler/domainstats/collector.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/collector.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	PrometheusCollectionTimeout = collector.CollectionTimeout
+
+	logVerbosityDebug = 4
 )
 
 var (
@@ -80,7 +82,7 @@ func domainStatsMetrics(rms ...resourceMetrics) []operatormetrics.Metric {
 func domainStatsCollectorCallback() []operatormetrics.CollectorResult {
 	cachedObjs := settings.vmiInformer.GetIndexer().List()
 	if len(cachedObjs) == 0 {
-		log.Log.V(4).Infof("No VMIs detected")
+		log.Log.V(logVerbosityDebug).Infof("No VMIs detected")
 		return []operatormetrics.CollectorResult{}
 	}
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/collector_test.go
@@ -113,7 +113,10 @@ func (fc fakeCollector) Collect(_ []*k6tv1.VirtualMachineInstance, scraper colle
 	return nil, true
 }
 
-func fakeCollect(scraper collector.MetricsScraper, wg *sync.WaitGroup, vmi *k6tv1.VirtualMachineInstance, vmiStats *VirtualMachineInstanceStats) {
+func fakeCollect(
+	scraper collector.MetricsScraper, wg *sync.WaitGroup,
+	vmi *k6tv1.VirtualMachineInstance, vmiStats *VirtualMachineInstanceStats,
+) {
 	defer wg.Done()
 
 	dScraper := scraper.(*DomainstatsScraper)

--- a/pkg/monitoring/metrics/virt-handler/domainstats/cpu_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/cpu_metrics.go
@@ -49,21 +49,27 @@ var (
 	guestLoad1m = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_guest_load_1m",
-			Help: "Guest system load average over 1 minute as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above.",
+			Help: "Guest system load average over 1 minute as reported by the guest agent. " +
+				"Load is defined as the number of processes in the runqueue or waiting for disk I/O. " +
+				"Requires qemu-guest-agent version 10.0.0 or above.",
 		},
 	)
 
 	guestLoad5m = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_guest_load_5m",
-			Help: "Guest system load average over 5 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above.",
+			Help: "Guest system load average over 5 minutes as reported by the guest agent. " +
+				"Load is defined as the number of processes in the runqueue or waiting for disk I/O. " +
+				"Requires qemu-guest-agent version 10.0.0 or above.",
 		},
 	)
 
 	guestLoad15m = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_guest_load_15m",
-			Help: "Guest system load average over 15 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above.",
+			Help: "Guest system load average over 15 minutes as reported by the guest agent. " +
+				"Load is defined as the number of processes in the runqueue or waiting for disk I/O. " +
+				"Requires qemu-guest-agent version 10.0.0 or above.",
 		},
 	)
 )

--- a/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_collector.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_collector.go
@@ -26,17 +26,15 @@ import (
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/collector"
 )
 
-var (
-	DomainDirtyRateStatsCollector = operatormetrics.Collector{
-		Metrics:         domainStatsMetrics(dirtyRateMetrics{}),
-		CollectCallback: domainDirtyRateStatsCollectorCallback,
-	}
-)
+var DomainDirtyRateStatsCollector = operatormetrics.Collector{
+	Metrics:         domainStatsMetrics(dirtyRateMetrics{}),
+	CollectCallback: domainDirtyRateStatsCollectorCallback,
+}
 
 func domainDirtyRateStatsCollectorCallback() []operatormetrics.CollectorResult {
 	cachedObjs := settings.vmiInformer.GetStore().List()
 	if len(cachedObjs) == 0 {
-		log.Log.V(4).Infof("No VMIs detected")
+		log.Log.V(logVerbosityDebug).Infof("No VMIs detected")
 		return []operatormetrics.CollectorResult{}
 	}
 
@@ -50,7 +48,9 @@ func domainDirtyRateStatsCollectorCallback() []operatormetrics.CollectorResult {
 	return execDomainDirtyRateStatsCollector(concCollector, vmis)
 }
 
-func execDomainDirtyRateStatsCollector(concCollector collector.Collector, vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+func execDomainDirtyRateStatsCollector(
+	concCollector collector.Collector, vmis []*k6tv1.VirtualMachineInstance,
+) []operatormetrics.CollectorResult {
 	scraper := NewDomainsDirtyRateStatsScraper(len(vmis))
 	go concCollector.Collect(vmis, scraper, PrometheusCollectionTimeout)
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_metrics.go
@@ -24,13 +24,11 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-var (
-	dirtyRateBytesPerSecond = operatormetrics.NewGauge(
-		operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_dirty_rate_bytes_per_second",
-			Help: "Guest dirty-rate in bytes per second.",
-		},
-	)
+var dirtyRateBytesPerSecond = operatormetrics.NewGauge(
+	operatormetrics.MetricOpts{
+		Name: "kubevirt_vmi_dirty_rate_bytes_per_second",
+		Help: "Guest dirty-rate in bytes per second.",
+	},
 )
 
 type dirtyRateMetrics struct{}

--- a/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_scrapper.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_scrapper.go
@@ -53,7 +53,7 @@ func (d DomainDirtyRateStatsScraper) Scrape(socketFile string, vmi *k6tv1.Virtua
 	// If it wakes up past the timeout, there is no point in send back any metric.
 	// In the best case the information is stale, in the worst case the information is stale *and*
 	// the reporting channel is already closed, leading to a possible panic - see below
-	elapsed := time.Now().Sub(ts)
+	elapsed := time.Since(ts)
 	if elapsed > collector.StatsMaxAge {
 		log.Log.Infof("took too long (%v) to collect stats from %s: ignored", elapsed, socketFile)
 		return

--- a/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
@@ -47,7 +47,9 @@ type VirtualMachineInstanceStats struct {
 	FsStats     k6tv1.VirtualMachineInstanceFileSystemList
 }
 
-func newVirtualMachineInstanceReport(vmi *k6tv1.VirtualMachineInstance, vmiStats *VirtualMachineInstanceStats) *VirtualMachineInstanceReport {
+func newVirtualMachineInstanceReport(
+	vmi *k6tv1.VirtualMachineInstance, vmiStats *VirtualMachineInstanceStats,
+) *VirtualMachineInstanceReport {
 	vmiReport := &VirtualMachineInstanceReport{
 		vmi:      vmi,
 		vmiStats: vmiStats,
@@ -70,11 +72,15 @@ func (vmiReport *VirtualMachineInstanceReport) buildRuntimeLabels() {
 	}
 }
 
-func (vmiReport *VirtualMachineInstanceReport) newCollectorResult(metric operatormetrics.Metric, value float64) operatormetrics.CollectorResult {
+func (vmiReport *VirtualMachineInstanceReport) newCollectorResult(
+	metric operatormetrics.Metric, value float64,
+) operatormetrics.CollectorResult {
 	return vmiReport.newCollectorResultWithLabels(metric, value, nil)
 }
 
-func (vmiReport *VirtualMachineInstanceReport) newCollectorResultWithLabels(metric operatormetrics.Metric, value float64, additionalLabels map[string]string) operatormetrics.CollectorResult {
+func (vmiReport *VirtualMachineInstanceReport) newCollectorResultWithLabels(
+	metric operatormetrics.Metric, value float64, additionalLabels map[string]string,
+) operatormetrics.CollectorResult {
 	vmiLabels := map[string]string{
 		"node":      vmiReport.vmi.Status.NodeName,
 		"namespace": vmiReport.vmi.Namespace,

--- a/pkg/monitoring/metrics/virt-handler/domainstats/domainstats_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/domainstats_test.go
@@ -30,24 +30,26 @@ import (
 
 var _ = Describe("domainstats", func() {
 	Context("collector functions", func() {
-		var metric = operatormetrics.NewCounter(
-			operatormetrics.MetricOpts{
-				Name: "test-metric-1",
-				Help: "test help 1",
-			},
-		)
+		var (
+			metric = operatormetrics.NewCounter(
+				operatormetrics.MetricOpts{
+					Name: "test-metric-1",
+					Help: "test help 1",
+				},
+			)
 
-		var vmiReport = &VirtualMachineInstanceReport{
-			vmi: &k6tv1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmi-1",
-					Namespace: "test-ns-1",
+			vmiReport = &VirtualMachineInstanceReport{
+				vmi: &k6tv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vmi-1",
+						Namespace: "test-ns-1",
+					},
+					Status: k6tv1.VirtualMachineInstanceStatus{
+						NodeName: "test-node-1",
+					},
 				},
-				Status: k6tv1.VirtualMachineInstanceStatus{
-					NodeName: "test-node-1",
-				},
-			},
-		}
+			}
+		)
 
 		It("newCollectorResultWithLabels should return a CollectorResult with the correct values", func() {
 			cr := vmiReport.newCollectorResultWithLabels(metric, 5, map[string]string{"test-label-1": "test-value-1"})

--- a/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics.go
@@ -56,8 +56,10 @@ func (filesystemMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []oper
 			"file_system_type": fsStat.FileSystemType,
 		}
 
-		crs = append(crs, vmiReport.newCollectorResultWithLabels(filesystemCapacityBytes, float64(fsStat.TotalBytes), fsLabels))
-		crs = append(crs, vmiReport.newCollectorResultWithLabels(filesystemUsedBytes, float64(fsStat.UsedBytes), fsLabels))
+		crs = append(crs,
+			vmiReport.newCollectorResultWithLabels(filesystemCapacityBytes, float64(fsStat.TotalBytes), fsLabels),
+			vmiReport.newCollectorResultWithLabels(filesystemUsedBytes, float64(fsStat.UsedBytes), fsLabels),
+		)
 	}
 
 	return crs

--- a/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics.go
@@ -32,21 +32,27 @@ var (
 	memoryAvailable = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_memory_available_bytes",
-			Help: "Amount of usable memory as seen by the domain. This value may not be accurate if a balloon driver is in use or if the guest OS does not initialize all assigned pages",
+			Help: "Amount of usable memory as seen by the domain. " +
+				"This value may not be accurate if a balloon driver is in use " +
+				"or if the guest OS does not initialize all assigned pages",
 		},
 	)
 
 	memoryUnused = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_memory_unused_bytes",
-			Help: "The amount of memory left completely unused by the system. Memory that is available but used for reclaimable caches should NOT be reported as free.",
+			Help: "The amount of memory left completely unused by the system. " +
+				"Memory that is available but used for reclaimable caches " +
+				"should NOT be reported as free.",
 		},
 	)
 
 	memoryCached = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_memory_cached_bytes",
-			Help: "The amount of memory that is being used to cache I/O and is available to be reclaimed, corresponds to the sum of `Buffers` + `Cached` + `SwapCached` in `/proc/meminfo`.",
+			Help: "The amount of memory that is being used to cache I/O " +
+				"and is available to be reclaimed, corresponds to the sum of " +
+				"`Buffers` + `Cached` + `SwapCached` in `/proc/meminfo`.",
 		},
 	)
 
@@ -67,14 +73,20 @@ var (
 	memoryPgmajfaultTotal = operatormetrics.NewCounter(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_memory_pgmajfault_total",
-			Help: "The number of page faults when disk IO was required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is required, it is considered as major fault.",
+			Help: "The number of page faults when disk IO was required. " +
+				"Page faults occur when a process makes a valid access to virtual memory " +
+				"that is not available. When servicing the page fault, if disk IO is required, " +
+				"it is considered as major fault.",
 		},
 	)
 
 	memoryPgminfaultTotal = operatormetrics.NewCounter(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_memory_pgminfault_total",
-			Help: "The number of other page faults, when disk IO was not required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is NOT required, it is considered as minor fault.",
+			Help: "The number of other page faults, when disk IO was not required. " +
+				"Page faults occur when a process makes a valid access to virtual memory " +
+				"that is not available. When servicing the page fault, if disk IO is NOT required, " +
+				"it is considered as minor fault.",
 		},
 	)
 
@@ -88,7 +100,9 @@ var (
 	memoryUsableBytes = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_memory_usable_bytes",
-			Help: "The amount of memory which can be reclaimed by balloon without pushing the guest system to swap, corresponds to 'Available' in /proc/meminfo.",
+			Help: "The amount of memory which can be reclaimed by balloon " +
+				"without pushing the guest system to swap, " +
+				"corresponds to 'Available' in /proc/meminfo.",
 		},
 	)
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics.go
@@ -122,14 +122,18 @@ func (networkMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operato
 
 		if net.RxBytesSet {
 			deprecatedLabels := map[string]string{"interface": iface, "type": "rx"}
-			crs = append(crs, vmiReport.newCollectorResultWithLabels(networkTrafficBytesDeprecated, float64(net.RxBytes), deprecatedLabels))
-			crs = append(crs, vmiReport.newCollectorResultWithLabels(networkReceiveBytes, float64(net.RxBytes), netLabels))
+			crs = append(crs,
+				vmiReport.newCollectorResultWithLabels(networkTrafficBytesDeprecated, float64(net.RxBytes), deprecatedLabels),
+				vmiReport.newCollectorResultWithLabels(networkReceiveBytes, float64(net.RxBytes), netLabels),
+			)
 		}
 
 		if net.TxBytesSet {
 			deprecatedLabels := map[string]string{"interface": iface, "type": "tx"}
-			crs = append(crs, vmiReport.newCollectorResultWithLabels(networkTrafficBytesDeprecated, float64(net.TxBytes), deprecatedLabels))
-			crs = append(crs, vmiReport.newCollectorResultWithLabels(networkTransmitBytes, float64(net.TxBytes), netLabels))
+			crs = append(crs,
+				vmiReport.newCollectorResultWithLabels(networkTrafficBytesDeprecated, float64(net.TxBytes), deprecatedLabels),
+				vmiReport.newCollectorResultWithLabels(networkTransmitBytes, float64(net.TxBytes), netLabels),
+			)
 		}
 
 		if net.RxPktsSet {

--- a/pkg/monitoring/metrics/virt-handler/domainstats/node_cpu_affinity_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/node_cpu_affinity_metrics.go
@@ -21,19 +21,17 @@ package domainstats
 
 import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 
-var (
-	nodeCpuAffinity = operatormetrics.NewGauge(
-		operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_node_cpu_affinity",
-			Help: "Number of VMI CPU affinities to node physical cores.",
-		},
-	)
+var nodeCPUAffinity = operatormetrics.NewGauge(
+	operatormetrics.MetricOpts{
+		Name: "kubevirt_vmi_node_cpu_affinity",
+		Help: "Number of VMI CPU affinities to node physical cores.",
+	},
 )
 
 type cpuAffinityMetrics struct{}
 
 func (cpuAffinityMetrics) Describe() []operatormetrics.Metric {
-	return []operatormetrics.Metric{nodeCpuAffinity}
+	return []operatormetrics.Metric{nodeCPUAffinity}
 }
 
 func (cpuAffinityMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operatormetrics.CollectorResult {
@@ -52,6 +50,6 @@ func (cpuAffinityMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []ope
 	}
 
 	return []operatormetrics.CollectorResult{
-		vmiReport.newCollectorResult(nodeCpuAffinity, affinityCount),
+		vmiReport.newCollectorResult(nodeCPUAffinity, affinityCount),
 	}
 }

--- a/pkg/monitoring/metrics/virt-handler/domainstats/node_cpu_affinity_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/node_cpu_affinity_metrics_test.go
@@ -56,7 +56,7 @@ var _ = Describe("node cpu affinity metrics", func() {
 			crs := cpuAffinityMetrics{}.Collect(vmiReport)
 			Expect(crs).To(ContainElement(testing.GomegaContainsCollectorResultMatcher(metric, expectedValue)))
 		},
-			Entry("kubevirt_vmi_node_cpu_affinity", nodeCpuAffinity, 3.0),
+			Entry("kubevirt_vmi_node_cpu_affinity", nodeCPUAffinity, 3.0),
 		)
 
 		It("result should be empty if stat not populated or set is false", func() {

--- a/pkg/monitoring/metrics/virt-handler/domainstats/scrapper.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/scrapper.go
@@ -30,6 +30,8 @@ import (
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 )
 
+const logVerbosityWarning = 2
+
 type DomainstatsScraper struct {
 	ch chan *VirtualMachineInstanceReport
 }
@@ -50,7 +52,7 @@ func (d DomainstatsScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachineI
 	}
 
 	if !exists || vmStats.DomainStats.Name == "" {
-		log.Log.V(2).Infof("disappearing VM on %s, ignored", socketFile) // VM may be shutting down
+		log.Log.V(logVerbosityWarning).Infof("disappearing VM on %s, ignored", socketFile) // VM may be shutting down
 		return
 	}
 
@@ -58,7 +60,7 @@ func (d DomainstatsScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachineI
 	// If it wakes up past the timeout, there is no point in send back any metric.
 	// In the best case the information is stale, in the worst case the information is stale *and*
 	// the reporting channel is already closed, leading to a possible panic - see below
-	elapsed := time.Now().Sub(ts)
+	elapsed := time.Since(ts)
 	if elapsed > collector.StatsMaxAge {
 		log.Log.Infof("took too long (%v) to collect stats from %s: ignored", elapsed, socketFile)
 		return

--- a/pkg/monitoring/metrics/virt-handler/domainstats/unit_converter.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/unit_converter.go
@@ -19,10 +19,15 @@
 
 package domainstats
 
+const (
+	nanosecondsPerSecond = 1_000_000_000
+	bytesPerKibibyte     = 1024
+)
+
 func nanosecondsToSeconds(ns uint64) float64 {
-	return float64(ns) / 1000000000
+	return float64(ns) / nanosecondsPerSecond
 }
 
 func kibibytesToBytes(kibibytes uint64) float64 {
-	return float64(kibibytes) * 1024
+	return float64(kibibytes) * bytesPerKibibyte
 }

--- a/pkg/monitoring/metrics/virt-handler/domainstats/unit_converter.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/unit_converter.go
@@ -20,8 +20,8 @@
 package domainstats
 
 const (
-	nanosecondsPerSecond = 1_000_000_000
-	bytesPerKibibyte     = 1024
+	nanosecondsPerSecond float64 = 1_000_000_000
+	bytesPerKibibyte     float64 = 1024
 )
 
 func nanosecondsToSeconds(ns uint64) float64 {

--- a/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics.go
@@ -31,7 +31,9 @@ var (
 	vcpuSeconds = operatormetrics.NewCounter(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_vcpu_seconds_total",
-			Help: "Total amount of time spent in each state by each vcpu (cpu_time excluding hypervisor time). Where `id` is the vcpu identifier and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`].",
+			Help: "Total amount of time spent in each state by each vcpu " +
+				"(cpu_time excluding hypervisor time). Where `id` is the vcpu identifier " +
+				"and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`].",
 		},
 	)
 

--- a/pkg/monitoring/metrics/virt-handler/handler/handler.go
+++ b/pkg/monitoring/metrics/virt-handler/handler/handler.go
@@ -26,13 +26,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func Handler(MaxRequestsInFlight int) http.Handler {
+func Handler(maxRequestsInFlight int) http.Handler {
 	return promhttp.InstrumentMetricHandler(
 		prometheus.DefaultRegisterer,
 		promhttp.HandlerFor(
 			prometheus.DefaultGatherer,
 			promhttp.HandlerOpts{
-				MaxRequestsInFlight: MaxRequestsInFlight,
+				MaxRequestsInFlight: maxRequestsInFlight,
 			}),
 	)
 }

--- a/pkg/monitoring/metrics/virt-handler/machine_type.go
+++ b/pkg/monitoring/metrics/virt-handler/machine_type.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_handler
+package virthandler
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"

--- a/pkg/monitoring/metrics/virt-handler/machine_type_test.go
+++ b/pkg/monitoring/metrics/virt-handler/machine_type_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_handler
+package virthandler
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -30,7 +30,7 @@ import (
 var _ = Describe("deprecated machine types metric", func() {
 	Context("ReportDeprecatedMachineTypes", func() {
 		BeforeEach(func() {
-			operatormetrics.UnregisterMetrics(machineTypeMetrics)
+			Expect(operatormetrics.UnregisterMetrics(machineTypeMetrics)).To(Succeed())
 			Expect(operatormetrics.RegisterMetrics(machineTypeMetrics)).To(Succeed())
 		})
 

--- a/pkg/monitoring/metrics/virt-handler/metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/metrics.go
@@ -16,7 +16,7 @@
  * Copyright The KubeVirt Authors.
  */
 
-package virt_handler
+package virthandler
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
@@ -29,7 +29,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/migrationdomainstats"
 )
 
-func SetupMetrics(nodeName string, MaxRequestsInFlight int, vmiInformer cache.SharedIndexInformer, machines []libvirtxml.CapsGuestMachine) error {
+func SetupMetrics(
+	nodeName string, maxRequestsInFlight int,
+	vmiInformer cache.SharedIndexInformer, machines []libvirtxml.CapsGuestMachine,
+) error {
 	if err := workqueue.SetupMetrics(); err != nil {
 		return err
 	}
@@ -44,7 +47,7 @@ func SetupMetrics(nodeName string, MaxRequestsInFlight int, vmiInformer cache.Sh
 	SetVersionInfo()
 	ReportDeprecatedMachineTypes(machines, nodeName)
 
-	domainstats.SetupDomainStatsCollector(MaxRequestsInFlight, vmiInformer)
+	domainstats.SetupDomainStatsCollector(maxRequestsInFlight, vmiInformer)
 
 	if err := migrationdomainstats.SetupMigrationStatsCollector(vmiInformer); err != nil {
 		return err

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/handler.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/handler.go
@@ -28,6 +28,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 
+const logVerbosityInfo = 3
+
 type vmiQueue interface {
 	all() ([]result, bool)
 	startPolling()
@@ -65,7 +67,7 @@ func (h *handler) Collect() []result {
 		allResults = append(allResults, vmiResults...)
 
 		if isFinished {
-			log.Log.V(3).Infof("deleting queue for VMI %s", key)
+			log.Log.V(logVerbosityInfo).Infof("deleting queue for VMI %s", key)
 			delete(h.vmiStats, key)
 		}
 	}

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/handler_test.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/handler_test.go
@@ -31,14 +31,12 @@ func (q *possiblyFinishedQueue) all() ([]result, bool) {
 	return nil, q.isFinished
 }
 
-func (_ *possiblyFinishedQueue) startPolling() {
+func (*possiblyFinishedQueue) startPolling() {
 	panic("not implemented")
 }
 
 var _ = Describe("Handler", func() {
-	var (
-		h *handler
-	)
+	var h *handler
 
 	BeforeEach(func() {
 		h = &handler{

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/queue.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/queue.go
@@ -39,6 +39,9 @@ const (
 	collectionTimeout = 10 * time.Second
 	pollingInterval   = 5 * time.Second
 	bufferSize        = 10
+
+	logVerbosityWarning = 2
+	logVerbosityDebug   = 4
 )
 
 type result struct {
@@ -76,17 +79,17 @@ func (q *queue) startPolling() {
 
 	ticker := time.NewTicker(pollingInterval)
 	go func() {
-		log.Log.V(4).Infof("collecting domain stats for VMI %s/%s (initial)", q.vmi.Namespace, q.vmi.Name)
+		log.Log.V(logVerbosityDebug).Infof("collecting domain stats for VMI %s/%s (initial)", q.vmi.Namespace, q.vmi.Name)
 		q.collect()
 
 		for {
 			select {
 			case <-q.ctx.Done():
-				log.Log.V(2).Infof("stopping domain stats collection for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
+				log.Log.V(logVerbosityWarning).Infof("stopping domain stats collection for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				log.Log.V(4).Infof("collecting domain stats for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
+				log.Log.V(logVerbosityDebug).Infof("collecting domain stats for VMI %s/%s", q.vmi.Namespace, q.vmi.Name)
 				q.collect()
 			}
 		}

--- a/pkg/monitoring/metrics/virt-handler/version_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/version_metrics.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_handler
+package virthandler
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"

--- a/pkg/monitoring/metrics/virt-handler/virt_handler_suite_test.go
+++ b/pkg/monitoring/metrics/virt-handler/virt_handler_suite_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_handler_test
+package virthandler_test
 
 import (
 	"testing"

--- a/pkg/monitoring/metrics/virt-operator/leader_metrics.go
+++ b/pkg/monitoring/metrics/virt-operator/leader_metrics.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_operator
+package virtoperator
 
 import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 

--- a/pkg/monitoring/metrics/virt-operator/metrics.go
+++ b/pkg/monitoring/metrics/virt-operator/metrics.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virt_operator
+package virtoperator
 
 import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"

--- a/pkg/monitoring/metrics/virt-operator/operator_metrics.go
+++ b/pkg/monitoring/metrics/virt-operator/operator_metrics.go
@@ -16,7 +16,7 @@
  * Copyright The KubeVirt Authors.
  */
 
-package virt_operator
+package virtoperator
 
 import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 

--- a/tests/libmonitoring/metrics.go
+++ b/tests/libmonitoring/metrics.go
@@ -38,7 +38,7 @@ func RegisterAllMetrics() error {
 		return err
 	}
 
-	// Create dummy worqueue metrics
+	// Create dummy workqueue metrics
 	workqueueMetricsProvider := workqueue.NewPrometheusMetricsProvider()
 	workqueueMetricsProvider.NewAddsMetric("")
 	workqueueMetricsProvider.NewDepthMetric("")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

linter disabled for pkg/monitoring/metrics

#### After this PR:

linter in pkg/monitoring/metrics

### References

jira-ticket: `
https://issues.redhat.com/browse/CNV-80328
https://issues.redhat.com/browse/CNV-80329
https://issues.redhat.com/browse/CNV-80330
https://issues.redhat.com/browse/CNV-80331
`

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

