### PR TITLE
Push fedora-with-test-tooling-container-disk as multiarch manifest list

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -365,7 +365,7 @@ oci_push(
 # Customized container-disk images
 oci_push(
     name = "push-fedora-with-test-tooling-container-disk",
-    image = "//containerimages:fedora-with-test-tooling",
+    image = "//containerimages:fedora-with-test-tooling-multiarch",
     repository = "quay.io/kubevirt/fedora-with-test-tooling-container-disk",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -360,7 +360,6 @@ oci_pull(
 
 # Pull fedora container-disk preconfigured with ci tooling
 # like stress and qemu guest agent pre-configured
-# TODO build fedora_with_test_tooling for multi-arch
 oci_pull(
     name = "fedora_with_test_tooling",
     digest = "sha256:897af945d1c58366086d5933ae4f341a5f1413b88e6c7f2b659436adc5d0f522",

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
@@ -97,6 +97,34 @@ oci_image(
         "@io_bazel_rules_go//go/platform:linux_s390x": "@fedora_with_test_tooling_s390x",
         "//conditions:default": "@fedora_with_test_tooling",
     }),
+    visibility = ["//visibility:public"],
+)
+
+oci_image(
+    name = "fedora-with-test-tooling-amd64",
+    base = "@fedora_with_test_tooling",
+    visibility = ["//visibility:public"],
+)
+
+oci_image(
+    name = "fedora-with-test-tooling-arm64",
+    base = "@fedora_with_test_tooling_aarch64",
+    visibility = ["//visibility:public"],
+)
+
+oci_image(
+    name = "fedora-with-test-tooling-s390x",
+    base = "@fedora_with_test_tooling_s390x",
+    visibility = ["//visibility:public"],
+)
+
+oci_image_index(
+    name = "fedora-with-test-tooling-multiarch",
+    images = [
+        ":fedora-with-test-tooling-amd64",
+        ":fedora-with-test-tooling-arm64",
+        ":fedora-with-test-tooling-s390x",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -35,7 +35,6 @@ default_targets="
     virt-synchronization-controller
     alpine-container-disk-demo
     alpine-with-test-tooling-container-disk
-    fedora-with-test-tooling-container-disk
     vm-killer
     sidecar-shim
     disks-images-provider


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`fedora-with-test-tooling-container-disk` is pushed as a single-architecture image, causing failures in OpenShift CI's `verify-image-manifest-lists` presubmit check.

#### After this PR:
`fedora-with-test-tooling-container-disk` is pushed as a proper OCI image index (manifest list) containing entries for amd64, arm64, and s390x.

### References
- Partially addresses OCPBUGS-77283

### Why we need it and why it was done in this way
The per-arch source images already exist in `WORKSPACE` as separate `oci_pull` entries (`fedora_with_test_tooling`, `fedora_with_test_tooling_aarch64`, `fedora_with_test_tooling_s390x`). Since these are pre-built images (pulled from registry, not compiled), we can always create the full multi-arch index regardless of the build host architecture using `oci_image_index` from `rules_oci` (v2.0.1, already available).

The following tradeoffs were made:
- The multiarch index is pushed separately from the per-arch loop in `multi-arch.sh` rather than through `push-container-manifest.sh`, because `push-container-manifest.sh` assembles manifest lists from per-arch tagged images using podman/docker CLI, which doesn't apply here — the index is already pre-assembled by Bazel from the pulled per-arch images.

The following alternatives were considered:
- Relying on `push-container-manifest.sh` to assemble the manifest list from per-arch pushes. This was rejected because pushing a pre-built manifest list per-arch would create arch-suffixed tags containing full manifest lists, which confuses `push-container-manifest.sh` (especially with podman).

### Special notes for your reviewer
- The existing `fedora-with-test-tooling` target (with `select()`) is preserved — it is still used by `bazel-build-images.sh` for per-arch builds.
- The new per-arch `oci_image` targets (`fedora-with-test-tooling-amd64`, `-arm64`, `-s390x`) use hardcoded base references (no `select()`), so they are platform-independent.
- Verification: after push, `skopeo inspect --raw docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk:<tag>` should show `mediaType: application/vnd.oci.image.index.v1+json`.

### Checklist
- [x] Design: Not required — straightforward use of existing `oci_image_index` rule
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Simple and focused changes
- [x] Refactor: Removed resolved TODO comment from WORKSPACE
- [x] Upgrade: No impact on upgrade flows
- [x] Testing: Build-level verification (Bazel targets). No new unit/e2e tests needed — this is a CI/build infrastructure change.
- [x] Documentation: Not required — no user-facing API change
- [x] Community: Not required
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```