### PR TITLE
fix:Add Linux build constraint for seccomp support

### DIFF
--- a/pkg/virt-handler/seccomp/seccomp.go
+++ b/pkg/virt-handler/seccomp/seccomp.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
  * This file is part of the KubeVirt project
  *

--- a/pkg/virt-handler/seccomp/seccomp_suite_test.go
+++ b/pkg/virt-handler/seccomp/seccomp_suite_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
  * This file is part of the KubeVirt project
  *

--- a/pkg/virt-handler/seccomp/seccomp_test.go
+++ b/pkg/virt-handler/seccomp/seccomp_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
  * This file is part of the KubeVirt project
  *


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The seccomp package files (`seccomp.go`, `seccomp_test.go`, `seccomp_suite_test.go`) lacked `//go:build linux` build constraints. Since these files depend on `seccomp.DefaultProfile()` from `github.com/containers/common/pkg/seccomp`, which is only defined in `default_linux.go` (a Linux-only file), the package fails to compile when `GOOS` is not `linux`.

#### After this PR:
All three files in `pkg/virt-handler/seccomp/` now have `//go:build linux` build constraints, matching the platform constraint of their vendored dependency. The package compiles correctly on all platforms and continues to function identically on Linux.

### Why we need it and why it was done in this way
The `seccomp.DefaultProfile()` function is defined in the vendored file `default_linux.go`, which Go only compiles when `GOOS=linux`. The seccomp package in virt-handler calls this function but had no matching build constraint, causing `undefined: seccomp.DefaultProfile` compilation errors on non-Linux platforms.

The following tradeoffs were made:
- Adding the build constraint to all three files ensures consistent behavior.

The following alternatives were considered:
- Creating stub implementations for non-Linux platforms was considered but rejected, since seccomp is a Linux kernel feature and virt-handler is a Linux-only component. A build constraint is the idiomatic Go approach.

### Special notes for your reviewer
This is a minimal, non-functional change. Only `//go:build linux` directives were added. No logic, imports, or behavior was modified.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required

### Release note
```release-note
NONE
```