### PR TITLE
  virt-api: fix nil pointer dereference in admitHotplugCPU webhook

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -193,6 +193,10 @@ func admitHotplug(
 
 func admitHotplugCPU(oldCPUTopology, newCPUTopology *v1.CPU) *admissionv1.AdmissionResponse {
 
+	if oldCPUTopology == nil || newCPUTopology == nil {
+		return nil
+	}
+
 	if oldCPUTopology.MaxSockets != newCPUTopology.MaxSockets {
 		return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
 			{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -484,7 +484,23 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			&v1.CPU{
 				MaxSockets: 8,
 			},
-			BeFalse()))
+			BeFalse()),
+		Entry("allow update when old CPU topology is nil",
+			nil,
+			&v1.CPU{
+				MaxSockets: 8,
+			},
+			BeTrue()),
+		Entry("allow update when new CPU topology is nil",
+			&v1.CPU{
+				MaxSockets: 8,
+			},
+			nil,
+			BeTrue()),
+		Entry("allow update when both CPU topologies are nil",
+			nil,
+			nil,
+			BeTrue()))
 
 	It("should reject updates to maxGuest", func() {
 		vmi := api.NewMinimalVMI("testvmi")


### PR DESCRIPTION


### What this PR does

admitHotplugCPU validates that maxSockets is not changed during a VMI update.
  However, spec.domain.cpu is an optional field, so both oldCPUTopology and
  newCPUTopology can be nil when a VMI has no explicit CPU topology defined.

  Accessing .MaxSockets on a nil pointer causes a panic in the virt-api admission
  webhook, returning a 500 Internal Server Error to any client updating such a VMI.

  This PR adds the same nil guard that already exists in the sibling function
  admitHotplugMemory:

  if oldCPUTopology == nil || newCPUTopology == nil {
      return nil
  }

  If either side has no CPU topology, there is no maxSockets immutability
  constraint to enforce, so the update is allowed.

### Changes

  - pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
  Added nil check at the start of admitHotplugCPU before any field access.
  - pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
  Added three new table entries to the existing "Updates in CPU topology" describe
  block:
    - old CPU nil, new CPU non-nil → admitted
    - old CPU non-nil, new CPU nil → admitted
    - both nil → admitted

  All three cases would previously have caused a panic.


  
- Fixes #16959 

### How to verify

   Build
  GOOS=linux GOARCH=amd64 go build
  ./pkg/virt-api/webhooks/validating-webhook/admitters/

   Vet
  GOOS=linux GOARCH=amd64 go vet
  ./pkg/virt-api/webhooks/validating-webhook/admitters/

  Run the unit tests in a Linux environment:
  go test ./pkg/virt-api/webhooks/validating-webhook/admitters/ -run "Updates in
  CPU topology"

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).


### Release Notes
```
Copilot said: Fixed a `virt-api` admission webhook panic (nil
Fixed a virt-api admission webhook panic (nil pointer deref) in admitHotplugCPU when updating VMIs without spec.domain.cpu, preventing 500 errors and allowing the update.
```

