### PR TITLE
  virt-api,virt-launcher: add keyboard input device type support

### DIFF
--- a/pkg/libvmi/devices.go
+++ b/pkg/libvmi/devices.go
@@ -38,6 +38,19 @@ func WithTablet(name string, bus v1.InputBus) Option {
 	}
 }
 
+// WithKeyboard adds keyboard device with given name and bus
+func WithKeyboard(name string, bus v1.InputBus) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Inputs = append(vmi.Spec.Domain.Devices.Inputs,
+			v1.Input{
+				Name: name,
+				Bus:  bus,
+				Type: v1.InputTypeKeyboard,
+			},
+		)
+	}
+}
+
 func WithAutoattachGraphicsDevice(enable bool) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = &enable

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -348,10 +348,10 @@ func validateInputDevices(field *k8sfield.Path, spec *v1.VirtualMachineInstanceS
 			})
 		}
 
-		if input.Type != v1.InputTypeTablet {
+		if input.Type != v1.InputTypeTablet && input.Type != v1.InputTypeKeyboard {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "Input device can have only tablet type.",
+				Message: "Input device can have only tablet or keyboard type.",
 				Field:   field.Child("domain", "devices", "inputs").Index(idx).Child("type").String(),
 			})
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -348,7 +348,7 @@ func validateInputDevices(field *k8sfield.Path, spec *v1.VirtualMachineInstanceS
 			})
 		}
 
-		if input.Type != v1.InputTypeTablet && input.Type != v1.InputTypeKeyboard {
+		if !v1.IsValidInputType(input.Type) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: "Input device can have only tablet or keyboard type.",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -708,24 +708,30 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Name: "tablet0",
 					Bus:  v1.InputBus("ps2"),
 				}, 1, []string{"fake.domain.devices.inputs[0].bus"}, "Expect bus error"),
-			Entry("and reject input with keyboard type and virtio bus",
+			Entry("and accept input with keyboard type and virtio bus",
 				v1.Input{
 					Type: v1.InputTypeKeyboard,
-					Name: "tablet0",
+					Name: "keyboard0",
 					Bus:  v1.InputBusVirtio,
-				}, 1, []string{"fake.domain.devices.inputs[0].type"}, "Expect type error"),
-			Entry("and reject input with keyboard type and usb bus",
+				}, 0, []string{}, "Expect no errors"),
+			Entry("and accept input with keyboard type and usb bus",
 				v1.Input{
 					Type: v1.InputTypeKeyboard,
-					Name: "tablet0",
+					Name: "keyboard0",
+					Bus:  v1.InputBusUSB,
+				}, 0, []string{}, "Expect no errors"),
+			Entry("and reject input with keyboard type and unsupported bus",
+				v1.Input{
+					Type: v1.InputTypeKeyboard,
+					Name: "keyboard0",
+					Bus:  v1.InputBus("ps2"),
+				}, 1, []string{"fake.domain.devices.inputs[0].bus"}, "Expect bus error"),
+			Entry("and reject input with unsupported type",
+				v1.Input{
+					Type: v1.InputType("mouse"),
+					Name: "mouse0",
 					Bus:  v1.InputBusUSB,
 				}, 1, []string{"fake.domain.devices.inputs[0].type"}, "Expect type error"),
-			Entry("and reject input with wrong type and wrong bus",
-				v1.Input{
-					Type: v1.InputTypeKeyboard,
-					Name: "tablet0",
-					Bus:  v1.InputBus("ps2"),
-				}, 2, []string{"fake.domain.devices.inputs[0].bus", "fake.domain.devices.inputs[0].type"}, "Expect type error"),
 		)
 
 		It("should reject negative requests.cpu value", func() {

--- a/pkg/virt-launcher/virtwrap/converter/compute/input_device.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/input_device.go
@@ -71,7 +71,7 @@ func apiInputDeviceFromV1InputDevice(input v1.Input) (api.Input, error) {
 		return api.Input{}, fmt.Errorf("input contains unsupported bus %s", input.Bus)
 	}
 
-	if input.Type != v1.InputTypeTablet {
+	if input.Type != v1.InputTypeTablet && input.Type != v1.InputTypeKeyboard {
 		return api.Input{}, fmt.Errorf("input contains unsupported type %s", input.Type)
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/input_device.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/input_device.go
@@ -71,7 +71,7 @@ func apiInputDeviceFromV1InputDevice(input v1.Input) (api.Input, error) {
 		return api.Input{}, fmt.Errorf("input contains unsupported bus %s", input.Bus)
 	}
 
-	if input.Type != v1.InputTypeTablet && input.Type != v1.InputTypeKeyboard {
+	if !v1.IsValidInputType(input.Type) {
 		return api.Input{}, fmt.Errorf("input contains unsupported type %s", input.Type)
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/input_device_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/input_device_test.go
@@ -109,6 +109,10 @@ var _ = Describe("Input Device Configurator", func() {
 		},
 			Entry("with USB bus on amd64", "amd64", v1.InputBusUSB, ""),
 			Entry("with virtio bus on amd64", "amd64", v1.InputBusVirtio, v1.VirtIO),
+			Entry("with USB bus on arm64", "arm64", v1.InputBusUSB, ""),
+			Entry("with virtio bus on arm64", "arm64", v1.InputBusVirtio, v1.VirtIO),
+			Entry("with USB bus on s390x", "s390x", v1.InputBusUSB, ""),
+			Entry("with virtio bus on s390x", "s390x", v1.InputBusVirtio, v1.VirtIO),
 		)
 	})
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -613,12 +613,22 @@ const (
 	InputTypeKeyboard InputType = "keyboard"
 )
 
+// IsValidInputType returns true if t is a supported input device type.
+func IsValidInputType(t InputType) bool {
+	switch t {
+	case InputTypeTablet, InputTypeKeyboard:
+		return true
+	default:
+		return false
+	}
+}
+
 type Input struct {
 	// Bus indicates the bus of input device to emulate.
 	// Supported values: virtio, usb.
 	Bus InputBus `json:"bus,omitempty"`
 	// Type indicated the type of input device.
-	// Supported values: tablet.
+	// Supported values: tablet, keyboard.
 	Type InputType `json:"type"`
 	// Name is the device name
 	Name string `json:"name"`


### PR DESCRIPTION


### What this PR does

InputTypeKeyboard has been a valid API type since it was added to the schema, but
the admission webhook and the libvirt domain converter both only accepted
InputTypeTablet, silently contradicting the public API.

  This PR aligns the implementation with the API contract by accepting both tablet
  and keyboard in validation and conversion. The keyboard device type is already
  proven to work at the libvirt level — the same converter file adds keyboard
  devices automatically for arm64 and s390x architecture-specific inputs.

  
- Fixes #16963 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- x ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
    Input device keyboard type now supported
    VMIs with `spec.domain.devices.inputs[].type: keyboard` were previously
    rejected by the admission webhook with the error "Input device can have
    only tablet type", even though `keyboard` is a valid type defined in the
    KubeVirt API schema. This has been fixed — both `tablet` and `keyboard`
    are now accepted by validation and correctly passed to the underlying
    libvirt domain configuration.
```

