### PR TITLE
  virt-launcher: fix wrong error variable used when YAML/JSON unmarshal both fail   in standalone mode

### DIFF
--- a/pkg/virt-launcher/standalone/standalone.go
+++ b/pkg/virt-launcher/standalone/standalone.go
@@ -38,8 +38,8 @@ func HandleStandaloneMode(domainManager virtwrap.DomainManager) {
 		if err := yaml.Unmarshal([]byte(vmiObjStr), &vmi); err != nil {
 			// Fallback to JSON if YAML fails
 			if jsonErr := json.Unmarshal([]byte(vmiObjStr), &vmi); jsonErr != nil {
-				log.Log.Reason(err).Error("Failed to unmarshal VMI from STANDALONE_VMI as YAML/JSON")
-				panic(err)
+				log.Log.Reason(jsonErr).Error("Failed to unmarshal VMI from STANDALONE_VMI as YAML/JSON")
+				panic(jsonErr)
 			}
 		}
 

--- a/pkg/virt-launcher/standalone/standalone_test.go
+++ b/pkg/virt-launcher/standalone/standalone_test.go
@@ -51,13 +51,13 @@ var _ = Describe("HandleStandaloneMode", func() {
 		standalone.HandleStandaloneMode(mockDM)
 	})
 
-	It("should panic on invalid JSON in STANDALONE_VMI", func() {
+	It("should panic with the JSON error when input is neither valid YAML nor valid JSON", func() {
 		os.Setenv("STANDALONE_VMI", "invalid json")
 		defer os.Unsetenv("STANDALONE_VMI")
 
 		Expect(func() {
 			standalone.HandleStandaloneMode(mockDM)
-		}).To(Panic())
+		}).To(PanicWith(MatchError(ContainSubstring("invalid character"))))
 	})
 
 	It("should panic if SyncVMI fails", func() {


### PR DESCRIPTION


### What this PR does

 In HandleStandaloneMode, the YAML-to-JSON fallback path panics with err (the YAML
   error) instead of jsonErr (the JSON error) when both parse attempts fail. This
  means every crash log produced in this scenario points to the wrong failure,
  making debugging misleading and time-consuming.

  The fix is two characters: replace err with jsonErr on both the log.Log.Reason
  and panic call sites.


- Fixes #16966 



  ### How to verify

  Run the unit tests on a Linux host:
  go test ./pkg/virt-launcher/standalone/ -v -run "HandleStandaloneMode"

  To reproduce the original bug manually before the fix:
  export STANDALONE_VMI="not: valid: json: {{"
  # Observe the panic message — it showed the YAML error before this fix


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).



### Release note

```release-note
- **virt-launcher standalone mode now reports the correct parse error on startup
  failure**
   - When `virt-launcher` is started in standalone mode with a `STANDALONE_VMI`
  environment
   - variable that cannot be parsed as either YAML or JSON, the crash log and panic
  value
   - previously showed the YAML parse error instead of the JSON error. This made
  diagnosing
    - startup failures unnecessarily difficult. The correct JSON error is now
  reported.

```

