### PR TITLE
  virt-launcher: fix nil pointer dereference in GenerateDomainForTargetCPUSetAndTopology when MigrationState is not set

### DIFF
--- a/pkg/liveupdate/memory/memory.go
+++ b/pkg/liveupdate/memory/memory.go
@@ -109,6 +109,10 @@ func ValidateLiveUpdateMemory(vmSpec *v1.VirtualMachineInstanceSpec, maxGuest *r
 func BuildMemoryDevice(vmi *v1.VirtualMachineInstance) (*api.MemoryDevice, error) {
 	domain := vmi.Spec.Domain
 
+	if vmi.Status.Memory == nil || vmi.Status.Memory.GuestAtBoot == nil {
+		return nil, fmt.Errorf("VMI memory status is not initialized, cannot build memory device")
+	}
+
 	pluggableMemory := domain.Memory.MaxGuest.DeepCopy()
 	pluggableMemory.Sub(*vmi.Status.Memory.GuestAtBoot)
 	pluggableMemorySize, err := vcpu.QuantityToByte(pluggableMemory)

--- a/pkg/liveupdate/memory/memory_test.go
+++ b/pkg/liveupdate/memory/memory_test.go
@@ -86,6 +86,28 @@ var _ = Describe("LiveUpdate Memory", func() {
 
 		Context("virtio-mem device", func() {
 
+			DescribeTable("should return an error when VMI memory status is uninitialized",
+				func(status *v1.VirtualMachineInstanceStatus) {
+					vmi := libvmi.New(
+						libvmi.WithArchitecture("amd64"),
+						libvmi.WithGuestMemory("128Mi"),
+						libvmi.WithMaxGuest("256Mi"),
+					)
+					if status != nil {
+						vmi.Status = *status
+					}
+					_, err := memory.BuildMemoryDevice(vmi)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("VMI memory status is not initialized"))
+				},
+				Entry("when Status.Memory is nil", nil),
+				Entry("when Status.Memory is set but GuestAtBoot is nil",
+					&v1.VirtualMachineInstanceStatus{
+						Memory: &v1.MemoryStatus{},
+					},
+				),
+			)
+
 			DescribeTable("should be correctly built", func(opts ...libvmi.Option) {
 				currentGuestMemory := resource.MustParse("64Mi")
 

--- a/pkg/virt-handler/migration.go
+++ b/pkg/virt-handler/migration.go
@@ -37,11 +37,15 @@ func FindMigrationIP(migrationIp string) (string, error) {
 		return migrationIp, fmt.Errorf("%s present but doesn't have an IP", v1.MigrationInterfaceName)
 	}
 	for _, addr := range addrs {
-		if !addr.(*net.IPNet).IP.IsGlobalUnicast() {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if !ipNet.IP.IsGlobalUnicast() {
 			// skip local/multicast IPs
 			continue
 		}
-		ip := addr.(*net.IPNet).IP.To16()
+		ip := ipNet.IP.To16()
 		if ip != nil {
 			return ip.String(), nil
 		}

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
@@ -20,6 +20,7 @@ package cpudedicated
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"libvirt.org/go/libvirtxml"
 
@@ -32,6 +33,10 @@ import (
 )
 
 func GenerateDomainForTargetCPUSetAndTopology(vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec) (*api.Domain, error) {
+	if vmi.Status.MigrationState == nil {
+		return nil, fmt.Errorf("cannot generate domain for target: VMI migration state is not initialized")
+	}
+
 	var targetTopology cmdv1.Topology
 	targetNodeCPUSet := vmi.Status.MigrationState.TargetCPUSet
 	err := json.Unmarshal([]byte(vmi.Status.MigrationState.TargetNodeTopology), &targetTopology)

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package cpudedicated_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestCPUDedicated(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_test.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_test.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package cpudedicated_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cpudedicated"
+)
+
+var _ = Describe("GenerateDomainForTargetCPUSetAndTopology", func() {
+	It("should return an error when MigrationState is nil", func() {
+		vmi := libvmi.New(libvmi.WithDedicatedCPUPlacement())
+		// MigrationState is nil by default on a freshly created VMI
+		Expect(vmi.Status.MigrationState).To(BeNil())
+
+		domSpec := &api.DomainSpec{}
+		_, err := cpudedicated.GenerateDomainForTargetCPUSetAndTopology(vmi, domSpec)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("migration state is not initialized"))
+	})
+})


### PR DESCRIPTION


### What this PR does

 GenerateDomainForTargetCPUSetAndTopology is only meaningful during live migration but had no guard against being called when vmi.Status.MigrationState is nil. Any invocation outside an active migration — or before the state is populated —
results in a panic that kills virt-launcher.

This PR adds a nil check at the function entry point and returns a clear error.  It also introduces the first unit tests for the cpudedicated package.

### How to verify


```bash
  GOOS=linux GOARCH=amd64 go build ./pkg/virt-launcher/virtwrap/cpudedicated/
  GOOS=linux GOARCH=amd64 go vet ./pkg/virt-launcher/virtwrap/cpudedicated/
  # On Linux:
  go test ./pkg/virt-launcher/virtwrap/cpudedicated/ -v
```
  
- Fixes #16968 


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
virt-launcher no longer panics in GenerateDomainForTargetCPUSetAndTopology 
when MigrationState has not been initialized. For VMIs with dedicated CPUs, 
this function accessed MigrationState fields without guarding against a nil pointer. 
If invoked outside an active live migration or before state is populated,
virt-launcher would panic and kill the running VM. 
The function now returns a descriptive error instead,
and the cpudedicated package now has unit test coverage for the first time.
```

