### PR TITLE
virt-handler/cache: fix deadlock — release watchDogLock before sending to eventChan

### DIFF
--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -20,8 +20,12 @@
 package cache
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 var _ = Describe("Domain Watcher", func() {
@@ -42,6 +46,91 @@ var _ = Describe("Domain Watcher", func() {
 			Expect(socketFiles).To(HaveLen(1))
 			Expect(socketFiles[0]).To(Equal(socketPath))
 
+		})
+	})
+
+	Context("handleStaleSocketConnections", func() {
+		It("should remove a socket from unresponsiveSockets when it is no longer in the socket list", func() {
+			ghostCacheDir := GinkgoT().TempDir()
+			InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+
+			const stalePath = "/nonexistent/socket.sock"
+			d := &domainWatcher{
+				eventChan:       make(chan watch.Event, 10),
+				watchdogTimeout: 30,
+				unresponsiveSockets: map[string]int64{
+					stalePath: time.Now().UTC().Unix(),
+				},
+			}
+
+			err := d.handleStaleSocketConnections()
+			Expect(err).ToNot(HaveOccurred())
+
+			d.watchDogLock.Lock()
+			defer d.watchDogLock.Unlock()
+			Expect(d.unresponsiveSockets).ToNot(HaveKey(stalePath))
+		})
+
+		It("should emit a Modified event when a socket exceeds the watchdog timeout", func() {
+			ghostCacheDir := GinkgoT().TempDir()
+			ghostRecordStore := InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+
+			const socketPath = "/nonexistent/socket.sock"
+			const uid = "test-uid-1234"
+			err := ghostRecordStore.Add("test-ns", "test-vmi", socketPath, uid)
+			Expect(err).ToNot(HaveOccurred())
+
+			d := &domainWatcher{
+				eventChan:       make(chan watch.Event, 10),
+				watchdogTimeout: 1,
+				unresponsiveSockets: map[string]int64{
+					// Mark the socket as unresponsive well before the timeout.
+					socketPath: time.Now().UTC().Add(-10 * time.Second).Unix(),
+				},
+			}
+
+			err = d.handleStaleSocketConnections()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(d.eventChan).To(Receive(HaveField("Type", watch.Modified)))
+		})
+
+		It("should not hold watchDogLock while sending to eventChan", func() {
+			ghostCacheDir := GinkgoT().TempDir()
+			ghostRecordStore := InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+
+			const socketPath = "/nonexistent/socket2.sock"
+			const uid = "test-uid-5678"
+			err := ghostRecordStore.Add("test-ns", "test-vmi2", socketPath, uid)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Zero-buffer channel
+			d := &domainWatcher{
+				eventChan:       make(chan watch.Event, 0),
+				watchdogTimeout: 1,
+				unresponsiveSockets: map[string]int64{
+					socketPath: time.Now().UTC().Add(-10 * time.Second).Unix(),
+				},
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_ = d.handleStaleSocketConnections()
+			}()
+
+			// The goroutine blocks on eventChan send
+			Eventually(func() bool {
+				if d.watchDogLock.TryLock() {
+					d.watchDogLock.Unlock()
+					return true
+				}
+				return false
+			}).WithTimeout(2 * time.Second).WithPolling(20 * time.Millisecond).Should(BeTrue())
+
+			// Unblock the goroutine and wait for it to finish.
+			<-d.eventChan
+			Eventually(done).WithTimeout(2 * time.Second).Should(BeClosed())
 		})
 	})
 })


### PR DESCRIPTION

### What this PR does

  - handleStaleSocketConnections held watchDogLock via defer while sending to
  eventChan, making it possible for a slow informer consumer to block the watchdog
  indefinitely.
  - Restructured the function to collect events and sockets-to-mark in local slices
   while holding the lock, then explicitly unlock before performing any channel
  sends or external I/O.
  - Added three unit tests: reaping a recovered socket, emitting a Modified event
  on timeout, and a concurrency test that asserts watchDogLock is released before
  the blocking channel send completes.

- Fixes #16970 

  ### Test plan

  - go build ./pkg/virt-handler/cache/ — no new errors
  - New Ginkgo specs in domain-watcher_test.go pass:
    - should remove a socket from unresponsiveSockets when it is no longer in the
  socket list
    - should emit a Modified event when a socket exceeds the watchdog timeout
    - should not hold watchDogLock while sending to eventChan
  - Existing listSockets spec still passes
  - No regressions in the virt-handler unit test suite


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
 **virt-handler**: fixed a potential deadlock where `watchDogLock` was held
    while sending to `eventChan` in `handleStaleSocketConnections`. Under a slow
    informer consumer this caused the watchdog timer to block indefinitely,
    preventing detection of unresponsive `virt-launcher` sockets and stalling
    VMI cleanup on affected nodes.
```

