### PR TITLE
fix: address silent error loss in vmpool admitter, netstat, and replicaset

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -31,6 +31,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/deviceinfo"
@@ -238,8 +239,9 @@ func (c *NetStat) getPodInterfacefromFileCache(vmi *v1.VirtualMachineInstance, i
 
 	podInterface := &cache.PodIfaceCacheData{}
 	if data, err := cache.ReadPodInterfaceCache(c.cacheCreator, string(vmi.UID), ifaceName); err == nil {
-		//FIXME error handling?
 		podInterface = data
+	} else {
+		log.Log.Reason(err).V(4).Infof("failed to read pod interface cache for VMI %s/%s iface %s", vmi.Namespace, vmi.Name, ifaceName)
 	}
 
 	c.podInterfaceVolatileCache.Store(vmiInterfaceKey(vmi.UID, ifaceName), podInterface)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
@@ -184,6 +184,7 @@ func ValidateVMPoolSpec(ar *admissionv1.AdmissionReview, field *k8sfield.Path, p
 				Type:    metav1.CauseTypeUnexpectedServerResponse,
 				Message: "Could not fetch old vmpool",
 			})
+			return causes
 		}
 
 		if !equality.Semantic.DeepEqual(pool.Spec.Selector, oldPool.Spec.Selector) {


### PR DESCRIPTION

### What this PR does

  - Bug 1 (vmpool-admitter): add return causes after unmarshal error in ValidateVMPoolSpec to prevent fall-through to the immutable-selector check against a zero-value struct
  - Bug 2 (netstat): replace //FIXME error handling? silence with log.Log.Reason(err).V(4).Infof(...) so pod interface cache read failures are visible in logs
  - Bug 3 (replicaset): drain the full errChan after wg.Wait() in scale() and cleanFinishedVmis(), using errors.Join to surface all concurrent create/delete failures — not just the first
  

- Fixes #16973 


### Test plan

  - go build ./pkg/virt-api/webhooks/validating-webhook/admitters/ 
  - go build ./pkg/network/setup/
  - go build ./pkg/virt-controller/watch/replicaset/
  - New test: vmpool-admitter_test.go — "should reject and stop validation when old object cannot be unmarshalled" verifies exactly 1 cause (UnexpectedServerResponse), not 2
  - New test: vmpool-admitter_test.go — "should reject selector change as immutable" verifies normal update path still works
  - New test: netstat_test.go — "UpdateStatus succeeds with empty IP when pod interface cache file is missing" verifies no error and empty IP
  - New test: replicaset_test.go — "should include all concurrent errors in the failure condition message when all creates fail" verifies all 3 failure messages appear in the condition


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
 -  virt-api: fixed vmpool admission webhook incorrectly appending a
    "selector is immutable" validation error alongside the real unmarshal
    error when processing an Update with a corrupt OldObject.

  - virt-handler: pod interface cache read failures in NetStat are now
    logged at debug level instead of being silently discarded, improving
    observability of VMI network status issues.

  - virt-controller: replicaset controller now reports all concurrent
    VMI create/delete failures in the ReplicaFailure condition instead of
    only the first one, giving operators a complete picture of scale errors.
```

