### PR TITLE
sriov: Adapt SR-IOV tests for igb emulated environments

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -75,6 +75,16 @@ case "$TARGET" in
     export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
     export KUBEVIRT_PROVIDER=${TARGET/-sig-network*/}
     ;;
+  *emulated-igb*)
+    export KUBEVIRT_PROVIDER=${TARGET/-emulated-igb*/}
+    export KUBEVIRT_FUNC_TEST_SUITE_ARGS="${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -emulated-sriov=true"
+    export KUBEVIRT_WITH_SRIOV=true
+    export KUBEVIRT_NUM_NODES=3
+    export KUBEVIRT_DEPLOY_CDI=false
+    export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
+    export KUBEVIRT_E2E_PARALLEL=false
+    export KUBEVIRT_VERBOSITY=${KUBEVIRT_VERBOSITY:-"virtLauncher:3,virtHandler:3"}
+    ;;
   *sig-storage*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-storage/}
     export KUBEVIRT_STORAGE="rook-ceph-default"
@@ -434,7 +444,7 @@ done
 kubectl version
 
 mkdir -p "$ARTIFACTS_PATH"
-export KUBEVIRT_E2E_PARALLEL=true
+export KUBEVIRT_E2E_PARALLEL="${KUBEVIRT_E2E_PARALLEL:-true}"
 # arm64 e2e test lane use kind provider
 if [[ $TARGET =~ .*kind.* ]]; then
   # MSHV tests do not require serial execution
@@ -552,6 +562,8 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
       label_filter='(sig-operator)'
     fi
   elif [[ $TARGET =~ sriov.* ]]; then
+    label_filter='(SRIOV)'
+  elif [[ $TARGET =~ emulated-igb ]]; then
     label_filter='(SRIOV)'
   elif [[ $TARGET =~ gpu.* ]]; then
     label_filter='(GPU)'

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -59,6 +59,7 @@ var DNSServiceNamespace = ""
 
 var MigrationNetworkNIC = "eth1"
 var MigrationNetworkName string
+var EmulatedSRIOV bool
 
 func init() {
 	kubecli.Init()
@@ -93,6 +94,7 @@ func init() {
 	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
 	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
 	flag.StringVar(&MigrationNetworkName, "migration-network-name", "", "name of the NetworkAttachmentDefinition CR to be used for dedicated migration network tests")
+	flag.BoolVar(&EmulatedSRIOV, "emulated-sriov", false, "Run SR-IOV tests in emulated mode")
 }
 
 func NormalizeFlags() {

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -87,7 +87,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 		BeforeEach(func() {
 			By("Creating a VM")
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
@@ -98,7 +98,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 			Eventually(matcher.ThisVM(hotPluggedVM)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			hotPluggedVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), hotPluggedVM.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(console.LoginToAlpine(hotPluggedVMI)).To(Succeed())
+			Expect(console.LoginToFedora(hotPluggedVMI)).To(Succeed())
 
 			By("Creating a NAD")
 			Expect(createSRIOVNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), nadName, sriovResourceName)).To(Succeed())

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,6 +54,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -141,8 +143,10 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			pciAddrStr := fmt.Sprintf("%s:%s:%s.%s", address.Domain[2:], address.Bus[2:], address.Slot[2:], address.Function[2:])
 			srcAddr := nic.Source.Address
 			sourcePCIAddress := fmt.Sprintf("%s:%s:%s.%s", srcAddr.Domain[2:], srcAddr.Bus[2:], srcAddr.Slot[2:], srcAddr.Function[2:])
-			alignedCPUsInt, err := hardware.LookupDeviceVCPUAffinity(sourcePCIAddress, domSpec)
+			vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(err).ToNot(HaveOccurred())
+			alignedCPUsInt := lookupDeviceVCPUAffinityOnPod(vmiPod, sourcePCIAddress, domSpec)
+			Expect(alignedCPUsInt).ToNot(BeEmpty(), "expected aligned CPUs for SR-IOV device")
 			deviceData := []cloudinit.DeviceData{
 				{
 					Type:        cloudinit.NICMetadataType,
@@ -884,4 +888,41 @@ func trimRawString2JSON(input string) string {
 		return ""
 	}
 	return input[startIdx : endIdx+1]
+}
+
+func lookupDeviceVCPUAffinityOnPod(pod *k8sv1.Pod, pciAddress string, domSpec *api.DomainSpec) []uint32 {
+	numaNodeStr, err := exec.ExecuteCommandOnPod(pod, "compute",
+		[]string{"cat", fmt.Sprintf("/sys/bus/pci/devices/%s/numa_node", pciAddress)})
+	Expect(err).ToNot(HaveOccurred())
+
+	numaNode, err := strconv.Atoi(strings.TrimSpace(numaNodeStr))
+	Expect(err).ToNot(HaveOccurred())
+
+	if numaNode < 0 {
+		return []uint32{}
+	}
+
+	cpuListStr, err := exec.ExecuteCommandOnPod(pod, "compute",
+		[]string{"cat", fmt.Sprintf("/sys/bus/node/devices/node%d/cpulist", numaNode)})
+	Expect(err).ToNot(HaveOccurred())
+
+	physicalCPUs, err := hardware.ParseCPUSetLine(strings.TrimSpace(cpuListStr), hardware.MAX_CPU_LIMIT)
+	Expect(err).ToNot(HaveOccurred())
+
+	if domSpec == nil || domSpec.CPUTune == nil || len(domSpec.CPUTune.VCPUPin) == 0 {
+		return []uint32{}
+	}
+
+	p2vCPUMap := make(map[string]uint32)
+	for _, vcpuPin := range domSpec.CPUTune.VCPUPin {
+		p2vCPUMap[vcpuPin.CPUSet] = vcpuPin.VCPU
+	}
+
+	var alignedVCPUs []uint32
+	for _, pcpu := range physicalCPUs {
+		if vCPU, exist := p2vCPUMap[strconv.Itoa(pcpu)]; exist {
+			alignedVCPUs = append(alignedVCPUs, vCPU)
+		}
+	}
+	return alignedVCPUs
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -59,6 +59,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -490,7 +491,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 
 		BeforeEach(func() {
-			netAttachDef := libnet.NewSriovNetAttachDef(sriovnetLinkEnabled, defaultVLAN, libnet.WithLinkState())
+			netAttachDef := libnet.NewSriovNetAttachDef(sriovnetLinkEnabled, defaultVLAN, withLinkState())
 			netAttachDef.Annotations = map[string]string{libnet.ResourceNameAnnotation: sriovResourceName}
 			_, err := libnet.CreateNetAttachDef(context.Background(), testsuite.NamespaceTestDefault, netAttachDef)
 			Expect(err).NotTo(HaveOccurred(), shouldCreateNetwork)
@@ -537,7 +538,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 				ipVlaned1, err = libnet.CidrToIP(cidrVlaned1)
 				Expect(err).ToNot(HaveOccurred())
 
-				netAttachDef := libnet.NewSriovNetAttachDef(sriovnetVlanned, specificVLAN, libnet.WithLinkState())
+				netAttachDef := libnet.NewSriovNetAttachDef(sriovnetVlanned, specificVLAN, withLinkState())
 				netAttachDef.Annotations = map[string]string{libnet.ResourceNameAnnotation: sriovResourceName}
 				_, err = libnet.CreateNetAttachDef(context.Background(), testsuite.NamespaceTestDefault, netAttachDef)
 				Expect(err).NotTo(HaveOccurred(), shouldCreateNetwork)
@@ -925,4 +926,11 @@ func lookupDeviceVCPUAffinityOnPod(pod *k8sv1.Pod, pciAddress string, domSpec *a
 		}
 	}
 	return alignedVCPUs
+}
+
+func withLinkState() func(map[string]interface{}) {
+	if flags.EmulatedSRIOV {
+		return func(_ map[string]interface{}) {}
+	}
+	return libnet.WithLinkState()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
SR-IOV e2e tests assumed real hardware and failed on emulated SR-IOV setups
(vm based provider with QEMU igb).

This PR fixes SR-IOV e2e tests to work on both emulated (QEMU igb) and real hardware SR-IOV environments.

A new lane support is added (emulated-igb).
The name of it doesn't mention network, nor "sriov", in order to keep test.sh simplest, without cross effect between network, sriov and the new lane.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

Depends on:
- [kubevirt/kubevirtci#1600](https://github.com/kubevirt/kubevirtci/pull/1600) - merged
- https://github.com/kubevirt/kubevirtci/pull/1722 (NUMA support for emulated SR-IOV) - merged

Lane presubmit phase2: [kubevirt/project-infra#5090](https://github.com/kubevirt/project-infra/pull/5090)

### Why we need it and why it was done in this way
The following tradeoffs were made:

The existing SR-IOV tests assumed real hardware.
On emulated SR-IOV, the following assumptions break:
1. The CNI `link_state` operation is unsupported.
All it does it to enable the interface, so we just skip it for emulated SR-IOV.

These changes make the tests generic without regressing real hardware behavior.

### Special notes for your reviewer

TODO - update `docs/network/sriov.md` on follow-up

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
None
```

