### PR TITLE
 fix: close migration proxy conn on stop, enforce IFNAMSIZ in bridge NIC   naming, return nil path on hotplug error

### DIFF
--- a/pkg/hotplug-disk/hotplug-disk.go
+++ b/pkg/hotplug-disk/hotplug-disk.go
@@ -94,7 +94,7 @@ func (h *hotplugDiskManager) GetFileSystemDirectoryTargetPathFromHostView(virtla
 func (h *hotplugDiskManager) GetFileSystemDiskTargetPathFromHostView(virtlauncherPodUID types.UID, volumeName string, create bool) (*safepath.Path, error) {
 	targetPath, err := h.GetHotplugTargetPodPathOnHost(virtlauncherPodUID)
 	if err != nil {
-		return targetPath, err
+		return nil, err
 	}
 	diskName := fmt.Sprintf("%s.img", volumeName)
 	if err := safepath.TouchAtNoFollow(targetPath, diskName, 0666); err != nil && !os.IsExist(err) {

--- a/pkg/hotplug-disk/hotplug-disk_test.go
+++ b/pkg/hotplug-disk/hotplug-disk_test.go
@@ -114,7 +114,8 @@ var _ = Describe("HotplugDisk", func() {
 
 	It("GetFileSystemDiskTargetPathFromHostView should fail on invalid UID", func() {
 		testUID := types.UID("abcde")
-		_, err := hotplug.GetFileSystemDiskTargetPathFromHostView(testUID, "testvolume", false)
+		res, err := hotplug.GetFileSystemDiskTargetPathFromHostView(testUID, "testvolume", false)
 		Expect(err).To(HaveOccurred())
+		Expect(res).To(BeNil())
 	})
 })

--- a/pkg/network/dhcp/bridge.go
+++ b/pkg/network/dhcp/bridge.go
@@ -58,7 +58,10 @@ func (d *BridgeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
 	fakeServerAddr, _ := netlink.ParseAddr(fakeBridgeIP)
 	dhcpConfig.AdvertisingIPAddr = fakeServerAddr.IP
 
-	newPodNicName := virtnetlink.GenerateNewBridgedVmiInterfaceName(d.podInterfaceName)
+	newPodNicName, err := virtnetlink.GenerateNewBridgedVmiInterfaceName(d.podInterfaceName)
+	if err != nil {
+		return nil, err
+	}
 	podNicLink, err := d.handler.LinkByName(newPodNicName)
 	if err != nil {
 		return nil, err

--- a/pkg/network/link/names.go
+++ b/pkg/network/link/names.go
@@ -44,7 +44,14 @@ func GenerateBridgeName(podInterfaceName string) string {
 	return "k6t-" + trimmedName
 }
 
-func GenerateNewBridgedVmiInterfaceName(originalPodInterfaceName string) string {
+// maxIfaceNameLen is the maximum Linux interface name length.
+const maxIfaceNameLen = 15
+
+func GenerateNewBridgedVmiInterfaceName(originalPodInterfaceName string) (string, error) {
 	trimmedName := strings.TrimPrefix(originalPodInterfaceName, namescheme.HashedIfacePrefix)
-	return fmt.Sprintf("%s-nic", trimmedName)
+	result := fmt.Sprintf("%s-nic", trimmedName)
+	if len(result) > maxIfaceNameLen {
+		return "", fmt.Errorf("generated interface name %q exceeds the maximum allowed length of %d characters", result, maxIfaceNameLen)
+	}
+	return result, nil
 }

--- a/pkg/network/link/names_test.go
+++ b/pkg/network/link/names_test.go
@@ -55,15 +55,26 @@ var _ = Describe("Common Methods", func() {
 	})
 	Context("GenerateNewBridgedVmiInterfaceName function", func() {
 		It("Should return the new bridge interface name", func() {
-			Expect(virtnetlink.GenerateNewBridgedVmiInterfaceName("eth0")).To(Equal("eth0-nic"))
+			name, err := virtnetlink.GenerateNewBridgedVmiInterfaceName("eth0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("eth0-nic"))
 		})
 		It("Should return another new bridge interface name", func() {
-			Expect(virtnetlink.GenerateNewBridgedVmiInterfaceName("net12")).To(Equal("net12-nic"))
+			name, err := virtnetlink.GenerateNewBridgedVmiInterfaceName("net12")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("net12-nic"))
 		})
 		It("Should return hash network name bridge interface name", func() {
-			hashedIfaceName := virtnetlink.GenerateNewBridgedVmiInterfaceName("pod16477688c0e")
+			hashedIfaceName, err := virtnetlink.GenerateNewBridgedVmiInterfaceName("pod16477688c0e")
+			Expect(err).NotTo(HaveOccurred())
 			Expect(len(hashedIfaceName)).To(BeNumerically("<=", maxInterfaceNameLength))
 			Expect(hashedIfaceName).To(Equal("16477688c0e-nic"))
+		})
+		It("Should return an error when the generated name exceeds 15 characters", func() {
+			// "toolongprefix" (13 chars) + "-nic" (4 chars) = 17 chars > 15
+			_, err := virtnetlink.GenerateNewBridgedVmiInterfaceName("toolongprefix")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exceeds the maximum allowed length"))
 		})
 	})
 	Context("GenerateBridgeName function", func() {

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -346,7 +346,10 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 		Metadata: &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
 	}
 
-	podIfaceAlternativeName := link.GenerateNewBridgedVmiInterfaceName(podIfaceName)
+	podIfaceAlternativeName, err := link.GenerateNewBridgedVmiInterfaceName(podIfaceName)
+	if err != nil {
+		return nil, err
+	}
 	podStatusIface, exist := ifaceStatusByName[podIfaceAlternativeName]
 	if !exist {
 		podStatusIface = ifaceStatusByName[podIfaceName]
@@ -474,7 +477,10 @@ func (n NetPod) managedTapSpec(podIfaceName string, vmiIfaceIndex int, ifaceStat
 	vmiNetworkName := n.vmiSpecIfaces[vmiIfaceIndex].Name
 	vmiNetwork := vmispec.LookupNetworkByName(n.vmiSpecNets, vmiNetworkName)
 
-	podIfaceAlternativeName := link.GenerateNewBridgedVmiInterfaceName(podIfaceName)
+	podIfaceAlternativeName, err := link.GenerateNewBridgedVmiInterfaceName(podIfaceName)
+	if err != nil {
+		return nil, err
+	}
 	podStatusIface, exist := ifaceStatusByName[podIfaceAlternativeName]
 	if !exist {
 		podStatusIface = ifaceStatusByName[podIfaceName]

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -461,6 +461,7 @@ func (m *migrationProxy) handleConnection(fd net.Conn) {
 		m.logger.Reason(err).Error("unable to create outbound leg of proxy to host")
 		return
 	}
+	defer conn.Close()
 
 	go func() {
 		//from outbound connection to proxy


### PR DESCRIPTION
### What this PR does
   
 Fixes three independent bugs across different subsystems:

  ### 1. File descriptor leak in migration proxy (`migration-proxy.go`)

  - `handleConnection` dials an outbound TCP/TLS connection but never closes it.
  - `fd` (the inbound side) is guarded by `defer fd.Close()` but `conn` has no
  matching defer. On `stopChan` close the goroutines exit cleanly but `conn`
  leaks, accumulating open file descriptors across many live migrations.

  ### 2. Missing IFNAMSIZ validation in `GenerateNewBridgedVmiInterfaceName`
  (`names.go`)

  - The function appended `-nic` to a trimmed name with no length check.
  Linux enforces a 15-character limit (`IFNAMSIZ - 1`) on interface names.
  A name exceeding this is silently truncated by the kernel, causing the
  bridge NIC name to not match what the rest of the network stack expects.

  ### 3. Inconsistent nil-path return in hotplug disk (`hotplug-disk.go`)

  - On the early error path, `GetFileSystemDiskTargetPathFromHostView` returned
  `targetPath, err` — a potentially non-nil `*safepath.Path` with a non-nil
  error — while the path below correctly returned `nil, err`. Callers that
  assume path is always nil on error could use an invalid path silently.

  
- Fixes #16976 


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
  Fixed a file descriptor leak in virt-handler where the outbound TCP/TLS          
  connection in the migration proxy was never closed when a proxy session          
  stopped, causing fd exhaustion over many successive live migrations.

  Fixed `GenerateNewBridgedVmiInterfaceName` to return an error when the
  generated bridge NIC name would exceed the 15-character Linux IFNAMSIZ
  limit, preventing silent kernel-level truncation that caused interface
  name mismatches for bridged VMI networks.

  Fixed `GetFileSystemDiskTargetPathFromHostView` to consistently return
  a nil path on all error paths, preventing callers from accidentally
  using a non-nil path alongside a non-nil error during hotplug disk
  target resolution.

```

