### PR TITLE
fix: resolve data race and errChan deadlock in abortChangeVMIs   goroutines

### DIFF
--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -638,18 +638,17 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 			defer wg.Done()
 			migList := migrationutils.ListWorkloadUpdateMigrations(c.migrationIndexer, vmi.Name, vmi.Namespace)
 			for _, mig := range migList {
-				err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), mig.Name, metav1.DeleteOptions{})
+				err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), mig.Name, metav1.DeleteOptions{})
 				if err != nil && !errors.IsNotFound(err) {
 					log.Log.Object(vmi).Reason(err).Errorf("Failed to delete the migration due to a migration abortion")
 					c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, FailedChangeAbortionReason, "Failed to abort change for vmi: %s: %v", vmi.Name, err)
 					errChan <- err
+					return
 				} else if err == nil {
 					log.Log.Infof("Delete migration %s due to an update change abortion", mig.Name)
 					c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, SuccessfulChangeAbortionReason, "Aborted change for vmi: %s", vmi.Name)
-
 				}
 			}
-
 		}(vmi)
 	}
 	wg.Wait()


### PR DESCRIPTION

### What this PR does
#### Before this PR:

`WorkloadUpdateController.sync()` iterates over `data.abortChangeVMIs` and launches one goroutine per VMI. Every concurrent goroutine is being written to the same memory location — a data race.

A second bug: `errChan` capacity equals `wgLen` (one slot per VMI), but the goroutine contains a nested `for _, mig := range migList` loop that can send one error per failing migration deletion. A VMI with ≥ 2 pending migrations that both fail to delete would overflow the channel, blocking the goroutine on `errChan <- err`, preventing `wg.Done()` from ever being called, and deadlocking `wg.Wait()` indefinitely.

#### After this PR:

- `err =` changed to `err :=` inside the goroutine; each goroutine now has its own local variable with no shared state.
 - `return` added after `errChan <- err`, matching the pattern already used in the `migrationCandidates` goroutine, so at most one error is ever sent per goroutine and the channel can never overflow.

### References
  
- Fixes #16979 

=
### Why we need it and why it was done in this way
  The two-character fix (`=` → `:=`) is the canonical Go idiom for avoiding variable capture in goroutines. `return` after the error send is already the convention in the two sibling goroutine blocks in the same function; applying it here makes the three blocks consistent and eliminates the overflow.

  An alternative would have been to make `errChan` unbuffered and drain  it in a separate goroutine before `wg.Wait()`. That approach was rejected as more invasive — it would change the existing error-handling semantics of the whole `sync()` function, whereas the minimal fix targets only the broken loop.


### Special notes for your reviewer

  The only observable behaviour change is that when a single VMI has multiple migration deletions and the first one fails, the remaining deletions in the loop are skipped (the goroutine returns early). This is acceptable: the error is reported, the controller re-queues and will  retry on the next sync cycle.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note

Fixed a data race in virt-controller where concurrent goroutines in
  WorkloadUpdateController.sync() wrote to a shared outer `err` variable
  when aborting workload-update migrations for multiple VMIs simultaneously.
  Also fixed a potential deadlock where a VMI with more than one pending
  migration deletion failure could overflow the error channel and block
  the controller goroutine indefinitely.

```

