### PR TITLE
sriov: Move ExternalNetResourceInjection FG to CI lane config

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -169,6 +169,7 @@ if [[ $TARGET =~ sriov.* ]]; then
   fi
   export KUBEVIRT_DEPLOY_CDI="false"
   export KUBEVIRT_VERBOSITY=${KUBEVIRT_VERBOSITY:-"virtLauncher:3,virtHandler:3"}
+  add_feature_gate "ExternalNetResourceInjection"
 elif [[ $TARGET =~ vgpu.* ]]; then
   export KUBEVIRT_NUM_NODES=1
 else

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -57,6 +57,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libdomain"
@@ -98,7 +99,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
 			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
 
-		config.EnableFeatureGate(featuregate.ExternalNetResourceInjection)
+		checks.FailTestIfNoFeatureGate(featuregate.ExternalNetResourceInjection)
 	})
 
 	Context("VMI connected to single SRIOV network", func() {


### PR DESCRIPTION
### What this PR does

Moves the `ExternalNetResourceInjection` feature gate from per-test enablement
(`config.EnableFeatureGate()` in `BeforeEach`) to the SR-IOV CI lane
configuration (`add_feature_gate` in `automation/test.sh`), so it is baked into
the KubeVirt CR at deploy time. The test now uses
`checks.FailTestIfNoFeatureGate()` to verify the gate is present without
mutating the CR.

### Why we need it and why it was done in this way

**The problem**: `ExternalNetResourceInjection` is one of the few FGs that
changes the virt-operator deployment ID hash, triggering a full pod rollout +
stabilization wait. The `BeforeEach` enables it (rollout), the global
`AfterEach` reverts it (another rollout). This turned a ~45 min lane into ~2h.

**Why this approach**: KubeVirt CI has three levels of FG enablement:

1. **`automation/test.sh`** — baked into the CR at deploy time. No runtime
   mutation, no reconciliation.
2. **e2e baseline (`AdjustKubeVirtResource`)** — appends ~20 FGs on top of (1)
   in `BeforeSuite`, saves as `KubeVirtDefaultConfig`.
3. **Per-test `BeforeEach`/`AfterEach`** — enables extra FGs at runtime; global
   `AfterEach` reverts to (2).

SR-IOV tests run on a dedicated lane with dedicated infrastructure (SR-IOV NICs)
and a dedicated job. It makes sense for that lane to provide the correct base
configuration — including this FG — at deploy time (level 1), not at test time
(level 3).

In general, feature gates should not be toggled back and
forth. In a typical production deployment they are applied once; CI should
behave the same — just enable them if they are not enabled by default. There are
rare conditions where it is worth testing what happens when a feature gate is
disabled, but that is the exception, not the rule. (Dan K.)

For a deeper analysis of the deployment ID mechanism and options to avoid
rollouts for this FG, see: #17081

### Release note

```release-note
NONE
```