### PR TITLE
[virtLauncher] fix SeaBIOS log error handling in libvirt_helper.go

### DIFF
--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -403,7 +403,8 @@ func startQEMUSeaBiosLogging(stopChan chan struct{}) {
 			return
 		}
 
-		log.Log.Errorf("%s exited, restarting", logLinePrefix)
+		log.Log.Errorf("%s exited", logLinePrefix)
+		return
 	}
 }
 


### PR DESCRIPTION
If QEMU closes the SeaBIOS pipe, it results in a flood of "SeaBIOS exited, restarting" messages.

