### PR TITLE
Fixed IOThread supplemental pool CPU pinning

### DIFF
--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -83,6 +83,7 @@ func safeAppend(cpusList []int, cpu int, limit int) ([]int, error) {
 
 // GetNumberOfVCPUs returns number of vCPUs
 // It counts sockets*cores*threads
+// It does not include sockets that are available for hotplug, but not enabled
 func GetNumberOfVCPUs(cpuSpec *v1.CPU) int64 {
 	vCPUs := cpuSpec.Cores
 	if cpuSpec.Sockets != 0 {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1160,7 +1160,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	prefixMap := newDeviceNamer(vmi.Status.VolumeStatus, vmi.Spec.Domain.Devices.Disks)
 	currentAutoThread := uint(1)
 	currentDedicatedThread := uint(autoThreads + 1)
-	supplementalIOThreads := iothreads.SupplementalPoolThreadCount(vmi)
+	supplementalIOThreads := iothreads.BuildSupplementalPoolIOThreads(vmi)
 	for _, disk := range vmi.Spec.Domain.Devices.Disks {
 		newDisk := api.Disk{}
 		emptyCDRom := false
@@ -1214,7 +1214,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	if vmi.Spec.Domain.CPU != nil {
 		// Adjust guest vcpu config. Currently will handle vCPUs to pCPUs pinning
 		if vmi.IsCPUDedicated() {
-			err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, c.Topology, c.CPUSet, hasIOThreads)
+			err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, c.Topology, c.CPUSet)
 			if err != nil {
 				return err
 			}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2933,7 +2933,7 @@ var _ = Describe("Converter", func() {
 	Context("Correctly handle supplementalPool with dedicated cpus", func() {
 		DescribeTable("should succeed assigning CPUs to supplementalPool",
 			func(vmiAnnotations map[string]string, isolateEmulator bool, vCPUs, iothreadCount uint32, expectedLayout api.CPUTune) {
-				c := &ConverterContext{
+				c := &convertertypes.ConverterContext{
 					Architecture:   archconverter.NewConverter(runtime.GOARCH),
 					AllowEmulation: true,
 					CPUSet:         []int{5, 6, 7, 8, 9, 10, 11, 12},

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2930,6 +2930,188 @@ var _ = Describe("Converter", func() {
 		})
 	})
 
+	Context("Correctly handle supplementalPool with dedicated cpus", func() {
+		DescribeTable("should succeed assigning CPUs to supplementalPool",
+			func(vmiAnnotations map[string]string, isolateEmulator bool, vCPUs, iothreadCount uint32, expectedLayout api.CPUTune) {
+				c := &ConverterContext{
+					Architecture:   archconverter.NewConverter(runtime.GOARCH),
+					AllowEmulation: true,
+					CPUSet:         []int{5, 6, 7, 8, 9, 10, 11, 12},
+					Topology: &cmdv1.Topology{
+						NumaCells: []*cmdv1.Cell{{
+							Cpus: []*cmdv1.CPU{
+								{Id: 5}, {Id: 6}, {Id: 7}, {Id: 8}, {Id: 9}, {Id: 10},
+								{Id: 11}, {Id: 12},
+							},
+						}},
+					},
+				}
+
+				vmi := libvmi.New(
+					libvmi.WithCPUCount(1, 1, vCPUs),
+					libvmi.WithIOThreadsPolicy(v1.IOThreadsPolicySupplementalPool),
+					libvmi.WithIOThreads(v1.DiskIOThreads{SupplementalPoolThreadCount: pointer.P(iothreadCount)}),
+					libvmi.WithDedicatedCPUPlacement(),
+				)
+				for key, value := range vmiAnnotations {
+					libvmi.WithAnnotation(key, value)(vmi)
+				}
+				if isolateEmulator {
+					libvmi.WithIsolateEmulatorThread()(vmi)
+				}
+
+				domain := vmiToDomain(vmi, c)
+
+				isExpectedThreadsLayout := equality.Semantic.DeepEqual(&expectedLayout, domain.Spec.CPUTune)
+				Expect(isExpectedThreadsLayout).To(BeTrue())
+			},
+			Entry("when no emulator thread isolation is used",
+				map[string]string{},
+				false,
+				uint32(2),
+				uint32(2),
+				api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{
+							VCPU:   0,
+							CPUSet: "5",
+						},
+						{
+							VCPU:   1,
+							CPUSet: "6",
+						},
+					},
+					IOThreadPin: []api.CPUTuneIOThreadPin{
+						{
+							IOThread: 1,
+							CPUSet:   "7",
+						},
+						{
+							IOThread: 2,
+							CPUSet:   "8",
+						},
+					},
+					EmulatorPin: nil,
+				}),
+			Entry("when EmulatorThreadCompleteToEvenParity is disabled and there is one extra CPU assigned for emulatorThread",
+				map[string]string{},
+				true,
+				uint32(2),
+				uint32(2),
+				api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{
+							VCPU:   0,
+							CPUSet: "5",
+						},
+						{
+							VCPU:   1,
+							CPUSet: "6",
+						},
+					},
+					IOThreadPin: []api.CPUTuneIOThreadPin{
+						{
+							IOThread: 1,
+							CPUSet:   "7",
+						},
+						{
+							IOThread: 2,
+							CPUSet:   "8",
+						},
+					},
+					EmulatorPin: &api.CPUEmulatorPin{
+						CPUSet: "9",
+					},
+				}),
+			Entry("when EmulatorThreadCompleteToEvenParity is enabled and there is one extra CPU assigned for emulatorThread (odd CPUs)",
+				map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""},
+				true,
+				uint32(3),
+				uint32(2),
+				api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{
+							VCPU:   0,
+							CPUSet: "5",
+						},
+						{
+							VCPU:   1,
+							CPUSet: "6",
+						},
+						{
+							VCPU:   2,
+							CPUSet: "7",
+						},
+					},
+					IOThreadPin: []api.CPUTuneIOThreadPin{
+						{
+							IOThread: 1,
+							CPUSet:   "8",
+						},
+						{
+							IOThread: 2,
+							CPUSet:   "9",
+						},
+					},
+					EmulatorPin: &api.CPUEmulatorPin{
+						CPUSet: "10",
+					},
+				}),
+			Entry("when EmulatorThreadCompleteToEvenParity is enabled and there are two extra CPUs assigned for emulatorThread (even CPUs)",
+				map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""},
+				true,
+				uint32(2),
+				uint32(2),
+				api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{
+							VCPU:   0,
+							CPUSet: "5",
+						},
+						{
+							VCPU:   1,
+							CPUSet: "6",
+						},
+					},
+					IOThreadPin: []api.CPUTuneIOThreadPin{
+						{
+							IOThread: 1,
+							CPUSet:   "7",
+						},
+						{
+							IOThread: 2,
+							CPUSet:   "8",
+						},
+					},
+					EmulatorPin: &api.CPUEmulatorPin{
+						CPUSet: "9,10",
+					},
+				}),
+			Entry("when EmulatorThreadCompleteToEvenParity is enabled and there are two extra CPUs assigned for emulatorThread (even CPUs with io+cpu)",
+				map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""},
+				true,
+				uint32(1),
+				uint32(1),
+				api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{
+							VCPU:   0,
+							CPUSet: "5",
+						},
+					},
+					IOThreadPin: []api.CPUTuneIOThreadPin{
+						{
+							IOThread: 1,
+							CPUSet:   "6",
+						},
+					},
+					EmulatorPin: &api.CPUEmulatorPin{
+						CPUSet: "7,8",
+					},
+				}),
+		)
+	})
+
 	Describe("newDeviceNamer", func() {
 		DescribeTable("should correctly build prefix map for different disk types",
 			func(volumeStatuses []v1.VolumeStatus, disks []v1.Disk, expectedPrefixes []string, expectedMappings map[string]map[string]string) {

--- a/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
+++ b/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
@@ -96,7 +96,7 @@ func getThreadPoolLimit(vmi *v1.VirtualMachineInstance) int {
 	}
 }
 
-func SupplementalPoolThreadCount(vmi *v1.VirtualMachineInstance) *api.DiskIOThreads {
+func BuildSupplementalPoolIOThreads(vmi *v1.VirtualMachineInstance) *api.DiskIOThreads {
 	if vmi.Spec.Domain.IOThreadsPolicy == nil || *vmi.Spec.Domain.IOThreadsPolicy != v1.IOThreadsPolicySupplementalPool {
 		return nil
 	}
@@ -105,4 +105,11 @@ func SupplementalPoolThreadCount(vmi *v1.VirtualMachineInstance) *api.DiskIOThre
 		iothreads.IOThread = append(iothreads.IOThread, api.DiskIOThread{Id: uint32(id)})
 	}
 	return iothreads
+}
+
+func SupplementalPoolThreadCount(vmi *v1.VirtualMachineInstance) int {
+	if vmi.Spec.Domain.IOThreads == nil || vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount == nil {
+		return 0
+	}
+	return int(*vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount)
 }

--- a/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
+++ b/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
@@ -108,7 +108,8 @@ func BuildSupplementalPoolIOThreads(vmi *v1.VirtualMachineInstance) *api.DiskIOT
 }
 
 func SupplementalPoolThreadCount(vmi *v1.VirtualMachineInstance) int {
-	if vmi.Spec.Domain.IOThreads == nil || vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount == nil {
+	if vmi.Spec.Domain.IOThreads == nil || vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount == nil ||
+		vmi.Spec.Domain.IOThreadsPolicy == nil || *vmi.Spec.Domain.IOThreadsPolicy != v1.IOThreadsPolicySupplementalPool {
 		return 0
 	}
 	return int(*vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount)

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/iothreads:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -16,6 +16,7 @@ import (
 	v1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/iothreads"
 )
 
 type VCPUPool interface {
@@ -23,6 +24,10 @@ type VCPUPool interface {
 	FitThread() (thread uint32, err error)
 }
 
+// CalculateRequestedVCPUs returns number of vCPUs
+// It counts sockets*cores*threads
+// It includes sockets that are available for hotplug, but not enabled.
+// The actual number of used sockets (and cpus available on the current node) may be lower
 func CalculateRequestedVCPUs(cpuTopology *api.CPUTopology) uint32 {
 	return cpuTopology.Cores * cpuTopology.Sockets * cpuTopology.Threads
 }
@@ -373,25 +378,43 @@ func appendDomainIOThreadPin(domain *api.Domain, thread uint32, cpuset string) {
 	domain.Spec.CPUTune.IOThreadPin = append(domain.Spec.CPUTune.IOThreadPin, iothreadPin)
 }
 
+func FormatDomainIOThreadSupplementalPin(cpuPool VCPUPool, vmi *v12.VirtualMachineInstance, domain *api.Domain) (int, error) {
+	if domain.Spec.IOThreads == nil {
+		return 0, fmt.Errorf("domain is missing IOThreads")
+	}
+
+	supplementalThreads := iothreads.SupplementalPoolThreadCount(vmi)
+	if supplementalThreads == 0 {
+		return 0, fmt.Errorf("domain is missing supplemental pool IOThreads")
+	}
+
+	for i := 1; i <= supplementalThreads; i++ {
+		// The cpus for the iothreads are additionally allocated and aren't part of the cpu set dedicated to the vcpus threads
+		availableThread, err := cpuPool.FitThread()
+		if err != nil {
+			e := fmt.Errorf("no CPU allocated for the iothread: %v", err)
+			log.Log.Reason(e).Error("failed to format iothread pin")
+			return i, e
+		}
+		appendDomainIOThreadPin(domain, uint32(i), fmt.Sprintf("%d", availableThread))
+	}
+	return supplementalThreads, nil
+}
+
 func FormatDomainIOThreadPin(vmi *v12.VirtualMachineInstance, domain *api.Domain, emulatorThreadsCPUSet string, cpuset []int) error {
 	if domain.Spec.IOThreads == nil {
 		return fmt.Errorf("domain is missing IOThreads")
 	}
 
+	// This is consistent with previous kubevirt behavior, but may not be a real libvirt restriction
+	if iothreads.SupplementalPoolThreadCount(vmi) > 0 {
+		return fmt.Errorf("domain has supplemental pool IOThreads and attempted to pin auto/shared IOThreads")
+	}
+
 	iothreads := int(domain.Spec.IOThreads.IOThreads)
-	vcpus := int(CalculateRequestedVCPUs(domain.Spec.CPU.Topology))
+	vcpus := int(hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU))
 
 	switch {
-	case vmi.Spec.Domain.IOThreads != nil && *vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount > 0:
-		indexEmulatorThread := 0
-		if emulatorThreadsCPUSet != "" {
-			indexEmulatorThread++
-		}
-		for i := 1; i <= int(*vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount); i++ {
-			// The cpus for the iothreads are additionally allocated and aren't part of the cpu set dedicated to the vcpus threads
-			cpu := vcpus + i + indexEmulatorThread
-			appendDomainIOThreadPin(domain, uint32(i), fmt.Sprintf("%d", cpu))
-		}
 	case vmi.IsCPUDedicated() && vmi.Spec.Domain.CPU.IsolateEmulatorThread:
 		// pin the IOThread on the same pCPU as the emulator thread
 		appendDomainIOThreadPin(domain, uint32(1), emulatorThreadsCPUSet)
@@ -450,7 +473,7 @@ func FormatEmulatorThreadPin(cpuPool VCPUPool, vmiAnnotations map[string]string,
 	return convertCPUListToCPUSet(emulatorThreads), nil
 }
 
-func AdjustDomainForTopologyAndCPUSet(domain *api.Domain, vmi *v12.VirtualMachineInstance, topology *v1.Topology, cpuset []int, useIOThreads bool) error {
+func AdjustDomainForTopologyAndCPUSet(domain *api.Domain, vmi *v12.VirtualMachineInstance, topology *v1.Topology, cpuset []int) error {
 	var cpuPool VCPUPool
 	requestedToplogy := &api.CPUTopology{
 		Sockets: domain.Spec.CPU.Topology.Sockets,
@@ -495,15 +518,25 @@ func AdjustDomainForTopologyAndCPUSet(domain *api.Domain, vmi *v12.VirtualMachin
 	}
 
 	var emulatorThreadsCPUSet string
+	var supplementalThreads int
+	if iothreads.SupplementalPoolThreadCount(vmi) > 0 {
+		// Supplemental pool threads must be pinned before emulator thread because they increase the pinned CPU count
+		// This will affect emulator parity
+		if supplementalThreads, err = FormatDomainIOThreadSupplementalPin(cpuPool, vmi, domain); err != nil {
+			log.Log.Reason(err).Error("failed to format domain supplemental pool iothread pinning.")
+			return err
+		}
+	}
 	if vmi.Spec.Domain.CPU.IsolateEmulatorThread {
-		vCPUs := hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU)
-		if emulatorThreadsCPUSet, err = FormatEmulatorThreadPin(cpuPool, vmi.Annotations, vCPUs); err != nil {
+		pinnedCPUs := hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU) + int64(supplementalThreads)
+		if emulatorThreadsCPUSet, err = FormatEmulatorThreadPin(cpuPool, vmi.Annotations, pinnedCPUs); err != nil {
 			log.Log.Reason(err).Error("failed to format emulation thread pin")
 			return err
 		}
 		appendDomainEmulatorThreadPin(domain, emulatorThreadsCPUSet)
 	}
-	if useIOThreads {
+	if iothreads.HasIOThreads(vmi) && iothreads.SupplementalPoolThreadCount(vmi) == 0 {
+		// Other IOThread pinning may share emulator thread, and must occur after emulator pin
 		if err := FormatDomainIOThreadPin(vmi, domain, emulatorThreadsCPUSet, cpuset); err != nil {
 			log.Log.Reason(err).Error("failed to format domain iothread pinning.")
 			return err

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -378,7 +378,7 @@ func appendDomainIOThreadPin(domain *api.Domain, thread uint32, cpuset string) {
 	domain.Spec.CPUTune.IOThreadPin = append(domain.Spec.CPUTune.IOThreadPin, iothreadPin)
 }
 
-func FormatDomainIOThreadSupplementalPin(cpuPool VCPUPool, vmi *v12.VirtualMachineInstance, domain *api.Domain) (int, error) {
+func formatDomainIOThreadSupplementalPin(cpuPool VCPUPool, vmi *v12.VirtualMachineInstance, domain *api.Domain) (int, error) {
 	if domain.Spec.IOThreads == nil {
 		return 0, fmt.Errorf("domain is missing IOThreads")
 	}
@@ -392,9 +392,8 @@ func FormatDomainIOThreadSupplementalPin(cpuPool VCPUPool, vmi *v12.VirtualMachi
 		// The cpus for the iothreads are additionally allocated and aren't part of the cpu set dedicated to the vcpus threads
 		availableThread, err := cpuPool.FitThread()
 		if err != nil {
-			e := fmt.Errorf("no CPU allocated for the iothread: %v", err)
-			log.Log.Reason(e).Error("failed to format iothread pin")
-			return i, e
+			err = fmt.Errorf("no CPU allocated for the iothread: %w", err)
+			return 0, err
 		}
 		appendDomainIOThreadPin(domain, uint32(i), fmt.Sprintf("%d", availableThread))
 	}
@@ -411,16 +410,16 @@ func FormatDomainIOThreadPin(vmi *v12.VirtualMachineInstance, domain *api.Domain
 		return fmt.Errorf("domain has supplemental pool IOThreads and attempted to pin auto/shared IOThreads")
 	}
 
-	iothreads := int(domain.Spec.IOThreads.IOThreads)
+	numIOThreads := int(domain.Spec.IOThreads.IOThreads)
 	vcpus := int(hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU))
 
 	switch {
 	case vmi.IsCPUDedicated() && vmi.Spec.Domain.CPU.IsolateEmulatorThread:
 		// pin the IOThread on the same pCPU as the emulator thread
 		appendDomainIOThreadPin(domain, uint32(1), emulatorThreadsCPUSet)
-	case iothreads >= vcpus:
+	case numIOThreads >= vcpus:
 		// pin an IOThread on a CPU
-		for thread := 1; thread <= iothreads; thread++ {
+		for thread := 1; thread <= numIOThreads; thread++ {
 			cpuset := fmt.Sprintf("%d", cpuset[thread%vcpus])
 			appendDomainIOThreadPin(domain, uint32(thread), cpuset)
 		}
@@ -431,10 +430,10 @@ func FormatDomainIOThreadPin(vmi *v12.VirtualMachineInstance, domain *api.Domain
 		//   1    0,1,2
 		//   2    3,4,5
 		//   3    6,7
-		series := vcpus % iothreads
+		series := vcpus % numIOThreads
 		curr := 0
-		for thread := 1; thread <= iothreads; thread++ {
-			remainder := vcpus/iothreads - 1
+		for thread := 1; thread <= numIOThreads; thread++ {
+			remainder := vcpus/numIOThreads - 1
 			if thread <= series {
 				remainder += 1
 			}
@@ -522,7 +521,7 @@ func AdjustDomainForTopologyAndCPUSet(domain *api.Domain, vmi *v12.VirtualMachin
 	if iothreads.SupplementalPoolThreadCount(vmi) > 0 {
 		// Supplemental pool threads must be pinned before emulator thread because they increase the pinned CPU count
 		// This will affect emulator parity
-		if supplementalThreads, err = FormatDomainIOThreadSupplementalPin(cpuPool, vmi, domain); err != nil {
+		if supplementalThreads, err = formatDomainIOThreadSupplementalPin(cpuPool, vmi, domain); err != nil {
 			log.Log.Reason(err).Error("failed to format domain supplemental pool iothread pinning.")
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
@@ -205,7 +205,7 @@ var _ = Describe("VCPU pinning", func() {
 				},
 			}
 			topology := hostTopology(1, 1, 0)
-			err := AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, []int{0}, false)
+			err := AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, []int{0})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domain.Spec.CPU.Topology).ToNot(BeNil())
 			Expect(domain.Spec.CPU.Topology.Sockets).To(Equal(uint32(1)))

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
@@ -39,13 +39,6 @@ func GenerateDomainForTargetCPUSetAndTopology(vmi *v1.VirtualMachineInstance, do
 		return nil, err
 	}
 
-	useIOThreads := false
-	for _, diskDevice := range vmi.Spec.Domain.Devices.Disks {
-		if diskDevice.DedicatedIOThread != nil && *diskDevice.DedicatedIOThread {
-			useIOThreads = true
-			break
-		}
-	}
 	domain := api.NewMinimalDomain(vmi.Name)
 	domain.Spec = *domSpec
 	cpuTopology := vcpu.GetCPUTopology(vmi)
@@ -62,7 +55,7 @@ func GenerateDomainForTargetCPUSetAndTopology(vmi *v1.VirtualMachineInstance, do
 		Placement: "static",
 		CPUs:      cpuCount,
 	}
-	err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, &targetTopology, targetNodeCPUSet, useIOThreads)
+	err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, &targetTopology, targetNodeCPUSet)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -511,7 +511,6 @@ func (l *LibvirtDomainManager) UpdateVCPUs(vmi *v1.VirtualMachineInstance, optio
 
 	// Adjust guest vcpu config. Currently will handle vCPUs to pCPUs pinning
 	if vmi.IsCPUDedicated() {
-		useIOThreads := false
 		if options != nil && options.Topology != nil {
 			topology = options.Topology
 		}
@@ -534,11 +533,7 @@ func (l *LibvirtDomainManager) UpdateVCPUs(vmi *v1.VirtualMachineInstance, optio
 
 		domain.Spec = *spec
 
-		if domain.Spec.CPUTune != nil && len(domain.Spec.CPUTune.IOThreadPin) > 0 {
-			useIOThreads = true
-		}
-
-		err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, podCPUSet, useIOThreads)
+		err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, podCPUSet)
 		if err != nil {
 			return fmt.Errorf("%s: %v", errMsgPrefix, err)
 		}


### PR DESCRIPTION
CPUSets were improperly calculated based on number of hotplug CPU's and ignored CPU topology. Used FitThread to calculate CPUSet correctly, and split the functionality of supplementalPool and other IOThread pinning modes. supplementalPool pinning should happen before isolateEmulatorThread so that emulator thread parity functions properly, but other modes share emulator pinning and must be done after. Additionally did some small cleanup by removing the useIOThreads argument that was improperly calculated by some callers, and used the proper library function instead.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Using IOThreads supplemental pool with dedicatedCpuPlacement caused libvirt failure. CPUSet for IOThreads were improperly calculated causing libvirt to attempt to pin them to non-existent CPUs
#### After this PR:
Values are calculated correctly and validated with additional tests.
### References
- Fixes #16992
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

