### PR TITLE
virt-operator: create operator cert before webhook configurations

### DIFF
--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -306,9 +306,33 @@ func (r *Reconciler) createOrUpdateCertificateSecrets(queue workqueue.TypedRateL
 			continue
 		}
 
+		// Already created before webhooks; see createOrUpdateOperatorCertificateSecret.
+		if secret.Name == components.VirtOperatorCertSecretName {
+			continue
+		}
+
 		_, err := r.createOrUpdateCertificateSecret(queue, caCert, secret, duration, renewBefore, caRenewBefore)
 		if err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) createOrUpdateOperatorCertificateSecret(queue workqueue.TypedRateLimitingInterface[string], caCert *tls.Certificate, duration *metav1.Duration, renewBefore *metav1.Duration, caRenewBefore *metav1.Duration) error {
+	secret := r.findOperatorCertSecret()
+	if secret == nil {
+		return nil
+	}
+
+	_, err := r.createOrUpdateCertificateSecret(queue, caCert, secret, duration, renewBefore, caRenewBefore)
+	return err
+}
+
+func (r *Reconciler) findOperatorCertSecret() *corev1.Secret {
+	for _, secret := range r.targetStrategy.CertificateSecrets() {
+		if secret.Name == components.VirtOperatorCertSecretName {
+			return secret
 		}
 	}
 	return nil
@@ -429,6 +453,12 @@ func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.Ty
 
 	// create/update export CA config map
 	_, err = r.createOrUpdateKubeVirtCAConfigMap(queue, caExportCert, nil, caExportRenewBefore, findRequiredCAConfigMap(components.KubeVirtExportCASecretName, r.targetStrategy.ConfigMaps()))
+	if err != nil {
+		return err
+	}
+
+	// Operator cert must exist before webhooks can validate against the new CA.
+	err = r.createOrUpdateOperatorCertificateSecret(queue, caCert, certDuration, certRenewBefore, caRenewBefore)
 	if err != nil {
 		return err
 	}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1734,6 +1734,20 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			kv, err = virtClient.KubeVirt(kv.Namespace).Create(context.Background(), kv, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
+			By("verifying operator cert secret is created before the webhook configuration")
+			Eventually(func() bool {
+				_, err := virtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
+					context.Background(), components.KubeVirtOperatorValidatingWebhookName, metav1.GetOptions{})
+				return err == nil
+			}, 120*time.Second, 100*time.Millisecond).Should(BeTrue(), "waiting for webhook %q to be created",
+				components.KubeVirtOperatorValidatingWebhookName)
+
+			_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), components.VirtOperatorCertSecretName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred(),
+				"operator cert secret %q must exist before webhook %q to avoid x509 errors",
+				components.VirtOperatorCertSecretName, components.KubeVirtOperatorValidatingWebhookName)
+
 			By("waiting for the kv CR to get a finalizer")
 			Eventually(func() bool {
 				kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})


### PR DESCRIPTION
### What this PR does

Fix a race condition during KubeVirt CR recreation where virt-operator is blocked by its own webhook.

After deleting and re-creating the KubeVirt CR, the reconciler creates the `ValidatingWebhookConfiguration` (`failurePolicy: Fail`) **before** the operator's own serving cert secret. When the operator tries to PATCH the finalizer onto the CR, the API server sends the admission review to `virt-operator-validator`. The operator is still serving a stale/fallback cert not trusted by the new CA bundle, so the TLS handshake fails: `x509: certificate signed by unknown authority`.

This is a race — the window grew over time as more cert secrets were added to the batch loop before the operator's own cert.

#### Fix

Reorder `createOrUpdateComponentsWithCertificates()` so the operator cert is created right after the CA, before any webhook:

```
CA secret + ConfigMap → Operator cert (moved here) → ValidatingWebhook → MutatingWebhook → remaining certs
```

Add a regression check to the existing single-replica CR test that asserts the operator cert secret exists before the webhook goes live.

### Special notes for your reviewer

- Two small helpers added in `core.go` to extract operator cert creation from the batch loop.
- Regression check added to existing `should update new single-replica CRs with a finalizer and be stable` test.

### Release note

```release-note
Bug fix: Fix a race condition where virt-operator's webhook was created before its own serving certificate, causing "x509: certificate signed by unknown authority" errors during KubeVirt CR recreation.
```
