### PR TITLE
e2e: Increase network test coverage for s390x arch

### DIFF
--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -139,7 +139,7 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			}, time.Second*30, time.Second*3).Should(Succeed())
 		},
 			Entry("In place", decorators.InPlaceHotplugNICs, inPlace),
-			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),
+			Entry("Migration based", decorators.WgS390x, decorators.MigrationBasedHotplugNICs, migrationBased),
 		)
 
 		DescribeTable("can migrate a VMI with hotplugged interfaces", func(plugMethod hotplugMethod) {
@@ -153,7 +153,7 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			Expect(libnet.InterfaceExists(hotPluggedVMI, guestSecondaryIfaceName)).To(Succeed())
 		},
 			Entry("In place", decorators.InPlaceHotplugNICs, inPlace),
-			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),
+			Entry("Migration based", decorators.WgS390x, decorators.MigrationBasedHotplugNICs, migrationBased),
 		)
 
 		DescribeTable("has connectivity over the secondary network", func(plugMethod hotplugMethod) {
@@ -209,7 +209,7 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			Expect(libnet.PingFromVMConsole(hotPluggedVMI, ip2)).To(Succeed())
 		},
 			Entry("In place", decorators.InPlaceHotplugNICs, inPlace),
-			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),
+			Entry("Migration based", decorators.WgS390x, decorators.MigrationBasedHotplugNICs, migrationBased),
 		)
 
 		DescribeTable("is able to hotplug multiple network interfaces", func(plugMethod hotplugMethod) {
@@ -271,7 +271,7 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			Expect(console.RunCommand(hotPluggedVMI, libnet.NewLinkStateAssersionCmd(secondIfaceMac.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
 		},
 			Entry("In place", decorators.InPlaceHotplugNICs, inPlace),
-			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),
+			Entry("Migration based", decorators.WgS390x, decorators.MigrationBasedHotplugNICs, migrationBased),
 		)
 	})
 }))
@@ -361,7 +361,7 @@ var _ = Describe(SIG("bridge nic-hotunplug", Serial, func() {
 			verifyUnpluggedIfaceClearedFromVMandVMI(vm.Namespace, vm.Name, linuxBridgeNetworkName1)
 		},
 			Entry("In place", decorators.InPlaceHotplugNICs, inPlace),
-			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),
+			Entry("Migration based", decorators.WgS390x, decorators.MigrationBasedHotplugNICs, migrationBased),
 		)
 	})
 }))

--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libmigration"
@@ -43,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("interface state up/down", func() {
+var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 	const (
 		primaryLogicalNetName    = "default"
 		secondary2LogicalNetName = "bridge2"

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -56,7 +56,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 			assertIPsNotEmptyForVMI(serverVMI)
 		})
 
-		Context("and connectivity between VMI/s is blocked by Default-deny networkpolicy", func() {
+		Context("and connectivity between VMI/s is blocked by Default-deny networkpolicy", decorators.WgS390x, func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {
@@ -139,7 +139,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 			})
 		})
 
-		Context("and ingress traffic to VMI identified via label at networkprofile's labelSelector is blocked", func() {
+		Context("and ingress traffic to VMI identified via label at networkprofile's labelSelector is blocked", decorators.WgS390x, func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {
@@ -203,7 +203,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 						assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 					})
 
-					It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", func() {
+					It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", decorators.WgS390x, func() {
 						By("Connect clientVMI from clientVMIAlternativeNamespace")
 						assertPingSucceed(clientVMIAlternativeNamespace, clientVMI)
 					})
@@ -211,7 +211,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 			})
 		})
 
-		Context("and TCP connectivity on ports 80 and 81 between VMI/s is allowed by networkpolicy", func() {
+		Context("and TCP connectivity on ports 80 and 81 between VMI/s is allowed by networkpolicy", decorators.WgS390x, func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {
@@ -242,7 +242,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 				assertHTTPPingSucceed(clientVMI, serverVMI, 81)
 			})
 		})
-		Context("and TCP connectivity on ports 80 between VMI/s is allowed by networkpolicy", func() {
+		Context("and TCP connectivity on ports 80 between VMI/s is allowed by networkpolicy", decorators.WgS390x, func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -39,6 +39,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
@@ -103,7 +104,7 @@ var _ = Describe(SIG("Port-forward", func() {
 				By(fmt.Sprintf("checking that service running on port %d can be reached", declaredPort))
 				Expect(testConnectivityThroughLocalPort(ipFamily, localPort)).To(Succeed())
 			},
-				Entry("IPv4", k8sv1.IPv4Protocol),
+				Entry("IPv4", decorators.WgS390x, k8sv1.IPv4Protocol),
 				Entry("IPv6", k8sv1.IPv6Protocol),
 			)
 		})
@@ -120,7 +121,7 @@ var _ = Describe(SIG("Port-forward", func() {
 				By(fmt.Sprintf("checking that service running on port %d can be reached", nonDeclaredPort))
 				Expect(testConnectivityThroughLocalPort(ipFamily, localPort)).To(Succeed())
 			},
-				Entry("IPv4", k8sv1.IPv4Protocol),
+				Entry("IPv4", decorators.WgS390x, k8sv1.IPv4Protocol),
 				Entry("IPv6", k8sv1.IPv6Protocol),
 			)
 		})
@@ -138,7 +139,7 @@ var _ = Describe(SIG("Port-forward", func() {
 				By(fmt.Sprintf("checking that service running on port %d can not be reached", nonDeclaredPort))
 				Expect(testConnectivityThroughLocalPort(ipFamily, localPort)).ToNot(Succeed())
 			},
-				Entry("IPv4", k8sv1.IPv4Protocol),
+				Entry("IPv4", decorators.WgS390x, k8sv1.IPv4Protocol),
 				Entry("IPv6", k8sv1.IPv6Protocol),
 			)
 		})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -123,7 +123,7 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				})
 
-				It("[test_id:4153]should report PodIP/s as its own on interface status", func() {
+				It("[test_id:4153]should report PodIP/s as its own on interface status", decorators.WgS390x, func() {
 					vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Expect(err).NotTo(HaveOccurred())
 

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -16,6 +16,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -30,7 +31,7 @@ const (
 	specifyingVMLivenessProbe  = "Specifying a VMI with a liveness probe"
 )
 
-var _ = Describe(SIG("[ref_id:1182]Probes", func() {
+var _ = Describe(SIG("[ref_id:1182]Probes", decorators.WgS390x, func() {
 	var (
 		err        error
 		virtClient kubecli.KubevirtClient

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -102,7 +102,7 @@ var _ = Describe(SIG("Services", func() {
 				Expect(job.WaitForJobToSucceed(tcpJob, 90*time.Second)).To(Succeed(), expectConnectivityToExposedService)
 			})
 
-			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", func() {
+			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", decorators.WgS390x, func() {
 				tcpJob, err := createServiceConnectivityJob("wrongservice", inboundVMI.Namespace, servicePort, jobFailureRetry)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -323,7 +323,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				Expect(libnet.PingFromVMConsole(vmiOne, ipAddr)).To(Succeed())
 			},
 				Entry("[test_id:1577]with secondary network only", []v1.Interface{linuxBridgeInterface}, []v1.Network{linuxBridgeNetwork}, "eth0", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
-				Entry("[test_id:1578]with default network and secondary network",
+				Entry("[test_id:1578]with default network and secondary network", decorators.WgS390x,
 					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterface},
 					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeNetwork},
 					"eth1",
@@ -365,7 +365,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToFedora)
 			})
 
-			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
+			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", decorators.WgS390x, func() {
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
 				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
 				linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress
@@ -417,7 +417,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 		})
 
 		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
-			It("[test_id:1756]should report all interfaces in Status", func() {
+			It("[test_id:1756]should report all interfaces in Status", decorators.WgS390x, func() {
 				interfaces := []v1.Interface{
 					*v1.DefaultMasqueradeNetworkInterface(),
 					linuxBridgeInterface,
@@ -578,7 +578,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 	Describe("[rfe_id:1758][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance definition", func() {
 		Context("with qemu guest agent", func() {
-			It("[test_id:1757] should report guest interfaces in VMI status", func() {
+			It("[test_id:1757] should report guest interfaces in VMI status", decorators.WgS390x, func() {
 				interfaces := []v1.Interface{
 					*v1.DefaultMasqueradeNetworkInterface(),
 					linuxBridgeInterface,

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -247,7 +247,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		})
 	})
 
-	It("[test_id:1774]should not configure any external interfaces when a VMI has no networks and auto attachment is disabled", func() {
+	It("[test_id:1774]should not configure any external interfaces when a VMI has no networks and auto attachment is disabled", decorators.WgS390x, func() {
 		vmi := libvmifact.NewAlpine(libvmi.WithAutoAttachPodInterface(false))
 
 		var err error
@@ -307,7 +307,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 	})
 
 	Context("VirtualMachineInstance with dhcp options", func() {
-		It("[test_id:1778]should offer extra dhcp options to pod iface", func() {
+		It("[test_id:1778]should offer extra dhcp options to pod iface", decorators.WgS390x, func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
 			dhcpVMI := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 
@@ -756,7 +756,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				By("checking the VirtualMachineInstance cannot send bigger than MTU sized frames to another VirtualMachineInstance")
 				Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize+1), "-M do")).ToNot(Succeed())
 			},
-				Entry("IPv4", k8sv1.IPv4Protocol),
+				Entry("IPv4", decorators.WgS390x, k8sv1.IPv4Protocol),
 				Entry("IPv6", k8sv1.IPv6Protocol),
 			)
 		})

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -37,6 +37,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/dns"
@@ -73,7 +74,7 @@ var _ = Describe(SIG("Subdomain", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("VMI should have the expected FQDN", func(f func() *v1.VirtualMachineInstance, subdom, hostname string) {
+		DescribeTable("VMI should have the expected FQDN", decorators.WgS390x, func(f func() *v1.VirtualMachineInstance, subdom, hostname string) {
 			vmiSpec := f()
 			var expectedFQDN, domain string
 			if subdom != "" {


### PR DESCRIPTION
### What this PR does
This PR introduces the WgS390x label for network tests to ensure they run on the s390x architecture. Labelling these tests enables accurate selection, better coverage, and alignment across architectures.

#### After this PR:
Test coverage will be increased to run more e2e tests for s390x arch.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

