### PR TITLE
 fix: guard against nil pod in workload-updater eviction goroutine

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -320,6 +320,11 @@ func ApplyVolumeRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request
 	return vmiSpec
 }
 
+// CurrentVMIPod returns the active launcher pod for the given VMI.
+// It returns (nil, err) when the pod indexer lookup fails, and
+// (nil, nil) when no matching pod exists in the cache (e.g. during
+// upgrades before the pod is observed by the informer). Callers must
+// handle both cases before dereferencing the returned pod.
 func CurrentVMIPod(vmi *v1.VirtualMachineInstance, podIndexer cache.Indexer) (*k8sv1.Pod, error) {
 
 	// current pod is the most recent pod created on the current VMI node

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -607,10 +607,14 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 
 			pod, err := controller.CurrentVMIPod(vmi, c.podIndexer)
 			if err != nil {
-
 				log.Log.Object(vmi).Reason(err).Errorf("Failed to detect active pod for vmi during workload update")
 				c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedEvictVirtualMachineInstanceReason, "Error detecting active pod for VMI during workload update: %v", err)
 				errChan <- err
+				return
+			}
+			if pod == nil {
+				log.Log.Object(vmi).Warningf("No active pod found for VMI %s/%s during workload update eviction, will retry on next sync", vmi.Namespace, vmi.Name)
+				return
 			}
 
 			err = c.clientset.CoreV1().Pods(vmi.Namespace).EvictV1beta1(context.Background(),

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -498,6 +498,36 @@ var _ = Describe("Workload Updater", func() {
 
 	})
 
+	Context("workload update eviction pod guard", func() {
+		It("should skip eviction without panicking when pod is not yet in cache", func() {
+			vmi := newVirtualMachineInstance("testvm-evict-no-pod", false, "madeup")
+			controller.vmiStore.Add(vmi)
+			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
+			kv := newKubeVirt(1)
+			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodEvict}
+			addKubeVirt(kv)
+
+			sanityExecute()
+			Expect(recorder.Events).To(BeEmpty())
+		})
+
+		It("should skip eviction without panicking when pod belongs to a different namespace", func() {
+			vmi := newVirtualMachineInstance("testvm-evict-err-pod", false, "madeup")
+			pod := newLauncherPodForVMI(vmi)
+			pod.Namespace = "other-namespace"
+			controller.vmiStore.Add(vmi)
+			controller.podIndexer.Add(pod)
+
+			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
+			kv := newKubeVirt(1)
+			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodEvict}
+			addKubeVirt(kv)
+
+			sanityExecute()
+			Expect(recorder.Events).To(BeEmpty())
+		})
+	})
+
 	Context("LiveUpdate features", func() {
 		It("VMI needs to be migrated when memory hotplug is requested", func() {
 			condition := v1.VirtualMachineInstanceCondition{


### PR DESCRIPTION

### What this PR does
#### Before this PR:

The eviction goroutine in `WorkloadUpdateController.sync()` called `CurrentVMIPod` but did not handle all of its return values correctly. `CurrentVMIPod` has two nil-pod paths:

  | Return          | Cause                                      |
  |-----------------|---------------------------------------------|
  | `(nil, err)`    | `podIndexer.ByIndex` fails                  |
  | `(nil, nil)`    | Pod not yet observed by the informer cache  |

  **Path A (`nil, err`):** The goroutine sent the error to `errChan` but
  had no `return`, falling through to `pod.Name` — a nil dereference if
  `pod == nil`.

  **Path B (`nil, nil`):** The `err != nil` guard was never entered, so  the goroutine fell straight through to `pod.Name`. This is the critical  path: during every KubeVirt operator upgrade, launcher pods briefly disappear from the informer cache before being re-observed. virt- controller crash-loops until the pod reappears.

#### After this PR:

- `return` is added after `errChan <- err` (Path A) — consistent with the pattern already used in the `migrationCandidates` goroutine.
  - An explicit `pod == nil` guard (Path B) logs a warning and returns, letting the controller re-queue and retry on the next sync cycle.
  - `CurrentVMIPod` in `controller.go` receives a doc comment explicitly documenting both nil return cases so future callers handle them. 

  
- Fixes #17001 


### Why we need it and why it was done in this way
The nil guard returns without sending to `errChan`, which means no error is propagated for the transient pod-not-in-cache case. This is  intentional: the condition is temporary, and the controller's periodic re-enqueue (line 499 in `sync()`) already ensures a retry. Returning an  error would cause exponential back-off and delay the eviction  unnecessarily.

  The alternative — returning an error and letting the queue back-off — was rejected because this is not an error condition but a cache consistency lag.

### Special notes for your reviewer

The second test ("pod in wrong namespace") exercises the same `(nil, nil)` code path as the first but with a pod present in the indexer under a different namespace, confirming that `CurrentVMIPod`'s ownership check works and the guard handles both sub-cases.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
  Fixed a nil pointer panic in virt-controller where the workload-update
  eviction goroutine could dereference a nil pod returned by
  CurrentVMIPod. This panic occurred reliably during KubeVirt operator
  upgrades when launcher pods were transiently absent from the informer
  cache, causing virt-controller to crash-loop until the pod reappeared.
```

