### PR TITLE
fix: inject PV node affinity for hotplugged RWO volumes into virt-launcher pod

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -264,13 +264,14 @@ func (t *TemplateService) setNodeAffinityForHotplugRWOVolumes(vmi *v1.VirtualMac
 	}
 }
 
-// hotplugVolumeIsRWO reports whether a hotplugged volume has ReadWriteOnce
+// hotplugVolumeIsRWO reports whether a hotplugged volume has node-local access
+// (ReadWriteOnce or ReadWriteOncePod), meaning it can only be attached on one node.
 func hotplugVolumeIsRWO(vs v1.VolumeStatus) bool {
 	if vs.PersistentVolumeClaimInfo == nil {
 		return false
 	}
 	for _, am := range vs.PersistentVolumeClaimInfo.AccessModes {
-		if am == k8sv1.ReadWriteOnce {
+		if am == k8sv1.ReadWriteOnce || am == k8sv1.ReadWriteOncePod {
 			return true
 		}
 	}
@@ -279,6 +280,9 @@ func hotplugVolumeIsRWO(vs v1.VolumeStatus) bool {
 
 // mergeNodeSelectorRequired AND-merges pvRequired into the pod's existing required node affinity.
 func mergeNodeSelectorRequired(affinity *k8sv1.Affinity, pvRequired *k8sv1.NodeSelector) *k8sv1.Affinity {
+	if len(pvRequired.NodeSelectorTerms) == 0 {
+		return affinity
+	}
 	if affinity == nil {
 		affinity = &k8sv1.Affinity{}
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -222,6 +222,87 @@ func modifyNodeAffintyToRejectLabel(origAffinity *k8sv1.Affinity, labelToReject 
 	return affinity
 }
 
+// setNodeAffinityForHotplugRWOVolumes merges the node affinity from every PV
+// that backs a hotplugged RWO volume into the virt-launcher pod spec. This ensures the Kubernetes scheduler places the pod on the same node as
+// any locally-bound storage, preventing the hotplug attachment pod from getting stuck Pending after a VM restart.
+func (t *TemplateService) setNodeAffinityForHotplugRWOVolumes(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
+	pvcNameByVolume := make(map[string]string, len(vmi.Spec.Volumes))
+	for _, vol := range vmi.Spec.Volumes {
+		switch {
+		case vol.PersistentVolumeClaim != nil:
+			pvcNameByVolume[vol.Name] = vol.PersistentVolumeClaim.ClaimName
+		case vol.DataVolume != nil:
+			pvcNameByVolume[vol.Name] = vol.DataVolume.Name
+		}
+	}
+
+	for _, volStatus := range vmi.Status.VolumeStatus {
+		if volStatus.HotplugVolume == nil || !hotplugVolumeIsRWO(volStatus) {
+			continue
+		}
+		pvcName, ok := pvcNameByVolume[volStatus.Name]
+		if !ok {
+			continue
+		}
+		obj, exists, err := t.persistentVolumeClaimStore.GetByKey(fmt.Sprintf("%s/%s", vmi.Namespace, pvcName))
+		if err != nil || !exists {
+			continue
+		}
+		pvc := obj.(*k8sv1.PersistentVolumeClaim)
+		if pvc.Spec.VolumeName == "" {
+			continue
+		}
+		pv, err := t.virtClient.CoreV1().PersistentVolumes().Get(context.Background(), pvc.Spec.VolumeName, metav1.GetOptions{})
+		if err != nil {
+			log.Log.Object(vmi).Reason(err).Warningf("failed to get PV %s for hotplug volume %s, skipping node affinity injection", pvc.Spec.VolumeName, volStatus.Name)
+			continue
+		}
+		if pv.Spec.NodeAffinity == nil || pv.Spec.NodeAffinity.Required == nil {
+			continue
+		}
+		pod.Spec.Affinity = mergeNodeSelectorRequired(pod.Spec.Affinity, pv.Spec.NodeAffinity.Required)
+	}
+}
+
+// hotplugVolumeIsRWO reports whether a hotplugged volume has ReadWriteOnce
+func hotplugVolumeIsRWO(vs v1.VolumeStatus) bool {
+	if vs.PersistentVolumeClaimInfo == nil {
+		return false
+	}
+	for _, am := range vs.PersistentVolumeClaimInfo.AccessModes {
+		if am == k8sv1.ReadWriteOnce {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeNodeSelectorRequired AND-merges pvRequired into the pod's existing required node affinity.
+func mergeNodeSelectorRequired(affinity *k8sv1.Affinity, pvRequired *k8sv1.NodeSelector) *k8sv1.Affinity {
+	if affinity == nil {
+		affinity = &k8sv1.Affinity{}
+	}
+	if affinity.NodeAffinity == nil {
+		affinity.NodeAffinity = &k8sv1.NodeAffinity{}
+	}
+	existing := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if existing == nil || len(existing.NodeSelectorTerms) == 0 {
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = pvRequired.DeepCopy()
+		return affinity
+	}
+	merged := make([]k8sv1.NodeSelectorTerm, 0, len(existing.NodeSelectorTerms)*len(pvRequired.NodeSelectorTerms))
+	for _, existingTerm := range existing.NodeSelectorTerms {
+		for _, pvTerm := range pvRequired.NodeSelectorTerms {
+			combined := existingTerm.DeepCopy()
+			combined.MatchExpressions = append(combined.MatchExpressions, pvTerm.MatchExpressions...)
+			combined.MatchFields = append(combined.MatchFields, pvTerm.MatchFields...)
+			merged = append(merged, *combined)
+		}
+	}
+	affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = merged
+	return affinity
+}
+
 func sysprepVolumeSource(sysprepVolume v1.SysprepSource) (k8sv1.VolumeSource, error) {
 	logger := log.DefaultLogger()
 	if sysprepVolume.Secret != nil {
@@ -681,6 +762,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	setNodeAffinityForPod(vmi, &pod)
+	t.setNodeAffinityForHotplugRWOVolumes(vmi, &pod)
 
 	serviceAccountName := serviceAccount(vmi.Spec.Volumes...)
 	if len(serviceAccountName) > 0 {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -6077,6 +6077,30 @@ var _ = Describe("Template", func() {
 			}))
 		})
 
+		It("should inject PV node affinity for a hotplugged ReadWriteOncePod volume", func() {
+			pvcStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+			pvc := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: testNamespace},
+				Spec:       k8sv1.PersistentVolumeClaimSpec{VolumeName: testPVName},
+			}
+			Expect(pvcStore.Add(pvc)).To(Succeed())
+
+			k8sClient := k8sfake.NewSimpleClientset(pvWithNodeAffinity(testNode))
+			testSvc := buildService(pvcStore, k8sClient)
+
+			pod := &k8sv1.Pod{}
+			testSvc.setNodeAffinityForHotplugRWOVolumes(hotplugVMI(testPVCName, k8sv1.ReadWriteOncePod), pod)
+
+			Expect(pod.Spec.Affinity).NotTo(BeNil())
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(ContainElement(k8sv1.NodeSelectorRequirement{
+				Key:      "kubernetes.io/hostname",
+				Operator: k8sv1.NodeSelectorOpIn,
+				Values:   []string{testNode},
+			}))
+		})
+
 		It("should not inject affinity for a hotplugged RWX volume", func() {
 			pvcStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
 			pvc := &k8sv1.PersistentVolumeClaim{
@@ -6172,6 +6196,8 @@ var _ = Describe("Template", func() {
 	})
 
 	Describe("mergeNodeSelectorRequired", func() {
+		const testNode = "node-1"
+
 		pvTerm := func(node string) k8sv1.NodeSelectorTerm {
 			return k8sv1.NodeSelectorTerm{
 				MatchExpressions: []k8sv1.NodeSelectorRequirement{{
@@ -6185,10 +6211,30 @@ var _ = Describe("Template", func() {
 			return &k8sv1.NodeSelector{NodeSelectorTerms: []k8sv1.NodeSelectorTerm{pvTerm(node)}}
 		}
 
-		It("should set PV affinity directly when pod has none", func() {
+		It("should set PV affinity directly when pod has nil affinity", func() {
 			result := mergeNodeSelectorRequired(nil, pvRequired(testNode))
 			terms := result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 			Expect(terms).To(ConsistOf(pvTerm(testNode)))
+		})
+
+		It("should set PV affinity when pod affinity has nil NodeAffinity", func() {
+			result := mergeNodeSelectorRequired(&k8sv1.Affinity{}, pvRequired(testNode))
+			terms := result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(ConsistOf(pvTerm(testNode)))
+		})
+
+		It("should return existing affinity unchanged when pvRequired has no terms", func() {
+			existingTerm := pvTerm("existing-node")
+			affinity := &k8sv1.Affinity{
+				NodeAffinity: &k8sv1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+						NodeSelectorTerms: []k8sv1.NodeSelectorTerm{existingTerm},
+					},
+				},
+			}
+			result := mergeNodeSelectorRequired(affinity, &k8sv1.NodeSelector{})
+			terms := result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(ConsistOf(existingTerm))
 		})
 
 		It("should produce the Cartesian product of existing and PV terms", func() {
@@ -6214,18 +6260,23 @@ var _ = Describe("Template", func() {
 		})
 
 		It("should produce a Cartesian product for multiple terms on each side", func() {
+			existing1, existing2 := pvTerm("A"), pvTerm("B")
+			pv1, pv2 := pvTerm("X"), pvTerm("Y")
 			affinity := &k8sv1.Affinity{
 				NodeAffinity: &k8sv1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
-						NodeSelectorTerms: []k8sv1.NodeSelectorTerm{pvTerm("A"), pvTerm("B")},
+						NodeSelectorTerms: []k8sv1.NodeSelectorTerm{existing1, existing2},
 					},
 				},
 			}
-			pv2 := &k8sv1.NodeSelector{NodeSelectorTerms: []k8sv1.NodeSelectorTerm{pvTerm("X"), pvTerm("Y")}}
-			result := mergeNodeSelectorRequired(affinity, pv2)
+			pvSelector := &k8sv1.NodeSelector{NodeSelectorTerms: []k8sv1.NodeSelectorTerm{pv1, pv2}}
+			result := mergeNodeSelectorRequired(affinity, pvSelector)
 			terms := result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-			// 2 existing × 2 PV = 4 combined terms.
+			// 2 existing × 2 PV = 4 combined terms, each carrying both sides' requirements.
 			Expect(terms).To(HaveLen(4))
+			for _, term := range terms {
+				Expect(term.MatchExpressions).To(HaveLen(2))
+			}
 		})
 	})
 })

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -5991,6 +5991,243 @@ var _ = Describe("Template", func() {
 			Expect(limExists).To(BeFalse())
 		})
 	})
+
+	Context("hotplug RWO volume node affinity injection", func() {
+		const (
+			testNamespace = "default"
+			testPVCName   = "rwo-pvc"
+			testPVName    = "rwo-pv"
+			testVolName   = "hotplug-vol"
+			testNode      = "node-1"
+		)
+
+		pvWithNodeAffinity := func(node string) *k8sv1.PersistentVolume {
+			return &k8sv1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: testPVName},
+				Spec: k8sv1.PersistentVolumeSpec{
+					NodeAffinity: &k8sv1.VolumeNodeAffinity{
+						Required: &k8sv1.NodeSelector{
+							NodeSelectorTerms: []k8sv1.NodeSelectorTerm{{
+								MatchExpressions: []k8sv1.NodeSelectorRequirement{{
+									Key:      "kubernetes.io/hostname",
+									Operator: k8sv1.NodeSelectorOpIn,
+									Values:   []string{node},
+								}},
+							}},
+						},
+					},
+				},
+			}
+		}
+
+		buildService := func(pvcStore cache.Store, k8sClient *k8sfake.Clientset) *TemplateService {
+			virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
+			return &TemplateService{
+				persistentVolumeClaimStore: pvcStore,
+				virtClient:                 virtClient,
+			}
+		}
+
+		hotplugVMI := func(pvcName string, accessMode k8sv1.PersistentVolumeAccessMode) *v1.VirtualMachineInstance {
+			return &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-vmi", Namespace: testNamespace},
+				Spec: v1.VirtualMachineInstanceSpec{
+					Volumes: []v1.Volume{{
+						Name: testVolName,
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+							},
+						},
+					}},
+				},
+				Status: v1.VirtualMachineInstanceStatus{
+					VolumeStatus: []v1.VolumeStatus{{
+						Name:          testVolName,
+						HotplugVolume: &v1.HotplugVolumeStatus{},
+						PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+							AccessModes: []k8sv1.PersistentVolumeAccessMode{accessMode},
+						},
+					}},
+				},
+			}
+		}
+
+		It("should inject PV node affinity into pod for a hotplugged RWO volume", func() {
+			pvcStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+			pvc := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: testNamespace},
+				Spec:       k8sv1.PersistentVolumeClaimSpec{VolumeName: testPVName},
+			}
+			Expect(pvcStore.Add(pvc)).To(Succeed())
+
+			k8sClient := k8sfake.NewSimpleClientset(pvWithNodeAffinity(testNode))
+			testSvc := buildService(pvcStore, k8sClient)
+
+			pod := &k8sv1.Pod{}
+			testSvc.setNodeAffinityForHotplugRWOVolumes(hotplugVMI(testPVCName, k8sv1.ReadWriteOnce), pod)
+
+			Expect(pod.Spec.Affinity).NotTo(BeNil())
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(ContainElement(k8sv1.NodeSelectorRequirement{
+				Key:      "kubernetes.io/hostname",
+				Operator: k8sv1.NodeSelectorOpIn,
+				Values:   []string{testNode},
+			}))
+		})
+
+		It("should not inject affinity for a hotplugged RWX volume", func() {
+			pvcStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+			pvc := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: testNamespace},
+				Spec:       k8sv1.PersistentVolumeClaimSpec{VolumeName: testPVName},
+			}
+			Expect(pvcStore.Add(pvc)).To(Succeed())
+
+			k8sClient := k8sfake.NewSimpleClientset(pvWithNodeAffinity(testNode))
+			testSvc := buildService(pvcStore, k8sClient)
+
+			pod := &k8sv1.Pod{}
+			testSvc.setNodeAffinityForHotplugRWOVolumes(hotplugVMI(testPVCName, k8sv1.ReadWriteMany), pod)
+
+			Expect(pod.Spec.Affinity).To(BeNil())
+		})
+
+		It("should not inject affinity for non-hotplugged volumes", func() {
+			pvcStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+			k8sClient := k8sfake.NewSimpleClientset(pvWithNodeAffinity(testNode))
+			testSvc := buildService(pvcStore, k8sClient)
+
+			vmi := hotplugVMI(testPVCName, k8sv1.ReadWriteOnce)
+			vmi.Status.VolumeStatus[0].HotplugVolume = nil
+
+			pod := &k8sv1.Pod{}
+			testSvc.setNodeAffinityForHotplugRWOVolumes(vmi, pod)
+
+			Expect(pod.Spec.Affinity).To(BeNil())
+		})
+
+		It("should merge PV affinity with existing pod affinity using AND semantics", func() {
+			pvcStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+			pvc := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: testNamespace},
+				Spec:       k8sv1.PersistentVolumeClaimSpec{VolumeName: testPVName},
+			}
+			Expect(pvcStore.Add(pvc)).To(Succeed())
+
+			k8sClient := k8sfake.NewSimpleClientset(pvWithNodeAffinity(testNode))
+			testSvc := buildService(pvcStore, k8sClient)
+
+			existingReq := k8sv1.NodeSelectorRequirement{
+				Key:      "topology.kubernetes.io/zone",
+				Operator: k8sv1.NodeSelectorOpIn,
+				Values:   []string{"zone-a"},
+			}
+			pod := &k8sv1.Pod{
+				Spec: k8sv1.PodSpec{
+					Affinity: &k8sv1.Affinity{
+						NodeAffinity: &k8sv1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+								NodeSelectorTerms: []k8sv1.NodeSelectorTerm{{
+									MatchExpressions: []k8sv1.NodeSelectorRequirement{existingReq},
+								}},
+							},
+						},
+					},
+				},
+			}
+			testSvc.setNodeAffinityForHotplugRWOVolumes(hotplugVMI(testPVCName, k8sv1.ReadWriteOnce), pod)
+
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			// Cartesian product: 1 existing × 1 PV term = 1 combined term with both requirements.
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(ContainElement(existingReq))
+			Expect(terms[0].MatchExpressions).To(ContainElement(k8sv1.NodeSelectorRequirement{
+				Key:      "kubernetes.io/hostname",
+				Operator: k8sv1.NodeSelectorOpIn,
+				Values:   []string{testNode},
+			}))
+		})
+
+		It("should skip injection when the PV has no node affinity", func() {
+			pvcStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+			pvc := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: testNamespace},
+				Spec:       k8sv1.PersistentVolumeClaimSpec{VolumeName: testPVName},
+			}
+			Expect(pvcStore.Add(pvc)).To(Succeed())
+
+			pvNoAffinity := &k8sv1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: testPVName},
+			}
+			k8sClient := k8sfake.NewSimpleClientset(pvNoAffinity)
+			testSvc := buildService(pvcStore, k8sClient)
+
+			pod := &k8sv1.Pod{}
+			testSvc.setNodeAffinityForHotplugRWOVolumes(hotplugVMI(testPVCName, k8sv1.ReadWriteOnce), pod)
+
+			Expect(pod.Spec.Affinity).To(BeNil())
+		})
+	})
+
+	Describe("mergeNodeSelectorRequired", func() {
+		pvTerm := func(node string) k8sv1.NodeSelectorTerm {
+			return k8sv1.NodeSelectorTerm{
+				MatchExpressions: []k8sv1.NodeSelectorRequirement{{
+					Key:      "kubernetes.io/hostname",
+					Operator: k8sv1.NodeSelectorOpIn,
+					Values:   []string{node},
+				}},
+			}
+		}
+		pvRequired := func(node string) *k8sv1.NodeSelector {
+			return &k8sv1.NodeSelector{NodeSelectorTerms: []k8sv1.NodeSelectorTerm{pvTerm(node)}}
+		}
+
+		It("should set PV affinity directly when pod has none", func() {
+			result := mergeNodeSelectorRequired(nil, pvRequired(testNode))
+			terms := result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(ConsistOf(pvTerm(testNode)))
+		})
+
+		It("should produce the Cartesian product of existing and PV terms", func() {
+			existingTerm := k8sv1.NodeSelectorTerm{
+				MatchExpressions: []k8sv1.NodeSelectorRequirement{{
+					Key: "zone", Operator: k8sv1.NodeSelectorOpIn, Values: []string{"a"},
+				}},
+			}
+			affinity := &k8sv1.Affinity{
+				NodeAffinity: &k8sv1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+						NodeSelectorTerms: []k8sv1.NodeSelectorTerm{existingTerm},
+					},
+				},
+			}
+			result := mergeNodeSelectorRequired(affinity, pvRequired(testNode))
+			terms := result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(ContainElements(
+				existingTerm.MatchExpressions[0],
+				pvTerm(testNode).MatchExpressions[0],
+			))
+		})
+
+		It("should produce a Cartesian product for multiple terms on each side", func() {
+			affinity := &k8sv1.Affinity{
+				NodeAffinity: &k8sv1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+						NodeSelectorTerms: []k8sv1.NodeSelectorTerm{pvTerm("A"), pvTerm("B")},
+					},
+				},
+			}
+			pv2 := &k8sv1.NodeSelector{NodeSelectorTerms: []k8sv1.NodeSelectorTerm{pvTerm("X"), pvTerm("Y")}}
+			result := mergeNodeSelectorRequired(affinity, pv2)
+			terms := result.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			// 2 existing × 2 PV = 4 combined terms.
+			Expect(terms).To(HaveLen(4))
+		})
+	})
 })
 
 func networkInfoAnnotVolume() k8sv1.Volume {


### PR DESCRIPTION

### What this PR does
#### Before this PR:

`renderLaunchManifest` created the virt-launcher pod with no knowledge of the node affinity constraints from hotplugged RWO PersistentVolumes. The Kubernetes scheduler could place the pod on any node. The hotplug attachment pod, which is created with hard node affinity to the VM's node, then got stuck `Pending` because the RWO volume resided on a different node — common with local-disk provisioners like TopoLVM.

#### After this PR:

 A new method `setNodeAffinityForHotplugRWOVolumes` is called from `renderLaunchManifest` immediately after `setNodeAffinityForPod`. For each volume in `vmi.Status.VolumeStatus` where:

  - `HotplugVolume != nil` (it is a hotplugged volume), **and**
  - `PersistentVolumeClaimInfo.AccessModes` contains `ReadWriteOnce`

 the method resolves the PVC from the in-memory cache, fetches the bound PV via `virtClient`, and merges `pv.Spec.NodeAffinity.Required` into the pod's `spec.affinity.nodeAffinity.requiredDuringScheduling` using **Cartesian-product AND semantics**:

  | Existing terms | PV terms | Result |
  |---|---|---|
  | ∅ | [P] | [P] |
  | [A] | [P] | [A∧P] |
  | [A, B] | [P, Q] | [A∧P, A∧Q, B∧P, B∧Q] |

  This correctly handles multiple hotplugged local volumes and composes with any existing affinity set on the VMI.

### References

  
- Fixes #16945 



### Why we need it and why it was done in this way
**Why fetch PVs via `virtClient` instead of adding a PV informer?** Adding a PV informer to `TemplateService` requires threading it through `NewTemplateService` and every call site (controller setup, tests). The `renderLaunchManifest` path runs once at VM start — not in a tight loop — so a single `PersistentVolumes().Get()` is acceptable. A warning  is logged on failure and the pod is still created, avoiding a hard failure for transient API errors.

 **Why Cartesian product for merging?**
  `NodeSelectorTerms` are OR'd by Kubernetes. To express A AND B with  two separate term lists, the correct encoding is the Cartesian product `[(A∧B)]`. This is the same technique used by the `node-affinity`  webhook in `cluster-autoscaler` and the Kubernetes topology manager.

 **Why skip RWX?**
  RWX volumes can be mounted from any node and carry no node-local  constraint, so injecting their PV affinity (which is often absent or irrelevant) would incorrectly restrict scheduling.

### Special notes for your reviewer

The existing `modifyNodeAffintyToRejectLabel` helper appends to each term using the same "per-term AND" approach. The new  `mergeNodeSelectorRequired` extends this to the full Cartesian case.

  `setNodeAffinityForHotplugRWOVolumes` silently skips volumes whose PVC is not yet in the local cache or whose PV cannot be fetched. This is  intentional: the controller will re-sync when the VMI is updated, and a missing PVC at pod-creation time means the volume isn't bound yet — the scheduler will land the pod wherever it can, and the hotplug  machinery will reconcile.



### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
  Fixed a scheduling issue where VMs with hotplugged ReadWriteOnce
  volumes backed by node-local storage (e.g., TopoLVM) could be
  restarted onto the wrong node, causing the hotplug attachment pod to
  get stuck Pending. The virt-launcher pod now inherits the node affinity
  from the PersistentVolumes backing any hotplugged RWO volumes, ensuring
  the scheduler respects local storage constraints.

```

