### PR TITLE
virtctl, evacuate: Provide required argument

### DIFF
--- a/pkg/virt-api/rest/evacuate_cancel_test.go
+++ b/pkg/virt-api/rest/evacuate_cancel_test.go
@@ -198,15 +198,18 @@ var _ = Describe("EvacuateCancel Subresource API", func() {
 			Expect(response.StatusCode()).To(Equal(http.StatusBadRequest))
 		})
 
-		It("Should fail because opts is invalid", func() {
+		It("Should fail because opts is empty(invalid)", func() {
 			vmi := newVMI(true, workerNode)
 			vm := createVM(newVM(vmi))
 			vmi.SetOwnerReferences([]metav1.OwnerReference{{UID: vm.UID}})
 			vmi = createVMI(vmi)
 
-			request.Request.Body = newInvalidBody()
+			opt := &v1.EvacuateCancelOptions{}
+
+			//empty opts is invalid
+			request.Request.Body = newEvacuateCancelBody(opt)
 			app.EvacuateCancelHandler(app.FetchVirtualMachineInstanceForVM)(request, response)
-			Expect(response.StatusCode()).To(Equal(http.StatusBadRequest))
+			Expect(response.StatusCode()).To(Equal(http.StatusInternalServerError))
 		})
 	})
 

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/pointer:go_default_library",
         "//pkg/virtctl/testing:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/containerizeddataimporter/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",

--- a/pkg/virtctl/vm/evacuate_cancel.go
+++ b/pkg/virtctl/vm/evacuate_cancel.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	virtv1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/clientconfig"
@@ -83,14 +84,14 @@ func (c *evacuateCancelCommand) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	opts := &virtv1.EvacuateCancelOptions{
+	opts := &v1.EvacuateCancelOptions{
 		DryRun: setDryRunOption(dryRun),
 	}
 
 	return handler(name, namespace, opts)
 }
 
-func (c *evacuateCancelCommand) getHandler(kind string) (func(name, namespace string, opts *virtv1.EvacuateCancelOptions) error, error) {
+func (c *evacuateCancelCommand) getHandler(kind string) (func(name, namespace string, opts *v1.EvacuateCancelOptions) error, error) {
 	switch strings.ToLower(kind) {
 	case "vm", "vms", "virtualmachine", "virtualmachines":
 		return c.handleVM, nil
@@ -100,8 +101,14 @@ func (c *evacuateCancelCommand) getHandler(kind string) (func(name, namespace st
 	return nil, fmt.Errorf("unsupported resource type %q", kind)
 }
 
-func (c *evacuateCancelCommand) handleVM(name, namespace string, opts *virtv1.EvacuateCancelOptions) error {
-	err := c.virtClient.VirtualMachine(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
+func (c *evacuateCancelCommand) handleVM(name, namespace string, opts *v1.EvacuateCancelOptions) error {
+	vmi, err := c.virtClient.VirtualMachineInstance(namespace).Get(c.cmd.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving VMI for evacuation cancel for VM %s/%s: %w", namespace, name, err)
+	}
+
+	opts.EvacuationNodeName = vmi.Status.NodeName
+	err = c.virtClient.VirtualMachine(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
 	if err != nil {
 		return fmt.Errorf("error canceling evacuation for VM %s/%s: %w", namespace, name, err)
 	}
@@ -109,8 +116,14 @@ func (c *evacuateCancelCommand) handleVM(name, namespace string, opts *virtv1.Ev
 	return nil
 }
 
-func (c *evacuateCancelCommand) handleVMI(name, namespace string, opts *virtv1.EvacuateCancelOptions) error {
-	err := c.virtClient.VirtualMachineInstance(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
+func (c *evacuateCancelCommand) handleVMI(name, namespace string, opts *v1.EvacuateCancelOptions) error {
+	vmi, err := c.virtClient.VirtualMachineInstance(namespace).Get(c.cmd.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving VMI for evacuation cancel for VMI %s/%s: %w", namespace, name, err)
+	}
+
+	opts.EvacuationNodeName = vmi.Status.NodeName
+	err = c.virtClient.VirtualMachineInstance(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
 	if err != nil {
 		return fmt.Errorf("error canceling evacuation for VMI %s/%s: %w", namespace, name, err)
 	}

--- a/pkg/virtctl/vm/evacuate_cancel.go
+++ b/pkg/virtctl/vm/evacuate_cancel.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	virtv1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/clientconfig"
@@ -83,14 +84,14 @@ func (c *evacuateCancelCommand) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	opts := &virtv1.EvacuateCancelOptions{
+	opts := &v1.EvacuateCancelOptions{
 		DryRun: setDryRunOption(dryRun),
 	}
 
 	return handler(name, namespace, opts)
 }
 
-func (c *evacuateCancelCommand) getHandler(kind string) (func(name, namespace string, opts *virtv1.EvacuateCancelOptions) error, error) {
+func (c *evacuateCancelCommand) getHandler(kind string) (func(name, namespace string, opts *v1.EvacuateCancelOptions) error, error) {
 	switch strings.ToLower(kind) {
 	case "vm", "vms", "virtualmachine", "virtualmachines":
 		return c.handleVM, nil
@@ -100,8 +101,18 @@ func (c *evacuateCancelCommand) getHandler(kind string) (func(name, namespace st
 	return nil, fmt.Errorf("unsupported resource type %q", kind)
 }
 
-func (c *evacuateCancelCommand) handleVM(name, namespace string, opts *virtv1.EvacuateCancelOptions) error {
-	err := c.virtClient.VirtualMachine(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
+func (c *evacuateCancelCommand) handleVM(name, namespace string, opts *v1.EvacuateCancelOptions) error {
+	vmi, err := c.virtClient.VirtualMachineInstance(namespace).Get(c.cmd.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving VMI for evacuation cancel for VM %s/%s: %w", namespace, name, err)
+	}
+
+	if vmi.Status.NodeName == "" {
+		return fmt.Errorf("VM %s/%s doesn't report Node name", namespace, name)
+	}
+
+	opts.EvacuationNodeName = vmi.Status.NodeName
+	err = c.virtClient.VirtualMachine(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
 	if err != nil {
 		return fmt.Errorf("error canceling evacuation for VM %s/%s: %w", namespace, name, err)
 	}
@@ -109,8 +120,18 @@ func (c *evacuateCancelCommand) handleVM(name, namespace string, opts *virtv1.Ev
 	return nil
 }
 
-func (c *evacuateCancelCommand) handleVMI(name, namespace string, opts *virtv1.EvacuateCancelOptions) error {
-	err := c.virtClient.VirtualMachineInstance(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
+func (c *evacuateCancelCommand) handleVMI(name, namespace string, opts *v1.EvacuateCancelOptions) error {
+	vmi, err := c.virtClient.VirtualMachineInstance(namespace).Get(c.cmd.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving VMI for evacuation cancel for VMI %s/%s: %w", namespace, name, err)
+	}
+
+	if vmi.Status.NodeName == "" {
+		return fmt.Errorf("VMI %s/%s doesn't report Node name", namespace, name)
+	}
+
+	opts.EvacuationNodeName = vmi.Status.NodeName
+	err = c.virtClient.VirtualMachineInstance(namespace).EvacuateCancel(c.cmd.Context(), name, opts)
 	if err != nil {
 		return fmt.Errorf("error canceling evacuation for VMI %s/%s: %w", namespace, name, err)
 	}

--- a/pkg/virtctl/vm/evacuate_cancel_test.go
+++ b/pkg/virtctl/vm/evacuate_cancel_test.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/testing"
@@ -77,6 +78,11 @@ var _ = Describe("Evacuate cancel command", func() {
 	})
 
 	It("should cancel evacuation for VM", func() {
+		vmiInterface.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(api.NewMinimalVMI(vmName), nil).
+			Times(1)
+
 		vmInterface.EXPECT().
 			EvacuateCancel(gomock.Any(), vmName, &v1.EvacuateCancelOptions{}).
 			Return(nil).
@@ -87,6 +93,11 @@ var _ = Describe("Evacuate cancel command", func() {
 	})
 
 	It("should return error on VM evacuate cancel failure", func() {
+		vmiInterface.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(api.NewMinimalVMI(vmName), nil).
+			Times(1)
+
 		expectedErr := fmt.Errorf("failure on VM")
 		vmInterface.EXPECT().
 			EvacuateCancel(gomock.Any(), vmName, &v1.EvacuateCancelOptions{}).
@@ -99,6 +110,11 @@ var _ = Describe("Evacuate cancel command", func() {
 
 	It("should cancel evacuation for VMI", func() {
 		vmiInterface.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(api.NewMinimalVMI(vmiName), nil).
+			Times(1)
+
+		vmiInterface.EXPECT().
 			EvacuateCancel(gomock.Any(), vmiName, &v1.EvacuateCancelOptions{}).
 			Return(nil).
 			Times(1)
@@ -108,6 +124,11 @@ var _ = Describe("Evacuate cancel command", func() {
 	})
 
 	It("should print dry-run message", func() {
+		vmiInterface.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(api.NewMinimalVMI(vmiName), nil).
+			Times(1)
+
 		cmd := testing.NewRepeatableVirtctlCommandWithOut("evacuate-cancel", "vmi", vmiName, "--dry-run")
 		vmiInterface.EXPECT().
 			EvacuateCancel(gomock.Any(), vmiName, &v1.EvacuateCancelOptions{

--- a/pkg/virtctl/vm/evacuate_cancel_test.go
+++ b/pkg/virtctl/vm/evacuate_cancel_test.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/testing"
@@ -48,6 +49,12 @@ var _ = Describe("Evacuate cancel command", func() {
 		vmName  = "testvm"
 		vmiName = "testvmi"
 	)
+
+	newVMI := func(vmName string) *v1.VirtualMachineInstance {
+		vmi := api.NewMinimalVMI(vmName)
+		vmi.Status.NodeName = "Hello"
+		return vmi
+	}
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
@@ -77,8 +84,15 @@ var _ = Describe("Evacuate cancel command", func() {
 	})
 
 	It("should cancel evacuation for VM", func() {
+		vmiInterface.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(newVMI(vmName), nil).
+			Times(1)
+
 		vmInterface.EXPECT().
-			EvacuateCancel(gomock.Any(), vmName, &v1.EvacuateCancelOptions{}).
+			EvacuateCancel(gomock.Any(), vmName, &v1.EvacuateCancelOptions{
+				EvacuationNodeName: "Hello",
+			}).
 			Return(nil).
 			Times(1)
 
@@ -87,9 +101,16 @@ var _ = Describe("Evacuate cancel command", func() {
 	})
 
 	It("should return error on VM evacuate cancel failure", func() {
+		vmiInterface.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(newVMI(vmName), nil).
+			Times(1)
+
 		expectedErr := fmt.Errorf("failure on VM")
 		vmInterface.EXPECT().
-			EvacuateCancel(gomock.Any(), vmName, &v1.EvacuateCancelOptions{}).
+			EvacuateCancel(gomock.Any(), vmName, &v1.EvacuateCancelOptions{
+				EvacuationNodeName: "Hello",
+			}).
 			Return(expectedErr).
 			Times(1)
 
@@ -99,7 +120,14 @@ var _ = Describe("Evacuate cancel command", func() {
 
 	It("should cancel evacuation for VMI", func() {
 		vmiInterface.EXPECT().
-			EvacuateCancel(gomock.Any(), vmiName, &v1.EvacuateCancelOptions{}).
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(newVMI(vmiName), nil).
+			Times(1)
+
+		vmiInterface.EXPECT().
+			EvacuateCancel(gomock.Any(), vmiName, &v1.EvacuateCancelOptions{
+				EvacuationNodeName: "Hello",
+			}).
 			Return(nil).
 			Times(1)
 
@@ -108,10 +136,16 @@ var _ = Describe("Evacuate cancel command", func() {
 	})
 
 	It("should print dry-run message", func() {
+		vmiInterface.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(newVMI(vmiName), nil).
+			Times(1)
+
 		cmd := testing.NewRepeatableVirtctlCommandWithOut("evacuate-cancel", "vmi", vmiName, "--dry-run")
 		vmiInterface.EXPECT().
 			EvacuateCancel(gomock.Any(), vmiName, &v1.EvacuateCancelOptions{
-				DryRun: []string{k8smetav1.DryRunAll},
+				DryRun:             []string{k8smetav1.DryRunAll},
+				EvacuationNodeName: "Hello",
 			}).Return(nil)
 
 		bytes, err := cmd()


### PR DESCRIPTION
### What this PR does
Fixes the `virtctl evacuate-cancel` command.

The "EvacuationNodeName" argument is required to
prevent accidental cancelation.

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: "virtctl evacuate-cancel" now works
```

