### PR TITLE
WIP tests/reporter: Collect etcd cluster info on test failure

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -252,6 +252,8 @@ func (r *KubernetesReporter) dumpTestObjects(duration time.Duration, vmiNamespac
 	r.logVirtualMachinePools(virtCli)
 	r.logMigrationPolicies(virtCli)
 
+	r.logEtcd(virtCli)
+
 	r.logContainerRuntimeDebug(virtCli, nodesDir, nodes)
 }
 
@@ -1710,4 +1712,88 @@ func (r *KubernetesReporter) logMigrationPolicies(virtCli kubecli.KubevirtClient
 	}
 
 	r.logObjects(policies, migrations.ResourceMigrationPolicies)
+}
+
+func (r *KubernetesReporter) logEtcd(virtCli kubecli.KubevirtClient) {
+	etcdPods, err := virtCli.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "component=etcd",
+	})
+	if err != nil {
+		printError("failed to fetch etcd pods: %v", err)
+		return
+	}
+
+	if len(etcdPods.Items) == 0 {
+		printInfo("no etcd pods found, skipping etcd log collection")
+		return
+	}
+
+	r.logObjects(etcdPods, "etcd_pods")
+
+	// Use the first running etcd pod to collect cluster-wide etcdctl output
+	var etcdPod *v1.Pod
+	for i := range etcdPods.Items {
+		if etcdPods.Items[i].Status.Phase == v1.PodRunning {
+			etcdPod = &etcdPods.Items[i]
+			break
+		}
+	}
+	if etcdPod == nil {
+		printError("no running etcd pod found, skipping etcdctl commands")
+		return
+	}
+
+	certArgs := etcdctlCertArgs(etcdPod)
+
+	type etcdctlCommand struct {
+		args           []string
+		fileNameSuffix string
+	}
+	etcdctlCommands := []etcdctlCommand{
+		{args: []string{"member", "list", "-w", "table"}, fileNameSuffix: "member-list"},
+		{args: []string{"endpoint", "status", "-w", "table"}, fileNameSuffix: "endpoint-status"},
+		{args: []string{"endpoint", "health"}, fileNameSuffix: "endpoint-health"},
+		{args: []string{"alarm", "list"}, fileNameSuffix: "alarm-list"},
+	}
+
+	for _, cmd := range etcdctlCommands {
+		command := append([]string{"etcdctl"}, append(cmd.args, certArgs...)...)
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(etcdPod, "etcd", command)
+		if err != nil {
+			printError("failed to execute etcdctl %s on etcd pod %s, stderr: %s, error: %v", cmd.args[0], etcdPod.Name, stderr, err)
+			continue
+		}
+
+		if stdout == "" {
+			continue
+		}
+
+		fileName := fmt.Sprintf("%d_etcd_%s.log", r.failureCount, cmd.fileNameSuffix)
+		if err := writeStringToFile(filepath.Join(r.artifactsDir, fileName), stdout); err != nil {
+			printError("failed to write etcd %s output: %v", cmd.fileNameSuffix, err)
+		}
+	}
+}
+
+func etcdctlCertArgs(etcdPod *v1.Pod) []string {
+	var cacert, cert, key string
+	for _, c := range etcdPod.Spec.Containers {
+		if c.Name != "etcd" {
+			continue
+		}
+		for _, arg := range append(c.Command, c.Args...) {
+			switch {
+			case strings.HasPrefix(arg, "--trusted-ca-file="):
+				cacert = strings.TrimPrefix(arg, "--trusted-ca-file=")
+			case strings.HasPrefix(arg, "--cert-file="):
+				cert = strings.TrimPrefix(arg, "--cert-file=")
+			case strings.HasPrefix(arg, "--key-file="):
+				key = strings.TrimPrefix(arg, "--key-file=")
+			}
+		}
+	}
+	if cacert == "" || cert == "" || key == "" {
+		return nil
+	}
+	return []string{"--cacert=" + cacert, "--cert=" + cert, "--key=" + key}
 }


### PR DESCRIPTION
### What this PR does
Collect etcd pod status and etcdctl output (member list, endpoint status, endpoint health, alarm list) when tests fail to aid debugging of etcd-related issues such as leader elections, db size growth, and compaction alarms.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

