### PR TITLE
fix(replicaset): merge default VMI labels and annotations

### DIFF
--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -20,6 +20,8 @@
 package libvmi
 
 import (
+	"sync"
+
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -41,10 +43,21 @@ func New(opts ...Option) *v1.VirtualMachineInstance {
 	return vmi
 }
 
-var defaultOptions []Option
+var (
+	defaultOptions []Option
+	defaultOptionsMux sync.RWMutex
+)
 
 func RegisterDefaultOption(opt Option) {
+	defaultOptionsMux.Lock()
+	defer defaultOptionsMux.Unlock()
 	defaultOptions = append(defaultOptions, opt)
+}
+
+func ClearDefaultOptions() {
+	defaultOptionsMux.Lock()
+	defer defaultOptionsMux.Unlock()
+	defaultOptions = nil
 }
 
 // randName returns a random name for a virtual machine
@@ -65,6 +78,8 @@ func baseVmi(name string) *v1.VirtualMachineInstance {
 		Spec: v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}},
 	}
 
+	defaultOptionsMux.RLock()
+	defer defaultOptionsMux.RUnlock()
 	for _, opt := range defaultOptions {
 		opt(vmi)
 	}

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -79,8 +79,11 @@ func baseVmi(name string) *v1.VirtualMachineInstance {
 	}
 
 	defaultOptionsMux.RLock()
-	defer defaultOptionsMux.RUnlock()
-	for _, opt := range defaultOptions {
+	opts := make([]Option, len(defaultOptions))
+	copy(opts, defaultOptions)
+	defaultOptionsMux.RUnlock()
+
+	for _, opt := range opts {
 		opt(vmi)
 	}
 

--- a/pkg/virt-controller/watch/replicaset/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset/replicaset.go
@@ -300,12 +300,19 @@ func (c *Controller) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis []*
 			go func() {
 				defer wg.Done()
 				vmi := libvmi.New()
+				// Store the labels and annotations from the initialized VMI
+				initialLabels := vmi.ObjectMeta.Labels
+				initialAnnotations := vmi.ObjectMeta.Annotations
+
+				// Initialize with the template's ObjectMeta (to keep finalizers etc.)
 				vmi.ObjectMeta = rs.Spec.Template.ObjectMeta
 				vmi.ObjectMeta.Name = ""
 				vmi.ObjectMeta.GenerateName = basename
 				vmi.Spec = rs.Spec.Template.Spec
-				// TODO check if vmi labels exist, and when make sure that they match. For now just override them
-				vmi.ObjectMeta.Labels = rs.Spec.Template.ObjectMeta.Labels
+
+				// Merge the labels and annotations, allowing the template to override the initialized values
+				vmi.ObjectMeta.Labels = labels.Merge(initialLabels, rs.Spec.Template.ObjectMeta.Labels)
+				vmi.ObjectMeta.Annotations = labels.Merge(initialAnnotations, rs.Spec.Template.ObjectMeta.Annotations)
 				vmi.ObjectMeta.OwnerReferences = []metav1.OwnerReference{OwnerRef(rs)}
 				vmi, err := c.clientset.VirtualMachineInstance(rs.ObjectMeta.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 				if err != nil {

--- a/pkg/virt-controller/watch/replicaset/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset/replicaset_test.go
@@ -28,6 +28,7 @@ import (
 	"kubevirt.io/client-go/kubevirt/fake"
 	"kubevirt.io/client-go/testing"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -161,6 +162,46 @@ var _ = Describe("Replicaset", func() {
 			testutils.ExpectEvents(recorder,
 				common.SuccessfulCreateVirtualMachineReason,
 				common.SuccessfulCreateVirtualMachineReason,
+				common.SuccessfulCreateVirtualMachineReason,
+			)
+		})
+
+		It("should respect default options from libvmi", func() {
+			// Register a default option that sets a label and an annotation
+			libvmi.RegisterDefaultOption(func(vmi *v1.VirtualMachineInstance) {
+				if vmi.Labels == nil {
+					vmi.Labels = make(map[string]string)
+				}
+				// Add a conflicting label to verify template takes precedence
+				vmi.Labels["test"] = "default-value"
+
+				if vmi.Annotations == nil {
+					vmi.Annotations = make(map[string]string)
+				}
+				vmi.Annotations["kubevirt.io/created-by-test"] = "true"
+				vmi.Annotations["kubevirt.io/test-annotation"] = "true"
+			})
+
+			// Ensure cleanup
+			defer libvmi.ClearDefaultOptions()
+
+			rs, _ := defaultReplicaSet(1)
+			addReplicaSet(rs)
+
+			controller.Execute()
+
+			expectVMIReplicas(rs, HaveLen(1))
+
+			vmiList, err := virtClientset.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmiList.Items).To(HaveLen(1))
+			createdVMI := vmiList.Items[0]
+
+			Expect(createdVMI.Labels).To(HaveKeyWithValue("test", "test")) // Template wins
+			Expect(createdVMI.Annotations).To(HaveKeyWithValue("kubevirt.io/created-by-test", "true"))
+			Expect(createdVMI.Annotations).To(HaveKeyWithValue("kubevirt.io/test-annotation", "true"))
+
+			testutils.ExpectEvents(recorder,
 				common.SuccessfulCreateVirtualMachineReason,
 			)
 		})


### PR DESCRIPTION
### What this PR does
This PR updates the ReplicaSet controller to merge default VMI labels and annotations instead of overwriting them.

**Before this PR:**
The code immediately overwrote **the entire `vmi.ObjectMeta` struct** with the values from the ReplicaSet template. This caused any default metadata set during initialization (e.g., by `libvmi.New()` or `libvmi.RegisterDefaultOption` in tests) to be lost.

**After this PR:**
The code now explicitly merges the initial labels and annotations with the ReplicaSet template's metadata.
- Template values take precedence in case of conflict (ensuring the VMI still matches the ReplicaSet selector).
- Default values (like `kubevirt.io/created-by-test`) are preserved.
- **Added a regression unit test to verify that default `libvmi` options are respected.**

### Why we need it and why it was done in this way
We need this to ensure that default VMI configurations and test harness metadata are respected during ReplicaSet operations. This is particularly important for the test suite, where `kubevirt.io/created-by-test` annotations are used for resource tracking and cleanup.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)

### Release note
```release-note
NONE
```