### PR TITLE
feat(virt-config): add dependency tracking for feature gates

### DIFF
--- a/pkg/virt-config/featuregate/feature-gates.go
+++ b/pkg/virt-config/featuregate/feature-gates.go
@@ -49,10 +49,11 @@ const (
 )
 
 type FeatureGate struct {
-	Name        string
-	State       State
-	VmiSpecUsed func(spec *v1.VirtualMachineInstanceSpec) bool
-	Message     string
+	Name         string
+	State        State
+	VmiSpecUsed  func(spec *v1.VirtualMachineInstanceSpec) bool
+	Message      string
+	Dependencies []string
 }
 
 var featureGates = map[string]FeatureGate{}

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -145,7 +145,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: NetworkBindingPlugingsGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: DynamicPodInterfaceNamingGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VolumesUpdateStrategy, State: GA})
-	RegisterFeatureGate(FeatureGate{Name: VolumeMigration, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: VolumeMigration, State: GA, Dependencies: []string{VolumesUpdateStrategy}})
 	RegisterFeatureGate(FeatureGate{Name: DisableCustomSELinuxPolicy, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: AutoResourceLimitsGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: ClusterProfiler, State: GA})

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -121,8 +121,11 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 	response := validating_webhooks.NewAdmissionResponse(results)
 
 	if featureGatesChanged(&currKV.Spec, &newKV.Spec) {
-		featureGates := newKV.Spec.Configuration.DeveloperConfiguration.FeatureGates
-		response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(featureGates)...)
+		devConfig := newKV.Spec.Configuration.DeveloperConfiguration
+		if devConfig != nil {
+			response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(devConfig.FeatureGates)...)
+			response.Warnings = append(response.Warnings, warnMissingFeatureGateDependencies(devConfig)...)
+		}
 	}
 
 	const mdevWarningfmt = "%s is deprecated, use mediatedDeviceTypes"
@@ -466,6 +469,53 @@ func warnDeprecatedFeatureGates(featureGates []string) (warnings []string) {
 	}
 
 	return warnings
+}
+
+func warnMissingFeatureGateDependencies(devConfig *v1.DeveloperConfiguration) (warnings []string) {
+	if devConfig == nil || len(devConfig.FeatureGates) == 0 {
+		return nil
+	}
+
+	enabled := make(map[string]struct{}, len(devConfig.FeatureGates))
+	emitted := map[string]struct{}{}
+
+	for _, fg := range devConfig.FeatureGates {
+		enabled[fg] = struct{}{}
+	}
+
+	for _, fg := range devConfig.FeatureGates {
+		fgInfo := featuregate.FeatureGateInfo(fg)
+		if fgInfo == nil || len(fgInfo.Dependencies) == 0 {
+			continue
+		}
+
+		for _, dep := range fgInfo.Dependencies {
+			if isDependencySatisfied(dep, enabled) {
+				continue
+			}
+
+			key := fg + "->" + dep
+			if _, seen := emitted[key]; seen {
+				continue
+			}
+			emitted[key] = struct{}{}
+
+			warning := fmt.Sprintf(`feature gate "%s" depends on "%s"; enable "%s" as well`, fg, dep, dep)
+			warnings = append(warnings, warning)
+			log.Log.Warning(warning)
+		}
+	}
+
+	return warnings
+}
+
+func isDependencySatisfied(dep string, enabled map[string]struct{}) bool {
+	depInfo := featuregate.FeatureGateInfo(dep)
+	if depInfo != nil && depInfo.State == featuregate.GA {
+		return true
+	}
+	_, depEnabled := enabled[dep]
+	return depEnabled
 }
 
 func warnDeprecatedArchitectures(archConfiguration *v1.ArchConfiguration) []string {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -501,6 +501,42 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				[]string{"Gate1", "Gate2", "Gate3"},
 				"Gate1", "Gate2", "Gate3"),
 		)
+
+		Context("Feature Gate Dependency Warnings", func() {
+			const (
+				requiredFG  = "UnitTestRequiredGate"
+				dependentFG = "UnitTestDependentGate"
+			)
+
+			BeforeEach(func() {
+				featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: requiredFG, State: featuregate.Alpha})
+				featuregate.RegisterFeatureGate(featuregate.FeatureGate{
+					Name:         dependentFG,
+					State:        featuregate.Alpha,
+					Dependencies: []string{requiredFG},
+				})
+				DeferCleanup(featuregate.UnregisterFeatureGate, dependentFG)
+				DeferCleanup(featuregate.UnregisterFeatureGate, requiredFG)
+			})
+
+			It("should warn when dependency is missing", func() {
+				warnings := warnMissingFeatureGateDependencies(&v1.DeveloperConfiguration{
+					FeatureGates: []string{dependentFG},
+				})
+
+				Expect(warnings).To(ContainElement(
+					fmt.Sprintf(`feature gate "%s" depends on "%s"; enable "%s" as well`, dependentFG, requiredFG, requiredFG),
+				))
+			})
+
+			It("should not warn when dependency is enabled", func() {
+				warnings := warnMissingFeatureGateDependencies(&v1.DeveloperConfiguration{
+					FeatureGates: []string{dependentFG, requiredFG},
+				})
+
+				Expect(warnings).To(BeEmpty())
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Currently, if a user enables a feature gate without enabling its dependencies, the system does not provide clear feedback. This can cause a unexpected behavior or failure.

#### After this PR:
This PR introduces a `Dependencies` field to the `FeatureGate` struct and implements a validation mechanism during the developer configuration update admission. If a feature gate is enabled but its required dependencies are missing, a clear warning is emitted to the logs and returned in the admission response.

### References
Fixes #16998 
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Added validation logic within the webhook admission phase. This introduces a slight processing overhead during `KubeVirt` CR updates, but the tradeoff is highly favorable as it drastically improves UX and prevents silent failures.
- Chose an iterative approach for populating the dependencies to unblock the core framework review rather than delaying the PR to research all existing feature gates upfront.

The following alternatives were considered:
- Hardcoding checks in the validation function: Considered writing explicit `if/else` blocks for each dependent feature. This was rejected because it doesn't scale well and makes the code difficult to maintain. The declarative approach (adding a `Dependencies` slice to the `FeatureGate` struct) is much cleaner.
- CRD OpenAPI Schema Validation (CEL): Considered using CEL rules in the CRD. Rejected because it is difficult to dynamically evaluate the Go-defined `State` (e.g., automatically passing if the dependency is already GA) purely within the schema.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
As a proof of concept and starting point, I have mapped out the dependency for `VolumeMigration` (which depends on `VolumesUpdateStrategy`).
If the maintainers agree with this architectural approach and validation mechanism, I am more than happy to map out the dependencies for other existing feature gates and add them iteratively in this PR.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-api: Added validation to ensure required dependent feature gates are enabled when enabling a specific feature gate.
```

