### PR TITLE
VEP-115: Add pcie root alignment for host devices

### DIFF
--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -116,8 +116,9 @@ func ParsePciAddress(pciAddress string) ([]string, error) {
 }
 
 var (
-	PciBasePath  = "/sys/bus/pci/devices"
-	NodeBasePath = "/sys/bus/node/devices"
+	PciBasePath     = "/sys/bus/pci/devices"
+	NodeBasePath    = "/sys/bus/node/devices"
+	DevicesBasePath = "/sys/devices"
 )
 
 func GetDeviceNumaNode(pciAddress string) (*uint32, error) {
@@ -194,6 +195,70 @@ func PCIAddressToString(pciBusID *api.Address) string {
 		strings.TrimPrefix(pciBusID.Bus, prefix),
 		strings.TrimPrefix(pciBusID.Slot, prefix),
 		strings.TrimPrefix(pciBusID.Function, prefix))
+}
+
+// LookupPCIeRootByPCIBusID retrieves the PCIe Root Complex for a given PCI Bus ID
+// in BDF (Bus-Device-Function) format, e.g., "0123:45:1e.7".
+//
+// It returns a string with the PCIe Root Complex information ("pci<domain>:<bus>")
+// or an error if the PCI Bus ID is invalid or the root complex cannot be determined.
+//
+// ref: https://wiki.xenproject.org/wiki/Bus:Device.Function_(BDF)_Notation
+func LookupPCIeRootByPCIBusID(pciBusID *api.Address) (string, error) {
+	if pciBusID == nil {
+		return "", fmt.Errorf("PCI Bus ID cannot be nil")
+	}
+
+	pciAddress := PCIAddressToString(pciBusID)
+
+	bdfRegexp := regexp.MustCompile(`^([0-9a-f]{4}):([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`)
+	if !bdfRegexp.MatchString(pciAddress) {
+		return "", fmt.Errorf("invalid PCI Bus ID format: %s", pciAddress)
+	}
+
+	pcieRoot, err := resolvePCIeRoot(pciBusID)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve PCIe Root Complex for PCI Bus ID %s: %w", pciAddress, err)
+	}
+
+	return pcieRoot, nil
+}
+
+// resolvePCIeRoot resolves the PCIe Root for a given PCI Bus ID
+// in BDF (Bus-Device-Function) format, e.g., "0123:45:1e.7",
+// by inspecting sysfs (/sys/devices).
+//
+// /sys/bus/pci/devices/<address> is a symlink to the actual device path in /sys/devices.
+// For example, /sys/bus/pci/devices/0000:00:1f.0 points to
+// /sys/devices/pci0000:01/...<intermediate PCI devices>.../0000:00:1f.0,
+// where "pci0000:01" is the PCIe Root.
+//
+// ref: https://wiki.xenproject.org/wiki/Bus:Device.Function_(BDF)_Notation
+func resolvePCIeRoot(pciBusID *api.Address) (string, error) {
+	pciAddress := PCIAddressToString(pciBusID)
+
+	sysBusPath := filepath.Join(PciBasePath, pciAddress)
+
+	target, err := os.Readlink(sysBusPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read symlink for PCI Bus ID %s: %w", sysBusPath, err)
+	}
+
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(sysBusPath), target)
+	}
+
+	devicePathPrefix := DevicesBasePath + "/pci"
+	if !strings.HasPrefix(target, devicePathPrefix) {
+		return "", fmt.Errorf("symlink target for PCI Bus ID %s is invalid: it must start with %s: %s", pciAddress, devicePathPrefix, target)
+	}
+	if filepath.Base(target) != pciAddress {
+		return "", fmt.Errorf("symlink target for PCI Bus ID %s is invalid: it must end with %s: %s", pciAddress, pciAddress, target)
+	}
+
+	pcieRootPart := strings.Split(strings.TrimPrefix(target, DevicesBasePath+"/"), "/")[0]
+
+	return pcieRootPart, nil
 }
 
 // LookupDevicesNumaNodes looks up the NUMA nodes of multiple devices based on

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -37,8 +37,9 @@ var _ = Describe("Hardware utils test", func() {
 	)
 
 	var (
-		originalPciBasePath  string
-		originalNodeBasePath string
+		originalPciBasePath     string
+		originalNodeBasePath    string
+		originalDevicesBasePath string
 
 		fakePciBasePath  string
 		fakeNodeBasePath string
@@ -85,6 +86,7 @@ var _ = Describe("Hardware utils test", func() {
 	BeforeEach(func() {
 		originalPciBasePath = PciBasePath
 		originalNodeBasePath = NodeBasePath
+		originalDevicesBasePath = DevicesBasePath
 
 		createTempSysfsStructure()
 
@@ -96,6 +98,7 @@ var _ = Describe("Hardware utils test", func() {
 	AfterEach(func() {
 		PciBasePath = originalPciBasePath
 		NodeBasePath = originalNodeBasePath
+		DevicesBasePath = originalDevicesBasePath
 
 		// Clean up temporary directories
 		if fakePciBasePath != "" {
@@ -272,6 +275,49 @@ var _ = Describe("Hardware utils test", func() {
 			// Device on NUMA node 0 has CPUs 0-3, so vCPUs 0 and 1 have CPUs on the same NUMA node
 			// vCPU 2 only has CPUs on NUMA node 1, so it's not included
 			Expect(vcpuList).To(ConsistOf(uint32(0), uint32(1)))
+		})
+	})
+
+	Context("lookup PCIe root by PCI bus ID", func() {
+		var createPCIeSymlink func(device, pcieRoot string)
+
+		BeforeEach(func() {
+			createPCIeSymlink = func(device, pcieRoot string) {
+				devicePath := filepath.Join(fakePciBasePath, device)
+				err := os.RemoveAll(devicePath)
+				Expect(err).ToNot(HaveOccurred())
+
+				target := filepath.Join(DevicesBasePath, pcieRoot, "0000:80:00.0", device)
+				err = os.Symlink(target, devicePath)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		It("should return correct PCIe root or error for various inputs", func() {
+			createPCIeSymlink("0000:81:01.0", "pci0000:80")
+			createPCIeSymlink("0000:82:01.0", "pci0000:90")
+
+			testData := []struct {
+				address      *api.Address
+				expectedRoot string
+				expectError  bool
+			}{
+				{nil, "", true},
+				{&api.Address{Domain: "invalid", Bus: "01", Slot: "00", Function: "0"}, "", true},
+				{&api.Address{Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}, "pci0000:80", false},
+				{&api.Address{Domain: "0x0000", Bus: "0x82", Slot: "0x01", Function: "0x0"}, "pci0000:90", false},
+				{&api.Address{Domain: "0x0000", Bus: "0xff", Slot: "0x01", Function: "0x0"}, "", true},
+			}
+
+			for _, t := range testData {
+				root, err := LookupPCIeRootByPCIBusID(t.address)
+				if t.expectError {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(root).To(Equal(t.expectedRoot))
+				}
+			}
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -102,10 +102,12 @@ const (
 	AddressPCI     = "pci"
 	AddressCCW     = "ccw"
 
-	ControllerTypePCI              = "pci"
-	ControllerModelPCIeRoot        = "pcie-root"
-	ControllerModelPCIeRootPort    = "pcie-root-port"
-	ControllerModelPCIeExpanderBus = "pcie-expander-bus"
+	ControllerTypePCI                   = "pci"
+	ControllerModelPCIeRoot             = "pcie-root"
+	ControllerModelPCIeRootPort         = "pcie-root-port"
+	ControllerModelPCIeExpanderBus      = "pcie-expander-bus"
+	ControllerModelPCIeSwitchUpstream   = "pcie-switch-upstream-port"
+	ControllerModelPCIeSwitchDownstream = "pcie-switch-downstream-port"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -15,6 +15,8 @@ import (
 
 const (
 	maxExpanderBusNr = 255
+
+	maxDownstreamPortsPerUpstream = 32
 )
 
 // iteratePCIAddresses invokes the callback function for each PCI device specified in the domain
@@ -170,6 +172,8 @@ func (p *pciRootSlotAssigner) PlacePCIDeviceAtNextSlot(address *api.Address) (*a
 type numaAwareTopology struct {
 	expanderBus               *api.Controller
 	rootPorts                 []*api.Controller
+	upstreamSwitches          []*api.Controller
+	downstreamSwitches        []*api.Controller
 	addressPerDeviceSourcePCI map[string]*api.Address
 }
 
@@ -182,6 +186,7 @@ type expanderBusAssigner struct {
 	topologyMap      map[uint32]*numaAwareTopology
 	devices          map[string]*api.HostDevice
 	devicesNUMANodes map[string]uint32
+	devicesPCIeRoots map[string]string
 
 	// lastAssignedBusNr tracks the last assigned bus number for expander buses.
 	// It starts from maxExpanderBusNr and decreases as expander buses are assigned
@@ -213,6 +218,7 @@ func newExpanderBusAssigner(domainSpec *api.DomainSpec) *expanderBusAssigner {
 		topologyMap:       make(map[uint32]*numaAwareTopology),
 		devices:           make(map[string]*api.HostDevice),
 		devicesNUMANodes:  make(map[string]uint32),
+		devicesPCIeRoots:  make(map[string]string),
 		controllerIndex:   currentControllerIndex,
 		controllerCount:   0,
 		lastAssignedBusNr: maxExpanderBusNr,
@@ -283,24 +289,43 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 		if numaNode, exists := numaNodes[address]; exists {
 			a.devices[address] = device
 			a.devicesNUMANodes[address] = numaNode
+
+			pcieRoot, err := hardware.LookupPCIeRootByPCIBusID(device.Source.Address)
+			if err != nil {
+				log.Log.Infof("device %s has no PCIe root information, skipping PCIe root alignment", address)
+				continue
+			}
+			a.devicesPCIeRoots[address] = pcieRoot
 		} else {
 			log.Log.Infof("device %s has no NUMA affinity information, skipping for pcie-expander-bus assignment", address)
 		}
 	}
 }
 
-// numaDeviceGroups represents a mapping of NUMA nodes to host devices.
-type numaDeviceGroups map[uint32][]*api.HostDevice
+// pcieDeviceGroups represents a mapping of PCIe root to host devices.
+type pcieDeviceGroups map[string][]*api.HostDevice
 
-// groupDevicesByNUMA groups devices by their NUMA node.
-func (a *expanderBusAssigner) groupDevicesByNUMA() numaDeviceGroups {
+// numaDeviceGroups represents a mapping of NUMA nodes to PCIe root groups.
+type numaDeviceGroups map[uint32]pcieDeviceGroups
+
+// groupDevicesByNUMAAndPCIeRoot groups devices by their NUMA node and PCIe root.
+// Devices without PCIe root information are each placed in their own group
+// (keyed by source PCI address) to avoid incorrect switch grouping.
+func (a *expanderBusAssigner) groupDevicesByNUMAAndPCIeRoot() numaDeviceGroups {
 	groups := make(numaDeviceGroups)
-	for addressKey, device := range a.devices {
-		numaNode, exists := a.devicesNUMANodes[addressKey]
+	for address, device := range a.devices {
+		numaNode, exists := a.devicesNUMANodes[address]
 		if !exists {
 			continue
 		}
-		groups[numaNode] = append(groups[numaNode], device)
+		pcieRoot, exists := a.devicesPCIeRoots[address]
+		if !exists {
+			pcieRoot = address
+		}
+		if groups[numaNode] == nil {
+			groups[numaNode] = make(pcieDeviceGroups)
+		}
+		groups[numaNode][pcieRoot] = append(groups[numaNode][pcieRoot], device)
 	}
 	return groups
 }
@@ -321,51 +346,103 @@ func (a *expanderBusAssigner) getNumaAwareTopology(numaKey uint32) *numaAwareTop
 }
 
 // addRootPort creates a PCIe root port and adds it to the topology.
-func (a *expanderBusAssigner) addRootPort(topology *numaAwareTopology, parentBus string) *api.Controller {
-	slot := uint32(len(topology.rootPorts))
+func (a *expanderBusAssigner) addRootPort(topology *numaAwareTopology, parentBus string, slot uint32) *api.Controller {
 	rootPort := a.createController(api.ControllerModelPCIeRootPort, parentBus, slot, nil)
 	topology.rootPorts = append(topology.rootPorts, rootPort)
 	return rootPort
 }
 
-// placeDevice creates a root port and assigns the device directly to it.
-func (a *expanderBusAssigner) placeDevice(topology *numaAwareTopology, device *api.HostDevice) error {
+// addUpstreamSwitch creates a PCIe upstream switch and adds it to the topology.
+func (a *expanderBusAssigner) addUpstreamSwitch(topology *numaAwareTopology, parentBus string) *api.Controller {
+	upstreamSwitch := a.createController(api.ControllerModelPCIeSwitchUpstream, parentBus, 0, nil)
+	topology.upstreamSwitches = append(topology.upstreamSwitches, upstreamSwitch)
+	return upstreamSwitch
+}
+
+// addDownstreamSwitch creates a PCIe downstream switch and adds it to the topology.
+func (a *expanderBusAssigner) addDownstreamSwitch(topology *numaAwareTopology, parentBus string, slot uint32) *api.Controller {
+	downstreamSwitch := a.createController(api.ControllerModelPCIeSwitchDownstream, parentBus, slot, nil)
+	topology.downstreamSwitches = append(topology.downstreamSwitches, downstreamSwitch)
+	return downstreamSwitch
+}
+
+// placeSingleDevice handles the simple case where only one device from a PCIe root
+// is placed. Creates a root port and assigns the device address directly to it.
+func (a *expanderBusAssigner) placeSingleDevice(topology *numaAwareTopology, device *api.HostDevice, rootPortSlot uint32) {
+	rootPort := a.addRootPort(topology, topology.expanderBus.Index, rootPortSlot)
+	sourceAddress := hardware.PCIAddressToString(device.Source.Address)
+	topology.addressPerDeviceSourcePCI[sourceAddress] = newPCIAddress(rootPort.Index, "0x00")
+}
+
+// placeMultipleDevices handles the case with upstream/downstream switches.
+// Creates a root port, upstream switch, and downstream switches for each device.
+func (a *expanderBusAssigner) placeMultipleDevices(topology *numaAwareTopology, devices []*api.HostDevice, rootPortSlot uint32) {
+	rootPort := a.addRootPort(topology, topology.expanderBus.Index, rootPortSlot)
+	upstreamSwitch := a.addUpstreamSwitch(topology, rootPort.Index)
+
+	for i, device := range devices {
+		slot := uint32(i)
+		downstreamSwitch := a.addDownstreamSwitch(topology, upstreamSwitch.Index, slot)
+		sourceAddress := hardware.PCIAddressToString(device.Source.Address)
+		topology.addressPerDeviceSourcePCI[sourceAddress] = newPCIAddress(downstreamSwitch.Index, "0x00")
+	}
+}
+
+// placeDevicesForPCIeRoot places devices from a PCIe root, choosing between single
+// or multiple device placement logic based on the number of devices.
+func (a *expanderBusAssigner) placeDevicesForPCIeRoot(topology *numaAwareTopology, pcieRoot string, devices []*api.HostDevice) error {
+	if len(devices) > maxDownstreamPortsPerUpstream {
+		return fmt.Errorf(
+			"too many devices on PCIe root %s: pcie-switch-upstream-port supports up to %d downstream ports",
+			pcieRoot,
+			maxDownstreamPortsPerUpstream)
+	}
+
 	if a.controllerIndex >= a.lastAssignedBusNr-1 {
 		return fmt.Errorf("insufficient bus numbers for NUMA-aligned PCIe topology: current controller index %d, last assigned expander bus number %d",
 			a.controllerIndex, a.lastAssignedBusNr)
 	}
 
-	rootPort := a.addRootPort(topology, topology.expanderBus.Index)
-	sourceAddress := hardware.PCIAddressToString(device.Source.Address)
-	topology.addressPerDeviceSourcePCI[sourceAddress] = newPCIAddress(rootPort.Index, "0x00")
+	rootPortSlot := uint32(len(topology.rootPorts))
+
+	if len(devices) == 1 {
+		a.placeSingleDevice(topology, devices[0], rootPortSlot)
+	} else {
+		a.placeMultipleDevices(topology, devices, rootPortSlot)
+	}
 
 	return nil
 }
 
-// buildTopology groups devices by NUMA node by using a pcie-expander-bus per
-// NUMA node. Within a pcie-expander-bus one pcie-root-port per device is created.
-// Each device is then placed behind its respective root port.
+// buildTopology groups devices by NUMA node and PCIe root, using a pcie-expander-bus
+// per NUMA node. Within a pcie-expander-bus, devices sharing the same PCIe root are
+// grouped under a pcie-switch-upstream-port with individual pcie-switch-downstream-ports.
+// A single device on a PCIe root is placed directly behind a pcie-root-port.
 //
-// pcie-expander-bus (one per NUMA node) -> pcie-root-port (one per device) -> device
+// pcie-expander-bus (one per NUMA node) -> pcie-root-port (one per PCIe root) ->
+//
+//	[single device: device directly on root port bus]
+//	[multiple devices: pcie-switch-upstream-port -> pcie-switch-downstream-ports -> devices]
 //
 // It modifies the topology per NUMA node in place by creating the necessary controllers
 // and updating the addresses of the devices.
 func (a *expanderBusAssigner) buildTopology() error {
-	numaDeviceGroups := a.groupDevicesByNUMA()
+	numaDeviceGroups := a.groupDevicesByNUMAAndPCIeRoot()
 
-	for numaKey, devices := range numaDeviceGroups {
+	for numaKey, pcieRootGroups := range numaDeviceGroups {
 		topology := a.getNumaAwareTopology(numaKey)
 
-		for _, device := range devices {
-			if err := a.placeDevice(topology, device); err != nil {
-				return fmt.Errorf("failed to place device %s: %w", hardware.PCIAddressToString(device.Source.Address), err)
+		for pcieRoot, devices := range pcieRootGroups {
+			if err := a.placeDevicesForPCIeRoot(topology, pcieRoot, devices); err != nil {
+				return err
 			}
 		}
 
 		// Set the busNr of the expander bus so that it has enough space for all
-		// its children. We start from 254 (1 expander bus + 1 root port, when one
-		// device is aligned with a NUMA node) and go downwards to leave space for
-		// system controllers and additional expander buses.
+		// its children. We start from maxExpanderBusNr and go downwards,
+		// reserving one bus for the expander bus itself plus one for each child
+		// controller, to leave space for system controllers and additional
+		// expander buses.
 		busNr := maxExpanderBusNr - a.controllerCount + 1
 		topology.expanderBus.Target.BusNr = ptr.To(busNr)
 
@@ -390,6 +467,12 @@ func (a *expanderBusAssigner) PlaceNumaAlignedDevices() error {
 
 		for _, rootPort := range topology.rootPorts {
 			a.domainSpec.Devices.Controllers = append(a.domainSpec.Devices.Controllers, *rootPort)
+		}
+		for _, upstreamSwitch := range topology.upstreamSwitches {
+			a.domainSpec.Devices.Controllers = append(a.domainSpec.Devices.Controllers, *upstreamSwitch)
+		}
+		for _, downstreamSwitch := range topology.downstreamSwitches {
+			a.domainSpec.Devices.Controllers = append(a.domainSpec.Devices.Controllers, *downstreamSwitch)
 		}
 
 		for sourceAddress, address := range topology.addressPerDeviceSourcePCI {

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -34,10 +34,11 @@ type addDevicesTestCase struct {
 
 var _ = Describe("PCIe Expander Bus Assigner", func() {
 	var (
-		originalPciBasePath  string
-		originalNodeBasePath string
-		fakePciBasePath      string
-		fakeNodeBasePath     string
+		originalPciBasePath     string
+		originalNodeBasePath    string
+		originalDevicesBasePath string
+		fakePciBasePath         string
+		fakeNodeBasePath        string
 	)
 
 	createDomainSpecWithNUMA := func(numaCells []api.NUMACell, vcpuPins []api.CPUTuneVCPUPin) *api.DomainSpec {
@@ -83,6 +84,53 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 		}
 	}
 
+	// setupFakeSysfsWithPCIeRoots creates a sysfs structure with both NUMA node
+	// info and PCIe root symlinks. Each device gets a directory under a fake
+	// devices tree, and a symlink in fakePciBasePath pointing to it.
+	setupFakeSysfsWithPCIeRoots := func(
+		devices map[string]struct{ numaNode, pcieRoot string },
+		numaNodes map[string]string,
+	) {
+		var err error
+		fakePciBasePath, err = os.MkdirTemp("", "pci_devices")
+		Expect(err).ToNot(HaveOccurred())
+
+		fakeNodeBasePath, err = os.MkdirTemp("", "numa_nodes")
+		Expect(err).ToNot(HaveOccurred())
+
+		fakeDevicesBasePath, err := os.MkdirTemp("", "sys_devices")
+		Expect(err).ToNot(HaveOccurred())
+		hardware.DevicesBasePath = fakeDevicesBasePath
+
+		for pciAddr, info := range devices {
+			// Create the real device directory under the fake device tree
+			deviceDir := filepath.Join(fakeDevicesBasePath, info.pcieRoot, "0000:00:00.0", pciAddr)
+			err = os.MkdirAll(deviceDir, 0o755)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Write numa_node file in the real device directory
+			err = os.WriteFile(filepath.Join(deviceDir, "numa_node"), []byte(info.numaNode+"\n"), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create symlink: fakePciBasePath/<address> -> fakeDevicesBasePath/<pcieRoot>/.../<address>
+			symlinkTarget := filepath.Join(fakeDevicesBasePath, info.pcieRoot, "0000:00:00.0", pciAddr)
+			err = os.Symlink(symlinkTarget, filepath.Join(fakePciBasePath, pciAddr))
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		for numaID, cpuList := range numaNodes {
+			numaNodePath := filepath.Join(fakeNodeBasePath, "node"+numaID)
+			err = os.MkdirAll(numaNodePath, 0o755)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(numaNodePath, "cpulist"), []byte(cpuList+"\n"), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		hardware.PciBasePath = fakePciBasePath
+		hardware.NodeBasePath = fakeNodeBasePath
+	}
+
 	setupFakeSysfs := func() {
 		var err error
 		fakePciBasePath, err = os.MkdirTemp("", "pci_devices")
@@ -125,6 +173,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 	BeforeEach(func() {
 		originalPciBasePath = hardware.PciBasePath
 		originalNodeBasePath = hardware.NodeBasePath
+		originalDevicesBasePath = hardware.DevicesBasePath
 		setupFakeSysfs()
 		hardware.PciBasePath = fakePciBasePath
 		hardware.NodeBasePath = fakeNodeBasePath
@@ -133,6 +182,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 	AfterEach(func() {
 		hardware.PciBasePath = originalPciBasePath
 		hardware.NodeBasePath = originalNodeBasePath
+		hardware.DevicesBasePath = originalDevicesBasePath
 		if fakePciBasePath != "" {
 			os.RemoveAll(fakePciBasePath)
 		}
@@ -310,6 +360,146 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 		)
 	})
 
+	Describe("PCIe root alignment", func() {
+		countControllersByModel := func(controllers []api.Controller, model string) int {
+			count := 0
+			for _, c := range controllers {
+				if c.Model == model {
+					count++
+				}
+			}
+			return count
+		}
+
+		It("should create switch hierarchy when multiple devices share a PCIe root", func() {
+			setupFakeSysfsWithPCIeRoots(
+				map[string]struct{ numaNode, pcieRoot string }{
+					"0000:81:01.0": {"0", "pci0000:80"},
+					"0000:81:02.0": {"0", "pci0000:80"},
+				},
+				map[string]string{"0": "0-3"},
+			)
+
+			domainSpec := createDomainSpecWithNUMA(
+				[]api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				[]api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "0"}},
+			)
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("device1", "0x81"),
+				createPCIDevice("device2", "0x81"),
+			}
+			// Fix source addresses to match fake sysfs
+			domainSpec.Devices.HostDevices[0].Source.Address.Slot = "0x01"
+			domainSpec.Devices.HostDevices[1].Source.Address.Slot = "0x02"
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			controllers := domainSpec.Devices.Controllers
+			// 1 expander bus + 1 root port + 1 upstream switch + 2 downstream switches = 5
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeExpanderBus)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeRootPort)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchUpstream)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchDownstream)).To(Equal(2))
+		})
+
+		It("should not create switches for a single device on a PCIe root", func() {
+			setupFakeSysfsWithPCIeRoots(
+				map[string]struct{ numaNode, pcieRoot string }{
+					"0000:81:01.0": {"0", "pci0000:80"},
+				},
+				map[string]string{"0": "0-3"},
+			)
+
+			domainSpec := createDomainSpecWithNUMA(
+				[]api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				[]api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "0"}},
+			)
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("device1", "0x81"),
+			}
+			domainSpec.Devices.HostDevices[0].Source.Address.Slot = "0x01"
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			controllers := domainSpec.Devices.Controllers
+			// 1 expander bus + 1 root port = 2 (no switches)
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeExpanderBus)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeRootPort)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchUpstream)).To(Equal(0))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchDownstream)).To(Equal(0))
+		})
+
+		It("should create separate root ports for devices on different PCIe roots", func() {
+			setupFakeSysfsWithPCIeRoots(
+				map[string]struct{ numaNode, pcieRoot string }{
+					"0000:81:01.0": {"0", "pci0000:80"},
+					"0000:91:01.0": {"0", "pci0000:90"},
+				},
+				map[string]string{"0": "0-3"},
+			)
+
+			domainSpec := createDomainSpecWithNUMA(
+				[]api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				[]api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "0"}},
+			)
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("device1", "0x81"),
+				createPCIDevice("device2", "0x91"),
+			}
+			domainSpec.Devices.HostDevices[0].Source.Address.Slot = "0x01"
+			domainSpec.Devices.HostDevices[1].Source.Address.Slot = "0x01"
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			controllers := domainSpec.Devices.Controllers
+			// 1 expander bus + 2 root ports = 3 (no switches, different PCIe roots)
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeExpanderBus)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeRootPort)).To(Equal(2))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchUpstream)).To(Equal(0))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchDownstream)).To(Equal(0))
+		})
+
+		It("should handle mixed PCIe roots on the same NUMA node", func() {
+			setupFakeSysfsWithPCIeRoots(
+				map[string]struct{ numaNode, pcieRoot string }{
+					"0000:81:01.0": {"0", "pci0000:80"},
+					"0000:81:02.0": {"0", "pci0000:80"},
+					"0000:91:01.0": {"0", "pci0000:90"},
+				},
+				map[string]string{"0": "0-3"},
+			)
+
+			domainSpec := createDomainSpecWithNUMA(
+				[]api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				[]api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "0"}},
+			)
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("device1", "0x81"),
+				createPCIDevice("device2", "0x81"),
+				createPCIDevice("device3", "0x91"),
+			}
+			domainSpec.Devices.HostDevices[0].Source.Address.Slot = "0x01"
+			domainSpec.Devices.HostDevices[1].Source.Address.Slot = "0x02"
+			domainSpec.Devices.HostDevices[2].Source.Address.Slot = "0x01"
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			controllers := domainSpec.Devices.Controllers
+			// pci0000:80 has 2 devices -> root port + upstream + 2 downstream
+			// pci0000:90 has 1 device -> root port only
+			// + 1 expander bus
+			// Total: 1 expander + 2 root ports + 1 upstream + 2 downstream = 6
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeExpanderBus)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeRootPort)).To(Equal(2))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchUpstream)).To(Equal(1))
+			Expect(countControllersByModel(controllers, api.ControllerModelPCIeSwitchDownstream)).To(Equal(2))
+		})
+	})
+
 	Describe("PlacePCIDevicesWithNUMAAlignment", func() {
 		var domainSpec *api.DomainSpec
 
@@ -346,7 +536,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Bus numbers calculated as 254 - controllerCount + 1:
+			// Bus numbers calculated as 255 - controllerCount + 1:
 			// NUMA 0: 255 - 2 + 1 = 254 (after creating expander bus + root port)
 			// NUMA 1: 255 - 4 + 1 = 252 (after creating 2nd expander bus + root port)
 			expectedBusNumbers := map[uint32]bool{254: false, 252: false}
@@ -356,7 +546,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 					Expect(controller.Target.BusNr).ToNot(BeNil())
 					busNr := *controller.Target.BusNr
 					_, expected := expectedBusNumbers[busNr]
-					Expect(expected).To(BeTrue(), "Bus number %d should be one of the expected values (253, 251)", busNr)
+					Expect(expected).To(BeTrue(), "Bus number %d should be one of the expected values (254, 252)", busNr)
 					expectedBusNumbers[busNr] = true
 				}
 			}


### PR DESCRIPTION
### What this PR does

This PR addresses the PCIe switch placement mirroring of host devices from the host to the guest introduced in [VEP 115](https://github.com/kubevirt/enhancements/blob/c64c5f27f4131ceba33b04b431172c3f60c793e6/veps/sig-compute/115-pcie-numa-topology-awareness/pcie-numa-topology-awareness.md) when NUMA alignment is enabled and applied.

#### Before this PR:

When multiple passthrough PCI devices share the same PCIe root complex on the host, the NUMA-aware PCIe topology places each device behind its own independent `pcie-root-port` under the `pcie-expander-bus`. This flat topology does not reflect the actual host PCIe hierarchy, which can lead to suboptimal device placement and missing locality information in the guest when multiple host devices belong to the same host PCIe root complex.

#### After this PR:

Devices sharing the same PCIe root complex on the host are grouped under a `pcie-switch-upstream-port` / `pcie-switch-downstream-port` hierarchy within the `pcie-expander-bus`. This mirrors the host's PCIe topology inside the guest:

  - **Single device on a PCIe root**: placed directly under a `pcie-root-port` (no change).
  - **Multiple devices on the same PCIe root**: placed under a shared `pcie-root-port` → `pcie-switch-upstream-port` → individual `pcie-switch-downstream-ports`.

The PCIe root complex of each device is resolved by following the sysfs symlink from `/sys/bus/pci/devices/<address>` to `/sys/devices/pci<domain>:<bus>/...`.

### References

- Previous PR of VEP 115: #16632

### Why we need it and why it was done in this way

The following tradeoffs were made:
  - Devices without PCIe root information (e.g. unresolvable sysfs symlinks) are each placed in their own group to
    avoid incorrect switch grouping, falling back to the existing flat topology behavior.
  - A maximum of 32 downstream ports per upstream switch is enforced, matching the PCIe spec limit.

The following alternatives were considered:
  - Keeping the flat topology for all devices regardless of PCIe root sharing. This was rejected because it loses host
   locality information that can be important for performance-sensitive workloads.

### Special notes for your reviewer

This builds on the NUMA-aware PCIe topology introduced in #16632.

### Checklist
This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR. Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout
  Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit
  tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution
  Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
Passthrough PCI devices sharing the same host PCIe root complex are now grouped under a PCIe switch hierarchy
(upstream/downstream ports) within the NUMA-aware pcie-expander-bus topology, preserving host PCIe locality in the
guest.
```