### PR TITLE
e2e, net: Gofumpt

### DIFF
--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -53,7 +53,6 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 		// Check if the hardware supports SRIOV
 		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
 			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
-
 	})
 
 	BeforeEach(func() {

--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -220,7 +220,6 @@ var _ = Describe(SIG("interface state up/down", func() {
 
 		Expect(console.RunCommand(vmi, libnet.NewLinkStateAssersionCmd(mac1.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
 		Expect(console.RunCommand(vmi, libnet.NewLinkStateAssersionCmd(mac2.String(), v1.InterfaceStateLinkDown), timeout)).To(Succeed())
-
 	})
 }))
 

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -51,7 +51,6 @@ import (
 )
 
 var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", Serial, func() {
-
 	var err error
 	const (
 		port1234 = 1234
@@ -139,7 +138,6 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", Seria
 			clientVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			//ports := []v1.Port{{Name: "http", Port: highTCPPort, Protocol: "TCP"}}
 			serverVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(passtBindingInterfaceWithPort(tcp, highTCPPort)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -152,7 +150,6 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", Seria
 			vmnetserver.StartTCPServer(serverVMI, highTCPPort, console.LoginToAlpine)
 			By("starting a TCP server on a port not specified on the VM spec")
 			vmnetserver.StartTCPServer(serverVMI, highTCPPort+1, console.LoginToAlpine)
-
 		})
 		DescribeTable("connectivity", func(ipFamily k8sv1.IPFamily) {
 			libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
@@ -224,7 +221,6 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", Seria
 		const udpPortForIPv6 = 1701
 
 		BeforeAll(func() {
-
 			By("Starting server VMI")
 			serverVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(passtBindingInterfaceWithPort(udp, udpPortForIPv4, udpPortForIPv6)),

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -203,7 +203,6 @@ var istioTests = func(vmType VmType) {
 			}
 
 			BeforeEach(func() {
-
 				bastionVMI = libvmifact.NewCirros(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -290,7 +290,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 			}
 
 			DescribeTable("should be able to ping between two vms", func(interfaces []v1.Interface,
-				networks []v1.Network, ifaceName, staticIPVm1, staticIPVm2 string) {
+				networks []v1.Network, ifaceName, staticIPVm1, staticIPVm2 string,
+			) {
 				if staticIPVm2 == "" || staticIPVm1 == "" {
 					ipam := map[string]string{"type": "host-local", "subnet": ptpSubnet}
 					Expect(createBridgeNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), linuxBridgeVlan100WithIPAMNetwork, bridge10Name, 0, ipam, bridge10MacSpoofCheck)).To(Succeed())
@@ -718,7 +719,7 @@ func indexInterfaceStatusByName(vmi *v1.VirtualMachineInstance) map[string]v1.Vi
 	return interfaceStatusByName
 }
 
-func createBridgeNetworkAttachmentDefinition(namespace, networkName string, bridgeName string, vlan int, ipam map[string]string, macSpoofCheck bool) error {
+func createBridgeNetworkAttachmentDefinition(namespace, networkName, bridgeName string, vlan int, ipam map[string]string, macSpoofCheck bool) error {
 	netAttachDef := libnet.NewBridgeNetAttachDef(
 		networkName,
 		bridgeName,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Some tests were not formatted by gofumpt.
In addition, removed commented code.
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

