### PR TITLE
VEP-10: use device specific lookup for metadata file even for resource claim template

### DIFF
--- a/pkg/dra/admitter/BUILD.bazel
+++ b/pkg/dra/admitter/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/dra/admitter",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/dra:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/dra/admitter/dra_admitter.go
+++ b/pkg/dra/admitter/dra_admitter.go
@@ -27,7 +27,6 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	v1 "kubevirt.io/api/core/v1"
 
-	drautil "kubevirt.io/kubevirt/pkg/dra"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
@@ -102,176 +101,155 @@ func validateCreationDRA(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSp
 	return causes
 }
 
+// draCapableDevice abstracts the common DRA-relevant fields shared by v1.GPU and v1.HostDevice.
+type draCapableDevice interface {
+	isDRA() bool
+	getDeviceName() string
+	getClaimRequest() *v1.ClaimRequest
+}
+
+type gpuAdapter v1.GPU
+
+func (g gpuAdapter) isDRA() bool                       { return g.DeviceName == "" && g.ClaimRequest != nil }
+func (g gpuAdapter) getDeviceName() string             { return g.DeviceName }
+func (g gpuAdapter) getClaimRequest() *v1.ClaimRequest { return g.ClaimRequest }
+
+type hostDeviceAdapter v1.HostDevice
+
+func (h hostDeviceAdapter) isDRA() bool                       { return h.DeviceName == "" && h.ClaimRequest != nil }
+func (h hostDeviceAdapter) getDeviceName() string             { return h.DeviceName }
+func (h hostDeviceAdapter) getClaimRequest() *v1.ClaimRequest { return h.ClaimRequest }
+
+type deviceValidationConfig struct {
+	fieldPath   string
+	typeName    string
+	gateEnabled bool
+	rejectMixed bool
+}
+
+type indexedDevice struct {
+	idx    int
+	device draCapableDevice
+}
+
 func validateDRAGPUs(field *k8sfield.Path, gpus []v1.GPU, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string]) {
-	var (
-		causes     []metav1.StatusCause
-		draGPUs    []v1.GPU
-		nonDRAGPUs []v1.GPU
-	)
-	gpusField := field.Child("domain", "devices", "gpus")
-
-	for _, gpu := range gpus {
-		if drautil.IsGPUDRA(gpu) {
-			draGPUs = append(draGPUs, gpu)
-		} else {
-			nonDRAGPUs = append(nonDRAGPUs, gpu)
-		}
+	devices := make([]draCapableDevice, len(gpus))
+	for i, g := range gpus {
+		devices[i] = gpuAdapter(g)
 	}
-
-	for _, gpu := range nonDRAGPUs {
-		if gpu.DeviceName == "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: "vmi.spec.domain.devices.gpus contains GPUs without deviceName or claimRequest; each GPU must specify either a deviceName or a claimRequest",
-				Field:   gpusField.String(),
-			})
-		}
-		if gpu.DeviceName != "" && gpu.ClaimRequest != nil {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "vmi.spec.domain.devices.gpus contains GPUs with both deviceName and claimRequest",
-				Field:   gpusField.String(),
-			})
-		}
-	}
-
-	// returns early because feature gate is not enabled
-	if len(draGPUs) > 0 && !checker.GPUsWithDRAGateEnabled() {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "vmi.spec.domain.devices.gpus contains DRA enabled GPUs but feature gate is not enabled",
-			Field:   gpusField.String(),
-		})
-		return causes, sets.New[string]()
-	}
-
-	var validDRAGPUs []v1.GPU
-	for i, gpu := range draGPUs {
-		valid := true
-		if gpu.ClaimName == nil || *gpu.ClaimName == "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: "claimName is required for DRA GPU",
-				Field:   gpusField.Index(i).Child("claimName").String(),
-			})
-			valid = false
-		}
-		if gpu.RequestName == nil || *gpu.RequestName == "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: "requestName is required for DRA GPU",
-				Field:   gpusField.Index(i).Child("requestName").String(),
-			})
-			valid = false
-		}
-		if valid {
-			validDRAGPUs = append(validDRAGPUs, gpu)
-		}
-	}
-
-	claimRequestPairs := sets.New[string]()
-	for i, gpu := range validDRAGPUs {
-		key := *gpu.ClaimName + "/" + *gpu.RequestName
-		if claimRequestPairs.Has(key) {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueDuplicate,
-				Message: fmt.Sprintf("duplicate claimName/requestName pair %q", key),
-				Field:   gpusField.Index(i).String(),
-			})
-		}
-		claimRequestPairs.Insert(key)
-	}
-
-	claimNames := sets.New[string]()
-	for _, gpu := range validDRAGPUs {
-		claimNames.Insert(*gpu.ClaimName)
-	}
-
-	return causes, claimNames
+	return validateDRADevices(field, devices, deviceValidationConfig{
+		fieldPath:   "gpus",
+		typeName:    "GPU",
+		gateEnabled: checker.GPUsWithDRAGateEnabled(),
+		rejectMixed: true,
+	})
 }
 
 func validateDRAHostDevices(field *k8sfield.Path, hostDevices []v1.HostDevice, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string]) {
+	devices := make([]draCapableDevice, len(hostDevices))
+	for i, hd := range hostDevices {
+		devices[i] = hostDeviceAdapter(hd)
+	}
+	return validateDRADevices(field, devices, deviceValidationConfig{
+		fieldPath:   "hostDevices",
+		typeName:    "HostDevice",
+		gateEnabled: checker.HostDevicesWithDRAEnabled(),
+		rejectMixed: false,
+	})
+}
+
+func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg deviceValidationConfig) ([]metav1.StatusCause, sets.Set[string]) {
 	var (
-		causes    []metav1.StatusCause
-		draHDs    []v1.HostDevice
-		nonDRAHDs []v1.HostDevice
+		causes     []metav1.StatusCause
+		draDevs    []indexedDevice
+		nonDRADevs []indexedDevice
 	)
-	hdField := field.Child("domain", "devices", "hostDevices")
+	devField := field.Child("domain", "devices", cfg.fieldPath)
 
-	for _, hd := range hostDevices {
-		if drautil.IsHostDeviceDRA(hd) {
-			draHDs = append(draHDs, hd)
+	for i, d := range devices {
+		if d.isDRA() {
+			draDevs = append(draDevs, indexedDevice{i, d})
 		} else {
-			nonDRAHDs = append(nonDRAHDs, hd)
+			nonDRADevs = append(nonDRADevs, indexedDevice{i, d})
 		}
 	}
 
-	for _, hd := range nonDRAHDs {
-		if hd.DeviceName == "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: "vmi.spec.domain.devices.hostDevices contains HostDevices without deviceName or claimRequest; each HostDevice must specify either a deviceName or a claimRequest",
-				Field:   hdField.String(),
-			})
-		}
-		if hd.DeviceName != "" && hd.ClaimRequest != nil {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "vmi.spec.domain.devices.hostDevices contains HostDevices with both deviceName and claimRequest",
-				Field:   hdField.String(),
-			})
-		}
-	}
-
-	if len(draHDs) > 0 && !checker.HostDevicesWithDRAEnabled() {
+	if cfg.rejectMixed && len(nonDRADevs) > 0 && len(draDevs) > 0 {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "vmi.spec.domain.devices.hostDevices contains DRA enabled HostDevices but feature gate is not enabled",
-			Field:   hdField.String(),
+			Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains both DRA and non-DRA %ss; each %s must be either DRA or non-DRA", cfg.fieldPath, cfg.typeName, cfg.typeName),
+			Field:   devField.String(),
 		})
 		return causes, sets.New[string]()
 	}
 
-	var validDRAHDs []v1.HostDevice
-	for i, hd := range draHDs {
-		valid := true
-		if hd.ClaimName == nil || *hd.ClaimName == "" {
+	for _, nd := range nonDRADevs {
+		if nd.device.getDeviceName() == "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: "claimName is required for DRA HostDevice",
-				Field:   hdField.Index(i).Child("claimName").String(),
+				Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains %ss without deviceName or claimRequest; each %s must specify either a deviceName or a claimRequest", cfg.fieldPath, cfg.typeName, cfg.typeName),
+				Field:   devField.String(),
+			})
+		} else if nd.device.getClaimRequest() != nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains %ss with both deviceName and claimRequest", cfg.fieldPath, cfg.typeName),
+				Field:   devField.String(),
+			})
+		}
+	}
+
+	if len(draDevs) > 0 && !cfg.gateEnabled {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains DRA enabled %ss but feature gate is not enabled", cfg.fieldPath, cfg.typeName),
+			Field:   devField.String(),
+		})
+		return causes, sets.New[string]()
+	}
+
+	var validDRA []indexedDevice
+	for _, id := range draDevs {
+		valid := true
+		cr := id.device.getClaimRequest()
+		if cr.ClaimName == nil || *cr.ClaimName == "" {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: fmt.Sprintf("claimName is required for DRA %s", cfg.typeName),
+				Field:   devField.Index(id.idx).Child("claimName").String(),
 			})
 			valid = false
 		}
-		if hd.RequestName == nil || *hd.RequestName == "" {
+		if cr.RequestName == nil || *cr.RequestName == "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: "requestName is required for DRA HostDevice",
-				Field:   hdField.Index(i).Child("requestName").String(),
+				Message: fmt.Sprintf("requestName is required for DRA %s", cfg.typeName),
+				Field:   devField.Index(id.idx).Child("requestName").String(),
 			})
 			valid = false
 		}
 		if valid {
-			validDRAHDs = append(validDRAHDs, hd)
+			validDRA = append(validDRA, id)
 		}
 	}
 
 	claimRequestPairs := sets.New[string]()
-	for i, hd := range validDRAHDs {
-		key := *hd.ClaimName + "/" + *hd.RequestName
+	for _, id := range validDRA {
+		cr := id.device.getClaimRequest()
+		key := *cr.ClaimName + "/" + *cr.RequestName
 		if claimRequestPairs.Has(key) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueDuplicate,
 				Message: fmt.Sprintf("duplicate claimName/requestName pair %q", key),
-				Field:   hdField.Index(i).String(),
+				Field:   devField.Index(id.idx).String(),
 			})
 		}
 		claimRequestPairs.Insert(key)
 	}
 
 	claimNames := sets.New[string]()
-	for _, hd := range validDRAHDs {
-		claimNames.Insert(*hd.ClaimName)
+	for _, id := range validDRA {
+		claimNames.Insert(*id.device.getClaimRequest().ClaimName)
 	}
 
 	return causes, claimNames

--- a/pkg/dra/admitter/dra_admitter_test.go
+++ b/pkg/dra/admitter/dra_admitter_test.go
@@ -439,6 +439,89 @@ var _ = Describe("DRA Admitter", func() {
 		})
 	})
 
+	Context("mixed DRA and non-DRA GPUs", func() {
+		It("should reject a VMI with both DRA and non-DRA GPUs", func() {
+			checker.gpuDRAEnabled = true
+			spec := &v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{
+						GPUs: []v1.GPU{
+							{
+								Name:       "dp-gpu",
+								DeviceName: "vfio.gpu.example.com",
+							},
+							{
+								Name: "dra-gpu",
+								ClaimRequest: &v1.ClaimRequest{
+									ClaimName:   ptr.To("claim1"),
+									RequestName: ptr.To("req1"),
+								},
+							},
+						},
+					},
+				},
+			}
+			causes := validateCreationDRA(field, spec, checker)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+			Expect(causes[0].Message).To(ContainSubstring("both DRA and non-DRA GPUs"))
+			Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus"))
+		})
+	})
+
+	Context("GPU index accuracy", func() {
+		BeforeEach(func() {
+			checker.gpuDRAEnabled = true
+		})
+
+		It("should report correct index for duplicate when an invalid DRA GPU precedes it", func() {
+			spec := &v1.VirtualMachineInstanceSpec{
+				ResourceClaims: []k8sv1.PodResourceClaim{{Name: "claim1"}},
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{
+						GPUs: []v1.GPU{
+							{
+								Name:         "gpu-invalid",
+								ClaimRequest: &v1.ClaimRequest{RequestName: ptr.To("req1")},
+							},
+							{
+								Name: "gpu-a",
+								ClaimRequest: &v1.ClaimRequest{
+									ClaimName:   ptr.To("claim1"),
+									RequestName: ptr.To("req1"),
+								},
+							},
+							{
+								Name: "gpu-dup",
+								ClaimRequest: &v1.ClaimRequest{
+									ClaimName:   ptr.To("claim1"),
+									RequestName: ptr.To("req1"),
+								},
+							},
+						},
+					},
+				},
+			}
+			causes := validateCreationDRA(field, spec, checker)
+
+			var claimNameCause, dupCause *metav1.StatusCause
+			for i := range causes {
+				switch causes[i].Type {
+				case metav1.CauseTypeFieldValueRequired:
+					claimNameCause = &causes[i]
+				case metav1.CauseTypeFieldValueDuplicate:
+					dupCause = &causes[i]
+				}
+			}
+
+			Expect(claimNameCause).NotTo(BeNil())
+			Expect(claimNameCause.Field).To(Equal("spec.domain.devices.gpus[0].claimName"))
+
+			Expect(dupCause).NotTo(BeNil())
+			Expect(dupCause.Field).To(Equal("spec.domain.devices.gpus[2]"))
+		})
+	})
+
 	Context("non-DRA (device-plugin) HostDevices", func() {
 		It("should accept a HostDevice with deviceName", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
@@ -756,6 +839,132 @@ var _ = Describe("DRA Admitter", func() {
 			}
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(BeEmpty())
+		})
+	})
+
+	Context("mixed DRA and non-DRA HostDevices", func() {
+		It("should accept a VMI with both DRA and non-DRA HostDevices", func() {
+			checker.hostDeviceDRAEnabled = true
+			spec := &v1.VirtualMachineInstanceSpec{
+				ResourceClaims: []k8sv1.PodResourceClaim{{Name: "claim1"}},
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{
+						HostDevices: []v1.HostDevice{
+							{
+								Name:       "dp-hd",
+								DeviceName: "vfio.device.example.com",
+							},
+							{
+								Name: "dra-hd",
+								ClaimRequest: &v1.ClaimRequest{
+									ClaimName:   ptr.To("claim1"),
+									RequestName: ptr.To("req1"),
+								},
+							},
+						},
+					},
+				},
+			}
+			causes := validateCreationDRA(field, spec, checker)
+			Expect(causes).To(BeEmpty())
+		})
+	})
+
+	Context("HostDevice index accuracy", func() {
+		BeforeEach(func() {
+			checker.hostDeviceDRAEnabled = true
+		})
+
+		It("should report correct index when non-DRA devices precede a DRA device with missing claimName", func() {
+			spec := &v1.VirtualMachineInstanceSpec{
+				ResourceClaims: []k8sv1.PodResourceClaim{{Name: "claim1"}},
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{
+						HostDevices: []v1.HostDevice{
+							{
+								Name:       "dp-hd",
+								DeviceName: "vfio.device.example.com",
+							},
+							{
+								Name:         "dra-hd-invalid",
+								ClaimRequest: &v1.ClaimRequest{RequestName: ptr.To("req1")},
+							},
+						},
+					},
+				},
+			}
+			causes := validateCreationDRA(field, spec, checker)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueRequired))
+			Expect(causes[0].Message).To(ContainSubstring("claimName is required"))
+			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[1].claimName"))
+		})
+
+		It("should report correct index for duplicate when non-DRA devices are interspersed", func() {
+			spec := &v1.VirtualMachineInstanceSpec{
+				ResourceClaims: []k8sv1.PodResourceClaim{{Name: "claim1"}},
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{
+						HostDevices: []v1.HostDevice{
+							{
+								Name:       "dp-hd",
+								DeviceName: "vfio.device.example.com",
+							},
+							{
+								Name: "dra-hd-a",
+								ClaimRequest: &v1.ClaimRequest{
+									ClaimName:   ptr.To("claim1"),
+									RequestName: ptr.To("req1"),
+								},
+							},
+							{
+								Name:       "dp-hd-2",
+								DeviceName: "another.device.example.com",
+							},
+							{
+								Name: "dra-hd-dup",
+								ClaimRequest: &v1.ClaimRequest{
+									ClaimName:   ptr.To("claim1"),
+									RequestName: ptr.To("req1"),
+								},
+							},
+						},
+					},
+				},
+			}
+			causes := validateCreationDRA(field, spec, checker)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueDuplicate))
+			Expect(causes[0].Message).To(ContainSubstring("duplicate claimName/requestName"))
+			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[3]"))
+		})
+
+		It("should report correct index for invalid DRA HostDevice after non-DRA devices", func() {
+			spec := &v1.VirtualMachineInstanceSpec{
+				ResourceClaims: []k8sv1.PodResourceClaim{{Name: "claim1"}},
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{
+						HostDevices: []v1.HostDevice{
+							{
+								Name:       "dp-hd-1",
+								DeviceName: "vfio.device1.example.com",
+							},
+							{
+								Name:       "dp-hd-2",
+								DeviceName: "vfio.device2.example.com",
+							},
+							{
+								Name:         "dra-hd-invalid",
+								ClaimRequest: &v1.ClaimRequest{},
+							},
+						},
+					},
+				},
+			}
+			causes := validateCreationDRA(field, spec, checker)
+			Expect(causes).To(HaveLen(2))
+			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[2].claimName"))
+			Expect(causes[1].Field).To(Equal("spec.domain.devices.hostDevices[2].requestName"))
 		})
 	})
 

--- a/pkg/dra/metadata/types.go
+++ b/pkg/dra/metadata/types.go
@@ -59,3 +59,18 @@ const (
 	// Note: This is not yet standardized under resource.kubernetes.io
 	MDevUUIDAttribute = resourcev1.QualifiedName("mdevUUID")
 )
+
+// APIVersionV1Alpha1 is the JSON apiVersion string for KEP-5304 DRA device
+// metadata files this consumer recognizes. Will be replaced by upstream
+// types once KEP-5304 lands in kubernetes (see TODO in kubevirt.io/kubevirt/pkg/dra).
+const APIVersionV1Alpha1 = "metadata.resource.k8s.io/v1alpha1"
+
+var supportedAPIVersions = map[string]bool{
+	APIVersionV1Alpha1: true,
+}
+
+// IsSupportedAPIVersion reports whether the given apiVersion string can be
+// decoded by this consumer.
+func IsSupportedAPIVersion(v string) bool {
+	return supportedAPIVersions[v]
+}

--- a/pkg/dra/utils.go
+++ b/pkg/dra/utils.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	k8sv1 "k8s.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
@@ -43,11 +44,13 @@ func IsHostDeviceDRA(hd v1.HostDevice) bool {
 	return hd.DeviceName == "" && hd.ClaimRequest != nil
 }
 
-// DownwardAPIAttributes reads DRA device metadata files (*-metadata.json) that will be
-// automatically provided by dra driver framework KEP-5304 is implemented and consumed by drivers.
-// See: kubernetes/enhancements#5304
+// KEP-5304 defines the in-container directory layout for DRA device metadata files.
+// See: kubernetes/enhancements#5304, k8s.io/dynamic-resource-allocation/api/metadata
 const (
-	DefaultMetadataBasePath = "/var/run/dra-device-attributes"
+	DefaultMetadataBasePath      = "/var/run/kubernetes.io/dra-device-attributes"
+	resourceClaimsSubdir         = "resourceclaims"
+	resourceClaimTemplatesSubdir = "resourceclaimtemplates"
+	metadataFileSuffix           = "-metadata.json"
 )
 
 // GetPCIAddressForClaim returns the PCI address for a device in the given claim and request.
@@ -105,61 +108,39 @@ func resolveDevice(basePath string, resourceClaims []k8sv1.PodResourceClaim, cla
 }
 
 // resolveClaimMetadata reads the metadata file for a claim ref + request pair.
-// For direct claims it constructs the exact path; for template claims it
-// searches by PodClaimName.
-// KEP-5304 container path: {base}/{claimName}/{requestName}/{driverName}-metadata.json
+// Direct claims:   {base}/resourceclaims/{claimName}/{requestName}/{driverName}-metadata.json
+// Template claims: {base}/resourceclaimtemplates/{podClaimName}/{requestName}/{driverName}-metadata.json
 func resolveClaimMetadata(basePath string, resourceClaims []k8sv1.PodResourceClaim, claimRefName, requestName string) (*metadata.DeviceMetadata, error) {
 	for _, rc := range resourceClaims {
 		if rc.Name != claimRefName {
 			continue
 		}
 		if rc.ResourceClaimName != nil && *rc.ResourceClaimName != "" {
-			return readMetadataFromDir(basePath, *rc.ResourceClaimName, requestName)
+			return readMetadataFromDir(filepath.Join(basePath, resourceClaimsSubdir), *rc.ResourceClaimName, requestName)
 		}
-		return findMetadataByPodClaimName(basePath, rc.Name, requestName)
+		return readMetadataFromDir(filepath.Join(basePath, resourceClaimTemplatesSubdir), rc.Name, requestName)
 	}
 	return nil, fmt.Errorf("metadata not found for claim %q", claimRefName)
 }
 
-// readMetadataFromDir reads the metadata file at the exact path for a direct claim.
+// readMetadataFromDir reads the single metadata file matching
+// {basePath}/{claimName}/{requestName}/*-metadata.json.
+// KubeVirt expects exactly one driver per request; multiple files indicate
+// a count > 1 allocation across drivers which is not supported.
 func readMetadataFromDir(basePath, claimName, requestName string) (*metadata.DeviceMetadata, error) {
-	pattern := filepath.Join(basePath, claimName, requestName, "*-metadata.json")
+	pattern := filepath.Join(basePath, claimName, requestName, "*"+metadataFileSuffix)
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		return nil, fmt.Errorf("failed to glob for metadata file: %w", err)
+		return nil, fmt.Errorf("failed to glob metadata for claim %q request %q: %w", claimName, requestName, err)
 	}
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("metadata not found for claim %q request %q", claimName, requestName)
+		return nil, fmt.Errorf("failed to read metadata for claim %q request %q: no files matching %s", claimName, requestName, pattern)
 	}
-	md, err := readMetadataFile(matches[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to read metadata for claim %q request %q: %w", claimName, requestName, err)
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("found %d metadata files for claim %q request %q but KubeVirt only supports exactly one driver per request", len(matches), claimName, requestName)
 	}
-	return md, nil
-}
-
-// findMetadataByPodClaimName searches for a template-generated claim's metadata
-// file by matching PodClaimName, scoped to the given request name.
-func findMetadataByPodClaimName(basePath, podClaimName, requestName string) (*metadata.DeviceMetadata, error) {
-	pattern := filepath.Join(basePath, "*", requestName, "*-metadata.json")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return nil, fmt.Errorf("failed to glob for metadata file: %w", err)
-	}
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("no metadata file found for templateclaim %q request %q", podClaimName, requestName)
-	}
-	for _, file := range matches {
-		md, err := readMetadataFile(file)
-		if err != nil {
-			log.Log.Reason(err).Warningf("Skipping metadata file %s", file)
-			continue
-		}
-		if md.PodClaimName != nil && *md.PodClaimName == podClaimName {
-			return md, nil
-		}
-	}
-	return nil, fmt.Errorf("no metadata file found with matching with pod claim name %q request %q", podClaimName, requestName)
+	log.Log.Infof("Reading DRA device metadata file %s", matches[0])
+	return readMetadataFile(matches[0])
 }
 
 func metadataRequestNames(md *metadata.DeviceMetadata) []string {
@@ -170,14 +151,61 @@ func metadataRequestNames(md *metadata.DeviceMetadata) []string {
 	return names
 }
 
+// readMetadataFile reads a KEP-5304 metadata file. The file is a JSON stream
+// containing the same data encoded once per API version (newest first).
+// We iterate through the stream and decode the first object whose apiVersion
+// we understand, skipping unknown versions so that a driver upgrade does not
+// break older consumers.
 func readMetadataFile(path string) (*metadata.DeviceMetadata, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading metadata file %q: %w", path, err)
+		return nil, fmt.Errorf("opening metadata file %q: %w", path, err)
 	}
-	var md metadata.DeviceMetadata
-	if err := json.Unmarshal(data, &md); err != nil {
-		return nil, fmt.Errorf("parsing metadata file %q: %w", path, err)
+	defer f.Close()
+
+	md, err := decodeMetadataFromStream(json.NewDecoder(f))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
 	}
-	return &md, nil
+	return md, nil
+}
+
+// decodeMetadataFromStream is a lightweight equivalent of
+// devicemetadata.DecodeMetadataFromStream that iterates a JSON stream and
+// returns the first object whose apiVersion is supported. Entries whose
+// apiVersion is not supported by KubeVirt (e.g. a newer version written by an
+// upgraded driver) are skipped silently. Any other failure is fatal.
+func decodeMetadataFromStream(dec *json.Decoder) (*metadata.DeviceMetadata, error) {
+	var unknownVersions []string
+	for dec.More() {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("read object from metadata stream: %w", err)
+		}
+
+		var peek struct {
+			APIVersion string `json:"apiVersion"`
+		}
+		if err := json.Unmarshal(raw, &peek); err != nil {
+			return nil, fmt.Errorf("decode metadata object: %w", err)
+		}
+		if peek.APIVersion == "" {
+			return nil, fmt.Errorf("decode metadata object: missing apiVersion")
+		}
+
+		if !metadata.IsSupportedAPIVersion(peek.APIVersion) {
+			unknownVersions = append(unknownVersions, peek.APIVersion)
+			continue
+		}
+
+		var md metadata.DeviceMetadata
+		if err := json.Unmarshal(raw, &md); err != nil {
+			return nil, fmt.Errorf("decode %s: %w", peek.APIVersion, err)
+		}
+		return &md, nil
+	}
+	if len(unknownVersions) == 0 {
+		return nil, fmt.Errorf("no metadata objects found in stream")
+	}
+	return nil, fmt.Errorf("no compatible metadata version found in stream (unknown versions: %s)", strings.Join(unknownVersions, ", "))
 }

--- a/pkg/dra/utils_test.go
+++ b/pkg/dra/utils_test.go
@@ -21,6 +21,7 @@ package dra
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -50,21 +51,31 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		os.RemoveAll(tempDir)
 	})
 
-	// KEP-5304 path: {base}/{claimName}/{requestName}/{driver}-metadata.json
-	createMetadataFile := func(claimName, requestName, driver string, md *metadata.DeviceMetadata) {
-		dir := filepath.Join(tempDir, claimName, requestName)
+	// Direct claims:   {base}/resourceclaims/{claimName}/{requestName}/{driverName}-metadata.json
+	// Template claims: {base}/resourceclaimtemplates/{podClaimName}/{requestName}/{driverName}-metadata.json
+	writeMetadataJSON := func(dir, driverName string, md *metadata.DeviceMetadata) {
 		Expect(os.MkdirAll(dir, 0755)).To(Succeed())
-
+		md.APIVersion = metadata.APIVersionV1Alpha1
+		md.Kind = "DeviceMetadata"
 		data, err := json.Marshal(md)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(dir, driverName+metadataFileSuffix), data, 0644)).To(Succeed())
+	}
 
-		Expect(os.WriteFile(filepath.Join(dir, driver+"-metadata.json"), data, 0644)).To(Succeed())
+	createMetadataFile := func(claimName, requestName string, md *metadata.DeviceMetadata) {
+		dir := filepath.Join(tempDir, resourceClaimsSubdir, claimName, requestName)
+		writeMetadataJSON(dir, "gpu.example.com", md)
+	}
+
+	createTemplateMetadataFile := func(podClaimName, requestName string, md *metadata.DeviceMetadata) {
+		dir := filepath.Join(tempDir, resourceClaimTemplatesSubdir, podClaimName, requestName)
+		writeMetadataJSON(dir, "gpu.example.com", md)
 	}
 
 	Context("lazy resolution", func() {
 		It("should resolve metadata for pre-existing claims (ResourceClaimName)", func() {
 			pciAddr := "0000:02:00.0"
-			createMetadataFile("my-gpu-claim", "gpu-request", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("my-gpu-claim", "gpu-request", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gpu-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "gpu-request",
@@ -91,7 +102,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 		It("should resolve metadata for template-generated claims (ResourceClaimTemplateName)", func() {
 			mdevUUID := "123e4567-e89b-12d3-a456-426614174000"
-			createMetadataFile("generated-claim-abc123", "vgpu-request", "gpu.example.com", &metadata.DeviceMetadata{
+			createTemplateMetadataFile("vmi-template-ref", "vgpu-request", &metadata.DeviceMetadata{
 				ObjectMeta:   metav1.ObjectMeta{Name: "generated-claim-abc123"},
 				PodClaimName: ptr.To("vmi-template-ref"),
 				Requests: []metadata.DeviceMetadataRequest{{
@@ -125,14 +136,14 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "missing-claim", "req1")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("metadata not found"))
+			Expect(err.Error()).To(ContainSubstring("failed to read metadata"))
 		})
 	})
 
 	Context("GetPCIAddressForClaim", func() {
 		It("should return the PCI address when present", func() {
 			pciAddr := "0000:03:00.0"
-			createMetadataFile("pci-claim", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("pci-claim", "req1", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "pci-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "req1",
@@ -161,7 +172,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		})
 
 		It("should return error when request not found in metadata file", func() {
-			createMetadataFile("claim1", "other-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("claim1", "other-req", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "other-req",
@@ -178,11 +189,11 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "missing-req")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("metadata not found for claim"))
+			Expect(err.Error()).To(ContainSubstring("failed to read metadata for claim"))
 		})
 
 		It("should return error when pciBusID attribute not present", func() {
-			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("claim1", "req1", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name:    "req1",
@@ -203,7 +214,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		It("should return error when request has multiple devices (count > 1)", func() {
 			pciAddr1 := "0000:03:00.0"
 			pciAddr2 := "0000:04:00.0"
-			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("claim1", "req1", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "req1",
@@ -232,7 +243,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	Context("GetMDevUUIDForClaim", func() {
 		It("should return the mdev UUID when present", func() {
 			uuid := "abcd1234-5678-90ab-cdef-1234567890ab"
-			createMetadataFile("mdev-claim", "vgpu-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("mdev-claim", "vgpu-req", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "mdev-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "vgpu-req",
@@ -262,7 +273,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 		It("should return error when mdevUUID attribute not present", func() {
 			pciAddr := "0000:01:00.0"
-			createMetadataFile("pci-only", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("pci-only", "req1", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "pci-only"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "req1",
@@ -290,7 +301,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			pciAddr := "0000:04:00.0"
 			mdevUUID := "11111111-2222-3333-4444-555555555555"
 
-			createMetadataFile("gpu-claim", "gpu-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("gpu-claim", "gpu-req", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "gpu-req",
@@ -302,7 +313,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				}},
 			})
 
-			createMetadataFile("vgpu-claim", "vgpu-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("vgpu-claim", "vgpu-req", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "vgpu-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "vgpu-req",
@@ -332,7 +343,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	Context("ResourceClaimTemplateName claims", func() {
 		It("should return PCI address for template-generated claim", func() {
 			pciAddr := "0000:05:00.0"
-			createMetadataFile("generated-pci-claim-xyz", "pci-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createTemplateMetadataFile("template-gpu-claim", "pci-req", &metadata.DeviceMetadata{
 				ObjectMeta:   metav1.ObjectMeta{Name: "generated-pci-claim-xyz"},
 				PodClaimName: ptr.To("template-gpu-claim"),
 				Requests: []metadata.DeviceMetadataRequest{{
@@ -357,7 +368,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 		It("should return mdev UUID for template-generated claim", func() {
 			mdevUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-			createMetadataFile("generated-vgpu-claim-abc", "vgpu-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createTemplateMetadataFile("template-vgpu-claim", "vgpu-req", &metadata.DeviceMetadata{
 				ObjectMeta:   metav1.ObjectMeta{Name: "generated-vgpu-claim-abc"},
 				PodClaimName: ptr.To("template-vgpu-claim"),
 				Requests: []metadata.DeviceMetadataRequest{{
@@ -384,7 +395,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			pciAddr := "0000:06:00.0"
 			mdevUUID := "12121212-3434-5656-7878-909090909090"
 
-			createMetadataFile("preexisting-claim", "pci-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("preexisting-claim", "pci-req", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "preexisting-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "pci-req",
@@ -396,7 +407,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				}},
 			})
 
-			createMetadataFile("generated-claim-def456", "vgpu-req", "gpu.example.com", &metadata.DeviceMetadata{
+			createTemplateMetadataFile("my-template-claim", "vgpu-req", &metadata.DeviceMetadata{
 				ObjectMeta:   metav1.ObjectMeta{Name: "generated-claim-def456"},
 				PodClaimName: ptr.To("my-template-claim"),
 				Requests: []metadata.DeviceMetadataRequest{{
@@ -431,13 +442,13 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "missing-template-claim", "req1")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no metadata file found"))
+			Expect(err.Error()).To(ContainSubstring("failed to read metadata"))
 		})
 	})
 
 	Context("request name mismatch in metadata content", func() {
 		It("should return error with available requests when request not found in metadata JSON", func() {
-			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+			createMetadataFile("claim1", "req1", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "actual-req",
@@ -457,6 +468,174 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			Expect(err.Error()).To(ContainSubstring("not found in metadata for claim"))
 			Expect(err.Error()).To(ContainSubstring("claim1"))
 			Expect(err.Error()).To(ContainSubstring("available requests: [actual-req]"))
+		})
+	})
+
+	Context("multiple driver files per request", func() {
+		It("should reject when multiple metadata files exist for the same request", func() {
+			pciAddr1 := "0000:08:00.0"
+			pciAddr2 := "0000:09:00.0"
+
+			dir := filepath.Join(tempDir, resourceClaimsSubdir, "multi-driver-claim", "gpu-req")
+			writeMetadataJSON(dir, "gpu-a.example.com", &metadata.DeviceMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "multi-driver-claim"},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "gpu-req",
+					Devices: []metadata.Device{{
+						Driver: "gpu-a.example.com",
+						Pool:   "worker-0",
+						Name:   "gpu-0",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.PCIBusIDAttribute: {StringValue: &pciAddr1},
+						},
+					}},
+				}},
+			})
+			writeMetadataJSON(dir, "gpu-b.example.com", &metadata.DeviceMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "multi-driver-claim"},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "gpu-req",
+					Devices: []metadata.Device{{
+						Driver: "gpu-b.example.com",
+						Pool:   "worker-0",
+						Name:   "gpu-1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.PCIBusIDAttribute: {StringValue: &pciAddr2},
+						},
+					}},
+				}},
+			})
+
+			resourceClaims := []k8sv1.PodResourceClaim{{
+				Name:              "my-claim",
+				ResourceClaimName: ptr.To("multi-driver-claim"),
+			}}
+
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "gpu-req")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("only supports exactly one driver per request"))
+		})
+	})
+
+	Context("JSON stream version negotiation", func() {
+		writeRawStreamFile := func(claimName, requestName, driverName string, objects ...string) {
+			dir := filepath.Join(tempDir, resourceClaimsSubdir, claimName, requestName)
+			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			var content []byte
+			for _, obj := range objects {
+				content = append(content, []byte(obj+"\n")...)
+			}
+			Expect(os.WriteFile(filepath.Join(dir, driverName+metadataFileSuffix), content, 0644)).To(Succeed())
+		}
+
+		It("should skip unknown apiVersion and decode v1alpha1 from stream", func() {
+			pciAddr := "0000:07:00.0"
+			v2Obj := `{"apiVersion":"metadata.resource.k8s.io/v2beta1","kind":"DeviceMetadata","metadata":{"name":"claim1"},"newField":"ignored"}`
+			v1Obj, err := json.Marshal(&metadata.DeviceMetadata{
+				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: "DeviceMetadata"},
+				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
+						},
+					}},
+				}},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			writeRawStreamFile("claim1", "req1", "gpu.example.com", v2Obj, string(v1Obj))
+
+			resourceClaims := []k8sv1.PodResourceClaim{{
+				Name:              "my-claim",
+				ResourceClaimName: ptr.To("claim1"),
+			}}
+			addr, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(addr).To(Equal(pciAddr))
+		})
+
+		It("should return error when stream contains only unsupported versions", func() {
+			writeRawStreamFile("claim2", "req1", "gpu.example.com",
+				`{"apiVersion":"metadata.resource.k8s.io/v99","kind":"DeviceMetadata"}`,
+			)
+
+			resourceClaims := []k8sv1.PodResourceClaim{{
+				Name:              "my-claim",
+				ResourceClaimName: ptr.To("claim2"),
+			}}
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no compatible metadata version found in stream (unknown versions: metadata.resource.k8s.io/v99)"))
+		})
+
+		It("should return error on empty stream", func() {
+			writeRawStreamFile("claim3", "req1", "gpu.example.com")
+
+			resourceClaims := []k8sv1.PodResourceClaim{{
+				Name:              "my-claim",
+				ResourceClaimName: ptr.To("claim3"),
+			}}
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no metadata objects"))
+		})
+
+		It("should fail if an entry's apiVersion cannot be peeked even when a later entry is valid", func() {
+			pciAddr := "0000:0a:00.0"
+			v1Obj, err := json.Marshal(&metadata.DeviceMetadata{
+				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: "DeviceMetadata"},
+				ObjectMeta: metav1.ObjectMeta{Name: "claim4"},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
+						},
+					}},
+				}},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			writeRawStreamFile("claim4", "req1", "gpu.example.com",
+				`"not-an-object"`,
+				string(v1Obj),
+			)
+
+			resourceClaims := []k8sv1.PodResourceClaim{{
+				Name:              "my-claim",
+				ResourceClaimName: ptr.To("claim4"),
+			}}
+			_, err = GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("decode metadata object"))
+		})
+
+		It("should fail if a supported-version entry fails to unmarshal even when a later entry is valid", func() {
+			pciAddr := "0000:0b:00.0"
+			badV1 := fmt.Sprintf(`{"apiVersion":%q,"kind":"DeviceMetadata","metadata":{"name":"claim5"},"requests":"this-should-be-an-array"}`, metadata.APIVersionV1Alpha1)
+			goodV1, err := json.Marshal(&metadata.DeviceMetadata{
+				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: "DeviceMetadata"},
+				ObjectMeta: metav1.ObjectMeta{Name: "claim5"},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
+						},
+					}},
+				}},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			writeRawStreamFile("claim5", "req1", "gpu.example.com", badV1, string(goodV1))
+
+			resourceClaims := []k8sv1.PodResourceClaim{{
+				Name:              "my-claim",
+				ResourceClaimName: ptr.To("claim5"),
+			}}
+			_, err = GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("decode %s", metadata.APIVersionV1Alpha1)))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
@@ -64,7 +64,7 @@ func CreateDRAHostDevices(vmi *v1.VirtualMachineInstance, basePath string) ([]ap
 }
 
 func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, vmiSpecs v1.VirtualMachineInstanceSpec) (*api.HostDevice, error) {
-	if hd.ClaimRequest == nil || hd.ClaimRequest.ClaimName == nil || hd.ClaimRequest.RequestName == nil {
+	if hd.ClaimRequest == nil || hd.ClaimRequest.ClaimName == nil || *hd.ClaimRequest.ClaimName == "" || hd.ClaimRequest.RequestName == nil || *hd.ClaimRequest.RequestName == "" {
 		return nil, fmt.Errorf("HostDevice %s has incomplete ClaimRequest", hd.Name)
 	}
 
@@ -75,7 +75,8 @@ func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, vmiSpecs v
 	// Check mdevUUID first: a device with both pciBusID and mdevUUID is a
 	// mediated (vGPU) device whose parent happens to expose pciBusID. Treating
 	// it as PCI passthrough would be incorrect.
-	if mdevUUID, err := drautil.GetMDevUUIDForClaim(basePath, resourceClaims, claimName, requestName); err == nil {
+	mdevUUID, mdevErr := drautil.GetMDevUUIDForClaim(basePath, resourceClaims, claimName, requestName)
+	if mdevErr == nil {
 		log.Log.V(2).Infof("Adding DRA MDEV HostDevice for %s", hd.Name)
 		model := "vfio-pci"
 		if vmiSpecs.Architecture == "s390x" {
@@ -94,7 +95,8 @@ func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, vmiSpecs v
 		}, nil
 	}
 
-	if pciAddr, err := drautil.GetPCIAddressForClaim(basePath, resourceClaims, claimName, requestName); err == nil {
+	pciAddr, pciErr := drautil.GetPCIAddressForClaim(basePath, resourceClaims, claimName, requestName)
+	if pciErr == nil {
 		log.Log.V(2).Infof("Adding DRA PCI HostDevice for %s", hd.Name)
 		hostAddr, err := device.NewPciAddressField(pciAddr)
 		if err != nil {
@@ -108,7 +110,7 @@ func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, vmiSpecs v
 		}, nil
 	}
 
-	return nil, fmt.Errorf("HostDevice %s has no mdevUUID or pciBusID in metadata for claim %s request %s", hd.Name, claimName, requestName)
+	return nil, fmt.Errorf("HostDevice %s has no mdevUUID or pciBusID in metadata for claim %s request %s (mdev: %v, pci: %v)", hd.Name, claimName, requestName, mdevErr, pciErr)
 }
 
 func validateCreationOfDRAHostDevices(genericHostDevices []v1.HostDevice, hostDevices []api.HostDevice) error {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev_test.go
@@ -34,9 +34,8 @@ var _ = Describe("CreateDRAHostDevices", func() {
 		os.RemoveAll(tempDir)
 	})
 
-	// KEP-5304 path: {base}/{claimName}/{requestName}/{driver}-metadata.json
 	createMetadataFile := func(claimName, requestName, driver string, md *metadata.DeviceMetadata) {
-		dir := filepath.Join(tempDir, claimName, requestName)
+		dir := filepath.Join(tempDir, "resourceclaims", claimName, requestName)
 		Expect(os.MkdirAll(dir, 0755)).To(Succeed())
 
 		data, err := json.Marshal(md)
@@ -65,7 +64,7 @@ var _ = Describe("CreateDRAHostDevices", func() {
 			createMetadataFile("claim1", "req1", "device.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",
@@ -120,7 +119,7 @@ var _ = Describe("CreateDRAHostDevices", func() {
 			createMetadataFile("claim1", "req1", "mdev.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",
@@ -177,7 +176,7 @@ var _ = Describe("CreateDRAHostDevices", func() {
 			createMetadataFile("claim1", "req1", "mdev.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",
@@ -235,7 +234,7 @@ var _ = Describe("CreateDRAHostDevices", func() {
 			createMetadataFile("claim1", "req1", "device.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
@@ -79,7 +79,7 @@ func CreateDRAGPUHostDevices(vmi *v1.VirtualMachineInstance, basePath string) ([
 }
 
 func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []k8sv1.PodResourceClaim) (*api.HostDevice, error) {
-	if gpu.ClaimRequest == nil || gpu.ClaimRequest.ClaimName == nil || gpu.ClaimRequest.RequestName == nil {
+	if gpu.ClaimRequest == nil || gpu.ClaimRequest.ClaimName == nil || *gpu.ClaimRequest.ClaimName == "" || gpu.ClaimRequest.RequestName == nil || *gpu.ClaimRequest.RequestName == "" {
 		return nil, fmt.Errorf("GPU %s has incomplete ClaimRequest", gpu.Name)
 	}
 
@@ -89,7 +89,8 @@ func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []k8sv1.
 	// Check mdevUUID first: a device with both pciBusID and mdevUUID is a
 	// mediated (vGPU) device whose parent happens to expose pciBusID. Treating
 	// it as PCI passthrough would be incorrect.
-	if mdevUUID, err := drautil.GetMDevUUIDForClaim(basePath, resourceClaims, claimName, requestName); err == nil {
+	mdevUUID, mdevErr := drautil.GetMDevUUIDForClaim(basePath, resourceClaims, claimName, requestName)
+	if mdevErr == nil {
 		log.Log.V(2).Infof("Adding DRA MDEV GPU device for %s", gpu.Name)
 		hostDevice := api.HostDevice{
 			Alias: api.NewUserDefinedAlias(AliasPrefix + gpu.Name),
@@ -115,7 +116,8 @@ func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []k8sv1.
 		return &hostDevice, nil
 	}
 
-	if pciAddr, err := drautil.GetPCIAddressForClaim(basePath, resourceClaims, claimName, requestName); err == nil {
+	pciAddr, pciErr := drautil.GetPCIAddressForClaim(basePath, resourceClaims, claimName, requestName)
+	if pciErr == nil {
 		log.Log.V(2).Infof("Adding DRA PCI GPU device for %s", gpu.Name)
 		hostAddr, err := device.NewPciAddressField(pciAddr)
 		if err != nil {
@@ -129,7 +131,7 @@ func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []k8sv1.
 		}, nil
 	}
 
-	return nil, fmt.Errorf("GPU %s has no mdevUUID or pciBusID in metadata for claim %s request %s", gpu.Name, claimName, requestName)
+	return nil, fmt.Errorf("GPU %s has no mdevUUID or pciBusID in metadata for claim %s request %s (mdev: %v, pci: %v)", gpu.Name, claimName, requestName, mdevErr, pciErr)
 }
 
 func hasGPUsWithDRA(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
@@ -41,9 +41,8 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 		os.RemoveAll(tempDir)
 	})
 
-	// KEP-5304 path: {base}/{claimName}/{requestName}/{driver}-metadata.json
 	createMetadataFile := func(claimName, requestName, driver string, md *metadata.DeviceMetadata) {
-		dir := filepath.Join(tempDir, claimName, requestName)
+		dir := filepath.Join(tempDir, "resourceclaims", claimName, requestName)
 		Expect(os.MkdirAll(dir, 0755)).To(Succeed())
 
 		data, err := json.Marshal(md)
@@ -77,7 +76,7 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",
@@ -140,7 +139,7 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",
@@ -204,7 +203,7 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",
@@ -269,7 +268,7 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			createMetadataFile("pgpu-claim", "gpu", "gpu.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pgpu-claim",
@@ -290,7 +289,7 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			createMetadataFile("vgpu-claim", "vgpu", "gpu.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "vgpu-claim",
@@ -372,7 +371,7 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DeviceMetadata",
-					APIVersion: "v1alpha1",
+					APIVersion: metadata.APIVersionV1Alpha1,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "claim1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
virt-launcher scanned all metadata files in a flat directory to find attributes for DRA devices, because the system-generated ResourceClaim name for template claims was not available at lookup time.

#### After this PR:
Adopts the KEP-5304 directory layout for DRA device metadata. Metadata is now read from structured paths `/var/run/kubernetes.io/dra-device-attributes/{resourceclaims,resourceclaimtemplates}/<claimName>/<requestName>/<driverName>-metadata.json`, using the pod-level claim name for templates so no scanning is needed. 

Metadata files are decoded as versioned JSON streams, skipping unsupported API versions for forward compatibility with newer drivers. 

Additionally, the DRA admitter validation is refactored to de-duplicate GPU and HostDevice checks, and error handling for unresolvable devices is improved.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VEP-10: bug fixes for DRA Devices to align kubevirt implementation to KEP-5304
```

