### PR TITLE
Add KubeletRootDir in KubeVirtDeploymentConfig

### DIFF
--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	VirtHandlerName                = "virt-handler"
-	kubeletPodsPath                = util.KubeletRoot + "/pods"
 	runtimesPath                   = "/var/run/kubevirt-libvirt-runtimes"
 	PrHelperName                   = "pr-helper"
 	prVolumeName                   = "pr-helper-socket-vol"
@@ -68,7 +67,13 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 }
 
 func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productName, productVersion, productComponent string) *appsv1.DaemonSet {
+	kubeletRootDir  := util.KubeletRoot
+	kubeletPodsPath := kubeletRootDir + "/pods"
 
+	if config.GetKubeletRootDir() != "" {
+		kubeletRootDir = config.GetKubeletRootDir()
+		kubeletPodsPath = kubeletRootDir + "/pods"
+	}
 	deploymentName := VirtHandlerName
 	imageName := fmt.Sprintf("%s%s", config.GetImagePrefix(), deploymentName)
 	image := config.VirtHandlerImage
@@ -315,7 +320,7 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 		{"virt-share-dir", util.VirtShareDir, util.VirtShareDir, &bidi},
 		{"virt-private-dir", util.VirtPrivateDir, util.VirtPrivateDir, nil},
 		{"kubelet-pods", kubeletPodsPath, "/pods", nil},
-		{"kubelet", util.KubeletRoot, util.KubeletRoot, &bidi},
+		{"kubelet", kubeletRootDir, kubeletRootDir, &bidi},
 		{"node-labeller", nodeLabellerVolumePath, nodeLabellerVolumePath, nil},
 	}
 
@@ -384,22 +389,24 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 					Path: reservation.GetPrHelperSocketDir(),
 					Type: &directoryOrCreate,
 				},
-			}}, corev1.Volume{
+			},
+		}, corev1.Volume{
 			Name: devDirVol,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/dev",
 				},
-			}}, corev1.Volume{
+			},
+		}, corev1.Volume{
 			Name: etcMultipath,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/etc/multipath",
 					Type: pointer.P(corev1.HostPathDirectoryOrCreate),
 				},
-			}})
+			},
+		})
 		pod.Containers = append(pod.Containers, RenderPrHelperContainer(prHelperImage, config.GetImagePullPolicy()))
 	}
 	return daemonset
-
 }

--- a/pkg/virt-operator/resource/generate/components/daemonsets_test.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets_test.go
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package components
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
+)
+
+var _ = Describe("DaemonSets", func() {
+
+	Context("virt-handler with custom KubeletRootDir", func() {
+		It("should use custom kubelet root path in volumes when KubeletRootDir is set", func() {
+			customKubeletRoot := "/custom/var/lib/kubelet"
+			config := &operatorutil.KubeVirtDeploymentConfig{
+				Registry:        "reg.io/kubevirt",
+				KubeVirtVersion: "v1.2.3",
+				Namespace:       "kubevirt",
+				KubeletRootDir:  customKubeletRoot,
+			}
+
+			ds := NewHandlerDaemonSet(config, "", "", "")
+
+			var kubeletVol, kubeletPodsVol *corev1.Volume
+			for i := range ds.Spec.Template.Spec.Volumes {
+				v := &ds.Spec.Template.Spec.Volumes[i]
+				switch v.Name {
+				case "kubelet":
+					kubeletVol = v
+				case "kubelet-pods":
+					kubeletPodsVol = v
+				}
+			}
+			Expect(kubeletVol).ToNot(BeNil(), "kubelet volume should exist")
+			Expect(kubeletPodsVol).ToNot(BeNil(), "kubelet-pods volume should exist")
+			Expect(kubeletVol.VolumeSource.HostPath).ToNot(BeNil())
+			Expect(kubeletVol.VolumeSource.HostPath.Path).To(Equal(customKubeletRoot))
+			Expect(kubeletPodsVol.VolumeSource.HostPath).ToNot(BeNil())
+			Expect(kubeletPodsVol.VolumeSource.HostPath.Path).To(Equal(customKubeletRoot + "/pods"))
+		})
+	})
+})

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -157,6 +157,10 @@ type KubeVirtDeploymentConfig struct {
 
 	// the images names of every image we use
 	ComponentImages
+	// KubeletRootDir is the path to the kubelet root directory on the node (e.g. /var/lib/kubelet).
+	// When set, the install strategy is generated with virt-handler volumes using this path.
+	KubeletRootDir string `json:"kubeletRootDir,omitempty" optional:"true"`
+
 	// everything else, which can e.g. come from KubeVirt CR spec
 	AdditionalProperties map[string]string `json:"additionalProperties,omitempty" optional:"true"`
 
@@ -203,11 +207,15 @@ func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVa
 	}
 	// don't use status.target* here, as that is always set, but we need to know if it was set by the spec and with that
 	// overriding shasums from env vars
-	return getConfig(kv.Spec.ImageRegistry,
+	config := getConfig(kv.Spec.ImageRegistry,
 		kv.Spec.ImageTag,
 		kv.Namespace,
 		additionalProperties,
 		envVarManager)
+	if kv.Spec.CustomizeComponents.Flags != nil && kv.Spec.CustomizeComponents.Flags.Handler != nil && kv.Spec.CustomizeComponents.Flags.Handler["kubelet-root"] != "" {
+		config.KubeletRootDir = kv.Spec.CustomizeComponents.Flags.Handler["kubelet-root"]
+	}
+	return config
 }
 
 func isFeatureGateEnabledInKvConfig(kvConfig *v1.KubeVirtConfiguration, featureGate string) bool {
@@ -703,6 +711,10 @@ func fieldsToString(v reflect.Value) string {
 
 func (c *KubeVirtDeploymentConfig) GetDeploymentID() string {
 	return c.ID
+}
+
+func (c *KubeVirtDeploymentConfig) GetKubeletRootDir() string {
+	return c.KubeletRootDir
 }
 
 func (c *KubeVirtDeploymentConfig) GetJson() (string, error) {

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -413,4 +413,51 @@ var _ = Describe("Operator Config", func() {
 					version:   "latest",
 				}))
 	})
+
+	Context("KubeletRootDir", func() {
+		DescribeTable(" KubeletRootDir set from Handler kubelet-root flag",
+			func(kv *v1.KubeVirt, expectKubeletRootDir string) {
+				Expect(envVarManager.Setenv(VirtOperatorImageEnvName, "registry.io/kubevirt/virt-operator:v1.2.3")).To(Succeed())
+				err := VerifyEnv()
+				Expect(err).ToNot(HaveOccurred())
+
+				config := GetTargetConfigFromKVWithEnvVarManager(kv, envVarManager)
+				Expect(config.KubeletRootDir).To(Equal(expectKubeletRootDir))
+			},
+			Entry("when CustomizeComponents.Flags.Handler has kubelet-root set",
+				&v1.KubeVirt{
+					Spec: v1.KubeVirtSpec{
+						CustomizeComponents: v1.CustomizeComponents{
+							Flags: &v1.Flags{
+								Handler: map[string]string{"kubelet-root": "/custom/kubelet/root"},
+							},
+						},
+					},
+				},
+				"/custom/kubelet/root"),
+			Entry("when CustomizeComponents.Flags is nil",
+				&v1.KubeVirt{Spec: v1.KubeVirtSpec{}},
+				""),
+			Entry("when CustomizeComponents.Flags.Handler is nil",
+				&v1.KubeVirt{
+					Spec: v1.KubeVirtSpec{
+						CustomizeComponents: v1.CustomizeComponents{
+							Flags: &v1.Flags{},
+						},
+					},
+				},
+				""),
+			Entry("when kubelet-root flag is empty",
+				&v1.KubeVirt{
+					Spec: v1.KubeVirtSpec{
+						CustomizeComponents: v1.CustomizeComponents{
+							Flags: &v1.Flags{
+								Handler: map[string]string{"kubelet-root": ""},
+							},
+						},
+					},
+				},
+				""),
+		)
+	})
 })


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Flag kubelet-root is passed to virt-handler, but volumes of daemoset are not updated.

#### After this PR:

If kubelet-root passed as flag to virt-handler, volumes are updated to use it as wel. Value kubelet-root is stored in KubeVirtDeploymentConfig.

Fixes: #5913


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


```release-note
kubelet-root value from CustomizeComponents flag is now passed to virt-handler daemonset volumes
```

