### PR TITLE
Cirros to AlpineWithTestTooling image change for portforward test

### DIFF
--- a/tests/libnet/vmnetserver/BUILD.bazel
+++ b/tests/libnet/vmnetserver/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//tests/console:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/tests/libnet/vmnetserver/servers.go
+++ b/tests/libnet/vmnetserver/servers.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	expect "github.com/google/goexpect"
@@ -37,12 +38,21 @@ import (
 type server string
 
 const (
-	TCPServer  = server("\"Hello World!\"&\n")
-	HTTPServer = server("\"HTTP/1.1 200 OK\\nContent-Length: 12\\n\\nHello World!\"&\n")
+	TCPServer  = server("'Hello World!'")
+	HTTPServer = server("printf \"HTTP/1.1 200 OK\nContent-Length: 12\n\nHello World!\"; sleep 2")
 )
 
-func (s server) composeNetcatServerCommand(port int, extraArgs ...string) string {
-	return fmt.Sprintf("nc %s -klp %d -e echo -e %s", strings.Join(extraArgs, " "), port, string(s))
+func (s server) composeServerCommand(port int, extraArgs ...string) string {
+	ncBase := fmt.Sprintf("nc %s -klp %d", strings.Join(extraArgs, " "), port)
+	switch s {
+	case HTTPServer:
+		return fmt.Sprintf("%s -e sh -c %q&", ncBase, string(s))
+	case TCPServer:
+		return fmt.Sprintf("%s -e printf %s&\n", ncBase, string(s))
+	default:
+		Fail(fmt.Sprintf("unknown server type: %q", s))
+		return ""
+	}
 }
 
 func StartTCPServer(vmi *v1.VirtualMachineInstance, port int, loginTo console.LoginToFunction) {
@@ -88,5 +98,5 @@ EOL`, inetSuffix, port)
 }
 
 func (s server) Start(vmi *v1.VirtualMachineInstance, port int, extraArgs ...string) {
-	Expect(console.RunCommand(vmi, s.composeNetcatServerCommand(port, extraArgs...), 60*time.Second)).To(Succeed())
+	Expect(console.RunCommand(vmi, s.composeServerCommand(port, extraArgs...), 60*time.Second)).To(Succeed())
 }

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -72,8 +72,8 @@ var _ = Describe(SIG("Port-forward", func() {
 				Skip(skipIPv6Message)
 			}
 
-			vmi := createCirrosVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
-			vmnetserver.StartHTTPServerWithSourceIP(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
+			vmi := createAlpineVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
+			vmnetserver.StartHTTPServerWithSourceIP(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToAlpine)
 
 			localPort = 1500 + GinkgoParallelProcess()
 			vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -163,15 +163,15 @@ func killPortForwardCommand(portForwardCmd *exec.Cmd) error {
 	return err
 }
 
-func createCirrosVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClient, ports []v1.Port) *v1.VirtualMachineInstance {
-	vmi := libvmifact.NewCirros(
+func createAlpineVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClient, ports []v1.Port) *v1.VirtualMachineInstance {
+	vmi := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 	)
 
 	vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 	return vmi
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:
portforward test is not enabled for s390x.

#### After this PR:
Cirros is not supported on s390x. I have replaced the `cirros` to `alpinewithtesttooling` image for the portforward test of the sig-network e2e tests inorder to enable it for s390x. Used `printf` instead of `echo -e` as Alpine/BusyBox echo does not support -e. The benchmarks(time taken for the tests) of the test runs are collected and the benchmarks are normal and there is no increase in the test time taken. They are getting tracked in the below github issue.

Partially addresses: https://github.com/kubevirt/kubevirt/issues/15043

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

```release-note
NONE
```

