### PR TITLE
Decouple k8s and kv client in pkg/instancetype

### DIFF
--- a/pkg/instancetype/controller/vm/BUILD.bazel
+++ b/pkg/instancetype/controller/vm/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],

--- a/pkg/instancetype/controller/vm/controller.go
+++ b/pkg/instancetype/controller/vm/controller.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
@@ -81,27 +81,39 @@ type controller struct {
 	instancetypeFindHandler
 	preferenceFindHandler
 
-	clientset     kubecli.KubevirtClient
+	virtClient    kubecli.KubevirtClient
+	k8sClient     kubernetes.Interface
 	clusterConfig *virtconfig.ClusterConfig
 	recorder      record.EventRecorder
 }
 
 func New(
 	instancetypeStore, clusterInstancetypeStore, preferenceStore, clusterPreferenceStore, revisionStore cache.Store,
-	virtClient kubecli.KubevirtClient, clusterConfig *virtconfig.ClusterConfig, recorder record.EventRecorder,
+	virtClient kubecli.KubevirtClient,
+	k8sClient kubernetes.Interface,
+	clusterConfig *virtconfig.ClusterConfig,
+	recorder record.EventRecorder,
 ) *controller {
-	finder := find.NewSpecFinder(instancetypeStore, clusterInstancetypeStore, revisionStore, virtClient)
-	prefFinder := preferencefind.NewSpecFinder(preferenceStore, clusterPreferenceStore, revisionStore, virtClient)
+	finder := find.NewSpecFinder(instancetypeStore, clusterInstancetypeStore, revisionStore, virtClient, k8sClient)
+	prefFinder := preferencefind.NewSpecFinder(preferenceStore, clusterPreferenceStore, revisionStore, virtClient, k8sClient)
 	return &controller{
 		instancetypeFindHandler: finder,
 		preferenceFindHandler:   prefFinder,
 		applyVMHandler:          apply.NewVMApplier(finder, prefFinder),
-		storeHandler:            revision.New(instancetypeStore, clusterInstancetypeStore, preferenceStore, clusterPreferenceStore, virtClient),
-		expandHandler:           expand.New(clusterConfig, finder, prefFinder),
-		upgradeHandler:          upgrade.New(revisionStore, virtClient),
-		clientset:               virtClient,
-		clusterConfig:           clusterConfig,
-		recorder:                recorder,
+		storeHandler: revision.New(
+			instancetypeStore,
+			clusterInstancetypeStore,
+			preferenceStore,
+			clusterPreferenceStore,
+			virtClient,
+			k8sClient,
+		),
+		expandHandler:  expand.New(clusterConfig, finder, prefFinder),
+		upgradeHandler: upgrade.New(revisionStore, virtClient, k8sClient),
+		virtClient:     virtClient,
+		k8sClient:      k8sClient,
+		clusterConfig:  clusterConfig,
+		recorder:       recorder,
 	}
 }
 
@@ -179,20 +191,20 @@ func (c *controller) handleExpand(
 
 	// Only update the VM if we have changed something by applying an instance type and preference
 	if !equality.Semantic.DeepEqual(vm, expandVMCopy) {
-		updatedVM, err := c.clientset.VirtualMachine(expandVMCopy.Namespace).Update(
+		updatedVM, err := c.virtClient.VirtualMachine(expandVMCopy.Namespace).Update(
 			context.Background(), expandVMCopy, metav1.UpdateOptions{})
 		if err != nil {
 			return vm, fmt.Errorf("error encountered when trying to update expanded VirtualMachine: %v", err)
 		}
 		updatedVM.Status = expandVMCopy.Status
-		updatedVM, err = c.clientset.VirtualMachine(updatedVM.Namespace).UpdateStatus(
+		updatedVM, err = c.virtClient.VirtualMachine(updatedVM.Namespace).UpdateStatus(
 			context.Background(), updatedVM, metav1.UpdateOptions{})
 		if err != nil {
 			return vm, fmt.Errorf("error encountered when trying to update expanded VirtualMachine Status: %v", err)
 		}
 		// We should clean up any instance type or preference controllerRevisions after successfully expanding the VM
 		if revision.HasControllerRevisionRef(vm.Status.InstancetypeRef) {
-			if err = c.clientset.AppsV1().ControllerRevisions(vm.Namespace).Delete(
+			if err = c.k8sClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(
 				context.Background(), vm.Status.InstancetypeRef.ControllerRevisionRef.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, common.NewSyncError(
 					fmt.Errorf(cleanControllerRevisionErrFmt, vm.Status.InstancetypeRef.ControllerRevisionRef.Name, vm.Name, err),
@@ -202,7 +214,7 @@ func (c *controller) handleExpand(
 		}
 
 		if revision.HasControllerRevisionRef(vm.Status.PreferenceRef) {
-			if err = c.clientset.AppsV1().ControllerRevisions(vm.Namespace).Delete(
+			if err = c.k8sClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(
 				context.Background(), vm.Status.PreferenceRef.ControllerRevisionRef.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, common.NewSyncError(
 					fmt.Errorf(cleanControllerRevisionErrFmt, vm.Status.PreferenceRef.ControllerRevisionRef.Name, vm.Name, err),

--- a/pkg/instancetype/controller/vm/controller_test.go
+++ b/pkg/instancetype/controller/vm/controller_test.go
@@ -122,8 +122,6 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 		virtClient.EXPECT().VirtualMachineClusterPreference().Return(
 			fake.NewSimpleClientset().InstancetypeV1beta1().VirtualMachineClusterPreferences()).AnyTimes()
 
-		virtClient.EXPECT().AppsV1().Return(k8sfake.NewSimpleClientset().AppsV1()).AnyTimes()
-
 		instancetypeInformer, _ := testutils.NewFakeInformerFor(&v1beta1.VirtualMachineInstancetype{})
 		instancetypeInformerStore = instancetypeInformer.GetStore()
 
@@ -144,6 +142,10 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
+		k8sClient := k8sfake.NewSimpleClientset()
+
+		virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
+
 		instancetypeController = instancetypecontroller.New(
 			instancetypeInformerStore,
 			clusterInstancetypeInformerStore,
@@ -151,6 +153,7 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			clusterPreferenceInformerStore,
 			controllerrevisionInformerStore,
 			virtClient,
+			k8sClient,
 			config,
 			recorder,
 		)

--- a/pkg/instancetype/find/BUILD.bazel
+++ b/pkg/instancetype/find/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/instancetype/find/controller_revision.go
+++ b/pkg/instancetype/find/controller_revision.go
@@ -25,25 +25,25 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"kubevirt.io/client-go/kubecli"
 )
 
 type controllerRevisionFinder struct {
-	store      cache.Store
-	virtClient kubecli.KubevirtClient
+	store     cache.Store
+	k8sClient kubernetes.Interface
 }
 
-func NewControllerRevisionFinder(store cache.Store, virtClient kubecli.KubevirtClient) *controllerRevisionFinder {
+func NewControllerRevisionFinder(store cache.Store, k8sClient kubernetes.Interface) *controllerRevisionFinder {
 	return &controllerRevisionFinder{
-		store:      store,
-		virtClient: virtClient,
+		store:     store,
+		k8sClient: k8sClient,
 	}
 }
 
 func (f *controllerRevisionFinder) Find(namespacedName types.NamespacedName) (*appsv1.ControllerRevision, error) {
 	if f.store == nil {
-		return f.virtClient.AppsV1().ControllerRevisions(namespacedName.Namespace).Get(
+		return f.k8sClient.AppsV1().ControllerRevisions(namespacedName.Namespace).Get(
 			context.Background(), namespacedName.Name, metav1.GetOptions{})
 	}
 
@@ -52,7 +52,7 @@ func (f *controllerRevisionFinder) Find(namespacedName types.NamespacedName) (*a
 		return nil, err
 	}
 	if !exists {
-		return f.virtClient.AppsV1().ControllerRevisions(namespacedName.Namespace).Get(
+		return f.k8sClient.AppsV1().ControllerRevisions(namespacedName.Namespace).Get(
 			context.Background(), namespacedName.Name, metav1.GetOptions{})
 	}
 	revision, ok := obj.(*appsv1.ControllerRevision)

--- a/pkg/instancetype/find/revision.go
+++ b/pkg/instancetype/find/revision.go
@@ -21,20 +21,20 @@ package find
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
-	"kubevirt.io/client-go/kubecli"
 )
 
 type revisionFinder struct {
 	controllerRevisionFinder *controllerRevisionFinder
 }
 
-func NewRevisionFinder(store cache.Store, virtClient kubecli.KubevirtClient) *revisionFinder {
+func NewRevisionFinder(store cache.Store, k8sClient kubernetes.Interface) *revisionFinder {
 	return &revisionFinder{
-		controllerRevisionFinder: NewControllerRevisionFinder(store, virtClient),
+		controllerRevisionFinder: NewControllerRevisionFinder(store, k8sClient),
 	}
 }
 

--- a/pkg/instancetype/find/spec.go
+++ b/pkg/instancetype/find/spec.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -38,11 +39,15 @@ type specFinder struct {
 	revisionFinder            *revisionFinder
 }
 
-func NewSpecFinder(store, clusterStore, revisionStore cache.Store, virtClient kubecli.KubevirtClient) *specFinder {
+func NewSpecFinder(
+	store, clusterStore, revisionStore cache.Store,
+	virtClient kubecli.KubevirtClient,
+	k8sClient kubernetes.Interface,
+) *specFinder {
 	return &specFinder{
 		instancetypeFinder:        NewInstancetypeFinder(store, virtClient),
 		clusterInstancetypeFinder: NewClusterInstancetypeFinder(clusterStore, virtClient),
-		revisionFinder:            NewRevisionFinder(revisionStore, virtClient),
+		revisionFinder:            NewRevisionFinder(revisionStore, k8sClient),
 	}
 }
 

--- a/pkg/instancetype/find/spec_test.go
+++ b/pkg/instancetype/find/spec_test.go
@@ -101,6 +101,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 			clusterInstancetypeInformerStore,
 			controllerRevisionInformerStore,
 			virtClient,
+			fakeK8sClientSet,
 		)
 	})
 
@@ -245,7 +246,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 		})
 
 		It("returns expected instancetype using only the client", func() {
-			finder = find.NewSpecFinder(nil, nil, nil, virtClient)
+			finder = find.NewSpecFinder(nil, nil, nil, virtClient, fakeK8sClientSet)
 			instancetypeSpec, err := finder.Find(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(instancetypeSpec).To(HaveValue(Equal(clusterInstancetype.Spec)))
@@ -414,7 +415,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 		})
 
 		It("returns expected instancetype using only the client", func() {
-			finder = find.NewSpecFinder(nil, nil, nil, virtClient)
+			finder = find.NewSpecFinder(nil, nil, nil, virtClient, fakeK8sClientSet)
 			instancetypeSpec, err := finder.Find(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(instancetypeSpec).To(HaveValue(Equal(fakeInstancetype.Spec)))

--- a/pkg/instancetype/infer/BUILD.bazel
+++ b/pkg/instancetype/infer/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/instancetype/infer/handler.go
+++ b/pkg/instancetype/infer/handler.go
@@ -21,6 +21,8 @@ package infer
 import (
 	"errors"
 
+	"k8s.io/client-go/kubernetes"
+
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -31,12 +33,16 @@ const logVerbosityLevel = 3
 type handler struct {
 	instancetypeHandler *volumeHandler
 	preferenceHandler   *volumeHandler
+	virtClient          kubecli.KubevirtClient
+	k8sClient           kubernetes.Interface
 }
 
-func New(virtClient kubecli.KubevirtClient) *handler {
+func New(virtClient kubecli.KubevirtClient, k8sClient kubernetes.Interface) *handler {
 	return &handler{
 		instancetypeHandler: newInstancetypeVolumeHandler(virtClient),
 		preferenceHandler:   newPreferenceVolumeHandler(virtClient),
+		virtClient:          virtClient,
+		k8sClient:           k8sClient,
 	}
 }
 

--- a/pkg/instancetype/infer/handler_test.go
+++ b/pkg/instancetype/infer/handler_test.go
@@ -97,7 +97,8 @@ var _ = Describe("InferFromVolume", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 
-		virtClient.EXPECT().CoreV1().Return(k8sfake.NewSimpleClientset().CoreV1()).AnyTimes()
+		k8sClient := k8sfake.NewSimpleClientset()
+		virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().CdiClient().Return(cdifake.NewSimpleClientset()).AnyTimes()
 		virtClient.EXPECT().KubernetesSnapshotClient().Return(snapshotfake.NewSimpleClientset()).AnyTimes()
 
@@ -234,7 +235,7 @@ var _ = Describe("InferFromVolume", func() {
 			context.Background(), dsWithSourceSnapshot, k8smetav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		handler = infer.New(virtClient)
+		handler = infer.New(virtClient, k8sClient)
 	})
 
 	DescribeTable("should infer defaults from VolumeSource and PersistentVolumeClaim",

--- a/pkg/instancetype/preference/find/BUILD.bazel
+++ b/pkg/instancetype/preference/find/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/instancetype/preference/find/revision.go
+++ b/pkg/instancetype/preference/find/revision.go
@@ -21,11 +21,11 @@ package find
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
-	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/instancetype/find"
 )
@@ -38,9 +38,9 @@ type revisionFinder struct {
 	controllerRevisionFinder controllerRevisionFinder
 }
 
-func NewRevisionFinder(store cache.Store, virtClient kubecli.KubevirtClient) *revisionFinder {
+func NewRevisionFinder(store cache.Store, k8sClient kubernetes.Interface) *revisionFinder {
 	return &revisionFinder{
-		controllerRevisionFinder: find.NewControllerRevisionFinder(store, virtClient),
+		controllerRevisionFinder: find.NewControllerRevisionFinder(store, k8sClient),
 	}
 }
 

--- a/pkg/instancetype/preference/find/spec.go
+++ b/pkg/instancetype/preference/find/spec.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -38,11 +39,15 @@ type specFinder struct {
 	revisionFinder          *revisionFinder
 }
 
-func NewSpecFinder(store, clusterStore, revisionStore cache.Store, virtClient kubecli.KubevirtClient) *specFinder {
+func NewSpecFinder(
+	store, clusterStore, revisionStore cache.Store,
+	virtClient kubecli.KubevirtClient,
+	k8sClient kubernetes.Interface,
+) *specFinder {
 	return &specFinder{
 		preferenceFinder:        NewPreferenceFinder(store, virtClient),
 		clusterPreferenceFinder: NewClusterPreferenceFinder(clusterStore, virtClient),
-		revisionFinder:          NewRevisionFinder(revisionStore, virtClient),
+		revisionFinder:          NewRevisionFinder(revisionStore, k8sClient),
 	}
 }
 

--- a/pkg/instancetype/preference/find/spec_test.go
+++ b/pkg/instancetype/preference/find/spec_test.go
@@ -96,7 +96,10 @@ var _ = Describe("Preference SpecFinder", func() {
 		controllerRevisionInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		controllerRevisionInformerStore = controllerRevisionInformer.GetStore()
 
-		finder = find.NewSpecFinder(preferenceInformerStore, clusterPreferenceInformerStore, controllerRevisionInformerStore, virtClient)
+		finder = find.NewSpecFinder(
+			preferenceInformerStore, clusterPreferenceInformerStore,
+			controllerRevisionInformerStore, virtClient, fakeK8sClientSet,
+		)
 	})
 
 	It("find returns nil when no preference is specified", func() {
@@ -234,7 +237,7 @@ var _ = Describe("Preference SpecFinder", func() {
 		})
 
 		It("returns expected preference using only the client", func() {
-			finder = find.NewSpecFinder(nil, nil, nil, virtClient)
+			finder = find.NewSpecFinder(nil, nil, nil, virtClient, fakeK8sClientSet)
 			preferenceSpec, err := finder.FindPreference(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(preferenceSpec).To(HaveValue(Equal(clusterPreference.Spec)))
@@ -399,7 +402,7 @@ var _ = Describe("Preference SpecFinder", func() {
 		})
 
 		It("returns expected preference using only the client", func() {
-			finder = find.NewSpecFinder(nil, nil, nil, virtClient)
+			finder = find.NewSpecFinder(nil, nil, nil, virtClient, fakeK8sClientSet)
 			preferenceSpec, err := finder.FindPreference(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(preferenceSpec).To(HaveValue(Equal(preference.Spec)))

--- a/pkg/instancetype/revision/BUILD.bazel
+++ b/pkg/instancetype/revision/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/instancetype/revision/handler.go
+++ b/pkg/instancetype/revision/handler.go
@@ -19,6 +19,7 @@
 package revision
 
 import (
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/kubecli"
@@ -30,6 +31,7 @@ type revisionHandler struct {
 	preferenceStore          cache.Store
 	clusterPreferenceStore   cache.Store
 	virtClient               kubecli.KubevirtClient
+	k8sClient                kubernetes.Interface
 }
 
 func New(
@@ -38,6 +40,7 @@ func New(
 	preferenceStore,
 	clusterPreferenceStore cache.Store,
 	virtClient kubecli.KubevirtClient,
+	k8sClient kubernetes.Interface,
 ) *revisionHandler {
 	return &revisionHandler{
 		instancetypeStore:        instancetypeStore,
@@ -45,5 +48,6 @@ func New(
 		preferenceStore:          preferenceStore,
 		clusterPreferenceStore:   clusterPreferenceStore,
 		virtClient:               virtClient,
+		k8sClient:                k8sClient,
 	}
 }

--- a/pkg/instancetype/revision/store.go
+++ b/pkg/instancetype/revision/store.go
@@ -293,7 +293,7 @@ func (h *revisionHandler) storeControllerRevision(vm *virtv1.VirtualMachine, obj
 		return nil, err
 	}
 
-	createdRevision, err := h.virtClient.AppsV1().ControllerRevisions(revision.Namespace).Create(
+	createdRevision, err := h.k8sClient.AppsV1().ControllerRevisions(revision.Namespace).Create(
 		context.Background(), revision, metav1.CreateOptions{})
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -301,7 +301,7 @@ func (h *revisionHandler) storeControllerRevision(vm *virtv1.VirtualMachine, obj
 		}
 
 		// Grab the existing revision to check the data it contains
-		existingRevision, err := h.virtClient.AppsV1().ControllerRevisions(revision.Namespace).Get(
+		existingRevision, err := h.k8sClient.AppsV1().ControllerRevisions(revision.Namespace).Get(
 			context.Background(), revision.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get ControllerRevision: %w", err)

--- a/pkg/instancetype/revision/store_test.go
+++ b/pkg/instancetype/revision/store_test.go
@@ -73,7 +73,9 @@ var _ = Describe("Instancetype and Preferences revision handler", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 
-		virtClient.EXPECT().AppsV1().Return(k8sfake.NewSimpleClientset().AppsV1()).AnyTimes()
+		k8sClient := k8sfake.NewSimpleClientset()
+
+		virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
 
 		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(
 			fakeclientset.NewSimpleClientset().KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).AnyTimes()
@@ -107,7 +109,8 @@ var _ = Describe("Instancetype and Preferences revision handler", func() {
 			clusterInstancetypeInformerStore,
 			preferenceInformerStore,
 			clusterInstancetypeInformerStore,
-			virtClient)
+			virtClient,
+			k8sClient)
 
 		vm = kubecli.NewMinimalVM("testvm")
 		vm.Spec.Template = &virtv1.VirtualMachineInstanceTemplateSpec{

--- a/pkg/instancetype/upgrade/BUILD.bazel
+++ b/pkg/instancetype/upgrade/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/instancetype/upgrade/handler.go
+++ b/pkg/instancetype/upgrade/handler.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -45,12 +46,14 @@ type controllerRevisionFinder interface {
 type upgrader struct {
 	controllerRevisionFinder controllerRevisionFinder
 	virtClient               kubecli.KubevirtClient
+	k8sClient                kubernetes.Interface
 }
 
-func New(store cache.Store, virtClient kubecli.KubevirtClient) *upgrader {
+func New(store cache.Store, virtClient kubecli.KubevirtClient, k8sClient kubernetes.Interface) *upgrader {
 	return &upgrader{
-		controllerRevisionFinder: find.NewControllerRevisionFinder(store, virtClient),
+		controllerRevisionFinder: find.NewControllerRevisionFinder(store, k8sClient),
 		virtClient:               virtClient,
+		k8sClient:                k8sClient,
 	}
 }
 
@@ -89,7 +92,7 @@ func (u *upgrader) Upgrade(vm *virtv1.VirtualMachine) error {
 	vm.ObjectMeta = patchedVM.ObjectMeta
 
 	if newInstancetypeCR != nil {
-		if err := u.virtClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(
+		if err := u.k8sClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(
 			context.Background(), vm.Status.InstancetypeRef.ControllerRevisionRef.Name, metav1.DeleteOptions{}); err != nil {
 			log.Log.Object(vm).Reason(err).Error("ignoring failure to delete ControllerRevision during stashed instance type object upgrade")
 		}
@@ -97,7 +100,7 @@ func (u *upgrader) Upgrade(vm *virtv1.VirtualMachine) error {
 	}
 
 	if newPreferenceCR != nil {
-		if err := u.virtClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(
+		if err := u.k8sClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(
 			context.Background(), vm.Status.PreferenceRef.ControllerRevisionRef.Name, metav1.DeleteOptions{}); err != nil {
 			log.Log.Object(vm).Reason(err).Error("ignoring failure to delete ControllerRevision during stashed preference object upgrade")
 		}
@@ -155,7 +158,7 @@ func (u *upgrader) upgradeControllerRevision(
 	}
 
 	// Recreate the CR with the now upgraded runtime.Object
-	newCR, err = u.virtClient.AppsV1().ControllerRevisions(vm.Namespace).Create(context.Background(), newCR, metav1.CreateOptions{})
+	newCR, err = u.k8sClient.AppsV1().ControllerRevisions(vm.Namespace).Create(context.Background(), newCR, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/instancetype/upgrade/upgrade_test.go
+++ b/pkg/instancetype/upgrade/upgrade_test.go
@@ -99,8 +99,6 @@ var _ = Describe("ControllerRevision upgrades", func() {
 		// Create a single fake clientset to be reused across all calls
 		fakeVMClient = fakeclientset.NewSimpleClientset()
 
-		virtClient.EXPECT().AppsV1().Return(k8sfake.NewSimpleClientset().AppsV1()).AnyTimes()
-
 		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(
 			fakeVMClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).AnyTimes()
 
@@ -110,7 +108,9 @@ var _ = Describe("ControllerRevision upgrades", func() {
 			libvmi.WithPreference("bar"),
 		)
 
-		upgradeHandler = upgrade.New(controllerrevisionInformerStore, virtClient)
+		k8sClient := k8sfake.NewSimpleClientset()
+		virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
+		upgradeHandler = upgrade.New(controllerrevisionInformerStore, virtClient, k8sClient)
 	})
 
 	createControllerRevisionFromObject := func(obj runtime.Object) *appsv1.ControllerRevision {

--- a/pkg/instancetype/webhooks/vm/BUILD.bazel
+++ b/pkg/instancetype/webhooks/vm/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],
 )
 
@@ -53,5 +54,6 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )

--- a/pkg/instancetype/webhooks/vm/admitter.go
+++ b/pkg/instancetype/webhooks/vm/admitter.go
@@ -21,6 +21,7 @@ package vm
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
@@ -67,10 +68,10 @@ type admitter struct {
 	requirementsChecker
 }
 
-func NewAdmitter(virtClient kubecli.KubevirtClient) *admitter {
+func NewAdmitter(virtClient kubecli.KubevirtClient, k8sClient kubernetes.Interface) *admitter {
 	return &admitter{
-		instancetypeFinder:  find.NewSpecFinder(nil, nil, nil, virtClient),
-		preferenceFinder:    preferenceFind.NewSpecFinder(nil, nil, nil, virtClient),
+		instancetypeFinder:  find.NewSpecFinder(nil, nil, nil, virtClient, k8sClient),
+		preferenceFinder:    preferenceFind.NewSpecFinder(nil, nil, nil, virtClient, k8sClient),
 		requirementsChecker: requirements.New(),
 		applyVMIHandler:     apply.NewVMIApplier(),
 	}

--- a/pkg/instancetype/webhooks/vm/admitter_test.go
+++ b/pkg/instancetype/webhooks/vm/admitter_test.go
@@ -27,6 +27,7 @@ import (
 
 	"go.uber.org/mock/gomock"
 	k8sv1 "k8s.io/api/core/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,7 +136,8 @@ var _ = Describe("Instance type and Preference VirtualMachine Admitter", func() 
 				libvmi.WithPreference(preferenceName),
 			)
 
-			admitter = webhook.NewAdmitter(virtClient)
+			k8sClient := k8sfake.NewSimpleClientset()
+			admitter = webhook.NewAdmitter(virtClient, k8sClient)
 		})
 
 		It("should reject if instancetype fails to apply to VMI", func() {

--- a/pkg/instancetype/webhooks/vm/mutator.go
+++ b/pkg/instancetype/webhooks/vm/mutator.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/api/instancetype/v1beta1"
@@ -53,11 +54,11 @@ type mutator struct {
 	findPreferenceSpecHandler
 }
 
-func NewMutator(virtClient kubecli.KubevirtClient) *mutator {
+func NewMutator(virtClient kubecli.KubevirtClient, k8sClient kubernetes.Interface) *mutator {
 	return &mutator{
-		inferHandler: infer.New(virtClient),
+		inferHandler: infer.New(virtClient, k8sClient),
 		// TODO(lyarwood): Wire up informers for use here to speed up lookups
-		findPreferenceSpecHandler: preferenceFind.NewSpecFinder(nil, nil, nil, virtClient),
+		findPreferenceSpecHandler: preferenceFind.NewSpecFinder(nil, nil, nil, virtClient, k8sClient),
 	}
 }
 

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -102,11 +102,13 @@ func SetupMetrics(
 			stores.ClusterInstancetype,
 			stores.ControllerRevision,
 			clientset,
+			clientset,
 		),
 		preferencefind.NewSpecFinder(
 			stores.Preference,
 			stores.ClusterPreference,
 			stores.ControllerRevision,
+			clientset,
 			clientset,
 		),
 	)

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -765,11 +765,13 @@ func setupTestCollector() {
 			clusterInstanceTypeInformer.GetStore(),
 			controllerRevisionInformer.GetStore(),
 			nil,
+			nil,
 		),
 		preferencefind.NewSpecFinder(
 			preferenceInformer.GetStore(),
 			clusterPreferenceInformer.GetStore(),
 			controllerRevisionInformer.GetStore(),
+			nil,
 			nil,
 		),
 	)

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -507,11 +507,13 @@ func (ctrl *VMExportController) Init() error {
 			ctrl.ClusterInstancetypeInformer.GetStore(),
 			ctrl.ControllerRevisionInformer.GetStore(),
 			ctrl.Client,
+			ctrl.Client,
 		),
 		preferencefind.NewSpecFinder(
 			ctrl.PreferenceInformer.GetStore(),
 			ctrl.ClusterPreferenceInformer.GetStore(),
 			ctrl.ControllerRevisionInformer.GetStore(),
+			ctrl.Client,
 			ctrl.Client,
 		),
 	)

--- a/pkg/virt-api/BUILD.bazel
+++ b/pkg/virt-api/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -41,6 +41,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	certificate2 "k8s.io/client-go/util/certificate"
 	"k8s.io/client-go/util/flowcontrol"
@@ -109,6 +110,7 @@ type virtAPIApp struct {
 	service.ServiceListen
 	SubresourcesOnly bool
 	virtCli          kubecli.KubevirtClient
+	k8sClient        kubernetes.Interface
 	aggregatorClient *aggregatorclient.Clientset
 	authorizor       rest.VirtApiAuthorizor
 	certsDirectory   string
@@ -168,6 +170,11 @@ func (app *virtAPIApp) Execute() {
 	}
 	clientConfig.RateLimiter = app.reloadableRateLimiter
 	app.virtCli, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	app.k8sClient, err = kubecli.GetK8sClientFromRESTConfig(clientConfig)
 	if err != nil {
 		panic(err)
 	}
@@ -232,7 +239,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Doc(fmt.Sprintf("KubeVirt \"%s\" Subresource API.", version.Version))
 		subws.Path(definitions.GroupVersionBasePath(version))
 
-		subresourceApp := rest.NewSubresourceAPIApp(app.virtCli, app.consoleServerPort, app.handlerTLSConfiguration, app.clusterConfig)
+		subresourceApp := rest.NewSubresourceAPIApp(app.virtCli, app.k8sClient, app.consoleServerPort, app.handlerTLSConfiguration, app.clusterConfig)
 
 		restartRouteBuilder := subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("restart")).
 			To(subresourceApp.RestartVMRequestHandler).

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/authorization/v1:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",

--- a/pkg/virt-api/rest/console_test.go
+++ b/pkg/virt-api/rest/console_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onsi/gomega/ghttp"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -86,7 +87,7 @@ var _ = Describe("Console Subresource api", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, k8sfake.NewSimpleClientset(), backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	DescribeTable("request validation", func(autoattachSerialConsole bool, phase v1.VirtualMachineInstancePhase) {

--- a/pkg/virt-api/rest/dialers_test.go
+++ b/pkg/virt-api/rest/dialers_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -119,7 +120,7 @@ var _ = Describe("NetDialer", func() {
 
 		runningStatus := libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running)))
 		vmi := libvmi.New(runningStatus)
-		app := NewSubresourceAPIApp(virtClient, int(port), nil, config)
+		app := NewSubresourceAPIApp(virtClient, k8sfake.NewSimpleClientset(), int(port), nil, config)
 		dialer := app.virtHandlerDialer(func(_ *v1.VirtualMachineInstance, _ kubecli.VirtHandlerConn) (string, error) {
 			return fullURL, nil
 		})

--- a/pkg/virt-api/rest/evacuate_cancel_test.go
+++ b/pkg/virt-api/rest/evacuate_cancel_test.go
@@ -133,7 +133,7 @@ var _ = Describe("EvacuateCancel Subresource API", func() {
 
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
-		app = NewSubresourceAPIApp(virtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(virtClient, kubeClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	createVMI := func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {

--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -38,6 +38,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	kubevirtcore "kubevirt.io/api/core"
 	v1 "kubevirt.io/api/core/v1"
@@ -99,7 +100,7 @@ var _ = Describe("Instancetype expansion subresources", func() {
 		}
 
 		config, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
-		app = NewSubresourceAPIApp(virtClient, 0, nil, config)
+		app = NewSubresourceAPIApp(virtClient, k8sfake.NewSimpleClientset(), 0, nil, config)
 
 		request = restful.NewRequest(&http.Request{})
 		recorder = httptest.NewRecorder()

--- a/pkg/virt-api/rest/memorydump_test.go
+++ b/pkg/virt-api/rest/memorydump_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -161,7 +162,7 @@ var _ = Describe("Memory dump Subresource api", func() {
 		cdiConfig := cdiConfigInit()
 		cdiClient = cdifake.NewSimpleClientset(cdiConfig)
 
-		app = NewSubresourceAPIApp(virtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(virtClient, k8sfake.NewSimpleClientset(), backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-api/rest/objectgraph_test.go
+++ b/pkg/virt-api/rest/objectgraph_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
@@ -122,7 +123,7 @@ var _ = Describe("Object Graph", func() {
 			}
 			var config *virtconfig.ClusterConfig
 			config, _, kvStore = testutils.NewFakeClusterConfigUsingKV(kv)
-			app = NewSubresourceAPIApp(kvClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+			app = NewSubresourceAPIApp(kvClient, k8sfake.NewSimpleClientset(), backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 		})
 
 		disableFeatureGates := func() {

--- a/pkg/virt-api/rest/portforward_test.go
+++ b/pkg/virt-api/rest/portforward_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -86,7 +87,7 @@ var _ = Describe("PortForward Subresource api", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, k8sfake.NewSimpleClientset(), backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	It("should fail with no 'name' path param", func() {

--- a/pkg/virt-api/rest/sev_test.go
+++ b/pkg/virt-api/rest/sev_test.go
@@ -38,6 +38,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -118,7 +119,7 @@ var _ = Describe("SEV Subresources", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstanceMigration(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstanceMigrations(metav1.NamespaceDefault)).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, k8sfake.NewSimpleClientset(), backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -33,6 +33,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -67,6 +68,7 @@ type instancetypeVMExpander interface {
 
 type SubresourceAPIApp struct {
 	virtCli                 kubecli.KubevirtClient
+	k8sClient               kubernetes.Interface
 	consoleServerPort       int
 	profilerComponentPort   int
 	handlerTLSConfiguration *tls.Config
@@ -75,15 +77,15 @@ type SubresourceAPIApp struct {
 	handlerHttpClient       *http.Client
 }
 
-func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, consoleServerPort int, tlsConfiguration *tls.Config, clusterConfig *virtconfig.ClusterConfig) *SubresourceAPIApp {
+func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, k8sClient kubernetes.Interface, consoleServerPort int, tlsConfiguration *tls.Config, clusterConfig *virtconfig.ClusterConfig) *SubresourceAPIApp {
 	// When this method is called from tools/openapispec.go when running 'make generate',
 	// the virtCli is nil, and accessing GeneratedKubeVirtClient() would cause nil dereference.
 	var instancetypeExpander instancetypeVMExpander
 	if virtCli != nil {
 		instancetypeExpander = expand.New(
 			clusterConfig,
-			find.NewSpecFinder(nil, nil, nil, virtCli),
-			preferenceFind.NewSpecFinder(nil, nil, nil, virtCli),
+			find.NewSpecFinder(nil, nil, nil, virtCli, k8sClient),
+			preferenceFind.NewSpecFinder(nil, nil, nil, virtCli, k8sClient),
 		)
 	}
 
@@ -96,6 +98,7 @@ func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, consoleServerPort int,
 
 	return &SubresourceAPIApp{
 		virtCli:                 virtCli,
+		k8sClient:               k8sClient,
 		consoleServerPort:       consoleServerPort,
 		profilerComponentPort:   defaultProfilerComponentPort,
 		handlerTLSConfiguration: tlsConfiguration,

--- a/pkg/virt-api/rest/vnc_test.go
+++ b/pkg/virt-api/rest/vnc_test.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -90,7 +91,7 @@ var _ = Describe("VNC Subresource api", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, k8sfake.NewSimpleClientset(), backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	It("should fail with no 'name' path param", func() {

--- a/pkg/virt-api/rest/volumes_test.go
+++ b/pkg/virt-api/rest/volumes_test.go
@@ -39,6 +39,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
@@ -123,7 +124,7 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(vmiClient).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance("").Return(vmiClient).AnyTimes()
 
-		app = NewSubresourceAPIApp(virtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(virtClient, k8sfake.NewSimpleClientset(), backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -52,7 +52,7 @@ type VMsMutator struct {
 func NewVMsMutator(clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) *VMsMutator {
 	return &VMsMutator{
 		ClusterConfig:       clusterConfig,
-		instancetypeMutator: instancetypeVMWebhooks.NewMutator(virtCli),
+		instancetypeMutator: instancetypeVMWebhooks.NewMutator(virtCli, virtCli),
 		virtClient:          virtCli,
 	}
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -164,7 +164,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		cdiClient = cdifake.NewSimpleClientset()
 		virtClient.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
 
-		mutator.instancetypeMutator = instancetypeVMWebhooks.NewMutator(virtClient)
+		mutator.instancetypeMutator = instancetypeVMWebhooks.NewMutator(virtClient, virtClient)
 	})
 
 	It("should allow VM being deleted without applying mutations", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -78,7 +78,7 @@ func NewVMsAdmitter(clusterConfig *virtconfig.ClusterConfig, client kubecli.Kube
 		VirtClient:              client,
 		DataSourceInformer:      informers.DataSourceInformer,
 		NamespaceInformer:       informers.NamespaceInformer,
-		InstancetypeAdmitter:    instancetypeWebhooks.NewAdmitter(client),
+		InstancetypeAdmitter:    instancetypeWebhooks.NewAdmitter(client, client),
 		ClusterConfig:           clusterConfig,
 		KubeVirtServiceAccounts: kubeVirtServiceAccounts,
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1360,7 +1360,7 @@ var _ = Describe("Validating VM Admitter", func() {
 			virtClient.EXPECT().VirtualMachineClusterInstancetype().Return(
 				fakeclientset.NewSimpleClientset().InstancetypeV1beta1().VirtualMachineClusterInstancetypes()).AnyTimes()
 
-			vmsAdmitter.InstancetypeAdmitter = instancetypeWebhooks.NewAdmitter(virtClient)
+			vmsAdmitter.InstancetypeAdmitter = instancetypeWebhooks.NewAdmitter(virtClient, virtClient)
 		})
 		It("should not apply instancetype to the VMISpec of the original VM", func() {
 			const clusterInstancetypeName = "clusterInstancetype"

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -53,6 +53,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8coresv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientrest "k8s.io/client-go/rest"
@@ -146,11 +147,14 @@ var (
 type VirtControllerApp struct {
 	service.ServiceListen
 
-	clientSet       kubecli.KubevirtClient
-	templateService *services.TemplateService
-	restClient      *clientrest.RESTClient
-	informerFactory controller.KubeInformerFactory
-	kvPodInformer   cache.SharedIndexInformer
+	clientSet             kubecli.KubevirtClient
+	k8sClient             kubernetes.Interface
+	templateService       *services.TemplateService
+	restClient            *clientrest.RESTClient
+	informerFactory       controller.KubeInformerFactory
+	kvPodInformer         cache.SharedIndexInformer
+	resourceClaimInformer cache.SharedIndexInformer
+	resourceSliceInformer cache.SharedIndexInformer
 
 	nodeInformer   cache.SharedIndexInformer
 	nodeController *node.Controller
@@ -321,6 +325,11 @@ func Execute() {
 	}
 	clientConfig.RateLimiter = app.reloadableRateLimiter
 	app.clientSet, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
+	if err != nil {
+		golog.Fatal(err)
+	}
+
+	app.k8sClient, err = kubecli.GetK8sClientFromRESTConfig(clientConfig)
 	if err != nil {
 		golog.Fatal(err)
 	}
@@ -841,6 +850,7 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 			vca.clusterPreferenceInformer.GetStore(),
 			vca.controllerRevisionInformer.GetStore(),
 			vca.clientSet,
+			vca.k8sClient,
 			vca.clusterConfig,
 			recorder,
 		),

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -4731,6 +4731,7 @@ var _ = Describe("VirtualMachine", func() {
 					clusterPreferenceInformerStore,
 					controllerrevisionInformerStore,
 					virtClient,
+					k8sfake.NewSimpleClientset(),
 					config,
 					controller.recorder,
 				)
@@ -6232,6 +6233,7 @@ var _ = Describe("VirtualMachine", func() {
 						nil,
 						controllerrevisionInformerStore,
 						virtClient,
+						k8sfake.NewSimpleClientset(),
 						config,
 						controller.recorder,
 					)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -284,8 +284,11 @@ func (k *KubeVirtTestData) BeforeTest() {
 		}
 
 		if action.GetVerb() == "create" && action.GetResource().Resource == "configmaps" {
-			dummyConfigMap := &k8sv1.ConfigMap{}
-			return true, dummyConfigMap, nil
+			create, ok := action.(testing.CreateAction)
+			if ok {
+				return true, create.GetObject(), nil
+			}
+			return true, &k8sv1.ConfigMap{}, nil
 		}
 
 		if action.GetVerb() == "update" && action.GetResource().Resource == "configmaps" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

#### Before this PR:
The `pkg/instancetype` package accessed standard Kubernetes APIs (e.g. `AppsV1().ControllerRevisions()`, `CoreV1().PersistentVolumeClaims()`) through the KubeVirt client (`kubecli.KubevirtClient`), which embeds the Kubernetes clientset. This tight coupling made it impossible to use `kubevirt/client-go` externally without painful dependency version pinning.

#### After this PR:
Standard Kubernetes API calls in `pkg/instancetype` are made through a separate `kubernetes.Interface` client, decoupled from the KubeVirt client. The following packages have been updated:
- `pkg/instancetype/find` — `controllerRevisionFinder` and `revisionFinder` now use `kubernetes.Interface` for `ControllerRevision` lookups
- `pkg/instancetype/preference/find` — same decoupling applied to the preference-side revision finder
- `pkg/instancetype/revision` — `ControllerRevision` create/get calls moved to `kubernetes.Interface`
- `pkg/instancetype/upgrade` — `ControllerRevision` create/delete calls moved to `kubernetes.Interface`
- `pkg/instancetype/infer` — `PersistentVolumeClaim` lookups moved to `kubernetes.Interface`; CDI client calls remain on `virtClient`
- `pkg/instancetype/vm` (controller) — `ControllerRevision` delete calls moved to `kubernetes.Interface`
- `pkg/virt-api/webhooks/vm` — `NewMutator` and `NewAdmitter` updated to accept and pass through `kubernetes.Interface`

### References
- Partially addresses #16916
- Follows the pattern established in #16106

### Why we need it and why it was done in this way
This is part of a broader effort to decouple the KubeVirt and Kubernetes clientsets across the codebase (tracked in #16916). The long-term goal is to remove the embedded Kubernetes clientset from `kubecli.KubevirtClient` entirely, which will make `kubevirt/client-go` usable by external consumers without dependency conflicts.

The approach mirrors the strategy used in #16106 for `pkg/virt-operator`: each package is decoupled independently, one PR at a time, to keep changes reviewable and avoid conflicts.
  
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

  


### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

