### PR TITLE
virt-handler, netstat: Fix VMI interface status flapping

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -183,9 +183,11 @@ func movePrimaryIfaceStatusToFront(
 		return interfacesStatus
 	}
 
-	return append(
-		[]v1.VirtualMachineInstanceNetworkInterface{interfacesStatus[primaryIfaceStatusIndex]},
-		append(interfacesStatus[:primaryIfaceStatusIndex], interfacesStatus[primaryIfaceStatusIndex+1:]...)...,
+	primary := interfacesStatus[primaryIfaceStatusIndex]
+	return slices.Concat(
+		[]v1.VirtualMachineInstanceNetworkInterface{primary},
+		interfacesStatus[:primaryIfaceStatusIndex],
+		interfacesStatus[primaryIfaceStatusIndex+1:],
 	)
 }
 

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -1018,7 +1018,7 @@ var _ = Describe("netstat", func() {
 		})
 
 		DescribeTable("verify primary interface is always first in Status.Interfaces list", func(ifaceIndexArr []int) {
-			for index := range ifaceIndexArr {
+			for _, index := range ifaceIndexArr {
 				Expect(setup.addNetworkInterface(
 					vmiSpecIfaces[index],
 					vmiSpecNetworks[index],
@@ -1027,7 +1027,19 @@ var _ = Describe("netstat", func() {
 				)).To(Succeed())
 			}
 
+			// Simulate the virt-controller's output: bare primary + multus-only secondaries
+			setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
+				{Name: prNetworkName},
+				{Name: secNetworkName1, InfoSource: netvmispec.InfoSourceMultusStatus},
+				{Name: secNetworkName2, InfoSource: netvmispec.InfoSourceMultusStatus},
+			}
+
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+			infoSourceDomainMultus := netvmispec.NewInfoSource(
+				netvmispec.InfoSourceDomain,
+				netvmispec.InfoSourceMultusStatus,
+			)
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
 				{
@@ -1044,7 +1056,7 @@ var _ = Describe("netstat", func() {
 					IP:         podIP,
 					IPs:        []string{podIP},
 					MAC:        MAC1,
-					InfoSource: netvmispec.InfoSourceDomain,
+					InfoSource: infoSourceDomainMultus,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
 					LinkState:  linkStateUp,
 				},
@@ -1053,7 +1065,7 @@ var _ = Describe("netstat", func() {
 					IP:         podIP,
 					IPs:        []string{podIP},
 					MAC:        MAC2,
-					InfoSource: netvmispec.InfoSourceDomain,
+					InfoSource: infoSourceDomainMultus,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
 					LinkState:  linkStateUp,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
When the VMI spec lists the primary interface after a secondary one, movePrimaryIfaceStatusToFront produces duplicate secondary interfaces and drops the primary. The virt-controller detects the missing primary and patches it back, but on the next sync the virt-handler corrupts the status again, causing an infinite reconciliation loop.
This is also visible in the virt-launcher log as SyncVMI commands many times per second.

The sub-slices passed to the inner `append` share the same backing array as the original slice. When the inner `append` shifts elements left to fill the gap, it overwrites the primary element in the backing array. Go does not guarantee that the primary element is read before the inner `append` executes, so the outer expression
captures the already-overwritten value.

Replace the nested `append` with `slices.Concat`, which always allocates a fresh backing array.

Also fix the existing ordering test which iterated over slice indices instead of values (`for index := range` instead of `for _, index := range`), causing all entries to add interfaces in the same order and never exercising the reordering logic. Seed the test with the virt-controller's status output, which is always present before the virt-handler processes the VMI.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an infinite VMI status update loop between virt-controller and virt-handler that occurred when the VMI spec listed the primary network interface after a secondary one.
```

