### PR TITLE
Ensure migration state is reset after decentralized live migration

### DIFF
--- a/pkg/synchronization-controller/BUILD.bazel
+++ b/pkg/synchronization-controller/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -934,6 +934,25 @@ func (s *SynchronizationController) SyncSourceMigrationStatus(ctx context.Contex
 	if newVMI.Status.MigrationState == nil {
 		newVMI.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{}
 	}
+
+	// Only update SourceState if this migration is still active and matches the VMI's current migration.
+	// This prevents stale updates from a completed decentralized migration from interfering with a new compute migration.
+	if migration.IsFinal() {
+		log.Log.Object(migration).Infof("Migration is final, ignoring source state update for VMI %s/%s", vmi.Namespace, vmi.Name)
+		return &syncv1.VMIStatusResponse{
+			Message: successMessage,
+		}, nil
+	}
+
+	// Check if the VMI's current migration matches this migration
+	if newVMI.Status.MigrationState.MigrationUID != "" && newVMI.Status.MigrationState.MigrationUID != migration.UID {
+		log.Log.Object(migration).Warningf("VMI %s/%s has different migration UID %s, ignoring source state update for migration %s",
+			vmi.Namespace, vmi.Name, newVMI.Status.MigrationState.MigrationUID, migration.UID)
+		return &syncv1.VMIStatusResponse{
+			Message: successMessage,
+		}, nil
+	}
+
 	log.Log.Object(newVMI).V(5).Infof("vmi migration source state: %#v", newVMI.Status.MigrationState.SourceState)
 	log.Log.Object(newVMI).V(5).Infof("remote migration source state: %#v", remoteStatus.MigrationState.SourceState)
 	newVMI.Status.MigrationState.SourceState = remoteStatus.MigrationState.SourceState.DeepCopy()
@@ -1054,6 +1073,24 @@ func (s *SynchronizationController) SyncTargetMigrationStatus(ctx context.Contex
 	newVMI := vmi.DeepCopy()
 	if newVMI.Status.MigrationState == nil {
 		newVMI.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{}
+	}
+
+	// Only update TargetState if this migration is still active and matches the VMI's current migration.
+	// This prevents stale updates from a completed decentralized migration from interfering with a new compute migration.
+	if migration.IsFinal() {
+		log.Log.Object(migration).Infof("Migration is final, ignoring target state update for VMI %s/%s", vmi.Namespace, vmi.Name)
+		return &syncv1.VMIStatusResponse{
+			Message: successMessage,
+		}, nil
+	}
+
+	// Check if the VMI's current migration matches this migration
+	if newVMI.Status.MigrationState.MigrationUID != "" && newVMI.Status.MigrationState.MigrationUID != migration.UID {
+		log.Log.Object(migration).Warningf("VMI %s/%s has different migration UID %s, ignoring target state update for migration %s",
+			vmi.Namespace, vmi.Name, newVMI.Status.MigrationState.MigrationUID, migration.UID)
+		return &syncv1.VMIStatusResponse{
+			Message: successMessage,
+		}, nil
 	}
 
 	log.Log.Object(newVMI).V(5).Infof("vmi migration target state: %#v", newVMI.Status.MigrationState.TargetState)

--- a/pkg/synchronization-controller/synchronization-controller_test.go
+++ b/pkg/synchronization-controller/synchronization-controller_test.go
@@ -35,6 +35,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -271,6 +272,91 @@ var _ = Describe("VMI status synchronization controller", func() {
 				},
 			}, "", false),
 		)
+
+		It("should return success when source migration is final without updating VMI", func() {
+			By("Set up migration as final (succeeded)")
+			migration.Status.Phase = virtv1.MigrationSucceeded
+			err := controller.migrationInformer.GetStore().Update(migration)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Set up VMI with migration state")
+			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID: migration.UID,
+			}
+			vmi, err = controller.client.VirtualMachineInstance(vmi.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Create request with source state")
+			remoteStatus := &virtv1.VirtualMachineInstanceStatus{
+				MigrationState: &virtv1.VirtualMachineInstanceMigrationState{
+					SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+						VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+							Node: "node1",
+						},
+					},
+				},
+			}
+			vmiStatusJson, err := json.Marshal(remoteStatus)
+			Expect(err).ToNot(HaveOccurred())
+			request := &syncv1.VMIStatusRequest{
+				MigrationID: testMigrationID,
+				VmiStatus: &syncv1.VMIStatus{
+					VmiStatusJson: vmiStatusJson,
+				},
+			}
+
+			By("Call SyncSourceMigrationStatus")
+			resp, err := controller.SyncSourceMigrationStatus(context.TODO(), request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Message).To(Equal(successMessage))
+
+			By("Verify VMI was not updated (SourceState should still be nil)")
+			updatedVMI, err := controller.client.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.SourceState).To(BeNil())
+		})
+
+		It("should return success when source VMI migration UID doesn't match without updating VMI", func() {
+			By("Set up VMI with different migration UID")
+			differentMigrationUID := "different-migration-uid"
+			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID: types.UID(differentMigrationUID),
+			}
+			vmi, err := controller.client.VirtualMachineInstance(vmi.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			err = controller.vmiInformer.GetStore().Update(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Create request with source state")
+			remoteStatus := &virtv1.VirtualMachineInstanceStatus{
+				MigrationState: &virtv1.VirtualMachineInstanceMigrationState{
+					SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+						VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+							Node: "node1",
+						},
+					},
+				},
+			}
+			vmiStatusJson, err := json.Marshal(remoteStatus)
+			Expect(err).ToNot(HaveOccurred())
+			request := &syncv1.VMIStatusRequest{
+				MigrationID: testMigrationID,
+				VmiStatus: &syncv1.VMIStatus{
+					VmiStatusJson: vmiStatusJson,
+				},
+			}
+
+			By("Call SyncSourceMigrationStatus")
+			resp, err := controller.SyncSourceMigrationStatus(context.TODO(), request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Message).To(Equal(successMessage))
+
+			By("Verify VMI was not updated (SourceState should still be nil)")
+			updatedVMI, err := controller.client.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.SourceState).To(BeNil())
+			Expect(updatedVMI.Status.MigrationState.MigrationUID).To(Equal(types.UID(differentMigrationUID)))
+		})
 	})
 
 	Context("grpc SyncTargetMigrationStatus", func() {
@@ -422,6 +508,91 @@ var _ = Describe("VMI status synchronization controller", func() {
 				},
 			}, "", false),
 		)
+
+		It("should return success when target migration is final without updating VMI", func() {
+			By("Set up migration as final (failed)")
+			migration.Status.Phase = virtv1.MigrationFailed
+			err := controller.migrationInformer.GetStore().Update(migration)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Set up VMI with migration state")
+			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID: migration.UID,
+			}
+			vmi, err = controller.client.VirtualMachineInstance(vmi.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Create request with target state")
+			remoteStatus := &virtv1.VirtualMachineInstanceStatus{
+				MigrationState: &virtv1.VirtualMachineInstanceMigrationState{
+					TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+						VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+							Node: "node1",
+						},
+					},
+				},
+			}
+			vmiStatusJson, err := json.Marshal(remoteStatus)
+			Expect(err).ToNot(HaveOccurred())
+			request := &syncv1.VMIStatusRequest{
+				MigrationID: testMigrationID,
+				VmiStatus: &syncv1.VMIStatus{
+					VmiStatusJson: vmiStatusJson,
+				},
+			}
+
+			By("Call SyncTargetMigrationStatus")
+			resp, err := controller.SyncTargetMigrationStatus(context.TODO(), request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Message).To(Equal(successMessage))
+
+			By("Verify VMI was not updated (TargetState should still be nil)")
+			updatedVMI, err := controller.client.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.TargetState).To(BeNil())
+		})
+
+		It("should return success when target VMI migration UID doesn't match without updating VMI", func() {
+			By("Set up VMI with different migration UID")
+			differentMigrationUID := "different-migration-uid"
+			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID: types.UID(differentMigrationUID),
+			}
+			vmi, err := controller.client.VirtualMachineInstance(vmi.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			err = controller.vmiInformer.GetStore().Update(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Create request with target state")
+			remoteStatus := &virtv1.VirtualMachineInstanceStatus{
+				MigrationState: &virtv1.VirtualMachineInstanceMigrationState{
+					TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+						VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+							Node: "node1",
+						},
+					},
+				},
+			}
+			vmiStatusJson, err := json.Marshal(remoteStatus)
+			Expect(err).ToNot(HaveOccurred())
+			request := &syncv1.VMIStatusRequest{
+				MigrationID: testMigrationID,
+				VmiStatus: &syncv1.VMIStatus{
+					VmiStatusJson: vmiStatusJson,
+				},
+			}
+
+			By("Call SyncTargetMigrationStatus")
+			resp, err := controller.SyncTargetMigrationStatus(context.TODO(), request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Message).To(Equal(successMessage))
+
+			By("Verify VMI was not updated (TargetState should still be nil)")
+			updatedVMI, err := controller.client.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.TargetState).To(BeNil())
+			Expect(updatedVMI.Status.MigrationState.MigrationUID).To(Equal(types.UID(differentMigrationUID)))
+		})
 	})
 
 	verifySource := func(controller *SynchronizationController, vmi *virtv1.VirtualMachineInstance, url string) {

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1188,7 +1188,7 @@ func (c *Controller) updateTargetPodNetworkInfo(vmi *virtv1.VirtualMachineInstan
 
 func (c *Controller) handleTargetPodHandoff(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
 
-	if vmi.IsMigrationSynchronized(migration) && vmi.Status.MigrationState.MigrationUID == migration.UID {
+	if vmi.IsMigrationSynchronized(migration) && vmi.Status.MigrationState != nil && vmi.Status.MigrationState.MigrationUID == migration.UID {
 		// already handed off
 		return nil
 	}
@@ -1424,7 +1424,8 @@ func (c *Controller) handleBackendStorage(migration *virtv1.VirtualMachineInstan
 	if migration.Status.MigrationState == nil {
 		migration.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{}
 	}
-	if !vmi.IsDecentralizedMigration() || vmi.IsMigrationSource() {
+	// Set source PVC when: not decentralized, or VMI is source for this migration, or a previous decentralized migration completed (so next migration can run MigrationHandoff).
+	if !vmi.IsDecentralizedMigration() || vmi.IsMigrationSource() || vmi.IsMigrationCompleted() {
 		migration.Status.MigrationState.SourcePersistentStatePVCName = backendstorage.CurrentPVCName(vmi)
 		if migration.Status.MigrationState.SourcePersistentStatePVCName == "" {
 			return fmt.Errorf("no backend-storage PVC found in VMI volume status")
@@ -1914,7 +1915,6 @@ func (c *Controller) sync(key string, migration *virtv1.VirtualMachineInstanceMi
 			}
 		}
 		return nil
-
 	case virtv1.MigrationRunning:
 		if migration.DeletionTimestamp != nil && vmi.IsMigrationSynchronized(migration) {
 			err = c.markMigrationAbortInVmiStatus(migration, vmi)

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -504,6 +504,27 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 			})
 
+			verifyTPMAndEFI := func(targetVM *v1.VirtualMachine, targetVMI *v1.VirtualMachineInstance) {
+				By("Stopping the VM")
+				libvmops.StopVirtualMachine(targetVM)
+				By("Starting the VM")
+				targetVM = libvmops.StartVirtualMachine(targetVM)
+				By("Logging in")
+				Expect(console.LoginToFedora(targetVMI)).To(Succeed())
+				By("Ensuring the TPM and EFI vars contain the same data after stop and start")
+				checkTPM(targetVMI)
+				checkEFI(targetVMI)
+			}
+
+			verifyComputeLiveMigrate := func(vmi *v1.VirtualMachineInstance) {
+				By("compute live migrating the VMI")
+				migration := libmigration.New(vmi.Name, vmi.Namespace)
+				migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+				// check VMI, confirm migration state
+				libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+			}
+
 			// TODO: Remove the RequiresRWOFsVMStateStorageClass once libvirt allows us to tell it to ignore the check
 			// for shared storage.
 			It("should decentralized migrate a VMI with persistent TPM+EFI enabled", decorators.RequiresDecentralizedLiveMigration, decorators.RequiresRWOFsVMStateStorageClass, Serial, func() {
@@ -541,18 +562,10 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				sourceMigration, targetMigration = libmigration.RunDecentralizedMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, sourceMigration, targetMigration)
 				libmigration.ConfirmVMIPostMigration(virtClient, targetVMI, targetMigration)
 
-				By("Ensuring the TPM is still functional and its state and EFI vars are carried over")
-				checkTPM(targetVMI)
-				checkEFI(targetVMI)
-				By("Stopping the VM")
-				libvmops.StopVirtualMachine(targetVM)
-				By("Starting the VM")
-				targetVM = libvmops.StartVirtualMachine(targetVM)
-				By("Logging in")
-				Expect(console.LoginToFedora(targetVMI)).To(Succeed())
-				By("Ensuring the TPM and EFI vars contain the same data after stop and start")
-				checkTPM(targetVMI)
-				checkEFI(targetVMI)
+				verifyComputeLiveMigrate(targetVMI)
+
+				verifyTPMAndEFI(targetVM, targetVMI)
+
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Properly detect that a migration decentralized or not is completed, and reset the migration state when starting a new migration (decentralized or not).

#### Before this PR:
After a decentralized live migration, the migration state was not properly reset when starting
a new compute migration. This was because isDecentralizedMigration was returning true and skipping the reset logic.

#### After this PR:
The check now also checks if the migration is complete before resetting. This allows the migration state to be reset upon subsequent migrations.

### References
- Fixes https://issues.redhat.com/browse/CNV-80525
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed migration not reporting succeeded when doing compute migration after decentralized live migration
```

