### PR TITLE
net: Graduate LiveUpdateNADRef feature gate

### DIFF
--- a/pkg/network/controllers/vm.go
+++ b/pkg/network/controllers/vm.go
@@ -35,13 +35,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-type clusterConfigurer interface {
-	LiveUpdateNADRefEnabled() bool
-}
-
 type VMController struct {
-	clientset         kubevirt.Interface
-	clusterConfigurer clusterConfigurer
+	clientset kubevirt.Interface
 }
 
 type syncError struct {
@@ -65,10 +60,9 @@ const (
 	hotPlugNetworkInterfaceErrorReason = "HotPlugNetworkInterfaceError"
 )
 
-func NewVMController(clientset kubevirt.Interface, clusterConfigurer clusterConfigurer) *VMController {
+func NewVMController(clientset kubevirt.Interface) *VMController {
 	return &VMController{
-		clientset:         clientset,
-		clusterConfigurer: clusterConfigurer,
+		clientset: clientset,
 	}
 }
 
@@ -87,7 +81,7 @@ func (v *VMController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstanc
 			func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool { return true },
 		)
 
-		updatedVMI := syncVMIInterfaces(vm, vmi, vmiIfaceStatusesByName, v.clusterConfigurer.LiveUpdateNADRefEnabled())
+		updatedVMI := syncVMIInterfaces(vm, vmi, vmiIfaceStatusesByName)
 
 		if err := v.vmiInterfacesPatch(&updatedVMI.Spec, vmi); err != nil {
 			return vm, &syncError{
@@ -116,7 +110,6 @@ func syncVMIInterfaces(
 	vm *v1.VirtualMachine,
 	vmi *v1.VirtualMachineInstance,
 	indexedStatusIfaces map[string]v1.VirtualMachineInstanceNetworkInterface,
-	isLiveUpdateNADRefEnabled bool,
 ) *v1.VirtualMachineInstance {
 	vmiCopy := vmi.DeepCopy()
 	hasOrdinalIfaces := namescheme.HasOrdinalSecondaryIfaces(vmi.Spec.Networks, vmi.Status.Interfaces)
@@ -127,9 +120,7 @@ func syncVMIInterfaces(
 	vmiCopy.Spec.Domain.Devices.Interfaces = ifaces
 	vmiCopy.Spec.Networks = networks
 
-	if isLiveUpdateNADRefEnabled {
-		vmiCopy.Spec.Networks = syncNetworks(vm.Spec.Template.Spec.Networks, vmiCopy.Spec.Networks)
-	}
+	vmiCopy.Spec.Networks = syncNetworks(vm.Spec.Template.Spec.Networks, vmiCopy.Spec.Networks)
 
 	return vmiCopy
 }

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -54,7 +54,7 @@ var _ = Describe("VM Network Controller", func() {
 		updatedNADName2   = "new-nad2"
 	)
 	DescribeTable("sync does nothing when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) {
-		c := controllers.NewVMController(fake.NewSimpleClientset(), stubClusterConfigurer{})
+		c := controllers.NewVMController(fake.NewSimpleClientset())
 		originalVM := vm.DeepCopy()
 		Expect(c.Sync(vm, vmi)).To(Equal(originalVM))
 	},
@@ -97,7 +97,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync fails when VMI patch returns an error", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 
 		// Setup `Patch` to fail.
 		injectedPatchError := errors.New("test patch error")
@@ -129,7 +129,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	DescribeTable("sync succeeds to hotplug new interface", func(ifaceToPlug v1.Interface) {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -177,7 +177,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync does not hotplug a new absent interface", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -217,7 +217,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	DescribeTable("sync succeeds to mark an existing interface for hotunplug", func(currentIfaceState v1.InterfaceState) {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 
 		multusAndDomainInfoSource := vmispec.NewInfoSource(vmispec.InfoSourceMultusStatus, vmispec.InfoSourceDomain)
 
@@ -274,7 +274,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync does not hotplug a new interface when it uses binding other than bridge or SR-IOV", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 
 		vmi := libvmi.New()
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
@@ -303,7 +303,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync succeeds to clear hotunplug interfaces from running VM", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		unpluggedIface := libvmi.InterfaceDeviceWithBridgeBinding("foonet")
 		unpluggedIface.State = v1.InterfaceStateAbsent
 		vmi := libvmi.New(
@@ -339,7 +339,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync succeeds to clear hotunplug interfaces from stopped VM", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		unpluggedIface := libvmi.InterfaceDeviceWithBridgeBinding("foonet")
 		unpluggedIface.State = v1.InterfaceStateAbsent
 		vmi := libvmi.New(
@@ -361,7 +361,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync does not hotunplug interfaces when nameing scheme is unknown", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -405,7 +405,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	DescribeTable("sync updates link state of an existing interface", func(fromState, toState v1.InterfaceState) {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		const defaultNetName = "default"
 		vmi := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
@@ -459,7 +459,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	DescribeTable("sync doesn't update link state if hot-unplug is underway ", func(toState v1.InterfaceState) {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		const defaultNetName = "default"
 		vmi := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
@@ -505,7 +505,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync does not hotunplug interfaces when legacy ordinal interface names are found", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -560,7 +560,7 @@ var _ = Describe("VM Network Controller", func() {
 		)
 
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 
 		multusAndDomainInfoSource := vmispec.NewInfoSource(vmispec.InfoSourceMultusStatus, vmispec.InfoSourceDomain)
 
@@ -621,7 +621,7 @@ var _ = Describe("VM Network Controller", func() {
 			netToDetachNADName = "detach-me-nad"
 		)
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{})
+		c := controllers.NewVMController(clientset)
 
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -665,9 +665,9 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(Equal(originalVMI.Spec.Domain.Devices.Interfaces))
 	})
 
-	DescribeTable("sync handles NAD reference updates", func(isFGEnabled bool, expectedNADNameOnVMISpec string) {
+	It("sync handles NAD reference updates by copying NAD reference to VMI", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{isLiveUpdateNADRefEnabled: isFGEnabled})
+		c := controllers.NewVMController(clientset)
 
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -691,15 +691,12 @@ var _ = Describe("VM Network Controller", func() {
 			Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(updatedVMI.Spec.Networks[1].Multus.NetworkName).To(Equal(expectedNADNameOnVMISpec))
-	},
-		Entry("by copying NAD reference to VMI when FG LiveUpdateNADRefEnabled is enabled", true, updatedNADName1),
-		Entry("by not copying NAD reference to VMI when FG LiveUpdateNADRefEnabled is disabled", false, nadName),
-	)
+		Expect(updatedVMI.Spec.Networks[1].Multus.NetworkName).To(Equal(updatedNADName1))
+	})
 
 	It("sync handles multiple NAD reference updates", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{isLiveUpdateNADRefEnabled: true})
+		c := controllers.NewVMController(clientset)
 
 		By("Creating a new VM)")
 		vmi := libvmi.New(
@@ -750,7 +747,7 @@ var _ = Describe("VM Network Controller", func() {
 
 	It("sync preserves auto-injected Pod network", func() {
 		clientset := fake.NewSimpleClientset()
-		c := controllers.NewVMController(clientset, stubClusterConfigurer{isLiveUpdateNADRefEnabled: true})
+		c := controllers.NewVMController(clientset)
 
 		expectedIfaces := []v1.Interface{libvmi.InterfaceDeviceWithMasqueradeBinding()}
 		expectedNets := []v1.Network{*v1.DefaultPodNetwork()}
@@ -819,12 +816,4 @@ func unplugNetworkInterface(vm *v1.VirtualMachine, netName string) *v1.VirtualMa
 
 func newEmptyVM() *v1.VirtualMachine {
 	return &v1.VirtualMachine{Spec: v1.VirtualMachineSpec{Template: &v1.VirtualMachineInstanceTemplateSpec{}}}
-}
-
-type stubClusterConfigurer struct {
-	isLiveUpdateNADRefEnabled bool
-}
-
-func (s stubClusterConfigurer) LiveUpdateNADRefEnabled() bool {
-	return s.isLiveUpdateNADRefEnabled
 }

--- a/pkg/network/migration/evaluator.go
+++ b/pkg/network/migration/evaluator.go
@@ -48,23 +48,17 @@ const (
 
 type timeProviderFunc func() metav1.Time
 
-type clusterConfigurer interface {
-	LiveUpdateNADRefEnabled() bool
-}
-
 type Evaluator struct {
-	timeProvider      timeProviderFunc
-	clusterConfigurer clusterConfigurer
+	timeProvider timeProviderFunc
 }
 
-func NewEvaluator(clusterConfigurer clusterConfigurer) Evaluator {
-	return NewEvaluatorWithTimeProvider(metav1.Now, clusterConfigurer)
+func NewEvaluator() Evaluator {
+	return NewEvaluatorWithTimeProvider(metav1.Now)
 }
 
-func NewEvaluatorWithTimeProvider(timeProvider timeProviderFunc, clusterConfigurer clusterConfigurer) Evaluator {
+func NewEvaluatorWithTimeProvider(timeProvider timeProviderFunc) Evaluator {
 	return Evaluator{
-		timeProvider:      timeProvider,
-		clusterConfigurer: clusterConfigurer,
+		timeProvider: timeProvider,
 	}
 }
 
@@ -74,7 +68,6 @@ func (e Evaluator) Evaluate(vmi *v1.VirtualMachineInstance,
 	result := shouldVMIBeMarkedForAutoMigration(
 		vmi,
 		pod,
-		e.clusterConfigurer.LiveUpdateNADRefEnabled(),
 	)
 
 	switch result {
@@ -99,7 +92,6 @@ func (e Evaluator) Evaluate(vmi *v1.VirtualMachineInstance,
 func shouldVMIBeMarkedForAutoMigration(
 	vmi *v1.VirtualMachineInstance,
 	pod *k8scorev1.Pod,
-	isLiveUpdateNADRefEnabled bool,
 ) migrationRequirementKind {
 	ifaces := vmi.Spec.Domain.Devices.Interfaces
 	nets := vmi.Spec.Networks
@@ -124,10 +116,6 @@ func shouldVMIBeMarkedForAutoMigration(
 
 		if result := shouldMigrateOnIfaceUnplug(iface, ifaceStatus, ifaceStatusExists); result != notRequired {
 			return result
-		}
-
-		if !isLiveUpdateNADRefEnabled {
-			continue
 		}
 
 		net := netsByName[iface.Name]

--- a/pkg/network/migration/evaluator_test.go
+++ b/pkg/network/migration/evaluator_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Evaluator", func() {
 
 	DescribeTable("Should not require migration", func(vmi *v1.VirtualMachineInstance) {
 		pod := &k8scorev1.Pod{}
-		Expect(migration.NewEvaluator(stubClusterConfigurer{}).Evaluate(vmi, pod)).To(Equal(k8scorev1.ConditionUnknown))
+		Expect(migration.NewEvaluator().Evaluate(vmi, pod)).To(Equal(k8scorev1.ConditionUnknown))
 	},
 		Entry("when no networks are specified",
 			libvmi.New(libvmi.WithAutoAttachPodInterface(false)),
@@ -102,7 +102,7 @@ var _ = Describe("Evaluator", func() {
 
 	DescribeTable("Should require a pending migration", func(vmi *v1.VirtualMachineInstance) {
 		pod := &k8scorev1.Pod{}
-		Expect(migration.NewEvaluator(stubClusterConfigurer{}).Evaluate(vmi, pod)).To(Equal(k8scorev1.ConditionFalse))
+		Expect(migration.NewEvaluator().Evaluate(vmi, pod)).To(Equal(k8scorev1.ConditionFalse))
 	},
 		Entry("when a secondary iface using bridge binding is hotplugged",
 			libvmi.New(
@@ -164,7 +164,7 @@ var _ = Describe("Evaluator", func() {
 			),
 		)
 
-		Expect(migration.NewEvaluator(stubClusterConfigurer{}).Evaluate(vmi, &k8scorev1.Pod{})).
+		Expect(migration.NewEvaluator().Evaluate(vmi, &k8scorev1.Pod{})).
 			To(Equal(k8scorev1.ConditionTrue))
 	})
 
@@ -197,7 +197,7 @@ var _ = Describe("Evaluator", func() {
 				return metav1.Time{Time: stubNow}
 			}
 
-			Expect(migration.NewEvaluatorWithTimeProvider(stubTimeProvider, stubClusterConfigurer{}).
+			Expect(migration.NewEvaluatorWithTimeProvider(stubTimeProvider).
 				Evaluate(vmi, &k8scorev1.Pod{})).To(Equal(expectedResult))
 		},
 			Entry("Should require a pending migration when timeout hasn't expired",
@@ -224,16 +224,14 @@ var _ = Describe("Evaluator", func() {
 
 			nadName1 = "nad1"
 			nadName2 = "nad2"
-
-			liveUpdateNADRefEnabled = true
 		)
 
 		DescribeTable("should trigger",
-			func(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod, isLiveUpdateEnabled bool, expectedMigration k8scorev1.ConditionStatus) {
-				evaluator := migration.NewEvaluator(stubClusterConfigurer{isLiveUpdateNADRefEnabled: isLiveUpdateEnabled})
+			func(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod, expectedMigration k8scorev1.ConditionStatus) {
+				evaluator := migration.NewEvaluator()
 				Expect(evaluator.Evaluate(vmi, pod)).To(Equal(expectedMigration))
 			},
-			Entry("no migration when NAD name in spec matches that in pod annotation and FG is enabled",
+			Entry("no migration when NAD name in spec matches that in pod annotation",
 				libvmi.New(
 					libvmi.WithNamespace(testNamespace),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName1)),
@@ -250,30 +248,9 @@ var _ = Describe("Evaluator", func() {
 					"k8s.v1.cni.cncf.io/network-status": fmt.Sprintf(`[{"interface": %q, "name": "%s/%s"}]`,
 						secondaryPodIfaceName1, testNamespace, nadName1),
 				}),
-				liveUpdateNADRefEnabled,
 				k8scorev1.ConditionUnknown,
 			),
-			Entry("no migration when NAD name in spec differs from that in pod annotation and FG is disabled",
-				libvmi.New(
-					libvmi.WithNamespace(testNamespace),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName1)),
-					libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName1, nadName1)),
-					libvmistatus.WithStatus(libvmistatus.New(
-						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:             secondaryNetworkName1,
-							PodInterfaceName: secondaryPodIfaceName1,
-							InfoSource:       multusAndDomainInfoSource,
-						}),
-					)),
-				),
-				newPod(map[string]string{
-					"k8s.v1.cni.cncf.io/network-status": fmt.Sprintf(`[{"interface": %q, "name": "%s/%s"}]`,
-						secondaryPodIfaceName1, testNamespace, nadName2),
-				}),
-				!liveUpdateNADRefEnabled,
-				k8scorev1.ConditionUnknown,
-			),
-			Entry("immediate migration when NAD name in spec differs from that in pod annotation and FG is enabled",
+			Entry("immediate migration when NAD name in spec differs from that in pod annotation",
 				libvmi.New(
 					libvmi.WithNamespace(testNamespace),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName1)),
@@ -290,11 +267,10 @@ var _ = Describe("Evaluator", func() {
 					"k8s.v1.cni.cncf.io/network-status": fmt.Sprintf(`[{"interface": %q, "name": "%s/%s"}]`,
 						secondaryPodIfaceName1, testNamespace, nadName1),
 				}),
-				liveUpdateNADRefEnabled,
 				k8scorev1.ConditionTrue,
 			),
 			Entry(
-				"immediate migration when a VM has NADs in different namespaces and one is out of sync and FG is enabled",
+				"immediate migration when a VM has NADs in different namespaces and one is out of sync",
 				libvmi.New(
 					libvmi.WithNamespace(testNamespace),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName1)),
@@ -321,20 +297,11 @@ var _ = Describe("Evaluator", func() {
 						secondaryPodIfaceName2, otherNamespace, nadName1,
 					),
 				}),
-				liveUpdateNADRefEnabled,
 				k8scorev1.ConditionTrue,
 			),
 		)
 	})
 })
-
-type stubClusterConfigurer struct {
-	isLiveUpdateNADRefEnabled bool
-}
-
-func (s stubClusterConfigurer) LiveUpdateNADRefEnabled() bool {
-	return s.isLiveUpdateNADRefEnabled
-}
 
 func newPod(annotations map[string]string) *k8scorev1.Pod {
 	return &k8scorev1.Pod{

--- a/pkg/network/vmliveupdate/restart.go
+++ b/pkg/network/vmliveupdate/restart.go
@@ -27,26 +27,18 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-type clusterConfigurer interface {
-	LiveUpdateNADRefEnabled() bool
-}
 type netChangePredicate func(map[string]v1.Network, map[string]v1.Network) bool
 
 // IsRestartRequired - Checks if the changes in network related fields require a reset of the VM
 // in order for them to be applied
-func IsRestartRequired(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, clusterConfigurer clusterConfigurer) bool {
+func IsRestartRequired(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) bool {
 	desiredIfaces := vm.Spec.Template.Spec.Domain.Devices.Interfaces
 	currentIfaces := vmi.Spec.Domain.Devices.Interfaces
 
 	desiredNets := vm.Spec.Template.Spec.Networks
 	currentNets := vmi.Spec.Networks
 
-	netChangePredicates := []netChangePredicate{haveCurrentNetsBeenRemoved}
-	if clusterConfigurer.LiveUpdateNADRefEnabled() {
-		netChangePredicates = append(netChangePredicates, haveNetsChangedIgnoringNADName)
-	} else {
-		netChangePredicates = append(netChangePredicates, haveCurrentNetsChanged)
-	}
+	netChangePredicates := []netChangePredicate{haveCurrentNetsBeenRemoved, haveNetsChangedIgnoringNADName}
 
 	return shouldIfacesChangeRequireRestart(desiredIfaces, currentIfaces) ||
 		shouldNetsChangeRequireRestart(desiredNets, currentNets, netChangePredicates...)
@@ -122,17 +114,6 @@ func haveCurrentNetsBeenRemoved(desiredNetsByName, currentNetsByName map[string]
 		}
 	}
 
-	return false
-}
-
-func haveCurrentNetsChanged(desiredNetsByName, currentNetsByName map[string]v1.Network) bool {
-	for currentNetName, currentNet := range currentNetsByName {
-		desiredNet := desiredNetsByName[currentNetName]
-
-		if !reflect.DeepEqual(desiredNet, currentNet) {
-			return true
-		}
-	}
 	return false
 }
 

--- a/pkg/network/vmliveupdate/restart_test.go
+++ b/pkg/network/vmliveupdate/restart_test.go
@@ -36,15 +36,14 @@ var _ = Describe("IsRestartRequired", func() {
 		secondaryNetName1 = "foo"
 		secondaryNADName1 = "foo-nad"
 
-		secondaryNetName2       = "bar"
-		secondaryNADName2       = "bar-nad"
-		liveUpdateNADRefEnabled = true
+		secondaryNetName2 = "bar"
+		secondaryNADName2 = "bar-nad"
 	)
 
 	DescribeTable("should not require restart when there is no change", func(vmi *v1.VirtualMachineInstance) {
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{liveUpdateNADRefEnabled})).To(BeFalse())
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
 	},
 		Entry("Without interfaces and networks",
 			libvmi.New(libvmi.WithAutoAttachPodInterface(false))),
@@ -74,7 +73,7 @@ var _ = Describe("IsRestartRequired", func() {
 			vm.Spec.Template.Spec.Networks,
 			*libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1),
 		)
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{liveUpdateNADRefEnabled})).To(BeFalse())
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
 	})
 
 	DescribeTable("should not require restart when interface state changes", func(current, desired v1.InterfaceState) {
@@ -89,7 +88,7 @@ var _ = Describe("IsRestartRequired", func() {
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
 		vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].State = desired
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{liveUpdateNADRefEnabled})).To(BeFalse())
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
 	},
 		Entry("From empty to empty", v1.InterfaceState(""), v1.InterfaceState("")),
 		Entry("From empty to absent", v1.InterfaceState(""), v1.InterfaceStateAbsent),
@@ -105,9 +104,7 @@ var _ = Describe("IsRestartRequired", func() {
 		Entry("From down to down", v1.InterfaceStateLinkDown, v1.InterfaceStateLinkDown),
 	)
 
-	DescribeTable("should not require restart when secondary NICs are hotplugged", func(
-		isliveUpdateNADRefEnabled bool,
-	) {
+	It("should not require restart when secondary NICs are hotplugged", func() {
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -132,14 +129,10 @@ var _ = Describe("IsRestartRequired", func() {
 
 		vm.Spec.Template.Spec.Networks = append(vm.Spec.Template.Spec.Networks, netsToHotplug...)
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{isliveUpdateNADRefEnabled})).To(BeFalse())
-	},
-		Entry("With FG enabled", liveUpdateNADRefEnabled),
-		Entry("With FG disabled", !liveUpdateNADRefEnabled))
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	})
 
-	DescribeTable("should not require restart when interfaces or networks order is changed", func(
-		isliveUpdateNADRefEnabled bool,
-	) {
+	It("should not require restart when interfaces or networks order is changed", func() {
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
@@ -154,11 +147,8 @@ var _ = Describe("IsRestartRequired", func() {
 		slices.Reverse(vm.Spec.Template.Spec.Domain.Devices.Interfaces)
 		slices.Reverse(vm.Spec.Template.Spec.Networks)
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{liveUpdateNADRefEnabled})).To(BeFalse())
-	},
-		Entry("With FG enabled", liveUpdateNADRefEnabled),
-		Entry("With FG disabled", !liveUpdateNADRefEnabled),
-	)
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	})
 
 	It("should require restart when interface binding changes", func() {
 		iface := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)
@@ -171,13 +161,12 @@ var _ = Describe("IsRestartRequired", func() {
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
 		vm.Spec.Template.Spec.Domain.Devices.Interfaces[0] = libvmi.InterfaceDeviceWithMasqueradeBinding()
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{liveUpdateNADRefEnabled})).To(BeTrue())
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
 	})
 
 	DescribeTable("should require restart when network source changes", func(
 		current,
 		desired v1.Network,
-		liveUpdateNADRefEnabled bool,
 	) {
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -187,22 +176,15 @@ var _ = Describe("IsRestartRequired", func() {
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
 		vm.Spec.Template.Spec.Networks[0] = desired
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{liveUpdateNADRefEnabled})).To(BeTrue())
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
 	},
-		Entry("From Pod to Multus, with FG enabled", *v1.DefaultPodNetwork(),
-			*libvmi.MultusNetwork("default", secondaryNADName1), liveUpdateNADRefEnabled),
-		Entry("From Multus to Pod, with FG enabled", *libvmi.MultusNetwork("default", secondaryNADName1),
-			*v1.DefaultPodNetwork(), liveUpdateNADRefEnabled),
-		Entry("From Pod to Multus, with FG disabled", *v1.DefaultPodNetwork(),
-			*libvmi.MultusNetwork("default", secondaryNADName1), !liveUpdateNADRefEnabled),
-		Entry("From Multus to Pod, with FG disabled", *libvmi.MultusNetwork("default", secondaryNADName1),
-			*v1.DefaultPodNetwork(), !liveUpdateNADRefEnabled),
+		Entry("From Pod to Multus", *v1.DefaultPodNetwork(),
+			*libvmi.MultusNetwork("default", secondaryNADName1)),
+		Entry("From Multus to Pod", *libvmi.MultusNetwork("default", secondaryNADName1),
+			*v1.DefaultPodNetwork()),
 	)
 
-	DescribeTable("should require restart when NAD name changes only if FG LiveUpdateNADRef is disabled", func(
-		isLiveUpdateNADRefEnabled bool,
-		shouldRequireRestart bool,
-	) {
+	It("should not require restart when NAD name changes", func() {
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
@@ -211,13 +193,10 @@ var _ = Describe("IsRestartRequired", func() {
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
 		vm.Spec.Template.Spec.Networks[0] = *libvmi.MultusNetwork(secondaryNetName1, secondaryNADName2)
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{isLiveUpdateNADRefEnabled})).To(Equal(shouldRequireRestart))
-	},
-		Entry("With FG enabled", liveUpdateNADRefEnabled, false),
-		Entry("With FG disabled", !liveUpdateNADRefEnabled, true),
-	)
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
+	})
 
-	DescribeTable("Should require restart when interfaces and networks are removed", func(isliveUpdateNADRefEnabled bool) {
+	It("Should require restart when interfaces and networks are removed", func() {
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
@@ -229,13 +208,10 @@ var _ = Describe("IsRestartRequired", func() {
 		vm.Spec.Template.Spec.Domain.Devices.Interfaces = vm.Spec.Template.Spec.Domain.Devices.Interfaces[:1]
 		vm.Spec.Template.Spec.Networks = vm.Spec.Template.Spec.Networks[:1]
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{isliveUpdateNADRefEnabled})).To(BeTrue())
-	},
-		Entry("With FG enabled", liveUpdateNADRefEnabled),
-		Entry("With FG disabled", !liveUpdateNADRefEnabled),
-	)
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
+	})
 
-	DescribeTable("should require restart when pod network is added to networkless VM", func(isliveUpdateNADRefEnabled bool) {
+	It("should require restart when pod network is added to networkless VM", func() {
 		vmi := libvmi.New()
 
 		vm := libvmi.NewVirtualMachine(
@@ -245,17 +221,6 @@ var _ = Describe("IsRestartRequired", func() {
 			),
 		)
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi, stubClusterConfigurer{isliveUpdateNADRefEnabled})).To(BeTrue())
-	},
-		Entry("With FG enabled", liveUpdateNADRefEnabled),
-		Entry("With FG disabled", !liveUpdateNADRefEnabled),
-	)
+		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
+	})
 })
-
-type stubClusterConfigurer struct {
-	isLiveUpdateNADRefEnabled bool
-}
-
-func (s stubClusterConfigurer) LiveUpdateNADRefEnabled() bool {
-	return s.isLiveUpdateNADRefEnabled
-}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -233,10 +233,6 @@ func (config *ClusterConfig) OptOutRoleAggregationEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.OptOutRoleAggregation)
 }
 
-func (config *ClusterConfig) LiveUpdateNADRefEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.LiveUpdateNADRef)
-}
-
 func (config *ClusterConfig) VGPULiveMigrationEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.VGPULiveMigration)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -217,11 +217,6 @@ const (
 	// allowing users to opt out of aggregating KubeVirt ClusterRoles to the default Kubernetes roles.
 	OptOutRoleAggregation = "OptOutRoleAggregation"
 
-	// LiveUpdateNADRef enables dynamic modification of NAD references for secondary networks on running VMs.
-	// Owner: SIG network
-	// Beta: v1.8
-	LiveUpdateNADRef = "LiveUpdateNADRef"
-
 	// Owner: @csomani1
 	// Alpha: v1.8.0
 	//
@@ -271,6 +266,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ContainerPathVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: ReservedOverheadMemlock, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: OptOutRoleAggregation, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: LiveUpdateNADRef, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: VGPULiveMigration, State: Alpha})
 }

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -143,6 +143,13 @@ const (
 	//
 	// PanicDevices allows defining panic devices for signaling crashes in the guest for a VirtualMachineInstance.
 	PanicDevicesGate = "PanicDevices"
+
+	// Owner: sig-network
+	// Beta: v1.8.0
+	// GA: v1.9.0
+	//
+	// LiveUpdateNADRef enables dynamic modification of NAD references for secondary networks on running VMs.
+	LiveUpdateNADRef = "LiveUpdateNADRef"
 )
 
 func init() {
@@ -181,4 +188,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: DisableMediatedDevicesHandling, State: Deprecated, Message: "DisableMDEVConfiguration has been deprecated since v1.8.0"})
 	RegisterFeatureGate(FeatureGate{Name: ExpandDisksGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: PanicDevicesGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: LiveUpdateNADRef, State: GA})
 }

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -711,7 +711,7 @@ func (vca *VirtControllerApp) initCommon() {
 		func(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, clusterCfg *virtconfig.ClusterConfig) []metav1.StatusCause {
 			return netadmitter.ValidateCreation(field, vmiSpec, clusterCfg)
 		},
-		netmigration.NewEvaluator(vca.clusterConfig),
+		netmigration.NewEvaluator(),
 		vca.additionalLauncherAnnotationsSync,
 		vca.additionalLauncherLabelsSync,
 	)
@@ -797,7 +797,6 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.clusterConfig,
 		netcontrollers.NewVMController(
 			vca.clientSet.GeneratedKubeVirtClient(),
-			vca.clusterConfig,
 		),
 		vm.NewFirmwareController(vca.clientSet.GeneratedKubeVirtClient()),
 		instancetypecontroller.New(

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3031,7 +3031,7 @@ func (c *Controller) syncRestartRequired(lastSeenVMSpec *virtv1.VirtualMachineSp
 		lastSeenVM.Spec.Template.Spec.Tolerations = currentVM.Spec.Template.Spec.Tolerations
 	}
 
-	if !netvmliveupdate.IsRestartRequired(currentVM, vmi, c.clusterConfig) {
+	if !netvmliveupdate.IsRestartRequired(currentVM, vmi) {
 		lastSeenVM.Spec.Template.Spec.Domain.Devices.Interfaces = currentVM.Spec.Template.Spec.Domain.Devices.Interfaces
 		lastSeenVM.Spec.Template.Spec.Networks = currentVM.Spec.Template.Spec.Networks
 	}

--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -66,7 +66,6 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		config.EnableFeatureGate("LiveUpdateNADRef")
 
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{
 			WorkloadUpdateMethods: []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR removes all conditional checks for the feature gate and graduates the LiveUpdateNADRef feature gate as the feature has been stabilized, e2e tests have been running for more than 2 weeks, the VEP has been updated to propose GA and hence the feature can be enabled by default. 

Generated by: Claude


#### Before this PR:

#### After this PR:

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/140
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The [T1 periodic tests](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.35-sig-network&width=20) have been passing regularly. So it is safe to graduate this feature.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Graduates LiveUpdateNADRef feature gate
```

