### PR TITLE
Add global flags passer for fork based operations

### DIFF
--- a/pkg/virtctl/scp/scp.go
+++ b/pkg/virtctl/scp/scp.go
@@ -95,8 +95,9 @@ func (o *scp) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	globalFlags := ssh.GlobalFlagsFromCmd(cmd)
 	clientArgs := o.BuildSCPTarget(local, remote, toRemote)
-	return ssh.LocalClientCmd("scp", remote.Kind, remote.Namespace, remote.Name, o.options, clientArgs).Run()
+	return ssh.LocalClientCmd("scp", remote.Kind, remote.Namespace, remote.Name, o.options, globalFlags, clientArgs).Run()
 }
 
 func (o *scp) BuildSCPTarget(local *LocalArgument, remote *RemoteArgument, toRemote bool) []string {

--- a/pkg/virtctl/ssh/BUILD.bazel
+++ b/pkg/virtctl/ssh/BUILD.bazel
@@ -27,5 +27,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -135,8 +135,26 @@ func (o *ssh) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	globalFlags := GlobalFlagsFromCmd(cmd)
 	clientArgs := o.BuildSSHTarget(kind, namespace, name)
-	return LocalClientCmd("ssh", kind, namespace, name, o.options, clientArgs).Run()
+	return LocalClientCmd("ssh", kind, namespace, name, o.options, globalFlags, clientArgs).Run()
+}
+
+func GlobalFlagsFromCmd(cmd *cobra.Command) []string {
+	var args []string
+	rootPFlags := cmd.Root().PersistentFlags()
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if rootPFlags.Lookup(f.Name) != nil {
+			if sv, ok := f.Value.(pflag.SliceValue); ok {
+				for _, v := range sv.GetSlice() {
+					args = append(args, "--"+f.Name+"="+v)
+				}
+			} else {
+				args = append(args, "--"+f.Name+"="+f.Value.String())
+			}
+		}
+	})
+	return args
 }
 
 func (o *ssh) BuildSSHTarget(kind, namespace, name string) []string {
@@ -237,8 +255,8 @@ func ParseTarget(arg string) (kind, namespace, name, username string, err error)
 	return kind, namespace, name, username, err
 }
 
-func LocalClientCmd(command, kind, namespace, name string, options *SSHOptions, clientArgs []string) *exec.Cmd {
-	args := []string{"-o", BuildProxyCommandOption(kind, namespace, name, options.SSHPort)}
+func LocalClientCmd(command, kind, namespace, name string, options *SSHOptions, globalFlags, clientArgs []string) *exec.Cmd {
+	args := []string{"-o", BuildProxyCommandOption(kind, namespace, name, options.SSHPort, globalFlags)}
 	if len(options.AdditionalSSHLocalOptions) > 0 {
 		args = append(args, options.AdditionalSSHLocalOptions...)
 	}
@@ -257,10 +275,14 @@ func LocalClientCmd(command, kind, namespace, name string, options *SSHOptions, 
 	return cmd
 }
 
-func BuildProxyCommandOption(kind, namespace, name string, port int) string {
+func BuildProxyCommandOption(kind, namespace, name string, port int, globalFlags []string) string {
 	proxyCommand := strings.Builder{}
 	proxyCommand.WriteString("ProxyCommand=")
 	proxyCommand.WriteString(os.Args[0])
+	for _, flag := range globalFlags {
+		proxyCommand.WriteRune(' ')
+		proxyCommand.WriteString("'" + strings.ReplaceAll(flag, "'", "'\\''") + "'")
+	}
 	proxyCommand.WriteString(" port-forward --stdio=true ")
 	proxyCommand.WriteString(kind)
 	proxyCommand.WriteRune('/')

--- a/pkg/virtctl/ssh/ssh_test.go
+++ b/pkg/virtctl/ssh/ssh_test.go
@@ -2,9 +2,11 @@ package ssh_test
 
 import (
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/ssh"
 )
@@ -70,6 +72,7 @@ var _ = Describe("SSH", func() {
 		Entry("kind vm with name with dot", "vm/testvm.default", "", "testvm.default", "vm", "", ""),
 		Entry("kind vm with name with dot and username", "user@vm/testvm.default", "", "testvm.default", "vm", "user", ""),
 	)
+	const commandSSH = "ssh"
 
 	Context("Wrapped SSH", func() {
 		const (
@@ -89,23 +92,94 @@ var _ = Describe("SSH", func() {
 
 		It("BuildProxyCommandOption", func() {
 			const sshPort = 12345
-			proxyCommand := ssh.BuildProxyCommandOption(fakeKind, fakeNamespace, fakeName, sshPort)
-			expected := fmt.Sprintf("port-forward --stdio=true fake-kind/fake-name/fake-ns %d", sshPort)
-			Expect(proxyCommand).To(ContainSubstring(expected))
+			proxyCommand := ssh.BuildProxyCommandOption(fakeKind, fakeNamespace, fakeName, sshPort, nil)
+			expected := fmt.Sprintf("ProxyCommand=%s port-forward --stdio=true %s/%s/%s %d",
+				os.Args[0], fakeKind, fakeName, fakeNamespace, sshPort)
+			Expect(proxyCommand).To(Equal(expected))
 		})
 
-		It("LocalClientCmd", func() {
+		DescribeTable("BuildProxyCommandOption with global flags", func(globalFlags []string, expectedFlags string) {
+			const sshPort = 12345
+			proxyCommand := ssh.BuildProxyCommandOption(fakeKind, fakeNamespace, fakeName, sshPort, globalFlags)
+			expected := fmt.Sprintf("ProxyCommand=%s %s port-forward --stdio=true %s/%s/%s %d",
+				os.Args[0], expectedFlags, fakeKind, fakeName, fakeNamespace, sshPort)
+			Expect(proxyCommand).To(Equal(expected))
+		},
+			Entry("plain flags", []string{"--context=my-context", "--kubeconfig=/path/to/config"},
+				"'--context=my-context' '--kubeconfig=/path/to/config'"),
+			Entry("flag with spaces in value", []string{"--kubeconfig=/path with space/config"},
+				"'--kubeconfig=/path with space/config'"),
+			Entry("flag with single quote in value", []string{"--context=it's-ctx"},
+				`'--context=it'\''s-ctx'`),
+		)
+
+		DescribeTable("LocalClientCmd", func(globalFlags []string) {
 			opts := ssh.DefaultSSHOptions()
 			opts.SSHPort = 12345
 			c := ssh.NewSSH(opts)
 			clientArgs := c.BuildSSHTarget(fakeKind, fakeNamespace, fakeName)
-			const commandSSH = "ssh"
-			cmd := ssh.LocalClientCmd(commandSSH, fakeKind, fakeNamespace, fakeName, opts, clientArgs)
+			cmd := ssh.LocalClientCmd(commandSSH, fakeKind, fakeNamespace, fakeName, opts, globalFlags, clientArgs)
 			Expect(cmd).ToNot(BeNil())
-			Expect(cmd.Args).To(HaveLen(4))
-			Expect(cmd.Args[0]).To(Equal(commandSSH))
-			Expect(cmd.Args[2]).To(Equal(ssh.BuildProxyCommandOption(fakeKind, fakeNamespace, fakeName, opts.SSHPort)))
-			Expect(cmd.Args[3]).To(Equal(c.BuildSSHTarget(fakeKind, fakeNamespace, fakeName)[0]))
+			Expect(cmd.Args).To(HaveExactElements(
+				Equal(commandSSH),
+				Equal("-o"),
+				Equal(ssh.BuildProxyCommandOption(fakeKind, fakeNamespace, fakeName, opts.SSHPort, globalFlags)),
+				Equal(clientArgs[0]),
+			))
+		},
+			Entry("with nil global flags", nil),
+			Entry("with global flags embeds them in ProxyCommand", []string{"--context=my-context", "--kubeconfig=/path/to/config"}),
+		)
+	})
+
+	Describe("GlobalFlagsFromCmd", func() {
+		var (
+			root  *cobra.Command
+			child *cobra.Command
+		)
+
+		BeforeEach(func() {
+			root = &cobra.Command{Use: "root"}
+			root.PersistentFlags().String("context", "", "kube context")
+			root.PersistentFlags().String("kubeconfig", "", "kubeconfig path")
+			root.PersistentFlags().StringSlice("as-groups", nil, "groups to impersonate")
+
+			child = &cobra.Command{
+				Use:  commandSSH,
+				RunE: func(cmd *cobra.Command, args []string) error { return nil },
+			}
+			child.Flags().String("local-flag", "", "local only flag")
+			root.AddCommand(child)
+		})
+
+		It("returns empty when no flags are set", func() {
+			root.SetArgs([]string{commandSSH})
+			Expect(root.Execute()).To(Succeed())
+			Expect(ssh.GlobalFlagsFromCmd(child)).To(BeEmpty())
+		})
+
+		It("extracts root persistent string flags that are set", func() {
+			root.SetArgs([]string{"--context=my-context", "--kubeconfig=/path/to/config", commandSSH})
+			Expect(root.Execute()).To(Succeed())
+			Expect(ssh.GlobalFlagsFromCmd(child)).To(ConsistOf(
+				"--context=my-context",
+				"--kubeconfig=/path/to/config",
+			))
+		})
+
+		It("excludes command-local flags from output", func() {
+			root.SetArgs([]string{commandSSH, "--local-flag=value"})
+			Expect(root.Execute()).To(Succeed())
+			Expect(ssh.GlobalFlagsFromCmd(child)).To(BeEmpty())
+		})
+
+		It("expands slice flags into individual entries", func() {
+			root.SetArgs([]string{"--as-groups=group1", "--as-groups=group2", commandSSH})
+			Expect(root.Execute()).To(Succeed())
+			Expect(ssh.GlobalFlagsFromCmd(child)).To(ConsistOf(
+				"--as-groups=group1",
+				"--as-groups=group2",
+			))
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does
Though other command supported from `virtctl` have inherited `globalflag`s they can refer, 
for `ssh` and `scp` as their mechanism is forking through new ssh + virtctl's portforward command,
we have to manually add each flags before `cmd.`exec`

I've added globalFlag passer for moving current global flags which modified but not passed into cmd.exec builder. 

#### Before this PR:
As current virtctl ssh command doesn't have logics for moving flag, it didn't support `virtctl`'s options.

#### After this PR:

global flags are now passed correctly for building new command. 

### References
- Fixes #16957


### Why we need it and why it was done in this way

I've put local transfering function for passing modified global flags into builder.
Though I've considered making it into common function and make other commands to use it, 
only ssh and scp use fork based mechanims.
which makes it unnecessary. 


### Special notes for your reviewer


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
none
```

