### PR TITLE
build: bump controller-gen from v0.16.3 to v0.20.1

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -83,7 +83,7 @@ RUN set -x && \
     go install -v github.com/golang/protobuf/protoc-gen-go@1643683 && \
     go install -v k8s.io/code-generator/cmd/client-gen@v0.32.5 && \
     go install -v github.com/securego/gosec/v2/cmd/gosec@0ce48a5 && \
-    go install -v sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.3 && \
+    go install -v sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.1 && \
     go install -v github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@a4b5158 && \
     go clean -cache -modcache
 

--- a/hack/builder/Dockerfile.cs10
+++ b/hack/builder/Dockerfile.cs10
@@ -86,7 +86,7 @@ RUN set -x && \
     go install -v github.com/golang/protobuf/protoc-gen-go@1643683 && \
     go install -v k8s.io/code-generator/cmd/client-gen@v0.32.5 && \
     go install -v github.com/securego/gosec/v2/cmd/gosec@0ce48a5 && \
-    go install -v sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.3 && \
+    go install -v sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.1 && \
     go install -v github.com/kubevirt/monitoring/monitoringlinter/cmd/monitoringlinter@a4b5158 && \
     go clean -cache -modcache
 


### PR DESCRIPTION
### What this PR does

Bumps controller-gen (sigs.k8s.io/controller-tools) from v0.16.3 to v0.20.1
in hack/builder/Dockerfile.

This bump is the prerequisite for KubeVirt to adopt +k8s:required / +k8s:optional
markers on its API types, which will allow gradual replacement of the
hand-authored schema.go with controller-gen-driven declarative validation.

### Special notes for your reviewer

Verified locally: controller-gen v0.20.1 generates identical CRD output for
all 11 API groups (20 CRDs total). All existing constraints (e.g., maxItems=256
on Volumes, Networks) are preserved.

```release-note
NONE
```

