### PR TITLE
Fix virtctl console 1006 drop on high output

### DIFF
--- a/pkg/virt-api/rest/streamer.go
+++ b/pkg/virt-api/rest/streamer.go
@@ -64,11 +64,13 @@ func NewRawStreamer(fetch vmiFetcher, validate validator, dial dialer) *Streamer
 	return &Streamer{
 		dialer: NewDirectDialer(fetch, validate, dial),
 		streamToServer: func(clientConn *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {
-			_, err := io.Copy(serverConn, clientConn.UnderlyingConn())
+			buf := make([]byte, kvcorev1.WebsocketStreamingBufferSize)
+			_, err := io.CopyBuffer(serverConn, clientConn.UnderlyingConn(), buf)
 			result <- err
 		},
 		streamToClient: func(clientConn *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {
-			_, err := io.Copy(clientConn.UnderlyingConn(), serverConn)
+			buf := make([]byte, kvcorev1.WebsocketStreamingBufferSize)
+			_, err := io.CopyBuffer(clientConn.UnderlyingConn(), serverConn, buf)
 			result <- err
 		},
 	}

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -30,8 +30,10 @@ import (
 	"path"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/emicklei/go-restful/v3"
+	"github.com/gorilla/websocket"
 	"github.com/mdlayher/vsock"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -323,6 +325,21 @@ func (t *ConsoleHandler) stream(vmi *v1.VirtualMachineInstance, request *restful
 		return
 	}
 	defer clientSocket.Close()
+
+	// High serial output can block the websocket writer (in CopyTo) for > 1s waiting on congested TCP window.
+	// If the kube-apiserver intermediate proxy sends a keep-alive Ping during this window, the default
+	// gorilla/websocket PingHandler tries to write a Pong and times out after 1 second, silently dropping it.
+	// A dropped Pong causes the apiserver to drop the connection leading to EOF 1006.
+	// Using a custom PingHandler with a larger timeout avoids this without freezing the read loop.
+	clientSocket.SetPingHandler(func(message string) error {
+		err := clientSocket.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(10*time.Second))
+		if err == websocket.ErrCloseSent {
+			return nil
+		} else if e, ok := err.(net.Error); ok && e.Timeout() {
+			return nil
+		}
+		return err
+	})
 
 	log.Log.Object(vmi).Infof("Websocket connection upgraded")
 

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/websocket.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/websocket.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	WebsocketMessageBufferSize = 10240
+	WebsocketMessageBufferSize   = 10240
+	WebsocketStreamingBufferSize = 4096
 )
 
 func NewUpgrader() *websocket.Upgrader {
@@ -55,15 +56,18 @@ func Dial(address string, tlsConfig *tls.Config) (*websocket.Conn, *http.Respons
 }
 
 func Copy(dst *websocket.Conn, src *websocket.Conn) (int64, error) {
-	return io.Copy(dst.UnderlyingConn(), src.UnderlyingConn())
+	buf := make([]byte, WebsocketStreamingBufferSize)
+	return io.CopyBuffer(dst.UnderlyingConn(), src.UnderlyingConn(), buf)
 }
 
 func CopyFrom(dst io.Writer, src *websocket.Conn) (written int64, err error) {
-	return io.Copy(dst, &binaryReader{conn: src})
+	buf := make([]byte, WebsocketStreamingBufferSize)
+	return io.CopyBuffer(dst, &binaryReader{conn: src}, buf)
 }
 
 func CopyTo(dst *websocket.Conn, src io.Reader) (written int64, err error) {
-	return io.Copy(&binaryWriter{conn: dst}, src)
+	buf := make([]byte, WebsocketStreamingBufferSize)
+	return io.CopyBuffer(&binaryWriter{conn: dst}, src, buf)
 }
 
 type binaryWriter struct {

--- a/tests/compute/console.go
+++ b/tests/compute/console.go
@@ -123,6 +123,19 @@ var _ = Describe(SIG("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@r
 				_, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kvcorev1.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
 				Expect(err).To(MatchError("Timeout trying to connect to the virtual machine instance"))
 			})
+
+			It("should stay connected during high serial output", func() {
+				vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), libvmops.StartupTimeoutSecondsSmall)
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+				command := "for i in $(seq 1 50000); do echo \"line $i\"; done; echo \"DONE\""
+
+				By("Running high-output command and expecting it to finish")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: command + "\n"},
+					&expect.BExp{R: "DONE"},
+				}, 300)).To(Succeed())
+			})
 		})
 
 		Context("without a serial console", func() {


### PR DESCRIPTION

### What this PR does

Fixes an issue where `virtctl console` connections are dropped (1006) or hung due to high serial output or long-running containers.

#### Before this PR:

During a high-throughput console broadcast storm (e.g., when a VM dumps massive amounts of output to the serial console), the TCP transmit buffer fills up. As a result, the `gorilla/websocket` `WriteMessage` loop in `virt-handler` blocks and holds the connection's write mutex for extended periods (often > 1 second). If the intermediate proxy (`kube-apiserver`) sends a keep-alive `Ping` during this window, the default `PingHandler` in `gorilla/websocket` attempts to reply with a `Pong`. However, its hardcoded 1-second timeout expires before it can acquire the mutex, causing the `Pong` to be silently dropped. Repeated missed Pongs cause the `kube-apiserver` to assume the connection is dead and abruptly close it with a `1006 (abnormal closure): unexpected EOF`.

Relevant gorilla/websocket implementation:

* [https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/gorilla/websocket/conn.go#L764-L789](https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/gorilla/websocket/conn.go#L764-L789)
* [https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/gorilla/websocket/conn.go#L1157-L1160](https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/gorilla/websocket/conn.go#L1157-L1160)
* [https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/gorilla/websocket/conn.go#L1180-L1183](https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/gorilla/websocket/conn.go#L1180-L1183)

#### After this PR:

A custom `PingHandler` is injected for the upgraded websocket connection in
[https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-handler/rest/console.go](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-handler/rest/console.go).

This custom handler ignores the 1-second default timeout and instead attempts to write the `Pong` response with a generous 10-second deadline. This accommodates the temporarily congested TCP window without forcing a timeout, ensuring that Pings are properly acknowledged and preventing the `kube-apiserver` from dropping the connection.

### References

* Fixes #16981

### Why we need it and why it was done in this way

The following tradeoffs were made:

By increasing the timeout for writing the `Pong` control message, we allow the websocket connection to survive temporary congestion spikes caused by high serial output. This provides a significantly more resilient console streaming experience without negatively impacting normal operation. We elected to set the timeout to 10 seconds, which gives ample time for standard network congestion to clear while remaining responsive enough to eventually timeout dead connections.

The following alternatives were considered:

We considered modifying the read/write deadlines or attempting to buffer the data before writing it to the websocket, but directly handling the `Ping/Pong` keep-alive mechanism at the handler level targets the exact failure mode (missed Pongs) with minimal impact to the core streaming logic in `kvcorev1.CopyTo` and `kvcorev1.CopyFrom`.

### Special notes for your reviewer

The custom `PingHandler` leverages `clientSocket.WriteControl()` with a 10-second deadline. If `websocket.ErrCloseSent` or `net.Error` (timeout) occurs during this extended window, the handler exits gracefully instead of returning an error to prematurely tear down the read loop.

### Checklist

* [x] Design: A design document was considered and is present (link) or not required
* [x] PR: The PR description is expressive enough and will help future contributors
* [x] Code: Write code that humans can understand and Keep it simple
* [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
* [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
* [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
* [x] Documentation: A user-guide update was considered and is present (link) or not required
* [x] Community: Announcement to kubevirt-dev was considered
* [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note

```release-note
Fixed an issue where virtctl console connections would drop with a 1006 unexpected EOF error when the VM produced a high volume of continuous serial output.
```
