### PR TITLE
tests: remove explicit CPU count in VM node selector test

### DIFF
--- a/tests/hotplug/affinity.go
+++ b/tests/hotplug/affinity.go
@@ -22,7 +22,6 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -94,7 +93,7 @@ var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.S
 		It("[test_id:11208]should successfully update node selector", func() {
 
 			By("Creating a running VM")
-			vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+			vmi := libvmifact.NewGuestless()
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
 			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 
@@ -147,7 +146,7 @@ var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.S
 		It("[test_id:11209]should successfully update node affinity", func() {
 
 			By("Creating a running VM")
-			vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+			vmi := libvmifact.NewGuestless()
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
 			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
### What this PR does
**Learning from the flake:**
The root cause of this flake on `periodic-kubevirt-e2e-test-S390X` was test isolation. The test `[test_id:11208]should successfully update node selector` was explicitly requesting two CPU cores using `libvmi.WithCPUCount(1, 2, 1)`. In resource-constrained CI environments (like S390X VMs), this led to the VM pod hanging in the `Pending` state, which would eventually time out after 360 seconds while waiting to become `Ready`. Tests verifying high-level behaviors that are hardware-agnostic (like node-selectors) should avoid enforcing explicit resource requirements, as it makes them sensitive to the environment they run on.
#### Before this PR:
The test timed out in the CI environment because the VM pod got stuck in `Pending` due to the lack of CPU resources.
#### After this PR:
The unnecessary high CPU requirement is removed from the VM initialization for this test. The test VM now schedules reliably with minimal default resource requests, eliminating the flaky timeouts.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
Fixes #17021
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->
### Why we need it and why it was done in this way
The following tradeoffs were made:
N/A - The explicit CPU topology has no effect on testing node selector hot-plugging. Dropping the requirement reduces resource demands without changing test validity.
The following alternatives were considered:
N/A
Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
### Special notes for your reviewer
This fixes a critical-urgent flake (#17021).
/triage accepted
<!-- optional -->
### Checklist
This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.
- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE