### PR TITLE
fix(builder): update qemu-static container image

### DIFF
--- a/hack/builder/build-cs10.sh
+++ b/hack/builder/build-cs10.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(
 # then we shouldn't alter the existing configuration to avoid the
 # risk of possibly breaking it
 if ! grep -q -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
-    ${KUBEVIRT_CRI} >&2 run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
+    ${KUBEVIRT_CRI} >&2 run --rm --privileged quay.io/linuxserver.io/qemu-static --reset -p yes
 fi
 
 # shellcheck source=hack/builder/common.sh

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(
 # then we shouldn't alter the existing configuration to avoid the
 # risk of possibly breaking it
 if ! grep -q -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
-    ${KUBEVIRT_CRI} >&2 run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
+    ${KUBEVIRT_CRI} >&2 run --rm --privileged quay.io/linuxserver.io/qemu-static --reset -p yes
 fi
 
 # shellcheck source=hack/builder/common.sh


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The previous image used an old version of QEMU (v7.2.0) which caused deadlocks with `go build` when cross-building the builder image.

#### After this PR:

KubeVirt builder related jobs should be fixed:
* [build-kubevirt-builder](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/build-kubevirt-builder)
* [publish-kubevirt-builder](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/publish-kubevirt-builder)

### Release note
```release-note
NONE
```