### PR TITLE
fix(network): delete linux interfaces from pod namespace on hot-unplug

### DIFF
--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/vishvananda/netlink"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -210,6 +211,13 @@ func (n NetPod) Setup() error {
 	}
 
 	unplugNetworks := vmispec.FilterNetworksByInterfaces(n.vmiSpecNets, unplugIfaces)
+	
+	// Physically delete the Linux network interfaces
+	if serr := n.teardownNetworks(unplugNetworks); serr != nil {
+		return serr
+	}
+
+	// Clear the KubeVirt state cache
 	if serr := n.clearCache(unplugNetworks); serr != nil {
 		return serr
 	}
@@ -710,4 +718,37 @@ func (n NetPod) clearCache(nets []v1.Network) error {
 		return k8serrors.NewAggregate(unplugErrors)
 	}
 	return n.state.Delete(nets)
+}
+
+func (n NetPod) teardownNetworks(nets []v1.Network) error {
+	if len(nets) == 0 {
+		return nil
+	}
+
+	// Execute the deletion inside the pod's network namespace
+	return n.state.NSExec.Do(func() error {
+		for _, network := range nets { // Fix 1: Renamed 'net' to 'network'
+			podInterfaceName := namescheme.HashedPodInterfaceName(network, n.vmiIfaceStatuses)
+
+			// Generate the exact names of the stale interfaces
+			linksToRemove := []string{
+				link.GenerateTapDeviceName(podInterfaceName, network),
+				link.GenerateBridgeName(podInterfaceName),
+				link.GenerateNewBridgedVmiInterfaceName(podInterfaceName),
+			}
+
+			// Iterate through and explicitly delete them
+			for _, linkName := range linksToRemove {
+				l, err := netlink.LinkByName(linkName)
+				if err == nil {
+					// If the link exists, try to delete it
+					if delErr := netlink.LinkDel(l); delErr != nil {
+						// Fix 2: Log non-trivial errors to aid in future debugging
+						log.Log.Reason(delErr).Errorf("failed to delete network link %s during hot-unplug", linkName)
+					}
+				}
+			}
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
Currently, when a secondary network is hot-unplugged in-place, KubeVirt only clears the internal interface cache but leaves stale virtual ethernet interfaces (`k6t-...`, `tap...`, and `...-nic`) dangling inside the `virt-launcher` pod's network namespace and the worker node. 

This PR introduces a `teardownNetworks` step inside `NetPod.Setup()` that executes within the pod's network namespace (`state.NSExec.Do`). It targets the specific tap, bridge, and dummy interfaces associated with the unplugged network and explicitly removes them via `netlink.LinkDel` before the cache is cleared.

**Which issue(s) this PR fixes:**
Fixes #14074

**Special note for reviewer:**
The deletion logic gracefully ignores errors if the links are already gone, ensuring it doesn't block the rest of the teardown process.

**Release note:**
```release-note
Fixed an issue that left stale virtual network interfaces (tap, bridge, and dummy) inside the virt-launcher pod and worker node after an in-place secondary network hot-unplug.