### PR TITLE
Fixes the nightly manifest push retry problem

### DIFF
--- a/hack/push-container-manifest.sh
+++ b/hack/push-container-manifest.sh
@@ -27,6 +27,27 @@ fi
 
 fail_if_cri_bin_missing
 
+function push_manifest_with_retry() {
+    local max_retries=5
+    local sleep_between=30
+    local attempt=1
+
+    while [ "${attempt}" -le "${max_retries}" ]; do
+        echo "INFO: manifest push attempt ${attempt}/${max_retries}: ${KUBEVIRT_CRI} manifest push $*"
+        if ${KUBEVIRT_CRI} manifest push "$@"; then
+            echo "INFO: manifest push succeeded on attempt ${attempt}"
+            return 0
+        fi
+        if [ "${attempt}" -eq "${max_retries}" ]; then
+            echo "ERROR: manifest push failed after ${max_retries} attempts"
+            return 1
+        fi
+        echo "WARNING: attempt ${attempt} failed, retrying in ${sleep_between}s..."
+        sleep "${sleep_between}"
+        attempt=$(( attempt + 1 ))
+    done
+}
+
 function podman_push_manifest() {
     image=$1
     # FIXME: Workaround https://github.com/containers/podman/issues/18360 and remove once https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f is released
@@ -41,7 +62,8 @@ function podman_push_manifest() {
             echo "Warning: Image ${TAGGED_IMAGE} does not exist, skipping"
         fi
     done
-    ${KUBEVIRT_CRI} manifest push --all ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+    push_manifest_with_retry --all \
+        "${DOCKER_PREFIX}/${image}:${DOCKER_TAG}" "${DOCKER_PREFIX}/${image}:${DOCKER_TAG}"
 }
 
 function docker_push_manifest() {
@@ -58,7 +80,7 @@ function docker_push_manifest() {
     done
     echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
     ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
-    ${KUBEVIRT_CRI} manifest push ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+    push_manifest_with_retry "${DOCKER_PREFIX}/${image}:${DOCKER_TAG}"
 }
 
 export DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
quay.io returns 200 OK: Healthcheck requested during blob uploads podman expects it to be 202 Accepted and treats the 200 as an error, which cause podman manifest push to exit as non-zero

Added push_manifest_with_retry in push-container-manifest.sh. it will retry the manifest push for 5 times with a 30s sleep between attempts
Both podman_push_manifest and docker_push_manifest now call this helper instead of running manifest push directly.

Fixes: https://github.com/kubevirt/kubevirt/issues/16844

/sig ci
/sig buildsystem
/kind bug

### Release Note
```Fix silent failure in nightly build when quay.io returns a
Healthcheck requested response during manifest push. The manifest
push step now retries for up to 5 times   before failing