### PR TITLE
Fix network policy for IPv4/IPv6

### DIFF
--- a/tests/libnet/cloudinit/BUILD.bazel
+++ b/tests/libnet/cloudinit/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnet/cloudinit",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
+        "//tests/libnet/cluster:go_default_library",
         "//tests/libnet/dns:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/tests/libnet/cloudinit/cloudinit.go
+++ b/tests/libnet/cloudinit/cloudinit.go
@@ -22,6 +22,8 @@ package cloudinit
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
 	"kubevirt.io/kubevirt/tests/libnet/dns"
 
 	"sigs.k8s.io/yaml"
@@ -81,16 +83,28 @@ func WithAddresses(addresses ...string) NetworkDataInterfaceOption {
 
 func WithDHCP4Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		enabled := true
-		networkDataInterface.DHCP4 = &enabled
+		networkDataInterface.DHCP4 = pointer.P(true)
 		return nil
 	}
 }
 
 func WithDHCP6Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		enabled := true
-		networkDataInterface.DHCP6 = &enabled
+		networkDataInterface.DHCP6 = pointer.P(true)
+		return nil
+	}
+}
+
+func WithDHCP4Disabled() NetworkDataInterfaceOption {
+	return func(networkDataInterface *CloudInitInterface) error {
+		networkDataInterface.DHCP4 = pointer.P(false)
+		return nil
+	}
+}
+
+func WithDHCP6Disabled() NetworkDataInterfaceOption {
+	return func(networkDataInterface *CloudInitInterface) error {
+		networkDataInterface.DHCP6 = pointer.P(false)
 		return nil
 	}
 }
@@ -176,18 +190,44 @@ const (
 	DefaultIPv6Gateway = "fd10:0:2::1"
 )
 
-// CreateDefaultCloudInitNetworkData generates a default configuration
-// for the Cloud-Init Network Data, in version 2 format.
-// The default configuration sets dynamic IPv4 (DHCP) and static IPv6 addresses,
-// including DNS settings of the cluster nameserver IP and search domains.
+// CreateDefaultCloudInitNetworkData returns cloud-init v2 network-config for eth0 from cluster IP family probes.
 func CreateDefaultCloudInitNetworkData() string {
-	data, err := NewNetworkData(
-		WithEthernet("eth0",
+	supportsIPv4, errV4 := cluster.SupportsIpv4()
+	if errV4 != nil {
+		panic(errV4)
+	}
+	supportsIPv6, errV6 := cluster.SupportsIpv6()
+	if errV6 != nil {
+		panic(errV6)
+	}
+
+	var ifaceOpts []NetworkDataInterfaceOption
+	switch {
+	case supportsIPv4 && supportsIPv6: // DHCPv4 + static IPv6 + gateway6
+		ifaceOpts = []NetworkDataInterfaceOption{
 			WithDHCP4Enabled(),
 			WithAddresses(DefaultIPv6CIDR),
 			WithGateway6(DefaultIPv6Gateway),
 			WithNameserverFromCluster(),
-		))
+		}
+	case supportsIPv4: // DHCPv4 only
+		ifaceOpts = []NetworkDataInterfaceOption{
+			WithDHCP4Enabled(),
+			WithDHCP6Disabled(),
+			WithNameserverFromCluster(),
+		}
+	case supportsIPv6: // static IPv6 + gateway6
+		ifaceOpts = []NetworkDataInterfaceOption{
+			WithDHCP4Disabled(),
+			WithAddresses(DefaultIPv6CIDR),
+			WithGateway6(DefaultIPv6Gateway),
+			WithNameserverFromCluster(),
+		}
+	default: // probes ok but neither family — should not happen
+		panic(fmt.Errorf("cluster IPv4/IPv6 probes succeeded but neither family is supported"))
+	}
+
+	data, err := NewNetworkData(WithEthernet("eth0", ifaceOpts...))
 	if err != nil {
 		panic(err)
 	}

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -23,6 +23,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	libvmi "kubevirt.io/kubevirt/pkg/libvmi"
+
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -56,7 +58,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 			assertIPsNotEmptyForVMI(serverVMI)
 		})
 
-		Context("and connectivity between VMI/s is blocked by Default-deny networkpolicy", decorators.WgS390x, func() {
+		Context("and connectivity between VMI/s is blocked by Default-deny networkpolicy", func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {
@@ -139,7 +141,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 			})
 		})
 
-		Context("and ingress traffic to VMI identified via label at networkprofile's labelSelector is blocked", decorators.WgS390x, func() {
+		Context("and ingress traffic to VMI identified via label at networkprofile's labelSelector is blocked", func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {
@@ -203,7 +205,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 						assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 					})
 
-					It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", decorators.WgS390x, func() {
+					It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", func() {
 						By("Connect clientVMI from clientVMIAlternativeNamespace")
 						assertPingSucceed(clientVMIAlternativeNamespace, clientVMI)
 					})
@@ -211,7 +213,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 			})
 		})
 
-		Context("and TCP connectivity on ports 80 and 81 between VMI/s is allowed by networkpolicy", decorators.WgS390x, func() {
+		Context("and TCP connectivity on ports 80 and 81 between VMI/s is allowed by networkpolicy", func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {
@@ -242,7 +244,7 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 				assertHTTPPingSucceed(clientVMI, serverVMI, 81)
 			})
 		})
-		Context("and TCP connectivity on ports 80 between VMI/s is allowed by networkpolicy", decorators.WgS390x, func() {
+		Context("and TCP connectivity on ports 80 between VMI/s is allowed by networkpolicy", func() {
 			var policy *networkv1.NetworkPolicy
 
 			BeforeEach(func() {
@@ -392,9 +394,13 @@ func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
 }
 
 func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {
-	clientVMI := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
-	var err error
-	clientVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
+	clientVMI := libvmifact.NewAlpineWithTestTooling(
+		libvmi.WithCloudInitNoCloud(
+			libvmifact.WithDummyCloudForFastBoot(),
+		),
+		libnet.WithMasqueradeNetworking(),
+	)
+	clientVMI, err := virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -405,6 +411,9 @@ func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.V
 
 func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, serverVMILabels map[string]string) (*v1.VirtualMachineInstance, error) {
 	serverVMI := libvmifact.NewAlpineWithTestTooling(
+		libvmi.WithCloudInitNoCloud(
+			libvmifact.WithDummyCloudForFastBoot(),
+		),
 		libnet.WithMasqueradeNetworking(
 			v1.Port{
 				Name:     "http80",

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
+var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", decorators.WgS390x, func() {
 	var (
 		virtClient      kubecli.KubevirtClient
 		serverVMILabels map[string]string


### PR DESCRIPTION
### What this PR does
Previously, guest network config could be mismatched with the cluster’s supported IP families, which could make network policy tests fail/flaky even when policy behaviour was correct.
By making cloud-init match cluster IP-family support at VM creation time, test behaviour becomes consistent across stack types without introducing per-family branching in ping/HTTP assertions.
This PR fixes network policy test behaviour across IPv4-only, IPv6-only, and dual-stack clusters by aligning guest cloud-init network config with the cluster IP families when creating the test VMIs.

#### Before this PR:
Guest cloud-init did not explicitly adapt to cluster IPv4/IPv6 capabilities.

#### After this PR:
Guest cloud-init is selected based on cluster IP-family support.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

```release-note
NONE
```

