### PR TITLE
tests: drop e2e test for Sidecar feature gate enforcement

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -90,7 +90,6 @@ go_test(
         "//pkg/cloud-init:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/controller:go_default_library",
-        "//pkg/hooks:go_default_library",
         "//pkg/hooks/v1alpha1:go_default_library",
         "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/hooks/v1alpha3:go_default_library",

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -37,12 +37,10 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/hooks"
 	hooksv1alpha1 "kubevirt.io/kubevirt/pkg/hooks/v1alpha1"
 	hooksv1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
 	hooksv1alpha3 "kubevirt.io/kubevirt/pkg/hooks/v1alpha3"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -288,18 +286,6 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 			)
 		})
 
-		Context("with sidecar feature gate disabled", Serial, func() {
-			BeforeEach(func() {
-				kvconfig.DisableFeatureGate(featuregate.SidecarGate)
-			})
-
-			It("[test_id:2666]should not start with hook sidecar annotation", func() {
-				By("Starting a VMI")
-				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).To(HaveOccurred(), "should not create a VMI without sidecar feature gate")
-				Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf("invalid entry metadata.annotations.%s", hooks.HookSidecarListAnnotationName)))
-			})
-		})
 	})
 })
 


### PR DESCRIPTION
The dropped e2e test [test_id:2666] "should not start with hook sidecar annotation" is costly: it is a Serial test that modifies the kubevirt cr, waits of it to reconcile, only to check that the adminission webhook does not allow VMIs with the sidecar annotation to be defined.

The admission webhook unit test in
pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go already covers both cases:
- "without sidecar feature gate enabled": rejects HookSidecarListAnnotationName
- "with sidecar feature gate enabled": accepts it

When CI failures skyrocket, the value of this e2e test is too small for its costs to CI runtime.

For example, https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.32-sig-compute/2022589293452595200/build-log.txt :
```
12:10:48: [sig-compute]HookSidecars [rfe_id:2667][crit:medium][vendor:cnv-qe@redhat.com][level:component] VMI definition with sidecar feature gate disabled [test_id:2666]should not start with hook sidecar annotation [sig-compute, Serial]
12:10:48: tests/vmi_hook_sidecar_test.go:291
12:10:48: 
12:10:48:   Captured StdOut/StdErr Output >>
12:10:48:   {"component":"portforward","level":"info","msg":"system is in sync with kubevirt config resource version 133289","pos":"kvconfig.go:102","timestamp":"2026-02-14T12:10:26.994910Z"}
12:10:48:   {"component":"portforward","level":"info","msg":"system is in sync with kubevirt config resource version 133589","pos":"kvconfig.go:102","timestamp":"2026-02-14T12:10:48.539617Z"}
12:10:48:   << Captured StdOut/StdErr Output
12:10:48: ------------------------------
12:12:17: SSSS
12:12:17: ------------------------------
12:12:17: • [88.894 seconds]
```

/kind cleanup

```release-note
NONE
```

