### PR TITLE
virtctl: add configurable VNC viewer support

### DIFF
--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -87,9 +87,8 @@ func NewCommand() *cobra.Command {
 		"--preserve-session: This option will preserve an existing VNC session instead of dropping it.")
 	cmd.Flags().IntVar(&customPort, "port", customPort,
 		"--port=0: Assigning a port value to this will try to run the proxy on the given port if the port is accessible; If unassigned, the proxy will run on a random port")
-	cmd.Flags().StringVar(&vncType, "vnc-type", "", "--vnc-type=tiger: Specify the type of VNC viewer to use (tiger, chicken, real, remote-viewer). Must provide --vnc-path")
-	cmd.Flags().StringVar(&vncPath, "vnc-path", "", "--vnc-path=/path/to/vnc: Specify the path to the VNC viewer executable. Must provide --vnc-type")
-	cmd.MarkFlagsRequiredTogether("vnc-type", "vnc-path")
+	cmd.Flags().StringVar(&vncType, "vnc-type", "", "--vnc-type=tiger: Specify the type of VNC viewer to use (tiger, chicken, real, remote-viewer). If --vnc-path is not provided, the binary is looked up in $PATH")
+	cmd.Flags().StringVar(&vncPath, "vnc-path", "", "--vnc-path=/path/to/vnc: Specify the path to the VNC viewer executable. Optional if the binary is in $PATH")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	cmd.AddCommand(screenshot.NewScreenshotCommand())
 	return cmd
@@ -219,12 +218,41 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getUserSpecifiedVnc(ctx context.Context, osType, vncType, vncPath string, port int) (string, []string, error) {
-	if _, err := os.Stat(vncPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil, fmt.Errorf("specified VNC path does not exist: %s", vncPath)
+func resolveVncBinary(vncType, vncPath string) (string, error) {
+	if vncPath != "" {
+		if _, err := os.Stat(vncPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return "", fmt.Errorf("specified VNC path does not exist: %s", vncPath)
+			}
+			return "", fmt.Errorf("error checking VNC path: %v", err)
 		}
-		return "", nil, fmt.Errorf("error checking VNC path: %v", err)
+		return vncPath, nil
+	}
+
+	var bin string
+	switch vncType {
+	case "tiger":
+		bin = TIGER_VNC
+	case "remote-viewer":
+		bin = REMOTE_VIEWER
+	case "chicken":
+		bin = MACOS_CHICKEN_VNC
+	case "real":
+		bin = MACOS_REAL_VNC
+	default:
+		return "", fmt.Errorf("unsupported vnc-type: %s", vncType)
+	}
+	path, err := exec.LookPath(bin)
+	if err != nil {
+		return "", fmt.Errorf("could not find %s in $PATH: %v", bin, err)
+	}
+	return path, nil
+}
+
+func getUserSpecifiedVnc(ctx context.Context, osType, vncType, vncPath string, port int) (string, []string, error) {
+	resolvedPath, err := resolveVncBinary(vncType, vncPath)
+	if err != nil {
+		return "", nil, err
 	}
 
 	var args []string
@@ -254,7 +282,7 @@ func getUserSpecifiedVnc(ctx context.Context, osType, vncType, vncPath string, p
 	default:
 		return "", nil, fmt.Errorf("virtctl does not support VNC on %v", osType)
 	}
-	return vncPath, args, nil
+	return resolvedPath, args, nil
 }
 
 func getAutoDetectedVnc(osType string, port int) (string, []string, error) {
@@ -295,7 +323,7 @@ func checkAndRunVNCViewer(ctx context.Context, errChan chan error, port int) {
 	vncBin := ""
 	osType := runtime.GOOS
 
-	if vncType != "" && vncPath != "" {
+	if vncType != "" {
 		vncBin, args, err = getUserSpecifiedVnc(ctx, osType, vncType, vncPath, port)
 	} else {
 		vncBin, args, err = getAutoDetectedVnc(osType, port)
@@ -322,7 +350,6 @@ func checkAndRunVNCViewer(ctx context.Context, errChan chan error, port int) {
 	}
 	errChan <- err
 }
-
 func tigerVncArgs(port int) (args []string) {
 	args = append(args, fmt.Sprintf(listenAddressFmt, port))
 	if log.Log.Verbosity(4) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
virtctl commands such as virtctl vnc automatically guessed which VNC viewer to use
based on available binaries like remote-viewer, virt-viewer, or vncviewer.
Users had no way to configure their preferred viewer explicitly.

###After this PR:
Makes --vnc-path optional when using --vnc-type. If --vnc-path is not provided, the VNC viewer binary is looked up in $PATH automatically based on the --vnc-type value. This lets users override the auto-detected viewer without needing to know the exact binary path.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make --vnc-path optional for --vnc-type, allowing VNC viewer binary lookup from $PATH automatically
```

