### PR TITLE
Hotplug livelock

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -321,7 +321,6 @@ func ApplyVolumeRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request
 }
 
 func CurrentVMIPod(vmi *v1.VirtualMachineInstance, podIndexer cache.Indexer) (*k8sv1.Pod, error) {
-
 	// current pod is the most recent pod created on the current VMI node
 	// OR the most recent pod created if no VMI node is set.
 
@@ -359,7 +358,6 @@ func CurrentVMIPod(vmi *v1.VirtualMachineInstance, podIndexer cache.Indexer) (*k
 }
 
 func VMIActivePodsCount(vmi *v1.VirtualMachineInstance, vmiPodIndexer cache.Indexer) int {
-
 	objs, err := vmiPodIndexer.ByIndex(cache.NamespaceIndex, vmi.Namespace)
 	if err != nil {
 		return 0
@@ -434,7 +432,6 @@ func SetSourcePod(migration *v1.VirtualMachineInstanceMigration, vmi *v1.Virtual
 		}
 		migration.Status.MigrationState.SourcePod = sourcePod.Name
 	}
-
 }
 
 func VMIHasHotplugVolumes(vmi *v1.VirtualMachineInstance) bool {
@@ -471,6 +468,7 @@ func VMIHasHotplugMemory(vmi *v1.VirtualMachineInstance) bool {
 	return vmiHasCondition(vmi, v1.VirtualMachineInstanceMemoryChange)
 }
 
+// AttachmentPods returns all attachment pods, including ephemeral trigger pods.
 func AttachmentPods(ownerPod *k8sv1.Pod, podIndexer cache.Indexer) ([]*k8sv1.Pod, error) {
 	objs, err := podIndexer.ByIndex(cache.NamespaceIndex, ownerPod.Namespace)
 	if err != nil {
@@ -509,7 +507,6 @@ func IsPodReady(pod *k8sv1.Pod) bool {
 			if containerStatus.State.Running == nil {
 				return false
 			}
-
 		} else if containerStatus.Ready == false {
 			return false
 		}
@@ -555,6 +552,7 @@ func isPodFailed(pod *k8sv1.Pod) bool {
 func PodExists(pod *k8sv1.Pod) bool {
 	return pod != nil
 }
+
 func GetHotplugVolumes(vmi *v1.VirtualMachineInstance, virtlauncherPod *k8sv1.Pod) []*v1.Volume {
 	hotplugVolumes := make([]*v1.Volume, 0)
 	podVolumes := virtlauncherPod.Spec.Volumes

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -69,28 +69,33 @@ import (
 )
 
 const (
-	containerDisks   = "container-disks"
-	hotplugDisks     = "hotplug-disks"
-	hookSidecarSocks = "hook-sidecar-sockets"
-	varRun           = "/var/run"
-	virtBinDir       = "virt-bin-share-dir"
-	hotplugDisk      = "hotplug-disk"
-	virtExporter     = "virt-exporter"
+	containerDisks       = "container-disks"
+	hotplugDisks         = "hotplug-disks"
+	hookSidecarSocks     = "hook-sidecar-sockets"
+	varRun               = "/var/run"
+	virtBinDir           = "virt-bin-share-dir"
+	hotplugDisk          = "hotplug-disk"
+	virtExporter         = "virt-exporter"
+	triggerPodAnnotation = "trigger-for"
 )
 
-const K8sDevicePrefix = "devices.kubevirt.io"
-const TunDevice = K8sDevicePrefix + "/tun"
-const VhostNetDevice = K8sDevicePrefix + "/vhost-net"
-const VhostVsockDevice = K8sDevicePrefix + "/vhost-vsock"
-const PrDevice = K8sDevicePrefix + "/pr-helper"
-const SevDeviceName = "sev"
-const TdxDeviceName = "tdx"
-const SevDevice = K8sDevicePrefix + "/" + SevDeviceName
-const TdxDevice = K8sDevicePrefix + "/" + TdxDeviceName
+const (
+	K8sDevicePrefix  = "devices.kubevirt.io"
+	TunDevice        = K8sDevicePrefix + "/tun"
+	VhostNetDevice   = K8sDevicePrefix + "/vhost-net"
+	VhostVsockDevice = K8sDevicePrefix + "/vhost-vsock"
+	PrDevice         = K8sDevicePrefix + "/pr-helper"
+	SevDeviceName    = "sev"
+	TdxDeviceName    = "tdx"
+	SevDevice        = K8sDevicePrefix + "/" + SevDeviceName
+	TdxDevice        = K8sDevicePrefix + "/" + TdxDeviceName
+)
 
-const debugLogs = "debugLogs"
-const logVerbosity = "logVerbosity"
-const virtiofsDebugLogs = "virtiofsdDebugLogs"
+const (
+	debugLogs         = "debugLogs"
+	logVerbosity      = "logVerbosity"
+	virtiofsDebugLogs = "virtiofsdDebugLogs"
+)
 
 const qemuTimeoutJitterRange = 120
 
@@ -185,7 +190,8 @@ func modifyNodeAffintyToRejectLabel(origAffinity *k8sv1.Affinity, labelToReject 
 		Operator: k8sv1.NodeSelectorOpDoesNotExist,
 	}
 	term := k8sv1.NodeSelectorTerm{
-		MatchExpressions: []k8sv1.NodeSelectorRequirement{requirement}}
+		MatchExpressions: []k8sv1.NodeSelectorRequirement{requirement},
+	}
 
 	nodeAffinity := &k8sv1.NodeAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
@@ -206,7 +212,6 @@ func modifyNodeAffintyToRejectLabel(origAffinity *k8sv1.Affinity, labelToReject 
 				NodeSelectorTerms: []k8sv1.NodeSelectorTerm{term},
 			}
 		}
-
 	} else if affinity != nil {
 		affinity.NodeAffinity = nodeAffinity
 	} else {
@@ -388,11 +393,14 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	if tempPod {
 		logger := log.DefaultLogger()
 		logger.Infof("RUNNING doppleganger pod for %s", vmi.Name)
-		command = []string{"/bin/bash",
+		command = []string{
+			"/bin/bash",
 			"-c",
-			"echo", "bound PVCs"}
+			"echo", "bound PVCs",
+		}
 	} else {
-		command = []string{"/usr/bin/virt-launcher-monitor",
+		command = []string{
+			"/usr/bin/virt-launcher-monitor",
 			"--qemu-timeout", generateQemuTimeoutWithJitter(t.launcherQemuTimeout),
 			"--name", domain,
 			"--uid", string(vmi.UID),
@@ -510,7 +518,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			volumeSource := k8sv1.VolumeSource{
 				ConfigMap: &k8sv1.ConfigMapVolumeSource{
 					LocalObjectReference: k8sv1.LocalObjectReference{Name: cm.Name},
-					DefaultMode:          pointer.P(int32(0755)),
+					DefaultMode:          pointer.P(int32(0o755)),
 				},
 			}
 			vol := k8sv1.Volume{
@@ -562,7 +570,8 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	if !t.clusterConfig.ImageVolumeEnabled() && (HaveContainerDiskVolume(vmi.Spec.Volumes) || util.HasKernelBootContainerImage(vmi)) {
-		initContainerCommand := []string{"/usr/bin/cp", "--preserve=all",
+		initContainerCommand := []string{
+			"/usr/bin/cp", "--preserve=all",
 			"/usr/bin/container-disk",
 			"/init/usr/bin/container-disk",
 		}
@@ -782,10 +791,11 @@ func newSidecarContainerRenderer(sidecarName string, vmiSpec *v1.VirtualMachineI
 		WithResourceRequirements(resources),
 		WithArgs(requestedHookSidecar.Args),
 		WithExtraEnvVars([]k8sv1.EnvVar{
-			k8sv1.EnvVar{
+			{
 				Name:  hooks.ContainerNameEnvVar,
 				Value: sidecarName,
-			}}),
+			},
+		}),
 	}
 
 	var mounts []k8sv1.VolumeMount
@@ -904,7 +914,6 @@ func (t *TemplateService) newVolumeRenderer(vmi *v1.VirtualMachineInstance, imag
 		t.containerDiskDir,
 		t.virtShareDir,
 		volumeOpts...)
-
 	if err != nil {
 		return nil, err
 	}
@@ -963,6 +972,18 @@ func gracePeriodInSeconds(vmi *v1.VirtualMachineInstance) int64 {
 
 func sidecarContainerName(i int) string {
 	return fmt.Sprintf("hook-sidecar-%d", i)
+}
+
+// AttachmentPodIsTrigger determines if a pod is a trigger pod and if it is, which volume it is triggering.
+func (t *TemplateService) AttachmentPodIsTrigger(pod *k8sv1.Pod) (bool, string) {
+	ephemeral, ok := pod.Annotations[v1.EphemeralProvisioningObject]
+	if !ok || ephemeral != "true" {
+		return false, ""
+	}
+
+	targetVolume := pod.Annotations[triggerPodAnnotation]
+
+	return true, targetVolume
 }
 
 func (t *TemplateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim) (*k8sv1.Pod, error) {
@@ -1105,9 +1126,11 @@ func (t *TemplateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 	sharedMount := k8sv1.MountPropagationHostToContainer
 	var command []string
 	if tempPod {
-		command = []string{"/bin/bash",
+		command = []string{
+			"/bin/bash",
 			"-c",
-			"exit", "0"}
+			"exit", "0",
+		}
 	} else {
 		command = []string{"/bin/sh", "-c", "/usr/bin/container-disk --copy-path /path/hp"}
 	}
@@ -1116,6 +1139,9 @@ func (t *TemplateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 	if tempPod {
 		// mark pod as temp - only used for provisioning
 		annotationsList[v1.EphemeralProvisioningObject] = "true"
+
+		// indicate which volume is being triggered
+		annotationsList[triggerPodAnnotation] = volume.Name
 	}
 
 	tmpTolerations := make([]k8sv1.Toleration, len(ownerPod.Spec.Tolerations))
@@ -1123,7 +1149,7 @@ func (t *TemplateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "hp-volume-",
+			GenerateName: "hp-trigger-",
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(ownerPod, schema.GroupVersionKind{
 					Group:   k8sv1.SchemeGroupVersion.Group,
@@ -1302,7 +1328,6 @@ func NewTemplateService(launcherImage string,
 	namespaceStore cache.Store,
 	opts ...templateServiceOption,
 ) *TemplateService {
-
 	precond.MustNotBeEmpty(launcherImage)
 	log.Log.V(1).Infof("Exporter Image: %s", exporterImage)
 	svc := TemplateService{

--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -160,7 +160,7 @@ func (c *Controller) handleBackendStorage(vmi *virtv1.VirtualMachineInstance) (s
 	return pvc.Name, nil
 }
 
-func (c *Controller) processHotplugVolumeStatus(
+func (c *Controller) processUtilityVolumeStatus(
 	vmi *virtv1.VirtualMachineInstance,
 	volumeName string,
 	pvcName string,
@@ -197,6 +197,52 @@ func (c *Controller) processHotplugVolumeStatus(
 			statusCopy.Message = fmt.Sprintf("Created hotplug attachment pod %s, for volume %s", attachmentPod.Name, volumeName)
 			statusCopy.Reason = controller.SuccessfulCreatePodReason
 			c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, statusCopy.Reason, statusCopy.Message)
+		}
+	}
+
+	*status = *statusCopy
+}
+
+func (c *Controller) processHotplugVolumeStatus(
+	vmi *virtv1.VirtualMachineInstance,
+	volume virtv1.Volume,
+	pvcName string,
+	status *virtv1.VolumeStatus,
+	attachmentPod *k8sv1.Pod,
+) {
+	volumeName := volume.Name
+	statusCopy := status.DeepCopy()
+
+	if statusCopy.HotplugVolume == nil {
+		statusCopy.HotplugVolume = &virtv1.HotplugVolumeStatus{}
+	}
+
+	if attachmentPod == nil {
+		if !c.volumeReady(statusCopy.Phase) {
+			statusCopy.HotplugVolume.AttachPodUID = ""
+			// Volume is not hotplugged in VM and Pod is gone, or hasn't been created yet, check for the PVC associated with the volume to set phase and message
+			phase, reason, message := c.getVolumePhaseMessageReason(pvcName, vmi.Namespace)
+			statusCopy.Phase = phase
+			log.Log.V(3).Infof("Setting phase %s for volume %s", phase, volumeName)
+			statusCopy.Message = message
+			statusCopy.Reason = reason
+		}
+	} else {
+		if podHasVolume(attachmentPod, &volume) {
+			status.HotplugVolume.AttachPodName = attachmentPod.Name
+			if len(attachmentPod.Status.ContainerStatuses) == 1 && attachmentPod.Status.ContainerStatuses[0].Ready {
+				status.HotplugVolume.AttachPodUID = attachmentPod.UID
+			} else {
+				// Remove UID of old pod if a new one is available, but not yet ready
+				status.HotplugVolume.AttachPodUID = ""
+			}
+			if canMoveToAttachedPhase(status.Phase) {
+				status.Phase = virtv1.HotplugVolumeAttachedToNode
+				log.Log.V(3).Infof("Setting phase %s for volume %s", status.Phase, volume.Name)
+				status.Message = fmt.Sprintf("Created hotplug attachment pod %s, for volume %s", attachmentPod.Name, volume.Name)
+				status.Reason = controller.SuccessfulCreatePodReason
+				c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, status.Reason, status.Message)
+			}
 		}
 	}
 
@@ -258,7 +304,7 @@ func (c *Controller) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, virt
 		return err
 	}
 
-	attachmentPod, _ := getActiveAndOldAttachmentPods(hotplugVolumes, attachmentPods)
+	attachmentPod := getLatestAttachmentPod(attachmentPods)
 
 	newStatus := make([]virtv1.VolumeStatus, 0)
 
@@ -287,7 +333,7 @@ func (c *Controller) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, virt
 		pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
 
 		if _, ok := hotplugVolumesMap[volume.Name]; ok {
-			c.processHotplugVolumeStatus(vmi, volume.Name, pvcName, &status, attachmentPod)
+			c.processHotplugVolumeStatus(vmi, volume, pvcName, &status, attachmentPod)
 		}
 		if volume.VolumeSource.PersistentVolumeClaim != nil || volume.VolumeSource.DataVolume != nil || volume.VolumeSource.MemoryDump != nil {
 			err = c.processPVCInfo(&status, pvcName, vmi.Namespace, false)
@@ -308,7 +354,7 @@ func (c *Controller) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, virt
 		}
 		// Remove from map so we can detect volumes removed from spec
 		delete(oldStatusMap, utilityVolume.Name)
-		c.processHotplugVolumeStatus(vmi, utilityVolume.Name, utilityVolume.ClaimName, &status, attachmentPod)
+		c.processUtilityVolumeStatus(vmi, utilityVolume.Name, utilityVolume.ClaimName, &status, attachmentPod)
 		err = c.processPVCInfo(&status, utilityVolume.ClaimName, vmi.Namespace, true)
 		if err != nil {
 			return err

--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -229,19 +229,19 @@ func (c *Controller) processHotplugVolumeStatus(
 		}
 	} else {
 		if podHasVolume(attachmentPod, &volume) {
-			status.HotplugVolume.AttachPodName = attachmentPod.Name
+			statusCopy.HotplugVolume.AttachPodName = attachmentPod.Name
 			if len(attachmentPod.Status.ContainerStatuses) == 1 && attachmentPod.Status.ContainerStatuses[0].Ready {
-				status.HotplugVolume.AttachPodUID = attachmentPod.UID
+				statusCopy.HotplugVolume.AttachPodUID = attachmentPod.UID
 			} else {
 				// Remove UID of old pod if a new one is available, but not yet ready
-				status.HotplugVolume.AttachPodUID = ""
+				statusCopy.HotplugVolume.AttachPodUID = ""
 			}
 			if canMoveToAttachedPhase(status.Phase) {
-				status.Phase = virtv1.HotplugVolumeAttachedToNode
-				log.Log.V(3).Infof("Setting phase %s for volume %s", status.Phase, volume.Name)
-				status.Message = fmt.Sprintf("Created hotplug attachment pod %s, for volume %s", attachmentPod.Name, volume.Name)
-				status.Reason = controller.SuccessfulCreatePodReason
-				c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, status.Reason, status.Message)
+				statusCopy.Phase = virtv1.HotplugVolumeAttachedToNode
+				log.Log.V(3).Infof("Setting phase %s for volume %s", statusCopy.Phase, volume.Name)
+				statusCopy.Message = fmt.Sprintf("Created hotplug attachment pod %s, for volume %s", attachmentPod.Name, volume.Name)
+				statusCopy.Reason = controller.SuccessfulCreatePodReason
+				c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, statusCopy.Reason, status.Message)
 			}
 		}
 	}

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -76,7 +76,6 @@ func NewController(templateService templateService,
 	additionalLauncherAnnotationsSync []string,
 	additionalLauncherLabelsSync []string,
 ) (*Controller, error) {
-
 	c := &Controller{
 		templateService: templateService,
 		Queue: workqueue.NewTypedRateLimitingQueueWithConfig[string](
@@ -193,6 +192,7 @@ type templateService interface {
 	RenderHotplugAttachmentPodTemplate(volumes []*virtv1.Volume, ownerPod *k8sv1.Pod, vmi *virtv1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim) (*k8sv1.Pod, error)
 	RenderHotplugAttachmentTriggerPodTemplate(volume *virtv1.Volume, ownerPod *k8sv1.Pod, vmi *virtv1.VirtualMachineInstance, pvcName string, isBlock, tempPod bool) (*k8sv1.Pod, error)
 	GetLauncherImage() string
+	AttachmentPodIsTrigger(pod *k8sv1.Pod) (bool, string)
 }
 
 type annotationsGenerator interface {
@@ -303,10 +303,8 @@ func (c *Controller) Execute() bool {
 }
 
 func (c *Controller) execute(key string) error {
-
 	// Fetch the latest Vm state from cache
 	obj, exists, err := c.vmiIndexer.GetByKey(key)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -3437,7 +3437,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 
 		DescribeTable("Should find active and old pods", func(hotplugVolumes []*virtv1.Volume, attachmentPods []*k8sv1.Pod, expectedActive *k8sv1.Pod, expectedOld []*k8sv1.Pod) {
-			active, old := getActiveAndOldAttachmentPods(hotplugVolumes, attachmentPods)
+			active, old := controller.getActiveAndOldAttachmentPods(hotplugVolumes, attachmentPods)
 			Expect(active).To(Equal(expectedActive))
 			Expect(old).To(ContainElements(expectedOld))
 		},

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -138,7 +138,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			ContainElement(
 				MatchFields(IgnoreExtras, Fields{
 					"Type":   BeEquivalentTo(virtv1.VirtualMachineInstanceDataVolumesReady),
-					"Status": BeEquivalentTo(expectedStatus)},
+					"Status": BeEquivalentTo(expectedStatus),
+				},
 				),
 			),
 		)
@@ -306,7 +307,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	}
 
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {
-
 		dvVolumeSource := virtv1.VolumeSource{
 			DataVolume: &virtv1.DataVolumeSource{
 				Name: "test1",
@@ -492,13 +492,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			},
 			Entry("fail if pod in failed state", k8sv1.PodFailed, nil, virtv1.Failed),
 			Entry("do nothing if pod succeed", k8sv1.PodSucceeded, nil, virtv1.Pending),
-			//The PodReasonUnschedulable is a transient condition. It can clear up if more resources are added to the cluster
+			// The PodReasonUnschedulable is a transient condition. It can clear up if more resources are added to the cluster
 			Entry("do nothing if pod Pending Unschedulable",
 				k8sv1.PodPending,
 				[]k8sv1.PodCondition{{
 					Type:   k8sv1.PodScheduled,
 					Status: k8sv1.ConditionFalse,
-					Reason: k8sv1.PodReasonUnschedulable}}, virtv1.Pending),
+					Reason: k8sv1.PodReasonUnschedulable,
+				}}, virtv1.Pending),
 		)
 
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
@@ -577,7 +578,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
 				expectMatchingPodCreation(vmi)
 			})
-
 		})
 
 		When("backend storage no RWX support", func() {
@@ -666,7 +666,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	})
 
 	Context("On valid VirtualMachineInstance given with PVC source, ownedRef of DataVolume", func() {
-
 		pvcVolumeSource := virtv1.VolumeSource{
 			PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 				ClaimName: "test1",
@@ -787,7 +786,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, kvcontroller.SuccessfulDeletePodReason)
 			expectPodDoesNotExist(pod.Namespace, pod.Name)
 			expectVMIDataVolumeReadyCondition(vmi.Namespace, vmi.Name, k8sv1.ConditionTrue)
-
 		})
 
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
@@ -827,7 +825,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
 			expectMatchingPodCreation(vmi)
 		})
-
 	})
 
 	Context("network annotations generation", func() {
@@ -887,7 +884,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 		})
 		It("should create empty status network interfaces patch, regardless of interfaces order", func() {
-
 			// Reverse the order of interfaces in the new VMI
 			newVMI.Status.Interfaces = slices.Clone(oldVMI.Status.Interfaces)
 			slices.Reverse(newVMI.Status.Interfaces)
@@ -898,7 +894,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(patch.IsEmpty()).To(BeTrue(), "Patch should be empty")
 		})
 		It("should create non empty status network interfaces patch", func() {
-
 			// Add a new interface to the new VMI
 			newVMI.Status.Interfaces = append(oldVMI.Status.Interfaces,
 				virtv1.VirtualMachineInstanceNetworkInterface{Name: "stubNetStatusUpdate3"},
@@ -1238,7 +1233,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		DescribeTable("should never proceed to creating the launcher pod if not all PVCs are there to determine if they are WFFC and/or an import is done",
 			func(syncReason string, volumeSource virtv1.VolumeSource) {
-
 				expectConditions := func(vmi *virtv1.VirtualMachineInstance) {
 					// PodScheduled and Synchronized (as well as Ready)
 					Expect(vmi.Status.Conditions).To(HaveLen(3), "there should be exactly 3 conditions")
@@ -1533,7 +1527,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			switch expectedPhase {
 			case virtv1.Scheduled:
-				testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
+				if attachmentPodPhase == k8sv1.PodRunning {
+					testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
+				} else {
+					// If the pod is not running we will not get a pod created event.
+				}
 				expectVMIScheduledState(vmi)
 			case virtv1.Scheduling:
 				expectVMIBeInPhase(vmi.Namespace, vmi.Name, virtv1.Scheduling)
@@ -3528,10 +3526,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pvc := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
-					Name:      "test"},
+					Name:      "test",
+				},
 				Spec: k8sv1.PersistentVolumeClaimSpec{},
 			}
 
@@ -3915,18 +3915,22 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			existingPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "existing"},
+					Name:      "existing",
+				},
 			}
 			hpPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "hotplug"},
+					Name:      "hotplug",
+				},
 				Status: k8sv1.PersistentVolumeClaimStatus{
 					Phase: k8sv1.ClaimBound,
 				},
@@ -4017,18 +4021,22 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			existingPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "existing"},
+					Name:      "existing",
+				},
 			}
 			hpPVC := &k8sv1.PersistentVolumeClaim{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name:      "hotplug"},
+					Name:      "hotplug",
+				},
 				Status: k8sv1.PersistentVolumeClaimStatus{
 					Phase: k8sv1.ClaimBound,
 				},
@@ -4065,7 +4073,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Target: "",
 					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
 						ClaimName:          "existing",
-						FilesystemOverhead: pointer.P(virtv1.Percent("0.055"))},
+						FilesystemOverhead: pointer.P(virtv1.Percent("0.055")),
+					},
 				},
 				{
 					Name:   "hotplug",
@@ -4182,7 +4191,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	})
 
 	Context("topology hints", func() {
-
 		getVmiWithInvTsc := func() *virtv1.VirtualMachineInstance {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
@@ -4257,13 +4265,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						testutils.ExpectEvent(recorder, kvcontroller.SuccessfulCreatePodReason)
 					})
 				})
-
 			})
-
 		})
 
 		Context("pod creation", func() {
-
 			It("does not need to happen if tsc requirement is of type RequiredForBoot", func() {
 				vmi := getVmiWithInvTsc()
 				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.RequiredForBoot))
@@ -4341,11 +4346,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			Expect(alc.calls).To(ConsistOf([]string{"Allocate", "Remove"}))
 		})
-
 	})
 
 	Context("Aggregating DataVolume conditions", func() {
-
 		dvVolumeSource1 := virtv1.VolumeSource{
 			DataVolume: &virtv1.DataVolumeSource{
 				Name: "test1",
@@ -4836,7 +4839,8 @@ func newPvc(namespace string, name string) *k8sv1.PersistentVolumeClaim {
 	return &k8sv1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
-			APIVersion: "v1"},
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -4848,7 +4852,8 @@ func newPvcWithOwner(namespace string, name string, ownerName string, isControll
 	return &k8sv1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
-			APIVersion: "v1"},
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -4998,7 +5003,6 @@ func addVolumeStatuses(vmi *virtv1.VirtualMachineInstance, volumeStatuses ...vir
 }
 
 func addActivePods(vmi *virtv1.VirtualMachineInstance, podUID types.UID, hostName string) *virtv1.VirtualMachineInstance {
-
 	if vmi.Status.ActivePods != nil {
 		vmi.Status.ActivePods[podUID] = hostName
 	} else {

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -79,7 +79,6 @@ func (c *Controller) getActiveAndOldAttachmentPods(readyHotplugVolumes []*v1.Vol
 	for _, attachmentPod := range hotplugAttachmentPods {
 		if trigger, _ := c.templateService.AttachmentPodIsTrigger(attachmentPod); trigger {
 			// This is a trigger pod... ignore
-			fmt.Printf("XXX Ignoring trigger pod: %s\n", attachmentPod.Name)
 			continue
 		}
 		if !podVolumesMatchesReadyVolumes(attachmentPod, readyHotplugVolumes) {

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -38,6 +38,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/common"
 )
 
+const attachmentPodTimeout = time.Second * 60
+
 func needsHandleHotplug(hotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod) bool {
 	if len(hotplugAttachmentPods) > 1 {
 		return true
@@ -49,10 +51,37 @@ func needsHandleHotplug(hotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8
 	return len(hotplugVolumes) > 0 || len(hotplugAttachmentPods) > 0
 }
 
-func getActiveAndOldAttachmentPods(readyHotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod) (*k8sv1.Pod, []*k8sv1.Pod) {
+// getLatestAttachmentPod returns the newest running pod.
+func getLatestAttachmentPod(attachmentPods []*k8sv1.Pod) *k8sv1.Pod {
+	pods := make([]*k8sv1.Pod, 0, len(attachmentPods))
+	for _, pod := range attachmentPods {
+		if pod.DeletionTimestamp == nil {
+			pods = append(pods, pod)
+		}
+	}
+	// Sort, newest first.
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].CreationTimestamp.After(pods[j].CreationTimestamp.Time)
+	})
+
+	for _, pod := range pods {
+		if pod.Status.Phase == k8sv1.PodRunning {
+			return pod
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) getActiveAndOldAttachmentPods(readyHotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod) (*k8sv1.Pod, []*k8sv1.Pod) {
 	var currentPod *k8sv1.Pod
 	oldPods := make([]*k8sv1.Pod, 0)
 	for _, attachmentPod := range hotplugAttachmentPods {
+		if trigger, _ := c.templateService.AttachmentPodIsTrigger(attachmentPod); trigger {
+			// This is a trigger pod... ignore
+			fmt.Printf("XXX Ignoring trigger pod: %s\n", attachmentPod.Name)
+			continue
+		}
 		if !podVolumesMatchesReadyVolumes(attachmentPod, readyHotplugVolumes) {
 			oldPods = append(oldPods, attachmentPod)
 		} else {
@@ -63,21 +92,23 @@ func getActiveAndOldAttachmentPods(readyHotplugVolumes []*v1.Volume, hotplugAtta
 		}
 	}
 	sort.Slice(oldPods, func(i, j int) bool {
-		return oldPods[i].CreationTimestamp.Time.After(oldPods[j].CreationTimestamp.Time)
+		return oldPods[i].CreationTimestamp.After(oldPods[j].CreationTimestamp.Time)
 	})
 	return currentPod, oldPods
 }
 
-// cleanupAttachmentPods deletes all old attachment pods when the following is true
-// 1. There is a currentPod that is running. (not nil and phase.Status == Running)
-// 2. There are no readyVolumes (numReadyVolumes == 0)
-// 3. The newest oldPod is not running and not marked for deletion.
-// If any of those are true, it will not delete the newest oldPod, since that one is the latest
-// pod that is closest to the desired state.
+// cleanupAttachmentPods deletes all unused attachment pods. If there is no
+// running current pod, then the most recent running old pod is kept as it
+// holds the most recent set of mounted volumes.
+//
+// Further, a pod is protected from deletion if it has volumes which have not
+// yet been unmounted inside the guest.
+//
+// The provided list of oldPods must be sorted by most recent pod.
 func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8sv1.Pod, vmi *v1.VirtualMachineInstance, numReadyVolumes int) common.SyncError {
 	foundRunning := false
 
-	var statusMap = make(map[string]v1.VolumeStatus)
+	statusMap := make(map[string]v1.VolumeStatus)
 	for _, vs := range vmi.Status.VolumeStatus {
 		if vs.HotplugVolume != nil {
 			statusMap[vs.Name] = vs
@@ -92,6 +123,9 @@ func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8s
 
 	currentPodIsNotRunning := currentPod == nil || currentPod.Status.Phase != k8sv1.PodRunning
 	for _, attachmentPod := range oldPods {
+		if ephemeral, _ := c.templateService.AttachmentPodIsTrigger(attachmentPod); ephemeral {
+			continue
+		}
 		if !foundRunning &&
 			attachmentPod.Status.Phase == k8sv1.PodRunning && attachmentPod.DeletionTimestamp == nil &&
 			numReadyVolumes > 0 &&
@@ -132,6 +166,41 @@ func volumeReadyForPodDelete(phase v1.VolumePhase) bool {
 	return true
 }
 
+// settleDuration calculates a reasonable time to allow the attacher pod to
+// settle before it can be replaced by another pod.
+func settleDuration(numVolumes int) time.Duration {
+	return time.Duration(5+float64(numVolumes)/10) * time.Second
+}
+
+func (c *Controller) alreadyTriggered(attachmentPods []*k8sv1.Pod, volumeName string) bool {
+	for _, pod := range attachmentPods {
+		trigger, target := c.templateService.AttachmentPodIsTrigger(pod)
+		if trigger && target == volumeName {
+			return true
+		}
+	}
+	return false
+}
+
+// mostRecentPendingPodAge returns the most recent pending pod and its age.
+//
+// This relies on the pods being in a newest first order.
+func (c *Controller) mostRecentPendingPodAge(pods []*k8sv1.Pod) (*k8sv1.Pod, time.Duration) {
+	for _, pod := range pods {
+		if ephemeral, _ := c.templateService.AttachmentPodIsTrigger(pod); ephemeral {
+			continue
+		}
+
+		if pod.Status.Phase == k8sv1.PodRunning {
+			continue
+		}
+
+		return pod, time.Since(pod.CreationTimestamp.Time)
+	}
+
+	return nil, 0
+}
+
 func (c *Controller) isUtilityVolumeWithBlockPVC(vmi *v1.VirtualMachineInstance, volume *v1.Volume) (bool, error) {
 	isUtilityVolume := false
 	for _, utilityVolume := range vmi.Spec.UtilityVolumes {
@@ -159,22 +228,18 @@ func (c *Controller) handleHotplugVolumes(hotplugVolumes []*v1.Volume, hotplugAt
 	readyHotplugVolumes := make([]*v1.Volume, 0)
 	// Find all ready volumes
 	for _, volume := range hotplugVolumes {
-		isUtilityVolumeWithBlockPVC, err := c.isUtilityVolumeWithBlockPVC(vmi, volume)
-		if err != nil {
-			return common.NewSyncError(err, controller.PVCNotReadyReason)
-		}
-		if isUtilityVolumeWithBlockPVC {
-			logger.V(3).Infof("Skipping utility volume %s: configured with block volume mode PVC, utility volumes require filesystem volume mode", volume.Name)
-			continue
-		}
-
+		var err error
 		ready, wffc, err := storagetypes.VolumeReadyToAttachToNode(vmi.Namespace, *volume, dataVolumes, c.dataVolumeIndexer, c.pvcIndexer)
 		if err != nil {
 			return common.NewSyncError(fmt.Errorf("Error determining volume status %v", err), controller.PVCNotReadyReason)
 		}
 		if wffc {
+			if c.alreadyTriggered(hotplugAttachmentPods, volume.Name) {
+				logger.V(5).Infof("De-bounce trigger pod creation for WaitForFirstConsumer: %s/%s", vmi.Namespace, volume.Name)
+				continue
+			}
 			// Volume in WaitForFirstConsumer, it has not been populated by CDI yet. create a dummy pod
-			logger.V(1).Infof("Volume %s/%s is in WaitForFistConsumer, triggering population", vmi.Namespace, volume.Name)
+			logger.V(1).Infof("Volume %s/%s is in WaitForFirstConsumer, triggering population", vmi.Namespace, volume.Name)
 			syncError := c.triggerHotplugPopulation(volume, vmi, virtLauncherPod)
 			if syncError != nil {
 				return syncError
@@ -189,23 +254,46 @@ func (c *Controller) handleHotplugVolumes(hotplugVolumes []*v1.Volume, hotplugAt
 		readyHotplugVolumes = append(readyHotplugVolumes, volume)
 	}
 
-	currentPod, oldPods := getActiveAndOldAttachmentPods(readyHotplugVolumes, hotplugAttachmentPods)
-	if currentPod == nil && !hasPendingPods(oldPods) && len(readyHotplugVolumes) > 0 {
-		if rateLimited, waitTime := c.requeueAfter(oldPods, time.Duration(len(readyHotplugVolumes)/-10)); rateLimited {
-			key, err := controller.KeyFunc(vmi)
-			if err != nil {
-				logger.Object(vmi).Reason(err).Error("failed to extract key from virtualmachine.")
-				return common.NewSyncError(fmt.Errorf("failed to extract key from virtualmachine. %v", err), controller.FailedHotplugSyncReason)
+	currentPod, oldPods := c.getActiveAndOldAttachmentPods(readyHotplugVolumes, hotplugAttachmentPods)
+	if currentPod == nil && len(readyHotplugVolumes) > 0 {
+		logger.V(5).Infof("Hotplug: work do do...")
+
+		if !hasPendingPods(oldPods) {
+			if rateLimited, waitTime := c.requeueAfter(oldPods, settleDuration(len(readyHotplugVolumes))); rateLimited {
+				logger.V(4).Infof("Hotplug: attachment pod creation delayed... allow the existing pod to settle: %v", waitTime)
+				key, err := controller.KeyFunc(vmi)
+				if err != nil {
+					logger.Object(vmi).Reason(err).Error("failed to extract key from virtualmachine.")
+					return common.NewSyncError(fmt.Errorf("failed to extract key from virtualmachine. %v", err), controller.FailedHotplugSyncReason)
+				}
+				c.Queue.AddAfter(key, waitTime)
+				return nil
 			}
-			c.Queue.AddAfter(key, waitTime)
-		} else {
+			logger.V(3).Infof("Hotplug: creating new attachment pod")
 			if newPod, err := c.createAttachmentPod(vmi, virtLauncherPod, readyHotplugVolumes); err != nil {
 				return err
 			} else {
-				currentPod = newPod
+				if newPod == nil {
+					logger.V(3).Infof("Hotplug: new pod not created (unknown reason)")
+					return nil
+				}
+				logger.V(3).Infof("Hotplug: created attachment pod %s (%d volumes)", newPod.Name, len(readyHotplugVolumes))
+				return nil
 			}
+		} else {
+			pendingPod, age := c.mostRecentPendingPodAge(oldPods)
+			if pendingPod != nil && age < attachmentPodTimeout {
+				logger.V(3).Infof("Hotplug: waiting for existing pending attached pod")
+				return nil
+			}
+
+			logger.V(3).Infof("Hotplug: pending pod %s, too old: %s, cleaning up", pendingPod.Name, age)
+			// Fall through to cleanup
 		}
 	}
+	// else: No work to do (there is either a current pod, or no volumes to attach). Fall through the cleanup
+
+	logger.V(3).Infof("Hotplug: cleaning up any outstanding attachment pods")
 	if err := c.cleanupAttachmentPods(currentPod, oldPods, vmi, len(readyHotplugVolumes)); err != nil {
 		return err
 	}
@@ -280,7 +368,7 @@ func (c *Controller) createAttachmentPodTemplate(vmi *v1.VirtualMachineInstance,
 		return nil, fmt.Errorf("failed to get PVC map: %v", err)
 	}
 	for volumeName, pvc := range volumeNamesPVCMap {
-		//Verify the PVC is ready to be used.
+		// Verify the PVC is ready to be used.
 		populated, err := cdiv1.IsSucceededOrPendingPopulation(pvc, func(name, namespace string) (*cdiv1.DataVolume, error) {
 			dv, exists, _ := c.dataVolumeIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
 			if !exists {
@@ -391,6 +479,19 @@ func (c *Controller) deleteAttachmentPod(vmi *v1.VirtualMachineInstance, attachm
 	return nil
 }
 
+// podHasVolume checks to see if the provided volume is defined on this attachment pod.
+func podHasVolume(pod *k8sv1.Pod, volume *v1.Volume) bool {
+	for _, specVolume := range pod.Spec.Volumes {
+		if specVolume.PersistentVolumeClaim != nil {
+			if specVolume.Name == volume.Name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func podVolumesMatchesReadyVolumes(attachmentPod *k8sv1.Pod, volumes []*v1.Volume) bool {
 	// -2 for empty dir and token
 	if len(attachmentPod.Spec.Volumes)-2 != len(volumes) {
@@ -418,8 +519,12 @@ func hasPendingPods(pods []*k8sv1.Pod) bool {
 	return false
 }
 
+// requeueAfter determines if we should and how long to delay subsequent work
+// until the oldest oldPod (the first) is threshold age.
+//
+// Note: oldPods needs to be sorted with the oldest pod first.
 func (c *Controller) requeueAfter(oldPods []*k8sv1.Pod, threshold time.Duration) (bool, time.Duration) {
-	if len(oldPods) > 0 && oldPods[0].CreationTimestamp.Time.After(time.Now().Add(-1*threshold)) {
+	if len(oldPods) > 0 && oldPods[0].CreationTimestamp.After(time.Now().Add(-1*threshold)) {
 		return true, threshold - time.Since(oldPods[0].CreationTimestamp.Time)
 	}
 	return false, 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

Consistently changing hotswap disks on a VM (changes more often than every 3 seconds) results in a livelock where no new disks are added to the VM and whilst removed disks are unmounted from the guest they are not freed from the underlying attachment pod. When changes to hotswap disks stop arrive the system catches up and mounts/frees the final set of disks.

In addition, wait for first consumer (WFFC) volumes caused an avalanche of trigger pods.

#### After this PR:

Disks are mounted to the VM (typically in batches every 5-8s) during consistent hotswap changes.

WFFC volumes are only triggered once.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Constant hotswap changes no longer block disk attachment/freeing.
```

