### PR TITLE
tests/operator: Drop vmexport featuregate tests

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -3929,6 +3929,61 @@ var _ = Describe("KubeVirt Operator", func() {
 		})
 	})
 
+	Context("VMExport feature gate", func() {
+		var kvTestData *KubeVirtTestData
+
+		BeforeEach(func() {
+			kvTestData = &KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			DeferCleanup(kvTestData.AfterTest)
+		})
+
+		It("should delete virt-exportproxy deployment when VMExport is disabled after being enabled", func() {
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Finalizers: []string{util.KubeVirtFinalizer},
+				},
+			}
+			enableExportFeatureGate(kv)
+			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
+
+			newKv := kv.DeepCopy()
+			newKv.ObjectMeta.Generation = 2
+			newKv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+			newConfig := util.GetTargetConfigFromKVWithEnvVarManager(newKv, kvTestData.mockEnvVarManager)
+
+			kvTestData.deleteFromCache = true
+			kubecontroller.SetLatestApiVersionAnnotation(newKv)
+			kvTestData.addKubeVirt(newKv)
+			kvTestData.addInstallStrategy(newConfig)
+
+			kvTestData.addAll(config, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(config, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(newConfig, newKv)
+			kvTestData.addVirtHandler(newConfig, newKv)
+			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeHandlerReady()
+
+			_, exists, err := kvTestData.controller.stores.DeploymentCache.GetByKey(fmt.Sprintf("%s/%s", NAMESPACE, "virt-exportproxy"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue(), "virt-exportproxy should exist when VMExport feature gate is enabled")
+
+			kvTestData.shouldExpectDeletions()
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates(newKv)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+
+			kvTestData.controller.Execute()
+
+			_, exists, err = kvTestData.controller.stores.DeploymentCache.GetByKey(fmt.Sprintf("%s/%s", NAMESPACE, "virt-exportproxy"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse(), "virt-exportproxy should be deleted when VMExport feature gate is disabled")
+		})
+	})
+
 	Context("when the monitor namespace does not exist", func() {
 		It("should not create ServiceMonitor resources", func() {
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1819,24 +1819,6 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		})
 	})
 
-	Context("with VMExport feature gate toggled", func() {
-
-		AfterEach(func() {
-			kvconfig.EnableFeatureGate(featuregate.VMExportGate)
-			testsuite.WaitExportProxyReady()
-		})
-
-		It("should delete and recreate virt-exportproxy", func() {
-			testsuite.WaitExportProxyReady()
-			kvconfig.DisableFeatureGate(featuregate.VMExportGate)
-
-			Eventually(func() error {
-				_, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.TODO(), "virt-exportproxy", metav1.GetOptions{})
-				return err
-			}, time.Minute*5, time.Second*2).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
-		})
-	})
-
 	Context("with ContainerPathVolumes feature gate toggled", func() {
 
 		AfterEach(func() {


### PR DESCRIPTION
Disabling and reenabling a feature gate is an expensive operation, taking a long minute on each execution.

VMExport is well tested by functional e2e tests and unit tests. The value of the specific non-functional tests in operation.go is very limited. 

https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.32-sig-operator/2023814892384948224/artifacts/junit.functest.xml
```
      <testcase name="[sig-operator]Operator with VMExport feature gate toggled should delete and recreate virt-exportproxy" classname="KubeVirt Tests Suite" time="60.044613686"></testcase>

```

BTW, it is high time we formally maturate this feature gate and have it always enabled.

/kind cleanup

```release-note
NONE
```

