### PR TITLE
e2e, net, nad swap: Fix flaking console login and ping in NAD swap tests

### DIFF
--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -49,7 +49,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("[QUARANTINE] NAD name live update", decorators.RequiresTwoSchedulableNodes, decorators.Quarantine, Serial, func() {
+var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNodes, Serial, func() {
 	const (
 		vmName          = "migrating-vm"
 		vmIP            = "10.1.1.100"


### PR DESCRIPTION
Flake 1: console login after the VM migrates flakes
Example: https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16927/pull-kubevirt-e2e-k8s-1.35-sig-network/2029193500305657856
This PR This removes the console login step altogether.
In a real scenario the user may not want to configure the guest IP after updating the NAD. If both the static VMIs have the same subnet there would be no need to reconfigure the IP of the migrating VMI. 

Flake 2: ping after migration fails
Example: https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.35-ipv6-sig-network/2028793861131735040

This PR makes sure that the migrating VM has completed its migration before fetching the node it is running on.  This node is later used to spawn the second VMI to verify connectivity.
Currently the node info is fetched just after migrationRequired condition disappears. This does not guarantee that migration has already happened and so sometimes the node info of the source VM is fetched. As
a result the second VMI is spawned on the source node rather than target node and the ping fails.
We see that in the logs:
https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17087/pull-kubevirt-check-tests-for-flakes/2033536745219297280/artifacts/k8s-reporter/1/1_overview.log

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
- Fixes https://github.com/kubevirt/kubevirt/issues/17086
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

