### PR TITLE
[cosmetic] Remove duplicate enum validation for RoleAggregationStrategy

### DIFF
--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -1031,13 +1031,6 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   roleAggregationStrategy:
-                    allOf:
-                    - enum:
-                      - AggregateToDefault
-                      - Manual
-                    - enum:
-                      - AggregateToDefault
-                      - Manual
                     description: |-
                       RoleAggregationStrategy controls whether RBAC cluster roles should be aggregated
                       to the default Kubernetes roles (admin, edit, view).
@@ -1045,6 +1038,9 @@ spec:
                       When set to "Manual", the labels are not added, and roles will not be aggregated to the default roles.
                       Setting this field to "Manual" requires the OptOutRoleAggregation feature gate to be enabled.
                       This is an Alpha feature and subject to change.
+                    enum:
+                    - AggregateToDefault
+                    - Manual
                     type: string
                   seccompConfiguration:
                     description: SeccompConfiguration holds Seccomp configuration
@@ -4508,13 +4504,6 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   roleAggregationStrategy:
-                    allOf:
-                    - enum:
-                      - AggregateToDefault
-                      - Manual
-                    - enum:
-                      - AggregateToDefault
-                      - Manual
                     description: |-
                       RoleAggregationStrategy controls whether RBAC cluster roles should be aggregated
                       to the default Kubernetes roles (admin, edit, view).
@@ -4522,6 +4511,9 @@ spec:
                       When set to "Manual", the labels are not added, and roles will not be aggregated to the default roles.
                       Setting this field to "Manual" requires the OptOutRoleAggregation feature gate to be enabled.
                       This is an Alpha feature and subject to change.
+                    enum:
+                    - AggregateToDefault
+                    - Manual
                     type: string
                   seccompConfiguration:
                     description: SeccompConfiguration holds Seccomp configuration

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1633,13 +1633,6 @@ var CRDsValidation map[string]string = map[string]string{
                   x-kubernetes-list-type: atomic
               type: object
             roleAggregationStrategy:
-              allOf:
-              - enum:
-                - AggregateToDefault
-                - Manual
-              - enum:
-                - AggregateToDefault
-                - Manual
               description: |-
                 RoleAggregationStrategy controls whether RBAC cluster roles should be aggregated
                 to the default Kubernetes roles (admin, edit, view).
@@ -1647,6 +1640,9 @@ var CRDsValidation map[string]string = map[string]string{
                 When set to "Manual", the labels are not added, and roles will not be aggregated to the default roles.
                 Setting this field to "Manual" requires the OptOutRoleAggregation feature gate to be enabled.
                 This is an Alpha feature and subject to change.
+              enum:
+              - AggregateToDefault
+              - Manual
               type: string
             seccompConfiguration:
               description: SeccompConfiguration holds Seccomp configuration for Kubevirt

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -3178,7 +3178,6 @@ type VirtTemplateDeployment struct {
 }
 
 // RoleAggregationStrategy represents the strategy for RBAC role aggregation
-// +kubebuilder:validation:Enum=AggregateToDefault;Manual
 type RoleAggregationStrategy string
 
 const (


### PR DESCRIPTION
Currently, in the kubevirt CRD there is an enum validation both on the `RoleAggregationStrategy` field and on the type, resulting in a duplication in the final CRD. We should keep the enum validation only on the field and remove it from the type so the CRD will be cleaner and more concise.

Signed-off-by: Oren Cohen <ocohen@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

