### PR TITLE
tests(quarantine): test_id:832

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2147,7 +2147,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 			})
 
-			It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", func() {
+			It("[QUARANTINE][test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", decorators.Quarantine, func() {
 				vmi := noDedicatedCPUVMI()
 				By("Starting a VirtualMachineInstance without dedicated cpus")
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

[sig-compute]Configurations [rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores [test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-compute%5DConfigurations+%5C%5Brfe_id%3A897%5D%5C%5Bcrit%3Amedium%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5DVirtualMachineInstance+with+CPU+pinning+cpu+pinning+with+fedora+images%2C+dedicated+and+non+dedicated+cpu+should+be+possible+on+same+node+via+spec.domain.cpu.cores+%5C%5Btest_id%3A832%5Dshould+start+a+vm+with+cpu+pinning+after+a+vm+with+no+cpu+pinning+on+same+node&maxAge=336h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 6% over 336h on
[pull-kubevirt-e2e-k8s-1.35-sig-compute-serial](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial):
Failures: [30h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17041/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2030727217620717568) [72h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15117/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2030032836521627648) [96h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16869/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2029578040589160448) [96h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17008/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2029483233904693248) [96h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17012/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2029472265027981312) [120h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16748/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2029136341287047168) [144h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16800/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028830741919436800) [168h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028519402978152448) [168h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16842/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028478159984267264) [168h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16462/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028442433955565568) [168h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16985/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028407448938745856) [168h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16556/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028329071003308032) [192h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16556/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028226357300826112) [192h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16676/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2028005322081177600) [240h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16905/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2027443350449164288) [264h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16836/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2027169301126975488) [264h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16806/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026941507390410752) [264h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16940/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026675739645972480) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026815534531612672) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16412/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026686672703328256) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026676482658537472) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026707010455605248) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16627/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026629186243792896) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16865/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026630206847979520) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15958/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026616403850694656) [312h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16670/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026432713845641216) [312h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16768/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026429064545308672) [312h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16815/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026363914429665280) [312h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16877/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026210873122492416) [312h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.35-sig-compute-serial/2026154416746270720)

#### After this PR:

Quarantined test

`[sig-compute]Configurations [rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores [test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node`

for impact of 6% over 336h on pull-kubevirt-e2e-k8s-1.35-sig-compute-serial


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

