### PR TITLE
virt-launcher: fix wrong error variable used in standalone JSON fallback

### DIFF
--- a/pkg/virt-launcher/standalone/standalone.go
+++ b/pkg/virt-launcher/standalone/standalone.go
@@ -38,8 +38,8 @@ func HandleStandaloneMode(domainManager virtwrap.DomainManager) {
 		if err := yaml.Unmarshal([]byte(vmiObjStr), &vmi); err != nil {
 			// Fallback to JSON if YAML fails
 			if jsonErr := json.Unmarshal([]byte(vmiObjStr), &vmi); jsonErr != nil {
-				log.Log.Reason(err).Error("Failed to unmarshal VMI from STANDALONE_VMI as YAML/JSON")
-				panic(err)
+				log.Log.Reason(jsonErr).Error("Failed to unmarshal VMI from STANDALONE_VMI as YAML/JSON")
+				panic(jsonErr)
 			}
 		}
 


### PR DESCRIPTION


### What this PR does

  Fix incorrect error variable used when standalone mode VMI JSON fallback
  fails in HandleStandaloneMode.                                                                                                                          
                                                                                                                                                          
  - The YAML unmarshal error (err) was being logged and panicked instead                                                                                  
  of the JSON-specific error (jsonErr)                                                                                                                    
  - Both log.Log.Reason(err) and panic(err) now correctly reference                                                                                       
  jsonErr    

### Changes                                                                                                                                                 
                                                            
  - pkg/virt-launcher/standalone/standalone.go: 2-line fix replacing                                                                                      
  err with jsonErr in the JSON fallback failure branch      
                                                                                                                                                          
  ### Test Plan                                                 
                                                                                                                                                          
  - Existing unit tests pass: go test ./pkg/virt-launcher/standalone/...                                                                                  
  - Manual verification: set STANDALONE_VMI to invalid content and
  confirm the panic/log message reflects the JSON error

- Fixes #17094 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
 virt-launcher: Fix misleading error message in standalone mode VMI unmarshaling                                                                     
  When `STANDALONE_VMI` environment variable contained content that failed                                                                                
  both YAML and JSON unmarshaling, virt-launcher incorrectly logged and
  panicked with the YAML parse error instead of the JSON parse error.                                                                                     
  Operators debugging misconfigured standalone mode deployments were shown
  an unrelated error, making root cause analysis unnecessarily difficult.                                                                                 
  The logged reason and panic value now correctly reflect the JSON unmarshal                                                                              
  failure.
```

