### PR TITLE
 hotplug-disk: return nil path on GetHotplugTargetPodPathOnHost failure

### DIFF
--- a/pkg/hotplug-disk/hotplug-disk.go
+++ b/pkg/hotplug-disk/hotplug-disk.go
@@ -94,7 +94,7 @@ func (h *hotplugDiskManager) GetFileSystemDirectoryTargetPathFromHostView(virtla
 func (h *hotplugDiskManager) GetFileSystemDiskTargetPathFromHostView(virtlauncherPodUID types.UID, volumeName string, create bool) (*safepath.Path, error) {
 	targetPath, err := h.GetHotplugTargetPodPathOnHost(virtlauncherPodUID)
 	if err != nil {
-		return targetPath, err
+		return nil, err
 	}
 	diskName := fmt.Sprintf("%s.img", volumeName)
 	if err := safepath.TouchAtNoFollow(targetPath, diskName, 0666); err != nil && !os.IsExist(err) {


### PR DESCRIPTION

### What this PR does

### Summary

  Fix GetFileSystemDiskTargetPathFromHostView returning a non-nil *safepath* .Path alongside an error, violating Go error return conventions and creating a risk of callers operating on an invalid path.

  ### Changes

  - pkg/hotplug-disk/hotplug-disk.go:97: change return targetPath, err
  to return nil, err when GetHotplugTargetPodPathOnHost fails

  ### Motivation

  The Go convention is that a non-nil error implies a nil/zero primary return
  value. The same function already follows this on line 101. The inconsistency
  was a latent bug — callers defensively relying on a nil path on error would
  silently get a non-nil one, potentially causing a dereference panic or
  incorrect path resolution downstream.

  ### Test Plan

  - Existing unit tests pass: go test ./pkg/hotplug-disk/...
  - Verify no callers use the returned path when err != nil

  
- Fixes #17096 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
NONE
```

