### PR TITLE
virt-handler: close outbound conn in migration proxy handleConnection

### DIFF
--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -461,6 +461,7 @@ func (m *migrationProxy) handleConnection(fd net.Conn) {
 		m.logger.Reason(err).Error("unable to create outbound leg of proxy to host")
 		return
 	}
+	defer conn.Close()
 
 	go func() {
 		//from outbound connection to proxy


### PR DESCRIPTION

### What this PR does

### Summary                                                                                                     
                                                                                                                
  Fixed a file descriptor leak in the migration proxy where the outbound  connection (conn) was never closed when handleConnection exited via the stopChan path.                                                                                            
                                                                                                                
  ### Root Cause                                                                                                    
                                                                                                              
`handleConnection` correctly deferred fd.Close() for the inbound connection but had no corresponding defer conn.Close() for the outbound dial. All exit paths error from copy goroutines or stopChan signal returned without closing conn.                                                                                
                                                                                                                
  ### Changes                                                                                                       
                                                                                                                
  - pkg/virt-handler/migration-proxy/migration-proxy.go: add  defer conn.Close() immediately after the successful dial (line 464)                                         
                                                                                                                
  ### Impact                                                                                                      
                                                                                                                
  Without this fix, each live migration leaks one file descriptor in virt-handler. In environments with frequent or high-volume live migration this accumulates and eventually causes file descriptor exhaustion, crashing the virt-handler node agent.                                                                                  
                                                                                                                
  ### Test Plan                                                                                                     
                                                                                                                
  - Existing unit tests pass: go test ./pkg/virt-handler/migration-proxy/...                                    
  - Run repeated live migrations and confirm file descriptor count in
  virt-handler does not grow unboundedly (e.g. via lsof -p <pid> | wc -l)                                       
  - Confirm proxy still correctly proxies data when conn is closed on                                           
  both normal completion and stopChan signal 

  
- Fixes #17098 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note

The migration proxy's handleConnection function correctly closed the                                          
  inbound connection on exit but never closed the outbound TCP/TLS                                              
  connection. When a live migration ended or virt-handler was stopped, the                                      
  outbound connection's file descriptor was leaked. In environments with                                        
  frequent or large-scale live migrations this caused file descriptor                                           
  exhaustion in virt-handler, eventually preventing it from opening new                                         
  connections and crashing the node agent. A defer conn.Close() is now                                          
  added immediately after a successful dial to ensure the outbound                                              
  connection is always released. 

```

