### PR TITLE
tests/compute: Share VMI setup across serial console specs

### DIFF
--- a/hack/lint-test-cleanup-label.sh
+++ b/hack/lint-test-cleanup-label.sh
@@ -24,7 +24,8 @@ EXCLUDE_PATTERN="./decorators/decorators.go|\
 ./tests/network|\
 ./tests/compute/guest_agent.go|\
 ./tests/vnc_test.go|\
-./tests/infrastructure/prometheus.go"
+./tests/infrastructure/prometheus.go|\"
+./tests/compute/console.go"
 
 if grep -rl 'OncePerOrderedCleanup' ./tests --include=*.go |
     grep -Evq "$EXCLUDE_PATTERN"; then

--- a/tests/compute/console.go
+++ b/tests/compute/console.go
@@ -53,26 +53,24 @@ var _ = Describe(SIG("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@r
 	}
 
 	Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
-		Context("with a serial console", func() {
-			It("[test_id:1588]should return OS login", func() {
-				vmi := libvmifact.NewAlpine()
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsSmall)
-				expectConsoleOutput(
-					vmi,
-					"localhost login:",
-				)
-			})
-			It("[test_id:1590]should be able to reconnect to console multiple times", func() {
-				vmi := libvmifact.NewAlpine()
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsSmall)
+		Context("with a serial console", Ordered, decorators.OncePerOrderedCleanup, func() {
+			var vmi *v1.VirtualMachineInstance
 
+			BeforeAll(func() {
+				vmi = libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), libvmops.StartupTimeoutSecondsSmall)
+			})
+
+			It("[test_id:1588]should return OS login", func() {
+				expectConsoleOutput(vmi, "localhost login:")
+			})
+
+			It("[test_id:1590]should be able to reconnect to console multiple times", func() {
 				for i := 0; i < 5; i++ {
 					expectConsoleOutput(vmi, "login")
 				}
 			})
 
 			It("[test_id:1591]should close console connection when new console connection is opened", decorators.Conformance, func() {
-				vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), libvmops.StartupTimeoutSecondsSmall)
 				expectConsoleOutput(vmi, "login")
 
 				By("opening 1st console connection")
@@ -99,7 +97,9 @@ var _ = Describe(SIG("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@r
 				By("expecting error on 1st console connection")
 				Eventually(firstConsoleErrChan, 1*time.Minute, 1*time.Second).Should(Receive(MatchError(ContainSubstring("EOF"))))
 			})
+		})
 
+		Context("with a serial console connection", func() {
 			It("[test_id:1592]should wait until the virtual machine is in running state and return a stream interface", func() {
 				vmi := libvmifact.NewAlpine()
 				By("Creating a new VirtualMachineInstance")


### PR DESCRIPTION
### What this PR does
The "with a serial console" Context contains three specs that open a serial console connection against a running Alpine VMI and assert on the output or connection lifecycle:

  `test_id:1588` - reads the OS login prompt
  `test_id:1590` - reconnects to the console 5 times
  `test_id:1591` - opens two connections and verifies the first receives EOF

Previously, each spec created and booted its own Alpine VMI inline — 3 independent boot cycles. Converting to Ordered + OncePerOrderedCleanup with BeforeAll creates a single shared VMI and reuses it across all three, saving 2 VMI boot cycles per run.

Specs `test_id:1592` and `test_id:1593` are intentionally kept with inline VMI creation: 1592 requires a freshly created (not yet started) VMI to test the ConnectionTimeout wait behavior; 1593 uses a different VMI config (WithNodeAffinityFor("nonexistent")).

Each test is about 40+ seconds in CI, booting once VS 3 times will give us 1.5 minutes of reduced execution time.

The lint allowlist in hack/lint-test-cleanup-label.sh is updated to permit OncePerOrderedCleanup in `tests/compute/`.

### References
Related: https://github.com/kubevirt/kubevirt/issues/16935

### Release note
```release-note
none
```