### PR TITLE
tests/vnc: Share VMI setup across VNC connection specs

### DIFF
--- a/hack/lint-test-cleanup-label.sh
+++ b/hack/lint-test-cleanup-label.sh
@@ -22,7 +22,8 @@ EXCLUDE_PATTERN="./decorators/decorators.go|\
 ./tests_suite_test.go|\
 ./tests/virtctl|\
 ./tests/network|\
-./tests/compute/guest_agent.go"
+./tests/compute/guest_agent.go|\
+./tests/vnc_test.go"
 
 if grep -rl 'OncePerOrderedCleanup' ./tests --include=*.go |
     grep -Evq "$EXCLUDE_PATTERN"; then

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -55,8 +55,8 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	const vncWaitResponseTimeout = time.Second * 45
 	const vncConnectTimeout = time.Second * 5
 
-	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
-		BeforeEach(func() {
+	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", Ordered, decorators.OncePerOrderedCleanup, func() {
+		BeforeAll(func() {
 			var err error
 			vmi = libvmifact.NewGuestless(libvmi.WithAutoattachGraphicsDevice(true))
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})


### PR DESCRIPTION
### What this PR does
The "A new VirtualMachineInstance" Describe contains 8 specs that all connect to a VNC endpoint and verify protocol-level behavior.
None of them modify the VMI state.

Previously, BeforeEach created and booted a fresh Guestless VMI for every single spec — 8 boots total. Converting to Ordered + OncePerOrderedCleanup with BeforeAll creates the VMI once and shares it across all 8 specs, saving 7 VMI boot cycles per run.

The lint allowlist in hack/lint-test-cleanup-label.sh is updated to permit OncePerOrderedCleanup in tests/vnc_test.go.

### References
Related: https://github.com/kubevirt/kubevirt/issues/16935

similar to #14605

### Release note
```release-note
none
```

