### PR TITLE
Replace panic() calls with structured error handling  

### DIFF
--- a/cmd/synchronization-controller/synchronization-controller.go
+++ b/cmd/synchronization-controller/synchronization-controller.go
@@ -184,7 +184,7 @@ func (app *synchronizationControllerApp) Run() {
 		break
 	}
 	if retryCount >= maxRetryCount {
-		panic(fmt.Errorf("unable to get kubevirt client config after %d retries %v", maxRetryCount, err))
+		log.Log.Reason(err).Criticalf("unable to get kubevirt client config after %d retries", maxRetryCount)
 	}
 
 	clientConfig.RateLimiter = app.reloadableRateLimiter
@@ -199,7 +199,7 @@ func (app *synchronizationControllerApp) Run() {
 		break
 	}
 	if retryCount >= maxRetryCount {
-		panic(fmt.Errorf("unable to get kubevirt client from rest config after %d retries %v", maxRetryCount, err))
+		log.Log.Reason(err).Criticalf("unable to get kubevirt client from rest config after %d retries", maxRetryCount)
 	}
 
 	app.namespace, err = clientutil.GetNamespace()
@@ -220,7 +220,7 @@ func (app *synchronizationControllerApp) Run() {
 
 	app.clusterConfig, err = virtconfig.NewClusterConfig(factory.CRD(), factory.KubeVirt(), app.namespace)
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Error creating cluster config")
 	}
 	// set log verbosity
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeLogVerbosity)
@@ -258,7 +258,7 @@ func (app *synchronizationControllerApp) Run() {
 		app.ip,
 	)
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Error creating synchronization controller")
 	}
 
 	go app.clientcertmanager.Start()
@@ -273,8 +273,7 @@ func (app *synchronizationControllerApp) runWithLeaderElection(synchronizationCo
 
 	id, err := os.Hostname()
 	if err != nil {
-		log.Log.Criticalf("unable to get hostname: %v", err)
-		panic(err)
+		log.Log.Reason(err).Critical("unable to get hostname")
 	}
 
 	tlsConfig := kvtls.SetupPromTLS(app.servercertmanager, app.clusterConfig)
@@ -333,7 +332,7 @@ func (app *synchronizationControllerApp) runWithLeaderElection(synchronizationCo
 			EventRecorder: recorder,
 		})
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Error creating resource lock")
 	}
 
 	controllerContext, controllerCancel := context.WithCancel(context.Background())
@@ -349,7 +348,7 @@ func (app *synchronizationControllerApp) runWithLeaderElection(synchronizationCo
 				OnStartedLeading: func(ctx context.Context) {
 					// run app
 					if err := synchronizationController.Run(10, controllerContext.Done()); err != nil {
-						panic(err)
+						log.Log.Reason(err).Critical("Failed to run synchronization controller")
 					}
 					log.Log.Info("successfully shut down controller")
 					wg.Done()
@@ -361,7 +360,7 @@ func (app *synchronizationControllerApp) runWithLeaderElection(synchronizationCo
 			},
 		})
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Error creating leader elector")
 	}
 	leaderElector.Run(app.ctx)
 	wg.Wait()

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -76,22 +76,22 @@ func init() {
 	libvirt.EventRegisterDefaultImpl()
 }
 
-func markReady() {
+func markReady() error {
 	err := os.Rename(cmdclient.UninitializedSocketOnGuest(), cmdclient.SocketOnGuest())
 	if err != nil {
-		panic(err)
+		return err
 	}
 	log.Log.Info("Marked as ready")
+	return nil
 }
 
 func startCmdServer(socketPath string,
 	domainManager virtwrap.DomainManager,
 	stopChan chan struct{},
-	options *cmdserver.ServerOptions) chan struct{} {
+	options *cmdserver.ServerOptions) (chan struct{}, error) {
 	done, err := cmdserver.RunServer(socketPath, domainManager, stopChan, options)
 	if err != nil {
-		log.Log.Reason(err).Error("Failed to start virt-launcher cmd server")
-		panic(err)
+		return nil, fmt.Errorf("failed to start virt-launcher cmd server: %w", err)
 	}
 
 	// ensure the cmdserver is responsive before continuing
@@ -113,13 +113,13 @@ func startCmdServer(socketPath string,
 	})
 
 	if err != nil {
-		panic(fmt.Errorf("failed to connect to cmd server: %v", err))
+		return nil, fmt.Errorf("failed to connect to cmd server: %w", err)
 	}
 
-	return done
+	return done, nil
 }
 
-func createLibvirtConnection(runWithNonRoot bool) virtcli.Connection {
+func createLibvirtConnection(runWithNonRoot bool) (virtcli.Connection, error) {
 	libvirtUri := "qemu:///system"
 	user := ""
 	if runWithNonRoot {
@@ -129,10 +129,10 @@ func createLibvirtConnection(runWithNonRoot bool) virtcli.Connection {
 
 	domainConn, err := virtcli.NewConnection(libvirtUri, user, "", 10*time.Second)
 	if err != nil {
-		panic(fmt.Sprintf("failed to connect to virtqemud: %v", err))
+		return nil, fmt.Errorf("failed to connect to virtqemud: %w", err)
 	}
 
-	return domainConn
+	return domainConn, nil
 }
 
 func startDomainEventMonitoring(
@@ -149,7 +149,7 @@ func startDomainEventMonitoring(
 	qemuAgentFSFreezeStatusInterval time.Duration,
 	metadataCache *metadata.Cache,
 	nonRoot bool,
-) {
+) error {
 	go func() {
 		for {
 			if res := libvirt.EventRunDefaultImpl(); res != nil {
@@ -161,14 +161,15 @@ func startDomainEventMonitoring(
 
 	err := notifier.StartDomainNotifier(domainConn, deleteNotificationSent, vmi, domainName, agentStore, qemuAgentSysInterval, qemuAgentFileInterval, qemuAgentUserInterval, qemuAgentVersionInterval, qemuAgentFSFreezeStatusInterval, metadataCache, nonRoot)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 func initializeDirs(ephemeralDiskDir string,
 	containerDiskDir string,
 	hotplugDiskDir string,
-	uid string) {
+	uid string) error {
 
 	// Resolve permission mismatch when system default mask is set more restrictive than 022.
 	mask := syscall.Umask(0)
@@ -176,63 +177,64 @@ func initializeDirs(ephemeralDiskDir string,
 
 	err := virtlauncher.InitializePrivateDirectories(filepath.Join("/var/run/kubevirt-private", uid))
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = cloudinit.SetLocalDirectory(filepath.Join(ephemeralDiskDir, "cloud-init-data"))
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = ignition.SetLocalDirectory(filepath.Join(ephemeralDiskDir, "ignition-data"))
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = containerdisk.SetLocalDirectory(containerDiskDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = hotplugdisk.SetLocalDirectory(hotplugDiskDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = virtlauncher.InitializeDisksDirectories(filepath.Join("/var/run/kubevirt-private", "vm-disks"))
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = virtlauncher.InitializeDisksDirectories(config.ConfigMapDisksDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = virtlauncher.InitializeDisksDirectories(config.SysprepDisksDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = virtlauncher.InitializeDisksDirectories(config.SecretDisksDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = virtlauncher.InitializeDisksDirectories(config.DownwardAPIDisksDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = virtlauncher.InitializeDisksDirectories(config.ServiceAccountDiskDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	err = virtlauncher.InitializeDisksDirectories(downwardmetrics.DownwardMetricsChannelDir)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 func detectDomainWithUUID(domainManager virtwrap.DomainManager) *api.Domain {
@@ -249,7 +251,7 @@ func detectDomainWithUUID(domainManager virtwrap.DomainManager) *api.Domain {
 	return nil
 }
 
-func waitForDomainUUID(timeout time.Duration, events chan watch.Event, stop chan struct{}, domainManager virtwrap.DomainManager) *api.Domain {
+func waitForDomainUUID(timeout time.Duration, events chan watch.Event, stop chan struct{}, domainManager virtwrap.DomainManager) (*api.Domain, error) {
 
 	ticker := time.NewTicker(timeout)
 	defer ticker.Stop()
@@ -261,24 +263,24 @@ func waitForDomainUUID(timeout time.Duration, events chan watch.Event, stop chan
 	for {
 		select {
 		case <-ticker.C:
-			panic(fmt.Errorf("timed out waiting for domain to be defined"))
+			return nil, fmt.Errorf("timed out waiting for domain to be defined")
 		case <-domainCheckTicker.C:
 			log.Log.V(3).Infof("Periodically checking for domain with UUID")
 			domain := detectDomainWithUUID(domainManager)
 			if domain != nil {
-				return domain
+				return domain, nil
 			}
 		case <-events:
 			log.Log.V(3).Infof("Checking for domain with UUID due to incoming libvirt event")
 			domain := detectDomainWithUUID(domainManager)
 			if domain != nil {
-				return domain
+				return domain, nil
 			}
 		case <-stop:
-			return nil
+			return nil, nil
 		case <-checkEarlyExit.C:
 			if cmdserver.ReceivedEarlyExitSignal() {
-				panic(fmt.Errorf("received early exit signal"))
+				return nil, fmt.Errorf("received early exit signal")
 			}
 		}
 	}
@@ -389,31 +391,33 @@ func main() {
 	log.Log.V(2).Infof("Hypervisor set to %s", *hypervisor)
 
 	// Initialize local and shared directories
-	initializeDirs(*ephemeralDiskDir, *containerDiskDir, *hotplugDiskDir, *uid)
+	if err := initializeDirs(*ephemeralDiskDir, *containerDiskDir, *hotplugDiskDir, *uid); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize directories")
+	}
 
 	if !*runWithNonRoot {
 		err := virtlauncher.InitializeConsoleLogFile(filepath.Join("/var/run/kubevirt-private", *uid))
 		if err != nil {
-			panic(err)
+			log.Log.Reason(err).Critical("Failed to initialize console log file")
 		}
 	}
 
 	if *simulateCrash {
-		panic(fmt.Errorf("Simulated virt-launcher crash"))
+		log.Log.Critical("Simulated virt-launcher crash")
 	}
 
 	// Block until all requested hookSidecars are ready
 	hookManager := hooks.GetManager()
 	err := hookManager.Collect(*hookSidecars, *qemuTimeout)
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Failed to collect hook sidecars")
 	}
 
 	vmi := v1.NewVMIReferenceWithUUID(*namespace, *name, types.UID(*uid))
 
 	ephemeralDiskCreator := ephemeraldisk.NewEphemeralDiskCreator(filepath.Join(*ephemeralDiskDir, "disk-data"))
 	if err := ephemeralDiskCreator.Init(); err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Failed to initialize ephemeral disk creator")
 	}
 
 	// Start virtqemud, virtlogd, and establish libvirt connection
@@ -422,7 +426,7 @@ func main() {
 	l := util.NewLibvirtWrapper(*runWithNonRoot)
 	err = l.SetupLibvirt(libvirtLogFilters)
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Failed to setup libvirt")
 	}
 
 	l.StartVirtqemud(stopChan)
@@ -431,7 +435,10 @@ func main() {
 
 	util.StartVirtlog(stopChan, domainName, *runWithNonRoot)
 
-	domainConn := createLibvirtConnection(*runWithNonRoot)
+	domainConn, err := createLibvirtConnection(*runWithNonRoot)
+	if err != nil {
+		log.Log.Reason(err).Critical("Failed to create libvirt connection")
+	}
 	defer domainConn.Close()
 
 	var agentStore = agentpoller.NewAsyncAgentStore()
@@ -459,13 +466,13 @@ func main() {
 	)
 	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn, *virtShareDir, *ephemeralDiskDir, &agentStore, *ovmfPath, ephemeralDiskCreator, metadataCache, signalStopChan, *diskMemoryLimitBytes, util.GetPodCPUSet, *imageVolumeEnabled, *libvirtHooksServerAndClientEnabled, preMigrationHookServer, *hypervisor, nbdclient.RegisterNBDServer)
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Failed to create libvirt domain manager")
 	}
 	if *libvirtHooksServerAndClientEnabled {
 		// TODO: replaceQemuHookWithCustomClient This code should be removed once the LibvirtHooksServerAndClient feature is GA.
 		// Instead of overriding the script at runtime, we can include the custom binary in the launcher image at build time.
 		if err := replaceQemuHookWithCustomClient(); err != nil {
-			panic(err)
+			log.Log.Reason(err).Critical("Failed to replace qemu hook with custom client")
 		}
 	}
 
@@ -474,7 +481,10 @@ func main() {
 	// to start/stop virtual machines
 	options := cmdserver.NewServerOptions(*allowEmulation)
 	cmdclient.SetBaseDir(*virtShareDir)
-	cmdServerDone := startCmdServer(cmdclient.UninitializedSocketOnGuest(), domainManager, stopChan, options)
+	cmdServerDone, err := startCmdServer(cmdclient.UninitializedSocketOnGuest(), domainManager, stopChan, options)
+	if err != nil {
+		log.Log.Reason(err).Critical("Failed to start cmd server")
+	}
 
 	gracefulShutdownCallback := func() {
 		domainManager.MarkGracefulShutdownVMI()
@@ -495,7 +505,9 @@ func main() {
 
 	events := make(chan watch.Event, 2)
 	// Send domain notifications to virt-handler
-	startDomainEventMonitoring(notifier, domainConn, events, vmi, domainName, &agentStore, *qemuAgentSysInterval, *qemuAgentFileInterval, *qemuAgentUserInterval, *qemuAgentVersionInterval, *qemuAgentFSFreezeStatusInterval, metadataCache, *runWithNonRoot)
+	if err := startDomainEventMonitoring(notifier, domainConn, events, vmi, domainName, &agentStore, *qemuAgentSysInterval, *qemuAgentFileInterval, *qemuAgentUserInterval, *qemuAgentVersionInterval, *qemuAgentFSFreezeStatusInterval, metadataCache, *runWithNonRoot); err != nil {
+		log.Log.Reason(err).Critical("Failed to start domain event monitoring")
+	}
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt,
@@ -514,10 +526,15 @@ func main() {
 	// Marking Ready allows the container's readiness check to pass.
 	// This informs virt-controller that virt-launcher is ready to handle
 	// managing virtual machines.
-	markReady()
+	if err := markReady(); err != nil {
+		log.Log.Reason(err).Critical("Failed to mark virt-launcher as ready")
+	}
 
 	standalone.HandleStandaloneMode(domainManager)
-	domain := waitForDomainUUID(*qemuTimeout, events, signalStopChan, domainManager)
+	domain, err := waitForDomainUUID(*qemuTimeout, events, signalStopChan, domainManager)
+	if err != nil {
+		log.Log.Reason(err).Critical("Failed waiting for domain UUID")
+	}
 	if domain != nil {
 		var pidDir string
 		if *runWithNonRoot {

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -309,7 +309,7 @@ func Execute() {
 	clientmetrics.RegisterRestConfigHooks()
 	clientConfig, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Failed to get kubevirt client config")
 	}
 	clientConfig.RateLimiter = app.reloadableRateLimiter
 	app.clientSet, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
@@ -351,7 +351,7 @@ func Execute() {
 	cache.WaitForCacheSync(stopChan, app.crdInformer.HasSynced, app.kubeVirtInformer.HasSynced)
 	app.clusterConfig, err = virtconfig.NewClusterConfig(app.crdInformer, app.kubeVirtInformer, app.kubevirtNamespace)
 	if err != nil {
-		panic(err)
+		log.Log.Reason(err).Critical("Failed to create cluster config")
 	}
 
 	app.reInitChan = make(chan string, 10)
@@ -477,18 +477,42 @@ func Execute() {
 		golog.Fatal(err)
 	}
 
-	app.initCommon()
-	app.initReplicaSet()
-	app.initPool()
-	app.initVirtualMachines()
-	app.initDisruptionBudgetController()
-	app.initEvacuationController()
-	app.initSnapshotController()
-	app.initRestoreController()
-	app.initExportController()
-	app.initWorkloadUpdaterController()
-	app.initCloneController()
-	app.initBackupController()
+	if err := app.initCommon(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize common controllers")
+	}
+	if err := app.initReplicaSet(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize replicaset controller")
+	}
+	if err := app.initPool(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize pool controller")
+	}
+	if err := app.initVirtualMachines(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize virtual machine controller")
+	}
+	if err := app.initDisruptionBudgetController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize disruption budget controller")
+	}
+	if err := app.initEvacuationController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize evacuation controller")
+	}
+	if err := app.initSnapshotController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize snapshot controller")
+	}
+	if err := app.initRestoreController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize restore controller")
+	}
+	if err := app.initExportController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize export controller")
+	}
+	if err := app.initWorkloadUpdaterController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize workload updater controller")
+	}
+	if err := app.initCloneController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize clone controller")
+	}
+	if err := app.initBackupController(); err != nil {
+		log.Log.Reason(err).Critical("Failed to initialize backup controller")
+	}
 	go app.Run()
 
 	<-app.reInitChan
@@ -570,7 +594,7 @@ func (vca *VirtControllerApp) Run() {
 	metrics.SetVirtControllerReady()
 	vca.leaderElector.Run(vca.ctx)
 	metrics.SetVirtControllerNotReady()
-	panic("unreachable")
+	log.Log.Critical("unreachable")
 }
 
 func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
@@ -650,7 +674,7 @@ func (vca *VirtControllerApp) newRecorder(namespace string, componentName string
 	return eventBroadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: componentName})
 }
 
-func (vca *VirtControllerApp) initCommon() {
+func (vca *VirtControllerApp) initCommon() error {
 	var err error
 
 	virtClient, err := kubecli.GetKubevirtClient()
@@ -716,18 +740,18 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.additionalLauncherLabelsSync,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "node-controller")
 	vca.nodeController, err = node.NewController(vca.clientSet, vca.nodeInformer, vca.vmiInformer, recorder)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	// Adding a timeout to the clientSet of the migration controller, to avoid potential deadlocks
 	clientSet, err := vca.clientSet.SetRestTimeout(migrationControllerRestTimeout)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	vca.migrationController, err = migration.NewController(
 		vca.templateService,
@@ -747,22 +771,24 @@ func (vca *VirtControllerApp) initCommon() {
 		netAnnotationsGenerator,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	vca.nodeTopologyUpdater = topology.NewNodeTopologyUpdater(vca.clientSet, topologyHinter, vca.nodeInformer)
+	return nil
 }
 
-func (vca *VirtControllerApp) initReplicaSet() {
+func (vca *VirtControllerApp) initReplicaSet() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "virtualmachinereplicaset-controller")
 	vca.rsController, err = replicaset.NewController(vca.vmiInformer, vca.rsInformer, recorder, vca.clientSet, controller.BurstReplicas)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initPool() {
+func (vca *VirtControllerApp) initPool() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "virtualmachinepool-controller")
 	vca.poolController, err = pool.NewController(vca.clientSet,
@@ -775,11 +801,12 @@ func (vca *VirtControllerApp) initPool() {
 		recorder,
 		controller.BurstReplicas)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initVirtualMachines() {
+func (vca *VirtControllerApp) initVirtualMachines() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "virtualmachine-controller")
 
@@ -813,11 +840,12 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.additionalLauncherLabelsSync,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initDisruptionBudgetController() {
+func (vca *VirtControllerApp) initDisruptionBudgetController() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "disruptionbudget-controller")
 	vca.disruptionBudgetController, err = disruptionbudget.NewDisruptionBudgetController(
@@ -829,11 +857,12 @@ func (vca *VirtControllerApp) initDisruptionBudgetController() {
 		vca.clientSet,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initWorkloadUpdaterController() {
+func (vca *VirtControllerApp) initWorkloadUpdaterController() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "workload-update-controller")
 	vca.workloadUpdateController, err = workloadupdater.NewWorkloadUpdateController(
@@ -846,11 +875,12 @@ func (vca *VirtControllerApp) initWorkloadUpdaterController() {
 		vca.clientSet,
 		vca.clusterConfig)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initEvacuationController() {
+func (vca *VirtControllerApp) initEvacuationController() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "evacuation-controller")
 	vca.evacuationController, err = evacuation.NewEvacuationController(
@@ -863,11 +893,12 @@ func (vca *VirtControllerApp) initEvacuationController() {
 		vca.clusterConfig,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initSnapshotController() {
+func (vca *VirtControllerApp) initSnapshotController() error {
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "snapshot-controller")
 	vca.snapshotController = &snapshot.VMSnapshotController{
 		Client:                    vca.clientSet,
@@ -886,11 +917,12 @@ func (vca *VirtControllerApp) initSnapshotController() {
 		ResyncPeriod:              vca.snapshotControllerResyncPeriod,
 	}
 	if err := vca.snapshotController.Init(); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initRestoreController() {
+func (vca *VirtControllerApp) initRestoreController() error {
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "restore-controller")
 	vca.restoreController = &snapshot.VMRestoreController{
 		Client:                    vca.clientSet,
@@ -907,11 +939,12 @@ func (vca *VirtControllerApp) initRestoreController() {
 		CRInformer:                vca.controllerRevisionInformer,
 	}
 	if err := vca.restoreController.Init(); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initExportController() {
+func (vca *VirtControllerApp) initExportController() error {
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "export-controller")
 	vca.exportController = &export.VMExportController{
 		ManifestRenderer:            vca.templateService,
@@ -944,22 +977,24 @@ func (vca *VirtControllerApp) initExportController() {
 		BackupCAConfigMapInformer:   vca.caBackupConfigMapInformer,
 	}
 	if err := vca.exportController.Init(); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initCloneController() {
+func (vca *VirtControllerApp) initCloneController() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "clone-controller")
 	vca.vmCloneController, err = clonecontroller.NewVmCloneController(
 		vca.clientSet, vca.vmCloneInformer, vca.vmSnapshotInformer, vca.vmRestoreInformer, vca.vmInformer, vca.vmSnapshotContentInformer, vca.persistentVolumeClaimInformer, recorder,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
-func (vca *VirtControllerApp) initBackupController() {
+func (vca *VirtControllerApp) initBackupController() error {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "backup-controller")
 	vca.vmBackupController, err = backup.NewVMBackupController(
@@ -975,8 +1010,9 @@ func (vca *VirtControllerApp) initBackupController() {
 		vca.kubevirtNamespace,
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 func (vca *VirtControllerApp) leaderProbe(_ *restful.Request, response *restful.Response) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`virt-launcher.go` contains 20 `panic()` calls, `synchronization-controller.go` contains 8 `panic()` calls, and `application.go` contains 18 `panic()` calls in initialization functions. When any of these fail, the process crashes with an unrecoverable panic and a raw stack trace instead of clean log output, making production debugging harder.

#### After this PR:
All `panic()` calls are replaced with either:
- `log.Log.Reason(err).Critical("message")` for fatal init errors in top level code
- `return error` propagated up the call chain so callers can handle gracefully

This produces structured, parseable log output consistent with other KubeVirt components like `virt-probe`.

### References
- Fixes #17107

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Functions like `markReady()`, `startCmdServer()`, `createLibvirtConnection()`, `startDomainEventMonitoring()`, `initializeDirs()`, and `waitForDomainUUID()` now return `error` instead of panicking. This required updating all callers but gives them the ability to handle failures gracefully.
- For top-level `main()` flow and init code where returning an error doesn't make sense, `log.Log.Reason(err).Critical()` is used which logs at FATAL level with structured output before exiting.
- The `init*()` methods in `application.go` now return `error`, with callers in `Execute()` using `log.Log.Reason(err).Critical()`.

The following alternatives were considered:
- Using `golog.Fatal()` - rejected because it doesn't produce structured logs compatible with log aggregation systems.
- Using `os.Exit(1)` directly - rejected because it skips deferred cleanup and doesn't log the error reason in a structured way.

### Special notes for your reviewer
- No logic was changed — only the error handling mechanism was replaced.
- Only three files were modified: `cmd/virt-launcher/virt-launcher.go`, `cmd/synchronization-controller/synchronization-controller.go`, and `pkg/virt-controller/watch/application.go`.
- `log.Log.Reason(err).Critical()` logs at FATAL level and then panics with a structured message (not a raw stack trace), matching the pattern used in `virt-probe` and `fake-cmd-server`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```