### PR TITLE
virt-controller: handOffMap leaks entries for finalized migrations until GC deletes the object

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -435,6 +435,7 @@ func (c *Controller) execute(key string) error {
 	}
 
 	if migration.IsFinal() {
+		c.removeHandOffKey(key)
 		err = c.garbageCollectFinalizedMigrations(vmi)
 		if err != nil {
 			return err


### PR DESCRIPTION


### What this PR does

### Summary
         
  Fixed the memory leak in the migration controller where handOffMap entries for finalized migrations were never eagerly removed, growing the map indefinitely until Kubernetes GC deleted the object.                                                          
                                                                                                                
  ### Root Cause                                                                                                    
                                                                                                                
  removeHandOffKey(key) was only called in the !exists branch (when the  informer cache no longer has the object). The migration.IsFinal() branch had no corresponding cleanup, so entries for Succeeded/Failed migrations stayed in handOffMap for the full GC lifetime of the object.                                       
                                                                                                                
  ### Changes                                                                                                       
                                                                                                                
  - pkg/virt-controller/watch/migration/migration.go:437: add  c.removeHandOffKey(key) as the first statement inside the
  migration.IsFinal() block                                                                                     
                                                                                                                
 ### Impact
                                                                                                                
  - Memory: eliminates unbounded growth of handOffMap in long-running virt-controller instances with frequent migrations
  - Correctness: prevents stale entries from causing isMigrationHandedOff to return true for new migrations that                                                   
  reuse the same namespace/name key                                                                             

- Fixes #17120 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
NONE
```


