### PR TITLE
 virt-handler: fix device plugin watching wrong dir for kubelet socket

### DIFF
--- a/pkg/virt-handler/device-manager/socket_device.go
+++ b/pkg/virt-handler/device-manager/socket_device.go
@@ -288,7 +288,14 @@ func (dpi *SocketDevicePlugin) healthCheck() error {
 	}
 	logger.Infof("device '%s' is present.", devicePath)
 
-	err = watcher.Add(filepath.Dir(dpi.socketPath))
+	// This allows us to detect when kubelet removes the socket on restart (event.Name == dpi.socketPath),
+	// so we can exit and trigger re-registration. 
+	if dpi.socketPath == "" {
+		return fmt.Errorf("device-plugin socket path is empty, kubelet restart detection will not work")
+	}
+	kubeletSocketDir := filepath.Dir(dpi.socketPath)
+	logger.Infof("watching kubelet socket directory: %s", kubeletSocketDir)
+	err = watcher.Add(kubeletSocketDir)
 
 	if err != nil {
 		return fmt.Errorf("failed to add the device-plugin kubelet path to the watcher: %v", err)

--- a/pkg/virt-handler/device-manager/socket_device.go
+++ b/pkg/virt-handler/device-manager/socket_device.go
@@ -288,7 +288,7 @@ func (dpi *SocketDevicePlugin) healthCheck() error {
 	}
 	logger.Infof("device '%s' is present.", devicePath)
 
-	err = watcher.Add(deviceDir)
+	err = watcher.Add(filepath.Dir(dpi.socketPath))
 
 	if err != nil {
 		return fmt.Errorf("failed to add the device-plugin kubelet path to the watcher: %v", err)


### PR DESCRIPTION


### What this PR does

### Summary
                                                                                                                
  Fix the device plugin's kubelet restart detection which was silently broken due to a duplicate watcher.Add(deviceDir) call. The second call should watch filepath.Dir(dpi.socketPath) — the directory containing the kubelet device-plugin socket — so that fsnotify can emit  events when that socket is removed.                                                                           
                                                                                                                
 ### Root Cause                                                                                                    
                                                                                                                
  monitorDevice calls watcher.Add twice. The first one is correct. The second one  was intended to watch the kubelet socket
  directory but used deviceDir again by mistake, making the call a no-op (fsnotify silently deduplicates). Because the socket directory was never added to the watcher, the event.Name == dpi.socketPath branch in the event loop was unreachable — dead code.                                                         
                                                                                                                
                                                                                                                
  ### Impact                                                    

  Without this fix, when kubelet restarts and removes the device plugin  socket, the device plugin never detects the removal and never re-registers. Devices (vhost-user NICs, SR-IOV VFs, etc.) on that node become permanently orphaned and VM scheduling silently fails until virt-handler is manually restarted.

- Fixes #17122 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
NONE
```

