### PR TITLE
docs: Add commit message guidelines section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ Signed-off-by: John Doe <jdoe@example.org>
 
 This can be done by adding [`--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to your git command line.
 
+For commit message formatting guidelines, see [Commit message guidelines](docs/commit-message-guidelines.md).
+
 ### Getting your code reviewed/merged
 
 Maintainers are here to help you enabling your use-case in a reasonable amount

--- a/docs/commit-message-guidelines.md
+++ b/docs/commit-message-guidelines.md
@@ -1,0 +1,89 @@
+# Commit message guidelines
+
+KubeVirt follows commit message guidelines based on the [Kubernetes Pull Request
+Process guide](https://www.kubernetes.dev/docs/guide/pull-requests/#commit-message-guidelines).
+For a general commit message convention, see [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Subject line
+
+- **Length**: Try to keep the subject line to 50 characters or less; do not exceed 72 characters
+- **Mood**: Use imperative mood (e.g., "Add", "Fix", "Update", "Remove", "Refactor")
+- **Capitalization**: The first word should be capitalized unless it starts with a lowercase symbol or other identifier
+- **Punctuation**: Do not end the subject line with a period
+
+### Commit prefix conventions
+
+Use a hybrid approach: start with the **intent** (type), followed by an **optional
+scope** (the SIG or area it belongs to) in parentheses. Format: `type(scope): description`.
+
+**Intent (required):**
+
+- `docs` - documentation changes
+- `fix` - bug fixes
+- `feat` - new features
+- `test` or `tests` - test changes
+- `build` - build system changes
+- `refactor` - code refactoring
+
+**Scope (optional):** Add the SIG or area in parentheses, e.g. `network`, `storage`,
+`virt-operator`, `backup`.
+
+**Examples:**
+
+- `fix(network): resolve SR-IOV interface binding issue`
+- `feat(storage): add pull mode support`
+- `docs: add commit message guidelines`
+
+## Commit message body
+
+- **Blank line**: Add a single blank line before the commit message body
+- **Length**: Wrap the commit message body at 72 characters
+- **Content**: Use the commit message body to explain the what and why of the commit
+- **GitHub keywords**: Do not use GitHub keywords (like "Fixes #xxxx") or (@)mentions
+  within your commit message. Place these in the **PR title or description**
+  instead, where they will properly trigger GitHub's issue linking and automation.
+
+## DCO compliance
+
+All commits must include a `Signed-off-by` line for [DCO compliance](../CONTRIBUTING.md#contributor-compliance-with-developer-certificate-of-origin-dco).
+See the [Contributing guide](../CONTRIBUTING.md#contributor-compliance-with-developer-certificate-of-origin-dco) for details.
+
+## Examples
+
+### Good example
+
+```
+feat(network): Add support for SR-IOV interfaces
+
+This change introduces support for SR-IOV network interfaces in
+KubeVirt, allowing VMs to directly access SR-IOV virtual functions
+for improved network performance.
+
+Signed-off-by: John Doe <jdoe@example.org>
+```
+
+### Bad example
+
+```
+Fixing network stuff
+
+I updated the network code to add SR-IOV support. This fixes
+the issue we were having.
+
+Fixes #123
+```
+
+Issues with the bad example:
+
+- Subject uses past tense ("Fixing") instead of imperative mood
+- Subject is too vague ("network stuff")
+- Body uses GitHub keywords ("Fixes #123") — use the PR title or description instead
+- Body doesn't explain the what and why clearly
+- Missing Signed-off-by line (required for DCO compliance)
+
+## Additional resources
+
+The [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
+provides a similar structure with type prefixes (feat, fix, docs, etc.) and can
+enhance commit display in tools like Refined GitHub. While not required for
+KubeVirt, you may find it helpful for categorization.

--- a/docs/commit-message-guidelines.md
+++ b/docs/commit-message-guidelines.md
@@ -1,59 +1,26 @@
 # Commit message guidelines
 
-KubeVirt follows commit message guidelines based on the [Kubernetes Pull Request
-Process guide](https://www.kubernetes.dev/docs/guide/pull-requests/#commit-message-guidelines).
-For a general commit message convention, see [Conventional Commits](https://www.conventionalcommits.org/).
+KubeVirt follows the [Commit Message Guidelines](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#commit-message-guidelines) in the Kubernetes contributor guide. Use the links below for the full explanation of each rule.
 
-## Subject line
+- [Try to keep the subject line to 50 characters or less; do not exceed 72 characters](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#try-to-keep-the-subject-line-to-50-characters-or-less-do-not-exceed-72-characters)
+- [The first word in the commit message subject should be capitalized unless it starts with a lowercase symbol or other identifier](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#the-first-word-in-the-commit-message-subject-should-be-capitalized-unless-it-starts-with-a-lowercase-symbol-or-other-identifier)
+- [Do not end the commit message subject with a period](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#do-not-end-the-commit-message-subject-with-a-period)
+- [Use imperative mood in your commit message subject](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#use-imperative-mood-in-your-commit-message-subject)
+- [Add a single blank line before the commit message body](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#add-a-single-blank-line-before-the-commit-message-body)
+- [Wrap the commit message body at 72 characters](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#wrap-the-commit-message-body-at-72-characters)
+- [Do not use GitHub keywords or (@)mentions within your commit message](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#do-not-use-github-keywords-or-mentions-within-your-commit-message)
+- [Use the commit message body to explain the what and why of the commit](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#use-the-commit-message-body-to-explain-the-what-and-why-of-the-commit)
 
-- **Length**: Try to keep the subject line to 50 characters or less; do not exceed 72 characters
-- **Mood**: Use imperative mood (e.g., "Add", "Fix", "Update", "Remove", "Refactor")
-- **Capitalization**: The first word should be capitalized unless it starts with a lowercase symbol or other identifier
-- **Punctuation**: Do not end the subject line with a period
+Optional subject prefixes (area) are described in [Providing additional context](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#providing-additional-context).
 
-### Commit prefix conventions
-
-Use a hybrid approach: start with the **intent** (type), followed by an **optional
-scope** (the SIG or area it belongs to) in parentheses. Format: `type(scope): description`.
-
-**Intent (required):**
-
-- `docs` - documentation changes
-- `fix` - bug fixes
-- `feat` - new features
-- `test` or `tests` - test changes
-- `build` - build system changes
-- `refactor` - code refactoring
-
-**Scope (optional):** Add the SIG or area in parentheses, e.g. `network`, `storage`,
-`virt-operator`, `backup`.
-
-**Examples:**
-
-- `fix(network): resolve SR-IOV interface binding issue`
-- `feat(storage): add pull mode support`
-- `docs: add commit message guidelines`
-
-## Commit message body
-
-- **Blank line**: Add a single blank line before the commit message body
-- **Length**: Wrap the commit message body at 72 characters
-- **Content**: Use the commit message body to explain the what and why of the commit
-- **GitHub keywords**: Do not use GitHub keywords (like "Fixes #xxxx") or (@)mentions
-  within your commit message. Place these in the **PR title or description**
-  instead, where they will properly trigger GitHub's issue linking and automation.
-
-## DCO compliance
-
-All commits must include a `Signed-off-by` line for [DCO compliance](../CONTRIBUTING.md#contributor-compliance-with-developer-certificate-of-origin-dco).
-See the [Contributing guide](../CONTRIBUTING.md#contributor-compliance-with-developer-certificate-of-origin-dco) for details.
+All commits need a `Signed-off-by` line for [DCO compliance](../CONTRIBUTING.md#contributor-compliance-with-developer-certificate-of-origin-dco).
 
 ## Examples
 
-### Good example
+### Prefer
 
 ```
-feat(network): Add support for SR-IOV interfaces
+net, vmi: Add support for SR-IOV interfaces
 
 This change introduces support for SR-IOV network interfaces in
 KubeVirt, allowing VMs to directly access SR-IOV virtual functions
@@ -62,7 +29,7 @@ for improved network performance.
 Signed-off-by: John Doe <jdoe@example.org>
 ```
 
-### Bad example
+### Avoid
 
 ```
 Fixing network stuff
@@ -73,17 +40,10 @@ the issue we were having.
 Fixes #123
 ```
 
-Issues with the bad example:
+Issues with this example:
 
-- Subject uses past tense ("Fixing") instead of imperative mood
+- Subject uses past tense ("Fixing") instead of [imperative mood](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#use-imperative-mood-in-your-commit-message-subject)
 - Subject is too vague ("network stuff")
-- Body uses GitHub keywords ("Fixes #123") — use the PR title or description instead
-- Body doesn't explain the what and why clearly
-- Missing Signed-off-by line (required for DCO compliance)
-
-## Additional resources
-
-The [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
-provides a similar structure with type prefixes (feat, fix, docs, etc.) and can
-enhance commit display in tools like Refined GitHub. While not required for
-KubeVirt, you may find it helpful for categorization.
+- Body does not clearly explain the what and why of the change
+- Body uses GitHub keyword `Fixes #123`—put issue links in the [PR title or description](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#do-not-use-github-keywords-or-mentions-within-your-commit-message) instead
+- Missing `Signed-off-by` line ([DCO](../CONTRIBUTING.md#contributor-compliance-with-developer-certificate-of-origin-dco))


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The coding conventions document did not include guidelines for commit message formatting, leaving contributors without clear guidance on how to structure commit messages.

#### After this PR:
 - A new document docs/commit-message-guidelines.md defines commit message guidelines and is linked from CONTRIBUTING.md.
 - Commit message guidelines are no longer in docs/coding-conventions.md, since they are commit conventions, not code conventions.
 - The guidelines include:
   - Reference to [Conventional Commits](https://www.conventionalcommits.org/) as the base convention
   - Subject line rules (length, imperative mood, capitalization, punctuation)
   - Commit message body rules (blank line, wrapping, content)
   - Hybrid prefix format: intent type (docs, fix, feat, etc.) plus optional scope in parentheses (e.g., fix(network):)
   - Clarification that GitHub keywords (e.g., “Fixes #xxxx”) go in the PR title or description, not in the commit message
   - DCO compliance note with link to CONTRIBUTING
   - Good and bad commit examples

### Why we need it and why it was done in this way
This change helps maintain consistency in commit messages across the KubeVirt project, making the git history more readable and easier to navigate. It aligns with Kubernetes best practices and provides clear examples for contributors.

The following tradeoffs were made:
- DCO requirements not repeated in the new doc, they stay in CONTRIBUTING, with a link to that section
- Adopted Kubernetes commit message guidelines rather than creating project-specific ones to maintain consistency with upstream practices
- New docs/commit-message-guidelines.md instead of putting guidelines in coding-conventions.md
- Link from CONTRIBUTING.md next to DCO, since commit formatting is part of the contribution flow

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: [Announcement to kubevirt-dev](https://groups.google.com/g/kubevirt-dev/c/PaS5vGtHHU8/m/iTRl94E_DAAJ)
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE