### PR TITLE
docs, net: Add ordinal naming scheme upgrade documentation

### DIFF
--- a/docs/network/ordinal-naming-scheme-upgrade.md
+++ b/docs/network/ordinal-naming-scheme-upgrade.md
@@ -1,0 +1,84 @@
+# Upgrading Secondary Interface Naming Scheme
+
+Release:
+
+- v1.8: Beta
+
+## Overview
+
+VMs created on KubeVirt versions prior to v1.0.0 use a legacy ordinal naming
+scheme (e.g., `net1`, `net2`) for secondary network interfaces attached via
+[Multus](https://github.com/k8snetworkplumbingwg/multus-cni). Starting from
+v1.0.0, KubeVirt switched to a hashed naming scheme (e.g., `podb1f25a43da3`)
+for predictable and stable interface names.
+
+To maintain network connectivity across live migrations and upgrades, KubeVirt
+has preserved the legacy ordinal naming for VMs that were already using it.
+However, the ordinal scheme is **incompatible with 
+[NIC hot-unplug](https://kubevirt.io/user-guide/network/hotplug_interfaces/#removing-an-interface-from-a-running-vm)** 
+and increases maintenance complexity.
+
+Starting with v1.8, KubeVirt provides an upgrade path to migrate these VMs
+from the ordinal naming scheme to the modern hashed naming scheme **without
+requiring a VM restart**.
+
+## Feature Gate
+
+This feature requires the following
+[feature gates](https://kubevirt.io/user-guide/cluster_admin/activating_feature_gates/#how-to-activate-a-feature-gate):
+
+- `PodSecondaryInterfaceNamingUpgrade` - controls the naming scheme upgrade
+  logic. Introduced in v1.8 at Beta stage, it must be explicitly enabled.
+- `LibvirtHooksServerAndClient` - enables the domain mutation hook mechanism
+  used to adjust tap device names during migration. Must be explicitly enabled.
+
+## How It Works
+
+When the feature gate is enabled, the naming scheme upgrade is performed
+automatically during the next **live migration** of the VM:
+
+1. The target virt-launcher pod is created with the hashed naming scheme,
+   regardless of the source pod's naming scheme.
+2. The domain XML is automatically adjusted on the target to map tap device
+   names from the old ordinal format (e.g., `tap1`) to the new hashed format
+   (e.g., `tapadd93534eeb`).
+3. After a successful migration, the VMI status is updated to reflect the new
+   interface names.
+
+No manual intervention is required beyond triggering a live migration.
+
+## Who Is Affected
+
+This feature only applies to VMs that were **originally created on KubeVirt
+versions prior to v1.0.0** and are still using the ordinal naming scheme for
+secondary network interfaces.
+
+VMs created on v1.0.0 or later already use the hashed naming scheme and are
+not affected.
+
+> **Note**: If a VM was created prior to v1.0.0 but has been restarted on
+> v1.0.0 or above, it already uses the hashed naming scheme and does not
+> require this upgrade.
+
+## Upgrading a VM
+
+To upgrade a VM's interface naming scheme, ensure both the
+`PodSecondaryInterfaceNamingUpgrade` and `LibvirtHooksServerAndClient` feature
+gates are enabled, then live migrate the VM:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstanceMigration
+metadata:
+  name: upgrade-naming-scheme
+spec:
+  vmiName: <vm-name>
+EOF
+```
+
+Please refer to the [Live Migration](https://kubevirt.io/user-guide/compute/live_migration/) documentation
+for more information.
+
+Once the migration completes, the VM will use the hashed naming scheme. This
+also **unblocks NIC hot-unplug** functionality for the VM.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Document the upgrade path for migrating VMs from the legacy ordinal secondary interface naming scheme to the modern hashed naming scheme, as described in VEP-111 [1].

[1] https://github.com/kubevirt/enhancements/issues/111

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
- https://github.com/kubevirt/user-guide/pull/972

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

