### PR TITLE
Fix bug in VirtualMachineStuckOnNode alert

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1072,28 +1072,41 @@ tests:
       # VMs that SHOULD alert (in problematic states with VMI)
       - series: 'kubevirt_vm_info{name="vm-stuck-starting", namespace="test-ns", status="starting", status_group="starting"}'
         values: "1x11"
-      - series: 'kubevirt_vmi_info{name="vm-stuck-starting", namespace="test-ns", node="worker-node-1"}'
+      - series: 'kubevirt_vmi_info{name="vm-stuck-starting", namespace="test-ns", node="worker-node-1", phase="running"}'
         values: "1x11"
       - series: 'kubevirt_vm_info{name="vm-image-error", namespace="test-ns", status="ErrImagePull", status_group="error"}'
         values: "1x11"
-      - series: 'kubevirt_vmi_info{name="vm-image-error", namespace="test-ns", node="worker-node-2"}'
+      - series: 'kubevirt_vmi_info{name="vm-image-error", namespace="test-ns", node="worker-node-2", phase="running"}'
         values: "1x11"
       - series: 'kubevirt_vm_info{name="vm-stuck-stopping", namespace="test-ns", status="stopping", status_group="non_running"}'
         values: "1x11"
-      - series: 'kubevirt_vmi_info{name="vm-stuck-stopping", namespace="test-ns", node="worker-node-3"}'
+      - series: 'kubevirt_vmi_info{name="vm-stuck-stopping", namespace="test-ns", node="worker-node-3", phase="running"}'
         values: "1x11"
       - series: 'kubevirt_vm_info{name="vm-terminating-with-vmi", namespace="test-ns", status="terminating", status_group="non_running"}'
         values: "1x11"
-      - series: 'kubevirt_vmi_info{name="vm-terminating-with-vmi", namespace="test-ns", node="worker-node-4"}'
+      - series: 'kubevirt_vmi_info{name="vm-terminating-with-vmi", namespace="test-ns", node="worker-node-4", phase="scheduled"}'
         values: "1x11"
       # VMs that should NOT alert (in healthy states with VMI)
       - series: 'kubevirt_vm_info{name="vm-running", namespace="test-ns", status="running", status_group="running"}'
         values: "1x11"
-      - series: 'kubevirt_vmi_info{name="vm-running", namespace="test-ns", node="worker-node-5"}'
+      - series: 'kubevirt_vmi_info{name="vm-running", namespace="test-ns", node="worker-node-5", phase="running"}'
         values: "1x11"
       - series: 'kubevirt_vm_info{name="vm-paused", namespace="test-ns", status="paused", status_group="running"}'
         values: "1x11"
-      - series: 'kubevirt_vmi_info{name="vm-paused", namespace="test-ns", node="worker-node-6"}'
+      - series: 'kubevirt_vmi_info{name="vm-paused", namespace="test-ns", node="worker-node-6", phase="scheduled"}'
+        values: "1x11"
+      # VMs that should NOT alert (problematic status but no VMI)
+      - series: 'kubevirt_vm_info{name="vm-starting-no-vmi", namespace="test-ns", status="starting", status_group="starting"}'
+        values: "1x11"
+      # VMs that should NOT alert (problematic status but VMI in non-matching phase)
+      - series: 'kubevirt_vm_info{name="vm-starting-pending-vmi", namespace="test-ns", status="starting", status_group="starting"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-starting-pending-vmi", namespace="test-ns", node="worker-node-11", phase="pending"}'
+        values: "1x11"
+      # VMs that should NOT alert (error status but VMI in non-matching phase)
+      - series: 'kubevirt_vm_info{name="vm-error-failed-vmi", namespace="test-ns", status="CrashLoopBackOff", status_group="error"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-error-failed-vmi", namespace="test-ns", node="worker-node-12", phase="failed"}'
         values: "1x11"
 
     alert_rule_test:
@@ -1157,6 +1170,151 @@ tests:
               namespace: "test-ns"
               status: "terminating"
               node: "worker-node-4"
+
+  # VirtualMachineStuckOnNode - duplicate VMI series regression tests
+  # Verifies topk-based dedup prevents many-to-many matching errors
+  # during VMI phase transitions and live migrations.
+  - interval: 1m
+    input_series:
+      # Phase transition: scheduling + running VMI coexist for same VM
+      - series: 'kubevirt_vm_info{name="vm-phase-overlap", namespace="test-ns", status="starting", status_group="starting"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-phase-overlap", namespace="test-ns", phase="scheduling"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-phase-overlap", namespace="test-ns", phase="running", node="worker-node-7"}'
+        values: "1x11"
+      # Scheduled phase: VMI bound to node but domain not yet started
+      - series: 'kubevirt_vm_info{name="vm-stuck-scheduled", namespace="test-ns", status="starting", status_group="starting"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-stuck-scheduled", namespace="test-ns", phase="scheduled", node="worker-node-8"}'
+        values: "1x11"
+      # Scheduled + running overlap: both phases match filter, topk must dedup
+      # topk picks the higher-valued series deterministically
+      - series: 'kubevirt_vm_info{name="vm-sched-run-overlap", namespace="test-ns", status="starting", status_group="starting"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-sched-run-overlap", namespace="test-ns", phase="scheduled", node="worker-node-9"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-sched-run-overlap", namespace="test-ns", phase="running", node="worker-node-10"}'
+        values: "2x11"
+      # Migration: two running VMIs on different nodes for same VM
+      # topk picks the higher-valued series deterministically
+      - series: 'kubevirt_vm_info{name="vm-migration-overlap", namespace="test-ns", status="stopping", status_group="non_running"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-migration-overlap", namespace="test-ns", phase="running", node="source-node"}'
+        values: "2x11"
+      - series: 'kubevirt_vmi_info{name="vm-migration-overlap", namespace="test-ns", phase="running", node="target-node"}'
+        values: "1x11"
+      # Error with migration overlap: tests inner and + outer group_left
+      - series: 'kubevirt_vm_info{name="vm-error-migration", namespace="test-ns", status="ErrImagePull", status_group="error"}'
+        values: "1x11"
+      - series: 'kubevirt_vmi_info{name="vm-error-migration", namespace="test-ns", phase="running", node="source-node-2"}'
+        values: "2x11"
+      - series: 'kubevirt_vmi_info{name="vm-error-migration", namespace="test-ns", phase="running", node="target-node-2"}'
+        values: "1x11"
+
+    alert_rule_test:
+      # no alert before 5 minutes
+      - eval_time: 4m
+        alertname: VirtualMachineStuckOnNode
+        exp_alerts: []
+      # alerts fire after 5 minutes; topk dedup ensures no many-to-many errors
+      - eval_time: 5m
+        alertname: VirtualMachineStuckOnNode
+        exp_alerts:
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-phase-overlap in namespace test-ns on node worker-node-7 has been in starting state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-phase-overlap"
+              namespace: "test-ns"
+              status: "starting"
+              node: "worker-node-7"
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-stuck-scheduled in namespace test-ns on node worker-node-8 has been in starting state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-stuck-scheduled"
+              namespace: "test-ns"
+              status: "starting"
+              node: "worker-node-8"
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-sched-run-overlap in namespace test-ns on node worker-node-10 has been in starting state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-sched-run-overlap"
+              namespace: "test-ns"
+              status: "starting"
+              node: "worker-node-10"
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-error-migration in namespace test-ns on node source-node-2 has been in ErrImagePull state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-error-migration"
+              namespace: "test-ns"
+              status: "ErrImagePull"
+              node: "source-node-2"
+          - exp_annotations:
+              summary: "Virtual machine stuck in unhealthy state for more than 5 minutes"
+              description: "Virtual machine vm-migration-overlap in namespace test-ns on node source-node has been in stopping state for more than 5 minutes. This may indicate issues with the VM lifecycle on the target node."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineStuckOnNode"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-migration-overlap"
+              namespace: "test-ns"
+              status: "stopping"
+              node: "source-node"
+
+  # VMCannotBeEvicted - duplicate VMI series regression test
+  # Verifies topk-based dedup prevents many-to-many matching errors
+  # when two running VMI series exist during live migration.
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_non_evictable{node="node1", namespace="ns-test", name="vm-evict-migration"}'
+        values: "1 1 1 1 1 1 1 1"
+      - series: 'kubevirt_vmi_info{phase="running", node="node1", namespace="ns-test", name="vm-evict-migration"}'
+        values: "1 1 1 1 1 1 1 1"
+      - series: 'kubevirt_vmi_info{phase="running", node="node2", namespace="ns-test", name="vm-evict-migration"}'
+        values: "1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: VMCannotBeEvicted
+        exp_alerts:
+          - exp_annotations:
+              description: "Eviction policy for VirtualMachine vm-evict-migration in namespace ns-test (on node node1) is set to Live Migration but the VM is not migratable"
+              summary: "The VM's eviction strategy is set to Live Migration but the VM is not migratable"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VMCannotBeEvicted"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "vm-evict-migration"
+              namespace: "ns-test"
+              node: "node1"
 
   # GuestFilesystemAlmostOutOfSpace - Warning (85% usage)
   - interval: 1m

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -66,8 +66,11 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "VMCannotBeEvicted",
-		Expr:  intstr.FromString("kubevirt_vmi_non_evictable * on(name, namespace) group_left() kubevirt_vmi_info{phase='running'} == 1"),
-		For:   ptr.To(promv1.Duration("1m")),
+		Expr: intstr.FromString(
+			"kubevirt_vmi_non_evictable * on(name, namespace) group_left() " +
+				"topk by(name, namespace) (1, kubevirt_vmi_info{phase='running'}) == 1",
+		),
+		For: ptr.To(promv1.Duration("1m")),
 		Annotations: map[string]string{
 			descriptionAnnotationKey: "Eviction policy for VirtualMachine {{ $labels.name }} in namespace {{ $labels.namespace }} " +
 				"(on node {{ $labels.node }}) is set to Live Migration but the VM is not migratable",
@@ -153,7 +156,8 @@ var vmsAlerts = []promv1.Rule{
 			"sum by (name, namespace, status, node)((kubevirt_vm_info{status='starting'} == 1 " +
 				"or kubevirt_vm_info{status='stopping'} == 1 or kubevirt_vm_info{status='terminating'} == 1 " +
 				"or (kubevirt_vm_info{status_group='error'} == 1 " +
-				"and on(name, namespace) kubevirt_vmi_info) ) * on(name, namespace) group_left(node) kubevirt_vmi_info)",
+				"and on(name, namespace) kubevirt_vmi_info{phase=~'scheduled|running'}) ) " +
+				"* on(name, namespace) group_left(node) topk by(name, namespace) (1, kubevirt_vmi_info{phase=~'scheduled|running'}))",
 		),
 		For: ptr.To(promv1.Duration("5m")),
 		Annotations: map[string]string{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
During VMI phase transitions or live migrations,
kubevirt_vmi_info can have multiple series for the same VM (e.g. phase=scheduling + phase=running,
or two running series on different nodes).
This breaks group_left joins which require right-side uniqueness per match group.

#### After this PR:
Fix VirtualMachineStuckOnNode and VMCannotBeEvicted alerts that were impacted by this.

### References
- Fixes #https://issues.redhat.com/browse/CNV-75832
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix VirtualMachineStuckOnNode and VMCannotBeEvicted alerts failing during live migration due to duplicate kubevirt_vmi_info series
```

