### PR TITLE
VEP 227: Enable UEFI Secure Boot for ARM64 guests

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -263,6 +263,7 @@ add_to_label_filter '(!USB)' '&&'
 add_to_label_filter '(!requires-arm64)' '&&'
 add_to_label_filter '(!requires-s390x)' '&&'
 add_to_label_filter '(!requires-cross-arch-emulation)' '&&'
+add_to_label_filter '(!requires-arm64-secure-boot)' '&&'
 add_to_label_filter '(!RequiresPersistentReservation)' '&&'
 
 if ! kubectl get clusterversion version &>/dev/null; then

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -634,6 +634,10 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     add_to_label_filter "(!requires-cross-arch-emulation)" "&&"
   fi
 
+  if [[ ${KUBEVIRT_ARM64_SECURE_BOOT} != "true" ]]; then
+    add_to_label_filter "(!requires-arm64-secure-boot)" "&&"
+  fi
+
   if [[ $KUBEVIRT_PROVIDER =~ k8s-1\.3[1-4] ]]; then
     add_to_label_filter "(!ImageVolume)" "&&"
   fi

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -362,6 +362,7 @@ func main() {
 	vGPUDedicatedHookEnabled := pflag.Bool("vgpu-dedicated-hook", false, "Enable target mdev UUID mutation for vGPU live migration")
 	vmStatsCollectorEnabled := pflag.Bool("vm-stats-collector", false, "Enable additional guest agent polling workers for VMStats monitoring data collection")
 	firmwareAutoSelectionEnabled := pflag.Bool("firmware-auto-selection", false, "Use libvirt firmware auto-selection for EFI Secure Boot")
+	arm64SecureBootEnabled := pflag.Bool("arm64-secure-boot", false, "Enable ARM64 UEFI Secure Boot via firmware auto-selection and uefi-vars")
 	hookSidecars := pflag.Uint("hook-sidecars", 0, "Number of requested hook sidecars, virt-launcher will wait for all of them to become available")
 	diskMemoryLimitBytes := pflag.Int64("disk-memory-limit", virtconfig.DefaultDiskVerificationMemoryLimitBytes, "Memory limit for disk verification")
 	ovmfPath := pflag.String("ovmf-path", virtconfig.DefaultARCHOVMFPath, "The directory that contains the EFI roms (like OVMF_CODE.fd)")
@@ -480,6 +481,7 @@ func main() {
 		domainName,
 		*vmStatsCollectorEnabled,
 		*firmwareAutoSelectionEnabled,
+		*arm64SecureBootEnabled,
 		*allowCrossArchEmulation,
 		notifier)
 	if err != nil {

--- a/pkg/libvmi/cpu.go
+++ b/pkg/libvmi/cpu.go
@@ -89,6 +89,9 @@ func WithNUMAGuestMappingPassthrough() Option {
 func WithArchitecture(arch string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Architecture = arch
+		if arch != "amd64" && vmi.Spec.Domain.Features != nil && vmi.Spec.Domain.Features.SMM != nil {
+			vmi.Spec.Domain.Features.SMM = nil
+		}
 	}
 }
 

--- a/pkg/libvmi/firmware.go
+++ b/pkg/libvmi/firmware.go
@@ -24,7 +24,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
-// WithUefi configures EFI bootloader and SecureBoot.
+// WithUefi configures EFI bootloader and SecureBoot. When secureBoot is
+// enabled, SMM is also enabled for amd64 guests as it is required to protect
+// UEFI variable writes. Other architectures do not use SMM.
+// Order-independent with WithArchitecture: WithArchitecture strips SMM
+// when setting a non-amd64 architecture.
 func WithUefi(secureBoot bool) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Spec.Domain.Firmware == nil {

--- a/pkg/libvmi/firmware.go
+++ b/pkg/libvmi/firmware.go
@@ -41,8 +41,8 @@ func WithUefi(secureBoot bool) Option {
 			vmi.Spec.Domain.Firmware.Bootloader.EFI = &v1.EFI{}
 		}
 		vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.P(secureBoot)
-		// secureBoot Requires SMM to be enabled
-		if secureBoot {
+		// SMM is required for SecureBoot on amd64 only.
+		if secureBoot && (vmi.Spec.Architecture == "amd64" || vmi.Spec.Architecture == "") {
 			if vmi.Spec.Domain.Features == nil {
 				vmi.Spec.Domain.Features = &v1.Features{}
 			}

--- a/pkg/libvmi/firmware_test.go
+++ b/pkg/libvmi/firmware_test.go
@@ -1,0 +1,33 @@
+package libvmi
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWithUefiAndWithArchitectureOrderIndependence(t *testing.T) {
+	RegisterTestingT(t)
+
+	archFirst := New(WithArchitecture("arm64"), WithUefi(true))
+	uefiFirst := New(WithUefi(true), WithArchitecture("arm64"))
+
+	Expect(archFirst.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).ToNot(BeNil())
+	Expect(*archFirst.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).To(BeTrue())
+	Expect(archFirst.Spec.Domain.Features == nil || archFirst.Spec.Domain.Features.SMM == nil).To(BeTrue())
+
+	Expect(uefiFirst.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).ToNot(BeNil())
+	Expect(*uefiFirst.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).To(BeTrue())
+	Expect(uefiFirst.Spec.Domain.Features == nil || uefiFirst.Spec.Domain.Features.SMM == nil).To(BeTrue())
+
+	amd64First := New(WithArchitecture("amd64"), WithUefi(true))
+	uefiThenAmd64 := New(WithUefi(true), WithArchitecture("amd64"))
+
+	Expect(amd64First.Spec.Domain.Features).ToNot(BeNil())
+	Expect(amd64First.Spec.Domain.Features.SMM).ToNot(BeNil())
+	Expect(*amd64First.Spec.Domain.Features.SMM.Enabled).To(BeTrue())
+
+	Expect(uefiThenAmd64.Spec.Domain.Features).ToNot(BeNil())
+	Expect(uefiThenAmd64.Spec.Domain.Features.SMM).ToNot(BeNil())
+	Expect(*uefiThenAmd64.Spec.Domain.Features.SMM.Enabled).To(BeTrue())
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -216,6 +216,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	}
 
 	causes = append(causes, validateDomainSpec(field.Child("domain"), &spec.Domain, spec.Architecture)...)
+	causes = append(causes, validateARM64SecureBoot(field.Child("domain"), spec, config)...)
 	causes = append(causes, validateVolumes(field.Child("volumes"), spec.Volumes, config)...)
 	causes = append(causes, storageadmitters.ValidateContainerDisks(field, spec)...)
 	causes = append(causes, storageadmitters.ValidateUtilityVolumesNotPresentOnCreation(field, spec)...)
@@ -1499,6 +1500,30 @@ func validateDomainSpec(field *k8sfield.Path, spec *v1.DomainSpec, arch string) 
 				Field:   field.String(),
 			})
 		}
+	}
+
+	return causes
+}
+
+func validateARM64SecureBoot(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+	if spec.Architecture != "arm64" || !secureBootEnabled(spec.Domain.Firmware) {
+		return nil
+	}
+
+	var causes []metav1.StatusCause
+	if !config.ARM64SecureBootEnabled() {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s feature gate is not enabled in kubevirt-config", featuregate.ARM64SecureBoot),
+			Field:   field.Child("firmware", "bootloader", "efi", "secureBoot").String(),
+		})
+	}
+	if !config.FirmwareAutoSelectionEnabled() {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s feature gate is required for ARM64 Secure Boot", featuregate.FirmwareAutoSelection),
+			Field:   field.Child("firmware", "bootloader", "efi", "secureBoot").String(),
+		})
 	}
 
 	return causes

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -215,7 +215,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		causes = appendStatusCauseForProbeNotAllowedWithNoPodNetworkPresent(field.Child("livenessProbe"), spec.LivenessProbe, causes)
 	}
 
-	causes = append(causes, validateDomainSpec(field.Child("domain"), &spec.Domain)...)
+	causes = append(causes, validateDomainSpec(field.Child("domain"), &spec.Domain, spec.Architecture)...)
 	causes = append(causes, validateVolumes(field.Child("volumes"), spec.Volumes, config)...)
 	causes = append(causes, storageadmitters.ValidateContainerDisks(field, spec)...)
 	causes = append(causes, storageadmitters.ValidateUtilityVolumesNotPresentOnCreation(field, spec)...)
@@ -1472,21 +1472,33 @@ func smmFeatureEnabled(features *v1.Features) bool {
 	return features != nil && features.SMM != nil && (features.SMM.Enabled == nil || *features.SMM.Enabled)
 }
 
-func validateDomainSpec(field *k8sfield.Path, spec *v1.DomainSpec) []metav1.StatusCause {
+func validateDomainSpec(field *k8sfield.Path, spec *v1.DomainSpec, arch string) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	causes = append(causes, storageadmitters.ValidateDisks(field.Child("devices").Child("disks"), spec.Devices.Disks)...)
 	causes = append(causes, validateFirmware(field.Child("firmware"), spec.Firmware)...)
 
-	// TDX uses stateless firmware with Secure Boot keys embedded in the ROM;
-	// it does not need SMM to protect UEFI variable writes.
-	tdxEnabled := spec.LaunchSecurity != nil && spec.LaunchSecurity.TDX != nil
-	if secureBootEnabled(spec.Firmware) && !smmFeatureEnabled(spec.Features) && !tdxEnabled {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s has EFI SecureBoot enabled. SecureBoot requires SMM, which is currently disabled.", field.String()),
-			Field:   field.String(),
-		})
+	if secureBootEnabled(spec.Firmware) {
+		tdxEnabled := spec.LaunchSecurity != nil && spec.LaunchSecurity.TDX != nil
+		switch arch {
+		case "amd64", "":
+			if !smmFeatureEnabled(spec.Features) && !tdxEnabled {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("%s has EFI SecureBoot enabled. SecureBoot requires SMM, which is currently disabled.", field.String()),
+					Field:   field.String(),
+				})
+			}
+		case "arm64":
+			// ARM64 Secure Boot uses the uefi-vars device and does not require SMM.
+			// Feature gate validation is handled by validateARM64SecureBoot.
+		default:
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("SecureBoot is not supported on architecture %s", arch),
+				Field:   field.String(),
+			})
+		}
 	}
 
 	return causes

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2582,7 +2582,57 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
-		It("should accept ARM64 EFI with SecureBoot and without SMM", func() {
+		It("should accept ARM64 EFI with SecureBoot and without SMM when feature gate is enabled", func() {
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.MultiArchitecture, featuregate.ARM64SecureBoot, featuregate.FirmwareAutoSelection}
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
+
+			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(true),
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(BeEmpty())
+		})
+
+		It("should reject ARM64 EFI with SecureBoot when ARM64SecureBoot feature gate is disabled", func() {
+			enableFeatureGates(featuregate.MultiArchitecture, featuregate.FirmwareAutoSelection)
+			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(true),
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.ARM64SecureBoot)))
+		})
+
+		It("should reject ARM64 EFI with SecureBoot when FirmwareAutoSelection feature gate is disabled", func() {
+			enableFeatureGates(featuregate.MultiArchitecture, featuregate.ARM64SecureBoot)
+			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(true),
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is required for ARM64 Secure Boot", featuregate.FirmwareAutoSelection)))
+		})
+
+		It("should reject ARM64 EFI with SecureBoot when both feature gates are disabled", func() {
 			enableFeatureGates(featuregate.MultiArchitecture)
 			vmi.Spec.Architecture = "arm64"
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
@@ -2594,10 +2644,24 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			// SMM validation should be skipped for arm64, but ARM64SecureBoot
-			// feature gate is not enabled so we expect that rejection instead
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Message).To(ContainSubstring("feature gate is not enabled"))
+			Expect(causes).To(HaveLen(2))
+			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.ARM64SecureBoot)))
+			Expect(causes[1].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is required for ARM64 Secure Boot", featuregate.FirmwareAutoSelection)))
+		})
+
+		It("should accept ARM64 EFI without SecureBoot and without ARM64SecureBoot feature gate", func() {
+			enableFeatureGates(featuregate.MultiArchitecture)
+			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(false),
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should still require SMM for amd64 EFI with SecureBoot", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2582,6 +2582,55 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
+		It("should accept ARM64 EFI with SecureBoot and without SMM", func() {
+			enableFeatureGates(featuregate.MultiArchitecture)
+			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(true),
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			// SMM validation should be skipped for arm64, but ARM64SecureBoot
+			// feature gate is not enabled so we expect that rejection instead
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("feature gate is not enabled"))
+		})
+
+		It("should still require SMM for amd64 EFI with SecureBoot", func() {
+			vmi.Spec.Architecture = "amd64"
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(true),
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("SecureBoot requires SMM"))
+		})
+
+		It("should reject SecureBoot on unsupported architectures", func() {
+			enableFeatureGates(featuregate.MultiArchitecture)
+			vmi.Spec.Architecture = "riscv64"
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(true),
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("SecureBoot is not supported on architecture riscv64"))
+		})
+
 		It("should not accept BIOS and EFI together", func() {
 			vmi.Spec.Subdomain = "testsubdomain"
 

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -107,6 +107,10 @@ func (config *ClusterConfig) WorkloadEncryptionTDXEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.WorkloadEncryptionTDX)
 }
 
+func (config *ClusterConfig) ARM64SecureBootEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.ARM64SecureBoot)
+}
+
 func (config *ClusterConfig) DockerSELinuxMCSWorkaroundEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.DockerSELinuxMCSWorkaround)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -293,6 +293,17 @@ const (
 	// PortRangesSpec enables the portRanges field, initially only on masquerade interfaces,
 	// allowing compact specification of contiguous port intervals to forward to the VM guest.
 	PortRangesSpec = "PortRangesSpec"
+
+	// Owner: sig-compute / @lyarwood
+	// Alpha: v1.10.0
+	//
+	// ARM64SecureBoot enables UEFI Secure Boot for ARM64 guests using
+	// libvirt firmware auto-selection and the QEMU uefi-vars device.
+	// Requires QEMU 10.0+, libvirt with uefi-vars/varstore support,
+	// and edk2-aarch64 firmware with Secure Boot templates. These
+	// components are only available in CentOS Stream 10 based
+	// virt-launcher images.
+	ARM64SecureBoot = "ARM64SecureBoot"
 )
 
 func init() {
@@ -343,4 +354,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MigrationStallDetection, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CrossArchitectureVirtualization, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PortRangesSpec, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: ARM64SecureBoot, State: Alpha})
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -493,6 +493,9 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if t.clusterConfig.FirmwareAutoSelectionEnabled() {
 			args = append(args, "--firmware-auto-selection")
 		}
+		if t.clusterConfig.ARM64SecureBootEnabled() {
+			command = append(command, "--arm64-secure-boot")
+		}
 		if customDebugFilters, exists := vmi.Annotations[v1.CustomLibvirtLogFiltersAnnotation]; exists {
 			log.Log.Object(vmi).Infof("Applying custom debug filters for vmi %s: %s", vmi.Name, customDebugFilters)
 			args = append(args, "--libvirt-log-filters", customDebugFilters)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -6412,6 +6412,25 @@ var _ = Describe("Template", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.Containers[0].Args).ToNot(ContainElement("--firmware-auto-selection"))
 		})
+
+		It("should pass --arm64-secure-boot flag to virt-launcher when enabled", func() {
+			config, kvStore, svc = configFactory(defaultArch)
+			enableFeatureGate(featuregate.ARM64SecureBoot)
+
+			vmi := libvmi.New(libvmi.WithNamespace("default"))
+			pod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod.Spec.Containers[0].Command).To(ContainElement("--arm64-secure-boot"))
+		})
+
+		It("should not pass --arm64-secure-boot flag when disabled", func() {
+			config, kvStore, svc = configFactory(defaultArch)
+
+			vmi := libvmi.New(libvmi.WithNamespace("default"))
+			pod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod.Spec.Containers[0].Command).ToNot(ContainElement("--arm64-secure-boot"))
+		})
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/os.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os.go
@@ -121,12 +121,7 @@ func (o OSDomainConfigurator) configureEFI(vmi *v1.VirtualMachineInstance, domai
 			},
 		}
 		domain.Spec.OS.BootLoader = nil
-		// ARM64 Secure Boot uses uefi-vars firmware descriptors ("device": "memory")
-		// which are incompatible with the pflash <nvram> element. Libvirt manages
-		// variable storage via <varstore> for these descriptors automatically.
-		// For x86_64 pflash firmware, we must keep the explicit <nvram> to preserve
-		// KubeVirt's NVRAM filename convention and prevent format mismatches.
-		if vmi.Spec.Architecture != "arm64" {
+		if vmi.Spec.Architecture == "amd64" {
 			domain.Spec.OS.NVRam = &api.NVRam{
 				Format: "raw",
 				NVRam:  filepath.Join(util.PathForNVram(vmi), vmi.Name+"_VARS.fd"),

--- a/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
@@ -168,7 +168,7 @@ var _ = Describe("OS Domain Configurator", func() {
 		)
 
 		It("should use firmware auto-selection when enabled", func() {
-			vmi := libvmi.New(withEFIBootloader(true))
+			vmi := libvmi.New(withEFIBootloader(true), libvmi.WithArchitecture("amd64"))
 			var domain api.Domain
 			autoSelectConfig := &compute.EFIConfiguration{
 				SecureLoader:              true,

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3750,6 +3750,7 @@ var _ = Describe("Converter", func() {
 				UsesFirmwareAutoSelection: true,
 			}
 
+			vmi.Spec.Architecture = "amd64"
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3770,6 +3770,32 @@ var _ = Describe("Converter", func() {
 			Expect(domainSpec.OS.NVRam.NVRam).To(Equal("/var/run/kubevirt-private/libvirt/qemu/nvram/testvmi_VARS.fd"))
 		})
 
+		It("should use pflash for ARM64 EFI without Secure Boot", func() {
+			vmi.Spec.Architecture = "arm64"
+			c.EFIConfiguration = &convertertypes.EFIConfiguration{
+				EFICode:      "AAVMF_CODE.fd",
+				EFIVars:      "AAVMF_VARS.fd",
+				SecureLoader: false,
+			}
+
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{
+						SecureBoot: pointer.P(false),
+					},
+				},
+			}
+			vmi.Status.RuntimeUser = 107
+			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+			Expect(domainSpec.OS.Firmware).To(BeEmpty())
+			Expect(domainSpec.OS.FirmwareInfo).To(BeNil())
+			Expect(domainSpec.OS.BootLoader).ToNot(BeNil())
+			Expect(domainSpec.OS.BootLoader.Type).To(Equal("pflash"))
+			Expect(domainSpec.OS.BootLoader.Secure).To(Equal("no"))
+			Expect(path.Base(domainSpec.OS.BootLoader.Path)).To(Equal("AAVMF_CODE.fd"))
+			Expect(path.Base(domainSpec.OS.NVRam.Template)).To(Equal("AAVMF_VARS.fd"))
+		})
+
 		DescribeTable("display device should be set to", func(arch string, bootloader v1.Bootloader, enableFG bool, expectedDevice string) {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{Bootloader: &bootloader}
 			c = &convertertypes.ConverterContext{

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -110,6 +110,7 @@ var _ = Describe("Live migration source", func() {
 			nil,
 			"", false,
 			false, // firmware auto-selection
+			false, // arm64 secure boot
 			false,
 			nil,
 		)
@@ -217,6 +218,7 @@ var _ = Describe("Live migration source", func() {
 				nil,
 				"", false,
 				false, // firmware auto-selection
+				false, // arm64 secure boot
 				false,
 				nil,
 			)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -245,6 +245,7 @@ type LibvirtDomainManager struct {
 	imageVolumeFeatureGateEnabled      bool
 	libvirtHooksServerAndClientEnabled bool
 	firmwareAutoSelectionEnabled       bool
+	arm64SecureBootEnabled             bool
 	setTimeOnce                        sync.Once
 
 	// Premigration hook server for VMI updates during migration
@@ -305,6 +306,7 @@ func NewLibvirtDomainManager(
 	domainName string,
 	vmStatsCollectorEnabled bool,
 	firmwareAutoSelectionEnabled bool,
+	arm64SecureBootEnabled bool,
 	allowCrossArchEmulation bool,
 	eventSender accesscredentials.EventSender,
 ) (DomainManager, error) {
@@ -328,6 +330,7 @@ func NewLibvirtDomainManager(
 		domainName,
 		vmStatsCollectorEnabled,
 		firmwareAutoSelectionEnabled,
+		arm64SecureBootEnabled,
 		allowCrossArchEmulation,
 		eventSender)
 }
@@ -351,6 +354,7 @@ func newLibvirtDomainManager(
 	domainName string,
 	vmStatsCollectorEnabled bool,
 	firmwareAutoSelectionEnabled bool,
+	arm64SecureBootEnabled bool,
 	allowCrossArchEmulation bool,
 	eventSender accesscredentials.EventSender,
 ) (DomainManager, error) {
@@ -388,6 +392,7 @@ func newLibvirtDomainManager(
 		imageVolumeFeatureGateEnabled:      imageVolumeEnabled,
 		libvirtHooksServerAndClientEnabled: libvirtHooksServerAndClientEnabled,
 		firmwareAutoSelectionEnabled:       firmwareAutoSelectionEnabled,
+		arm64SecureBootEnabled:             arm64SecureBootEnabled,
 		hookServer:                         hookServer,
 		hypervisorName:                     hypervisorName,
 		hypervisorDeviceAvailable:          hypervisorDeviceAvailable,
@@ -1277,7 +1282,9 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 			vmType = efi.TDX
 		}
 
-		if secureBoot && vmType == efi.None && l.firmwareAutoSelectionEnabled {
+		useAutoSelection := secureBoot && vmType == efi.None && l.firmwareAutoSelectionEnabled
+
+		if useAutoSelection {
 			log.Log.V(4).Infof("Using firmware auto-selection for EFI Secure Boot")
 			efiConf = &convertertypes.EFIConfiguration{
 				SecureLoader:              true,

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1283,6 +1283,9 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		}
 
 		useAutoSelection := secureBoot && vmType == efi.None && l.firmwareAutoSelectionEnabled
+		if vmi.Spec.Architecture == "arm64" && !l.arm64SecureBootEnabled {
+			useAutoSelection = false
+		}
 
 		if useAutoSelection {
 			log.Log.V(4).Infof("Using firmware auto-selection for EFI Secure Boot")

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Manager", func() {
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
 	ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
 	newLibvirtDomainManagerDefault := func() (DomainManager, error) {
-		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 	}
 
 	BeforeEach(func() {
@@ -683,7 +683,7 @@ var _ = Describe("Manager", func() {
 				func() {
 					isFreeCalled <- true
 				})
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			Expect(manager.UnpauseVMI(vmi)).To(Succeed())
 			Eventually(func() bool {
 				select {
@@ -774,7 +774,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{
 				VirtualMachineSMBios: &cmdv1.SMBios{},
 				PreallocatedVolumes:  []string{"permvolume1"},
@@ -905,7 +905,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AttachDeviceFlags(strings.ToLower(string(attachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1013,7 +1013,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1087,7 +1087,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1188,7 +1188,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1327,7 +1327,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1457,7 +1457,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1535,7 +1535,7 @@ var _ = Describe("Manager", func() {
 			defer os.RemoveAll(ovmfDir)
 			err = os.WriteFile(filepath.Join(ovmfDir, efi.EFICodeSEV), loaderBytes, 0644)
 			Expect(err).ToNot(HaveOccurred())
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			sevMeasurementInfo, err := manager.GetLaunchMeasurement(vmi)
 			if runtime.GOARCH == "amd64" {
 				Expect(err).ToNot(HaveOccurred())
@@ -1852,7 +1852,7 @@ var _ = Describe("Manager", func() {
 				Physical: 20 * 1024 * 1024 * 1024,
 			}, nil)
 
-			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
@@ -2748,7 +2748,7 @@ var _ = Describe("Manager", func() {
 				options := &cmdv1.VirtualMachineOptions{
 					ClusterConfig: &cmdv1.ClusterConfig{VGPULiveMigrationEnabled: true},
 				}
-				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, true, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, true, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 				Expect(err).ToNot(HaveOccurred())
 				libvirtManager := manager.(*LibvirtDomainManager)
 
@@ -2794,7 +2794,7 @@ var _ = Describe("Manager", func() {
 			func(state libvirt.DomainState) {
 				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 				mockLibvirt.DomainEXPECT().UndefineFlags(libvirt.DOMAIN_UNDEFINE_KEEP_NVRAM | libvirt.DOMAIN_UNDEFINE_CHECKPOINTS_METADATA).Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 				Expect(manager.DeleteVMI(newVMI(testNamespace, testVmName))).To(Succeed())
 			},
 			Entry("crashed", libvirt.DOMAIN_CRASHED),
@@ -2976,7 +2976,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			})
 
 			It("should report nil when no OS info exists in the cache", func() {
@@ -3000,7 +3000,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 			})
 
 			It("should return nil when no interfaces exists in the cache", func() {
@@ -3044,7 +3044,7 @@ var _ = Describe("Manager", func() {
 				},
 			},
 		})
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3080,7 +3080,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3107,7 +3107,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3134,7 +3134,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3180,7 +3180,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3552,7 +3552,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should use firmware auto-selection for standard secure boot when feature gate is enabled", func() {
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			options := &cmdv1.VirtualMachineOptions{
@@ -3579,7 +3579,7 @@ var _ = Describe("Manager", func() {
 			Expect(os.WriteFile(filepath.Join(ovmfDir, efiCodeFile), []byte("code"), 0644)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(ovmfDir, efiVarsFile), []byte("vars"), 0644)).To(Succeed())
 
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, firmwareAutoSelection, false, nil)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, firmwareAutoSelection, false, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			libvirtManager := manager.(*LibvirtDomainManager)
@@ -3615,7 +3615,7 @@ var _ = Describe("Manager", func() {
 				Expect(os.WriteFile(filepath.Join(ovmfDir, f), []byte("data"), 0644)).To(Succeed())
 			}
 
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			libvirtManager := manager.(*LibvirtDomainManager)

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -121,9 +121,10 @@ var (
 	WgS390x = Label("wg-s390x")
 	WgArm64 = Label("wg-arm64")
 
-	RequiresAMD64 = Label("requires-amd64")
-	RequiresS390X = Label("requires-s390x")
-	RequiresARM64 = Label("requires-arm64")
+	RequiresAMD64           = Label("requires-amd64")
+	RequiresS390X           = Label("requires-s390x")
+	RequiresARM64           = Label("requires-arm64")
+	RequiresARM64SecureBoot = Label("requires-arm64-secure-boot")
 
 	RequiresCrossArchEmulation = Label("requires-cross-arch-emulation")
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -352,6 +352,30 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Entry("should enable EFI secure boot with firmware auto-selection", Serial, true, "SecureBoot enabled", true),
 		)
 
+		// TODO: Switch to quay.io/containerdisks/fedora:45 once Fedora 45 ships
+		// with a properly signed aarch64 Secure Boot chain. Fedora 44's
+		// fbaa64.efi (fallback) is signed with a test certificate, causing a
+		// Security Violation on first boot. See:
+		// https://www.jcline.org/blog/fedora/2026/04/01/fedora-aarch64-secureboot.html
+		// Once switched to Fedora 45, SSH into the guest and assert that
+		// Secure Boot is enabled within the OS (e.g. mokutil --sb-state).
+		It("should enable ARM64 EFI secure boot", Serial, decorators.WgArm64, decorators.RequiresARM64, decorators.RequiresARM64SecureBoot, func() {
+			kvconfig.EnableFeatureGate(featuregate.ARM64SecureBoot)
+			kvconfig.EnableFeatureGate(featuregate.FirmwareAutoSelection)
+
+			vmi := libvmi.New(
+				libvmi.WithContainerDisk("disk0", "quay.io/containerdisks/ubuntu:24.04"),
+				libvmi.WithMemoryRequest("1Gi"),
+				libvmi.WithRng(),
+				libvmi.WithArchitecture("arm64"),
+				libvmi.WithUefi(true),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			By("Starting the VirtualMachineInstance with ARM64 Secure Boot")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+		})
+
 		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test", func() {
 			It("[test_id:732]Check Free memory on the VMI", func() {
 				overcommitVmi := libvmifact.NewAlpine(overcommitGuestOverhead())


### PR DESCRIPTION
### What this PR does

#### Before this PR
UEFI Secure Boot is only supported for x86_64 guests using SMM and pflash-based OVMF firmware. ARM64 guests cannot use Secure Boot because ARM64 lacks SMM and uses a fundamentally different mechanism (QEMU `uefi-vars-sysbus` device) for UEFI variable protection.

#### After this PR
ARM64 guests can request UEFI Secure Boot via the existing `spec.domain.firmware.bootloader.efi.secureBoot` API field. When enabled on ARM64:
- The webhook skips the SMM requirement (SMM is an x86-only concept) and validates that both `ARM64SecureBoot` and `FirmwareAutoSelection` feature gates are enabled
- The converter uses libvirt firmware auto-selection (`<os firmware='efi'>` with firmware feature elements) — the same mechanism used for x86_64 Secure Boot via [VEP 241](https://github.com/kubevirt/enhancements/issues/241)
- Libvirt handles firmware selection, `uefi-vars-sysbus` device setup, and UEFI variable storage automatically

A new `ARM64SecureBoot` feature gate (Alpha) guards this functionality, requiring cluster admins to opt in when their virt-launcher images include the required components (QEMU 10.0+, libvirt with varstore support, edk2-aarch64 with Secure Boot templates — only available in CentOS Stream 10 based images).

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/227
- VEP PR: https://github.com/kubevirt/enhancements/pull/228
- VEP alignment PR: https://github.com/kubevirt/enhancements/pull/469
- Built on [VEP 241](https://github.com/kubevirt/enhancements/issues/241) (firmware auto-selection), merged in https://github.com/kubevirt/kubevirt/pull/17263

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Builds on the firmware auto-selection infrastructure from kubevirt/enhancements#241, reusing the domain schema types (`FirmwareInfo`, `FirmwareFeature`) and the `UsesFirmwareAutoSelection` code path. ARM64 Secure Boot generates the same input XML as x86_64, but libvirt resolves it to a ROM loader + uefi-vars device instead of pflash.
- Added a dedicated `ARM64SecureBoot` feature gate (in addition to `FirmwareAutoSelection` from kubevirt/enhancements#241) because ARM64 Secure Boot has additional requirements: QEMU 10.0+, libvirt with varstore support, and edk2-aarch64 firmware — only available in CentOS Stream 10 images.
- ARM64 feature gate validation is inlined into `validateDomainSpec` via an architecture switch, keeping all domain-level Secure Boot validation in one place.

The following alternatives were considered:
- Directly configuring the QEMU `uefi-vars-sysbus` device. Rejected because it would bypass libvirt's firmware management and require KubeVirt to manage firmware paths and variable storage directly.
- Re-introducing the firmware auto-selection types independently from x86_64. Rejected in favour of building on kubevirt/enhancements#241's shared infrastructure.

### Special notes for your reviewer
- [VEP 241](https://github.com/kubevirt/enhancements/issues/241) (firmware auto-selection for x86_64 Secure Boot) is merged; this PR is rebased on top of it.
- The `ARM64SecureBoot` feature gate requires `FirmwareAutoSelection` (kubevirt/enhancements#241) to also be enabled.
- Depends on CentOS Stream 10 based virt-launcher images ([VEP 210](https://github.com/kubevirt/enhancements/issues/210)) for the required QEMU 10.0+, libvirt, and edk2 firmware versions.
- The E2E test uses Ubuntu 24.04 as a temporary fallback (Fedora 44 and earlier have unsigned or test-signed aarch64 shim/GRUB); a TODO is in place to switch to Fedora 45 once it ships.

### Checklist
- [x] Design: VEP https://github.com/kubevirt/enhancements/pull/228
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [ ] Documentation: A user-guide update was considered and is present (link) or not required.
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Add support for UEFI Secure Boot on ARM64 guests via a new ARM64SecureBoot feature gate. When enabled, ARM64 guests can request Secure Boot using the existing EFI bootloader API, with libvirt firmware auto-selection handling firmware and uefi-vars device configuration automatically.
```
