### PR TITLE
fix: hotplug volume status race condition

### DIFF
--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -173,15 +173,13 @@ func (c *Controller) processHotplugVolumeStatus(
 		statusCopy.HotplugVolume = &virtv1.HotplugVolumeStatus{}
 	}
 
+	usePVCStatus := false
+
 	if attachmentPod == nil {
 		if !c.volumeReady(statusCopy.Phase) {
 			statusCopy.HotplugVolume.AttachPodUID = ""
 			// Volume is not hotplugged in VM and Pod is gone, or hasn't been created yet, check for the PVC associated with the volume to set phase and message
-			phase, reason, message := c.getVolumePhaseMessageReason(pvcName, vmi.Namespace)
-			statusCopy.Phase = phase
-			log.Log.V(3).Infof("Setting phase %s for volume %s", phase, volumeName)
-			statusCopy.Message = message
-			statusCopy.Reason = reason
+			usePVCStatus = true
 		}
 	} else {
 		statusCopy.HotplugVolume.AttachPodName = attachmentPod.Name
@@ -198,6 +196,22 @@ func (c *Controller) processHotplugVolumeStatus(
 			statusCopy.Reason = controller.SuccessfulCreatePodReason
 			c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, statusCopy.Reason, statusCopy.Message)
 		}
+		// Handle race condition where an unplugged volume was quickly re-attached.
+		// The old attachment pod may still be cleaning up while the new one is created,
+		// causing the new volume to inherit HotplugVolumeDetaching status from the previous
+		// hotplug instead of being reset. We reset the phase based on PVC status so it can
+		// properly transition through the normal attach flow on the next reconcile.
+		if statusCopy.Phase == virtv1.HotplugVolumeDetaching {
+			usePVCStatus = true
+		}
+	}
+
+	if usePVCStatus {
+		phase, reason, message := c.getVolumePhaseMessageReason(pvcName, vmi.Namespace)
+		statusCopy.Phase = phase
+		log.Log.V(3).Infof("Setting phase %s for volume %s", phase, volumeName)
+		statusCopy.Message = message
+		statusCopy.Reason = reason
 	}
 
 	*status = *statusCopy

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -3320,6 +3320,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", virtv1.HotplugVolumeAttachedToNode, "Created hotplug attachment pod test-pod, for volume volume%d", kvcontroller.SuccessfulCreatePodReason, indexes...)
 		}
 
+		makeDetachVolumeStatus := func(indexes ...int) []virtv1.VolumeStatus {
+			return makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", virtv1.HotplugVolumeDetaching, "Deleted hotplug attachment pod test-pod, for volume%d", kvcontroller.SuccessfulDeletePodReason, indexes...)
+		}
+
 		DescribeTable("updateVolumeStatus", func(oldStatus []virtv1.VolumeStatus, specVolumes []*virtv1.Volume, podIndexes []int, pvcIndexes []int, expectedStatus []virtv1.VolumeStatus, expectedEvents []string) {
 			vmi := newPendingVirtualMachine("testvmi")
 			volumes := make([]virtv1.Volume, 0)
@@ -3380,6 +3384,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				[]int{0},
 				makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", virtv1.HotplugVolumeDetaching, "Deleted hotplug attachment pod test-pod, for volume volume0", kvcontroller.SuccessfulDeletePodReason, 0),
 				[]string{kvcontroller.SuccessfulDeletePodReason}),
+			Entry("should update volume status, if volume gets stuck in Detaching state due to it being removed and re-added",
+				makeDetachVolumeStatus(),
+				makeVolumes(0),
+				[]int{0},
+				[]int{0},
+				makeVolumeStatusesForUpdateWithMessage("", "", virtv1.VolumeBound, "PVC is in phase Bound", kvcontroller.PVCNotReadyReason, 0),
+				[]string{}),
 			Entry("should keep status and not update phase if volume is still Ready",
 				makeVolumeStatusesForUpdateWithMessage("", "", virtv1.VolumeReady, "", "", 0),
 				makeVolumes(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Certain hotplug tests are seen occasionally failing when testing an unplug and re-attach operation, resulting in the new hotplug volume status being stuck in the `Detaching` phase despite the associated PVC is bound and the attachment pod is marked as `Running`

- Failed run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17066/pull-kubevirt-e2e-k8s-1.33-sig-storage-1.8/2030703140499623936

I believe what is happening here is if the new attachment pod is created while the old attachment pod is still being cleaned up, it is possible that the new hotplug volume never has a chance to reset it's status. It instead inherits the old `Detaching` status from the previous hotplug volume, since they share the same volume name. 

This status would normally be reset to status of the PVC status however, this only can occur when we see the attachment pod has not yet been created. 
https://github.com/kubevirt/kubevirt/blob/f7ab74fe8ddb53cb2ed1d0069c3474f28eb5f672/pkg/virt-controller/watch/vmi/storage.go#L176-L181


Since the new attachment pod does exists, we don't grab the corrected status from the PVC since it believes it has already been set prior to the attachment pod creation. Additionally, since the volume is still marked as `Detaching` the `canMoveToAttachedPhase()` will continually fail, preventing it from ever reaching the desired `Attached` phase.

#### Before this PR:
Allows hotplug volume status to be stuck in Detaching phase

#### After this PR:
Allow hotplug volume to reset it's status if it is seen to be in Detaching phase when an associated attachment pod exists and the volume exists in the updated VMI spec.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix hotplug volume status being stuck in Detaching phase
```

