### PR TITLE
automation: log ci.bazelrc contents at the start of e2e runs

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -360,6 +360,10 @@ build --remote_download_toplevel
 build --noshow_progress
 EOF
 
+echo "=== ci.bazelrc ==="
+cat ci.bazelrc
+echo "=================="
+
 # Build and test images with a custom image name prefix
 export IMAGE_PREFIX_ALT=${IMAGE_PREFIX_ALT:-kv-}
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The assembled `ci.bazelrc` contents are not visible in the job output, making it difficult to verify that the remote cache and other Bazel settings are correctly configured.

#### After this PR:
The contents of `ci.bazelrc` are logged immediately after assembly, providing visibility into the Bazel configuration used by each e2e run.

### References
- Follow-up to #17112

### Why we need it and why it was done in this way
As there are a number of moving parts in the Bazel cache configuration (bootstrap `/etc/bazel.bazelrc`, `ci.bazelrc`, `hack/dockerized` rsync), having the resulting file in the build log makes it straightforward to verify jobs are running with the expected configuration.

### Special notes for your reviewer
Suggested by @brianmcarey in #17112.

/cc @brianmcarey

### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```