### PR TITLE
OWNERS: add sig-buildsystem reviewers/approvers for bazel files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,18 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-reviewers:
-  - code-reviewers
-approvers:
-  - approvers
-emeritus_approvers:
-  - emeritus_approvers
+filters:
+  ".*":
+    reviewers:
+      - code-reviewers
+    approvers:
+      - approvers
+    emeritus_approvers:
+      - emeritus_approvers
+  "BUILD\\.bazel|.*\\.bzl|WORKSPACE":
+    reviewers:
+      - sig-buildsystem-reviewers
+    approvers:
+      - sig-buildsystem-approvers
+    labels:
+      - sig/buildsystem
   


### PR DESCRIPTION
## Summary

- Restructure the root `OWNERS` file to use filter-based rules
- Add `sig-buildsystem-reviewers` and `sig-buildsystem-approvers` as reviewers/approvers for Bazel build files (`BUILD.bazel`, `*.bzl`, `WORKSPACE`)
- Automatically apply the `sig/buildsystem` label to PRs touching these files

## Why

Currently sig-buildsystem members cannot approve changes to Bazel build files unless they are also root approvers. This means that maintainers who are responsible for the build system and have the most context on day-to-day Bazel changes have to rely on root approvers to provide the final `/approve`.

By adding sig-buildsystem as explicit reviewers and approvers for Bazel files, we enable the sig to self-sufficiently review and approve build file changes without requiring root approver involvement for every PR.

The existing root reviewers/approvers remain unchanged for all files via the `".*"` catch-all filter, so there is no reduction in review coverage.

The `sig-buildsystem-approvers` and `sig-buildsystem-reviewers` aliases already exist in `OWNERS_ALIASES`.

Fixes #17104

## Test plan

- [ ] Verify that non-Bazel file PRs continue to use the existing reviewers/approvers
- [ ] Verify that a future PR touching `BUILD.bazel` files gets sig-buildsystem reviewers assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)