### PR TITLE
tests: increase startupTimeout in VMIlifecycle tests to 120s

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -77,7 +77,7 @@ import (
 var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle", decorators.SigCompute, decorators.VMIlifecycle, decorators.WgArm64, func() {
 
 	const fakeLibvirtLogFilters = "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"
-	const startupTimeout = 60
+	const startupTimeout = 120
 
 	Context("when virt-handler is deleted", Serial, decorators.WgS390x, func() {
 		It("[test_id:4716]should label the node with kubevirt.io/schedulable=false", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The `VMIlifecycle` tests used a hardcoded `startupTimeout` of 60 seconds. On arm64 nodes in CI, VMIs occasionally take ~70-80 seconds to reach the `Running` phase, causing intermittent test failures (as reported in #17147).

#### After this PR:
The `startupTimeout` in [tests/vmi_lifecycle_test.go](https://github.com/kubevirt/kubevirt/tree/main/tests/vmi_lifecycle_test.go:0:0-0:0) is increased to 120 seconds. This provides a 2x buffer, which is sufficient to accommodate slower startup times on arm64 and heavily loaded CI environments.

### References
- Fixes #17147

### Why we need it and why it was done in this way
Arm64 compute nodes often exhibit slower disk I/O or image pulling performance compared to amd64 nodes in our CI lanes. A 60-second timeout was found to be too aggressive for these environments. Doubling the timeout is a standard practice for mitigating such hardware-specific flakes without compromising the validity of the tests.

### Special notes for your reviewer
This change only affects the `VMIlifecycle` test suite in [tests/vmi_lifecycle_test.go](https://github.com/kubevirt/kubevirt/tree/main/tests/vmi_lifecycle_test.go:0:0-0:0).

### Checklist

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
