### PR TITLE
tests: add VMI startup profiling gated by KUBEVIRT_E2E_PROFILE_VMI_STARTUP

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -355,6 +355,11 @@ done
 kubectl version
 
 mkdir -p "$ARTIFACTS_PATH"
+
+if [[ $TARGET =~ sig-compute ]]; then
+  export KUBEVIRT_E2E_PROFILE_VMI_STARTUP=true
+fi
+
 export KUBEVIRT_E2E_PARALLEL=true
 # arm64 e2e test lane use kind provider
 if [[ $TARGET =~ .*kind.* ]] || [[ $TARGET =~ .*k3d.* ]] || [[ $TARGET =~ wg-arm64 ]]; then

--- a/tests/libwait/profiler.go
+++ b/tests/libwait/profiler.go
@@ -1,0 +1,230 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libwait
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+var profilingEnabled = os.Getenv("KUBEVIRT_E2E_PROFILE_VMI_STARTUP") != ""
+
+var (
+	profileMu      sync.Mutex
+	profileRecords []VMIStartupProfile
+)
+
+type PhaseTransition struct {
+	Phase     string    `json:"phase"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type ContainerTiming struct {
+	Name     string     `json:"name"`
+	Started  *time.Time `json:"started,omitempty"`
+	Finished *time.Time `json:"finished,omitempty"`
+}
+
+type PodTimings struct {
+	Created        time.Time         `json:"created"`
+	Scheduled      *time.Time        `json:"scheduled,omitempty"`
+	InitContainers []ContainerTiming `json:"initContainers,omitempty"`
+	Containers     []ContainerTiming `json:"containers,omitempty"`
+}
+
+type VMIStartupProfile struct {
+	TestName         string            `json:"testName"`
+	VMIName          string            `json:"vmiName"`
+	Namespace        string            `json:"namespace"`
+	TimeoutSeconds   int               `json:"timeoutSeconds"`
+	Succeeded        bool              `json:"succeeded"`
+	TargetPhases     []string          `json:"targetPhases"`
+	FinalPhase       string            `json:"finalPhase"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	PhaseTransitions []PhaseTransition `json:"phaseTransitions"`
+	PodTimings       *PodTimings       `json:"podTimings,omitempty"`
+}
+
+func recordStartupProfile(originalVMI *v1.VirtualMachineInstance, waiting *Waiting) {
+	if !profilingEnabled {
+		return
+	}
+
+	profile := VMIStartupProfile{
+		TestName:       ginkgo.CurrentSpecReport().FullText(),
+		VMIName:        originalVMI.Name,
+		Namespace:      originalVMI.Namespace,
+		TimeoutSeconds: waiting.timeout,
+		TargetPhases:   phaseStrings(waiting.phases),
+	}
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		appendProfile(profile)
+		return
+	}
+
+	vmi, err := virtClient.VirtualMachineInstance(originalVMI.Namespace).Get(
+		context.Background(), originalVMI.Name, metav1.GetOptions{})
+	if err != nil {
+		appendProfile(profile)
+		return
+	}
+
+	profile.FinalPhase = string(vmi.Status.Phase)
+	profile.CreationTimestamp = vmi.CreationTimestamp.Time
+	profile.Succeeded = isTargetPhase(vmi.Status.Phase, waiting.phases)
+
+	for _, pt := range vmi.Status.PhaseTransitionTimestamps {
+		profile.PhaseTransitions = append(profile.PhaseTransitions, PhaseTransition{
+			Phase:     string(pt.Phase),
+			Timestamp: pt.PhaseTransitionTimestamp.Time,
+		})
+	}
+
+	if vmi.UID != "" {
+		profile.PodTimings = collectPodTimings(virtClient, vmi)
+	}
+
+	appendProfile(profile)
+}
+
+func collectPodTimings(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) *PodTimings {
+	labelSelector := fmt.Sprintf("%s=%s", v1.CreatedByLabel, string(vmi.GetUID()))
+	pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(
+		context.Background(),
+		metav1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil || len(pods.Items) == 0 {
+		return nil
+	}
+
+	pod := &pods.Items[0]
+	timings := &PodTimings{
+		Created: pod.CreationTimestamp.Time,
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == k8sv1.PodScheduled && cond.Status == k8sv1.ConditionTrue {
+			t := cond.LastTransitionTime.Time
+			timings.Scheduled = &t
+		}
+	}
+
+	for _, cs := range pod.Status.InitContainerStatuses {
+		ct := ContainerTiming{Name: cs.Name}
+		if cs.State.Terminated != nil {
+			t := cs.State.Terminated.StartedAt.Time
+			ct.Started = &t
+			f := cs.State.Terminated.FinishedAt.Time
+			ct.Finished = &f
+		}
+		timings.InitContainers = append(timings.InitContainers, ct)
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		ct := ContainerTiming{Name: cs.Name}
+		if cs.State.Running != nil {
+			t := cs.State.Running.StartedAt.Time
+			ct.Started = &t
+		} else if cs.State.Terminated != nil {
+			t := cs.State.Terminated.StartedAt.Time
+			ct.Started = &t
+			f := cs.State.Terminated.FinishedAt.Time
+			ct.Finished = &f
+		}
+		timings.Containers = append(timings.Containers, ct)
+	}
+
+	return timings
+}
+
+func appendProfile(profile VMIStartupProfile) {
+	profileMu.Lock()
+	defer profileMu.Unlock()
+	profileRecords = append(profileRecords, profile)
+}
+
+// FlushProfiles writes all collected VMI startup profiles to a JSON file
+// in the artifacts directory. It is a no-op when profiling is disabled.
+func FlushProfiles() {
+	if !profilingEnabled {
+		return
+	}
+
+	profileMu.Lock()
+	defer profileMu.Unlock()
+
+	if len(profileRecords) == 0 {
+		return
+	}
+
+	artifactsDir := os.Getenv("ARTIFACTS")
+	if artifactsDir == "" {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "KUBEVIRT_E2E_PROFILE_VMI_STARTUP enabled but ARTIFACTS not set, skipping profile flush\n")
+		return
+	}
+
+	filename := fmt.Sprintf("vmi-startup-profile-%d.json", ginkgo.GinkgoParallelProcess())
+	outputPath := filepath.Join(artifactsDir, filename)
+
+	data, err := json.MarshalIndent(profileRecords, "", "  ")
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to marshal VMI startup profiles: %v\n", err)
+		return
+	}
+
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to write VMI startup profiles to %s: %v\n", outputPath, err)
+		return
+	}
+
+	fmt.Fprintf(ginkgo.GinkgoWriter, "Wrote %d VMI startup profiles to %s\n", len(profileRecords), outputPath)
+}
+
+func phaseStrings(phases []v1.VirtualMachineInstancePhase) []string {
+	s := make([]string, len(phases))
+	for i, p := range phases {
+		s[i] = string(p)
+	}
+	return s
+}
+
+func isTargetPhase(phase v1.VirtualMachineInstancePhase, targets []v1.VirtualMachineInstancePhase) bool {
+	for _, t := range targets {
+		if phase == t {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -73,6 +73,9 @@ func WaitForVMIPhase(vmi *v1.VirtualMachineInstance, phases []v1.VirtualMachineI
 	}
 
 	WithWarningsIgnoreList(testsuite.TestRunConfiguration.WarningToIgnoreList)(&waiting)
+
+	defer recordStartupProfile(vmi, &waiting)
+
 	return waiting.watchVMIForPhase(vmi)
 }
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -33,6 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnode"
+	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/reporter"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
@@ -148,6 +149,10 @@ var _ = ReportAfterSuite("Collect cluster data", func(report Report) {
 	kvReport.Cleanup()
 
 	kvReport.Report(report)
+})
+
+var _ = ReportAfterSuite("VMI startup profiling", func(_ Report) {
+	libwait.FlushProfiles()
 })
 
 var _ = ReportAfterSuite("TestTests", func(report Report) {


### PR DESCRIPTION
### What this PR does
Before this PR:
No visibility into where VMI startup time is spent during e2e test runs, making it difficult to determine appropriate timeout values for different architectures.

After this PR:
When `KUBEVIRT_E2E_PROFILE_VMI_STARTUP` is set, each call to `WaitForVMIPhase` records VMI phase transition timestamps and launcher pod container lifecycle timings. Results are written to `${ARTIFACTS}/vmi-startup-profile-{N}.json` at suite end.

Fixes #17147

### Why we need it and why it was done in this way
ARM64 sig-compute lanes are seeing flaky VMI startup timeouts (e.g. `StartupTimeoutSecondsSmall = 60s`) because init containers alone can consume 40+ seconds on slower ARM64 KinD nodes, leaving insufficient time for the compute container to start and QEMU to boot.

Before increasing timeouts, we want data-driven evidence of where time is spent across architectures. This profiling infrastructure instruments the central `WaitForVMIPhase` function to capture:
- VMI phase transition timestamps (`Pending` → `Scheduling` → `Scheduled` → `Running`)
- Pod scheduling time
- Init container start/finish times
- Compute container start time

The following tradeoffs were made:
- Profiling is gated behind a single env var (`KUBEVIRT_E2E_PROFILE_VMI_STARTUP`) with zero cost when disabled (early return on first check)
- Data is collected in-memory and flushed once at suite end rather than writing per-test to avoid I/O overhead
- Pod timings are fetched best-effort — errors are silently ignored to avoid affecting test outcomes

The following alternatives were considered:
- Using Prometheus metrics (requires Prometheus deployment, not available in all lanes)
- Adding architecture-specific timeout multipliers (premature without data)
- Instrumenting at the `libvmops.RunVMIAndExpectLaunch` level (would miss direct `WaitForVMIPhase` callers)

### Special notes for your reviewer
- The `defer recordStartupProfile(...)` in `WaitForVMIPhase` ensures data is captured even when the test times out (the defer runs before the Ginkgo panic propagates)
- Enabled for all `sig-compute` lanes in `automation/test.sh` — plan is to collect data for ~1 week from both arm64 and amd64 lanes, then use it to inform timeout decisions
- Output is a JSON array written to `${ARTIFACTS}/vmi-startup-profile-{N}.json` where N is the Ginkgo parallel process ID

### Checklist

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```