### PR TITLE
node-labeller: suppress SEV-ES label on SEV-SNP hosts (CVE-2025-48514)

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -169,10 +169,11 @@ func (n *NodeLabeller) getDomCapabilities() (HostDomCapabilities, error) {
 	}
 
 	if hostDomCapabilities.SEV.Supported == isSupported && hostDomCapabilities.SEV.MaxESGuests > 0 {
-		hostDomCapabilities.SEV.SupportedES = isSupported
 		if hostDomCapabilities.LaunchSecurity.Supported == isSupported && slices.Contains(hostDomCapabilities.LaunchSecurity.SecTypes.Values, "sev-snp") {
+			hostDomCapabilities.SEV.SupportedES = isUnusable
 			hostDomCapabilities.SEV.SupportedSNP = isSupported
 		} else {
+			hostDomCapabilities.SEV.SupportedES = isSupported
 			hostDomCapabilities.SEV.SupportedSNP = isUnusable
 		}
 	} else {

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -170,7 +170,12 @@ func (n *NodeLabeller) getDomCapabilities() (HostDomCapabilities, error) {
 
 	if hostDomCapabilities.SEV.Supported == isSupported && hostDomCapabilities.SEV.MaxESGuests > 0 {
 		if hostDomCapabilities.LaunchSecurity.Supported == isSupported && slices.Contains(hostDomCapabilities.LaunchSecurity.SecTypes.Values, "sev-snp") {
-			hostDomCapabilities.SEV.SupportedES = isUnusable
+			// CVE-2025-48514: a privileged SEV-ES guest can attack SNP guests on
+			// older firmware (loss of confidentiality); newer PSP firmware rejects
+			// SEV-ES guests outright. MaxESGuests is left as-is because it reflects
+			// raw hardware capacity; SupportedES is suppressed so the node label is
+			// never applied and the scheduler never places SEV-ES VMs here.
+			hostDomCapabilities.SEV.SupportedES = isUnusable // suppressed: CVE-2025-48514
 			hostDomCapabilities.SEV.SupportedSNP = isSupported
 		} else {
 			hostDomCapabilities.SEV.SupportedES = isSupported

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -198,13 +198,17 @@ var _ = Describe("Node-labeller config", func() {
 					Expect(nlController.SEV.ReducedPhysBits).To(Equal(uint(1)))
 					Expect(nlController.SEV.MaxGuests).To(Equal(uint(15)))
 
-					if withES {
+					if withES && !withSNP {
+						// SEV-ES without SNP
 						Expect(nlController.SEV.SupportedES).To(Equal("yes"))
 						Expect(nlController.SEV.MaxESGuests).To(Equal(uint(15)))
-
-						if withSNP {
-							Expect(nlController.SEV.SupportedSNP).To(Equal("yes"))
-						}
+					} else if withSNP {
+						
+						// A privileged SEV-ES guest can attack SNP guests on older firmware;
+						// newer PSP firmware rejects SEV-ES guests outright.
+						Expect(nlController.SEV.SupportedES).To(Equal("no"))
+						Expect(nlController.SEV.MaxESGuests).To(Equal(uint(15)))
+						Expect(nlController.SEV.SupportedSNP).To(Equal("yes"))
 					} else {
 						Expect(nlController.SEV.SupportedES).To(Equal("no"))
 						Expect(nlController.SEV.MaxESGuests).To(BeZero())
@@ -220,7 +224,7 @@ var _ = Describe("Node-labeller config", func() {
 			},
 			Entry("when only SEV is supported", true, false, false),
 			Entry("when both SEV and SEV-ES are supported", true, true, false),
-			Entry("when SEV, SEV-ES, and SEV-SNP are all supported", true, true, true),
+			Entry("when SEV-SNP is supported, SEV-ES is suppressed (CVE-2025-48514)", true, true, true),
 			Entry("when none of SEV, SEV-ES, and SEV-SNP is supported", false, false, false),
 		)
 	})

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -203,11 +203,13 @@ var _ = Describe("Node-labeller config", func() {
 						Expect(nlController.SEV.SupportedES).To(Equal("yes"))
 						Expect(nlController.SEV.MaxESGuests).To(Equal(uint(15)))
 					} else if withSNP {
-						
-						// A privileged SEV-ES guest can attack SNP guests on older firmware;
-						// newer PSP firmware rejects SEV-ES guests outright.
+						// CVE-2025-48514: a privileged SEV-ES guest can attack SNP guests on
+						// older firmware; newer PSP firmware rejects SEV-ES guests outright.
+						// SupportedES is suppressed ("no") to block scheduling, but MaxESGuests
+						// intentionally stays non-zero, it reflects raw hardware capacity as
+						// reported by the hypervisor, not usability.
 						Expect(nlController.SEV.SupportedES).To(Equal("no"))
-						Expect(nlController.SEV.MaxESGuests).To(Equal(uint(15)))
+						Expect(nlController.SEV.MaxESGuests).To(Equal(uint(15))) // raw hw capacity, not usability
 						Expect(nlController.SEV.SupportedSNP).To(Equal("yes"))
 					} else {
 						Expect(nlController.SEV.SupportedES).To(Equal("no"))

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -161,6 +161,7 @@ var _ = Describe("Node-labeller ", func() {
 
 		node := retrieveNode(kubeClient)
 		Expect(node.Labels).To(HaveKey(v1.SEVESLabel))
+		Expect(node.Labels).ToNot(HaveKey(v1.SEVSNPLabel))
 	})
 
 	It("should not add SEV-ES label on SEV-SNP host (CVE-2025-48514)", func() {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -152,11 +152,25 @@ var _ = Describe("Node-labeller ", func() {
 	})
 
 	It("should add SEVES label", func() {
+		// Use a fixture with SEV-ES but no SEV-SNP so the CVE-2025-48514 guard
+		nlController.domCapabilitiesFileName = "domcapabilities_sev.xml"
+		Expect(nlController.loadAll()).Should(Succeed())
+
 		res := nlController.execute()
 		Expect(res).To(BeTrue())
 
 		node := retrieveNode(kubeClient)
 		Expect(node.Labels).To(HaveKey(v1.SEVESLabel))
+	})
+
+	It("should not add SEV-ES label on SEV-SNP host (CVE-2025-48514)", func() {
+		// The default virsh_domcapabilities.xml advertises SEV-SNP.
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(Not(HaveKey(v1.SEVESLabel)))
+		Expect(node.Labels).To(HaveKey(v1.SEVSNPLabel))
 	})
 
 	It("should not add SecureExecution label", func() {


### PR DESCRIPTION
### What this PR does

### Summary

  - CVE-2025-48514 — AMD SEV firmware allows a privileged SEV-ES guest to attack co-resident SEV-SNP guests
  (CWE-1220, CVSS 4.0 Medium). On older firmware this causes a loss of confidentiality; on newer PSP firmware
  (API ≥ 1.58) the guest is rejected outright, causing VM startup failures.
  - when a host reports SEV-SNP capability via launchSecurity, the kubevirt.io/sev-es label is now suppressed. SEV-ES VMs are therefore never scheduled onto SEV-SNP nodes.
  - No changes done to the scheduling logic, API types, or admission webhooks are required — the existing label-based
   node selector already enforces placement.

### Test plan

  - go test ./pkg/virt-handler/node-labeller/... passes on amd64
  - On a SEV-SNP host: confirm kubevirt.io/sev-es label is absent and kubevirt.io/sev-snp is present after
  virt-handler restart
  -  scheduling a SEV-ES VM onto a SEV-SNP node — scheduler must reject it

  
- Fixes #17118

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@orelmisan @0xFelix