### PR TITLE
[release-1.0] MDEV tests: fix checkAllMDEVCreated issue upon multiple GPUs

### DIFF
--- a/nogo_config.json
+++ b/nogo_config.json
@@ -175,6 +175,7 @@
       "tests/canary_upgrade_test.go": "canary_upgrade_test does not pass errcheck yet",
       "tests/infra_test.go": "infra_test.go does not pass errcheck yet",
       "tests/kubectl_test.go": "kubectl_test does not pass errcheck yet",
+      "tests/mdev_configuration_allocation_test.go": "mdev_configuration_allocation_test does not pass errcheck yet",
       "tests/migration_test.go": "migration_test does not pass errcheck yet",
       "tests/replicaset_test.go": "replicaset_test does not pass errcheck yet",
       "tests/usbredir_test.go": "kubectl_test does not pass errcheck yet",

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -1,10 +1,14 @@
 package tests_test
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,6 +39,15 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
+const (
+	mdevBusPath               = "/sys/class/mdev_bus/"
+	mdevSupportedTypesDirName = "mdev_supported_types"
+)
+
+var (
+	nvMaxInstanceRE = regexp.MustCompile(`\bmax_instance=(\d+)\b`)
+)
+
 var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU, decorators.SigCompute, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -56,7 +69,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		}
 	}
 
-	checkAllMDEVCreated := func(mdevTypeName string, expectedInstancesCount int) func() (*k8sv1.Pod, error) {
+	checkAllMDEVCreated := func(mdevTypeName string, expectedInstancesCount uint) func() (*k8sv1.Pod, error) {
 		return func() (*k8sv1.Pod, error) {
 			By(fmt.Sprintf("Checking the number of created mdev types, should be %d of %s type ", expectedInstancesCount, mdevTypeName))
 			check := fmt.Sprintf(`set -x
@@ -124,7 +137,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		var deviceName = "nvidia.com/GRID_T4-1B"
 		var mdevSelector = "GRID T4-1B"
 		var desiredMdevTypeName = "nvidia-222"
-		var expectedInstancesNum = 16
+		var expectedInstancesNum uint
 		var config v1.KubeVirtConfiguration
 		var originalFeatureGates []string
 
@@ -151,6 +164,9 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 			noGPUDevicesAreAvailable()
 		}
 		BeforeEach(func() {
+			By("Determining the expected amount of mediated device instances used for the test")
+			expectedInstancesNum = getNumOfInstancesByMdevType(desiredMdevTypeName)
+
 			addMdevsConfiguration()
 
 			By("Verifying that an expected amount of devices has been created")
@@ -203,14 +219,16 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		var updatedMdevSelector = "GRID T4-2B"
 		var parentDeviceID = "10de:1eb8"
 		var desiredMdevTypeName = "nvidia-222"
-		var expectedInstancesNum = 16
+		var expectedInstancesNum uint
 		var config v1.KubeVirtConfiguration
 		var mdevTestLabel = "mdevTestLabel1"
 
 		BeforeEach(func() {
-			kv := util.GetCurrentKv(virtClient)
+			By("Determining the expected amount of mediated device instances used for the test")
+			expectedInstancesNum = getNumOfInstancesByMdevType(desiredMdevTypeName)
 
 			By("Creating a configuration for mediated devices")
+			kv := util.GetCurrentKv(virtClient)
 			config = kv.Spec.Configuration
 			config.DeveloperConfiguration.FeatureGates = append(config.DeveloperConfiguration.FeatureGates, virtconfig.GPUGate)
 			config.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{
@@ -309,8 +327,10 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*ramfb=.?on.?`), "RamFB should not be enabled")
 		})
 		It("[QUARANTINE] Should override default mdev configuration on a specific node", func() {
+			By("Determining the expected amount of mediated device instances used for the test")
 			newDesiredMdevTypeName := "nvidia-223"
-			newExpectedInstancesNum := 8
+			newExpectedInstancesNum := getNumOfInstancesByMdevType(newDesiredMdevTypeName)
+
 			By("Creating a configuration for mediated devices")
 			config.MediatedDevicesConfiguration.NodeMediatedDeviceTypes = []v1.NodeMediatedDeviceTypesConfig{
 				{
@@ -353,10 +373,9 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		})
 	})
 	Context("with generic mediated devices", func() {
-		const mdevBusPath = "/sys/class/mdev_bus/"
 		const findMdevCapableDevices = "ls -df1 " + mdevBusPath + "0000* | head -1"
-		const findSupportedTypeFmt = "ls -df1 " + mdevBusPath + "%s/mdev_supported_types/* | head -1"
-		const deviceNameFmt = mdevBusPath + "%s/mdev_supported_types/%s/name"
+		const findSupportedTypeFmt = "ls -df1 " + mdevBusPath + "%s/" + mdevSupportedTypesDirName + "/* | head -1"
+		const deviceNameFmt = mdevBusPath + "%s/" + mdevSupportedTypesDirName + "/%s/name"
 		const unbindCmdFmt = "echo %s > %s/unbind"
 		const bindCmdFmt = "echo %s > %s/bind"
 		const uuidRegex = "????????-????-????-????-????????????"
@@ -498,3 +517,64 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		})
 	})
 })
+
+// Note: this may not work for non-NVIDIA devices as it relies on `getMaxInstancesOfNVGpu`
+func getNumOfInstancesByMdevType(typeName string) (num uint) {
+	devIDs, err := getSupportedDevIDsByMdevType(typeName)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, devID := range devIDs {
+		maxIns, err := getMaxInstancesOfNVGpu(devID, typeName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(maxIns).To(BeNumerically(">", 0))
+		num += maxIns
+	}
+
+	Expect(num).To(BeNumerically(">", 0))
+	return num
+}
+
+func getSupportedDevIDsByMdevType(typeName string) ([]string, error) {
+	var devIDs []string
+	devices, err := os.ReadDir(mdevBusPath)
+	if err != nil {
+		return devIDs, err
+	}
+
+	for _, device := range devices {
+		path := filepath.Join(mdevBusPath, device.Name(), mdevSupportedTypesDirName, typeName)
+		if _, err := os.Stat(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return devIDs, err
+		}
+		devIDs = append(devIDs, device.Name())
+	}
+	return devIDs, nil
+}
+
+// NVIDIA driver implements the `max_instance` attribute via `description`
+// $ cat /sys/class/mdev_bus/0000:ab:00.0/mdev_supported_types/nvidia-222/description
+// num_heads=4, frl_config=45, framebuffer=1024M, max_resolution=5120x2880, max_instance=16
+func getMaxInstancesOfNVGpu(devID string, typeName string) (uint, error) {
+	path := filepath.Join(mdevBusPath, devID, mdevSupportedTypesDirName, typeName, "description")
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if matches := nvMaxInstanceRE.FindStringSubmatch(line); matches != nil {
+			num, err := strconv.ParseUint(matches[1], 10, 0)
+			if err != nil {
+				return 0, err
+			}
+			return uint(num), nil
+		}
+	}
+	return 0, fmt.Errorf("no max_instance is found")
+}

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -1,11 +1,8 @@
 package tests_test
 
 import (
-	"bufio"
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -44,16 +41,17 @@ const (
 	mdevSupportedTypesDirName = "mdev_supported_types"
 )
 
-var (
-	nvMaxInstanceRE = regexp.MustCompile(`\bmax_instance=(\d+)\b`)
-)
-
 var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU, decorators.SigCompute, func() {
 	var err error
+	var testNodeName string
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
+		// There should be only one node in this lane
+		nodes := libnode.GetAllSchedulableNodes(virtClient).Items
+		Expect(nodes).To(HaveLen(1))
+		testNodeName = nodes[0].Name
 	})
 
 	waitForPod := func(outputPod *k8sv1.Pod, fetchPod func() (*k8sv1.Pod, error)) wait.ConditionFunc {
@@ -165,7 +163,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		}
 		BeforeEach(func() {
 			By("Determining the expected amount of mediated device instances used for the test")
-			expectedInstancesNum = getNumOfInstancesByMdevType(desiredMdevTypeName)
+			expectedInstancesNum = getNumOfInstancesOnNodeByMdevType(testNodeName, desiredMdevTypeName)
 
 			addMdevsConfiguration()
 
@@ -225,7 +223,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 
 		BeforeEach(func() {
 			By("Determining the expected amount of mediated device instances used for the test")
-			expectedInstancesNum = getNumOfInstancesByMdevType(desiredMdevTypeName)
+			expectedInstancesNum = getNumOfInstancesOnNodeByMdevType(testNodeName, desiredMdevTypeName)
 
 			By("Creating a configuration for mediated devices")
 			kv := util.GetCurrentKv(virtClient)
@@ -329,7 +327,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		It("[QUARANTINE] Should override default mdev configuration on a specific node", func() {
 			By("Determining the expected amount of mediated device instances used for the test")
 			newDesiredMdevTypeName := "nvidia-223"
-			newExpectedInstancesNum := getNumOfInstancesByMdevType(newDesiredMdevTypeName)
+			newExpectedInstancesNum := getNumOfInstancesOnNodeByMdevType(testNodeName, newDesiredMdevTypeName)
 
 			By("Creating a configuration for mediated devices")
 			config.MediatedDevicesConfiguration.NodeMediatedDeviceTypes = []v1.NodeMediatedDeviceTypesConfig{
@@ -347,9 +345,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 			Eventually(checkAllMDEVCreated(desiredMdevTypeName, expectedInstancesNum), 3*time.Minute, 15*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
 
 			By("Adding a mdevTestLabel1 that should trigger mdev config change")
-			// There should be only one node in this lane
-			singleNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
-			libnode.AddLabelToNode(singleNode.Name, cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(vmi)), mdevTestLabel)
+			libnode.AddLabelToNode(testNodeName, cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(vmi)), mdevTestLabel)
 
 			By("Creating a Fedora VMI")
 			vmi = tests.NewRandomFedoraVMIWithGuestAgent()
@@ -382,13 +378,12 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		const mdevUUIDPathFmt = "/sys/class/mdev_bus/%s/%s"
 		const mdevTypePathFmt = "/sys/class/mdev_bus/%s/%s/mdev_type"
 
-		var node string
 		var driverPath string
 		var rootPCIId string
 
 		runBashCmd := func(cmd string) (string, string, error) {
 			args := []string{"bash", "-x", "-c", cmd}
-			stdout, stderr, err := tests.ExecuteCommandOnNodeThroughVirtHandler(virtClient, node, args)
+			stdout, stderr, err := tests.ExecuteCommandOnNodeThroughVirtHandler(virtClient, testNodeName, args)
 			stdout = strings.TrimSpace(stdout)
 			stderr = strings.TrimSpace(stderr)
 			return stdout, stderr, err
@@ -419,9 +414,6 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 
 		BeforeEach(func() {
 			Skip("Unbinding older NVIDIA GPUs, such as the Tesla T4 found on vgpu lanes, doesn't work reliably")
-			nodes := libnode.GetAllSchedulableNodes(virtClient).Items
-			Expect(nodes).To(HaveLen(1))
-			node = nodes[0].Name
 			rootPCIId = "none"
 		})
 
@@ -518,63 +510,26 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 	})
 })
 
-// Note: this may not work for non-NVIDIA devices as it relies on `getMaxInstancesOfNVGpu`
-func getNumOfInstancesByMdevType(typeName string) (num uint) {
-	devIDs, err := getSupportedDevIDsByMdevType(typeName)
+// Note: this may not work for non-NVIDIA devices as it relies on `<type-id>/description` which is optional
+//
+//	NVIDIA driver implements the `max_instance` attribute via `description`
+//	$ cat /sys/class/mdev_bus/0000:ab:00.0/mdev_supported_types/nvidia-222/description
+//	num_heads=4, frl_config=45, framebuffer=1024M, max_resolution=5120x2880, max_instance=16
+func getNumOfInstancesOnNodeByMdevType(nodeName string, typeID string) uint {
+	cmd := fmt.Sprintf(`num=0
+	for dev in %s*/%[2]s/%[3]s; do
+	  ins=$(/usr/bin/grep -m1 -oPs '\bmax_instance=\K\d+\b' ${dev}/description)
+	  if [[ -n $ins ]]; then
+	    ((num+=$ins))
+	  fi
+	done
+	echo $num`, mdevBusPath, mdevSupportedTypesDirName, typeID)
+	args := []string{"bash", "-x", "-c", cmd}
+	stdout, err := tests.ExecuteCommandInVirtHandlerPod(nodeName, args)
 	Expect(err).ToNot(HaveOccurred())
 
-	for _, devID := range devIDs {
-		maxIns, err := getMaxInstancesOfNVGpu(devID, typeName)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(maxIns).To(BeNumerically(">", 0))
-		num += maxIns
-	}
-
+	num, err := strconv.ParseUint(strings.TrimSpace(stdout), 10, 0)
+	Expect(err).ToNot(HaveOccurred())
 	Expect(num).To(BeNumerically(">", 0))
-	return num
-}
-
-func getSupportedDevIDsByMdevType(typeName string) ([]string, error) {
-	var devIDs []string
-	devices, err := os.ReadDir(mdevBusPath)
-	if err != nil {
-		return devIDs, err
-	}
-
-	for _, device := range devices {
-		path := filepath.Join(mdevBusPath, device.Name(), mdevSupportedTypesDirName, typeName)
-		if _, err := os.Stat(path); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-			return devIDs, err
-		}
-		devIDs = append(devIDs, device.Name())
-	}
-	return devIDs, nil
-}
-
-// NVIDIA driver implements the `max_instance` attribute via `description`
-// $ cat /sys/class/mdev_bus/0000:ab:00.0/mdev_supported_types/nvidia-222/description
-// num_heads=4, frl_config=45, framebuffer=1024M, max_resolution=5120x2880, max_instance=16
-func getMaxInstancesOfNVGpu(devID string, typeName string) (uint, error) {
-	path := filepath.Join(mdevBusPath, devID, mdevSupportedTypesDirName, typeName, "description")
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if matches := nvMaxInstanceRE.FindStringSubmatch(line); matches != nil {
-			num, err := strconv.ParseUint(matches[1], 10, 0)
-			if err != nil {
-				return 0, err
-			}
-			return uint(num), nil
-		}
-	}
-	return 0, fmt.Errorf("no max_instance is found")
+	return uint(num)
 }


### PR DESCRIPTION
### What this PR does

This is a manual backport of https://github.com/kubevirt/kubevirt/pull/17009 and https://github.com/kubevirt/kubevirt/pull/17280.

It is required to enable an additional GPU on a CI bare-metal node for VEP 109 testing (vGPU Live Migration) without breaking the vgpu lane for older release branches.

Fixes: https://github.com/kubevirt/kubevirt/issues/16732

### Release note
```release-note
NONE
```

