### PR TITLE
feat: Add hotplug disk validation to VM admitter

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -43,6 +43,7 @@ import (
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-api"
 	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	storageadmitters "kubevirt.io/kubevirt/pkg/storage/admitters"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	migrationutil "kubevirt.io/kubevirt/pkg/util/migrations"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
@@ -164,6 +165,11 @@ func (admitter *VMsAdmitter) Admit(ctx context.Context, ar *admissionv1.Admissio
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	} else if len(causes) > 0 {
+		return webhookutils.ToAdmissionResponse(causes)
+	}
+
+	causes = admitter.validateDeclarativeHotplugDisks(ar, vmCopy)
+	if len(causes) > 0 {
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
@@ -457,4 +463,73 @@ func (admitter *VMsAdmitter) validateVolumeRequests(ctx context.Context, vm *v1.
 
 	return nil, nil
 
+}
+
+func (admitter *VMsAdmitter) validateDeclarativeHotplugDisks(ar *admissionv1.AdmissionReview, vm *v1.VirtualMachine) []metav1.StatusCause {
+	if admitter.ClusterConfig.HotplugVolumesEnabled() {
+		return nil
+	}
+
+	oldVolumeNames := make(map[string]struct{})
+	oldDiskNames := make(map[string]struct{})
+	if ar.Request.Operation == admissionv1.Update && ar.Request.OldObject.Raw != nil {
+		oldVM := &v1.VirtualMachine{}
+		if err := json.Unmarshal(ar.Request.OldObject.Raw, oldVM); err == nil {
+			for _, volume := range oldVM.Spec.Template.Spec.Volumes {
+				oldVolumeNames[volume.Name] = struct{}{}
+			}
+			for _, disk := range oldVM.Spec.Template.Spec.Domain.Devices.Disks {
+				oldDiskNames[disk.Name] = struct{}{}
+			}
+		}
+	}
+
+	volumeMap := make(map[string]v1.Volume, len(vm.Spec.Template.Spec.Volumes))
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		volumeMap[volume.Name] = volume
+	}
+
+	newHotplugVolumes := make(map[string]int)
+	for i, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+		volume, ok := volumeMap[disk.Name]
+		if !ok {
+			continue
+		}
+		if !storagetypes.IsDeclarativeHotplugVolume(&volume) {
+			continue
+		}
+		if _, existed := oldVolumeNames[volume.Name]; existed {
+			continue
+		}
+		if _, existed := oldDiskNames[disk.Name]; existed {
+			continue
+		}
+		newHotplugVolumes[volume.Name] = i
+	}
+
+	if len(newHotplugVolumes) == 0 {
+		return nil
+	}
+
+	if !admitter.ClusterConfig.DeclarativeHotplugVolumesEnabled() {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("hotpluggable volumes are defined but the %s feature gate is not enabled", featuregate.DeclarativeHotplugVolumesGate),
+			Field:   k8sfield.NewPath("spec", "template", "spec", "volumes").String(),
+		}}
+	}
+
+	for name, diskIdx := range newHotplugVolumes {
+		d := vm.Spec.Template.Spec.Domain.Devices.Disks[diskIdx]
+		causes := storageadmitters.ValidateHotplugDiskConfiguration(
+			&d, name,
+			"Declarative hotplug",
+			k8sfield.NewPath("spec", "template", "spec", "domain", "devices", "disks").Index(diskIdx).String(),
+		)
+		if len(causes) > 0 {
+			return causes
+		}
+	}
+
+	return nil
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -950,6 +950,290 @@ var _ = Describe("Validating VM Admitter", func() {
 			false),
 	)
 
+	It("should reject hotpluggable volume when DeclarativeHotplugVolumes feature gate is not enabled", func() {
+		vmi := api.NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name:       "hotplugdisk",
+			DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{Bus: "scsi"}},
+		})
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "hotplugdisk",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+					Hotpluggable:                      true,
+				},
+			},
+		})
+
+		vm := &v1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmi.Name,
+				Namespace: vmi.Namespace,
+			},
+			Spec: v1.VirtualMachineSpec{
+				Running: pointer.P(false),
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				},
+			},
+		}
+
+		resp := admitVm(vmsAdmitter, vm)
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(resp.Result.Message).To(ContainSubstring("feature gate is not enabled"))
+	})
+
+	DescribeTable("should validate declarative hotplug disk configuration", func(disk v1.Disk, volume v1.Volume, isValid bool) {
+		enableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
+		DeferCleanup(disableFeatureGates)
+
+		vmi := api.NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
+
+		vm := &v1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmi.Name,
+				Namespace: vmi.Namespace,
+			},
+			Spec: v1.VirtualMachineSpec{
+				Running: pointer.P(false),
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				},
+			},
+		}
+
+		resp := admitVm(vmsAdmitter, vm)
+		Expect(resp.Allowed).To(Equal(isValid))
+	},
+		Entry("should accept disk with scsi bus",
+			v1.Disk{
+				Name: "hotplugdisk",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "scsi"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			true),
+		Entry("should accept disk with virtio bus",
+			v1.Disk{
+				Name: "hotplugdisk",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "virtio"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			true),
+		Entry("should accept LUN with scsi bus",
+			v1.Disk{
+				Name: "hotpluglun",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{Bus: "scsi"},
+				},
+			},
+			v1.Volume{
+				Name: "hotpluglun",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			true),
+		Entry("should reject disk with sata bus",
+			v1.Disk{
+				Name: "hotplugdisk",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "sata"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			false),
+		Entry("should reject disk with usb bus",
+			v1.Disk{
+				Name: "hotplugdisk",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "usb"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			false),
+		Entry("should reject LUN with virtio bus",
+			v1.Disk{
+				Name: "hotpluglun",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{Bus: "virtio"},
+				},
+			},
+			v1.Volume{
+				Name: "hotpluglun",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			false),
+		Entry("should reject CDRom device type",
+			v1.Disk{
+				Name: "hotplugcdrom",
+				DiskDevice: v1.DiskDevice{
+					CDRom: &v1.CDRomTarget{Bus: "scsi"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugcdrom",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			false),
+		Entry("should skip validation for non-hotpluggable volume",
+			v1.Disk{
+				Name: "regulardisk",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "sata"},
+				},
+			},
+			v1.Volume{
+				Name: "regulardisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      false,
+					},
+				},
+			},
+			true),
+		Entry("should accept DataVolume hotplug with scsi bus",
+			v1.Disk{
+				Name: "hotplugdv",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "scsi"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdv",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name:         "test-dv",
+						Hotpluggable: true,
+					},
+				},
+			},
+			true),
+		Entry("should reject DataVolume hotplug with sata bus",
+			v1.Disk{
+				Name: "hotplugdv",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "sata"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdv",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name:         "test-dv",
+						Hotpluggable: true,
+					},
+				},
+			},
+			false),
+		Entry("should reject dedicated IOThreads without virtio bus",
+			v1.Disk{
+				Name:              "hotplugdisk",
+				DedicatedIOThread: pointer.P(true),
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "scsi"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			false),
+		Entry("should accept dedicated IOThreads with virtio bus",
+			v1.Disk{
+				Name:              "hotplugdisk",
+				DedicatedIOThread: pointer.P(true),
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "virtio"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			true),
+		Entry("should reject invalid boot order",
+			v1.Disk{
+				Name:      "hotplugdisk",
+				BootOrder: pointer.P(uint(0)),
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{Bus: "scsi"},
+				},
+			},
+			v1.Volume{
+				Name: "hotplugdisk",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+						Hotpluggable:                      true,
+					},
+				},
+			},
+			false),
+	)
+
 	Context("with Volume", func() {
 
 		BeforeEach(func() {

--- a/tests/objectgraph_test.go
+++ b/tests/objectgraph_test.go
@@ -162,8 +162,10 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 			hotplugOptions := &v1.AddVolumeOptions{
 				Name: hotplugPVC.Name,
 				Disk: &v1.Disk{
-					DiskDevice: v1.DiskDevice{},
-					Serial:     hotplugPVC.Name,
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
+					},
+					Serial: hotplugPVC.Name,
 				},
 				VolumeSource: &v1.HotplugVolumeSource{
 					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR expands the vm admitter to handle hotplugged disks when using DeclarativeHotplugVolumes.

#### Before this PR:
The validation was done on vmi level, propagating error to vm's status.
#### After this PR:
The change is rejected, providing an error message to the user.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
This validation is needed in order for the kubevirt toolset in kubernetes-mcp-server to understand if and why the
hotplug is failing. Whether due to disabled feature gate or invalid disk/bus combination.

This validation is already in place in vmi admitter, when using the deprecated HotplugVolumes featuregate.
### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

