### PR TITLE
tests: add fallback for testing-infra manifests path

### DIFF
--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -106,6 +106,10 @@ func SynchronizedBeforeTestSetup() []byte {
 	}
 
 	if flags.DeployTestingInfrastructureFlag {
+		manifests := GetListOfManifests()
+		Expect(manifests).NotTo(BeEmpty(),
+			fmt.Sprintf("-deploy-testing-infra: no *.yaml found (resolved from -path-to-testing-infra-manifests=%q; see testsuite/manifest.go)",
+				flags.PathToTestingInfrastrucureManifests))
 		WipeTestingInfrastructure()
 		DeployTestingInfrastructure()
 	}
@@ -375,7 +379,7 @@ func getKWOKNodeCount() int {
 
 func deployOrWipeTestingInfrastrucure(actionOnObject func(unstructured.Unstructured) error) {
 	// Deploy / delete test infrastructure / dependencies
-	manifests := GetListOfManifests(flags.PathToTestingInfrastrucureManifests)
+	manifests := GetListOfManifests()
 	for _, manifest := range manifests {
 		objects := ReadManifestYamlFile(manifest)
 		for _, obj := range objects {

--- a/tests/testsuite/manifest.go
+++ b/tests/testsuite/manifest.go
@@ -43,9 +43,56 @@ import (
 	"kubevirt.io/client-go/log"
 
 	putil "kubevirt.io/kubevirt/pkg/util"
+
+	"kubevirt.io/kubevirt/tests/flags"
 )
 
-func GetListOfManifests(pathToManifestsDir string) []string {
+// tryBinaryRelative returns _out/manifests/testing relative to the test binary’s directory, or "" if not present.
+func tryBinaryRelative() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	candidate := filepath.Join(filepath.Dir(exe), "..", "_out", "manifests", "testing")
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		return candidate
+	}
+	return ""
+}
+
+// tryCwdRelative returns _out/manifests/testing relative to the current working directory, or "" if not present.
+func tryCwdRelative() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	candidate := filepath.Join(cwd, "_out", "manifests", "testing")
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		return candidate
+	}
+	return ""
+}
+
+// resolveManifestsDir returns a valid manifests dir, or "" if none found.
+func resolveManifestsDir(pathToManifestsDir string) string {
+	if info, err := os.Stat(pathToManifestsDir); err == nil && info.IsDir() {
+		return pathToManifestsDir
+	}
+	if p := tryBinaryRelative(); p != "" {
+		return p
+	}
+	if p := tryCwdRelative(); p != "" {
+		return p
+	}
+	fmt.Printf("WARNING: no valid testing manifests directory found. Skipping testing infra deployment.\n")
+	return ""
+}
+
+func GetListOfManifests() []string {
+	pathToManifestsDir := resolveManifestsDir(flags.PathToTestingInfrastrucureManifests)
+	if pathToManifestsDir == "" {
+		return nil
+	}
 	var manifests []string
 	matchFileName := func(pattern, filename string) bool {
 		match, err := filepath.Match(pattern, filename)


### PR DESCRIPTION
#### Before this PR:
- The test binary used only the path from `--path-to-testing-infra-manifests` (default: `manifests/testing`).
- `GetListOfManifests` did not check if that path existed and did not try any other location.
- If the path was missing or invalid (e.g. default when the directory does not exist, or when the caller does not pass the flag), `filepath.Walk` failed and the code panicked.
- The entire test run aborted in `[SynchronizedBeforeSuite]` with:
  - `ERROR: Cannot access a path "manifests/testing": lstat manifests/testing: no such file or directory`
  - `panic: lstat manifests/testing: no such file or directory`
This broke runs where the test binary is executed from a host.

#### After this PR:
- If the given path exists and is a directory, it is used unchanged.
- If the path is missing or not a directory, the code tries in order:
  1. `_out/manifests/testing` relative to the test binary’s directory (e.g. `.../bin/tests.test` → `.../_out/manifests/testing`).
  2. `_out/manifests/testing` relative to the current working directory.
- If no valid directory is found, the function returns an empty list instead of panicking; no testing-infra manifests are applied and the suite continues.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

