### PR TITLE
virt-controller: fix logic on weird migration unit test

### DIFF
--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -1967,7 +1967,12 @@ var _ = Describe("Migration watcher", func() {
 				Failed:       false,
 				Completed:    true,
 			}
+			// Create the completed migration object but don't add it to the controller queue
+			_, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(completedMigration.Namespace).Create(context.Background(), completedMigration, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
 			runningMigration := newMigration("running-migration", vmi.Name, v1.MigrationRunning)
+			addMigration(runningMigration)
 
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				MigrationUID:                   runningMigration.UID,
@@ -1975,18 +1980,12 @@ var _ = Describe("Migration watcher", func() {
 				SourceNode:                     "node02",
 				TargetNodeAddress:              "10.10.10.10:1234",
 				StartTimestamp:                 pointer.P(metav1.Now()),
-				EndTimestamp:                   pointer.P(metav1.Now()),
 				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
-				Failed:                         false,
-				Completed:                      true,
 			}
 
-			addMigration(completedMigration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
-			addPod(newTargetPodForVirtualMachine(vmi, completedMigration, k8sv1.PodRunning))
-
-			addMigration(runningMigration)
+			addPod(newTargetPodForVirtualMachine(vmi, runningMigration, k8sv1.PodRunning))
 
 			sanityExecute()
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The migration controller gets executed against the completed migration instead of the running one

#### After this PR:
The migration controller runs against the running migration.
The test still doesn't make much sense to me, but at least it's coherent.
Maybe it would be make more sense to have 2 completed migrations? Then the title would need to be adjusted

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
