### PR TITLE
virt-handler/cache: fix deadlock — release watchDogLock before blocking I/O

### DIFF
--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -157,8 +157,18 @@ func (d *domainWatcher) handleResync() {
 			continue
 		}
 
-		d.eventChan <- watch.Event{Type: watch.Modified, Object: domain}
+		select {
+		case d.eventChan <- watch.Event{Type: watch.Modified, Object: domain}:
+		case <-d.stopChan:
+			return
+		}
 	}
+}
+
+// staleDomainEvent groups an event and its originating socket for post-lock processing.
+type staleDomainEvent struct {
+	event  watch.Event
+	socket string
 }
 
 func (d *domainWatcher) handleStaleSocketConnections() error {
@@ -180,15 +190,15 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 		unresponsive = append(unresponsive, socket)
 	}
 
-	d.watchDogLock.Lock()
-	defer d.watchDogLock.Unlock()
+	// Collect work that must happen outside the lock 
+	var pendingEvents []staleDomainEvent
 
+	d.watchDogLock.Lock()
 	now := time.Now().UTC().Unix()
 
 	// Add new unresponsive sockets
 	for _, socket := range unresponsive {
-		_, ok := d.unresponsiveSockets[socket]
-		if !ok {
+		if _, ok := d.unresponsiveSockets[socket]; !ok {
 			d.unresponsiveSockets[socket] = now
 		}
 	}
@@ -211,7 +221,6 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 		diff := now - timeStamp
 
 		if diff > int64(d.watchdogTimeout) {
-
 			record, exists := GhostRecordGlobalStore.findBySocket(key)
 
 			if !exists {
@@ -222,16 +231,28 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 				domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
 				domain.ObjectMeta.UID = record.UID
 				domain.Spec.Metadata.KubeVirt.UID = record.UID
-				now := metav1.Now()
-				domain.ObjectMeta.DeletionTimestamp = &now
+				deletionTime := metav1.Now()
+				domain.ObjectMeta.DeletionTimestamp = &deletionTime
 				log.Log.Object(domain).Warningf("detected unresponsive virt-launcher command socket (%s) for domain", key)
-				d.eventChan <- watch.Event{Type: watch.Modified, Object: domain}
-
-				err := cmdclient.MarkSocketUnresponsive(key)
-				if err != nil {
-					log.Log.Reason(err).Errorf("Unable to mark vmi as unresponsive socket %s", key)
-				}
+				pendingEvents = append(pendingEvents, staleDomainEvent{
+					event:  watch.Event{Type: watch.Modified, Object: domain},
+					socket: key,
+				})
 			}
+		}
+	}
+	d.watchDogLock.Unlock()
+
+	// Send events and mark sockets unresponsive outside the lock 
+	for _, pending := range pendingEvents {
+		select {
+		case d.eventChan <- pending.event:
+		case <-d.stopChan:
+			return nil
+		}
+
+		if err := cmdclient.MarkSocketUnresponsive(pending.socket); err != nil {
+			log.Log.Reason(err).Errorf("Unable to mark vmi as unresponsive socket %s", pending.socket)
 		}
 	}
 


### PR DESCRIPTION


### What this PR does

### Problem                                                                                                       
  
  handleStaleSocketConnections held watchDogLock across two blocking operations:                                
                                                                                                              
  1. d.eventChan <- watch.Event{...} — blocks when the event consumer is slow or the buffer (100 entries) is    
  full.                                                                                                       
  2. cmdclient.MarkSocketUnresponsive(key) — a Unix-socket RPC call that can block.                             
                                                                                                                
  Any goroutine on the node waiting to acquire watchDogLock (e.g. during a domain cache resync) deadlocks,      
  freezing all VMI reconciliation on that node.                                                                 
                                                                                                                
  ### Fix                                                                                                         

  handleStaleSocketConnections: separate the critical section (mutating unresponsiveSockets) from the I/O       
  operations (channel sends, RPC calls).
                                                                                                                
  - Acquire watchDogLock, compute all pending events into a local []staleDomainEvent slice, then explicitly call
   Unlock() (no defer) before the loop that sends events and calls MarkSocketUnresponsive.
  - Channel sends are wrapped in a select on stopChan so the worker exits cleanly.                              
  - A new unexported staleDomainEvent struct keeps the watch.Event and socket key together without heap-escaping
   any lock-protected state.                                                                                    
                                                                                                                
  handleResync: wrap the channel send in a select on stopChan so the worker goroutine is not blocked at         
  shutdown.                                                 
                                                                                                                
  ### Behaviour unchanged                                       

The ordering semantics are identical: the map is updated before any event is emitted, and  MarkSocketUnresponsive is still called after the event is sent, exactly once per timed-out socket per tick.


- Fixes #17183 


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


@orelmisan @0xFelix 

