### PR TITLE
virt-controller/workload-updater: fix data race — use := in abortChangeVMIs goroutine

### DIFF
--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -638,7 +638,7 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 			defer wg.Done()
 			migList := migrationutils.ListWorkloadUpdateMigrations(c.migrationIndexer, vmi.Name, vmi.Namespace)
 			for _, mig := range migList {
-				err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), mig.Name, metav1.DeleteOptions{})
+				err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), mig.Name, metav1.DeleteOptions{})
 				if err != nil && !errors.IsNotFound(err) {
 					log.Log.Object(vmi).Reason(err).Errorf("Failed to delete the migration due to a migration abortion")
 					c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, FailedChangeAbortionReason, "Failed to abort change for vmi: %s: %v", vmi.Name, err)


### PR DESCRIPTION


### What this PR does


### Problem 

WorkloadUpdateController.sync spawns goroutines for three VMI lists: migrationCandidates, evictionCandidates, and abortChangeVMIs. The first two correctly use err := inside their goroutines. The abortChangeVMIs loop  mistakenly uses err =, which assigns into the outer err variable declared at line 464 (key, err := controller.KeyFunc(kv)).                                                                                    

With multiple goroutines running concurrently, every write to err is a data race on the same memory address. The Go race detector reports this as DATA RACE. Depending on scheduling, an error from one goroutine can overwrite another's, causing silent misclassification of abort failures. 


### Fix                                                                                                           
  
  One-character change on line 641: err = → err :=.                                                             
                                                            
This gives each goroutine its own stack-local err. The existing errChan pattern already propagates errors safely across goroutines; this change makes the abortChangeVMIs loop consistent with the other two loops in the same function.         


  
- Fixes #17185

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```



@orelmisan @0xFelix 
