### PR TITLE
tests: enhance failure messages in storage test files.

### DIFF
--- a/tests/storage/cbt.go
+++ b/tests/storage/cbt.go
@@ -81,10 +81,10 @@ var _ = Describe(SIG("CBT", func() {
 
 		By(fmt.Sprintf("Creating VM %s with CBT label", vm.Name))
 		vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred(), "failed to create VirtualMachine")
 		libstorage.WaitForCBTEnabled(virtClient, vm.Namespace, vm.Name)
 		vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 
 		By("Verify CBT overlay exists")
 		stdout := libpod.RunCommandOnVmiPod(vmi, []string{"find", cbt.PathForCBT(vmi), "-type", "f", "-name", fmt.Sprintf("%s.qcow2", volumeName)})
@@ -92,24 +92,24 @@ var _ = Describe(SIG("CBT", func() {
 
 		By("Remove CBT Label")
 		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachine %s/%s", vm.Namespace, vm.Name)
 		delete(vm.Labels, cbt.CBTKey)
 		patch, err := patch.New(patch.WithAdd("/metadata/labels", vm.Labels)).GeneratePayload()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to generate patch payload")
 
 		vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to patch VirtualMachine")
 
 		By("Verify CBT state PendingRestart")
 		Eventually(func() v1.ChangedBlockTrackingState {
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachine %s/%s", vm.Namespace, vm.Name)
 			return cbt.CBTState(vm.Status.ChangedBlockTracking)
 		}, 1*time.Minute, 3*time.Second).Should(Equal(v1.ChangedBlockTrackingPendingRestart))
 
 		By("Restarting the VM")
 		err = virtClient.VirtualMachine(vm.Namespace).Restart(context.Background(), vm.Name, &v1.RestartOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to restart VirtualMachine")
 		Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
 
 		By("Verify CBT state disabled")
@@ -131,16 +131,16 @@ var _ = Describe(SIG("CBT", func() {
 
 		By("Verify CBT overlay deleted")
 		vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 		libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 		pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(pod).NotTo(BeNil())
+		Expect(err).ToNot(HaveOccurred(), "failed to get Pod for VirtualMachineInstance")
+		Expect(pod).NotTo(BeNil(), "expected value to not be nil")
 
 		var cmdOutput string
 		cmdOutput, err = exec.ExecuteCommandOnPod(pod, "compute", []string{"ls", "-d", cbt.PathForCBT(vmi)})
 		Expect(err.Error()).To(ContainSubstring("No such file or directory"))
-		Expect(cmdOutput).To(BeEmpty())
+		Expect(cmdOutput).To(BeEmpty(), "expected output to be empty")
 	})
 
 	DescribeTable("Patch to match cbt label selector", func(patchFunc func(vm *v1.VirtualMachine)) {
@@ -155,37 +155,37 @@ var _ = Describe(SIG("CBT", func() {
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
 		_, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")
 		Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
 		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachine %s/%s", vm.Namespace, vm.Name)
 		Expect(cbt.CBTState(vm.Status.ChangedBlockTracking)).To(Equal(v1.ChangedBlockTrackingUndefined))
 
 		patchFunc(vm)
 
 		Eventually(func() v1.ChangedBlockTrackingState {
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachine %s/%s", vm.Namespace, vm.Name)
 			return cbt.CBTState(vm.Status.ChangedBlockTracking)
 		}, 1*time.Minute, 3*time.Second).Should(Equal(v1.ChangedBlockTrackingPendingRestart))
 
 		By("Restarting the VM")
 		err = virtClient.VirtualMachine(vm.Namespace).Restart(context.Background(), vm.Name, &v1.RestartOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to restart VirtualMachine")
 
 		libstorage.WaitForCBTEnabled(virtClient, vm.Namespace, vm.Name)
 		vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 
 		stdout := libpod.RunCommandOnVmiPod(vmi, []string{"find", cbt.PathForCBT(vmi), "-type", "f", "-name", fmt.Sprintf("%s.qcow2", volumeName)})
 		Expect(stdout).To(ContainSubstring(cbt.GetQCOW2OverlayPath(vmi, volumeName)))
 	},
 		Entry("patch vm", func(vm *v1.VirtualMachine) {
 			patch, err := patch.New(patch.WithAdd("/metadata/labels", cbt.CBTLabel)).GeneratePayload()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to generate patch payload")
 
 			_, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to patch VirtualMachine")
 
 		}),
 		Entry("patch vm namespace", func(vm *v1.VirtualMachine) {
@@ -215,13 +215,13 @@ var _ = Describe(SIG("CBT", func() {
 			)
 
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred(), "failed to create VirtualMachine")
 			Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
 
 			By("Waiting for CBT to be enabled")
 			libstorage.WaitForCBTEnabled(virtClient, vm.Namespace, vm.Name)
 			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 			By(fmt.Sprintf("Creating DataVolume for hotplug with volume mode %s", volumeMode))
@@ -235,7 +235,7 @@ var _ = Describe(SIG("CBT", func() {
 				),
 			)
 			hotplugDV, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Create(context.Background(), hotplugDV, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create DataVolume")
 
 			By("Hotplugging the DataVolume")
 			vm = libstorage.AddHotplugDiskAndVolume(virtClient, vm, hotplugVolumeName, hotplugDV.Name)
@@ -245,7 +245,7 @@ var _ = Describe(SIG("CBT", func() {
 
 			By("Verifying QCOW2 overlay was created for hotplug volume")
 			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 			overlayPath := cbt.GetQCOW2OverlayPath(vmi, hotplugVolumeName)
 			stdout := libpod.RunCommandOnVmiPod(vmi, []string{"find", cbt.PathForCBT(vmi), "-type", "f", "-name", fmt.Sprintf("%s.qcow2", hotplugVolumeName)})
 			Expect(stdout).To(ContainSubstring(overlayPath), "Expected CBT overlay to exist for hotplug volume")
@@ -311,10 +311,10 @@ func runCBTPersistenceTest(virtClient kubecli.KubevirtClient, op string) {
 	volumeName := vm.Spec.Template.Spec.Volumes[0].Name
 
 	vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine for CBT persistence test")
 	Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
 	vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 	By("Verifying CBT is enabled")
@@ -342,24 +342,24 @@ func runCBTPersistenceTest(virtClient kubecli.KubevirtClient, op string) {
 func checkCBTIntegrityForPersistenceTest(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, cbtOverlayPath string) {
 	By("Checking CBT data integrity")
 	vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-	Expect(err).ShouldNot(HaveOccurred())
+	Expect(err).ShouldNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 	pvcName := backendstorage.CurrentPVCName(vmi)
 	Expect(pvcName).ToNot(BeEmpty(), "Backend storage PVC name should not be empty")
 	vm = libvmops.StopVirtualMachine(vm)
 	pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), pvcName, metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "failed to get PersistentVolumeClaim")
 	pod := libstorage.RenderPodWithPVC(
 		"cbt-consumer-"+rand.String(5),
 		[]string{"/bin/bash", "-c", "touch /tmp/startup; while true; do echo hello; sleep 2; done"},
 		nil, pvc,
 	)
 	pod, err = libpod.Run(pod, vm.Namespace)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to run Pod")
 	containerName := pod.Spec.Containers[0].Name
 	stdout, err := exec.ExecuteCommandOnPod(pod, containerName, []string{"/bin/sh", "-c", fmt.Sprintf("qemu-img info %s/%s", libstorage.DefaultPvcMountPath, cbtOverlayPath)})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "failed to execute command on Pod")
 	By("Verifying qcow2 file is not corrupted")
 	Expect(stdout).To(ContainSubstring("corrupt: false"))
 	err = virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "failed to delete Pod")
 }

--- a/tests/storage/configuration.go
+++ b/tests/storage/configuration.go
@@ -62,7 +62,7 @@ var _ = Describe("[sig-storage] Storage configuration", decorators.SigStorage, d
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc), libdv.StorageWithBlockVolumeMode()),
 			)
 			dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create DataVolume")
 			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 
 			vmi := libvmi.New(
@@ -76,7 +76,7 @@ var _ = Describe("[sig-storage] Storage configuration", decorators.SigStorage, d
 
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsSmall)
 			runningVMISpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get running VMI domain spec")
 
 			disks := runningVMISpec.Devices.Disks
 			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -69,7 +69,7 @@ var _ = Describe(SIG("K8s IO events", Serial, func() {
 		removeFaultyDisk(nodeName, deviceName)
 
 		err := virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to delete PersistentVolume")
 	})
 	It("[test_id:6225]Should catch the IO error event", func() {
 		By("Creating VMI with faulty disk")
@@ -140,7 +140,7 @@ func executeDeviceMapperOnNode(nodeName string, cmd []string) {
 		},
 	}
 	pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Create(context.Background(), pod, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "failed to create Pod")
 
 	Eventually(matcher.ThisPod(pod), 30).Should(matcher.HaveSucceeded())
 }

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -84,15 +84,15 @@ var _ = Describe(SIG("Memory dump", func() {
 		By("Creating VirtualMachine")
 		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")
 		Eventually(func() bool {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
 				return false
 			}
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vm.Namespace, vm.Name)
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine %s/%s", vm.Namespace, vm.Name)
 			return vm.Status.Ready && vmi.Status.Phase == v1.Running
 		}, 180*time.Second, time.Second).Should(BeTrue())
 
@@ -149,7 +149,7 @@ var _ = Describe(SIG("Memory dump", func() {
 			}
 
 			if updatedVM.Status.MemoryDumpRequest.Phase != v1.MemoryDumpCompleted {
-				return fmt.Errorf(fmt.Sprintf(waitMemoryDumpCompletion, updatedVM.Status.MemoryDumpRequest.Phase))
+				return fmt.Errorf(waitMemoryDumpCompletion, updatedVM.Status.MemoryDumpRequest.Phase)
 			}
 
 			foundPvc := false
@@ -212,7 +212,7 @@ var _ = Describe(SIG("Memory dump", func() {
 		)
 		lsOutput = strings.TrimSpace(lsOutput)
 		log.Log.Infof("%s", lsOutput)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to execute command on Pod")
 		wcOutput, err := exec.ExecuteCommandOnPod(
 			executorPod,
 			executorPod.Spec.Containers[0].Name,
@@ -220,7 +220,7 @@ var _ = Describe(SIG("Memory dump", func() {
 		)
 		wcOutput = strings.TrimSpace(wcOutput)
 		log.Log.Infof("%s", wcOutput)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to execute command on Pod")
 
 		Expect(strings.Contains(lsOutput, "memory.dump")).To(BeTrue())
 		// Could be that a 'lost+found' directory is in it, check if the
@@ -263,7 +263,7 @@ var _ = Describe(SIG("Memory dump", func() {
 		waitAndVerifyMemoryDumpCompletion(vm, pvcName)
 		verifyMemoryDumpNotOnVMI(vm, pvcName)
 		pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.NamespaceTestDefault).Get(context.Background(), pvcName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get PersistentVolumeClaim")
 
 		return verifyMemoryDumpOutput(pvc, previousOutput, false)
 	}
@@ -273,7 +273,7 @@ var _ = Describe(SIG("Memory dump", func() {
 		removeMemoryDumpFunc(vm.Name, vm.Namespace)
 		waitAndVerifyMemoryDumpDissociation(vm, pvcName)
 		pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.NamespaceTestDefault).Get(context.Background(), pvcName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get PersistentVolumeClaim")
 		// Verify the content is still on the pvc
 		verifyMemoryDumpOutput(pvc, previousOutput, true)
 	}
@@ -381,7 +381,7 @@ var _ = Describe(SIG("Memory dump", func() {
 			memoryDumpPVC2 = libstorage.NewPVC(memoryDumpPVCName2, memoryDumpPVCSize, "no-exist")
 			memoryDumpPVC2.Namespace = vm.Namespace
 			memoryDumpPVC2, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Create(context.Background(), memoryDumpPVC2, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create PersistentVolumeClaim")
 			memoryDumpVMSubresource(vm.Name, vm.Namespace, memoryDumpPVC2.Name)
 
 			By("Wait memory dump in progress")
@@ -391,7 +391,7 @@ var _ = Describe(SIG("Memory dump", func() {
 					return err
 				}
 				if updatedVM.Status.MemoryDumpRequest == nil || updatedVM.Status.MemoryDumpRequest.Phase != v1.MemoryDumpInProgress {
-					return fmt.Errorf(fmt.Sprintf(waitMemoryDumpInProgress, updatedVM.Status.MemoryDumpRequest.Phase))
+					return fmt.Errorf(waitMemoryDumpInProgress, updatedVM.Status.MemoryDumpRequest.Phase)
 				}
 
 				return nil
@@ -401,7 +401,7 @@ var _ = Describe(SIG("Memory dump", func() {
 			removeMemoryDumpVMSubresource(vm.Name, vm.Namespace)
 			waitAndVerifyMemoryDumpDissociation(vm, memoryDumpPVCName)
 			memoryDumpPVC2, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), memoryDumpPVC2.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get PersistentVolumeClaim")
 			if memoryDumpPVC2.Annotations != nil {
 				Expect(memoryDumpPVC2.Annotations[v1.PVCMemoryDumpAnnotation]).To(BeNil())
 			}

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -73,7 +73,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 	executeTargetCli := func(podName string, args []string) {
 		cmd := append([]string{"/usr/bin/targetcli"}, args...)
 		pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get Pod")
 
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli", cmd)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("command='targetcli %v' stdout='%s' stderr='%s'", args, stdout, stderr))
@@ -91,7 +91,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 		// Create targetcli container
 		By("Create targetcli pod")
 		pod, err := libpod.Run(libpod.RenderTargetcliPod(podName, pvc), testsuite.NamespacePrivileged)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to run Pod")
 		node = pod.Spec.NodeName
 		// The vm-killer image is built with bazel and the /etc/ld.so.cache isn't built
 		// at the package installation. The targetcli utility relies on ctype python package that
@@ -99,7 +99,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 		// To fix this issue, we run ldconfig before targetcli
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli", []string{"ldconfig"})
 		By(fmt.Sprintf("ldconfig: stdout: %v stderr: %v", stdout, stderr))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to run ldconfig on targetcli pod")
 
 		// Create backend file. Let some room for metedata and create a
 		// slightly smaller backend image, we use 800M instead of 1G. In
@@ -124,7 +124,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 	findSCSIdisk := func(podName string, model string) string {
 		var device string
 		pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get Pod")
 
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli",
 			[]string{"/bin/lsblk", "--scsi", "-o", "NAME,MODEL", "-p", "-n"})
@@ -150,20 +150,20 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 			&expect.BSnd{S: fmt.Sprintf("%s\n", cmd)},
 			&expect.BExp{R: ""},
 		}, 20)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to execute console batch command")
 		return strings.Contains(res[0].Output, output)
 	}
 
 	waitForVirtHandlerWithPrHelperReadyOnNode := func(node string) {
 		ready := false
 		fieldSelector, err := fields.ParseSelector("spec.nodeName==" + string(node))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to parse field selector")
 		labelSelector, err := labels.Parse(fmt.Sprintf(v1.AppLabel + "=virt-handler"))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to parse label selector")
 		selector := metav1.ListOptions{FieldSelector: fieldSelector.String(), LabelSelector: labelSelector.String()}
 		Eventually(func() bool {
 			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), selector)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to list Pods")
 			if len(pods.Items) < 1 {
 				return false
 			}
@@ -186,7 +186,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 	BeforeEach(func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get KubeVirt client")
 		fgDisabled = !checks.HasFeature(featuregate.PersistentReservation)
 		if fgDisabled {
 			config.EnableFeatureGate(featuregate.PersistentReservation)
@@ -211,10 +211,10 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 			// Avoid races if there is some delay in the device creation
 			Eventually(findSCSIdisk, 20*time.Second, 1*time.Second).WithArguments(targetCliPod, backendDisk).ShouldNot(BeEmpty())
 			device = findSCSIdisk(targetCliPod, backendDisk)
-			Expect(device).ToNot(BeEmpty())
+			Expect(device).ToNot(BeEmpty(), "expected SCSI device to be found")
 			By(fmt.Sprintf("Create PVC with SCSI disk %s", device))
 			pv, pvc, err = CreatePVandPVCwithSCSIDisk(node, device, testsuite.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create PV and PVC")
 			waitForVirtHandlerWithPrHelperReadyOnNode(node)
 			// Switching the PersistentReservation feature gate on/off
 			// causes redeployment of all KubeVirt components.
@@ -240,7 +240,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				libvmi.WithNodeAffinityFor(node),
 			)
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachineInstance with SCSI disk")
 			libwait.WaitForSuccessfulVMIStart(vmi,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
@@ -263,11 +263,11 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 			// Restart virt-handler
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(),
 				vmi.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", testsuite.GetTestNamespace(vmi), vmi.Name)
 			pod, err := libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get virt-handler Pod")
 			err = virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to delete Pod")
 			// Wait unti new handler pod is ready
 			oldPodName := pod.Name
 			Eventually(func(g Gomega) bool {
@@ -296,7 +296,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				libvmi.WithNodeAffinityFor(node),
 			)
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create VMI with the SCSI disk")
 			libwait.WaitForSuccessfulVMIStart(vmi,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
@@ -308,7 +308,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				libvmi.WithNodeAffinityFor(node),
 			)
 			vmi2, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi2)).Create(context.Background(), vmi2, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create second VirtualMachineInstance with SCSI disk")
 			libwait.WaitForSuccessfulVMIStart(vmi2,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
@@ -373,7 +373,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 						libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"touch", mpathSocket})
 						DeferCleanup(func() {
 							_, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"rm", "-f", mpathSocket})
-							Expect(err).ToNot(HaveOccurred())
+							Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to remove fake multipathd.socket in node %s", node.Name))
 						})
 					}
 				}
@@ -384,7 +384,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				for _, node := range nodes.Items {
 					Eventually(func(g Gomega) {
 						output, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"cat", "/proc/mounts"})
-						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(err).ToNot(HaveOccurred(), "failed to execute command in virt-handler pod on node %s", node.Name)
 						g.Expect(strings.Count(output, "multipathd.socket")).Should(Equal(1),
 							"the multipathd socket should be mounted only once")
 					}).

--- a/tests/storage/utility-volumes.go
+++ b/tests/storage/utility-volumes.go
@@ -62,7 +62,7 @@ func getKubevirtControllerClient(virtCli kubecli.KubevirtClient, namespace strin
 	}
 
 	client, err := kubecli.GetKubevirtClientFromRESTConfig(impersonationConfig)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "failed to get KubeVirt client")
 	return client
 }
 
@@ -143,11 +143,11 @@ var _ = Describe(SIG("Utility Volumes", func() {
 
 			vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 			vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")
 			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
 
 			vmi, err = virtClient.VirtualMachineInstance(testNamespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", testNamespace, vm.Name)
 		})
 
 		It("should successfully hotplug and unhotplug a utility volume", func() {
@@ -156,9 +156,9 @@ var _ = Describe(SIG("Utility Volumes", func() {
 			verifyUtilityVolumeInVMISpec(virtClient, vmi, utilityVolumeName)
 			libstorage.VerifyVolumeStatus(virtClient, vmi, v1.HotplugVolumeMounted, "", false, utilityVolumeName)
 			vmi, err := virtClient.VirtualMachineInstance(testNamespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", testNamespace, vmi.Name)
 			attachmentPodName := libstorage.AttachmentPodName(vmi)
-			Expect(attachmentPodName).ToNot(BeEmpty())
+			Expect(attachmentPodName).ToNot(BeEmpty(), "expected attachment pod name to not be empty")
 			removeUtilityVolume(vmi.Name, testNamespace)
 			verifyUtilityVolumeRemovedFromVMI(virtClient, vmi, utilityVolumeName)
 			Eventually(matcher.ThisPodWith(vmi.Namespace, attachmentPodName), 90*time.Second, 1*time.Second).Should(matcher.BeGone())
@@ -187,11 +187,11 @@ var _ = Describe(SIG("Utility Volumes", func() {
 
 			vm := libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 			vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")
 			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
 
 			vmi, err = virtClient.VirtualMachineInstance(testNamespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", testNamespace, vm.Name)
 		})
 
 		It("should wait utility volumes detach before scheduling migration", func() {
@@ -208,14 +208,14 @@ var _ = Describe(SIG("Utility Volumes", func() {
 
 			Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
 				migration, err = virtClient.VirtualMachineInstanceMigration(testNamespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstanceMigration")
 				return migration.Status.Phase
 			}, 30*time.Second, 1*time.Second).Should(Equal(v1.MigrationPending))
 
 			// Verify condition is set to indicate utility volumes are blocking
 			Eventually(func() bool {
 				migration, err = virtClient.VirtualMachineInstanceMigration(testNamespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstanceMigration")
 				for _, condition := range migration.Status.Conditions {
 					if condition.Type == v1.VirtualMachineInstanceMigrationBlockedByUtilityVolumes &&
 						condition.Status == k8sv1.ConditionTrue {
@@ -234,7 +234,7 @@ var _ = Describe(SIG("Utility Volumes", func() {
 			// Verify condition is removed after utility volumes are detached
 			Eventually(func() bool {
 				migration, err = virtClient.VirtualMachineInstanceMigration(testNamespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstanceMigration")
 				for _, condition := range migration.Status.Conditions {
 					if condition.Type == v1.VirtualMachineInstanceMigrationBlockedByUtilityVolumes {
 						return false
@@ -246,13 +246,13 @@ var _ = Describe(SIG("Utility Volumes", func() {
 			// Wait for migration to succeed
 			Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
 				migration, err := virtClient.VirtualMachineInstanceMigration(testNamespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstanceMigration")
 				return migration.Status.Phase
 			}, 240*time.Second, 1*time.Second).Should(Equal(v1.MigrationSucceeded))
 
 			// Verify VM migrated to a different node
 			vmi, err = virtClient.VirtualMachineInstance(testNamespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", testNamespace, vmi.Name)
 			targetNode := vmi.Status.NodeName
 			Expect(targetNode).ToNot(Equal(sourceNode))
 
@@ -260,7 +260,7 @@ var _ = Describe(SIG("Utility Volumes", func() {
 			pods, err := virtClient.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("kubevirt.io/created-by=%s", vmi.UID),
 			})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to list Pods")
 
 			for _, pod := range pods.Items {
 				if pod.Spec.NodeName == targetNode {
@@ -303,7 +303,7 @@ func verifyUtilityVolumeInVMISpec(virtClient kubecli.KubevirtClient, vmi *v1.Vir
 func verifyUtilityVolumeRemovedFromVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, utilityVolumeName string) {
 	Eventually(func() bool {
 		currentVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vmi.Namespace, vmi.Name)
 
 		for _, utilityVolume := range currentVMI.Spec.UtilityVolumes {
 			if utilityVolume.Name == utilityVolumeName {
@@ -315,7 +315,7 @@ func verifyUtilityVolumeRemovedFromVMI(virtClient kubecli.KubevirtClient, vmi *v
 
 	Eventually(func() bool {
 		currentVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachineInstance %s/%s", vmi.Namespace, vmi.Name)
 
 		for _, volumeStatus := range currentVMI.Status.VolumeStatus {
 			if volumeStatus.Name == utilityVolumeName {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The e2e storage tests in several smaller test files (reservation.go, cbt.go, declarative-hotplug.go, utility-volumes.go, memorydump.go, events.go, and configuration.go) contained approximately 90 bare Gomega assertions (e.g., Expect(err).ToNot(HaveOccurred())). When these assertions failed in CI, they produced generic stack traces without detailing *which* operation failed or on *which* specific resource, making debugging flaky tests difficult.

#### After this PR:
Added descriptive, context-aware failure messages to all bare Gomega assertions across these 7 storage test files.:
1. Operations specify the exact action being performed (e.g., "failed to get VirtualMachineInstance" instead of just "unexpected error").
2. Resource namespace and name are consistently included where available to provide immediate context in log outputs.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Partially addresses #10347

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
This PR extends the enhancements to the rest of the smaller storage test files in a single batch following #17150 . 

### Special notes for your reviewer
None

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```