### PR TITLE
test: add unit tests for serial console log, virt-handler controller, and guest agent

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "rendercontainer_test.go",
         "renderresources_test.go",
         "rendervolumes_test.go",
+        "serialconsolelog_test.go",
         "services_suite_test.go",
         "template_test.go",
         "virtiofs_test.go",

--- a/pkg/virt-controller/services/serialconsolelog_test.go
+++ b/pkg/virt-controller/services/serialconsolelog_test.go
@@ -1,0 +1,206 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package services
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+)
+
+func newClusterConfigWithSerialConsoleLog(disabled bool) *virtconfig.ClusterConfig {
+	kvConfig := &v1.KubeVirtConfiguration{
+		DeveloperConfiguration: &v1.DeveloperConfiguration{},
+	}
+	if disabled {
+		kvConfig.VirtualMachineOptions = &v1.VirtualMachineOptions{
+			DisableSerialConsoleLog: &v1.DisableSerialConsoleLog{},
+		}
+	}
+	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kvConfig)
+	return config
+}
+
+var _ = Describe("Serial Console Log", func() {
+
+	Context("isSerialConsoleLogEnabled", func() {
+		It("should return true when no VMI overrides are set and config enables it", func() {
+			vmi := &v1.VirtualMachineInstance{}
+			config := newClusterConfigWithSerialConsoleLog(false)
+			Expect(isSerialConsoleLogEnabled(vmi, config)).To(BeTrue())
+		})
+
+		It("should return false when config disables serial console log", func() {
+			vmi := &v1.VirtualMachineInstance{}
+			config := newClusterConfigWithSerialConsoleLog(true)
+			Expect(isSerialConsoleLogEnabled(vmi, config)).To(BeFalse())
+		})
+
+		It("should return false when AutoattachSerialConsole is false", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							AutoattachSerialConsole: pointer.P(false),
+						},
+					},
+				},
+			}
+			config := newClusterConfigWithSerialConsoleLog(false)
+			Expect(isSerialConsoleLogEnabled(vmi, config)).To(BeFalse())
+		})
+
+		It("should return true when LogSerialConsole is explicitly true", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							LogSerialConsole: pointer.P(true),
+						},
+					},
+				},
+			}
+			// Even with config disabled, VMI-level override wins
+			config := newClusterConfigWithSerialConsoleLog(true)
+			Expect(isSerialConsoleLogEnabled(vmi, config)).To(BeTrue())
+		})
+
+		It("should return false when LogSerialConsole is explicitly false", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							LogSerialConsole: pointer.P(false),
+						},
+					},
+				},
+			}
+			config := newClusterConfigWithSerialConsoleLog(false)
+			Expect(isSerialConsoleLogEnabled(vmi, config)).To(BeFalse())
+		})
+
+		It("should return false when AutoattachSerialConsole is false even if LogSerialConsole is true", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							AutoattachSerialConsole: pointer.P(false),
+							LogSerialConsole:        pointer.P(true),
+						},
+					},
+				},
+			}
+			config := newClusterConfigWithSerialConsoleLog(false)
+			Expect(isSerialConsoleLogEnabled(vmi, config)).To(BeFalse())
+		})
+	})
+
+	Context("resourcesForSerialConsoleLogContainer", func() {
+		It("should return default resources when no overrides are configured", func() {
+			config := newClusterConfigWithSerialConsoleLog(false)
+			resources := resourcesForSerialConsoleLogContainer(false, false, config)
+
+			Expect(resources.Requests[k8sv1.ResourceMemory]).To(Equal(resource.MustParse("35M")))
+			Expect(resources.Requests[k8sv1.ResourceCPU]).To(Equal(resource.MustParse("5m")))
+			Expect(resources.Limits[k8sv1.ResourceMemory]).To(Equal(resource.MustParse("60M")))
+			Expect(resources.Limits[k8sv1.ResourceCPU]).To(Equal(resource.MustParse("15m")))
+		})
+
+		It("should equalize requests and limits for dedicated CPUs", func() {
+			config := newClusterConfigWithSerialConsoleLog(false)
+			resources := resourcesForSerialConsoleLogContainer(true, false, config)
+
+			Expect(resources.Requests[k8sv1.ResourceCPU]).To(Equal(resources.Limits[k8sv1.ResourceCPU]))
+			Expect(resources.Requests[k8sv1.ResourceMemory]).To(Equal(resources.Limits[k8sv1.ResourceMemory]))
+		})
+
+		It("should equalize requests and limits for guaranteed QOS", func() {
+			config := newClusterConfigWithSerialConsoleLog(false)
+			resources := resourcesForSerialConsoleLogContainer(false, true, config)
+
+			Expect(resources.Requests[k8sv1.ResourceCPU]).To(Equal(resources.Limits[k8sv1.ResourceCPU]))
+			Expect(resources.Requests[k8sv1.ResourceMemory]).To(Equal(resources.Limits[k8sv1.ResourceMemory]))
+		})
+
+		It("should not equalize requests and limits when neither dedicated CPU nor guaranteed QOS", func() {
+			config := newClusterConfigWithSerialConsoleLog(false)
+			resources := resourcesForSerialConsoleLogContainer(false, false, config)
+
+			Expect(resources.Requests[k8sv1.ResourceMemory]).ToNot(Equal(resources.Limits[k8sv1.ResourceMemory]))
+			Expect(resources.Requests[k8sv1.ResourceCPU]).ToNot(Equal(resources.Limits[k8sv1.ResourceCPU]))
+		})
+	})
+
+	Context("generateSerialConsoleLogContainer", func() {
+		It("should return nil when serial console log is disabled", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							AutoattachSerialConsole: pointer.P(false),
+						},
+					},
+				},
+			}
+			config := newClusterConfigWithSerialConsoleLog(false)
+			container := generateSerialConsoleLogContainer(vmi, "test-image", config, 1)
+			Expect(container).To(BeNil())
+		})
+
+		It("should return a valid container when serial console log is enabled", func() {
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "test-uid",
+				},
+			}
+			config := newClusterConfigWithSerialConsoleLog(false)
+			container := generateSerialConsoleLogContainer(vmi, "test-image", config, 2)
+			Expect(container).ToNot(BeNil())
+			Expect(container.Name).To(Equal("guest-console-log"))
+			Expect(container.Image).To(Equal("test-image"))
+			Expect(container.Command).To(Equal([]string{"/usr/bin/virt-tail"}))
+			Expect(container.Args).To(ContainElement("--logfile"))
+		})
+
+		It("should set security context with non-root user", func() {
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "test-uid",
+				},
+			}
+			config := newClusterConfigWithSerialConsoleLog(false)
+			container := generateSerialConsoleLogContainer(vmi, "test-image", config, 1)
+			Expect(container).ToNot(BeNil())
+			Expect(container.SecurityContext).ToNot(BeNil())
+			Expect(*container.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(*container.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(container.SecurityContext.Capabilities.Drop).To(ContainElement(k8sv1.Capability("ALL")))
+		})
+	})
+})

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -82,6 +82,8 @@ go_test(
     timeout = "long",
     srcs = [
         "cbt_test.go",
+        "controller_test.go",
+        "guestagent_test.go",
         "migration-source_test.go",
         "migration-target_test.go",
         "migration_test.go",

--- a/pkg/virt-handler/controller_test.go
+++ b/pkg/virt-handler/controller_test.go
@@ -1,0 +1,336 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virthandler
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+var _ = Describe("Controller", func() {
+
+	Context("isMigrationInProgress", func() {
+		var now metav1.Time
+
+		BeforeEach(func() {
+			now = metav1.NewTime(time.Now())
+		})
+
+		It("should return false when both vmi and domain are nil", func() {
+			Expect(isMigrationInProgress(nil, nil)).To(BeFalse())
+		})
+
+		It("should return false when VMI has no migration state", func() {
+			vmi := &v1.VirtualMachineInstance{}
+			Expect(isMigrationInProgress(vmi, nil)).To(BeFalse())
+		})
+
+		It("should return true when VMI migration has started but not ended", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						StartTimestamp: &now,
+					},
+				},
+			}
+			Expect(isMigrationInProgress(vmi, nil)).To(BeTrue())
+		})
+
+		It("should return false when VMI migration has both start and end timestamps", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						StartTimestamp: &now,
+						EndTimestamp:   &now,
+					},
+				},
+			}
+			Expect(isMigrationInProgress(vmi, nil)).To(BeFalse())
+		})
+
+		It("should return true when domain has migration metadata with start but no end", func() {
+			domain := &api.Domain{
+				Spec: api.DomainSpec{
+					Metadata: api.Metadata{
+						KubeVirt: api.KubeVirtMetadata{
+							Migration: &api.MigrationMetadata{
+								StartTimestamp: &now,
+							},
+						},
+					},
+				},
+			}
+			Expect(isMigrationInProgress(nil, domain)).To(BeTrue())
+		})
+
+		It("should return false when domain has migration metadata with start and end", func() {
+			domain := &api.Domain{
+				Spec: api.DomainSpec{
+					Metadata: api.Metadata{
+						KubeVirt: api.KubeVirtMetadata{
+							Migration: &api.MigrationMetadata{
+								StartTimestamp: &now,
+								EndTimestamp:   &now,
+							},
+						},
+					},
+				},
+			}
+			Expect(isMigrationInProgress(nil, domain)).To(BeFalse())
+		})
+
+		DescribeTable("should return true when domain is paused for migration reasons",
+			func(reason api.StateChangeReason) {
+				domain := &api.Domain{
+					Status: api.DomainStatus{
+						Status: api.Paused,
+						Reason: reason,
+					},
+				}
+				Expect(isMigrationInProgress(nil, domain)).To(BeTrue())
+			},
+			Entry("paused for migration", api.ReasonPausedMigration),
+			Entry("paused for starting up", api.ReasonPausedStartingUp),
+			Entry("paused for postcopy", api.ReasonPausedPostcopy),
+		)
+
+		It("should return false when domain is paused for a non-migration reason", func() {
+			domain := &api.Domain{
+				Status: api.DomainStatus{
+					Status: api.Paused,
+					Reason: api.ReasonPausedUser,
+				},
+			}
+			Expect(isMigrationInProgress(nil, domain)).To(BeFalse())
+		})
+
+		It("should return true when VMI is a migration target and migration is not completed", func() {
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.CreateMigrationTarget: "true",
+					},
+				},
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						Completed: false,
+					},
+				},
+			}
+			Expect(isMigrationInProgress(vmi, nil)).To(BeTrue())
+		})
+
+		It("should return false when VMI is a migration target and migration is completed", func() {
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.CreateMigrationTarget: "true",
+					},
+				},
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						Completed: true,
+					},
+				},
+			}
+			Expect(isMigrationInProgress(vmi, nil)).To(BeFalse())
+		})
+	})
+
+	Context("isMigrationSource", func() {
+		const host = "node1"
+
+		It("should return false when migration state is nil", func() {
+			c := &BaseController{host: host}
+			vmi := &v1.VirtualMachineInstance{}
+			Expect(c.isMigrationSource(vmi)).To(BeFalse())
+		})
+
+		It("should return false when source node does not match host", func() {
+			c := &BaseController{host: host}
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						SourceNode:         "other-node",
+						TargetNodeAddress:  "10.0.0.1",
+						Completed:          false,
+					},
+				},
+			}
+			Expect(c.isMigrationSource(vmi)).To(BeFalse())
+		})
+
+		It("should return false when target node address is empty", func() {
+			c := &BaseController{host: host}
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						SourceNode:        host,
+						TargetNodeAddress: "",
+						Completed:         false,
+					},
+				},
+			}
+			Expect(c.isMigrationSource(vmi)).To(BeFalse())
+		})
+
+		It("should return false when migration is completed", func() {
+			c := &BaseController{host: host}
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						SourceNode:        host,
+						TargetNodeAddress: "10.0.0.1",
+						Completed:         true,
+					},
+				},
+			}
+			Expect(c.isMigrationSource(vmi)).To(BeFalse())
+		})
+
+		It("should return true when all conditions are met for non-decentralized migration", func() {
+			c := &BaseController{host: host}
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						SourceNode:        host,
+						TargetNodeAddress: "10.0.0.1",
+						Completed:         false,
+					},
+				},
+			}
+			Expect(c.isMigrationSource(vmi)).To(BeTrue())
+		})
+	})
+
+	Context("getVMIFromCache", func() {
+		It("should return VMI when it exists in the store", func() {
+			store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmi",
+					Namespace: "default",
+				},
+			}
+			Expect(store.Add(vmi)).To(Succeed())
+
+			c := &BaseController{vmiStore: store}
+			result, exists, err := c.getVMIFromCache("default/test-vmi")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(result.Name).To(Equal("test-vmi"))
+			Expect(result.Namespace).To(Equal("default"))
+		})
+
+		It("should return a new VMI with name and namespace when not found in store", func() {
+			store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			c := &BaseController{vmiStore: store}
+
+			result, exists, err := c.getVMIFromCache("default/test-vmi")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(result.Name).To(Equal("test-vmi"))
+			Expect(result.Namespace).To(Equal("default"))
+		})
+	})
+
+	Context("getDomainFromCache", func() {
+		It("should return domain when it exists and is not deleted", func() {
+			store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			domain := &api.Domain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-domain",
+					Namespace: "default",
+				},
+				Spec: api.DomainSpec{
+					Metadata: api.Metadata{
+						KubeVirt: api.KubeVirtMetadata{
+							UID: "test-uid",
+						},
+					},
+				},
+			}
+			Expect(store.Add(domain)).To(Succeed())
+
+			c := &BaseController{domainStore: store}
+			result, exists, uid, err := c.getDomainFromCache("default/test-domain")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(result).ToNot(BeNil())
+			Expect(uid).To(BeEquivalentTo("test-uid"))
+		})
+
+		It("should treat domain with DeletionTimestamp as non-existent", func() {
+			store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			now := metav1.NewTime(time.Now())
+			domain := &api.Domain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-domain",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+				},
+				Spec: api.DomainSpec{
+					Metadata: api.Metadata{
+						KubeVirt: api.KubeVirtMetadata{
+							UID: "test-uid",
+						},
+					},
+				},
+			}
+			Expect(store.Add(domain)).To(Succeed())
+
+			c := &BaseController{domainStore: store}
+			result, exists, uid, err := c.getDomainFromCache("default/test-domain")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(result).To(BeNil())
+			Expect(uid).To(BeEquivalentTo("test-uid"))
+		})
+
+		It("should return not found when domain is not in the store", func() {
+			store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			c := &BaseController{domainStore: store}
+
+			result, exists, uid, err := c.getDomainFromCache("default/missing")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(result).To(BeNil())
+			Expect(uid).To(BeEquivalentTo(""))
+		})
+	})
+
+	Context("setupNetwork", func() {
+		It("should return nil when networks list is empty", func() {
+			c := &BaseController{}
+			vmi := &v1.VirtualMachineInstance{}
+			err := c.setupNetwork(vmi, []v1.Network{}, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/virt-handler/controller_test.go
+++ b/pkg/virt-handler/controller_test.go
@@ -177,9 +177,9 @@ var _ = Describe("Controller", func() {
 			vmi := &v1.VirtualMachineInstance{
 				Status: v1.VirtualMachineInstanceStatus{
 					MigrationState: &v1.VirtualMachineInstanceMigrationState{
-						SourceNode:         "other-node",
-						TargetNodeAddress:  "10.0.0.1",
-						Completed:          false,
+						SourceNode:        "other-node",
+						TargetNodeAddress: "10.0.0.1",
+						Completed:         false,
 					},
 				},
 			}

--- a/pkg/virt-handler/guestagent_test.go
+++ b/pkg/virt-handler/guestagent_test.go
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virthandler
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Guest Agent", func() {
+
+	Context("guestAgentCommandSubsetSupported", func() {
+		It("should return true when all required commands are present and enabled", func() {
+			available := map[string]bool{
+				"guest-ping": true,
+				"guest-info": true,
+			}
+			Expect(guestAgentCommandSubsetSupported([]string{"guest-ping", "guest-info"}, available)).To(BeTrue())
+		})
+
+		It("should return false when a required command is missing", func() {
+			available := map[string]bool{
+				"guest-ping": true,
+			}
+			Expect(guestAgentCommandSubsetSupported([]string{"guest-ping", "guest-info"}, available)).To(BeFalse())
+		})
+
+		It("should return false when a required command is present but disabled", func() {
+			available := map[string]bool{
+				"guest-ping": true,
+				"guest-info": false,
+			}
+			Expect(guestAgentCommandSubsetSupported([]string{"guest-ping", "guest-info"}, available)).To(BeFalse())
+		})
+
+		It("should return true for an empty required commands list", func() {
+			available := map[string]bool{"guest-ping": true}
+			Expect(guestAgentCommandSubsetSupported([]string{}, available)).To(BeTrue())
+		})
+
+		It("should return true for an empty required list and empty available map", func() {
+			Expect(guestAgentCommandSubsetSupported([]string{}, map[string]bool{})).To(BeTrue())
+		})
+	})
+
+	Context("sshRelatedCommandsSupported", func() {
+		It("should return true when new SSH commands are available", func() {
+			available := map[string]bool{}
+			for _, cmd := range sshRelatedGuestAgentCommands {
+				available[cmd] = true
+			}
+			Expect(sshRelatedCommandsSupported(available)).To(BeTrue())
+		})
+
+		It("should return true when old SSH commands are available", func() {
+			available := map[string]bool{}
+			for _, cmd := range oldSSHRelatedGuestAgentCommands {
+				available[cmd] = true
+			}
+			Expect(sshRelatedCommandsSupported(available)).To(BeTrue())
+		})
+
+		It("should return false when neither new nor old SSH commands are available", func() {
+			available := map[string]bool{
+				"guest-ping": true,
+			}
+			Expect(sshRelatedCommandsSupported(available)).To(BeFalse())
+		})
+
+		It("should return false when SSH commands are present but disabled", func() {
+			available := map[string]bool{}
+			for _, cmd := range sshRelatedGuestAgentCommands {
+				available[cmd] = false
+			}
+			for _, cmd := range oldSSHRelatedGuestAgentCommands {
+				available[cmd] = false
+			}
+			Expect(sshRelatedCommandsSupported(available)).To(BeFalse())
+		})
+
+		It("should return true when only partial old commands plus full new commands are available", func() {
+			available := map[string]bool{
+				// Only partial old commands
+				"guest-exec": true,
+			}
+			// Add all new SSH commands
+			for _, cmd := range sshRelatedGuestAgentCommands {
+				available[cmd] = true
+			}
+			Expect(sshRelatedCommandsSupported(available)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Adds unit tests for three previously untested or under-tested areas:

1. **`pkg/virt-controller/services/serialconsolelog_test.go`** -- Tests for the serial console log subsystem in virt-controller:
   - `isSerialConsoleLogEnabled`: Validates the enable/disable logic based on cluster config (`DisableSerialConsoleLog`), VMI-level overrides (`LogSerialConsole`), and `AutoattachSerialConsole` settings.
   - `resourcesForSerialConsoleLogContainer`: Verifies default resource requests/limits and the equalization behavior for dedicated CPUs and guaranteed QoS.
   - `generateSerialConsoleLogContainer`: Confirms container generation returns nil when disabled, produces a valid container with correct name/image/command when enabled, and sets proper security context (non-root, no privilege escalation, drop all capabilities).

2. **`pkg/virt-handler/controller_test.go`** -- Tests for virt-handler's base controller logic:
   - `isMigrationInProgress`: Covers all migration detection paths including VMI migration state timestamps, domain migration metadata, paused domain states (migration, postcopy, starting-up reasons), and migration target annotations.
   - `isMigrationSource`: Validates source node matching, target address checks, and completion state checks.
   - `getVMIFromCache`: Tests cache hit (returns stored VMI) and cache miss (returns a stub VMI with name/namespace parsed from the key).
   - `getDomainFromCache`: Tests cache hit, deleted domains (DeletionTimestamp set), and cache miss scenarios.
   - `setupNetwork`: Verifies no-op behavior when the networks list is empty.

3. **`pkg/virt-handler/guestagent_test.go`** -- Tests for guest agent command support detection:
   - `guestAgentCommandSubsetSupported`: Validates subset checking logic for required vs. available commands, including disabled commands and empty inputs.
   - `sshRelatedCommandsSupported`: Tests detection of both new and old SSH command sets, disabled commands, and mixed availability scenarios.

### Why we need it and why it was done in this way

These functions contain non-trivial branching logic (migration detection, serial console enable/disable precedence, guest agent command matching) that was not covered by unit tests. Adding targeted tests for these internal functions improves confidence in correctness and guards against regressions. Each test file is placed alongside the source code it tests, following the existing project conventions.

### Special notes for your reviewer

- These are pure unit test additions -- no production code is modified.
- All tests use Ginkgo/Gomega, consistent with the rest of the KubeVirt test suite.
- The tests exercise unexported functions, so they are in the same package as the code under test.

### Checklist

- [x] Design: A design document was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [x] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```
