### PR TITLE
api: add +listType markers to CPU.Features and update whitelist

### DIFF
--- a/api/api-rule-violations-known.list
+++ b/api/api-rule-violations-known.list
@@ -2,7 +2,6 @@ API rule violation: list_type_missing,kubevirt.io/api/backup/v1alpha1,VirtualMac
 API rule violation: list_type_missing,kubevirt.io/api/backup/v1alpha1,VirtualMachineBackupTrackerList,Items
 API rule violation: list_type_missing,kubevirt.io/api/clone/v1alpha1,VirtualMachineCloneList,Items
 API rule violation: list_type_missing,kubevirt.io/api/clone/v1beta1,VirtualMachineCloneList,Items
-API rule violation: list_type_missing,kubevirt.io/api/core/v1,CPU,Features
 API rule violation: list_type_missing,kubevirt.io/api/core/v1,DHCPOptions,NTPServers
 API rule violation: list_type_missing,kubevirt.io/api/core/v1,DHCPOptions,PrivateOptions
 API rule violation: list_type_missing,kubevirt.io/api/core/v1,Devices,Disks

--- a/api/api-rule-violations.list
+++ b/api/api-rule-violations.list
@@ -2,7 +2,6 @@ API rule violation: list_type_missing,kubevirt.io/api/backup/v1alpha1,VirtualMac
 API rule violation: list_type_missing,kubevirt.io/api/backup/v1alpha1,VirtualMachineBackupTrackerList,Items
 API rule violation: list_type_missing,kubevirt.io/api/clone/v1alpha1,VirtualMachineCloneList,Items
 API rule violation: list_type_missing,kubevirt.io/api/clone/v1beta1,VirtualMachineCloneList,Items
-API rule violation: list_type_missing,kubevirt.io/api/core/v1,CPU,Features
 API rule violation: list_type_missing,kubevirt.io/api/core/v1,DHCPOptions,NTPServers
 API rule violation: list_type_missing,kubevirt.io/api/core/v1,DHCPOptions,PrivateOptions
 API rule violation: list_type_missing,kubevirt.io/api/core/v1,Devices,Disks

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -370,6 +370,8 @@ type CPU struct {
 	Model string `json:"model,omitempty"`
 	// Features specifies the CPU features list inside the VMI.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Features []CPUFeature `json:"features,omitempty"`
 	// DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node
 	// with enough dedicated pCPUs and pin the vCPUs to it.

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -271,7 +271,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/api/core/v1.WeightedPodAffinityTerm":                                                      schema_k8sio_api_core_v1_WeightedPodAffinityTerm(ref),
 		"k8s.io/api/core/v1.WindowsSecurityContextOptions":                                                schema_k8sio_api_core_v1_WindowsSecurityContextOptions(ref),
 		"k8s.io/apimachinery/pkg/api/resource.Quantity":                                                   schema_apimachinery_pkg_api_resource_Quantity(ref),
-		"k8s.io/apimachinery/pkg/api/resource.int64Amount":                                                schema_apimachinery_pkg_api_resource_int64Amount(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup":                                                   schema_pkg_apis_meta_v1_APIGroup(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList":                                               schema_pkg_apis_meta_v1_APIGroupList(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.APIResource":                                                schema_pkg_apis_meta_v1_APIResource(ref),
@@ -15668,15 +15667,12 @@ func schema_pkg_apis_meta_v1_InternalEvent(ref common.ReferenceCallback) common.
 					"Object": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Bookmark: the object (instance of a type being watched) where\n   only ResourceVersion field is set. On successful restart of watch from a\n   bookmark resourceVersion, client is guaranteed to not get repeat event\n   nor miss any events.\n * If Type is Error: *api.Status is recommended; other types may make sense\n   depending on context.",
-							Ref:         ref("k8s.io/apimachinery/pkg/runtime.Object"),
 						},
 					},
 				},
 				Required: []string{"Type", "Object"},
 			},
 		},
-		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/runtime.Object"},
 	}
 }
 
@@ -19004,6 +19000,14 @@ func schema_kubevirtio_api_core_v1_CPU(ref common.ReferenceCallback) common.Open
 						},
 					},
 					"features": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Features specifies the CPU features list inside the VMI.",
 							Type:        []string{"array"},


### PR DESCRIPTION
### What this PR does
This PR adds declarative OpenAPI validation markers to the `CPU.Features` field and updates the corresponding API violation manifests.
#### Before this PR:
- `CPU.Features` was missing `+listType` markers, causing it to be flagged as an API rule violation.
- The violation was suppressed via `api/api-rule-violations-known.list` (whitelist).
#### After this PR:
- `CPU.Features` is explicitly marked with +listType=map and +listMapKey=name.
- The generated OpenAPI schema now reflects the list-map properties.
- The `list_type_missing` violation for this field is resolved.


### References
Addresses transition to declarative validation

### Special notes for your reviewer
`CPU.Features` violation was removed from the report - verified.

```release-note
None
```

