### PR TITLE
tests: use Fedora for graceful shutdown test [test_id:1655]

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1634,8 +1634,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Context("with grace period greater than 0", func() {
 			It("[test_id:1655]should run graceful shutdown", decorators.Conformance, func() {
 				By("Setting a VirtualMachineInstance termination grace period to 5")
-				// Give the VirtualMachineInstance a custom grace period
-				vmi := libvmifact.NewAlpine(libvmi.WithTerminationGracePeriod(5))
+				vmi := libvmifact.NewFedora(libvmi.WithTerminationGracePeriod(5))
 
 				By("Creating the VirtualMachineInstance")
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)


### PR DESCRIPTION
### What this PR does
The graceful shutdown test (test_id:1655) uses ACPI shutdown to verify that a VMI shuts down cleanly within its termination grace period. When commit 61621f1d88 switched the test image from Cirros to Alpine for s390x enablement, it inadvertently broke the ACPI shutdown path: Alpine does not run acpid and silently ignores ACPI power button signals.

This causes the grace period to always expire, forcing virt-handler to destroy the domain. The forced destruction disrupts the libvirt connection inside virt-launcher, leading to a slow and variable cleanup. The 15-second BeGone() timeout then occasionally trips, causing a flaky test failure.

Switch to Fedora, which handles ACPI shutdown via systemd. This is consistent with the sibling tests (test_id:1653/1654) in the same Context that already use Fedora for ACPI graceful shutdown verification.

#### Before this PR:
- Alpine ignores ACPI → grace period expires → force-destroy → slow, variable cleanup → flaky 15s timeout

#### After this PR:
- Fedora responds to ACPI via systemd → clean shutdown → fast cleanup → no flake

### References
- 61621f1d88 — switched Cirros to Alpine for s390x (introduced the issue)
- 9e7e2277a7 — same fix applied for soft-reboot test with ACPI

### Release note
```release-note
NONE
```
