### PR TITLE
virt-launcher/virtwrap: add compensating rollback to syncDisks for partial disk operation failures

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1240,6 +1240,58 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 	return oldSpec, nil
 }
 
+// diskUpdateRecord holds the old and new disk spec for a completed UpdateDeviceFlags call
+type diskUpdateRecord struct {
+	oldDisk api.Disk
+	newDisk api.Disk
+}
+
+// rollbackDetachedDisks re-attaches disks that were successfully detached earlier in the same syncDisks call
+func rollbackDetachedDisks(dom cli.VirDomain, disks []api.Disk, logger *log.FilteredLogger) {
+	for i := len(disks) - 1; i >= 0; i-- {
+		disk := disks[i]
+		attachBytes, err := xml.Marshal(disk)
+		if err != nil {
+			logger.Reason(err).Errorf("rollback: failed to marshal disk %s for re-attachment", disk.Alias.GetName())
+			continue
+		}
+		if err := dom.AttachDeviceFlags(strings.ToLower(string(attachBytes)), affectDeviceLiveAndConfigLibvirtFlags); err != nil {
+			logger.Reason(err).Errorf("rollback: failed to re-attach disk %s after partial detach failure", disk.Alias.GetName())
+		}
+	}
+}
+
+// rollbackAttachedDisks detaches disks that were successfully attached earlier in the same syncDisks call
+func rollbackAttachedDisks(dom cli.VirDomain, disks []api.Disk, logger *log.FilteredLogger) {
+	for i := len(disks) - 1; i >= 0; i-- {
+		disk := disks[i]
+		detachBytes, err := xml.Marshal(disk)
+		if err != nil {
+			logger.Reason(err).Errorf("rollback: failed to marshal disk %s for detachment", disk.Alias.GetName())
+			continue
+		}
+		if err := dom.DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags); err != nil {
+			logger.Reason(err).Errorf("rollback: failed to detach disk %s after partial attach failure", disk.Alias.GetName())
+		}
+	}
+}
+
+// rollbackUpdatedDisks reverts UpdateDeviceFlags calls that succeeded earlier in
+// the same syncDisks call by re-applying each disk's previous spec.
+func rollbackUpdatedDisks(dom cli.VirDomain, records []diskUpdateRecord, logger *log.FilteredLogger) {
+	for i := len(records) - 1; i >= 0; i-- {
+		old := records[i].oldDisk
+		revertBytes, err := xml.Marshal(old)
+		if err != nil {
+			logger.Reason(err).Errorf("rollback: failed to marshal old spec for disk %s", old.Alias.GetName())
+			continue
+		}
+		if err := dom.UpdateDeviceFlags(strings.ToLower(string(revertBytes)), affectDeviceLiveAndConfigLibvirtFlags); err != nil {
+			logger.Reason(err).Errorf("rollback: failed to revert update for disk %s", old.Alias.GetName())
+		}
+	}
+}
+
 func (l *LibvirtDomainManager) syncDisks(
 	domain *api.Domain,
 	spec *api.DomainSpec,
@@ -1248,6 +1300,9 @@ func (l *LibvirtDomainManager) syncDisks(
 ) error {
 	logger := log.Log.Object(vmi)
 
+	// detachedDisks accumulates every disk that was successfully detached
+	var detachedDisks []api.Disk
+
 	// Look up all the disks to detach
 	for _, detachDisk := range getDetachedDisks(spec.Devices.Disks, domain.Spec.Devices.Disks) {
 		volumeName := detachDisk.Alias.GetName()
@@ -1255,22 +1310,35 @@ func (l *LibvirtDomainManager) syncDisks(
 		detachBytes, err := xml.Marshal(detachDisk)
 		if err != nil {
 			logger.Reason(err).Error("marshalling detached disk failed")
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
 		err = dom.DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 		if err != nil {
 			logger.Reason(err).Error("detaching device")
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
 		if err := storage.DeleteQCOW2Overlay(vmi, volumeName); err != nil {
 			logger.Reason(err).Error("deleting CBT overlay")
+			// The disk is already detached from libvirt; re-attach it before
+			// returning so the domain's device tree remains consistent.
+			rollbackDetachedDisks(dom, append(detachedDisks, detachDisk), logger)
 			return err
 		}
+		detachedDisks = append(detachedDisks, detachDisk)
 	}
+
+	// attachedDisks accumulates every disk that was successfully attached so
+	// that they can be detached if a later operation in this sync fails.
+	var attachedDisks []api.Disk
+
 	// Look up all the disks to attach
 	for _, attachDisk := range getAttachedDisks(spec.Devices.Disks, domain.Spec.Devices.Disks) {
 		allowAttach, err := checkIfDiskReadyToUse(getBackendSource(attachDisk))
 		if err != nil {
+			rollbackAttachedDisks(dom, attachedDisks, logger)
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
 		if !allowAttach {
@@ -1280,6 +1348,8 @@ func (l *LibvirtDomainManager) syncDisks(
 		// set drivers cache mode
 		err = converter.SetDriverCacheMode(&attachDisk, l.directIOChecker)
 		if err != nil {
+			rollbackAttachedDisks(dom, attachedDisks, logger)
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
 		converter.SetOptimalIOMode(&attachDisk, converter.IsPreAllocated)
@@ -1287,20 +1357,38 @@ func (l *LibvirtDomainManager) syncDisks(
 		attachBytes, err := xml.Marshal(attachDisk)
 		if err != nil {
 			logger.Reason(err).Error("marshalling attached disk failed")
+			rollbackAttachedDisks(dom, attachedDisks, logger)
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
 		err = dom.AttachDeviceFlags(strings.ToLower(string(attachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 		if err != nil {
 			logger.Reason(err).Error("attaching device")
+			rollbackAttachedDisks(dom, attachedDisks, logger)
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
+		attachedDisks = append(attachedDisks, attachDisk)
 	}
+
+	// Build a lookup of domain's current disk specs by target device
+	oldDiskByTarget := make(map[string]api.Disk, len(domain.Spec.Devices.Disks))
+	for _, d := range domain.Spec.Devices.Disks {
+		oldDiskByTarget[d.Target.Device] = d
+	}
+
+	// updatedDisks accumulates every disk that was successfully updated
+	var updatedDisks []diskUpdateRecord
+
 	// Look up all the disks to UPDATE
 	for _, updateDisk := range getUpdatedDisks(spec.Devices.Disks, domain.Spec.Devices.Disks) {
 		sourceFile := getBackendSource(updateDisk)
 		if sourceFile != "" {
 			allowUpdate, err := checkIfDiskReadyToUse(sourceFile)
 			if err != nil {
+				rollbackUpdatedDisks(dom, updatedDisks, logger)
+				rollbackAttachedDisks(dom, attachedDisks, logger)
+				rollbackDetachedDisks(dom, detachedDisks, logger)
 				return err
 			}
 			if !allowUpdate {
@@ -1313,14 +1401,23 @@ func (l *LibvirtDomainManager) syncDisks(
 		updateBytes, err := xml.Marshal(updateDisk)
 		if err != nil {
 			logger.Reason(err).Error("marshalling updated disk failed")
+			rollbackUpdatedDisks(dom, updatedDisks, logger)
+			rollbackAttachedDisks(dom, attachedDisks, logger)
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
 
 		err = dom.UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 		if err != nil {
 			logger.Reason(err).Error("updating device")
+			rollbackUpdatedDisks(dom, updatedDisks, logger)
+			rollbackAttachedDisks(dom, attachedDisks, logger)
+			rollbackDetachedDisks(dom, detachedDisks, logger)
 			return err
 		}
+
+		oldDisk := oldDiskByTarget[updateDisk.Target.Device]
+		updatedDisks = append(updatedDisks, diskUpdateRecord{oldDisk: oldDisk, newDisk: updateDisk})
 	}
 
 	// Resize and notify the VM about changed disks


### PR DESCRIPTION

### What this PR does

### Problem

  syncDisks runs three sequential libvirt device-operation loops with no rollback. Any mid-loop failure permanently leaves the running VM's device tree in a state that no valid spec describes. Depending on which loop and which iteration fails, a running guest may lose a disk entirely, end up with duplicate disks, or have CD-ROM drives split across two different backing files. All of these can cause guest crashes or disk data corruption.

  ### Solution

  Three package-level rollback helpers (all best-effort, LIFO ordered):

  - rollbackDetachedDisks(dom, disks, logger) — re-attaches each disk via AttachDeviceFlags
  - rollbackAttachedDisks(dom, disks, logger) — removes each disk via DetachDeviceFlags
  - rollbackUpdatedDisks(dom, records, logger) — re-applies oldDisk spec via UpdateDeviceFlags

  diskUpdateRecord type — captures {oldDisk, newDisk} for each successful UpdateDeviceFlags call, providing the
  exact prior backing source for reversion.

  Inside syncDisks:
  - Each loop appends to a local slice (detachedDisks, attachedDisks, updatedDisks) only after the libvirt call
  succeeds.
  - Every error return is preceded by rollback in reverse dependency order: rollbackUpdatedDisks →
  rollbackAttachedDisks → rollbackDetachedDisks.
  - The DeleteQCOW2Overlay edge case (disk already detached from libvirt before the overlay removal fails) is
  handled by explicitly including the just-detached disk in the rollback slice before returning.

  ### What rollback does NOT fix

  Rollback is best-effort. If a rollback call to libvirt itself fails (e.g. libvirt crashes mid-rollback), the  helper logs the error and continues to the next disk. This is acceptable: the controller's sync loop will reconcile on the next iteration, and at minimum the original error is returned so the caller can requeue.

 * No behaviour change on the success path *

  When all three loops complete without error the code follows exactly the same path as before. The only new allocations are the three slice headers, which are nil on a no-op sync.

  
- Fixes #17201



### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


@0xFelix @Aseeef 