### PR TITLE
virt-controller/migration: break out of infinite MigrationHandoff retry loop — enforce max attempts and    force MigrationFailed 

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -97,6 +97,7 @@ const defaultFinalizedMigrationGarbageCollectionBuffer = 5
 // period of time, so we want to make this timeout long enough that it doesn't
 // cause the migration to fail when it could have reasonably succeeded.
 const defaultCatchAllPendingTimeoutSeconds = int64(60 * 15)
+const maxBackendStorageHandoffAttempts = 5
 
 // This controller is driven by a priority queue, so that proper attention is
 // given to active migrations. When a pending migration gets re-enqueued for
@@ -509,6 +510,40 @@ func (c *Controller) canMigrateVMI(migration *virtv1.VirtualMachineInstanceMigra
 	return true, nil
 }
 
+// clearVMIMigrationTargetState patches the VMI to mark the ongoing migration as
+// failed/completed and zeroes out the target-specific fields in MigrationState.
+func (c *Controller) clearVMIMigrationTargetState(vmi *virtv1.VirtualMachineInstance, migration *virtv1.VirtualMachineInstanceMigration) error {
+	if vmi.Status.MigrationState == nil || vmi.Status.MigrationState.Completed {
+		return nil
+	}
+
+	vmiCopy := vmi.DeepCopy()
+	now := v1.Now()
+
+	if vmiCopy.Status.MigrationState.StartTimestamp == nil {
+		vmiCopy.Status.MigrationState.StartTimestamp = &now
+	}
+	vmiCopy.Status.MigrationState.EndTimestamp = &now
+	vmiCopy.Status.MigrationState.Failed = true
+	vmiCopy.Status.MigrationState.Completed = true
+	if vmiCopy.Status.MigrationState.FailureReason == "" {
+		vmiCopy.Status.MigrationState.FailureReason = "Backend storage PVC handoff failed after maximum retries"
+	}
+
+	vmiCopy.Status.MigrationState.TargetNode = ""
+	vmiCopy.Status.MigrationState.TargetNodeAddress = ""
+	vmiCopy.Status.MigrationState.TargetPod = ""
+	vmiCopy.Status.MigrationState.TargetNodeDomainReadyTimestamp = nil
+	vmiCopy.Status.MigrationState.TargetNodeDomainDetected = false
+	vmiCopy.Status.MigrationState.TargetDirectMigrationNodePorts = nil
+	vmiCopy.Status.MigrationState.TargetAttachmentPodUID = ""
+	vmiCopy.Status.MigrationState.TargetCPUSet = nil
+	vmiCopy.Status.MigrationState.TargetNodeTopology = ""
+	vmiCopy.Status.MigrationState.TargetMemoryOverhead = nil
+
+	return c.patchVMI(vmi, vmiCopy)
+}
+
 func (c *Controller) failMigration(migration *virtv1.VirtualMachineInstanceMigration) error {
 	err := backendstorage.MigrationAbort(c.clientset, migration)
 	if err != nil {
@@ -829,8 +864,50 @@ func (c *Controller) processMigrationPhase(
 				if backendstorage.IsBackendStorageNeeded(vmi) {
 					err := backendstorage.MigrationHandoff(c.clientset, c.pvcStore, migration)
 					if err != nil {
+						// Track consecutive failures in a status condition so that a
+						// persistently broken PVC patch (quota, finalizer, missing PVC)
+						// cannot keep the migration stuck in Running forever.
+						failures := 1
+						if cond := conditionManager.GetCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationHandoffFailed); cond != nil {
+							if n, parseErr := strconv.Atoi(cond.Reason); parseErr == nil && n > 0 {
+								failures = n + 1
+							}
+						}
+
+						if failures >= maxBackendStorageHandoffAttempts {
+							log.Log.Object(migration).Errorf(
+								"Backend storage handoff failed %d/%d times; forcing migration to Failed: %v",
+								failures, maxBackendStorageHandoffAttempts, err)
+							c.recorder.Eventf(migration, k8sv1.EventTypeWarning, controller.FailedMigrationReason,
+								"Backend storage PVC handoff failed after %d attempts, migration cannot complete: %v",
+								failures, err)
+							if failErr := c.failMigration(migrationCopy); failErr != nil {
+								return failErr
+							}
+							if vmiErr := c.clearVMIMigrationTargetState(vmi, migration); vmiErr != nil {
+								log.Log.Object(vmi).Reason(vmiErr).Errorf(
+									"Failed to clear VMI migration target state after handoff exhaustion for migration %s/%s",
+									migration.Namespace, migration.Name)
+							}
+							return nil
+						}
+						conditionManager.UpdateCondition(migrationCopy, &virtv1.VirtualMachineInstanceMigrationCondition{
+							Type:               virtv1.VirtualMachineInstanceMigrationHandoffFailed,
+							Status:             k8sv1.ConditionTrue,
+							LastProbeTime:      v1.Now(),
+							LastTransitionTime: v1.Now(),
+							Reason:             strconv.Itoa(failures),
+							Message: fmt.Sprintf(
+								"Backend storage PVC handoff attempt %d/%d failed: %v",
+								failures, maxBackendStorageHandoffAttempts, err),
+						})
+						log.Log.Object(migration).Reason(err).Warningf(
+							"Backend storage handoff attempt %d/%d failed, will retry",
+							failures, maxBackendStorageHandoffAttempts)
 						return err
 					}
+					// Handoff succeeded 
+					conditionManager.RemoveCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationHandoffFailed)
 				}
 
 				patchBytes, err := patch.New(

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -772,6 +772,9 @@ const (
 	VirtualMachineInstanceDecentralizedMigrationBlocked VirtualMachineInstanceMigrationConditionType = "decentralizedMigrationBlocked"
 	// VirtualMachineInstanceMigrationBlockedByBackup indicates that migration is waiting for backup to complete or abort
 	VirtualMachineInstanceMigrationBlockedByBackup VirtualMachineInstanceMigrationConditionType = "migrationBlockedByBackup"
+	// VirtualMachineInstanceMigrationHandoffFailed indicates that the backend-storage PVC
+	// handoff step has failed at least once.
+	VirtualMachineInstanceMigrationHandoffFailed VirtualMachineInstanceMigrationConditionType = "migrationHandoffFailed"
 )
 
 type VirtualMachineInstanceCondition struct {


### PR DESCRIPTION

### What this PR does

### Problem                                                                                                       
                                                            
  When backendstorage.MigrationHandoff fails persistently during MigrationRunning, the controller returns the   
  error without advancing the migration phase, producing an infinite loop. There is no retry counter, no
  deadline, and no transition to MigrationFailed. The guest hangs because neither the source nor target         
  virt-handler owns the domain.                             

  ### Solution

  New API condition type (staging/src/kubevirt.io/api/core/v1/types.go):                                        
  
  VirtualMachineInstanceMigrationHandoffFailed = "migrationHandoffFailed"                                       
                                                                                                                
  The Reason field stores the decimal attempt count. UpdateCondition persists it through the normal UpdateStatus
   path; no new struct fields are needed.                                                                       
                                                                                                                
  maxBackendStorageHandoffAttempts = 5 (migration.go) — 5 total attempts before the migration is forced to      
  Failed.
                                                                                                                
  Retry logic replaces the bare return err:                                                                     
  - Parsing attempt count from the condition (0 if the condition is absent)
  - Increment; if still below the limit, calling UpdateCondition + return err (requeue with existing back-off)     
  - If at or above the limit: emit a Warning event, calling failMigration(migrationCopy), call                
  clearVMIMigrationTargetState, return nil (no requeue)                                                         
                                                                                                                
  clearVMIMigrationTargetState — new controller method that patches the VMI with:                               
  - MigrationState.Failed = true, Completed = true, EndTimestamp = now                                          
  - All target fields zeroed: TargetNode, TargetNodeAddress, TargetPod, TargetNodeDomainReadyTimestamp,         
  TargetNodeDomainDetected, TargetDirectMigrationNodePorts, TargetAttachmentPodUID, TargetCPUSet,               
  TargetNodeTopology, TargetMemoryOverhead                                                                      
                                                            
  Without clearing these fields, the source virt-handler continues to see a non-nil                             
  TargetNodeDomainReadyTimestamp and yields authority over the domain, leaving the guest hung even after the    
  migration is marked Failed.
                                                                                                                
  Success path cleanup: after a successful MigrationHandoff, RemoveCondition ensureing a transient failure during 
  one migration cannot bleed into a future one on the same object.

- Fixes #17203 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


@0xFelix 
