### PR TITLE
cleanup: Refactor High Complexity Functions in instancetype Package

### DIFF
--- a/pkg/instancetype/apply/cpu.go
+++ b/pkg/instancetype/apply/cpu.go
@@ -1,4 +1,3 @@
-//nolint:gocyclo
 /*
  * This file is part of the KubeVirt project
  *
@@ -112,7 +111,15 @@ func validateCPU(
 	baseConflict *conflict.Conflict,
 	instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec,
 	vmiSpec *virtv1.VirtualMachineInstanceSpec,
-) (conflicts conflict.Conflicts) {
+) conflict.Conflicts {
+	var conflicts conflict.Conflicts
+	conflicts = append(conflicts, validateCPUResources(baseConflict, vmiSpec)...)
+	conflicts = append(conflicts, validateCPUTopology(baseConflict, vmiSpec)...)
+	conflicts = append(conflicts, validateCPUFeatures(baseConflict, instancetypeSpec, vmiSpec)...)
+	return conflicts
+}
+
+func validateCPUResources(baseConflict *conflict.Conflict, vmiSpec *virtv1.VirtualMachineInstanceSpec) (conflicts conflict.Conflicts) {
 	if _, hasCPURequests := vmiSpec.Domain.Resources.Requests[k8sv1.ResourceCPU]; hasCPURequests {
 		conflicts = append(conflicts, baseConflict.NewChild("domain", "resources", "requests", string(k8sv1.ResourceCPU)))
 	}
@@ -120,7 +127,10 @@ func validateCPU(
 	if _, hasCPULimits := vmiSpec.Domain.Resources.Limits[k8sv1.ResourceCPU]; hasCPULimits {
 		conflicts = append(conflicts, baseConflict.NewChild("domain", "resources", "limits", string(k8sv1.ResourceCPU)))
 	}
+	return conflicts
+}
 
+func validateCPUTopology(baseConflict *conflict.Conflict, vmiSpec *virtv1.VirtualMachineInstanceSpec) (conflicts conflict.Conflicts) {
 	if vmiSpec.Domain.CPU.Sockets != 0 {
 		conflicts = append(conflicts, baseConflict.NewChild("domain", "cpu", "sockets"))
 	}
@@ -132,7 +142,14 @@ func validateCPU(
 	if vmiSpec.Domain.CPU.Threads != 0 {
 		conflicts = append(conflicts, baseConflict.NewChild("domain", "cpu", "threads"))
 	}
+	return conflicts
+}
 
+func validateCPUFeatures(
+	baseConflict *conflict.Conflict,
+	instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec,
+	vmiSpec *virtv1.VirtualMachineInstanceSpec,
+) (conflicts conflict.Conflicts) {
 	if vmiSpec.Domain.CPU.Model != "" && instancetypeSpec.CPU.Model != nil {
 		conflicts = append(conflicts, baseConflict.NewChild("domain", "cpu", "model"))
 	}
@@ -152,6 +169,5 @@ func validateCPU(
 	if vmiSpec.Domain.CPU.Realtime != nil && instancetypeSpec.CPU.Realtime != nil {
 		conflicts = append(conflicts, baseConflict.NewChild("domain", "cpu", "realtime"))
 	}
-
 	return conflicts
 }

--- a/pkg/instancetype/preference/apply/device.go
+++ b/pkg/instancetype/preference/apply/device.go
@@ -1,4 +1,3 @@
-//nolint:gocyclo
 /*
  * This file is part of the KubeVirt project
  *
@@ -54,6 +53,18 @@ func ApplyDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
 		return
 	}
 
+	applyQueueAndVirtioPreferences(preferenceSpec, vmiSpec)
+	applyMiscellaneousDevicePreferences(preferenceSpec, vmiSpec)
+	applyVideoPreferences(preferenceSpec, vmiSpec)
+
+	ApplyAutoAttachPreferences(preferenceSpec, vmiSpec)
+	applyDiskPreferences(preferenceSpec, vmiSpec)
+	applyInterfacePreferences(preferenceSpec, vmiSpec)
+	applyInputPreferences(preferenceSpec, vmiSpec)
+	applyPanicDevicePreferences(preferenceSpec, vmiSpec)
+}
+
+func applyQueueAndVirtioPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
 	// We only want to apply a preference bool when...
 	//
 	// 1. A preference has actually been provided
@@ -70,7 +81,9 @@ func ApplyDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
 	if preferenceSpec.Devices.PreferredNetworkInterfaceMultiQueue != nil && vmiSpec.Domain.Devices.NetworkInterfaceMultiQueue == nil {
 		vmiSpec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.P(*preferenceSpec.Devices.PreferredNetworkInterfaceMultiQueue)
 	}
+}
 
+func applyMiscellaneousDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
 	// FIXME DisableHotplug isn't a pointer bool so we don't have a way to tell if a user has actually set it, for now override.
 	if preferenceSpec.Devices.PreferredDisableHotplug != nil {
 		vmiSpec.Domain.Devices.DisableHotplug = *preferenceSpec.Devices.PreferredDisableHotplug
@@ -87,7 +100,9 @@ func ApplyDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
 	if preferenceSpec.Devices.PreferredTPM != nil && vmiSpec.Domain.Devices.TPM == nil {
 		vmiSpec.Domain.Devices.TPM = preferenceSpec.Devices.PreferredTPM.DeepCopy()
 	}
+}
 
+func applyVideoPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
 	if preferenceSpec.Devices.PreferredVideoType != nil {
 		if vmiSpec.Domain.Devices.Video == nil {
 			vmiSpec.Domain.Devices.Video = &virtv1.VideoDevice{}
@@ -96,12 +111,6 @@ func ApplyDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
 			vmiSpec.Domain.Devices.Video.Type = *preferenceSpec.Devices.PreferredVideoType
 		}
 	}
-
-	ApplyAutoAttachPreferences(preferenceSpec, vmiSpec)
-	applyDiskPreferences(preferenceSpec, vmiSpec)
-	applyInterfacePreferences(preferenceSpec, vmiSpec)
-	applyInputPreferences(preferenceSpec, vmiSpec)
-	applyPanicDevicePreferences(preferenceSpec, vmiSpec)
 }
 
 func applyInputPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {

--- a/pkg/instancetype/preference/apply/disk.go
+++ b/pkg/instancetype/preference/apply/disk.go
@@ -1,4 +1,3 @@
-//nolint:gocyclo
 /*
  * This file is part of the KubeVirt project
  *
@@ -35,27 +34,7 @@ func applyDiskPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, 
 		}
 
 		if vmiDisk.DiskDevice.Disk != nil {
-			if preferenceSpec.Devices.PreferredDiskBus != "" && vmiDisk.DiskDevice.Disk.Bus == "" {
-				vmiDisk.DiskDevice.Disk.Bus = preferenceSpec.Devices.PreferredDiskBus
-			}
-
-			if preferenceSpec.Devices.PreferredDiskBlockSize != nil && vmiDisk.BlockSize == nil {
-				vmiDisk.BlockSize = preferenceSpec.Devices.PreferredDiskBlockSize.DeepCopy()
-			}
-
-			if preferenceSpec.Devices.PreferredDiskCache != "" && vmiDisk.Cache == "" {
-				vmiDisk.Cache = preferenceSpec.Devices.PreferredDiskCache
-			}
-
-			if preferenceSpec.Devices.PreferredDiskIO != "" && vmiDisk.IO == "" {
-				vmiDisk.IO = preferenceSpec.Devices.PreferredDiskIO
-			}
-
-			if preferenceSpec.Devices.PreferredDiskDedicatedIoThread != nil &&
-				vmiDisk.DedicatedIOThread == nil &&
-				vmiDisk.DiskDevice.Disk.Bus == virtv1.DiskBusVirtio {
-				vmiDisk.DedicatedIOThread = pointer.P(*preferenceSpec.Devices.PreferredDiskDedicatedIoThread)
-			}
+			applyDiskTargetPreferences(preferenceSpec, vmiDisk)
 		} else if vmiDisk.DiskDevice.CDRom != nil {
 			if preferenceSpec.Devices.PreferredCdromBus != "" && vmiDisk.DiskDevice.CDRom.Bus == "" {
 				vmiDisk.DiskDevice.CDRom.Bus = preferenceSpec.Devices.PreferredCdromBus
@@ -65,5 +44,29 @@ func applyDiskPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, 
 				vmiDisk.DiskDevice.LUN.Bus = preferenceSpec.Devices.PreferredLunBus
 			}
 		}
+	}
+}
+
+func applyDiskTargetPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiDisk *virtv1.Disk) {
+	if preferenceSpec.Devices.PreferredDiskBus != "" && vmiDisk.DiskDevice.Disk.Bus == "" {
+		vmiDisk.DiskDevice.Disk.Bus = preferenceSpec.Devices.PreferredDiskBus
+	}
+
+	if preferenceSpec.Devices.PreferredDiskBlockSize != nil && vmiDisk.BlockSize == nil {
+		vmiDisk.BlockSize = preferenceSpec.Devices.PreferredDiskBlockSize.DeepCopy()
+	}
+
+	if preferenceSpec.Devices.PreferredDiskCache != "" && vmiDisk.Cache == "" {
+		vmiDisk.Cache = preferenceSpec.Devices.PreferredDiskCache
+	}
+
+	if preferenceSpec.Devices.PreferredDiskIO != "" && vmiDisk.IO == "" {
+		vmiDisk.IO = preferenceSpec.Devices.PreferredDiskIO
+	}
+
+	if preferenceSpec.Devices.PreferredDiskDedicatedIoThread != nil &&
+		vmiDisk.DedicatedIOThread == nil &&
+		vmiDisk.DiskDevice.Disk.Bus == virtv1.DiskBusVirtio {
+		vmiDisk.DedicatedIOThread = pointer.P(*preferenceSpec.Devices.PreferredDiskDedicatedIoThread)
 	}
 }

--- a/pkg/instancetype/preference/apply/features.go
+++ b/pkg/instancetype/preference/apply/features.go
@@ -1,4 +1,3 @@
-//nolint:gocyclo
 /*
  * This file is part of the KubeVirt project
  *
@@ -64,6 +63,12 @@ func applyHyperVFeaturePreferences(preferenceSpec *v1beta1.VirtualMachinePrefere
 		vmiSpec.Domain.Features.Hyperv = &virtv1.FeatureHyperv{}
 	}
 
+	applyHyperVFeaturePreferencesPart1(preferenceSpec, vmiSpec)
+	applyHyperVFeaturePreferencesPart2(preferenceSpec, vmiSpec)
+	applyHyperVFeaturePreferencesPart3(preferenceSpec, vmiSpec)
+}
+
+func applyHyperVFeaturePreferencesPart1(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
 	// TODO clean this up with reflection?
 	if preferenceSpec.Features.PreferredHyperv.EVMCS != nil && vmiSpec.Domain.Features.Hyperv.EVMCS == nil {
 		vmiSpec.Domain.Features.Hyperv.EVMCS = preferenceSpec.Features.PreferredHyperv.EVMCS.DeepCopy()
@@ -84,7 +89,9 @@ func applyHyperVFeaturePreferences(preferenceSpec *v1beta1.VirtualMachinePrefere
 	if preferenceSpec.Features.PreferredHyperv.Relaxed != nil && vmiSpec.Domain.Features.Hyperv.Relaxed == nil {
 		vmiSpec.Domain.Features.Hyperv.Relaxed = preferenceSpec.Features.PreferredHyperv.Relaxed.DeepCopy()
 	}
+}
 
+func applyHyperVFeaturePreferencesPart2(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
 	if preferenceSpec.Features.PreferredHyperv.Reset != nil && vmiSpec.Domain.Features.Hyperv.Reset == nil {
 		vmiSpec.Domain.Features.Hyperv.Reset = preferenceSpec.Features.PreferredHyperv.Reset.DeepCopy()
 	}
@@ -104,7 +111,9 @@ func applyHyperVFeaturePreferences(preferenceSpec *v1beta1.VirtualMachinePrefere
 	if preferenceSpec.Features.PreferredHyperv.SyNICTimer != nil && vmiSpec.Domain.Features.Hyperv.SyNICTimer == nil {
 		vmiSpec.Domain.Features.Hyperv.SyNICTimer = preferenceSpec.Features.PreferredHyperv.SyNICTimer.DeepCopy()
 	}
+}
 
+func applyHyperVFeaturePreferencesPart3(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
 	if preferenceSpec.Features.PreferredHyperv.TLBFlush != nil && vmiSpec.Domain.Features.Hyperv.TLBFlush == nil {
 		vmiSpec.Domain.Features.Hyperv.TLBFlush = preferenceSpec.Features.PreferredHyperv.TLBFlush.DeepCopy()
 	}

--- a/pkg/instancetype/preference/apply/firmware.go
+++ b/pkg/instancetype/preference/apply/firmware.go
@@ -1,4 +1,3 @@
-//nolint:gocyclo
 /*
  * This file is part of the KubeVirt project
  *
@@ -42,6 +41,11 @@ func applyFirmwarePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSp
 		vmiFirmware.Bootloader = &virtv1.Bootloader{}
 	}
 
+	applyBiosPreferences(firmware, vmiFirmware)
+	applyEfiPreferences(firmware, vmiFirmware)
+}
+
+func applyBiosPreferences(firmware *v1beta1.FirmwarePreferences, vmiFirmware *virtv1.Firmware) {
 	if firmware.PreferredUseBios != nil &&
 		*firmware.PreferredUseBios &&
 		vmiFirmware.Bootloader.BIOS == nil &&
@@ -52,7 +56,9 @@ func applyFirmwarePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSp
 	if firmware.PreferredUseBiosSerial != nil && vmiFirmware.Bootloader.BIOS != nil && vmiFirmware.Bootloader.BIOS.UseSerial == nil {
 		vmiFirmware.Bootloader.BIOS.UseSerial = pointer.P(*firmware.PreferredUseBiosSerial)
 	}
+}
 
+func applyEfiPreferences(firmware *v1beta1.FirmwarePreferences, vmiFirmware *virtv1.Firmware) {
 	if vmiFirmware.Bootloader.EFI == nil && vmiFirmware.Bootloader.BIOS == nil && firmware.PreferredEfi != nil {
 		vmiFirmware.Bootloader.EFI = firmware.PreferredEfi.DeepCopy()
 		// When using PreferredEfi return early to avoid applying DeprecatedPreferredUseEfi or DeprecatedPreferredUseSecureBoot below


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Several files within `pkg/instancetype/` contained an overarching `//nolint:gocyclo` directive on line 1. These directives bypassed the project's linter maximum cyclomatic complexity threshold (15) due to extremely long handler functions masking complexity issues.

#### After this PR:
The monolithic logic within these application handlers has been extracted and split logically into smaller internal sub-component helper routines. This brings the cyclomatic complexity for all newly shaped functions well below the threshold limit. 

Consequently, all `//nolint:gocyclo` directives have been stripped at the top of these respective files:
* `pkg/instancetype/apply/cpu.go`
* `pkg/instancetype/preference/apply/device.go`
* `pkg/instancetype/preference/apply/disk.go`
* `pkg/instancetype/preference/apply/firmware.go`
* `pkg/instancetype/preference/apply/features.go`

### References
- Fixes #17205

### Why we need it and why it was done in this way
Reducing cyclomatic complexity improves code health, readability, and testability. Relying on file level `//nolint:gocyclo` directives masks complexity issues and makes it easier for new code in these files to cross complexity thresholds without being noticed by linters.

The following tradeoffs were made:
This introduces a few more private function signatures inside these modules, however, they heavily reduce cognitive load for developers trying to read how these instancetype features map configuration structs.

The following alternatives were considered:
Ignoring the lint rules and leaving the logic wrapped within the large handlers indefinitely. 

### Special notes for your reviewer
This change only implements a structural abstraction process. There are absolutely zero logical shifts occurring within the actual `apply` mechanisms. 

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```