### PR TITLE
feat: support annotation-based volume to pvc mapping for vm export

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -101,6 +101,9 @@ const (
 	annContentType = "cdi.kubevirt.io/storage.contentType"
 	// annCertParams stores "current" cert rotation params in pod in order to detect changes
 	annCertParams = "kubevirt.io/export.certParameters"
+	// annVolumePVCMap is a JSON string that maps pvcs and volumes
+	// example: '{"vol-ovidkvnd":"tpl-vol-ovidkvnd","vol-data":"pvc-data-01"}'
+	annVolumePVCMap = "export.kubevirt.io/volume-pvc-map"
 
 	caDefaultPath = "/etc/virt-controller/exportca"
 	caCertFile    = caDefaultPath + "/tls.crt"

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -20,6 +20,7 @@
 package export
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1beta1"
 	"kubevirt.io/client-go/log"
@@ -160,9 +162,16 @@ func (ctrl *VMExportController) getPVCsFromVMI(vmi *virtv1.VirtualMachineInstanc
 
 	// No need to handle error when using VMI to fetch volumes
 	volumes, _ := storageutils.GetVolumes(vmi, ctrl.Client, storageutils.WithAllVolumes)
+	volumePVCMap := ctrl.volumePVCMapFromAnnotations(vmi.Annotations)
 
 	for _, volume := range volumes {
-		pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
+		// if user specific pvc and volume mapping in annotation
+		// let annotation mappings take precedence
+		pvcName := volumePVCMap[volume.Name]
+		if pvcName == "" {
+			pvcName = storagetypes.PVCNameFromVirtVolume(&volume)
+		}
+
 		if pvc, err := ctrl.getPVCsFromName(vmi.Namespace, pvcName); err != nil {
 			log.Log.V(3).Infof("Error getting PVC %s/%s: %v", vmi.Namespace, pvcName, err)
 		} else if pvc != nil {
@@ -275,9 +284,16 @@ func (ctrl *VMExportController) getPVCsFromVM(vm *virtv1.VirtualMachine) ([]*cor
 		}
 		return nil, false, err
 	}
+	volumePVCMap := ctrl.volumePVCMapFromAnnotations(vm.Spec.Template.ObjectMeta.Annotations)
 
 	for _, volume := range volumes {
-		pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
+		// if user specific pvc and volume mapping in annotation
+		// let annotation mappings take precedence
+		pvcName := volumePVCMap[volume.Name]
+		if pvcName == "" {
+			pvcName = storagetypes.PVCNameFromVirtVolume(&volume)
+		}
+
 		if pvcName == "" {
 			continue
 		}
@@ -326,4 +342,20 @@ func (ctrl *VMExportController) getVmi(namespace, name string) (*virtv1.VirtualM
 		return nil, exists, err
 	}
 	return obj.(*virtv1.VirtualMachineInstance).DeepCopy(), true, nil
+}
+
+// volumePVCMapFromAnnotations parse annotations key annVolumePVCMap to a map
+func (ctrl *VMExportController) volumePVCMapFromAnnotations(annotations map[string]string) map[string]string {
+	value := annotations[annVolumePVCMap]
+	if value == "" {
+		return nil
+	}
+
+	volumePVCMap := map[string]string{}
+	if err := json.Unmarshal([]byte(value), &volumePVCMap); err != nil {
+		log.Log.V(3).Infof("Error parsing annotation %s: %v", annVolumePVCMap, err)
+		return nil
+	}
+
+	return volumePVCMap
 }

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -334,6 +334,20 @@ var _ = Describe("PVC source", func() {
 		return vm
 	}
 
+	createVMWithHostDisk := func() *virtv1.VirtualMachine {
+		vm := createVMWithoutVolumes()
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "hostdisk-volume",
+			VolumeSource: virtv1.VolumeSource{
+				HostDisk: &virtv1.HostDisk{
+					Path: "/tmp/hostdisk-volume.img",
+					Type: virtv1.HostDiskExists,
+				},
+			},
+		})
+		return vm
+	}
+
 	createVMIWithDataVolumes := func() *virtv1.VirtualMachineInstance {
 		return &virtv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
@@ -347,6 +361,39 @@ var _ = Describe("PVC source", func() {
 						VolumeSource: virtv1.VolumeSource{
 							DataVolume: &virtv1.DataVolumeSource{
 								Name: "volume1",
+							},
+						},
+					},
+					{
+						Name: "volume2",
+						VolumeSource: virtv1.VolumeSource{
+							DataVolume: &virtv1.DataVolumeSource{
+								Name: "volume2",
+							},
+						},
+					},
+				},
+			},
+			Status: virtv1.VirtualMachineInstanceStatus{
+				Phase: virtv1.Running,
+			},
+		}
+	}
+
+	createVMIWithHostDisk := func() *virtv1.VirtualMachineInstance {
+		return &virtv1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testVmName,
+				Namespace: testNamespace,
+			},
+			Spec: virtv1.VirtualMachineInstanceSpec{
+				Volumes: []virtv1.Volume{
+					{
+						Name: "hostdisk-volume",
+						VolumeSource: virtv1.VolumeSource{
+							HostDisk: &virtv1.HostDisk{
+								Path: "/tmp/hostdisk-volume.img",
+								Type: virtv1.HostDiskExists,
 							},
 						},
 					},
@@ -448,6 +495,95 @@ var _ = Describe("PVC source", func() {
 		testutils.ExpectEvent(recorder, serviceCreatedEvent)
 	})
 
+	It("Should create VM export, when HostDisk volume is mapped by annotation", func() {
+		testVMExport := createVMVMExport()
+		vm := createVMWithHostDisk()
+		vm.Spec.Template.ObjectMeta.Annotations = map[string]string{
+			annVolumePVCMap: `{"hostdisk-volume":"mapped-pvc"}`,
+		}
+		controller.VMInformer.GetStore().Add(vm)
+		controller.PVCInformer.GetStore().Add(createPVC("mapped-pvc", "kubevirt"))
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyKubevirtInternal(vmExport, vmExport.Name, testNamespace, "mapped-pvc")
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(podReadyReason))
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+	})
+
+	It("Should create VM export, when annotation map is invalid and fallback to volume resolution", func() {
+		testVMExport := createVMVMExport()
+		vm := createVMWithPVCs()
+		vm.Spec.Template.ObjectMeta.Annotations = map[string]string{
+			annVolumePVCMap: `{`,
+		}
+		controller.VMInformer.GetStore().Add(vm)
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyKubevirtInternal(vmExport, vmExport.Name, testNamespace, "volume1", "volume2")
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(podReadyReason))
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+	})
+
+	It("Should prefer annotation mapping over default VM volume resolution", func() {
+		testVMExport := createVMVMExport()
+		vm := createVMWithPVCs()
+		vm.Spec.Template.ObjectMeta.Annotations = map[string]string{
+			annVolumePVCMap: `{"volume1":"mapped-pvc"}`,
+		}
+		controller.VMInformer.GetStore().Add(vm)
+		controller.PVCInformer.GetStore().Add(createPVC("mapped-pvc", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyKubevirtInternal(vmExport, vmExport.Name, testNamespace, "mapped-pvc", "volume2")
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(podReadyReason))
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+	})
+
 	DescribeTable("Should create VM export, when VM is stopped, but VMI exists", func(vmiPhase virtv1.VirtualMachineInstancePhase) {
 		testVMExport := createVMVMExport()
 		controller.VMInformer.GetStore().Add(createVMWithDataVolumes())
@@ -479,6 +615,42 @@ var _ = Describe("PVC source", func() {
 		Entry("with succeeded phase", virtv1.Succeeded),
 		Entry("with failed phase", virtv1.Failed),
 	)
+
+	It("Should use annotation map when resolving PVCs from VMI", func() {
+		vmi := createVMIWithHostDisk()
+		vmi.Annotations = map[string]string{
+			annVolumePVCMap: `{"hostdisk-volume":"mapped-pvc"}`,
+		}
+
+		controller.PVCInformer.GetStore().Add(createPVC("mapped-pvc", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+
+		pvcs := controller.getPVCsFromVMI(vmi)
+		pvcNames := make([]string, 0, len(pvcs))
+		for _, pvc := range pvcs {
+			pvcNames = append(pvcNames, pvc.Name)
+		}
+
+		Expect(pvcNames).To(ConsistOf("mapped-pvc", "volume2"))
+	})
+
+	It("Should prefer annotation mapping over default VMI volume resolution", func() {
+		vmi := createVMIWithDataVolumes()
+		vmi.Annotations = map[string]string{
+			annVolumePVCMap: `{"volume1":"mapped-pvc"}`,
+		}
+
+		controller.PVCInformer.GetStore().Add(createPVC("mapped-pvc", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+
+		pvcs := controller.getPVCsFromVMI(vmi)
+		pvcNames := make([]string, 0, len(pvcs))
+		for _, pvc := range pvcs {
+			pvcNames = append(pvcNames, pvc.Name)
+		}
+
+		Expect(pvcNames).To(ConsistOf("mapped-pvc", "volume2"))
+	})
 
 	It("Should NOT create VM export, when VM is started", func() {
 		testVMExport := createVMVMExport()


### PR DESCRIPTION
Support annotation-based volume->PVC mapping for VM export

Related issue: Fixes #17190

### What this PR does

#### Before this PR
The VM export path resolved PVC names only through existing volume resolution logic
(`PVCNameFromVirtVolume`). For some volumes, this could result in an empty PVC name
in export flow, so the volume was not exportable.

#### After this PR
This PR adds annotation-based fallback mapping for VM export sources:

- Reads `export.kubevirt.io/volume-pvc-map` as a JSON map (`volumeName -> pvcName`).
- Applies in both VM and VMI export paths.
- Keeps existing default resolution first (`PVCNameFromVirtVolume`).
- Uses mapped PVC only when default resolution returns empty.

In short: this is an export-path behavior improvement using annotations, not an API change.

### Scope
- Export controller VM/VMI source handling only.
- No API schema change.
- No generated API/codegen updates required.

### Why this approach
- Solves the immediate export use case without introducing a new API field.
- Keeps backward compatibility and existing resolution behavior as primary.
- Uses an explicit, opt-in annotation only where default PVC resolution is insufficient.

### References
Fixes #17190

### Release note
```release-note
Export: Added support for annotation-based volume-to-PVC mapping via
`export.kubevirt.io/volume-pvc-map` in VM/VMI export paths. Default PVC resolution
is preserved and mapping is used only as fallback when default resolution is empty.
```