### PR TITLE
q(test_id:3150): flaky Operator test

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1184,7 +1184,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			allKvInfraPodsAreReady(kv)
 		})
 
-		It("[test_id:3150]should be able to update kubevirt install with custom image tag", decorators.Upgrade, func() {
+		It("[QUARANTINE][test_id:3150]should be able to update kubevirt install with custom image tag", decorators.Quarantine, decorators.Upgrade, func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Fail("KubeVirtVersionTagAlt must be configured for custom image tag tests")
 			}


### PR DESCRIPTION
Quarantine flaky test

`[sig-operator]Operator [rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]infrastructure management [test_id:3150]should be able to update kubevirt install with custom image tag`

[🔎](https://search.ci.kubevirt.io/?search=%5C%5Bsig-operator%5DOperator+%5C%5Brfe_id%3A2291%5D%5C%5Bcrit%3Ahigh%5D%5C%5Bvendor%3Acnv-qe%40redhat.com%5D%5C%5Blevel%3Acomponent%5Dinfrastructure+management+%5C%5Btest_id%3A3150%5Dshould+be+able+to+update+kubevirt+install+with+custom+image+tag&maxAge=336h&context=1&type=junit&name=&excludeName=periodic-.*&maxMatches=1&maxBytes=20971520&groupBy=job) 💥 8% over 336h on
[pull-kubevirt-e2e-k8s-1.33-sig-operator](https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.33-sig-operator):
Failures: [120h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-e2e-k8s-1.33-sig-operator/2031960203527720960) [144h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16228/pull-kubevirt-e2e-k8s-1.33-sig-operator/2031632879926120448) [168h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17088/pull-kubevirt-e2e-k8s-1.33-sig-operator/2031475268564029440) [192h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16882/pull-kubevirt-e2e-k8s-1.33-sig-operator/2030980158965420032) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16882/pull-kubevirt-e2e-k8s-1.33-sig-operator/2029634357701906432) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16882/pull-kubevirt-e2e-k8s-1.33-sig-operator/2029553046169587712) [288h0m0s](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16882/pull-kubevirt-e2e-k8s-1.33-sig-operator/2029536424356745216)

[1]: https://storage.googleapis.com/kubevirt-prow/reports/most-flaky-tests/kubevirt/kubevirt/index.html#test_%5bsig-operator%5dOperator%20%5brfe_id%3a2291%5d%5bcrit%3ahigh%5d%5bvendor%3acnv-qe%40redhat.com%5d%5blevel%3acomponent%5dinfrastructure%20management%20%5btest_id%3a3150%5dshould%20be%20able%20to%20update%20kubevirt%20install%20with%20custom%20image%20tag

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

