### PR TITLE
validation: fix architecture defaulting in VMI admitter

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -126,7 +126,7 @@ func (admitter *VMICreateAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 	_, isKubeVirtServiceAccount := admitter.KubeVirtServiceAccounts[ar.Request.UserInfo.Username]
 	causes = append(causes, ValidateVirtualMachineInstanceMetadata(k8sfield.NewPath("metadata"), &vmi.ObjectMeta, admitter.ClusterConfig, isKubeVirtServiceAccount)...)
 	causes = append(causes, webhooks.ValidateVirtualMachineInstanceHyperv(k8sfield.NewPath("spec").Child("domain").Child("features").Child("hyperv"), &vmi.Spec)...)
-	causes = append(causes, ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("spec"), &vmi.Spec)...)
+	causes = append(causes, ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("spec"), &vmi.Spec, admitter.ClusterConfig)...)
 	if len(causes) > 0 {
 		return webhookutils.ToAdmissionResponse(causes)
 	}
@@ -150,9 +150,12 @@ func warnDeprecatedAPIs(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.
 	return warnings
 }
 
-func ValidateVirtualMachineInstancePerArch(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+func ValidateVirtualMachineInstancePerArch(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	arch := spec.Architecture
+	if arch == "" {
+		arch = config.GetDefaultArchitecture()
+	}
 
 	switch arch {
 	case "amd64":

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -154,7 +154,12 @@ func ValidateVirtualMachineInstancePerArch(field *k8sfield.Path, spec *v1.Virtua
 	var causes []metav1.StatusCause
 	arch := spec.Architecture
 	if arch == "" {
-		arch = config.GetDefaultArchitecture()
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueRequired,
+			Message: "architecture is required but missing (should have been defaulted by mutation webhook)",
+			Field:   field.Child("architecture").String(),
+		})
+		return causes
 	}
 
 	switch arch {
@@ -770,7 +775,7 @@ func validateThreadCountOnArchitecture(field *k8sfield.Path, spec *v1.VirtualMac
 	var causes []metav1.StatusCause
 	arch := spec.Architecture
 	if arch == "" {
-		arch = config.GetDefaultArchitecture()
+		return causes
 	}
 
 	// Verify CPU thread count requested is 1 for ARM64 VMI architecture.
@@ -2106,7 +2111,7 @@ func validatePanicDevices(field *k8sfield.Path, spec *v1.VirtualMachineInstanceS
 
 	arch := spec.Architecture
 	if arch == "" {
-		arch = config.GetDefaultArchitecture()
+		return causes
 	}
 
 	if arch == "s390x" {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3767,7 +3767,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		DescribeTable("should accept supported video models per architecture", func(arch, videoType string) {
 			vmi.Spec.Domain.Devices.Video.Type = videoType
 			vmi.Spec.Architecture = arch
-			causes := ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("fake"), &vmi.Spec)
+			causes := ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty(), fmt.Sprintf("expected video type %s to be valid on arch %s", videoType, arch))
 		},
 			Entry("amd64 allows vga", "amd64", "vga"),
@@ -3785,7 +3785,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		DescribeTable("should reject unsupported video models per architecture", func(arch, videoType string) {
 			vmi.Spec.Domain.Devices.Video.Type = videoType
 			vmi.Spec.Architecture = arch
-			causes := ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("fake"), &vmi.Spec)
+			causes := ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).ToNot(BeEmpty(), fmt.Sprintf("expected video type %s to be invalid on arch %s", videoType, arch))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.video.type"))
 		},
@@ -3814,6 +3814,27 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Entry("s390x rejects none", "s390x", "none"),
 			Entry("s390x rejects invalid model", "s390x", "invalidmodel"),
 		)
+	})
+
+	Context("with architecture validation", func() {
+		var vmi *v1.VirtualMachineInstance
+		BeforeEach(func() {
+			vmi = api.NewMinimalVMI("testvmi")
+		})
+
+		It("should accept when architecture is empty (defaulted)", func() {
+			vmi.Spec.Architecture = ""
+			causes := ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("spec"), &vmi.Spec, config)
+			Expect(causes).To(BeEmpty(), "should accept empty architecture when it can be defaulted")
+		})
+
+		It("should fail when architecture is unsupported", func() {
+			vmi.Spec.Architecture = "invalidarch"
+			causes := ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("spec"), &vmi.Spec, config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("spec.architecture"))
+			Expect(causes[0].Message).To(ContainSubstring("unsupported architecture: invalidarch"))
+		})
 	})
 
 	Context("with RebootPolicy", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3822,10 +3822,12 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi = api.NewMinimalVMI("testvmi")
 		})
 
-		It("should accept when architecture is empty (defaulted)", func() {
+		It("should fail when architecture is empty", func() {
 			vmi.Spec.Architecture = ""
 			causes := ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("spec"), &vmi.Spec, config)
-			Expect(causes).To(BeEmpty(), "should accept empty architecture when it can be defaulted")
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("spec.architecture"))
+			Expect(causes[0].Message).To(ContainSubstring("architecture is required but missing"))
 		})
 
 		It("should fail when architecture is unsupported", func() {


### PR DESCRIPTION
### What this PR does

This PR fixes an architecture-validation inconsistency in the VMI admitter. 
Function `ValidateVirtualMachineInstancePerArch` in vmi-create-admitter.go rejects empty architecture fields. However, the mutation webhook and other validation functions (like `validateThreadCountOnArchitecture`) default this field from the cluster config. If validation is called on an unmutated object, it will fail unnecessarily.

#### Before this PR:
VMIs without an explicit architecture field were rejected by the validating webhook with an unsupported architecture:  error, even if cluster defaults were available.

#### After this PR:
The 
`ValidateVirtualMachineInstancePerArch` function now correctly resolves empty architecture fields using cluster defaults, ensuring consistency with KubeVirt's defaulting and validation patterns.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

