### PR TITLE
tests/infrastructure/prometheues: remove test_id:4145

### DIFF
--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/replicaset:go_default_library",
-        "//pkg/monitoring/metrics/virt-handler/domainstats:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -33,8 +33,6 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
-	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/domainstats"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnode"
 
@@ -399,56 +397,6 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		Entry("[test_id:4554] vcpu seconds", "kubevirt_vmi_vcpu_seconds_total", ">="),
 		Entry("[test_id:4556] vmi unused memory", "kubevirt_vmi_memory_unused_bytes", ">="),
 	)
-
-	It("[QUARANTINE][test_id:4145]should include correct labels for a running VMI", decorators.Quarantine, func() {
-		// Build expected metrics from the domainstats collector, excluding
-		// conditionally emitted metrics that require features not available
-		// on a basic Alpine VMI:
-		//   - filesystem metrics require qemu-guest-agent
-		//   - guest load metrics require qemu-guest-agent >= 10.0.0
-		conditionalMetrics := map[string]struct{}{
-			"kubevirt_vmi_filesystem_capacity_bytes": {},
-			"kubevirt_vmi_filesystem_used_bytes":     {},
-			"kubevirt_vmi_guest_load_1m":             {},
-			"kubevirt_vmi_guest_load_5m":             {},
-			"kubevirt_vmi_guest_load_15m":            {},
-		}
-
-		var expectedVMIMetrics []string
-		for _, m := range domainstats.Collector.Metrics {
-			if _, excluded := conditionalMetrics[m.GetOpts().Name]; !excluded {
-				expectedVMIMetrics = append(expectedVMIMetrics, m.GetOpts().Name)
-			}
-		}
-
-		By("Collecting metrics filtered by VMI name and namespace")
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
-		fetcher := metricsutil.NewMetricsFetcher("")
-		fetcher.AddNameFilter("kubevirt_vmi_")
-		fetcher.AddLabelFilter("name", preparedVMIs[0].Name, "namespace", preparedVMIs[0].Namespace)
-
-		metrics, err := fetcher.LoadMetrics(metricsPayload)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Checking that all expected metrics are present")
-		for _, metricName := range expectedVMIMetrics {
-			Expect(metrics).To(HaveKey(metricName),
-				"Expected metric %s to be present for VMI %s/%s",
-				metricName, preparedVMIs[0].Namespace, preparedVMIs[0].Name)
-		}
-
-		By("Checking that all VMI metrics have correct labels")
-		nodeName := pod.Spec.NodeName
-		for metricName, results := range metrics {
-			for _, result := range results {
-				Expect(result.Labels).To(SatisfyAll(
-					HaveKeyWithValue("node", nodeName),
-					HaveKeyWithValue("namespace", preparedVMIs[0].Namespace),
-					HaveKeyWithValue("name", preparedVMIs[0].Name),
-				), "Metric %s has incorrect labels", metricName)
-			}
-		}
-	})
 
 	It("[test_id:4147]should include kubernetes labels to VMI metrics", func() {
 		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)


### PR DESCRIPTION
### What this PR does

This PR removes the quarantined e2e test `test_id:4145` ("should include correct labels for a running VMI") rather than attempting another dequarantine.

This test has a history of repeated quarantine/fix/break cycles caused by a fundamental design flaw: it validates labels on **all** `kubevirt_vmi_*` metrics scraped from the endpoint, but assumes they all carry domainstats-style labels (`node`, `namespace`, `name`). Any new `kubevirt_vmi_*` metric registered outside the domainstats collector with a different label set breaks the test.

#### Before this PR:

The test is quarantined. Each attempt to fix it requires manually maintaining an exclusion list of metrics that don't fit the expected label schema. The exclusion list silently grows every time a new `kubevirt_vmi_*` metric is added outside the domainstats collector.

#### After this PR:

The test is removed. The label correctness it validates is already covered by existing unit tests:

- **`domainstats_test.go`** - verifies that `newCollectorResult()` and `newCollectorResultWithLabels()` always attach `node`, `namespace`, and `name` labels to every `CollectorResult`.
- **Structural guarantee** - every domainstats metric must go through one of these two functions to produce a `CollectorResult`. There is no alternate code path. Label correctness is enforced by construction, not by runtime assertion.
- **Per-metric unit tests** (`cpu_metrics_test.go`, `memory_metrics_test.go`, `block_metrics_test.go`, `network_metrics_test.go`, `filesystem_metrics_test.go`) validate that each collector emits the expected metrics with correct values.

### References

- [PR #16476](https://github.com/kubevirt/kubevirt/pull/16476) - refactored and quarantined the test
- [PR #16773](https://github.com/kubevirt/kubevirt/pull/16773) - rewrote the test to fix stale-metric flakiness
- [PR #17295](https://github.com/kubevirt/kubevirt/pull/17295) - introduced `kubevirt_vmi_sync_total`, breaking the test again

### Release note
```release-note
NONE
```
