### PR TITLE
Fix TARGET match condition for mshv test lanes

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -86,6 +86,12 @@ case "$TARGET" in
     export KUBEVIRT_HUGEPAGES_2M=512
     export KUBEVIRT_REALTIME_SCHEDULER=true
     ;;
+  *sig-compute-parallel-wg-mshv-amd64*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-parallel-wg-mshv-amd64/}
+    export KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true
+    add_feature_gate "ConfigurableHypervisor"
+    export HYPERVISOR="hyperv-direct"
+    ;;
   *sig-compute-migrations-wg-arm64*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations-wg-arm64/}
     export KUBEVIRT_E2E_PARALLEL_NODES=3
@@ -135,12 +141,6 @@ case "$TARGET" in
   *wg-arm64*)
     export KUBEVIRT_PROVIDER=${TARGET/-wg-arm64}
     export KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true
-    ;;
-  *wg-mshv-amd64*)
-    export KUBEVIRT_PROVIDER=${TARGET/-wg-mshv-amd64/}
-    export KUBEVIRT_COLLECT_CONTAINER_RUNTIME_DEBUG=true
-    add_feature_gate "ConfigurableHypervisor"
-    export HYPERVISOR="hyperv-direct"
     ;;
   *sev*)
     export KUBEVIRT_PROVIDER=${TARGET/-sev}


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Due to the case condition for matching `*wg-mshv-amd64*` is located after `*sig-compute*`, the MSHV test target of `kind-1.33-sig-compute-parallel-wg-mshv-amd64` would match the `*sig-compute*` case. This is not expected as the `*sig-compute*` case configures the script for KVM sig-compute test lane.

#### After this PR:

Make the matching condition for MSHV test lane more specific by including the test suite into the match substring. Move the condition up in the case chain to avoid matching with existing KVM based conditions.

### References

VEP tracking issue: https://github.com/kubevirt/enhancements/issues/97

### Why we need it and why it was done in this way

The existing pattern of `*sig-compute-migrations-wg-arm64*` was followed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

