### PR TITLE
tests: fix flaky vmi console timeouts

### DIFF
--- a/tests/console/BUILD.bazel
+++ b/tests/console/BUILD.bazel
@@ -15,8 +15,10 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/google.golang.org/grpc/codes:go_default_library",
     ],
 )

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -27,7 +27,10 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/gomega"
+
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	"github.com/onsi/ginkgo/v2"
 
@@ -47,6 +50,9 @@ const (
 	UTFPosEscape        = "\u001b\\[[0-9]+;[0-9]+H"
 
 	consoleConnectionTimeout = 30 * time.Second
+	sendTimeout              = 3 * time.Second
+	guestAgentTimeout        = 12 * time.Minute
+	guestAgentPollInterval   = 2 * time.Second
 )
 
 var (
@@ -216,7 +222,6 @@ func NewExpecter(
 				timeout.String(),
 			)
 	}
-	timeout -= serialConsoleCreateDuration
 
 	go func() {
 		resCh <- con.Stream(kvcorev1.StreamOptions{
@@ -225,7 +230,7 @@ func NewExpecter(
 		})
 	}()
 
-	opts = append(opts, expect.SendTimeout(timeout), expect.Verbose(true), expect.VerboseWriter(ginkgo.GinkgoWriter))
+	opts = append(opts, expect.SendTimeout(sendTimeout), expect.Verbose(true), expect.VerboseWriter(ginkgo.GinkgoWriter))
 	return expect.SpawnGeneric(&expect.GenOptions{
 		In:  vmiWriter,
 		Out: expecterReader,
@@ -300,4 +305,9 @@ func RetValueWithPrompt(retcode string) string {
 
 func RetValue(retcode string) string {
 	return `[\r\n]` + retcode + CRLF
+}
+
+func WaitForGuestAgentConnected(vmi *v1.VirtualMachineInstance, virtClient kubecli.KubevirtClient) {
+	Eventually(matcher.ThisVMI(vmi), guestAgentTimeout, guestAgentPollInterval).
+		Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 }

--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	connectionTimeout = 10 * time.Second
-	promptTimeout     = 5 * time.Second
+	connectionTimeout   = 20 * time.Second
+	defaultLoginTimeout = 180 * time.Second
+	promptTimeout       = 5 * time.Second
 )
 
 // LoginToFunction represents any of the LoginTo* functions
@@ -55,7 +56,7 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) err
 		&expect.BSnd{S: "gocubsgo\n"},
 		&expect.BExp{R: PromptExpression},
 	}
-	loginTimeout := 180 * time.Second
+	loginTimeout := defaultLoginTimeout
 	if len(timeout) > 0 {
 		loginTimeout = timeout[0]
 	}
@@ -105,7 +106,7 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) err
 		&expect.BSnd{S: "root\n"},
 		&expect.BExp{R: PromptExpression},
 	}
-	loginTimeout := 180 * time.Second
+	loginTimeout := defaultLoginTimeout
 	if len(timeout) > 0 {
 		loginTimeout = timeout[0]
 	}
@@ -126,12 +127,7 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) err
 func LoginToFedora(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) error {
 	virtClient := kubevirt.Client()
 
-	// TODO: This is temporary workaround for issue seen in CI
-	// We see that 10seconds for an initial boot is not enough
-	// At the same time it seems the OS is booted within 10sec
-	// We need to have a look on Running -> Booting time
-	const double = 2
-	expecter, _, err := NewExpecter(virtClient, vmi, double*connectionTimeout)
+	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
 	if err != nil {
 		return err
 	}
@@ -188,7 +184,7 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) err
 		&expect.BSnd{S: "sudo su\n"},
 		&expect.BExp{R: PromptExpression},
 	}
-	loginTimeout := 2 * time.Minute
+	loginTimeout := defaultLoginTimeout
 	if len(timeout) > 0 {
 		loginTimeout = timeout[0]
 	}
@@ -197,7 +193,7 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) err
 		log.DefaultLogger().Object(vmi).Reason(err).Errorf("Login attempt failed: %+v", res)
 		// Try once more since sometimes the login prompt is ripped apart by asynchronous daemon updates
 		if retryRes, retryErr := expecter.ExpectBatch(b, loginTimeout); retryErr != nil {
-			log.DefaultLogger().Object(vmi).Reason(retryErr).Errorf("Retried login attempt after two minutes failed: %+v", retryRes)
+			log.DefaultLogger().Object(vmi).Reason(retryErr).Errorf("Retried login attempt after three minutes failed: %+v", retryRes)
 			return retryErr
 		}
 	}

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1131,6 +1131,12 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				}, 3*time.Minute, 3*time.Second).Should(Equal(clone.Succeeded), "clone should finish successfully")
 			}
 
+			// waits for GuestAgentConnected condition prior to calling console.LoginToFedora
+			loginToFedora := func(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) error {
+				console.WaitForGuestAgentConnected(vmi, virtClient)
+				return console.LoginToFedora(vmi, timeout...)
+			}
+
 			It("[test_id:5259]should restore a vm multiple from the same snapshot", func() {
 				vm, vmi = createAndStartVM(renderVMWithRegistryImportDataVolume(cd.ContainerDiskCirros, snapshotStorageClass))
 
@@ -1395,14 +1401,8 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Expect(pvcs.Items).To(HaveLen(1))
 				pvc := pvcs.Items[0]
 
-				loginFunc := func(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) error {
-					// Wait for cloud init to finish and start the agent inside the vmi.
-					Eventually(matcher.ThisVMI(vmi)).WithTimeout(4 * time.Minute).WithPolling(2 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-					return console.LoginToFedora(vmi)
-				}
-
-				doRestoreNoVMStart("", loginFunc, onlineSnapshot, true, vm.Name)
-				startVMAfterRestore(vm.Name, "", true, loginFunc)
+				doRestoreNoVMStart("", loginToFedora, onlineSnapshot, true, vm.Name)
+				startVMAfterRestore(vm.Name, "", true, loginToFedora)
 				Expect(restore.Status.Restores).To(HaveLen(2))
 
 				By("Expect original backend PVC to be deleted")
@@ -1579,7 +1579,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				originalDVName := vm.Spec.DataVolumeTemplates[0].Name
-				doRestore("", console.LoginToFedora, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))
+				doRestore("", loginToFedora, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))
 				verifyRestore(restoreToNewVM, originalDVName)
 			},
 				Entry("[test_id:6836] to the same VM", false),
@@ -1660,7 +1660,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				By("Add persistent hotplug disk")
 				persistVolName := AddVolumeAndVerify(virtClient, snapshotStorageClass, vm)
 
-				doRestore("", console.LoginToFedora, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))
+				doRestore("", loginToFedora, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))
 				Expect(restore.Status.Restores).To(HaveLen(2))
 				if restoreToNewVM {
 					checkNewVMEquality()
@@ -1991,7 +1991,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				vm = libvmops.StartVirtualMachine(vm)
 				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
 				Expect(vm.Spec.RunStrategy).To(HaveValue(Equal(v1.RunStrategyRerunOnFailure)))
-				doRestoreNoVMStart("", console.LoginToFedora, onlineSnapshot, false, vm.Name)
+				doRestoreNoVMStart("", loginToFedora, onlineSnapshot, false, vm.Name)
 				Expect(restore.Status.Restores).To(HaveLen(1))
 				restoredVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -2032,7 +2032,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					getMemoryDump(vm.Name, vm.Namespace, memoryDumpPVCName)
 					waitMemoryDumpCompletion(vm)
 
-					doRestoreNoVMStart("", console.LoginToFedora, onlineSnapshot, false, getTargetVMName(restoreToNewVM, newVmName))
+					doRestoreNoVMStart("", loginToFedora, onlineSnapshot, false, getTargetVMName(restoreToNewVM, newVmName))
 					Expect(restore.Status.Restores).To(HaveLen(1))
 					Expect(restore.Status.Restores[0].VolumeName).ToNot(Equal(memoryDumpPVCName))
 
@@ -2048,7 +2048,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					}
 					Expect(restorePVC.Spec.DataSource.Name).To(Equal(expectedSource))
 
-					startVMAfterRestore(getTargetVMName(restoreToNewVM, newVmName), "", false, console.LoginToFedora)
+					startVMAfterRestore(getTargetVMName(restoreToNewVM, newVmName), "", false, loginToFedora)
 
 					targetVM := getTargetVM(restoreToNewVM)
 					targetVMI, err := virtClient.VirtualMachineInstance(targetVM.Namespace).Get(context.Background(), targetVM.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In the restore test suite, we are seeing two different flaky timeouts occur during calls to `LoginToFedora()`. One is being caused by the `SerialConsole` API call exceeding the timeout duration of 20s (in one failed run, it was seen to take 35s). Suggesting to increase this timeout threshold to 1minute.

Additionally, in other test cases it is seen that after a snapshot/restore, tests will start a new Fedora VMI and immediately attempt to console in to the VMI while it is still in the boot phase. This eventually throws an error in `LoginToFedora()` because it exceeds the loginTimeout value of 2 minutes.
Suggesting that the test functions that use Fedora VMs should first check that the VMI has the `AgentConnected` condition prior to attempting to establish a serial connection.

Example run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.34-sig-storage/2026321390910574592

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```