### PR TITLE
tests: gate console access on GuestAgentConnected for Fedora tests to…

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1418,6 +1418,8 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		It("soft reboot vmi with ACPI feature enabled should succeed", decorators.Conformance, func() {
 			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewFedora(), vmiLaunchTimeout)
+
+			Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			By("Disable qemu-guest-agent service in the VMI to force ACPI mode reboot")


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `soft reboot vmi with ACPI feature enabled should succeed` e2e test immediately attempted to use `console.LoginToFedora` right after `RunVMIAndExpectLaunch`. Because the OS hadn't stabilized and cloud-init hadn't finished, Fedora's `pam_nologin` feature blocked the SSH/console access, causing the test to randomly flake with 30s/120s timeouts.

#### After this PR:
The test now cleanly waits for the `VirtualMachineInstanceAgentConnected` condition using an `Eventually` block before attempting to open the console login. This aligns the test with the recommended healthy gate.

### References
Fixes #17085

### Why we need it and why it was done in this way
As noted in the linked issue, gating the console access on `GuestAgentConnected` is the recommended way to eliminate the F39 test flakes.

The following tradeoffs were made:
N/A

The following alternatives were considered:
N/A

### Special notes for your reviewer
@oshoval - This implements the healthy gate fix for the Fedora test flakes we discussed.
Since I am a new contributor, could a maintainer please review and comment `/ok-to-test` so the CI test lanes can run? Thank you!

### Checklist

- [ ] Design: A design document was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note

```release-note
NONE
