### PR TITLE
[WIP] Fix: guest agent probe failures during live migration

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -628,7 +628,51 @@ func (l *LibvirtDomainManager) Exec(domainName, command string, args []string, t
 	return agent.GuestExec(l.virConn, domainName, command, args, timeoutSeconds)
 }
 
+// handleGuestPingDuringMigration checks if we're in an active migration and whether
+// the guest ping should be handled specially. During migration, the target pod may
+// not have the domain running yet, so we return success to prevent kubelet from
+// terminating the target pod.
+//
+// Returns:
+//   - handled: true if the ping was handled (caller should return immediately with the error)
+//   - err: the error to return (nil means success)
+func (l *LibvirtDomainManager) handleGuestPingDuringMigration(domainName string) (handled bool, err error) {
+	migrationMetadata, migrationExists := l.metadataCache.Migration.Load()
+	if !migrationExists || migrationMetadata.UID == "" || migrationMetadata.EndTimestamp != nil || migrationMetadata.Failed {
+		return false, nil
+	}
+
+	domain, err := l.virConn.LookupDomainByName(domainName)
+	if err != nil {
+		if domainerrors.IsNotFound(err) {
+			log.Log.V(4).Infof("Guest agent ping during migration - domain not found, returning success to prevent target pod termination")
+			return true, nil
+		}
+		log.Log.Reason(err).Warning("Guest agent ping during migration - unexpected error looking up domain, returning success to prevent target pod termination")
+		return true, nil
+	}
+	defer domain.Free()
+
+	state, _, err := domain.GetState()
+	if err != nil {
+		log.Log.Reason(err).Warning("Guest agent ping during migration - cannot get domain state, returning success to prevent target pod termination")
+		return true, nil
+	}
+
+	if state != libvirt.DOMAIN_RUNNING {
+		log.Log.V(4).Infof("Guest agent ping during migration - domain not running (state %d), returning success to prevent target pod termination", state)
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func (l *LibvirtDomainManager) GuestPing(domainName string) error {
+	if handled, err := l.handleGuestPingDuringMigration(domainName); handled {
+		return err
+	}
+
+	// Normal case: ping the guest agent
 	pingCmd := `{"execute":"guest-ping"}`
 	_, err := l.virConn.QemuAgentCommand(pingCmd, domainName)
 	return err

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -3741,6 +3741,129 @@ var _ = Describe("Manager helper functions", func() {
 	})
 })
 
+var _ = Describe("GuestPing during migration", func() {
+	var mockLibvirt *testing.Libvirt
+	var ctrl *gomock.Controller
+	var testVirtShareDir string
+	var testEphemeralDiskDir string
+	var metadataCache *metadata.Cache
+	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
+	ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
+
+	newTestLibvirtManager := func() *LibvirtDomainManager {
+		agentStore := agentpoller.NewAsyncAgentStore()
+		manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName)
+		Expect(err).ToNot(HaveOccurred())
+		return manager.(*LibvirtDomainManager)
+	}
+
+	storeActiveMigration := func() {
+		metadataCache.Migration.Store(api.MigrationMetadata{
+			UID:            types.UID("test-migration-uid"),
+			StartTimestamp: &metav1.Time{Time: time.Now()},
+		})
+	}
+
+	BeforeEach(func() {
+		testVirtShareDir = fmt.Sprintf("fake-virt-share-%d", GinkgoRandomSeed())
+		testEphemeralDiskDir = fmt.Sprintf("fake-ephemeral-disk-%d", GinkgoRandomSeed())
+		ctrl = gomock.NewController(GinkgoT())
+		mockLibvirt = testing.NewLibvirt(ctrl)
+		metadataCache = metadata.NewCache()
+	})
+
+	It("should return success when domain doesn't exist during active migration", func() {
+		storeActiveMigration()
+		mockLibvirt.VirtConnectionEXPECT().LookupDomainByName(testDomainName).Return(nil, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should return success when domain lookup fails with unexpected error during active migration", func() {
+		storeActiveMigration()
+		mockLibvirt.VirtConnectionEXPECT().LookupDomainByName(testDomainName).Return(nil, libvirt.Error{Code: libvirt.ERR_INTERNAL_ERROR, Message: "connection reset"})
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should return success when domain is not running during active migration", func() {
+		storeActiveMigration()
+
+		mockDomain := mockLibvirt.Domain(testDomainName)
+		mockLibvirt.VirtConnectionEXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
+		mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, 1, nil)
+		mockLibvirt.DomainEXPECT().Free()
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should ping guest agent when domain is running during active migration", func() {
+		storeActiveMigration()
+
+		mockDomain := mockLibvirt.Domain(testDomainName)
+		mockLibvirt.VirtConnectionEXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
+		mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+		mockLibvirt.DomainEXPECT().Free()
+
+		mockLibvirt.VirtConnectionEXPECT().QemuAgentCommand(`{"execute":"guest-ping"}`, testDomainName).Return("", nil)
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should propagate guest agent error when domain is running during active migration", func() {
+		storeActiveMigration()
+
+		mockDomain := mockLibvirt.Domain(testDomainName)
+		mockLibvirt.VirtConnectionEXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
+		mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+		mockLibvirt.DomainEXPECT().Free()
+
+		mockLibvirt.VirtConnectionEXPECT().QemuAgentCommand(`{"execute":"guest-ping"}`, testDomainName).Return("", fmt.Errorf("guest agent not responding"))
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("guest agent not responding"))
+	})
+
+	It("should ping guest agent normally when no active migration", func() {
+		mockLibvirt.VirtConnectionEXPECT().QemuAgentCommand(`{"execute":"guest-ping"}`, testDomainName).Return("", nil)
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should ping guest agent normally when migration has completed", func() {
+		metadataCache.Migration.Store(api.MigrationMetadata{
+			UID:            types.UID("test-migration-uid"),
+			StartTimestamp: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+			EndTimestamp:   &metav1.Time{Time: time.Now()},
+		})
+
+		mockLibvirt.VirtConnectionEXPECT().QemuAgentCommand(`{"execute":"guest-ping"}`, testDomainName).Return("", nil)
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should ping guest agent normally when migration has failed", func() {
+		metadataCache.Migration.Store(api.MigrationMetadata{
+			UID:            types.UID("test-migration-uid"),
+			StartTimestamp: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+			Failed:         true,
+			FailureReason:  "test failure",
+		})
+
+		mockLibvirt.VirtConnectionEXPECT().QemuAgentCommand(`{"execute":"guest-ping"}`, testDomainName).Return("", nil)
+
+		err := newTestLibvirtManager().GuestPing(testDomainName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
 var _ = Describe("calculateHotplugPortCount", func() {
 	const gb = 1024 * 1024 * 1024
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
When a VM with guest agent probe configured undergoes live migration, the target virt-launcher pod is created with the same probe configuration. However, the guest agent is not running on the target pod yet (still on source), causing the probe to fail and kubelet to terminate the target pod, which leads to migration failure.

#### After this PR:
This commit modifies the GuestPing method to detect when a migration is in progress and return success for the target pod when the domain doesn't exist or is not running yet. This prevents premature pod termination while still maintaining normal probe behavior on the source pod and after migration completes.

Code was assisted by Cursor AI.
### References
- Fixes https://redhat.atlassian.net/browse/CNV-82217
- Partially addresses #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: guest agent probe failures during live migration
```

