### PR TITLE
VMPool: enable setHostnameToVMName feature for domain discovery

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21976,6 +21976,9 @@
      },
      "appendIndexToSecretRefs": {
       "type": "boolean"
+     },
+     "setHostnameToVMName": {
+      "type": "boolean"
      }
     }
    },

--- a/pkg/virt-controller/watch/pool/pool.go
+++ b/pkg/virt-controller/watch/pool/pool.go
@@ -949,6 +949,9 @@ func (c *Controller) scaleOut(pool *poolv1.VirtualMachinePool, count int) error 
 			vm.Labels = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels)
 			vm.Annotations = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Annotations)
 			vm.Spec = *indexVMSpec(&pool.Spec, index)
+			if pool.Spec.NameGeneration != nil && pool.Spec.NameGeneration.SetHostnameToVMName != nil && *pool.Spec.NameGeneration.SetHostnameToVMName {
+				vm.Spec.Template.Spec.Hostname = name
+			}
 			vm = injectPoolRevisionLabelsIntoVM(vm, revisionName)
 			controller.AddFinalizer(vm, poolv1.VirtualMachinePoolControllerFinalizer)
 
@@ -1086,6 +1089,9 @@ func (c *Controller) opportunisticUpdate(pool *poolv1.VirtualMachinePool, vmOutd
 			vmCopy.Labels = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels)
 			vmCopy.Annotations = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Annotations)
 			vmCopy.Spec = *indexVMSpec(&pool.Spec, index)
+			if pool.Spec.NameGeneration != nil && pool.Spec.NameGeneration.SetHostnameToVMName != nil && *pool.Spec.NameGeneration.SetHostnameToVMName {
+				vmCopy.Spec.Template.Spec.Hostname = vmCopy.Name
+			}
 			vmCopy = injectPoolRevisionLabelsIntoVM(vmCopy, revisionName)
 
 			// Preserve VM identity/specific fields that were set during VM creation

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -21335,6 +21335,8 @@ var CRDsValidation map[string]string = map[string]string{
               type: boolean
             appendIndexToSecretRefs:
               type: boolean
+            setHostnameToVMName:
+              type: boolean
           type: object
         paused:
           description: Indicates that the pool is paused.

--- a/staging/src/kubevirt.io/api/pool/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/pool/v1alpha1/deepcopy_generated.go
@@ -164,6 +164,11 @@ func (in *VirtualMachinePoolNameGeneration) DeepCopyInto(out *VirtualMachinePool
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SetHostnameToVMName != nil {
+		in, out := &in.SetHostnameToVMName, &out.SetHostnameToVMName
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/pool/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/pool/v1alpha1/types.go
@@ -161,6 +161,7 @@ type VirtualMachinePoolAutohealingStrategy struct {
 type VirtualMachinePoolNameGeneration struct {
 	AppendIndexToConfigMapRefs *bool `json:"appendIndexToConfigMapRefs,omitempty"`
 	AppendIndexToSecretRefs    *bool `json:"appendIndexToSecretRefs,omitempty"`
+	SetHostnameToVMName        *bool `json:"setHostnameToVMName,omitempty"`
 }
 
 // VirtualMachinePoolList is a list of VirtualMachinePool resources.

--- a/staging/src/kubevirt.io/api/pool/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/pool/v1beta1/deepcopy_generated.go
@@ -164,6 +164,11 @@ func (in *VirtualMachinePoolNameGeneration) DeepCopyInto(out *VirtualMachinePool
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SetHostnameToVMName != nil {
+		in, out := &in.SetHostnameToVMName, &out.SetHostnameToVMName
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/pool/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/pool/v1beta1/types.go
@@ -161,6 +161,7 @@ type VirtualMachinePoolAutohealingStrategy struct {
 type VirtualMachinePoolNameGeneration struct {
 	AppendIndexToConfigMapRefs *bool `json:"appendIndexToConfigMapRefs,omitempty"`
 	AppendIndexToSecretRefs    *bool `json:"appendIndexToSecretRefs,omitempty"`
+	SetHostnameToVMName        *bool `json:"setHostnameToVMName,omitempty"`
 }
 
 // VirtualMachinePoolList is a list of VirtualMachinePool resources.

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -32974,6 +32974,12 @@ func schema_kubevirtio_api_pool_v1alpha1_VirtualMachinePoolNameGeneration(ref co
 							Format: "",
 						},
 					},
+					"setHostnameToVMName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -33535,6 +33541,12 @@ func schema_kubevirtio_api_pool_v1beta1_VirtualMachinePoolNameGeneration(ref com
 						},
 					},
 					"appendIndexToSecretRefs": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"setHostnameToVMName": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

#### Before this PR:
There was no way to get guaranteed VM DNS names when using VMPool

#### After this PR:
VMPool has a configuration option to enable DNS name discovery using headless service

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes https://github.com/kubevirt/kubevirt/issues/17244

- Partially addresses #
-->

- Fixes https://github.com/kubevirt/kubevirt/issues/17244
- Partially addresses https://github.com/kubevirt/kubevirt/issues/17245
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

