### PR TITLE
docs: fix grammar and styling in libvirt-pod-networking

### DIFF
--- a/docs/network/libvirt-pod-networking.md
+++ b/docs/network/libvirt-pod-networking.md
@@ -13,7 +13,7 @@ This is obviously suboptimal:
 
 - It is not integrated with Kubernetes
 - It does not provide the VMI with connectivity to pods
-- It requires to specify host specific bits (the network device to use)
+- It requires specifying host-specific bits (the network device to use)
 
 The purpose of this document is to describe one approach of how we can provide
 a minimal integrated solution, with few workarounds.
@@ -57,7 +57,7 @@ Prerequisites:
   networking), as future Kubernetes multi-networking will work with pods,
   and as we do not want to mess with the hosts network namespace
 - A CNI proxy to allow pods to perform CNI actions in the context of the host
-  (this needs to be implemented, as part of this feature, or as an dependent
+  (this needs to be implemented, as part of this feature, or as a dependent
   one)
 
 Conceptually the implementation works by assuming that every vNIC will be
@@ -65,7 +65,7 @@ mapped to a _new_ pod interface. To achieve this, for every vNIC a _new_ pod
 interface is requested through CNI.
 Another crucial constraint for this design is that in Kubernetes IP addresses
 are getting assigned to pods, not interfaces. Thus this solution needs to
-achieve the same, and provide IP addresses to VMIs, not just a interface.
+achieve the same, and provide IP addresses to VMIs, not just an interface.
 
 During this document we call each of these _new_ pod interfaces _VMI interface_,
 in order to differentiate them from the originally-allocated pod interface
@@ -101,25 +101,25 @@ from the networking sub-system.
 
 ## Drawbacks & Limitations
 
-* Every virtual NIC can only use a single IP address (the one provided via
+- Every virtual NIC can only use a single IP address (the one provided via
   DHCP)
-* A new VMI interface is required for every vNIC.
-* Cleanup of the VMI interfaces in case of an uncontrolled pod shutdown is
+- A new VMI interface is required for every vNIC.
+- Cleanup of the VMI interfaces in case of an uncontrolled pod shutdown is
   currently not handled
 
 
 ## Benefits & Opportunities
 
-* Biggest plus is that this solution is using Kubernetes infrastructure for
+- Biggest plus is that this solution is using Kubernetes infrastructure for
   networking, is pretty much on the KubeVirt side (except for calling CNI on
   the host side), it is also reusing much of libvirt's network functionality.
-* If the CNI plugins are modified to signal if they can also provide L2
+- If the CNI plugins are modified to signal if they can also provide L2
   connectivity, then there is the chance, that a very similar mechanism can be
   used in future to provide L2 connectivity to VMIs (i.e. with the bridge or
   vxlan plugins).
 
 
-# Future development
+## Future development
 
 This approach is to provide initial, Kubernetes-friendly network connectivity
 for virtual machines.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR fixes grammatical errors and formatting inconsistencies within the [libvirt-pod-networking.md](cci:7://file:///home/kartheekbudime/kubevirt/docs/network/libvirt-pod-networking.md:0:0-0:0) design document.

#### Before this PR:
There were several grammar mistakes (such as "a interface" and "an dependent") and inconsistent uses of Markdown formatting (bulleted lists randomly switching between asterisks and dashes, and one incorrectly sized header `# Future development`).

#### After this PR:
The document has proper phrasing ("an interface", "a dependent"). The formatting for bulleted lists uses consistent dashes (`-`), and the final header is properly sized to match the rest of the document (`## Future development`).

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
N/A

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
To improve the readability, consistency, and polish of KubeVirt's documentation.

The following tradeoffs were made:
N/A

The following alternatives were considered:
N/A

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Just a quick drive-by documentation cleanup!

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
