### PR TITLE
e2e, fedora: Bump fedora guest image to F43

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -370,10 +370,9 @@ oci_pull(
 
 # Pull fedora container-disk preconfigured with ci tooling
 # like stress and qemu guest agent pre-configured
-# TODO build fedora_with_test_tooling for multi-arch
 oci_pull(
     name = "fedora_with_test_tooling",
-    digest = "sha256:897af945d1c58366086d5933ae4f341a5f1413b88e6c7f2b659436adc5d0f522",
+    digest = "sha256:11b6f78fe13216e448b63ef4272da75582450178ca086c98e6b97c03c90e766c",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
 
@@ -391,13 +390,13 @@ oci_pull(
 
 oci_pull(
     name = "fedora_with_test_tooling_aarch64",
-    digest = "sha256:3d5a2a95f7f9382dc6730073fe19a6b1bc668b424c362339c88c6a13dff2ef49",
+    digest = "sha256:e3b856b2875394c6e0d28287045ce32e917197a3777ab0ca0d5c943fcc6fde93",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
 
 oci_pull(
     name = "fedora_with_test_tooling_s390x",
-    digest = "sha256:3d9f468750d90845a81608ea13c85237ea295c6295c911a99dc5e0504c8bc05b",
+    digest = "sha256:39fa5525170d055926fc9b473cf65a4f781952c5b5bf84ae0a2ef0e1e2d881e7",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
 

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -41,7 +41,9 @@ spec:
           eth0:
             addresses: [ fd10:0:2::2/120 ]
             dhcp4: true
-            gateway6: fd10:0:2::1
+            routes:
+            - to: ::/0
+              via: fd10:0:2::1
       userData: |-
         #cloud-config
         password: fedora

--- a/tests/libnet/cloudinit/cloudinit.go
+++ b/tests/libnet/cloudinit/cloudinit.go
@@ -111,7 +111,10 @@ func WithDHCP6Disabled() NetworkDataInterfaceOption {
 
 func WithGateway6(gateway6 string) NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		networkDataInterface.Gateway6 = gateway6
+		networkDataInterface.Routes = append(networkDataInterface.Routes, CloudInitRoute{
+			To:  "::/0",
+			Via: gateway6,
+		})
 		return nil
 	}
 }

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -97,7 +97,7 @@ import (
 )
 
 const (
-	fedoraVMSize               = "256M"
+	fedoraVMSize               = "512Mi"
 	secretDiskSerial           = "D23YZ9W6WA5DJ487"
 	stressDefaultVMSize        = "100M"
 	stressLargeVMSize          = "400M"

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -154,7 +154,6 @@ var _ = Describe(SIG("Services", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToFedora)
-			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToFedora)
 		})
 
 		Context("with a service matching the vmi exposed", func() {
@@ -163,6 +162,7 @@ var _ = Describe(SIG("Services", func() {
 				serviceName := "myservice"
 
 				libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
+				startFedoraTCPServer(inboundVMI, servicePort, ipFamily)
 
 				By("setting up resources to expose the VMI via a service")
 				if ipFamily == k8sv1.IPv6Protocol {
@@ -207,4 +207,13 @@ func createServiceConnectivityJob(serviceName, namespace string, servicePort int
 	tcpJob := job.NewHelloWorldJobTCP(serviceFQDN, strconv.Itoa(servicePort))
 	tcpJob.Spec.BackoffLimit = &retries
 	return kubevirt.Client().BatchV1().Jobs(namespace).Create(context.Background(), tcpJob, k8smetav1.CreateOptions{})
+}
+
+func startFedoraTCPServer(vmi *v1.VirtualMachineInstance, port int, ipFamily k8sv1.IPFamily) {
+	familyFlag := "-4"
+	if ipFamily == k8sv1.IPv6Protocol {
+		familyFlag = "-6"
+	}
+	serverCommand := fmt.Sprintf("ncat %s -lk %d --sh-exec 'printf \"Hello World!\"' &", familyFlag, port)
+	Expect(console.RunCommand(vmi, serverCommand, 60*time.Second)).To(Succeed())
 }

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -1202,7 +1202,9 @@ var _ = Describe("Backup with migration", func() {
 				),
 			)
 
-			vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
+			vm = libvmi.NewVirtualMachine(
+				libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace, libvmi.WithMemoryRequest("512Mi")),
+				libvmi.WithDataVolumeTemplate(dv),
 				libvmi.WithLabels(cbt.CBTLabel),
 				libvmi.WithRunStrategy(v1.RunStrategyAlways),
 			)

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1249,5 +1249,12 @@ func renderVMWithRegistryImportDataVolume(containerDisk cd.ContainerDisk, storag
 			libdv.StorageWithVolumeSize(cd.ContainerDiskSizeBySourceURL(importUrl)),
 		),
 	)
-	return libstorage.RenderVMWithDataVolumeTemplate(dv)
+	var vmiOpts []libvmi.Option
+	if containerDisk == cd.ContainerDiskFedoraTestTooling {
+		vmiOpts = append(vmiOpts, libvmi.WithMemoryRequest("512Mi"))
+	}
+	return libvmi.NewVirtualMachine(
+		libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace, vmiOpts...),
+		libvmi.WithDataVolumeTemplate(dv),
+	)
 }

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1383,7 +1383,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			)
 
 			DescribeTable("Should restore a vm with backend storage", func(onlineSnapshot bool) {
-				vm = createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)
+				vm = createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithMemoryRequest("512Mi"))
 				vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
 				vm, vmi = createAndStartVM(vm)
 				Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -263,7 +263,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators
 func copyExampleGuestAgent(vmi *v1.VirtualMachineInstance) {
 	const port = 4444
 
-	err := console.RunCommand(vmi, fmt.Sprintf("netcat-openbsd -vl %d > /usr/bin/example-guest-agent < /dev/null &", port), 60*time.Second)
+	err := console.RunCommand(vmi, fmt.Sprintf("nc -vl %d > /usr/bin/example-guest-agent < /dev/null &", port), 60*time.Second)
 	Expect(err).ToNot(HaveOccurred())
 
 	file, err := os.Open(flags.KubeVirtExampleGuestAgentPath)

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -283,7 +283,7 @@ func copyExampleGuestAgent(vmi *v1.VirtualMachineInstance) {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Wait for netcat to exit
-	err = console.RunCommand(vmi, "while pgrep netcat; do sleep 3; done", 60*time.Second)
+	err = console.RunCommand(vmi, "while pgrep netcat; do sleep 1; done", 90*time.Second)
 	Expect(err).ToNot(HaveOccurred())
 }
 

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -486,7 +486,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 	vmi.Spec.Networks = []v1.Network{{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 	initFedora(&vmi.Spec)
-	networkData := "version: 2\nethernets:\n  eth0:\n    addresses: [ fd10:0:2::2/120 ]\n    dhcp4: true\n    gateway6: fd10:0:2::1\n"
+	networkData := "version: 2\nethernets:\n  eth0:\n    addresses: [ fd10:0:2::2/120 ]\n    dhcp4: true\n    routes:\n    - to: ::/0\n      via: fd10:0:2::1\n"
 	addNoCloudDiskWitUserDataNetworkData(
 		&vmi.Spec,
 		generateCloudConfigString(cloudConfigUserPassword, cloudConfigInstallAndStartService),


### PR DESCRIPTION
### What this PR does

Depends on kubevirt/kubevirtci#1657 - merged

Adapts the KubeVirt test suite to the Fedora 43 guest image built by the
companion kubevirtci PR. All changes are test/helper fixes required because
Fedora 43 ships newer versions of cloud-init, NetworkManager, and related
tooling.

Changes:

* cloud-init: replace deprecated `gateway6` with explicit routes

cloud-init 22.4 deprecated the `gateway6` shorthand in network-config-format-v2.
cloud-init 25.2 (Fedora 43) stops applying it via the NetworkManager renderer
entirely, leaving guests with no default IPv6 route.

Replace `gateway6: <gw>` with an explicit route entry `{to: ::/0, via: <gw>}`
in the `WithGateway6` helper (`tests/libnet/cloudinit/cloudinit.go`), the
vms-generator hardcoded network data string, and the `examples/vmi-masquerade.yaml`
example.

* Memory: bump Fedora VMI memory to 512Mi

Fedora 43 requires more memory than the previous 256Mi default for reliable
boot, matching what `libvmifact.NewFedora()` already sets.

- **storage tests** (`tests/storage/datavolume.go`, `restore.go`): bump
  `renderVMWithRegistryImportDataVolume` and the `createVMWithCloudInit` call
  site to 512Mi for `ContainerDiskFedoraTestTooling` VMIs.
- **migration and backup tests** (`tests/migration/migration.go`,
  `tests/storage/backup.go`): bump the `fedoraVMSize` constant from `"256M"` to
  `"512Mi"`. Also fix `backup.go` to construct the VMI directly with 512Mi
  instead of going through `RenderVMWithDataVolumeTemplate`, which only accepts
  VM-level options and fell back to the 256Mi default.

* vsock: use `nc` alias for OpenBSD netcat

The F43 image keeps OpenBSD netcat semantics as default `nc` via alternatives.
`netcat-openbsd` is not available in this setup. Update `copyExampleGuestAgent`
to use `"nc"` instead of `"netcat-openbsd"` (`tests/vmi_vsock_test.go`).

* network/services: use explicit `ncat` in Fedora connectivity paths

Use nmap-ncat in Fedora services connectivity paths
In Fedora masquerade service table entries. Start the service listener via
explicit ncat with required family flags (-4/-6) to match IPv4/IPv6 cases.
Keep shared non-Fedora paths unchanged by scoping this to the Fedora flow, and
remove the duplicate Fedora login from this path.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

