### PR TITLE
tests: wait for operator reconciliation in BlockUninstallIfWorkloadsExist

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1036,9 +1036,6 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 		Describe("[rfe_id:3578][crit:high][vendor:cnv-qe@redhat.com][level:component] deleting with BlockUninstallIfWorkloadsExist", func() {
 			BeforeEach(func() {
-				allKvInfraPodsAreReady(originalKv)
-				sanityCheckDeploymentsExist()
-
 				By("setting the right uninstall strategy")
 				patchBytes, err := patch.New(patch.WithAdd("/spec/uninstallStrategy", v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist)).GeneratePayload()
 				Expect(err).ToNot(HaveOccurred())
@@ -1048,6 +1045,10 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 					return kv.Spec.UninstallStrategy, err
 				}, 60*time.Second, time.Second).Should(Equal(v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist))
+
+				By("waiting for the operator to finish reconciling after the patch")
+				allKvInfraPodsAreReady(originalKv)
+				sanityCheckDeploymentsExist()
 			})
 
 			AfterEach(func() {
@@ -1060,6 +1061,10 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 					return kv.Spec.UninstallStrategy, err
 				}, 60*time.Second, time.Second).Should(BeEmpty())
+
+				By("waiting for the operator to finish reconciling after the patch")
+				allKvInfraPodsAreReady(originalKv)
+				sanityCheckDeploymentsExist()
 			})
 
 			It("[test_id:3683]should be blocked if a workload exists", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The `BlockUninstallIfWorkloadsExist` `BeforeEach` calls `allKvInfraPodsAreReady` and `sanityCheckDeploymentsExist` before patching the KubeVirt CR. This catches any pending reconciliation from the previous test's `AfterEach` but does not wait for the reconciliation triggered by the `BeforeEach` patch itself. The `AfterEach` also doesn't wait for reconciliation after removing the uninstall strategy.

This means the test can attempt to create a VMI while the operator is still reconciling, saturating the kube-apiserver and causing the virt-api webhook to timeout.

#### After this PR:

- `BeforeEach`: `allKvInfraPodsAreReady` and `sanityCheckDeploymentsExist` are moved from before the patch to after it, so they wait for the reconciliation triggered by setting the uninstall strategy.
- `AfterEach`: `allKvInfraPodsAreReady` and `sanityCheckDeploymentsExist` are added after removing the uninstall strategy, ensuring reconciliation completes before the next test cycle.

### References

- Fixes #17258

### Why we need it and why it was done in this way

The flake has **21 hits across 4 sig-operator jobs in the last 14 days**. Artifact analysis of [a representative failure](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16860/pull-kubevirt-e2e-k8s-1.33-sig-operator/2033528161798459392) confirmed:

- virt-api pods were healthy (running, 0 restarts, serving HTTP 200s)
- The kube-apiserver logged "client disconnected" and "Handler timeout" errors during the failure
- The virt-operator was mid-reconciliation with all deployments and the virt-handler DaemonSet rolling

### Special notes for your reviewer

Both `BeforeEach` and `AfterEach` patch the KubeVirt CR, each triggering an operator reconciliation. Both now wait for reconciliation to complete with `allKvInfraPodsAreReady` and `sanityCheckDeploymentsExist` after their respective patches.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```