### PR TITLE
tests/libpod: avoid source port collision

### DIFF
--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -99,12 +99,12 @@ func listPods(labelSelectors ...string) []k8sv1.Pod {
 
 func verifyTLSEnforcement(pods []k8sv1.Pod, containerPort int, cipher *tls.CipherSuite) {
 	for i := range pods {
-		func(i int, pod *k8sv1.Pod) {
+		func(pod *k8sv1.Pod) {
 			stopChan := make(chan struct{})
 			defer close(stopChan)
 			const expectTimeout = 10 * time.Second
-			localPort := 8440 + i
-			Expect(libpod.ForwardPorts(pod, []string{fmt.Sprintf("%d:%d", localPort, containerPort)}, stopChan, expectTimeout)).To(Succeed())
+			localPort, fwErr := libpod.ForwardPorts(pod, []string{fmt.Sprintf("0:%d", containerPort)}, stopChan, expectTimeout)
+			Expect(fwErr).ToNot(HaveOccurred())
 
 			acceptedTLSConfig := &tls.Config{
 				//nolint:gosec
@@ -131,6 +131,6 @@ func verifyTLSEnforcement(pods []k8sv1.Pod, containerPort int, cipher *tls.Ciphe
 				// The error message changed with the golang 1.19 update
 				BeEquivalentTo("tls: no supported versions satisfy MinVersion and MaxVersion"),
 			))
-		}(i, &pods[i])
+		}(&pods[i])
 	}
 }

--- a/tests/libkubevirt/config/kvconfig.go
+++ b/tests/libkubevirt/config/kvconfig.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -173,14 +172,10 @@ func WaitForConfigToBePropagatedToComponent(podLabel, resourceVersion string, co
 }
 
 func callURLOnPod(pod *k8sv1.Pod, port, url string) ([]byte, error) {
-	const minPort = 4321
-	const maxPortIncrease = 6000
-	//nolint:gosec
-	randPort := strconv.Itoa(minPort + rand.Intn(maxPortIncrease))
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	readyTimeout := 5 * time.Second
-	err := libpod.ForwardPorts(pod, []string{fmt.Sprintf("%s:%s", randPort, port)}, stopChan, readyTimeout)
+	localPort, err := libpod.ForwardPorts(pod, []string{"0:" + port}, stopChan, readyTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +188,7 @@ func callURLOnPod(pod *k8sv1.Pod, port, url string) ([]byte, error) {
 	client := &http.Client{Transport: tr}
 	req, err := http.NewRequestWithContext(
 		context.Background(), "GET",
-		fmt.Sprintf("https://localhost:%s/%s", randPort, strings.TrimSuffix(url, "/")), http.NoBody)
+		fmt.Sprintf("https://localhost:%d/%s", localPort, strings.TrimSuffix(url, "/")), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/libpod/certs.go
+++ b/tests/libpod/certs.go
@@ -24,9 +24,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"math/rand"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
@@ -68,12 +66,6 @@ func GetCertsForPods(labelSelector, namespace, port string) ([][]byte, error) {
 }
 
 func getCert(pod *k8sv1.Pod, port string) []byte {
-	const (
-		basePort  = 4321
-		portRange = 6000
-	)
-	//nolint:gosec
-	randPort := strconv.Itoa(basePort + rand.Intn(portRange))
 	var rawCert []byte
 	mutex := &sync.Mutex{}
 	conf := &tls.Config{
@@ -93,10 +85,10 @@ func getCert(pod *k8sv1.Pod, port string) []byte {
 		stopChan := make(chan struct{})
 		defer close(stopChan)
 		const timeout = 10
-		err := ForwardPorts(pod, []string{fmt.Sprintf("%s:%s", randPort, port)}, stopChan, timeout*time.Second)
+		localPort, err := ForwardPorts(pod, []string{"0:" + port}, stopChan, timeout*time.Second)
 		ExpectWithOffset(offset, err).ToNot(HaveOccurred())
 
-		conn, err := tls.Dial("tcp4", fmt.Sprintf("localhost:%s", randPort), conf)
+		conn, err := tls.Dial("tcp4", fmt.Sprintf("localhost:%d", localPort), conf)
 		if err == nil {
 			defer conn.Close()
 		}
@@ -110,9 +102,16 @@ func getCert(pod *k8sv1.Pod, port string) []byte {
 	return certificate
 }
 
-func ForwardPorts(pod *k8sv1.Pod, ports []string, stop chan struct{}, readyTimeout time.Duration) error {
+// ForwardPorts starts port-forwarding from a pod's remote port to a local port
+// and waits until the tunnel is ready. Returns the assigned local port number.
+// Pass "0:remotePort" in ports to let the OS pick a free ephemeral local port.
+func ForwardPorts(pod *k8sv1.Pod, ports []string, stop chan struct{}, readyTimeout time.Duration) (uint16, error) {
+	if len(ports) != 1 {
+		return 0, fmt.Errorf("ForwardPorts requires exactly one port mapping, got %d", len(ports))
+	}
 	errChan := make(chan error, 1)
 	readyChan := make(chan struct{})
+	var forwarder *portforward.PortForwarder
 	go func() {
 		cli := kubevirt.Client()
 
@@ -133,23 +132,30 @@ func ForwardPorts(pod *k8sv1.Pod, ports []string, stop chan struct{}, readyTimeo
 			return
 		}
 		dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
-		forwarder, err := portforward.New(dialer, ports, stop, readyChan, GinkgoWriter, GinkgoWriter)
+		forwarder, err = portforward.New(dialer, ports, stop, readyChan, GinkgoWriter, GinkgoWriter)
 		if err != nil {
 			errChan <- err
 			return
 		}
-		err = forwarder.ForwardPorts()
-		if err != nil {
+		if err = forwarder.ForwardPorts(); err != nil {
 			errChan <- err
 		}
 	}()
 
+	// Wait for forwarding to be ready, then get ports synchronously
 	select {
 	case err := <-errChan:
-		return err
+		return 0, err
 	case <-readyChan:
-		return nil
+		assignedPorts, err := forwarder.GetPorts()
+		if err != nil {
+			return 0, err
+		}
+		if len(assignedPorts) == 0 {
+			return 0, fmt.Errorf("no ports were forwarded")
+		}
+		return assignedPorts[0].Local, nil
 	case <-time.After(readyTimeout):
-		return fmt.Errorf("failed to forward ports, timed out")
+		return 0, fmt.Errorf("failed to forward ports, timed out")
 	}
 }

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1348,7 +1348,8 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 					errors := make(chan error, len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts))
 					for port := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
-						portI, _ := strconv.Atoi(port)
+						portI, err := strconv.Atoi(port)
+						Expect(err).ToNot(HaveOccurred())
 						go func(port int) {
 							defer GinkgoRecover()
 							defer wg.Done()
@@ -1426,7 +1427,8 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 					errors := make(chan error, len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts))
 					for port := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
-						portI, _ := strconv.Atoi(port)
+						portI, err := strconv.Atoi(port)
+						Expect(err).ToNot(HaveOccurred())
 						go func(port int) {
 							defer GinkgoRecover()
 							defer wg.Done()

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1346,21 +1346,20 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					var wg sync.WaitGroup
 					wg.Add(len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts))
 
-					i := 0
 					errors := make(chan error, len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts))
 					for port := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
 						portI, _ := strconv.Atoi(port)
-						go func(i int, port int) {
+						go func(port int) {
 							defer GinkgoRecover()
 							defer wg.Done()
 							stopChan := make(chan struct{})
 							defer close(stopChan)
-							Expect(libpod.ForwardPorts(handler, []string{fmt.Sprintf("4321%d:%d", i, port)}, stopChan, 10*time.Second)).To(Succeed())
-							_, err := tls.Dial("tcp", fmt.Sprintf("localhost:4321%d", i), tlsConfig)
+							localPort, fwErr := libpod.ForwardPorts(handler, []string{fmt.Sprintf("0:%d", port)}, stopChan, 10*time.Second)
+							Expect(fwErr).ToNot(HaveOccurred())
+							_, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", localPort), tlsConfig)
 							Expect(err).To(HaveOccurred())
 							errors <- err
-						}(i, portI)
-						i++
+						}(portI)
 					}
 					wg.Wait()
 					close(errors)
@@ -1425,25 +1424,24 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					var wg sync.WaitGroup
 					wg.Add(len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts))
 
-					i := 0
 					errors := make(chan error, len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts))
 					for port := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
 						portI, _ := strconv.Atoi(port)
-						go func(i int, port int) {
+						go func(port int) {
 							defer GinkgoRecover()
 							defer wg.Done()
 							stopChan := make(chan struct{})
 							defer close(stopChan)
-							Expect(libpod.ForwardPorts(handler, []string{fmt.Sprintf("4321%d:%d", i, port)}, stopChan, 10*time.Second)).To(Succeed())
-							conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:4321%d", i), tlsConfig)
+							localPort, fwErr := libpod.ForwardPorts(handler, []string{fmt.Sprintf("0:%d", port)}, stopChan, 10*time.Second)
+							Expect(fwErr).ToNot(HaveOccurred())
+							conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", localPort), tlsConfig)
 							if conn != nil {
 								b := make([]byte, 1)
 								_, err = conn.Read(b)
 							}
 							Expect(err).To(HaveOccurred())
 							errors <- err
-						}(i, portI)
-						i++
+						}(portI)
 					}
 					wg.Wait()
 					close(errors)


### PR DESCRIPTION
Modify  `libpod.ForwardPorts` to return a source port from the operating system instead of hoping that a random one would be free.
I am not sure that this significantly improves test reliability, but it cleans up the code and does things properly.

/kind cleanup

```release-note
NONE
```

