### PR TITLE
sync: propagate Failed and Completed fields in source sync

### DIFF
--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -1224,8 +1224,6 @@ func copyLegacyTargetFields(vmi *virtv1.VirtualMachineInstance, migrationState *
 	}
 	vmi.Status.MigrationState.TargetPod = targetState.Pod
 	copyCommonLegacyFields(vmi.Status.MigrationState, migrationState)
-	vmi.Status.MigrationState.Completed = migrationState.Completed
-	vmi.Status.MigrationState.Failed = migrationState.Failed
 }
 
 func copyLegacySourceFields(vmi *virtv1.VirtualMachineInstance, migrationState *virtv1.VirtualMachineInstanceMigrationState) {
@@ -1250,6 +1248,12 @@ func copyCommonLegacyFields(targetMigrationState, sourceMigrationState *virtv1.V
 	}
 	if sourceMigrationState.EndTimestamp != nil {
 		targetMigrationState.EndTimestamp = sourceMigrationState.EndTimestamp
+	}
+	if sourceMigrationState.Completed {
+		targetMigrationState.Completed = true
+	}
+	if sourceMigrationState.Failed {
+		targetMigrationState.Failed = true
 	}
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`copyLegacySourceFields` (used when syncing source state to the target via `SyncSourceMigrationStatus`) did not copy the `Failed` or `Completed` fields from the source's `MigrationState` to the target VMI. In contrast, `copyLegacyTargetFields` (used for target→source sync) did copy both fields.

This asymmetry meant that when the source virt-handler set `Failed=true` on the source VMI after a pod deletion during a cross-namespace migration, this state was never synced to the target VMI. The migration controller for the target migration only reads the target VMI, so the target migration incorrectly reached `Succeeded` instead of `Failed`.

#### After this PR:

`Completed` and `Failed` propagation is moved into `copyCommonLegacyFields` (called by both `copyLegacySourceFields` and `copyLegacyTargetFields`), using sticky semantics (only set to true, never clear) to prevent a stale sync from regressing a locally-set failure state.

### References

- Fixes #17261

### Why we need it and why it was done in this way

The consistently failing test `should properly propagate failure from target to source` (`tests/migration/namespace.go:637`) times out waiting for the target migration to reach `Failed`, because the target VMI's `MigrationState.Failed` is never set — the source's failure state is not synced to the target.

The following tradeoffs were made:

Using sticky semantics (`if source.Failed { target.Failed = true }`) rather than unconditional assignment to prevent a stale sync from clearing a locally-set failure state.

The following alternatives were considered:

1. Having the migration controller check the `decentralizedMigrationBlocked` condition when determining migration phase — this would serve as a fallback for cases where the sync race is too tight (source cleaned up before sync happens). This may still be needed as a follow-up.
2. Adding explicit failure propagation in the sync controller when `handleTargetState` fails — this would handle the case where the source is already unreachable.

### Special notes for your reviewer

There is a secondary timing issue: this fix only works if the source sync controller sends one more sync after `Failed=true` is set and before the source objects are cleaned up. If cleanup happens too fast, the sync call won't happen and the `decentralizedMigrationBlocked` condition path would need to serve as a fallback (separate fix).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: Existing e2e test `should properly propagate failure from target to source` covers this fix
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Bug fix: Fixed cross-namespace migration failure propagation where source migration failure was not synced to the target, causing the target migration to incorrectly reach Succeeded instead of Failed.
```