### PR TITLE
OWNERS: allow sig-test to approve all *_test.go files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,4 +15,6 @@ filters:
       - sig-buildsystem-approvers
     labels:
       - sig/buildsystem
-  
+  ".*_test\\.go$":
+    approvers:
+      - sig-test-approvers


### PR DESCRIPTION
### What this PR does
#### Before this PR:
sig-test-approvers can only approve test files under `tests/`.

#### After this PR:
sig-test-approvers can approve any `*_test.go` file across the entire repo via a root OWNERS filter.

### References

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Only approvers are added, not reviewers, to avoid noisy reviewer assignments on every PR touching test files.

The following alternatives were considered:
- Adding OWNERS files in each subdirectory — rejected as it would require many files and ongoing maintenance.

Links to places where the discussion took place:

### Special notes for your reviewer
The root OWNERS file was recently restructured to use filters for the base reviewers/approvers and buildsystem. This PR adds a `".*_test\.go$"` filter on top of that structure.

### Checklist

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```