### PR TITLE
tests/clone: run in parallel

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -15,7 +15,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/events"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -49,14 +49,15 @@ const (
 	vmAPIGroup = "kubevirt.io"
 )
 
-var _ = Describe("VirtualMachineClone Tests", Serial, func() {
+var _ = Describe("VirtualMachineClone Tests", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 
-		config.EnableFeatureGate(featuregate.SnapshotGate)
+		Expect(checks.HasFeature(featuregate.SnapshotGate)).To(BeTrue(),
+			"SnapshotGate must be enabled by suite setup")
 
 		format.MaxLength = 0
 	})


### PR DESCRIPTION
The top-level Describe was marked Serial to protect a BeforeEach call to
config.EnableFeatureGate(SnapshotGate). However, AdjustKubeVirtResource
in testsuite/kubevirtresource.go already appends SnapshotGate to the
KubeVirt feature gate list during suite setup, making EnableFeatureGate a
silent no-op: the function returns early without calling
UpdateKubeVirtConfigValueAndWait when checks.HasFeature() returns true.

The Serial constraint forced 10 clone tests into the Serial job, which
is already the slow and unreliable. I'm not a fan of parallelism, as
what we most anctiously need is stabilty. But that's a matter for a
future discussion.

The clone tests only create namespace-scoped VirtualMachineClone objects, so
parallel workers cannot collide, so they can safely run in normal jobs.


```release-note
NONE
```

