### PR TITLE
tests: use Guestless VMs in multiple tests

### DIFF
--- a/tests/compute/subresources/expandspec.go
+++ b/tests/compute/subresources/expandspec.go
@@ -106,7 +106,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 
 		Context("with existing VM", func() {
 			It("[test_id:TODO] should return unchanged VirtualMachine, if instancetype is not used", func() {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -136,7 +136,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 
 		Context("with passed VM in request", func() {
 			It("[test_id:TODO] should return unchanged VirtualMachine, if instancetype is not used", func() {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 
 				expandedVm, err := virtClient.ExpandSpec(testsuite.GetTestNamespace(vm)).ForVirtualMachine(vm)
 				Expect(err).ToNot(HaveOccurred())
@@ -169,7 +169,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 			)
 
 			DescribeTable("[test_id:TODO] should fail, if instancetype expansion hits a conflict", func(matcherFn func() *v1.InstancetypeMatcher) {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.Instancetype = matcherFn()
 
 				_, err := virtClient.ExpandSpec(testsuite.GetTestNamespace(vm)).ForVirtualMachine(vm)
@@ -181,7 +181,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 			)
 
 			DescribeTable("[test_id:TODO] should fail, if VM and endpoint namespace are different", func(matcherFn func() *v1.InstancetypeMatcher) {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.Instancetype = matcherFn()
 				vm.Namespace = "madethisup"
 
@@ -248,7 +248,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 
 		Context("with existing VM", func() {
 			It("[test_id:TODO] should return unchanged VirtualMachine, if preference is not used", func() {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 
 				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -260,7 +260,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 			})
 
 			DescribeTable("[test_id:TODO] should return VirtualMachine with preference expanded", func(matcherFn func() *v1.PreferenceMatcher) {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.Preference = matcherFn()
 
 				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
@@ -279,7 +279,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 
 		Context("with passed VM in request", func() {
 			It("[test_id:TODO] should return unchanged VirtualMachine, if preference is not used", func() {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 
 				expandedVm, err := virtClient.ExpandSpec(testsuite.GetTestNamespace(vm)).ForVirtualMachine(vm)
 				Expect(err).ToNot(HaveOccurred())
@@ -287,7 +287,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 			})
 
 			DescribeTable("[test_id:TODO] should return VirtualMachine with preference expanded", func(matcherFn func() *v1.PreferenceMatcher) {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.Preference = matcherFn()
 
 				expandedVm, err := virtClient.ExpandSpec(testsuite.GetTestNamespace(vm)).ForVirtualMachine(vm)
@@ -300,7 +300,7 @@ var _ = Describe(compute.SIG("ExpandSpec subresource", decorators.SigComputeInst
 			)
 
 			DescribeTable("[test_id:TODO] should fail, if referenced preference does not exist", func(matcher *v1.PreferenceMatcher) {
-				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.Preference = matcher
 
 				_, err := virtClient.ExpandSpec(testsuite.GetTestNamespace(vm)).ForVirtualMachine(vm)

--- a/tests/compute/subresources/migrate.go
+++ b/tests/compute/subresources/migrate.go
@@ -54,7 +54,7 @@ var _ = Describe(compute.SIG("Migrate subresource", func() {
 		Expect(len(nodes.Items)).To(BeNumerically(">", 1), "Migration tests require at least 2 nodes")
 
 		By("Creating a VM with RunStrategyAlways")
-		vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine(
+		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		), libvmi.WithRunStrategy(v1.RunStrategyAlways))
@@ -83,7 +83,7 @@ var _ = Describe(compute.SIG("Migrate subresource", func() {
 			Fail("Migration tests require at least 2 nodes")
 		}
 		By("Creating a VM with RunStrategyAlways")
-		vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine(
+		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		), libvmi.WithRunStrategy(v1.RunStrategyAlways))

--- a/tests/compute/subresources/rbac.go
+++ b/tests/compute/subresources/rbac.go
@@ -48,7 +48,7 @@ var _ = Describe(compute.SIG("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.co
 		})
 
 		It("[test_id:3170]should allow access to vm subresource endpoint", func() {
-			vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+			vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 			vm, err := kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = saClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Start(context.Background(), vm.Name, &v1.StartOptions{})
@@ -77,7 +77,7 @@ var _ = Describe(compute.SIG("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.co
 		})
 
 		It("[test_id:3171]should block access to vm subresource endpoint", func() {
-			vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+			vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 			vm, err := kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = saClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Start(context.Background(), vm.Name, &v1.StartOptions{})

--- a/tests/compute/subresources/stop.go
+++ b/tests/compute/subresources/stop.go
@@ -81,7 +81,7 @@ var _ = Describe(compute.SIG("Stop subresource", func() {
 
 	It("should be able to stop a VM during crashloop backoff when when 'runStrategy: Always' is set", func() {
 		By("Creating VirtualMachine")
-		vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine(
+		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(
 			libvmi.WithAnnotation(v1.FuncTestLauncherFailFastAnnotation, ""),
 		), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})

--- a/tests/compute/vmidefaults.go
+++ b/tests/compute/vmidefaults.go
@@ -211,7 +211,7 @@ var _ = Describe(SIG("VMIDefaults", func() {
 
 		It("[test_id:TODO]Should be applied to a device added by AutoattachInputDevice", func() {
 			By("Creating a VirtualMachine with AutoattachInputDevice enabled")
-			vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 			vm.Spec.Template.Spec.Domain.Devices.AutoattachInputDevice = pointer.P(true)
 			vm, err := kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/infrastructure/k8s-client-changes.go
+++ b/tests/infrastructure/k8s-client-changes.go
@@ -73,7 +73,7 @@ var _ = Describe(SIGSerial("changes to the kubernetes client", func() {
 
 	It("on the controller rate limiter should lead to delayed VMI starts", func() {
 		By("first getting the basetime for a replicaset")
-		replicaset := replicaset.New(libvmifact.NewAlpine(libvmi.WithMemoryRequest("1Mi")), 0)
+		replicaset := replicaset.New(libvmifact.NewGuestless(libvmi.WithMemoryRequest("1Mi")), 0)
 		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), replicaset, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		start := time.Now()

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -367,7 +367,7 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 		})
 
 		It("should not schedule vmi with host-model cpuModel to node with obsolete host-model cpuModel", func() {
-			vmi := libvmifact.NewFedora(
+			vmi := libvmifact.NewGuestless(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)

--- a/tests/migration/evacuation.go
+++ b/tests/migration/evacuation.go
@@ -54,7 +54,7 @@ import (
 var _ = Describe(SIG("VM Live Migration triggered by evacuation", decorators.RequiresTwoSchedulableNodes, func() {
 	Context("during evacuation", func() {
 		It("should add eviction-in-progress annotation to source virt-launcher pod", func() {
-			vmi := libvmifact.NewAlpine(
+			vmi := libvmifact.NewGuestless(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
@@ -108,7 +108,7 @@ var _ = Describe(SIG("VM Live Migration triggered by evacuation", decorators.Req
 		Context("when evacuating fails", func() {
 			var vmi *v1.VirtualMachineInstance
 			BeforeEach(func() {
-				vmi = libvmifact.NewAlpine(
+				vmi = libvmifact.NewGuestless(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithAnnotation(v1.FuncTestForceLauncherMigrationFailureAnnotation, ""),
@@ -216,7 +216,7 @@ var _ = Describe(SIG("VM Live Migration triggered by evacuation", decorators.Req
 
 		Context("VirtualMachineInstanceEvictionRequested condition", func() {
 			It("should set VirtualMachineInstanceEvictionRequested condition when VMI marked for eviction", func() {
-				vmi := libvmifact.NewCirros(
+				vmi := libvmifact.NewGuestless(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
@@ -267,7 +267,7 @@ var _ = Describe(SIG("VM Live Migration triggered by evacuation", decorators.Req
 
 				It("should keep VirtualMachineInstanceEvictionRequested condition when migration fails", func() {
 					By("Starting the VirtualMachineInstance")
-					vmi := libvmifact.NewCirros(
+					vmi := libvmifact.NewGuestless(
 						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						libvmi.WithAnnotation(v1.FuncTestForceLauncherMigrationFailureAnnotation, ""),

--- a/tests/migration/nodeselector.go
+++ b/tests/migration/nodeselector.go
@@ -67,7 +67,7 @@ var _ = Describe(SIG("Live Migration with addedNodeSelector", decorators.Require
 		}
 
 		By("starting a VM (with a node selector) on the source node")
-		vmi := libvmifact.NewFedora(
+		vmi := libvmifact.NewGuestless(
 			libnet.WithMasqueradeNetworking(),
 		)
 		vmi.Spec.NodeSelector = map[string]string{zoneLabelKey: vmiLabelValue}

--- a/tests/migration/priority.go
+++ b/tests/migration/priority.go
@@ -76,7 +76,7 @@ var _ = Describe(SIG("Live Migrations with priority", decorators.RequiresTwoSche
 	It("with a live-migrate eviction strategy set", Serial, func() {
 		var vmis []*v1.VirtualMachineInstance
 		for i := 0; i < 5; i++ {
-			vmi := libvmifact.NewAlpine(
+			vmi := libvmifact.NewGuestless(
 				libnet.WithMasqueradeNetworking(),
 				libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 				libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -169,7 +169,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 
 	newOfflineVirtualMachinePool := func() *poolv1.VirtualMachinePool {
 		By("Create a new VirtualMachinePool")
-		return createVirtualMachinePool(newPoolFromVMI(libvmifact.NewAlpine()))
+		return createVirtualMachinePool(newPoolFromVMI(libvmifact.NewGuestless()))
 	}
 
 	DescribeTable("pool should scale", func(startScale int, stopScale int) {
@@ -209,7 +209,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 		})
 
 		_, err = virtClient.VirtualMachinePool(testsuite.NamespaceTestDefault).Create(context.Background(), newPool, metav1.CreateOptions{})
-		Expect(err.Error()).To(ContainSubstring("admission webhook \"virtualmachinepool-validator.kubevirt.io\" denied the request: spec.virtualMachineTemplate.spec.template.spec.domain.devices.disks[1].Name 'testdisk' not found"))
+		Expect(err.Error()).To(ContainSubstring("admission webhook \"virtualmachinepool-validator.kubevirt.io\" denied the request: spec.virtualMachineTemplate.spec.template.spec.domain.devices.disks[0].Name 'testdisk' not found"))
 	})
 
 	It("should remove VMs once they are marked for deletion", func() {
@@ -798,7 +798,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 
 	It("should use DescendingOrder scale-in strategy when specified", func() {
 		By("Create a new VirtualMachinePool with DescendingOrder scale-in policy")
-		pool := newPoolFromVMI(libvmifact.NewAlpine())
+		pool := newPoolFromVMI(libvmifact.NewGuestless())
 
 		// Set up DescendingOrder scale-in strategy
 		pool.Spec.ScaleInStrategy = &poolv1.VirtualMachinePoolScaleInStrategy{

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -127,7 +127,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	newReplicaSet := func() *v1.VirtualMachineInstanceReplicaSet {
 		By("Create a new VirtualMachineInstance replica set")
-		template := libvmifact.NewAlpine(
+		template := libvmifact.NewGuestless(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
@@ -156,7 +156,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	)
 
 	DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale with the horizontal pod autoscaler", func(startScale int, stopScale int) {
-		template := libvmifact.NewAlpine(
+		template := libvmifact.NewGuestless(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
@@ -219,7 +219,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(reviewResponse.Details.Causes).To(HaveLen(1))
-		Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[1].name"))
+		Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[0].name"))
 	})
 	It("[test_id:1413]should update readyReplicas once VMIs are up", func() {
 		newRS := newReplicaSet()
@@ -404,7 +404,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	It("should replace a VMI immediately when a virt-launcher pod gets deleted", func() {
 		By("Creating new replica set")
-		template := libvmifact.NewAlpine(
+		template := libvmifact.NewGuestless(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithTerminationGracePeriod(200),
@@ -463,7 +463,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			}
 			vmLabelKey := "test" + rand.String(5)
 			vmLabelValue := "test" + rand.String(5)
-			vmi := libvmifact.NewAlpine()
+			vmi := libvmifact.NewGuestless()
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
 			vmi.Spec.TopologySpreadConstraints = []k8sv1.TopologySpreadConstraint{
 				{

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -82,7 +82,7 @@ var _ = Describe(SIG("Memory dump", func() {
 
 	createAndStartVM := func() *v1.VirtualMachine {
 		By("Creating VirtualMachine")
-		vm := libvmi.NewVirtualMachine(libvmifact.NewCirros(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(func() bool {

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -69,7 +69,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 
-		vmi = libvmifact.NewAlpine(libvmi.WithLabel(flavorKey, memoryFlavor))
+		vmi = libvmifact.NewGuestless(libvmi.WithLabel(flavorKey, memoryFlavor))
 
 		selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{flavorKey: memoryFlavor}}
 		memory = resource.MustParse("128M")
@@ -137,7 +137,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(reviewResponse.Details.Causes).To(HaveLen(1))
-			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[1]"))
+			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[0]"))
 		})
 	})
 
@@ -202,7 +202,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			newPreset, err := getPreset(virtClient, cpuPrefix)
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi = libvmifact.NewAlpine(libvmi.WithLabel(flavorKey, cpuFlavor))
+			vmi = libvmifact.NewGuestless(libvmi.WithLabel(flavorKey, cpuFlavor))
 
 			newVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -230,7 +230,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 
 			// reset the label so it will not match
-			vmi = libvmifact.NewAlpine()
+			vmi = libvmifact.NewGuestless()
 			newVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -276,7 +276,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 
 			exclusionMarking := "virtualmachineinstancepresets.admission.kubevirt.io/exclude"
-			vmi = libvmifact.NewAlpine(libvmi.WithLabel(flavorKey, cpuFlavor), libvmi.WithAnnotation(exclusionMarking, "true"))
+			vmi = libvmifact.NewGuestless(libvmi.WithLabel(flavorKey, cpuFlavor), libvmi.WithAnnotation(exclusionMarking, "true"))
 
 			newVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Tests that do not interact with the guest operating system should not boot one. Booting from an OS, even a lightweight like Alpine, wastes IO, CPU and time.

```release-note
NONE
```

