### PR TITLE
tests/hotplug: wrap AddVolume in Eventually

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -157,19 +157,9 @@ var _ = Describe(SIG("Hotplug", func() {
 	}
 
 	addVolumeVMWithSource := func(name, namespace string, volumeOptions *v1.AddVolumeOptions) {
-		var err error
-
-		// Try at least 3 times, this is done because `AddVolume` is inherently racy in the way it's implemented
-		// as when it patches the VM Status it expects the field `volumeRequests` to be there (by using a test json patch op),
-		// but at the same time virt-controller trims this field when all requests have been satisfied.
-		// To avoid hitting these we should explicitly try multiple times.
-		for i := 0; i < 3; i++ {
-			err = virtClient.VirtualMachine(namespace).AddVolume(context.Background(), name, volumeOptions)
-			if err == nil {
-				break
-			}
-		}
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			return virtClient.VirtualMachine(namespace).AddVolume(context.Background(), name, volumeOptions)
+		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}
 
 	addDVVolumeVM := func(name, namespace, volumeName, claimName string, bus v1.DiskBus, dryRun bool, cache v1.DriverCache) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
There is a known race condition that can be hit during `AddVolume()` calls where the virt-api and virt-controller are attempting to update the VMs status at the same time causing the json patch operation for `/status/volumeRequests` fail.

#11690 originally updated this helper function in the test suite to force multiple retries of the API call in case this race condition was hit, citing the original 3s timeout was not enough time for a retry if the operation exceeded 3s. However, certain hotplug tests that perform an `AddVolume` immediately after VM creation have been seen to still trigger this race condition since the three retries are in such quick succession seem to clash with the initial batch of status updates from the virt-controller.

Instead of trying to make this API call three times consecutively, we should revert back to wrapping this call in an Eventually block with a polling interval and longer 10s timeout to still allow for multiple retries, but to ensure they are spaced out to avoid the race condition during VM creation.

Jira issue: https://redhat.atlassian.net/browse/CNV-81051

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

