### PR TITLE
[release-1.6] tests/infra/prometheous: remove test_id:4146

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -541,30 +541,6 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		Entry("[test_id:6241] by IPv6", k8sv1.IPv6Protocol),
 	)
 
-	DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
-		ip := libnet.GetIP(handlerMetricIPs, family)
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
-
-		fetcher := metricsutil.NewMetricsFetcher("")
-		fetcher.AddNameFilter("kubevirt_vmi_")
-		fetcher.AddLabelFilter("phase", "Running")
-
-		metrics, err := fetcher.LoadMetrics(metricsPayload)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Checking the collected metrics")
-		for _, results := range metrics {
-			for _, metricResult := range results {
-				Expect(metricResult.Value).To(Equal(float64(len(preparedVMIs))))
-			}
-		}
-	},
-		Entry("[test_id:4146] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6242] by IPv6", k8sv1.IPv6Protocol),
-	)
-
 	DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
 		libnet.SkipWhenClusterNotSupportIPFamily(family)
 


### PR DESCRIPTION
### What this PR does
This PR is a manual backport of https://github.com/kubevirt/kubevirt/pull/16860

There were several cleanups in this area and automatic cherry-pick hit a conflict due to recent refactor of ipv4, ipv6 tests cleanup

### Jira Ticket
```jira ticket
https://redhat.atlassian.net/browse/CNV-65250
https://redhat.atlassian.net/browse/CNV-80153
```

### Release note
```release-note
none
```



