### PR TITLE
S390x: Skip PCIe NUMA topology awareness for s390x arch

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
@@ -92,3 +92,7 @@ func (converterAMD64) HasVMPort() bool {
 func (converterAMD64) SupportPCIHole64Disabling() bool {
 	return true
 }
+
+func (converterAMD64) SupportPCIePlacement() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
@@ -69,3 +69,7 @@ func (converterARM64) HasVMPort() bool {
 func (converterARM64) SupportPCIHole64Disabling() bool {
 	return false
 }
+
+func (converterARM64) SupportPCIePlacement() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/arch/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/converter.go
@@ -40,6 +40,7 @@ type Converter interface {
 	RequiresMPXCPUValidation() bool
 	ShouldVerboseLogsBeEnabled() bool
 	SupportPCIHole64Disabling() bool
+	SupportPCIePlacement() bool
 }
 
 func NewConverter(arch string) Converter {

--- a/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
@@ -72,3 +72,13 @@ func (converterS390X) HasVMPort() bool {
 func (converterS390X) SupportPCIHole64Disabling() bool {
 	return false
 }
+
+func (converterS390X) SupportPCIePlacement() bool {
+	// s390x does not support PCIe topology features used in other architectures.
+	// Specifically:
+	// - No PCIe root ports
+	// - No expander buses
+	// - No PCI-based NUMA alignment
+	// All devices are attached via zPCI in a flat topology.
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1145,8 +1145,12 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			}
 
 			if c.PCINUMAAwareTopologyEnabled {
-				if err := PlacePCIDevicesWithNUMAAlignment(&domain.Spec); err != nil {
-					log.Log.Reason(err).Warningf("Failed to process PCIe NUMA-aware topology, falling back to default placement")
+				if c.Architecture.SupportPCIePlacement() {
+					if err := PlacePCIDevicesWithNUMAAlignment(&domain.Spec); err != nil {
+						log.Log.Reason(err).Warningf("Failed to process PCIe NUMA-aware topology, falling back to default placement")
+					}
+				} else {
+					log.Log.Infof("Skipping PCIe NUMA alignment: architecture %s does not support PCIe placement", c.Architecture.GetArchitecture())
 				}
 			}
 		}
@@ -1163,8 +1167,12 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	if val := vmi.Annotations[v1.PlacePCIDevicesOnRootComplex]; val == "true" {
-		if err := PlacePCIDevicesOnRootComplex(&domain.Spec); err != nil {
-			return err
+		if c.Architecture.SupportPCIePlacement() {
+			if err := PlacePCIDevicesOnRootComplex(&domain.Spec); err != nil {
+				return err
+			}
+		} else {
+			log.Log.Infof("Skipping PCIe root complex placement: architecture %s does not support PCIe placement", c.Architecture.GetArchitecture())
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1920,6 +1920,7 @@ var _ = Describe("Converter", func() {
 		Context("with PCINUMAAwareTopology feature gate enabled", func() {
 			BeforeEach(func() {
 				c.PCINUMAAwareTopologyEnabled = true
+				c.Architecture = archconverter.NewConverter(amd64)
 			})
 
 			It("should create PCIe controllers for NUMA-aligned devices", func() {
@@ -1966,6 +1967,29 @@ var _ = Describe("Converter", func() {
 					}
 				}
 				Expect(expanderBusCount).To(Equal(0), "expected no PCIe expander bus controllers when feature is disabled")
+			})
+		})
+
+		Context("with PCINUMAAwareTopology feature gate enabled for s390x architecture", func() {
+			BeforeEach(func() {
+				c.PCINUMAAwareTopologyEnabled = true
+				c.Architecture = archconverter.NewConverter(s390x)
+				vmiArchMutate(s390x, vmi, c)
+			})
+
+			It("should not create any PCIe controllers even with NUMA topology enabled", func() {
+				c = createContextWithDevices(vmi, c)
+				domain := vmiToDomain(vmi, c)
+
+				for _, controller := range domain.Spec.Devices.Controllers {
+					Expect(controller.Model).To(
+						And(
+							Not(Equal(api.ControllerModelPCIeExpanderBus)),
+							Not(Equal(api.ControllerModelPCIeRootPort)),
+						),
+						"s390x should not have pcie-expander-bus or pcie-root-port controllers",
+					)
+				}
 			})
 		})
 	})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR introduces an architecture-aware capability check to prevent PCIe NUMA topology placement on s390x, where PCIe hierarchy is not supported. PCI topology models (v1/v2/v3) rely on PCIe hierarchy, which does not apply to s390x.

The existing PCIe NUMA-aware topology logic (PR #16632) attempts to create pcie-expander-bus and pcie-root-port controllers using the expander bus assigner. However, these controller types are not supported on the s390-ccw-virtio machine type

#### Before this PR:

When the PCINUMAAwareTopology feature gate is enabled, the system attempts to inject pcie-expander-bus and pcie-root-port libvirt controllers, which are not supported on s390x. The `PlacePCIDevicesWithNUMAAlignment()` and `PlacePCIDevicesOnRootComplex()` code paths currently lack architecture awareness.

#### After this PR:

On s390x, PCIe NUMA topology placement is skipped using the new capability check. Other architectures like amd64 and arm64 continue to behave as before, while s390x avoids unsupported configurations by not applying PCIe placement logic.

#### Fixes: https://github.com/kubevirt/kubevirt/issues/17266

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

