### PR TITLE
Revert "bazel server: reload on network changes"

### DIFF
--- a/hack/bazel-server.sh
+++ b/hack/bazel-server.sh
@@ -3,21 +3,6 @@ if [ "$KUBEVIRT_NO_BAZEL" = true ]; then
     sleep infinity
 else
     BAZEL_PID=$(bazel info | grep server_pid | cut -d " " -f 2)
-
-    # Shut down the bazel server on network changes
-    (
-        initial=$(cat /proc/net/route 2>/dev/null)
-        while kill -0 $BAZEL_PID 2>/dev/null; do
-            sleep 5
-            current=$(cat /proc/net/route 2>/dev/null)
-            if [ "$initial" != "$current" ]; then
-                echo "Network change detected, shutting down bazel server..."
-                bazel shutdown
-                break
-            fi
-        done
-    ) &
-
     while kill -0 $BAZEL_PID 2>/dev/null; do sleep 1; done
     # Might not be necessary, just to be sure that exec shutdowns always succeed
     # and are not killed by docker.


### PR DESCRIPTION
## Summary

- Reverts PR #16885 which added a background process to monitor `/proc/net/route` and shut down the bazel server on network changes
- The [pull-kubevirt-code-lint failure rate](https://grafana.ci.kubevirt.io/d/efpTS3t4z/e2e-jobs-overview-v2?orgId=1&refresh=2h&var-job_name=pull-kubevirt-code-lint&viewPanel=4) shows a significant increase right after that PR was merged
<img width="1810" height="986" alt="image" src="https://github.com/user-attachments/assets/4811a13c-48f7-4250-91ef-ae54e974b8ee" />

Further digging shows that many test lanes fail with the same symptom of "Error 1" after trying to connect to the bazel server: https://search.ci.kubevirt.io/?search=Error+1&maxAge=168h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job


## Test plan

- [ ] Verify `pull-kubevirt-code-lint` failure rate stabilizes after merge

```release-note
Maintenance: revert bazel server network change monitoring
```