### PR TITLE
Fix VM restore when backend storage is not snapshottable

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -704,7 +704,33 @@ func (t *vmRestoreTarget) reconcileBackendVolume(snapshotVM *snapshotv1.VirtualM
 		return true, nil
 	}
 
-	// Retrieve only the backend volume
+	// Check if the backend volume was actually included in the snapshot by looking at the snapshot content
+	vmSnapshot, err := t.controller.getVMSnapshot(t.vmRestore)
+	if err != nil {
+		return false, err
+	}
+
+	content, err := t.controller.getSnapshotContent(vmSnapshot)
+	if err != nil {
+		return false, err
+	}
+
+	backendVolumeName := storageutils.BackendPVCVolumeName(snapshotVM.Name)
+	backendIncludedInSnapshot := false
+	for _, vb := range content.Spec.VolumeBackups {
+		if vb.VolumeName == backendVolumeName {
+			backendIncludedInSnapshot = true
+			break
+		}
+	}
+
+	// If the backend volume was not included in the snapshot (e.g., due to missing VolumeSnapshotClass),
+	// skip reconciliation. VM will reuse the existing backend PVC.
+	if !backendIncludedInSnapshot {
+		log.Log.Object(t.vmRestore).Warningf("Backend storage volume %s not included in the snapshot, VMState StorageClass might not have snapshot support. A new empty backend storage volume will be created when the VM starts.", backendVolumeName)
+		return true, nil
+	}
+
 	volumes, err := storageutils.GetVolumes(snapshotVM, t.controller.Client, storageutils.WithBackendVolume)
 	if err != nil {
 		// Not checking for ErrNoBackendPVC, simply returning
@@ -1299,8 +1325,6 @@ func (t *vmRestoreTarget) Own(obj metav1.Object) {
 			BlockOwnerDeletion: pointer.P(true),
 		},
 	})
-
-	return
 }
 
 func (ctrl *VMRestoreController) deleteObsoleteVolumes(vmRestore *snapshotv1.VirtualMachineRestore, target restoreTarget) error {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -48,6 +48,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -1414,6 +1415,107 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Entry("with offline snapshot", false),
 				Entry("with online snapshot", true),
 			)
+
+			Context("With non-snapshottable backend storage", Serial, func() {
+				var noSnapshotSC string
+				var originalBackendSC string
+
+				BeforeEach(func() {
+					noSnapshotSC = libstorage.GetNoVolumeSnapshotStorageClass("")
+					if noSnapshotSC == "" {
+						Skip("No storage class without VolumeSnapshotClass support available")
+					}
+
+					// Patch kubevirt config to use non-snapshottable storage for backend
+					kv := libkubevirt.GetCurrentKv(virtClient)
+					originalBackendSC = kv.Spec.Configuration.VMStateStorageClass
+
+					patchData := fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/configuration/vmStateStorageClass", "value": "%s"}]`, noSnapshotSC)
+					_, err = virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(func() string {
+						kv := libkubevirt.GetCurrentKv(virtClient)
+						return kv.Spec.Configuration.VMStateStorageClass
+					}, 30*time.Second, 1*time.Second).Should(Equal(noSnapshotSC))
+				})
+
+				AfterEach(func() {
+					// Restore original VMStateStorageClass
+					kv := libkubevirt.GetCurrentKv(virtClient)
+					patchData := fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/configuration/vmStateStorageClass", "value": "%s"}]`, originalBackendSC)
+					_, err = virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				DescribeTable("Should restore a VM when backend storage PVC was not included in snapshot", func(restoreToSameVM bool) {
+					vm = createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)
+					vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+					vm, vmi = createAndStartVM(vm)
+					Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
+
+					pvcs, err := virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).List(context.Background(), metav1.ListOptions{
+						LabelSelector: "persistent-state-for=" + vmi.Name,
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pvcs.Items).To(HaveLen(1))
+					originalBackendPVC := pvcs.Items[0]
+
+					By(stoppingVM)
+					vm = libvmops.StopVirtualMachine(vm)
+
+					By(creatingSnapshot)
+					snapshot = createSnapshot(vm)
+
+					content, err := virtClient.VirtualMachineSnapshotContent(snapshot.Namespace).Get(
+						context.Background(), *snapshot.Status.VirtualMachineSnapshotContentName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(content.Spec.VolumeBackups).To(HaveLen(1), "Only data volume should be in snapshot, not backend storage")
+
+					By("Restoring VM")
+					targetVMName := vm.Name
+					var targetVMUID *types.UID
+					if restoreToSameVM {
+						targetVMUID = &vm.UID
+					} else {
+						targetVMName = vm.Name + "-restored"
+						targetVMUID = nil
+					}
+
+					restore = createRestoreDef(targetVMName, snapshot.Name)
+					restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					restore = waitRestoreComplete(restore, targetVMName, targetVMUID)
+					Expect(restore.Status.Restores).To(HaveLen(1), "Only data volume should be restored")
+
+					By("Starting VM")
+					restoredVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), targetVMName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					restoredVM = libvmops.StartVirtualMachine(restoredVM)
+					Eventually(ThisVM(restoredVM)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
+
+					By("Verifying new backend PVC was created")
+					Eventually(func() bool {
+						pvcs, err := virtClient.CoreV1().PersistentVolumeClaims(restoredVM.Namespace).List(context.Background(), metav1.ListOptions{
+							LabelSelector: "persistent-state-for=" + targetVMName,
+						})
+						if err != nil || len(pvcs.Items) != 1 {
+							return false
+						}
+						pvc := pvcs.Items[0]
+						// For same VM: verify it has the same UID as the original backend PVC
+						// For different VM: verify it has different UID and that it doesn't have datasourceref
+						if restoreToSameVM {
+							return pvc.UID == originalBackendPVC.UID
+						}
+						return pvc.Spec.DataSource == nil && pvc.Spec.DataSourceRef == nil && pvc.UID != originalBackendPVC.UID
+					}, 60*time.Second, 2*time.Second).Should(BeTrue())
+				},
+					Entry("when restoring to the same VM", true),
+					//Entry("when restoring to a different VM", false), // Currently not supported, PR in progress
+				)
+			})
 
 			DescribeTable("should reject vm start if restore in progress", func(deleteFunc string) {
 				vm, vmi = createAndStartVM(renderVMWithRegistryImportDataVolume(cd.ContainerDiskCirros, snapshotStorageClass))


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

When `VMStateStorageClass` doesn't have snapshot support, the backend PVC cannot be included in VM snapshots. This previously caused issues during VM restore.

This PR adds a check to detect when the backend storage it's not been included in the snapshot and continues the restore normally if that's the case.

### References
  
- Fixes # https://redhat.atlassian.net/browse/CNV-82065

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix VM restore when backend storage is not snapshottable
```

