### PR TITLE
Fix fragile migration admission logic using StorageLiveMigratable condition

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -57,14 +57,22 @@ func NewMigrationCreateAdmitter(virtClient kubevirt.Interface, clusterConfig *vi
 }
 
 func isMigratable(vmi *v1.VirtualMachineInstance, migration *v1.VirtualMachineInstanceMigration) error {
+	if vmi.IsMigratable() {
+		return nil
+	}
+
+	if migration.IsDecentralized() {
+		for _, c := range vmi.Status.Conditions {
+			if c.Type == v1.VirtualMachineInstanceIsStorageLiveMigratable &&
+				c.Status == k8sv1.ConditionTrue {
+				return nil
+			}
+		}
+	}
+
 	for _, c := range vmi.Status.Conditions {
 		if c.Type == v1.VirtualMachineInstanceIsMigratable &&
 			c.Status == k8sv1.ConditionFalse {
-			// Allow cross namespace/cluster migrations with non migratable disks.
-			// TODO: this is fragile since there could be other reasons for the VMI to be non migratable.
-			if c.Reason == v1.VirtualMachineInstanceReasonDisksNotMigratable && migration.IsDecentralized() {
-				continue
-			}
 			return fmt.Errorf("Cannot migrate VMI, Reason: %s, Message: %s", c.Reason, c.Message)
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -57,26 +57,34 @@ func NewMigrationCreateAdmitter(virtClient kubevirt.Interface, clusterConfig *vi
 }
 
 func isMigratable(vmi *v1.VirtualMachineInstance, migration *v1.VirtualMachineInstanceMigration) error {
-	if vmi.IsMigratable() {
+	var liveMigratableCond, storageMigratableCond *v1.VirtualMachineInstanceCondition
+
+	for i := range vmi.Status.Conditions {
+		c := &vmi.Status.Conditions[i]
+		if c.Type == v1.VirtualMachineInstanceIsMigratable {
+			liveMigratableCond = c
+		} else if c.Type == v1.VirtualMachineInstanceIsStorageLiveMigratable {
+			storageMigratableCond = c
+		}
+	}
+
+	if liveMigratableCond == nil || liveMigratableCond.Status == k8sv1.ConditionTrue {
 		return nil
 	}
 
 	if migration.IsDecentralized() {
-		for _, c := range vmi.Status.Conditions {
-			if c.Type == v1.VirtualMachineInstanceIsStorageLiveMigratable &&
-				c.Status == k8sv1.ConditionTrue {
+		// If StorageLiveMigratable is explicitly set, trust it as the source of truth for decentralized migrations.
+		if storageMigratableCond != nil {
+			if storageMigratableCond.Status == k8sv1.ConditionTrue {
 				return nil
 			}
+		} else if liveMigratableCond.Reason == v1.VirtualMachineInstanceReasonDisksNotMigratable {
+			// Legacy fallback for VMIs where StorageLiveMigratable might not be set yet.
+			return nil
 		}
 	}
 
-	for _, c := range vmi.Status.Conditions {
-		if c.Type == v1.VirtualMachineInstanceIsMigratable &&
-			c.Status == k8sv1.ConditionFalse {
-			return fmt.Errorf("Cannot migrate VMI, Reason: %s, Message: %s", c.Reason, c.Message)
-		}
-	}
-	return nil
+	return fmt.Errorf("Cannot migrate VMI, Reason: %s, Message: %s", liveMigratableCond.Reason, liveMigratableCond.Message)
 }
 
 func ensureNoMigrationConflict(ctx context.Context, virtClient kubevirt.Interface, vmiName string, namespace string) error {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -223,6 +223,35 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
+		It("should allow decentralized migration for VMIs with non-migratable disks but otherwise migratable using legacy fallback", func() {
+			vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
+			vmi.Status.Phase = v1.Running
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:    v1.VirtualMachineInstanceIsMigratable,
+					Status:  k8sv1.ConditionFalse,
+					Reason:  v1.VirtualMachineInstanceReasonDisksNotMigratable,
+					Message: "cannot migrate VMI with shared and non-shared volumes",
+				},
+			}
+
+			migration := createMigration(vmi.Namespace, testMigrationName, vmi.Name)
+			migration.Spec.SendTo = &v1.VirtualMachineInstanceMigrationSource{
+				MigrationID: "migrationID",
+				ConnectURL:  "1.1.1.1:12345",
+			}
+			enableFeatureGate(featuregate.DecentralizedLiveMigration)
+
+			virtClient := kubevirtfake.NewSimpleClientset(vmi)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient, config, nil)
+
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
+
+			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
 		It("should reject decentralized migration for VMIs that are not migratable for reasons other than storage", func() {
 			vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
 			vmi.Status.Phase = v1.Running

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -190,6 +190,75 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			Expect(resp.Result.Message).To(ContainSubstring("DisksNotLiveMigratable"))
 		})
 
+		It("should allow decentralized migration for VMIs with non-migratable disks but otherwise migratable", func() {
+			vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
+			vmi.Status.Phase = v1.Running
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:    v1.VirtualMachineInstanceIsMigratable,
+					Status:  k8sv1.ConditionFalse,
+					Reason:  v1.VirtualMachineInstanceReasonDisksNotMigratable,
+					Message: "cannot migrate VMI with shared and non-shared volumes",
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+			}
+
+			migration := createMigration(vmi.Namespace, testMigrationName, vmi.Name)
+			migration.Spec.SendTo = &v1.VirtualMachineInstanceMigrationSource{
+				MigrationID: "migrationID",
+				ConnectURL:  "1.1.1.1:12345",
+			}
+			enableFeatureGate(featuregate.DecentralizedLiveMigration)
+
+			virtClient := kubevirtfake.NewSimpleClientset(vmi)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient, config, nil)
+
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
+
+			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should reject decentralized migration for VMIs that are not migratable for reasons other than storage", func() {
+			vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
+			vmi.Status.Phase = v1.Running
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:    v1.VirtualMachineInstanceIsMigratable,
+					Status:  k8sv1.ConditionFalse,
+					Reason:  v1.VirtualMachineInstanceReasonInterfaceNotMigratable,
+					Message: "interface is not migratable",
+				},
+				{
+					Type:    v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status:  k8sv1.ConditionFalse,
+					Reason:  v1.VirtualMachineInstanceReasonInterfaceNotMigratable,
+					Message: "interface is not migratable",
+				},
+			}
+
+			migration := createMigration(vmi.Namespace, testMigrationName, vmi.Name)
+			migration.Spec.SendTo = &v1.VirtualMachineInstanceMigrationSource{
+				MigrationID: "migrationID",
+				ConnectURL:  "1.1.1.1:12345",
+			}
+			enableFeatureGate(featuregate.DecentralizedLiveMigration)
+
+			virtClient := kubevirtfake.NewSimpleClientset(vmi)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient, config, nil)
+
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
+
+			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(ContainSubstring("interface is not migratable"))
+		})
+
 		DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
 			input := map[string]interface{}{}
 			json.Unmarshal([]byte(data), &input)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1308,6 +1308,10 @@ func (c *VirtualMachineController) calculateLiveStorageMigrationCondition(vmi *v
 		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonTDXNotMigratable, "VMI uses TDX")
 	}
 
+	if util.IsSecureExecutionVMI(vmi) {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonSecureExecutionNotMigratable, "VMI uses Secure Execution")
+	}
+
 	if reservation.HasVMIPersistentReservation(vmi) {
 		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonPRNotMigratable, "VMI uses SCSI persistent reservation")
 	}


### PR DESCRIPTION
### What this PR does
This PR fixes a fragile implementation in KubeVirt's migration admission logic.

#### Before this PR:
The migration admission webhook relied on matching the `Reason` field of the `LiveMigratable` condition against a specific string (`DisksNotMigratable`) to allow decentralised migrations with non-shared storage. This was fragile because `virt-handler` only reports the first encountered reason in the condition, potentially hiding other blocking factors like incompatible network or CPU features.

#### After this PR:
The admission webhook now uses the `StorageLiveMigratable` condition, which is a dedicated condition checking all factors except storage. This ensures that decentralized migrations are only allowed when the VMI is otherwise fully migratable. Additionally, the `StorageLiveMigratable` calculation in `virt-handler` was updated to include missing checks (e.g., Secure Execution) for consistency with the main `LiveMigratable` condition.

### References

N/A

### Why we need it and why it was done in this way
The previous implementation was fragile and depended on the internal ordering of checks in `virt-handler`. By leveraging the `StorageLiveMigratable` condition—already used elsewhere in KubeVirt for similar purposes—we make the admission logic robust against changes in `virt-handler` and more transparent about migration decisions.

### The following tradeoffs were made: 
Non-significant; we are using an existing condition pattern.


### Special notes for your reviewer
This PR synchronizes the `StorageLiveMigratable` condition in virt-handler with the main `LiveMigratable` condition to ensure it's a reliable source of truth for the admission webhook.


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

```release-note
None
```

