### PR TITLE
tests: Fix goroutine leak in event watcher infrastructure

### DIFF
--- a/tests/libwait/BUILD.bazel
+++ b/tests/libwait/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//tests/watcher:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -152,9 +152,13 @@ func (w *Waiting) watchVMIForPhase(vmi *v1.VirtualMachineInstance) *v1.VirtualMa
 		objectEventWatcher.SetWarningsPolicy(*w.wp)
 	}
 
+	watcherCtx, watcherCancel := context.WithCancel(w.ctx)
+	defer watcherCancel()
+	watcherDone := make(chan struct{})
 	go func() {
 		defer ginkgo.GinkgoRecover()
-		objectEventWatcher.WaitFor(w.ctx, watcher.NormalEvent, v1.Started)
+		defer close(watcherDone)
+		objectEventWatcher.WaitFor(watcherCtx, watcher.NormalEvent, v1.Started)
 	}()
 
 	var retrievedVMI *v1.VirtualMachineInstance
@@ -177,6 +181,9 @@ func (w *Waiting) watchVMIForPhase(vmi *v1.VirtualMachineInstance) *v1.VirtualMa
 		return retrievedVMI.Status.Phase
 	}, time.Duration(w.timeout)*time.Second, 1*time.Second).Should(gomega.BeElementOf(w.phases),
 		fmt.Sprintf("Timed out waiting for VMI %s to enter %s phase(s)", vmi.Name, w.phases))
+
+	watcherCancel()
+	<-watcherDone
 
 	return retrievedVMI
 }

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -141,25 +142,35 @@ func (w *Waiting) watchVMIForPhase(vmi *v1.VirtualMachineInstance) *v1.VirtualMa
 		gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
 	}
 
-	const offset = 2
-	objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(w.timeout+offset) * time.Second)
+	// When warning detection is enabled, spawn a goroutine that monitors
+	// events for unexpected warnings while Eventually polls for the desired
+	// VMI phase. The goroutine runs until the phase is reached and the
+	// context is canceled.
 	if w.wp.FailOnWarnings {
 		// let's ignore PSA events as kubernetes internally uses a namespace informer
 		// that might not be up to date after virt-controller relabeled the namespace
 		// to use a 'privileged' policy
 		// TODO: remove this when KubeVirt will be able to run VMs under the 'restricted' level
 		w.wp.WarningsIgnoreList = append(w.wp.WarningsIgnoreList, "violates PodSecurity")
+		objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion()
 		objectEventWatcher.SetWarningsPolicy(*w.wp)
-	}
 
-	watcherCtx, watcherCancel := context.WithCancel(w.ctx)
-	defer watcherCancel()
-	watcherDone := make(chan struct{})
-	go func() {
-		defer ginkgo.GinkgoRecover()
-		defer close(watcherDone)
-		objectEventWatcher.WaitFor(watcherCtx, watcher.NormalEvent, v1.Started)
-	}()
+		watcherCtx, watcherCancel := context.WithCancel(w.ctx)
+		watcherDone := make(chan struct{})
+		// The goroutine is stopped by context cancellation, so the process
+		// function never signals completion on its own.
+		neverDone := func(event *corev1.Event) bool { return false }
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			defer close(watcherDone)
+			objectEventWatcher.Watch(watcherCtx, neverDone, "fail on warning for VMI "+vmi.Name)
+		}()
+		defer func() {
+			defer ginkgo.GinkgoRecover()
+			watcherCancel()
+			<-watcherDone
+		}()
+	}
 
 	var retrievedVMI *v1.VirtualMachineInstance
 	// FIXME the event order is wrong. First the document should be updated
@@ -181,9 +192,6 @@ func (w *Waiting) watchVMIForPhase(vmi *v1.VirtualMachineInstance) *v1.VirtualMa
 		return retrievedVMI.Status.Phase
 	}, time.Duration(w.timeout)*time.Second, 1*time.Second).Should(gomega.BeElementOf(w.phases),
 		fmt.Sprintf("Timed out waiting for VMI %s to enter %s phase(s)", vmi.Name, w.phases))
-
-	watcherCancel()
-	<-watcherDone
 
 	return retrievedVMI
 }

--- a/tests/watcher/watcher.go
+++ b/tests/watcher/watcher.go
@@ -177,18 +177,19 @@ func (w *ObjectEventWatcher) Watch(ctx context.Context, processFunc ProcessFunc,
 	}
 
 	eventWatcher, err := cli.CoreV1().Events(v1.NamespaceAll).
-		Watch(context.Background(), metav1.ListOptions{
+		Watch(ctx, metav1.ListOptions{
 			FieldSelector:   fields.ParseSelectorOrDie(strings.Join(selector, ",")).String(),
 			ResourceVersion: resourceVersion,
 		})
 	if err != nil {
 		panic(err)
 	}
-	defer eventWatcher.Stop()
 	done := make(chan struct{})
+	stopped := make(chan struct{})
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(stopped)
 		for watchEvent := range eventWatcher.ResultChan() {
 			if watchEvent.Type != watch.Error {
 				event := watchEvent.Object.(*v1.Event)
@@ -197,6 +198,9 @@ func (w *ObjectEventWatcher) Watch(ctx context.Context, processFunc ProcessFunc,
 					break
 				}
 			} else {
+				if ctx.Err() != nil {
+					break
+				}
 				switch watchEvent.Object.(type) {
 				case *metav1.Status:
 					status := watchEvent.Object.(*metav1.Status)
@@ -227,6 +231,9 @@ func (w *ObjectEventWatcher) Watch(ctx context.Context, processFunc ProcessFunc,
 		case <-done:
 		}
 	}
+
+	eventWatcher.Stop()
+	<-stopped
 }
 
 func (w *ObjectEventWatcher) WaitFor(ctx context.Context, eventType EventType, reason interface{}) (e *v1.Event) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Two problems in the event watcher infrastructure used by `WaitForSuccessfulVMIStart` and all VMI phase-waiting functions:

1. **Goroutine leak**: `ObjectEventWatcher.Watch()` spawned a fire-and-forget goroutine to process Kubernetes events. When the caller returned, this goroutine could continue running. If it processed a warning event and called `Fail()` after the test moved on, it corrupted the next test's failure state via Ginkgo's `global.Failer` - a case that is almost impossible to debug.

2. **Vestigial event watcher**: The goroutine in `watchVMIForPhase` was a vestige of a [2018 refactor](https://github.com/kubevirt/kubevirt/pull/1724) (commit 2fc0f47fe2) that moved `WaitFor(Started)` into a background goroutine when `Eventually` polling became the primary gate. Over time it accumulated problems: it hardcoded `WaitFor(NormalEvent, Started)` regardless of the target phase, ran unconditionally even when `FailOnWarnings` was false, and silently timed out when the Started event was missed due to the resource version race.

#### After this PR:

**Commit 1**: Fix `Watch()` to propagate context and join its goroutine before returning.

**Commit 2**: Replace the vestigial `WaitFor(Started)` goroutine with a conditional warning-only monitor.

### References

- Original refactor that introduced the goroutine: https://github.com/kubevirt/kubevirt/pull/1724 (commit 2fc0f47fe2, 2018)

### Why we need it and why it was done in this way

Making `Watch()` fully synchronous (using `context.WithTimeout` instead of goroutine + select) was considered but would be a larger refactor changing timeout semantics.

### Special notes for your reviewer

The fix may surface previously-hidden test failures where warning events were silently lost due to the goroutine leak. This is correct behavior.

### Checklist

- [ ] ~~Design: A design document was considered and is present (link) or not required~~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] ~~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~
- [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [ ] ~~Documentation: A user-guide update was considered and is present (link) or not required~~
- [ ] ~~Community: Announcement to kubevirt-dev was considered~~
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note
```release-note
NONE
```