### PR TITLE
Add kubevirt_vmi_sync_total metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -90,6 +90,7 @@
 | kubevirt_vmi_storage_read_traffic_bytes_total | Metric | Counter | Total number of bytes read from storage. |
 | kubevirt_vmi_storage_write_times_seconds_total | Metric | Counter | Total time spent on write operations. |
 | kubevirt_vmi_storage_write_traffic_bytes_total | Metric | Counter | Total number of written bytes. |
+| kubevirt_vmi_sync_total | Metric | Counter | Total number of times a VirtualMachineInstance has been synced. |
 | kubevirt_vmi_vcpu_delay_seconds_total | Metric | Counter | Amount of time spent by each vcpu waiting in the queue instead of running. |
 | kubevirt_vmi_vcpu_seconds_total | Metric | Counter | Total amount of time spent in each state by each vcpu (cpu_time excluding hypervisor time). Where `id` is the vcpu identifier and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`]. |
 | kubevirt_vmi_vcpu_wait_seconds_total | Metric | Counter | Amount of time spent by each vcpu while waiting on I/O. |

--- a/pkg/monitoring/metrics/common/vmisync/BUILD.bazel
+++ b/pkg/monitoring/metrics/common/vmisync/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "metrics_suite_test.go",
+        "metrics_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
+    ],
+)

--- a/pkg/monitoring/metrics/common/vmisync/metrics.go
+++ b/pkg/monitoring/metrics/common/vmisync/metrics.go
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package vmisync
+
+import (
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"k8s.io/client-go/tools/cache"
+	"kubevirt.io/client-go/log"
+)
+
+var (
+	vmiSyncMetrics = []operatormetrics.Metric{
+		vmiSyncTotal,
+	}
+
+	vmiSyncTotal = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_sync_total",
+			Help: "Total number of times a VirtualMachineInstance has been synced.",
+		},
+		[]string{"namespace", "name"},
+	)
+)
+
+func SetupMetrics() error {
+	return operatormetrics.RegisterMetrics(vmiSyncMetrics)
+}
+
+func VMISynced(namespace, name string) {
+	counter, err := vmiSyncTotal.GetMetricWithLabelValues(namespace, name)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to get vmi sync counter for vmi %s/%s", namespace, name)
+		return
+	}
+	counter.Inc()
+}
+
+func ResetVMISync(key string) {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to parse key %s for vmi sync metric deletion", key)
+		return
+	}
+	vmiSyncTotal.DeleteLabelValues(namespace, name)
+}

--- a/pkg/monitoring/metrics/common/vmisync/metrics_suite_test.go
+++ b/pkg/monitoring/metrics/common/vmisync/metrics_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package vmisync_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVmiSync(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/monitoring/metrics/common/vmisync/metrics_test.go
+++ b/pkg/monitoring/metrics/common/vmisync/metrics_test.go
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package vmisync
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ioprometheusclient "github.com/prometheus/client_model/go"
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+)
+
+var _ = Describe("VMI sync metrics", func() {
+	BeforeEach(func() {
+		Expect(SetupMetrics()).To(Succeed())
+		vmiSyncTotal.Reset()
+	})
+
+	AfterEach(func() {
+		Expect(operatormetrics.CleanRegistry()).To(Succeed())
+	})
+
+	It("should increment the counter when VMISynced is called", func() {
+		VMISynced("test-ns", "test-vmi")
+
+		Expect(getCounterValue("test-ns", "test-vmi")).To(Equal(1.0))
+	})
+
+	It("should accumulate the counter across multiple VMISynced calls", func() {
+		VMISynced("test-ns", "test-vmi")
+		VMISynced("test-ns", "test-vmi")
+		VMISynced("test-ns", "test-vmi")
+
+		Expect(getCounterValue("test-ns", "test-vmi")).To(Equal(3.0))
+	})
+
+	It("should remove the metric series when ResetVMISync is called", func() {
+		VMISynced("test-ns", "test-vmi")
+		Expect(activeSeriesCount()).To(Equal(1))
+
+		ResetVMISync("test-ns/test-vmi")
+		Expect(activeSeriesCount()).To(Equal(0))
+	})
+
+	It("should only remove the specified VMI's series on ResetVMISync", func() {
+		VMISynced("test-ns", "vmi-1")
+		VMISynced("test-ns", "vmi-2")
+
+		ResetVMISync("test-ns/vmi-1")
+		Expect(activeSeriesCount()).To(Equal(1))
+	})
+
+	It("should accumulate syncs from multiple controllers into a single series per VMI", func() {
+		VMISynced("test-ns", "test-vmi") // VirtualMachineController
+		VMISynced("test-ns", "test-vmi") // MigrationSourceController
+		VMISynced("test-ns", "test-vmi") // MigrationTargetController
+
+		Expect(getCounterValue("test-ns", "test-vmi")).To(Equal(3.0))
+		Expect(activeSeriesCount()).To(Equal(1))
+	})
+})
+
+func getCounterValue(namespace, name string) float64 {
+	m := &ioprometheusclient.Metric{}
+	counter, err := vmiSyncTotal.GetMetricWithLabelValues(namespace, name)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, counter.Write(m)).To(Succeed())
+	return m.GetCounter().GetValue()
+}
+
+func activeSeriesCount() int {
+	ch := make(chan prometheus.Metric, 100)
+	vmiSyncTotal.Collect(ch)
+	close(ch)
+	count := 0
+	for range ch {
+		count++
+	}
+	return count
+}

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/instancetype/preference/find:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/common/labels:go_default_library",
+        "//pkg/monitoring/metrics/common/vmisync:go_default_library",
         "//pkg/monitoring/metrics/common/workqueue:go_default_library",
         "//pkg/network/resources:go_default_library",
         "//pkg/util/hardware:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/find"
 	preferencefind "kubevirt.io/kubevirt/pkg/instancetype/preference/find"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
+	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/workqueue"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
@@ -115,6 +116,10 @@ func SetupMetrics(
 	}
 
 	if err := workqueue.SetupMetrics(); err != nil {
+		return err
+	}
+
+	if err := vmisync.SetupMetrics(); err != nil {
 		return err
 	}
 

--- a/pkg/monitoring/metrics/virt-handler/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/monitoring/metrics/common/client:go_default_library",
+        "//pkg/monitoring/metrics/common/vmisync:go_default_library",
         "//pkg/monitoring/metrics/common/workqueue:go_default_library",
         "//pkg/monitoring/metrics/virt-handler/domainstats:go_default_library",
         "//pkg/monitoring/metrics/virt-handler/migrationdomainstats:go_default_library",

--- a/pkg/monitoring/metrics/virt-handler/metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/metrics.go
@@ -24,6 +24,7 @@ import (
 	"libvirt.org/go/libvirtxml"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
+	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/workqueue"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/domainstats"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/migrationdomainstats"
@@ -38,6 +39,10 @@ func SetupMetrics(
 	}
 
 	if err := client.SetupMetrics(); err != nil {
+		return err
+	}
+
+	if err := vmisync.SetupMetrics(); err != nil {
 		return err
 	}
 

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/monitoring/metrics/common/vmisync:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -49,6 +49,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
@@ -583,6 +584,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 		if err != nil {
 			return fmt.Errorf("patching of vmi conditions and activePods failed: %v", err)
 		}
+		metrics.VMISynced(vmi.Namespace, vmi.Name)
 
 		return nil
 	}
@@ -603,6 +605,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 			c.vmiExpectations.SetExpectations(key, 0, 0)
 			return err
 		}
+		metrics.VMISynced(vmiCopy.Namespace, vmiCopy.Name)
 	}
 
 	return nil

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/controller"
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/storage/velero"
@@ -316,6 +317,7 @@ func (c *Controller) execute(key string) error {
 		c.podExpectations.DeleteExpectations(key)
 		c.vmiExpectations.DeleteExpectations(key)
 		c.cidsMap.Remove(key)
+		metrics.ResetVMISync(key)
 		return nil
 	}
 	vmi := obj.(*virtv1.VirtualMachineInstance)

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/hotplug-disk:go_default_library",
         "//pkg/hypervisor:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/monitoring/metrics/common/vmisync:go_default_library",
         "//pkg/network/domainspec:go_default_library",
         "//pkg/network/errors:go_default_library",
         "//pkg/network/setup:go_default_library",

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/hypervisor"
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -371,6 +372,7 @@ func (c *MigrationSourceController) sync(vmi *v1.VirtualMachineInstance, domain 
 			c.vmiExpectations.SetExpectations(key, 0, 0)
 			return err
 		}
+		metrics.VMISynced(vmi.Namespace, vmi.Name)
 	}
 
 	if syncErr != nil {
@@ -400,6 +402,9 @@ func (c *MigrationSourceController) execute(key string) error {
 		!vmi.IsDecentralizedMigration() && vmi.IsFinal()) ||
 		vmi.DeletionTimestamp != nil {
 		c.logger.V(4).Infof("vmi for key %v is terminating, succeeded or does not exists", key)
+		if !vmiExists {
+			metrics.ResetVMISync(key)
+		}
 		return nil
 	}
 

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -51,6 +51,7 @@ import (
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/hypervisor"
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	"kubevirt.io/kubevirt/pkg/network/domainspec"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -410,6 +411,7 @@ func (c *MigrationTargetController) updateVMI(vmi *v1.VirtualMachineInstance, ol
 			}
 			return err
 		}
+		metrics.VMISynced(vmi.Namespace, vmi.Name)
 	}
 
 	return nil
@@ -555,6 +557,7 @@ func (c *MigrationTargetController) execute(key string) error {
 	if !vmiExists {
 		c.logger.V(4).Infof("vmi for key %v does not exists", key)
 		c.vmiExpectations.DeleteExpectations(key)
+		metrics.ResetVMISync(key)
 		return nil
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -56,6 +56,7 @@ import (
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/hypervisor"
+	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	"kubevirt.io/kubevirt/pkg/network/domainspec"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
@@ -408,11 +409,16 @@ func (c *VirtualMachineController) execute(key string) error {
 		return nil
 	}
 
-	return c.sync(key,
+	err = c.sync(key,
 		vmi.DeepCopy(),
 		vmiExists,
 		domain,
 		domainExists)
+	_, localExists, _ := c.getVMIFromCache(key)
+	if !localExists {
+		metrics.ResetVMISync(key)
+	}
+	return err
 
 }
 
@@ -1097,6 +1103,7 @@ func (c *VirtualMachineController) updateVMIStatus(oldStatus *v1.VirtualMachineI
 			c.vmiExpectations.SetExpectations(key, 0, 0)
 			return err
 		}
+		metrics.VMISynced(vmi.Namespace, vmi.Name)
 	}
 
 	// Record an event on the VMI when the VMI's phase changes

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -203,6 +203,15 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			Eventually(func() []testing.PromResult {
 				return fetchPrometheusKubevirtMetrics(virtClient).Data.Result
 			}, 3*time.Minute, 10*time.Second).Should(ContainElement(gomegaContainsMetricMatcher(metric, nil)))
+
+			By("Waiting until vmi sync metrics are removed")
+			Eventually(func() error {
+				_, err := libmonitoring.GetMetricValueWithLabels(virtClient, "kubevirt_vmi_sync_total", map[string]string{
+					"namespace": vmiRef.Namespace,
+					"name":      vmiRef.Name,
+				})
+				return err
+			}, 3*time.Minute, 10*time.Second).Should(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Adds a metric to track number of times a controller has synced a VMI.
<img width="1908" height="231" alt="Screenshot From 2026-03-25 21-37-58" src="https://github.com/user-attachments/assets/320c9253-4c79-4644-9f6f-aa5fb55d7d47" />
<img width="1887" height="723" alt="Screenshot From 2026-03-25 22-06-15" src="https://github.com/user-attachments/assets/aeeea47a-9ccf-4941-820a-097792ae5af9" />

#### Before this PR:
Observing how frequently virt-controller or virt-handler was reconciling a specific VMI required manually parsing logs across both components.

#### After this PR:
A new counter metric kubevirt_vmi_sync_total{controller, namespace, name} tracks the number of successful syncs per VMI per controller. A high rate(kubevirt_vmi_sync_total[5m]) on both virt-controller and virt-handler for the same VMI is a direct indicator of a reconcile storm.
  
### Fixes
jira-ticket: https://redhat.atlassian.net/browse/CNV-80580

### Why we need it and why it was done in this way
Bugs were found where two controllers repeatedly update the same VMI field, causing patch storms (flip-flops): virt-controller sets a value, virt-handler changes it back, virt-controller sets it again, and so on. Both controllers succeed on every sync, so no errors are returned and exponential backoff never activates, the controllers keep triggering each other indefinitely. A per-VMI sync counter makes these storms observable and alertable without requiring log analysis.

The following tradeoffs were made:
- virt-handler metric cleanup: the counter reset is tied to the local VMI cache. Syncs performed using the global cache fallback (e.g., the brief startup window before the local informer indexes the VMI) are not counted. This ensures reliable series cleanup on VMI deletion, at the cost of missing a few early-lifecycle syncs that are irrelevant to storm detection.
- No-op reconciles are not counted: The counter is only incremented when sync() actually executed, not when it determined no action was needed.

The following alternatives were considered:

- Using logs only: no aggregation or alerting capability.
- Using kubevirt_workqueue_adds_total: cannot identify the specific VMI.
- Separate metrics per component: a single metric with a controller label follows the existing pattern in the as kubevirt_workqueue_* metrics (which use a name label to distinguish controllers) and avoids duplicating the metric definition.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
new metric kubevirt_vmi_sync_total added in order to track number of times a controller has synced a VMI.
```

