### PR TITLE
Fix pool autoheal requeue for stuck failing VMs

### DIFF
--- a/pkg/virt-controller/watch/pool/pool.go
+++ b/pkg/virt-controller/watch/pool/pool.go
@@ -1979,13 +1979,28 @@ func isAutohealingEnabled(pool *poolv1.VirtualMachinePool) bool {
 }
 
 func (c *Controller) autoHealFailingVMs(pool *poolv1.VirtualMachinePool, vms []*virtv1.VirtualMachine) error {
-	vmsToCleanup := filterFailingVMsToStart(vms, pool.Spec.Autohealing)
+	vmsToCleanup, requeueAfter := filterFailingVMsToStart(vms, pool.Spec.Autohealing)
+
+	// VMs in a failing status sometimes won't generate further watch events while stuck
+	// (e.g. an Unschedulable VMI stays Pending indefinitely). Without an explicit
+	// re-queue the pool would never reconcile again to cross the threshold, so we
+	// schedule one for exactly when the earliest VM becomes eligible.
+	if requeueAfter > 0 {
+		key, err := controller.KeyFunc(pool)
+		if err != nil {
+			return err
+		}
+		log.Log.Object(pool).Infof("Pool %s/%s has VMs not yet eligible for autohealing, requeueing in %v", pool.Namespace, pool.Name, requeueAfter)
+		c.queue.AddAfter(key, requeueAfter)
+	}
 
 	return c.scaleIn(pool, vmsToCleanup, len(vmsToCleanup))
 }
 
-func filterFailingVMsToStart(vms []*virtv1.VirtualMachine, autohealing *poolv1.VirtualMachinePoolAutohealingStrategy) []*virtv1.VirtualMachine {
+func filterFailingVMsToStart(vms []*virtv1.VirtualMachine, autohealing *poolv1.VirtualMachinePoolAutohealingStrategy) ([]*virtv1.VirtualMachine, time.Duration) {
 	var filtered []*virtv1.VirtualMachine
+	var minRequeue time.Duration
+
 	for _, vm := range vms {
 		// Check for consecutive VMI start failures (tracked in Status.StartFailure)
 		if vm.Status.StartFailure != nil && vm.Status.StartFailure.ConsecutiveFailCount >= getFailureToStartThreshold(autohealing) {
@@ -1994,16 +2009,27 @@ func filterFailingVMsToStart(vms []*virtv1.VirtualMachine, autohealing *poolv1.V
 		}
 
 		// Check for status-based failures (CrashLoopBackOff, Unschedulable, etc.)
-		if shouldAutohealBasedOnStatus(vm, autohealing) {
-			filtered = append(filtered, vm)
+		if hasFailingStatus(vm) {
+			failingSince, failing := getFailingSince(vm)
+			if !failing {
+				continue
+			}
+			if hasVMBeenFailingLongEnough(vm, autohealing, failingSince) {
+				filtered = append(filtered, vm)
+			} else {
+				requeueAfter := getMinFailingToStartDuration(autohealing) - failingSince
+				if minRequeue == 0 || requeueAfter < minRequeue {
+					minRequeue = requeueAfter
+				}
+			}
 		}
 	}
 
-	return filtered
+	return filtered, minRequeue
 }
 
-// shouldAutohealBasedOnStatus checks if a VM's PrintableStatus indicates it should be autohealed
-func shouldAutohealBasedOnStatus(vm *virtv1.VirtualMachine, autohealing *poolv1.VirtualMachinePoolAutohealingStrategy) bool {
+// hasFailingStatus reports whether the VM's PrintableStatus is one that may require autohealing.
+func hasFailingStatus(vm *virtv1.VirtualMachine) bool {
 	switch vm.Status.PrintableStatus {
 	case virtv1.VirtualMachineStatusCrashLoopBackOff,
 		virtv1.VirtualMachineStatusUnschedulable,
@@ -2011,23 +2037,27 @@ func shouldAutohealBasedOnStatus(vm *virtv1.VirtualMachine, autohealing *poolv1.
 		virtv1.VirtualMachineStatusPvcNotFound,
 		virtv1.VirtualMachineStatusErrImagePull,
 		virtv1.VirtualMachineStatusImagePullBackOff:
-		return hasVMBeenFailingLongEnough(vm, autohealing)
+		return true
 	default:
 		return false
 	}
 }
 
 // hasVMBeenFailingLongEnough checks if VM has not been ready for minimum duration
-func hasVMBeenFailingLongEnough(vm *virtv1.VirtualMachine, autohealing *poolv1.VirtualMachinePoolAutohealingStrategy) bool {
-	condManager := controller.NewVirtualMachineConditionManager()
-	if c := condManager.GetCondition(vm, virtv1.VirtualMachineReady); c != nil && c.Status == k8score.ConditionFalse {
-		failingSince := c.LastProbeTime.Time
-		if time.Since(failingSince) >= getMinFailingToStartDuration(autohealing) {
-			log.Log.Object(vm).Infof("VM %s/%s has been failing to start for %v, adding to list", vm.Namespace, vm.Name, time.Since(failingSince))
-			return true
-		}
+func hasVMBeenFailingLongEnough(vm *virtv1.VirtualMachine, autohealing *poolv1.VirtualMachinePoolAutohealingStrategy, failingSince time.Duration) bool {
+	if failingSince >= getMinFailingToStartDuration(autohealing) {
+		log.Log.Object(vm).Infof("VM %s/%s has been failing to start for %v, adding to list", vm.Namespace, vm.Name, failingSince)
+		return true
 	}
 	return false
+}
+
+func getFailingSince(vm *virtv1.VirtualMachine) (time.Duration, bool) {
+	condManager := controller.NewVirtualMachineConditionManager()
+	if c := condManager.GetCondition(vm, virtv1.VirtualMachineReady); c != nil && c.Status == k8score.ConditionFalse {
+		return time.Since(c.LastProbeTime.Time), true
+	}
+	return 0, false
 }
 
 func getFailureToStartThreshold(autohealing *poolv1.VirtualMachinePoolAutohealingStrategy) int {

--- a/pkg/virt-controller/watch/pool/pool_test.go
+++ b/pkg/virt-controller/watch/pool/pool_test.go
@@ -1500,6 +1500,7 @@ var _ = Describe("Pool", func() {
 			Expect(vms.Items).To(BeEmpty())
 
 			Expect(testing.FilterActions(&fakeVirtClient.Fake, "delete", "virtualmachines")).To(HaveLen(1))
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(0))
 		},
 			Entry("CrashLoopBackOff", v1.VirtualMachineStatusCrashLoopBackOff),
 			Entry("Unschedulable", v1.VirtualMachineStatusUnschedulable),
@@ -1508,6 +1509,177 @@ var _ = Describe("Pool", func() {
 			Entry("ErrImagePull", v1.VirtualMachineStatusErrImagePull),
 			Entry("ImagePullBackOff", v1.VirtualMachineStatusImagePullBackOff),
 		)
+
+		It("should requeue the pool when a VM is in a failing state but the duration threshold has not elapsed", func() {
+			pool, vm := DefaultPool(1)
+			pool.Spec.Autohealing = &poolv1.VirtualMachinePoolAutohealingStrategy{}
+
+			addPool(pool)
+			poolRevision := createPoolRevision(pool)
+			addCR(poolRevision)
+
+			vm.Name = fmt.Sprintf("%s-0", pool.Name)
+			vm.Labels = pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels
+			vm.Labels[v1.VirtualMachinePoolRevisionName] = poolRevision.Name
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusUnschedulable
+			vm.Status.Conditions = []v1.VirtualMachineCondition{
+				{
+					Type:          v1.VirtualMachineReady,
+					Status:        k8sv1.ConditionFalse,
+					Reason:        "TestReason",
+					LastProbeTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+				},
+			}
+			addVM(vm)
+
+			sanityExecute()
+
+			vms, err := fakeVirtClient.KubevirtV1().VirtualMachines(pool.Namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(HaveLen(1))
+
+			Expect(testing.FilterActions(&fakeVirtClient.Fake, "delete", "virtualmachines")).To(BeEmpty())
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(1))
+		})
+
+		It("should pick the shortest requeue duration among multiple failing VMs", func() {
+			autohealing := &poolv1.VirtualMachinePoolAutohealingStrategy{}
+
+			failingVM := func(name string, failingFor time.Duration) *v1.VirtualMachine {
+				return &v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+					Status: v1.VirtualMachineStatus{
+						PrintableStatus: v1.VirtualMachineStatusUnschedulable,
+						Conditions: []v1.VirtualMachineCondition{
+							{
+								Type:          v1.VirtualMachineReady,
+								Status:        k8sv1.ConditionFalse,
+								Reason:        "TestReason",
+								LastProbeTime: metav1.NewTime(time.Now().Add(-failingFor)),
+							},
+						},
+					},
+				}
+			}
+
+			vms := []*v1.VirtualMachine{
+				failingVM("vm-0", 1*time.Minute),
+				failingVM("vm-1", 4*time.Minute),
+				failingVM("vm-2", 2*time.Minute),
+			}
+
+			filtered, requeueAfter := filterFailingVMsToStart(vms, autohealing)
+			Expect(filtered).To(BeEmpty())
+			Expect(requeueAfter).To(BeNumerically("~", time.Minute, 10*time.Second))
+		})
+
+		It("should not cleanup or requeue a failing VM without a Ready condition", func() {
+			pool, vm := DefaultPool(1)
+			pool.Spec.Autohealing = &poolv1.VirtualMachinePoolAutohealingStrategy{}
+
+			addPool(pool)
+			poolRevision := createPoolRevision(pool)
+			addCR(poolRevision)
+
+			vm.Name = fmt.Sprintf("%s-0", pool.Name)
+			vm.Labels = pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels
+			vm.Labels[v1.VirtualMachinePoolRevisionName] = poolRevision.Name
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusUnschedulable
+			vm.Status.Conditions = nil
+			addVM(vm)
+
+			sanityExecute()
+
+			vms, err := fakeVirtClient.KubevirtV1().VirtualMachines(pool.Namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(HaveLen(1))
+
+			Expect(testing.FilterActions(&fakeVirtClient.Fake, "delete", "virtualmachines")).To(BeEmpty())
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(0))
+		})
+
+		It("should cleanup eligible VMs and requeue not-yet-eligible ones in the same pool", func() {
+			pool, vm := DefaultPool(2)
+			pool.Spec.Autohealing = &poolv1.VirtualMachinePoolAutohealingStrategy{}
+
+			addPool(pool)
+			poolRevision := createPoolRevision(pool)
+			addCR(poolRevision)
+
+			eligibleVM := vm.DeepCopy()
+			eligibleVM.Name = fmt.Sprintf("%s-0", pool.Name)
+			eligibleVM.Labels = pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels
+			eligibleVM.Labels[v1.VirtualMachinePoolRevisionName] = poolRevision.Name
+			eligibleVM.Status.PrintableStatus = v1.VirtualMachineStatusUnschedulable
+			eligibleVM.Status.Conditions = []v1.VirtualMachineCondition{
+				{
+					Type:          v1.VirtualMachineReady,
+					Status:        k8sv1.ConditionFalse,
+					Reason:        "TestReason",
+					LastProbeTime: metav1.NewTime(time.Now().Add(-6 * time.Minute)),
+				},
+			}
+			addVM(eligibleVM)
+
+			notYetEligibleVM := vm.DeepCopy()
+			notYetEligibleVM.Name = fmt.Sprintf("%s-1", pool.Name)
+			notYetEligibleVM.Labels = pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels
+			notYetEligibleVM.Labels[v1.VirtualMachinePoolRevisionName] = poolRevision.Name
+			notYetEligibleVM.Status.PrintableStatus = v1.VirtualMachineStatusUnschedulable
+			notYetEligibleVM.Status.Conditions = []v1.VirtualMachineCondition{
+				{
+					Type:          v1.VirtualMachineReady,
+					Status:        k8sv1.ConditionFalse,
+					Reason:        "TestReason",
+					LastProbeTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+				},
+			}
+			addVM(notYetEligibleVM)
+
+			sanityExecute()
+
+			vms, err := fakeVirtClient.KubevirtV1().VirtualMachines(pool.Namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(HaveLen(1))
+
+			Expect(testing.FilterActions(&fakeVirtClient.Fake, "delete", "virtualmachines")).To(HaveLen(1))
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(1))
+		})
+
+		It("should not requeue a VM that already qualifies for cleanup via start failures", func() {
+			pool, vm := DefaultPool(1)
+			pool.Spec.Autohealing = &poolv1.VirtualMachinePoolAutohealingStrategy{}
+
+			addPool(pool)
+			poolRevision := createPoolRevision(pool)
+			addCR(poolRevision)
+
+			vm.Name = fmt.Sprintf("%s-0", pool.Name)
+			vm.Labels = pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels
+			vm.Labels[v1.VirtualMachinePoolRevisionName] = poolRevision.Name
+			vm.Status.StartFailure = &v1.VirtualMachineStartFailure{
+				ConsecutiveFailCount: 3,
+			}
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusUnschedulable
+			vm.Status.Conditions = []v1.VirtualMachineCondition{
+				{
+					Type:          v1.VirtualMachineReady,
+					Status:        k8sv1.ConditionFalse,
+					Reason:        "TestReason",
+					LastProbeTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+				},
+			}
+			addVM(vm)
+
+			sanityExecute()
+
+			vms, err := fakeVirtClient.KubevirtV1().VirtualMachines(pool.Namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(BeEmpty())
+
+			Expect(testing.FilterActions(&fakeVirtClient.Fake, "delete", "virtualmachines")).To(HaveLen(1))
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(0))
+		})
 
 		It("should not cleanup VMs without autohealing enabled, even if the VM failed to start", func() {
 			pool, vm := DefaultPool(3)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
If VMs are left in an `Unschedulable` state (for example after pushing a bad spec) and they have an opportunistic or unmanaged update strategy, they can be left stuck indefinitely. Enabling auto-healing should solve this, but VMs in this state generate no new watch events, so the reconciler never re-runs to check whether the threshold has elapsed.

#### After this PR:
The auto-healing reconciler requeues the pool for the next time a failing VM becomes eligible for replacement.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix pool autoheal requeue for stuck failing VMs
```

