### PR TITLE
Fix migration monitor busy loop after successful migration

### DIFF
--- a/pkg/virt-launcher/notify-client/BUILD.bazel
+++ b/pkg/virt-launcher/notify-client/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/reference:go_default_library",

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -13,6 +13,7 @@ import (
 
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"libvirt.org/go/libvirt"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -702,16 +703,24 @@ func (n *Notifier) Close() {
 }
 
 func processJobCompletedEvent(domain *api.Domain, d cli.VirDomain, jobCompletedEvent *libvirt.DomainEventJobCompleted, metadataCache *metadata.Cache) bool {
-	if jobCompletedEvent.Info.Operation != libvirt.DOMAIN_JOB_OPERATION_BACKUP {
-		log.Log.V(3).Infof("Recieved a job completion event for operation %v", jobCompletedEvent.Info.Operation)
+	switch jobCompletedEvent.Info.Operation {
+	case libvirt.DOMAIN_JOB_OPERATION_MIGRATION_OUT:
+		var uid types.UID
+		if migration, exists := metadataCache.Migration.Load(); exists {
+			uid = migration.UID
+		}
+		virtwrap.LogMigrationInfo(log.Log, uid, &jobCompletedEvent.Info)
+		return false
+	case libvirt.DOMAIN_JOB_OPERATION_BACKUP:
+		storage.HandleBackupJobCompletedEvent(d, jobCompletedEvent, metadataCache)
+		if value, exists := metadataCache.Backup.Load(); exists {
+			domain.Spec.Metadata.KubeVirt.Backup = &value
+		}
+		return true
+	default:
+		log.Log.V(3).Infof("Received a job completion event for operation %v", jobCompletedEvent.Info.Operation)
 		return false
 	}
-
-	storage.HandleBackupJobCompletedEvent(d, jobCompletedEvent, metadataCache)
-	if value, exists := metadataCache.Backup.Load(); exists {
-		domain.Spec.Metadata.KubeVirt.Backup = &value
-	}
-	return true
 }
 
 func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, events chan watch.Event, c cli.Connection, vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -87,7 +87,6 @@ type migrationMonitor struct {
 
 	progressTimeout          int64
 	acceptableCompletionTime int64
-	migrationFailedWithError error
 }
 
 type inflightMigrationAborted struct {
@@ -589,44 +588,37 @@ func (m *migrationMonitor) startMonitor() {
 	logInterval := 0
 
 	for {
+		var ok bool
 		err = nil
 		select {
-		case err = <-m.migrationErr:
+		case err, ok = <-m.migrationErr:
+			if !ok {
+				return
+			}
 		case <-time.After(monitorSleepPeriodMS * time.Millisecond):
 		}
 
-		if err != nil && m.migrationFailedWithError == nil {
-			logger.Reason(err).Error("Received a live migration error. Will check the latest migration status.")
-			m.migrationFailedWithError = err
-		} else if m.migrationFailedWithError != nil {
-			logger.Info("Didn't manage to get a job status. Post the received error and finalize.")
-			logger.Reason(m.migrationFailedWithError).Error(liveMigrationFailed)
+		if err != nil {
+			logger.Reason(err).Error(liveMigrationFailed)
 			var abortStatus v1.MigrationAbortStatus
-			if strings.Contains(m.migrationFailedWithError.Error(), "canceled by client") {
+			if strings.Contains(err.Error(), "canceled by client") {
 				abortStatus = v1.MigrationAbortSucceeded
 			}
-			// Improve the error message when the volume migration fails because the destination size is smaller then the source volume
-			if len(vmi.Status.MigratedVolumes) > 0 && strings.Contains(standardizeSpaces(m.migrationFailedWithError.Error()),
+			// Improve the error message when the volume migration fails because the destination size is smaller than the source volume
+			if len(vmi.Status.MigratedVolumes) > 0 && strings.Contains(standardizeSpaces(err.Error()),
 				"has to be smaller or equal to the actual size of the containing file") {
 				m.l.setMigrationResult(true, fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v",
-					m.migrationFailedWithError), abortStatus)
+					err), abortStatus)
 				return
 			}
-			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", m.migrationFailedWithError), abortStatus)
+			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", err), abortStatus)
 			return
 		}
 
-		var jobStats *libvirt.DomainJobInfo
-		jobStats, err = dom.GetJobStats(0)
+		jobStats, err := dom.GetJobStats(0)
 		if err != nil {
-			logger.Reason(err).Info("failed to get domain job info, checking for completed job")
-			jobStats, err = dom.GetJobStats(libvirt.DOMAIN_JOB_STATS_COMPLETED | libvirt.DOMAIN_JOB_STATS_KEEP_COMPLETED)
-			if err != nil {
-				// This could only happen when the domain is gone (successful migration) but there is lock contention in stats retrieval.
-				// In case of a sudden domain crash the migrationErr handling above takes care of it.
-				logger.Reason(err).Warning("failed to get completed job stats, will retry")
-				continue
-			}
+			logger.Reason(err).Info("failed to get domain job info, will retry")
+			continue
 		}
 
 		if jobStats.DataRemainingSet {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -651,10 +651,6 @@ func (m *migrationMonitor) startMonitor() {
 			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
-		case libvirt.DOMAIN_JOB_CANCELLED:
-			logger.Info("Migration was canceled")
-			m.l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)
-			return
 		}
 	}
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -32,6 +32,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -305,11 +306,8 @@ func (l *LibvirtDomainManager) startMigration(vmi *v1.VirtualMachineInstance, op
 
 func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachineInstance, migrationMode v1.MigrationMode) (bool, error) {
 	migrationMetadata, exists := l.metadataCache.Migration.Load()
-	migrationUID := vmi.Status.MigrationState.MigrationUID
-	if vmi.Status.MigrationState.SourceState != nil {
-		migrationUID = vmi.Status.MigrationState.SourceState.MigrationUID
-	}
-	if exists && migrationMetadata.UID == migrationUID {
+	uid := MigrationUID(vmi)
+	if exists && migrationMetadata.UID == uid {
 		if migrationMetadata.EndTimestamp == nil {
 			// don't stop on currently executing migrations
 			return true, nil
@@ -323,7 +321,7 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 
 	now := metav1.Now()
 	m := api.MigrationMetadata{
-		UID:            migrationUID,
+		UID:            uid,
 		StartTimestamp: &now,
 		Mode:           migrationMode,
 	}
@@ -635,10 +633,7 @@ func (m *migrationMonitor) startMonitor() {
 			m.remainingData = jobStats.DataRemaining
 		}
 
-		migrationUID := vmi.Status.MigrationState.MigrationUID
-		if vmi.Status.MigrationState.SourceState != nil {
-			migrationUID = vmi.Status.MigrationState.SourceState.MigrationUID
-		}
+		uid := MigrationUID(vmi)
 		switch jobStats.Type {
 		case libvirt.DOMAIN_JOB_UNBOUNDED:
 			aborted := m.processInflightMigration(dom, jobStats)
@@ -649,10 +644,10 @@ func (m *migrationMonitor) startMonitor() {
 			}
 			logInterval++
 			if logInterval%monitorLogInterval == 0 {
-				logMigrationInfo(logger, string(migrationUID), jobStats)
+				logMigrationInfo(logger, uid, jobStats)
 			}
 		case libvirt.DOMAIN_JOB_COMPLETED:
-			logMigrationInfo(logger, string(migrationUID), jobStats)
+			logMigrationInfo(logger, uid, jobStats)
 			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
@@ -664,8 +659,18 @@ func (m *migrationMonitor) startMonitor() {
 	}
 }
 
+func MigrationUID(vmi *v1.VirtualMachineInstance) types.UID {
+	if s := vmi.Status.MigrationState; s != nil {
+		if s.SourceState != nil {
+			return s.SourceState.MigrationUID
+		}
+		return s.MigrationUID
+	}
+	return ""
+}
+
 // logMigrationInfo logs the same migration info as `virsh -r domjobinfo`
-func logMigrationInfo(logger *log.FilteredLogger, uid string, info *libvirt.DomainJobInfo) {
+func logMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.DomainJobInfo) {
 	bToMiB := func(bytes uint64) uint64 {
 		return bytes / 1024 / 1024
 	}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -457,47 +457,6 @@ func (m *migrationMonitor) isMigrationProgressing() bool {
 	return true
 }
 
-func (m *migrationMonitor) determineNonRunningMigrationStatus(dom cli.VirDomain) *libvirt.DomainJobInfo {
-	logger := log.Log.Object(m.vmi)
-	// check if an ongoing migration has been completed before we could capture the outcome
-	if m.lastProgressUpdate > m.start {
-		logger.Info("Migration job has probably completed before we could capture the status. Getting latest status.")
-		// at this point the migration is over, but we don't know the result.
-		// check if we were trying to cancel this job. In this case, finalize the migration.
-		migration, _ := m.l.metadataCache.Migration.Load()
-		if migration.AbortStatus == string(v1.MigrationAbortInProgress) {
-			logger.Info("Migration job was canceled")
-			return &libvirt.DomainJobInfo{
-				Type:             libvirt.DOMAIN_JOB_CANCELLED,
-				DataRemaining:    m.remainingData,
-				DataRemainingSet: true,
-			}
-		}
-
-		// If the domain is active, it means that the migration has failed.
-		domainState, _, err := dom.GetState()
-		if err != nil {
-			logger.Reason(err).Error("failed to get domain state")
-			if libvirtError, ok := err.(libvirt.Error); ok &&
-				(libvirtError.Code == libvirt.ERR_NO_DOMAIN ||
-					libvirtError.Code == libvirt.ERR_OPERATION_INVALID) {
-				logger.Info("domain is not running on this node")
-				return nil
-			}
-		}
-		if domainState == libvirt.DOMAIN_RUNNING {
-			logger.Info("Migration job failed")
-			return &libvirt.DomainJobInfo{
-				Type:             libvirt.DOMAIN_JOB_FAILED,
-				DataRemaining:    m.remainingData,
-				DataRemainingSet: true,
-			}
-		}
-	}
-	logger.Info("Migration job didn't start yet")
-	return nil
-}
-
 func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *libvirt.DomainJobInfo) *inflightMigrationAborted {
 	logger := log.Log.Object(m.vmi)
 
@@ -610,7 +569,6 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 }
 
 func (m *migrationMonitor) startMonitor() {
-	var completedJobInfo *libvirt.DomainJobInfo
 	vmi := m.vmi
 
 	m.start = time.Now().UTC().UnixNano()
@@ -660,13 +618,10 @@ func (m *migrationMonitor) startMonitor() {
 			return
 		}
 
-		jobStats := completedJobInfo
-		if jobStats == nil {
-			jobStats, err = dom.GetJobStats(0)
-			if err != nil {
-				logger.Reason(err).Warning("failed to get domain job info, will retry")
-				continue
-			}
+		jobStats, err := dom.GetJobStats(0)
+		if err != nil {
+			logger.Reason(err).Warning("failed to get domain job info, will retry")
+			continue
 		}
 
 		if jobStats.DataRemainingSet {
@@ -690,7 +645,7 @@ func (m *migrationMonitor) startMonitor() {
 				logMigrationInfo(logger, string(migrationUID), jobStats)
 			}
 		case libvirt.DOMAIN_JOB_NONE:
-			completedJobInfo = m.determineNonRunningMigrationStatus(dom)
+			logger.Info("Migration job is not active")
 		case libvirt.DOMAIN_JOB_CANCELLED:
 			logger.Info("Migration was canceled")
 			m.l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -371,6 +371,11 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason stri
 		return nil
 	}
 
+	// Improve the error message when the volume migration fails because the destination size is smaller than the source volume
+	if failed && strings.Contains(standardizeSpaces(reason), "has to be smaller or equal to the actual size of the containing file") {
+		reason = fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v", reason)
+	}
+
 	l.metadataCache.Migration.WithSafeBlock(func(migrationMetadata *api.MigrationMetadata, _ bool) {
 		if failed {
 			migrationMetadata.Failed = true
@@ -603,13 +608,6 @@ func (m *migrationMonitor) startMonitor() {
 			var abortStatus v1.MigrationAbortStatus
 			if strings.Contains(err.Error(), "canceled by client") {
 				abortStatus = v1.MigrationAbortSucceeded
-			}
-			// Improve the error message when the volume migration fails because the destination size is smaller than the source volume
-			if len(vmi.Status.MigratedVolumes) > 0 && strings.Contains(standardizeSpaces(err.Error()),
-				"has to be smaller or equal to the actual size of the containing file") {
-				m.l.setMigrationResult(true, fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v",
-					err), abortStatus)
-				return
 			}
 			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", err), abortStatus)
 			return

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -679,13 +679,19 @@ func logMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.D
 		return bytes * 8 / 1000000
 	}
 
+	// For completed jobs, Downtime is the final downtime, DowntimeNet contains the actual network overhead during the cutover
+	downtimeInfo := fmt.Sprintf("ExpectedDowntime:%dms", info.Downtime)
+	if info.DowntimeNetSet && info.DowntimeNet > 0 {
+		downtimeInfo = fmt.Sprintf("Downtime:%dms DowntimeNet:%dms", info.Downtime, info.DowntimeNet)
+	}
+
 	logger.V(2).Info(fmt.Sprintf(`Migration info for %s: TimeElapsed:%dms DataProcessed:%dMiB DataRemaining:%dMiB DataTotal:%dMiB `+
 		`MemoryProcessed:%dMiB MemoryRemaining:%dMiB MemoryTotal:%dMiB MemoryBandwidth:%dMbps DirtyRate:%dMbps `+
-		`Iteration:%d PostcopyRequests:%d ConstantPages:%d NormalPages:%d NormalData:%dMiB ExpectedDowntime:%dms `+
+		`Iteration:%d PostcopyRequests:%d ConstantPages:%d NormalPages:%d NormalData:%dMiB %s `+
 		`DiskMbps:%d`,
 		uid, info.TimeElapsed, bToMiB(info.DataProcessed), bToMiB(info.DataRemaining), bToMiB(info.DataTotal),
 		bToMiB(info.MemProcessed), bToMiB(info.MemRemaining), bToMiB(info.MemTotal), bpsToMbps(info.MemBps), bpsToMbps(info.MemDirtyRate*info.MemPageSize),
-		info.MemIteration, info.MemPostcopyReqs, info.MemConstant, info.MemNormal, bToMiB(info.MemNormalBytes), info.Downtime,
+		info.MemIteration, info.MemPostcopyReqs, info.MemConstant, info.MemNormal, bToMiB(info.MemNormalBytes), downtimeInfo,
 		bpsToMbps(info.DiskBps),
 	))
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -636,11 +636,8 @@ func (m *migrationMonitor) startMonitor() {
 			}
 			logInterval++
 			if logInterval%monitorLogInterval == 0 {
-				logMigrationInfo(logger, uid, jobStats)
+				LogMigrationInfo(logger, uid, jobStats)
 			}
-		case libvirt.DOMAIN_JOB_COMPLETED:
-			logMigrationInfo(logger, uid, jobStats)
-			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
 		}
@@ -657,8 +654,8 @@ func MigrationUID(vmi *v1.VirtualMachineInstance) types.UID {
 	return ""
 }
 
-// logMigrationInfo logs the same migration info as `virsh -r domjobinfo`
-func logMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.DomainJobInfo) {
+// LogMigrationInfo logs the same migration info as `virsh -r domjobinfo`
+func LogMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.DomainJobInfo) {
 	bToMiB := func(bytes uint64) uint64 {
 		return bytes / 1024 / 1024
 	}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -618,10 +618,17 @@ func (m *migrationMonitor) startMonitor() {
 			return
 		}
 
-		jobStats, err := dom.GetJobStats(0)
+		var jobStats *libvirt.DomainJobInfo
+		jobStats, err = dom.GetJobStats(0)
 		if err != nil {
-			logger.Reason(err).Warning("failed to get domain job info, will retry")
-			continue
+			logger.Reason(err).Info("failed to get domain job info, checking for completed job")
+			jobStats, err = dom.GetJobStats(libvirt.DOMAIN_JOB_STATS_COMPLETED | libvirt.DOMAIN_JOB_STATS_KEEP_COMPLETED)
+			if err != nil {
+				// This could only happen when the domain is gone (successful migration) but there is lock contention in stats retrieval.
+				// In case of a sudden domain crash the migrationErr handling above takes care of it.
+				logger.Reason(err).Warning("failed to get completed job stats, will retry")
+				continue
+			}
 		}
 
 		if jobStats.DataRemainingSet {
@@ -644,6 +651,9 @@ func (m *migrationMonitor) startMonitor() {
 			if logInterval%monitorLogInterval == 0 {
 				logMigrationInfo(logger, string(migrationUID), jobStats)
 			}
+		case libvirt.DOMAIN_JOB_COMPLETED:
+			logMigrationInfo(logger, string(migrationUID), jobStats)
+			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
 		case libvirt.DOMAIN_JOB_CANCELLED:

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1825,15 +1825,13 @@ var _ = Describe("Manager", func() {
 		})
 		It("migration should switch to PostCopy", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a completed event otherwise this
+				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
-					}
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{}
 				}
 
 				migrationData -= 125
@@ -1876,15 +1874,13 @@ var _ = Describe("Manager", func() {
 
 		It("migration should switch to PostCopy eventually", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a completed event otherwise this
+				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
-					}
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{}
 				}
 
 				migrationData -= 125
@@ -1940,15 +1936,13 @@ var _ = Describe("Manager", func() {
 		})
 		It("migration should switch to Paused if AllowWorkloadDisruption is allowed and PostCopy is not", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a completed event otherwise this
+				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
-					}
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{}
 				}
 
 				migrationData -= 125
@@ -2133,14 +2127,11 @@ var _ = Describe("Manager", func() {
 			}
 
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			gomock.InOrder(
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
-					func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
-						migrationErrorChan <- fmt.Errorf("operation aborted: canceled by client")
-						return fake_jobinfo_running, nil
-					},
-				),
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil),
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
+				func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
+					migrationErrorChan <- fmt.Errorf("operation aborted: canceled by client")
+					return fake_jobinfo_running, nil
+				},
 			)
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
@@ -2149,6 +2140,51 @@ var _ = Describe("Manager", func() {
 				migration, _ := metadataCache.Migration.Load()
 				return migration.AbortStatus
 			}, 5*time.Second, 2).Should(Equal(string(v1.MigrationAbortSucceeded)))
+		})
+
+		It("monitor should exit when migration error channel is closed", func() {
+			migrationErrorChan := make(chan error)
+
+			options := &cmdclient.MigrationOptions{
+				Bandwidth:               resource.MustParse("64Mi"),
+				ProgressTimeout:         3,
+				CompletionTimeoutPerGiB: 150,
+			}
+			vmi := newVMI(testNamespace, testVmName)
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID: "111222333",
+			}
+
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.UID = vmi.Status.MigrationState.MigrationUID
+			metadataCache.Migration.Store(migrationMetadata)
+
+			manager := &LibvirtDomainManager{
+				virConn:       mockLibvirt.VirtConnection,
+				virtShareDir:  testVirtShareDir,
+				metadataCache: metadataCache,
+				cpuSetGetter:  fakeCpuSetGetter,
+			}
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
+				func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{
+						Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+						DataRemainingSet: true,
+						DataRemaining:    uint64(32479827777),
+					}, nil
+				},
+			)
+
+			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			done := make(chan struct{})
+			go func() {
+				monitor.startMonitor()
+				close(done)
+			}()
+			Eventually(done, 5*time.Second).Should(BeClosed())
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2099,15 +2099,8 @@ var _ = Describe("Manager", func() {
 			manager, _ := newLibvirtDomainManagerDefault()
 			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
 		})
-		It("migration cancellation should be finilized even if we missed status update", func() {
-			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
-			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_NONE,
-					DataRemaining: uint64(0),
-				}
-			}()
+		It("migration cancellation should be finalized even if we missed status update", func() {
+			migrationErrorChan := make(chan error, 1)
 			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
 					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
@@ -2139,11 +2132,9 @@ var _ = Describe("Manager", func() {
 			}
 
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
-			gomock.InOrder(
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil),
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo, nil),
-			)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil)
+
+			migrationErrorChan <- fmt.Errorf("operation canceled by client")
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1828,11 +1828,11 @@ var _ = Describe("Manager", func() {
 			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a different event otherwise this
+				// stop decreasing data and send a completed event otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_CANCELLED,
+						Type: libvirt.DOMAIN_JOB_COMPLETED,
 					}
 				}
 
@@ -1879,11 +1879,11 @@ var _ = Describe("Manager", func() {
 			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a different event otherwise this
+				// stop decreasing data and send a completed event otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_CANCELLED,
+						Type: libvirt.DOMAIN_JOB_COMPLETED,
 					}
 				}
 
@@ -1943,11 +1943,11 @@ var _ = Describe("Manager", func() {
 			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a different event otherwise this
+				// stop decreasing data and send a completed event otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_CANCELLED,
+						Type: libvirt.DOMAIN_JOB_COMPLETED,
 					}
 				}
 
@@ -2101,6 +2101,7 @@ var _ = Describe("Manager", func() {
 		})
 		It("migration cancellation should be finalized even if we missed status update", func() {
 			migrationErrorChan := make(chan error, 1)
+			defer close(migrationErrorChan)
 			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
 					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
@@ -2132,9 +2133,15 @@ var _ = Describe("Manager", func() {
 			}
 
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil)
-
-			migrationErrorChan <- fmt.Errorf("operation canceled by client")
+			gomock.InOrder(
+				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
+					func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
+						migrationErrorChan <- fmt.Errorf("operation aborted: canceled by client")
+						return fake_jobinfo_running, nil
+					},
+				),
+				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil),
+			)
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()


### PR DESCRIPTION
### What this PR does

When a migration completes successfully, the source domain transitions to Shutoff/Migrated and the migrate() function returns, closing migrationErrorChan. 
The monitor goroutine's select then returns immediately on every iteration (reading nil from a closed channel), and GetJobStats(0) fails because the domain is inactive. The original code logged a warning and called continue, creating a busy loop that spins at 100% CPU for the lifetime of the virt-launcher pod.
Fix this by simplifying the monitor loop by removing the inconsequential handling of various errors and calling GetJobStats(0) unconditionally each iteration, and enhance logMigrationInfo to show actual Downtime/DowntimeNet (instead of ExpectedDowntime) when completed job data is available. The completed job is not queried at all, instead an async event carries all the data and logs them.

Assisted-by: claude-4.6-opus

#### Before this PR:

on successful migration there's a 100% CPU busy loop until the pod dies, spamming log and causing more libvirt contention

#### After this PR:

no more log flood, more accurate final stats information

### References

- Fixes #17281 

### Why we need it and why it was done in this way
The following tradeoffs were made:

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```