### PR TITLE
Start DHCPv6 server for bridge bindings

### DIFF
--- a/pkg/network/setup/netpod/discoverbridge.go
+++ b/pkg/network/setup/netpod/discoverbridge.go
@@ -71,6 +71,24 @@ func (n NetPod) storeBridgeBindingDHCPInterfaceData(currentStatus *nmstate.Statu
 		}
 	}
 
+	if ipv6Address := firstIPGlobalUnicast(podIfaceStatus.IPv6); ipv6Address != nil {
+		dhcpConfig.IPAMDisabled = false
+
+		addr, err := vishnetlink.ParseAddr(fmt.Sprintf("%s/%d", ipv6Address.IP, ipv6Address.PrefixLen))
+		if err != nil {
+			return err
+		}
+		dhcpConfig.IPv6 = *addr
+
+		if dhcpConfig.MAC == nil {
+			mac, err := resolveMacAddress(podIfaceStatus.MacAddress, vmiSpecIface.MacAddress)
+			if err != nil {
+				return err
+			}
+			dhcpConfig.MAC = mac
+		}
+	}
+
 	log.Log.V(4).Infof("The generated dhcpConfig: %s\nRoutes: %+v", dhcpConfig.String(), dhcpConfig.Routes)
 	if err := cache.WriteDHCPInterfaceCache(n.cacheCreator, strconv.Itoa(n.podPID), podIfaceName, &dhcpConfig); err != nil {
 		return fmt.Errorf("failed to save DHCP configuration: %v", err)

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -414,6 +414,7 @@ var _ = Describe("netpod", func() {
 
 		expDHCPConfig, err := expectedDHCPConfig(
 			"10.222.222.1/30",
+			primaryIPv6Address+"/64",
 			podIfaceOrignalMAC,
 			defaultGatewayIP4Address,
 			"192.168.1.0/24",
@@ -567,6 +568,7 @@ var _ = Describe("netpod", func() {
 
 		expDHCPConfig, err := expectedDHCPConfig(
 			"10.222.222.1/30",
+			primaryIPv6Address+"/64",
 			podIfaceOrignalMAC,
 			defaultGatewayIP4Address,
 			"192.168.1.0/24",
@@ -1924,7 +1926,7 @@ func (c *tempCacheCreator) New(filePath string) *cache.Cache {
 	return cache.NewCustomCache(filePath, kfs.NewWithRootPath(c.tmpDir))
 }
 
-func expectedDHCPConfig(podIfaceCIDR, podIfaceMAC, defaultGW, staticRouteDst, staticRouteToWiderSubnet string) (*cache.DHCPConfig, error) {
+func expectedDHCPConfig(podIfaceCIDR, podIfaceIPv6CIDR, podIfaceMAC, defaultGW, staticRouteDst, staticRouteToWiderSubnet string) (*cache.DHCPConfig, error) {
 	ipv4, err := vishnetlink.ParseAddr(podIfaceCIDR)
 	if err != nil {
 		return nil, err
@@ -1948,14 +1950,24 @@ func expectedDHCPConfig(podIfaceCIDR, podIfaceMAC, defaultGW, staticRouteDst, st
 		{Dst: destAddr.IPNet, Gw: net.ParseIP(defaultGW)},
 		{Dst: staticRouteToWiderSubnetDest.IPNet, Gw: nil},
 	}
-	return &cache.DHCPConfig{
+	dhcpConfig := &cache.DHCPConfig{
 		IP:           *ipv4,
 		MAC:          mac,
 		Routes:       &routes,
 		IPAMDisabled: false,
 		Gateway:      net.ParseIP(defaultGW),
 		Subdomain:    "",
-	}, nil
+	}
+
+	if podIfaceIPv6CIDR != "" {
+		ipv6, err := vishnetlink.ParseAddr(podIfaceIPv6CIDR)
+		if err != nil {
+			return nil, err
+		}
+		dhcpConfig.IPv6 = *ipv6
+	}
+
+	return dhcpConfig, nil
 }
 
 type netnsStub struct {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The bridge binding's `storeBridgeBindingDHCPInterfaceData` only populated IPv4 in the `DHCPConfig` cache, leaving the `IPv6` field empty. Since `StartDHCP` checks `nic.IPv6.IPNet \!= nil` before launching the DHCPv6 server, the server was never started for bridge bindings — even when the CNI assigned an IPv6 address (e.g., via OVN-K secondary networks with dual-stack).

#### After this PR:

The bridge binding discovery now populates the `IPv6` field in the DHCP config cache from the pod interface's global unicast IPv6 address. This causes `StartDHCP` to launch the DHCPv6 server, serving the IPv6 address to the guest VM via DHCPv6.

### References

### Why we need it and why it was done in this way
The pod network annotation (`k8s.ovn.org/pod-networks`) shows both IPv4 and IPv6 assigned at the CNI level, but the guest VM never receives the IPv6 address because the DHCPv6 server is not started.

The fix follows the same pattern already used for IPv4: extract the global unicast IP from the nmstate interface status and store it in the DHCP config cache. The MAC address resolution is shared with IPv4 when both are present, and handled independently for IPv6-only cases.

The following alternatives were considered:
- Adding a separate code path for IPv6 DHCP config generation — rejected because the existing `DHCPConfig` struct already has an `IPv6` field, it just wasn't being populated.

### Special notes for your reviewer
- The "setup bridge binding without IP" test uses a link-local IPv6 address (`fe80::1`), which is correctly filtered out by `firstIPGlobalUnicast` — this test remains unchanged and still asserts `IPAMDisabled: true`.
- The fix handles both dual-stack (IPv4+IPv6) and IPv6-only scenarios. In dual-stack, the MAC is already resolved from IPv4 processing. In IPv6-only, the MAC is resolved in the IPv6 block.

### Checklist

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Bug fix: Start DHCPv6 server for bridge bindings when IPv6 is assigned at the CNI level, enabling dual-stack and IPv6-only guest networking on secondary networks.
```