### PR TITLE
cleanup: decouple VMExportController using storage registry

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -64,6 +64,7 @@ import (
 	kutil "kubevirt.io/kubevirt/pkg/util"
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/registry"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
@@ -140,6 +141,49 @@ const (
 	// ReadinessPath is the endpoint used to check the readiness probe
 	ReadinessPath = "/exportready"
 )
+
+func CreateVMExportController(ctx *registry.ControllerContext, volumeSnapshotProvider *snapshot.VMSnapshotController) (registry.RunnableController, error) {
+	exportController := &VMExportController{
+		ManifestRenderer:            ctx.TemplateService,
+		Client:                      ctx.ClientSet,
+		VMExportInformer:            ctx.InformerFactory.VirtualMachineExport(),
+		PVCInformer:                 ctx.InformerFactory.PersistentVolumeClaim(),
+		PodInformer:                 ctx.InformerFactory.Pod(),
+		DataVolumeInformer:          ctx.InformerFactory.DataVolume(),
+		ServiceInformer:             ctx.InformerFactory.ExportService(),
+		Recorder:                    ctx.Recorder,
+		ConfigMapInformer:           ctx.InformerFactory.KubeVirtExportCAConfigMap(),
+		IngressCache:                ctx.IngressCache,
+		RouteCache:                  ctx.RouteCache,
+		KubevirtNamespace:           ctx.KubevirtNamespace,
+		RouteConfigMapInformer:      ctx.InformerFactory.ExportRouteConfigMap(),
+		SecretInformer:              ctx.InformerFactory.UnmanagedSecrets(),
+		VolumeSnapshotProvider:      volumeSnapshotProvider,
+		VMSnapshotInformer:          ctx.InformerFactory.VirtualMachineSnapshot(),
+		VMSnapshotContentInformer:   ctx.InformerFactory.VirtualMachineSnapshotContent(),
+		VMInformer:                  ctx.InformerFactory.VirtualMachine(),
+		VMIInformer:                 ctx.InformerFactory.VMI(),
+		CRDInformer:                 ctx.InformerFactory.CRD(),
+		KubeVirtInformer:            ctx.InformerFactory.KubeVirt(),
+		InstancetypeInformer:        ctx.InformerFactory.VirtualMachineInstancetype(),
+		ClusterInstancetypeInformer: ctx.InformerFactory.VirtualMachineClusterInstancetype(),
+		PreferenceInformer:          ctx.InformerFactory.VirtualMachinePreference(),
+		ClusterPreferenceInformer:   ctx.InformerFactory.VirtualMachineClusterPreference(),
+		ControllerRevisionInformer:  ctx.InformerFactory.ControllerRevision(),
+		VMBackupInformer:            ctx.InformerFactory.VirtualMachineBackup(),
+		BackupCAConfigMapInformer:   ctx.InformerFactory.KubeVirtBackupCAConfigMap(),
+	}
+
+	if err := exportController.Init(); err != nil {
+		return nil, err
+	}
+
+	return exportController, nil
+}
+
+func (c *VMExportController) Name() string {
+	return "VMExportController"
+}
 
 // variable so can be overridden in tests
 var currentTime = func() *metav1.Time {

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -85,9 +85,15 @@ import (
 	instancetypecontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/vm"
 	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
+	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
+	netcontrollers "kubevirt.io/kubevirt/pkg/network/controllers"
+	netmigration "kubevirt.io/kubevirt/pkg/network/migration"
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
+	netannotations "kubevirt.io/kubevirt/pkg/network/pod/annotations"
 	"kubevirt.io/kubevirt/pkg/service"
 	backup "kubevirt.io/kubevirt/pkg/storage/cbt"
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
+	storageannotations "kubevirt.io/kubevirt/pkg/storage/pod/annotations"
 	"kubevirt.io/kubevirt/pkg/storage/snapshot"
 	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -95,14 +101,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/disruptionbudget"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/registry"
 	workloadupdater "kubevirt.io/kubevirt/pkg/virt-controller/watch/workload-updater"
-
-	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
-	netcontrollers "kubevirt.io/kubevirt/pkg/network/controllers"
-	netmigration "kubevirt.io/kubevirt/pkg/network/migration"
-	"kubevirt.io/kubevirt/pkg/network/netbinding"
-	netannotations "kubevirt.io/kubevirt/pkg/network/pod/annotations"
-	storageannotations "kubevirt.io/kubevirt/pkg/storage/pod/annotations"
 )
 
 const (
@@ -197,7 +197,7 @@ type VirtControllerApp struct {
 	caBackupConfigMapInformer    cache.SharedIndexInformer
 	exportRouteConfigMapInformer cache.SharedInformer
 	exportServiceInformer        cache.SharedIndexInformer
-	exportController             *export.VMExportController
+	storageControllers           []registry.RunnableController
 	snapshotController           *snapshot.VMSnapshotController
 	restoreController            *snapshot.VMRestoreController
 	vmExportInformer             cache.SharedIndexInformer
@@ -476,7 +476,6 @@ func Execute() {
 	); err != nil {
 		golog.Fatal(err)
 	}
-
 	app.initCommon()
 	app.initReplicaSet()
 	app.initPool()
@@ -485,7 +484,27 @@ func Execute() {
 	app.initEvacuationController()
 	app.initSnapshotController()
 	app.initRestoreController()
-	app.initExportController()
+	ctrlCtx := &registry.ControllerContext{
+		ClientSet:         app.clientSet,
+		InformerFactory:   app.informerFactory,
+		Recorder:          app.newRecorder(k8sv1.NamespaceAll, "storage-controllers"),
+		KubevirtNamespace: app.kubevirtNamespace,
+		TemplateService:   app.templateService,
+		IngressCache:      app.ingressCache,
+		RouteCache:        app.routeCache,
+	}
+	storageControllerInits := []registry.ControllerInitFunc{
+		func(ctx *registry.ControllerContext) (registry.RunnableController, error) {
+			return export.CreateVMExportController(ctx, app.snapshotController)
+		},
+	}
+	for _, initFn := range storageControllerInits {
+		ctrl, err := initFn(ctrlCtx)
+		if err != nil {
+			panic(err)
+		}
+		app.storageControllers = append(app.storageControllers, ctrl)
+	}
 	app.initWorkloadUpdaterController()
 	app.initCloneController()
 	app.initBackupController()
@@ -620,11 +639,13 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 				log.Log.Warningf("error running the restore controller: %v", err)
 			}
 		}()
-		go func() {
-			if err := vca.exportController.Run(vca.exportControllerThreads, stop); err != nil {
-				log.Log.Warningf("error running the export controller: %v", err)
-			}
-		}()
+		for _, ctrl := range vca.storageControllers {
+			go func(c registry.RunnableController) {
+				if err := c.Run(vca.exportControllerThreads, stop); err != nil {
+					log.Log.Warningf("error running storage controller %s: %v", c.Name(), err)
+				}
+			}(ctrl)
+		}
 		go vca.workloadUpdateController.Run(stop)
 		go vca.nodeTopologyUpdater.Run(vca.nodeTopologyUpdatePeriod, stop)
 		go func() {
@@ -908,43 +929,6 @@ func (vca *VirtControllerApp) initRestoreController() {
 		CRInformer:                vca.controllerRevisionInformer,
 	}
 	if err := vca.restoreController.Init(); err != nil {
-		panic(err)
-	}
-}
-
-func (vca *VirtControllerApp) initExportController() {
-	recorder := vca.newRecorder(k8sv1.NamespaceAll, "export-controller")
-	vca.exportController = &export.VMExportController{
-		ManifestRenderer:            vca.templateService,
-		Client:                      vca.clientSet,
-		VMExportInformer:            vca.vmExportInformer,
-		PVCInformer:                 vca.persistentVolumeClaimInformer,
-		PodInformer:                 vca.allPodInformer,
-		DataVolumeInformer:          vca.dataVolumeInformer,
-		ServiceInformer:             vca.exportServiceInformer,
-		Recorder:                    recorder,
-		ConfigMapInformer:           vca.caExportConfigMapInformer,
-		IngressCache:                vca.ingressCache,
-		RouteCache:                  vca.routeCache,
-		KubevirtNamespace:           vca.kubevirtNamespace,
-		RouteConfigMapInformer:      vca.exportRouteConfigMapInformer,
-		SecretInformer:              vca.unmanagedSecretInformer,
-		VolumeSnapshotProvider:      vca.snapshotController,
-		VMSnapshotInformer:          vca.vmSnapshotInformer,
-		VMSnapshotContentInformer:   vca.vmSnapshotContentInformer,
-		VMInformer:                  vca.vmInformer,
-		VMIInformer:                 vca.vmiInformer,
-		CRDInformer:                 vca.crdInformer,
-		KubeVirtInformer:            vca.kubeVirtInformer,
-		InstancetypeInformer:        vca.instancetypeInformer,
-		ClusterInstancetypeInformer: vca.clusterInstancetypeInformer,
-		PreferenceInformer:          vca.preferenceInformer,
-		ClusterPreferenceInformer:   vca.clusterPreferenceInformer,
-		ControllerRevisionInformer:  vca.controllerRevisionInformer,
-		VMBackupInformer:            vca.vmBackupInformer,
-		BackupCAConfigMapInformer:   vca.caBackupConfigMapInformer,
-	}
-	if err := vca.exportController.Init(); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -45,7 +45,6 @@ import (
 	clone "kubevirt.io/api/clone/v1beta1"
 	v1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1"
-	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/kubecli"
@@ -56,7 +55,6 @@ import (
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
 	"kubevirt.io/kubevirt/pkg/rest"
 	backup "kubevirt.io/kubevirt/pkg/storage/cbt"
-	"kubevirt.io/kubevirt/pkg/storage/export/export"
 	"kubevirt.io/kubevirt/pkg/storage/snapshot"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -119,18 +117,10 @@ var _ = Describe("Application", func() {
 		vmRestoreInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineRestore{})
 		vmExportInformer, _ := testutils.NewFakeInformerFor(&exportv1.VirtualMachineExport{})
 		configMapInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
-		routeConfigMapInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		dvInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
-		exportServiceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Service{})
 		cloneInformer, _ := testutils.NewFakeInformerFor(&clone.VirtualMachineClone{})
 		backupInformer, _ := testutils.NewFakeInformerFor(&backupv1.VirtualMachineBackup{})
 		backupTrackerInformer, _ := testutils.NewFakeInformerFor(&backupv1.VirtualMachineBackupTracker{})
-		secretInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Secret{})
-		instancetypeInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineInstancetype{})
-		clusterInstancetypeInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterInstancetype{})
-		preferenceInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
-		clusterPreferenceInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
-		controllerRevisionInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 
 		var qemuGid int64 = 107
 
@@ -229,32 +219,6 @@ var _ = Describe("Application", func() {
 			Recorder:                  recorder,
 		}
 		_ = app.restoreController.Init()
-		app.exportController = &export.VMExportController{
-			Client:                      virtClient,
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
-			VMExportInformer:            vmExportInformer,
-			PVCInformer:                 pvcInformer,
-			PodInformer:                 podInformer,
-			DataVolumeInformer:          dataVolumeInformer,
-			ServiceInformer:             exportServiceInformer,
-			ConfigMapInformer:           configMapInformer,
-			RouteConfigMapInformer:      routeConfigMapInformer,
-			Recorder:                    recorder,
-			SecretInformer:              secretInformer,
-			VMSnapshotInformer:          vmSnapshotInformer,
-			VMSnapshotContentInformer:   vmSnapshotContentInformer,
-			VMInformer:                  vmInformer,
-			VMIInformer:                 vmiInformer,
-			CRDInformer:                 crdInformer,
-			KubeVirtInformer:            kvInformer,
-			InstancetypeInformer:        instancetypeInformer,
-			ClusterInstancetypeInformer: clusterInstancetypeInformer,
-			PreferenceInformer:          preferenceInformer,
-			ClusterPreferenceInformer:   clusterPreferenceInformer,
-			ControllerRevisionInformer:  controllerRevisionInformer,
-			VMBackupInformer:            backupInformer,
-		}
-		_ = app.exportController.Init()
 		app.persistentVolumeClaimInformer = pvcInformer
 		app.nodeInformer = nodeInformer
 		app.resourceQuotaInformer = resourceQuotaInformer

--- a/pkg/virt-controller/watch/registry/registry.go
+++ b/pkg/virt-controller/watch/registry/registry.go
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package registry
+
+import (
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+)
+
+// RunnableController represents a generic controller that can be started.
+type RunnableController interface {
+	Run(threadiness int, stopCh <-chan struct{}) error
+	Name() string
+}
+
+// ControllerInitFunc is the signature for building a storage controller.
+type ControllerInitFunc func(ctx *ControllerContext) (RunnableController, error)
+
+// ControllerContext holds ONLY the common shared dependencies.
+// Controller-specific dependencies should be passed directly to the constructor.
+type ControllerContext struct {
+	ClientSet         kubecli.KubevirtClient
+	InformerFactory   controller.KubeInformerFactory
+	Recorder          record.EventRecorder
+	KubevirtNamespace string
+	TemplateService   *services.TemplateService
+	IngressCache      cache.Store
+	RouteCache        cache.Store
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The `VMExportController` was explicitly initialized and managed within the core `VirtControllerApp` in `application.go`, creating a tight circular dependency between the core control plane and the storage package.

#### After this PR:
The `VMExportController` is decoupled using a new registration-based provider pattern. It now self-registers via an `init()` function, and the core app orchestrates it through a generic `RunnableController` interface and `ControllerContext`.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Partially addresses #17226
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
This refactor is required to move towards a modular architecture where SIG-specific logic (like SIG-storage) is isolated from the virt-controller core.

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

