### PR TITLE
monitoring tests: prefer guestless VMs

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -105,7 +105,7 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 		*/
 
 		By("creating a VMI in a user defined namespace")
-		vmi := libvmifact.NewAlpine()
+		vmi := libvmifact.NewGuestless()
 		vmi.Namespace = testsuite.GetTestNamespace(vmi)
 		startVMI(vmi)
 

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -147,7 +147,7 @@ var _ = Describe("[sig-monitoring]Monitoring", decorators.SigMonitoring, func() 
 		It("KubeVirtDeprecatedAPIRequested should be triggered when a deprecated API is requested", func() {
 			By("Creating a VMI")
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).
-				Create(context.Background(), libvmifact.NewCirros(), metav1.CreateOptions{})
+				Create(context.Background(), libvmifact.NewGuestless(), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Requesting the VMI using the deprecated API version")

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -420,7 +420,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 
 		It("Should correctly update metrics on successful VMIM", func() {
 			By("Creating VMIs")
-			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
+			vmi := libvmifact.NewGuestless(libnet.WithMasqueradeNetworking())
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
 
 			By("Migrating VMIs")
@@ -452,7 +452,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			const migrationPollInterval = 5 * time.Second
 
 			By("Creating VMIs")
-			vmi := libvmifact.NewFedora(
+			vmi := libvmifact.NewGuestless(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
@@ -529,7 +529,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			libmonitoring.ReduceAlertPendingTime(virtClient)
 
 			By("starting non-migratable VMI with eviction strategy set to LiveMigrate ")
-			vmi := libvmifact.NewAlpine(libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate))
+			vmi := libvmifact.NewGuestless(libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate))
 
 			vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(
 				context.Background(), vmi, metav1.CreateOptions{},


### PR DESCRIPTION
Tests that do not interact with the guest operating system should not boot one. Booting from an OS, even a lightweight like Alpine, wastes IO, CPU and time.

Migration metrics: migration phase counters are emitted by virt-controller based on the VMIM object state, the guest OS plays no role. **saves 4-6 min.**

VMCannotBeEvicted alert: the alert fires based on the VMI's eviction strategy and IsMigratable condition, both set from the VMI spec, not the guest OS. **saves 30-60 sec.**

KubeVirtDeprecatedAPIRequested alert: the alert is triggered by a deprecated REST API call to virt-api, the VMI only needs to exist in the API server. **minor time saved.**

Prometheus namespace label test: The test only checks that a PromQL query returns "success". kubevirt_vmi_memory_resident_bytes is reported for any QEMU process, guest or not. **no CI impact now, correct for when unquarantined.**

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### References

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

