### PR TITLE
cleanup: remove unused valid:required tags from KubeVirt API types

### DIFF
--- a/staging/src/kubevirt.io/api/clone/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/clone/v1alpha1/types.go
@@ -33,7 +33,7 @@ type VirtualMachineClone struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   VirtualMachineCloneSpec   `json:"spec" valid:"required"`
+	Spec   VirtualMachineCloneSpec   `json:"spec"`
 	Status VirtualMachineCloneStatus `json:"status,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/api/clone/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/clone/v1beta1/types.go
@@ -35,7 +35,7 @@ type VirtualMachineClone struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   VirtualMachineCloneSpec   `json:"spec" valid:"required"`
+	Spec   VirtualMachineCloneSpec   `json:"spec"`
 	Status VirtualMachineCloneStatus `json:"status,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -48,7 +48,7 @@ type VirtualMachineInstance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineInstance Spec contains the VirtualMachineInstance specification.
-	Spec VirtualMachineInstanceSpec `json:"spec" valid:"required"`
+	Spec VirtualMachineInstanceSpec `json:"spec"`
 	// Status is the high level overview of how the VirtualMachineInstance is doing. It contains information available to controllers and users.
 	Status VirtualMachineInstanceStatus `json:"status,omitempty"`
 }
@@ -337,9 +337,9 @@ type StorageMigratedVolumeInfo struct {
 	// VolumeName is the name of the volume that is being migrated
 	VolumeName string `json:"volumeName"`
 	// SourcePVCInfo contains the information about the source PVC
-	SourcePVCInfo *PersistentVolumeClaimInfo `json:"sourcePVCInfo,omitempty" valid:"required"`
+	SourcePVCInfo *PersistentVolumeClaimInfo `json:"sourcePVCInfo,omitempty"`
 	// DestinationPVCInfo contains the information about the destination PVC
-	DestinationPVCInfo *PersistentVolumeClaimInfo `json:"destinationPVCInfo,omitempty" valid:"required"`
+	DestinationPVCInfo *PersistentVolumeClaimInfo `json:"destinationPVCInfo,omitempty"`
 }
 
 // PersistentVolumeClaimInfo contains the relavant information virt-handler needs cached about a PVC
@@ -1502,7 +1502,7 @@ func NewVMIReferenceWithUUID(namespace string, name string, uuid types.UID) *Vir
 
 type VMISelector struct {
 	// Name of the VirtualMachineInstance to migrate
-	Name string `json:"name" valid:"required"`
+	Name string `json:"name"`
 }
 
 func NewVMReferenceFromNameWithNS(namespace string, name string) *VirtualMachine {
@@ -1571,7 +1571,7 @@ type VirtualMachineInstanceReplicaSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineInstance Spec contains the VirtualMachineInstance specification.
-	Spec VirtualMachineInstanceReplicaSetSpec `json:"spec" valid:"required"`
+	Spec VirtualMachineInstanceReplicaSetSpec `json:"spec"`
 	// Status is the high level overview of how the VirtualMachineInstance is doing. It contains information available to controllers and users.
 	// +nullable
 	Status VirtualMachineInstanceReplicaSetStatus `json:"status,omitempty"`
@@ -1594,10 +1594,10 @@ type VirtualMachineInstanceReplicaSetSpec struct {
 
 	// Label selector for pods. Existing ReplicaSets whose pods are
 	// selected by this will be the ones affected by this deployment.
-	Selector *metav1.LabelSelector `json:"selector" valid:"required"`
+	Selector *metav1.LabelSelector `json:"selector"`
 
 	// Template describes the pods that will be created.
-	Template *VirtualMachineInstanceTemplateSpec `json:"template" valid:"required"`
+	Template *VirtualMachineInstanceTemplateSpec `json:"template"`
 
 	// Indicates that the replica set is paused.
 	// +optional
@@ -1668,7 +1668,7 @@ type VirtualMachineInstanceTemplateSpec struct {
 	// +nullable
 	ObjectMeta metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineInstance Spec contains the VirtualMachineInstance specification.
-	Spec VirtualMachineInstanceSpec `json:"spec,omitempty" valid:"required"`
+	Spec VirtualMachineInstanceSpec `json:"spec,omitempty"`
 }
 
 // VirtualMachineInstanceMigration represents the object tracking a VMI's migration
@@ -1679,7 +1679,7 @@ type VirtualMachineInstanceTemplateSpec struct {
 type VirtualMachineInstanceMigration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              VirtualMachineInstanceMigrationSpec   `json:"spec" valid:"required"`
+	Spec              VirtualMachineInstanceMigrationSpec   `json:"spec"`
 	Status            VirtualMachineInstanceMigrationStatus `json:"status,omitempty"`
 }
 
@@ -1702,7 +1702,7 @@ const (
 
 type VirtualMachineInstanceMigrationSpec struct {
 	// The name of the VMI to perform the migration on. VMI must exist in the migration objects namespace
-	VMIName string `json:"vmiName,omitempty" valid:"required"`
+	VMIName string `json:"vmiName,omitempty"`
 
 	// AddedNodeSelector is an additional selector that can be used to
 	// complement a NodeSelector or NodeAffinity as set on the VM
@@ -1819,7 +1819,7 @@ type VirtualMachineInstancePreset struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineInstance Spec contains the VirtualMachineInstance specification.
-	Spec VirtualMachineInstancePresetSpec `json:"spec,omitempty" valid:"required"`
+	Spec VirtualMachineInstancePresetSpec `json:"spec,omitempty"`
 }
 
 // VirtualMachineInstancePresetList is a list of VirtualMachinePresets
@@ -1868,7 +1868,7 @@ type VirtualMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec contains the specification of VirtualMachineInstance created
-	Spec VirtualMachineSpec `json:"spec" valid:"required"`
+	Spec VirtualMachineSpec `json:"spec"`
 	// Status holds the current state of the controller and brief information
 	// about its associated VirtualMachineInstance
 	Status VirtualMachineStatus `json:"status,omitempty"`
@@ -2368,7 +2368,7 @@ type Probe struct {
 type KubeVirt struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              KubeVirtSpec   `json:"spec" valid:"required"`
+	Spec              KubeVirtSpec   `json:"spec"`
 	Status            KubeVirtStatus `json:"status,omitempty"`
 }
 
@@ -2467,7 +2467,7 @@ type KubeVirtSpec struct {
 	ImageRegistry string `json:"imageRegistry,omitempty"`
 
 	// The ImagePullPolicy to use.
-	ImagePullPolicy k8sv1.PullPolicy `json:"imagePullPolicy,omitempty" valid:"required"`
+	ImagePullPolicy k8sv1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// The imagePullSecrets to pull the container images from
 	// Defaults to none

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
@@ -35,7 +35,7 @@ import (
 type MigrationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              MigrationPolicySpec `json:"spec" valid:"required"`
+	Spec              MigrationPolicySpec `json:"spec"`
 	// +nullable
 	Status MigrationPolicyStatus `json:"status,omitempty"`
 }

--- a/staging/src/kubevirt.io/api/pool/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/pool/v1alpha1/types.go
@@ -51,7 +51,7 @@ type VirtualMachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   VirtualMachinePoolSpec   `json:"spec" valid:"required"`
+	Spec   VirtualMachinePoolSpec   `json:"spec"`
 	Status VirtualMachinePoolStatus `json:"status,omitempty"`
 }
 
@@ -61,7 +61,7 @@ type VirtualMachineTemplateSpec struct {
 	// +nullable
 	ObjectMeta metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineSpec contains the VirtualMachine specification.
-	Spec virtv1.VirtualMachineSpec `json:"spec,omitempty" valid:"required"`
+	Spec virtv1.VirtualMachineSpec `json:"spec,omitempty"`
 }
 
 // +k8s:openapi-gen=true
@@ -112,10 +112,10 @@ type VirtualMachinePoolSpec struct {
 
 	// Label selector for pods. Existing Poolss whose pods are
 	// selected by this will be the ones affected by this deployment.
-	Selector *metav1.LabelSelector `json:"selector" valid:"required"`
+	Selector *metav1.LabelSelector `json:"selector"`
 
 	// Template describes the VM that will be created.
-	VirtualMachineTemplate *VirtualMachineTemplateSpec `json:"virtualMachineTemplate" valid:"required"`
+	VirtualMachineTemplate *VirtualMachineTemplateSpec `json:"virtualMachineTemplate"`
 
 	// Indicates that the pool is paused.
 	// +optional

--- a/staging/src/kubevirt.io/api/pool/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/pool/v1beta1/types.go
@@ -51,7 +51,7 @@ type VirtualMachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   VirtualMachinePoolSpec   `json:"spec" valid:"required"`
+	Spec   VirtualMachinePoolSpec   `json:"spec"`
 	Status VirtualMachinePoolStatus `json:"status,omitempty"`
 }
 
@@ -61,7 +61,7 @@ type VirtualMachineTemplateSpec struct {
 	// +nullable
 	ObjectMeta metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineSpec contains the VirtualMachine specification.
-	Spec virtv1.VirtualMachineSpec `json:"spec,omitempty" valid:"required"`
+	Spec virtv1.VirtualMachineSpec `json:"spec,omitempty"`
 }
 
 // +k8s:openapi-gen=true
@@ -112,10 +112,10 @@ type VirtualMachinePoolSpec struct {
 
 	// Label selector for pods. Existing Poolss whose pods are
 	// selected by this will be the ones affected by this deployment.
-	Selector *metav1.LabelSelector `json:"selector" valid:"required"`
+	Selector *metav1.LabelSelector `json:"selector"`
 
 	// Template describes the VM that will be created.
-	VirtualMachineTemplate *VirtualMachineTemplateSpec `json:"virtualMachineTemplate" valid:"required"`
+	VirtualMachineTemplate *VirtualMachineTemplateSpec `json:"virtualMachineTemplate"`
 
 	// Indicates that the pool is paused.
 	// +optional

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -233,7 +233,7 @@ type VirtualMachine struct {
 	// +nullable
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineSpec contains the VirtualMachine specification.
-	Spec v1.VirtualMachineSpec `json:"spec,omitempty" valid:"required"`
+	Spec v1.VirtualMachineSpec `json:"spec,omitempty"`
 	// Status holds the current state of the controller and brief information
 	// about its associated VirtualMachineInstance
 	Status v1.VirtualMachineStatus `json:"status,omitempty"`

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -236,7 +236,7 @@ type VirtualMachine struct {
 	// +nullable
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VirtualMachineSpec contains the VirtualMachine specification.
-	Spec v1.VirtualMachineSpec `json:"spec,omitempty" valid:"required"`
+	Spec v1.VirtualMachineSpec `json:"spec,omitempty"`
 	// Status holds the current state of the controller and brief information
 	// about its associated VirtualMachineInstance
 	Status v1.VirtualMachineStatus `json:"status,omitempty"`


### PR DESCRIPTION
This PR removes all occurrences of the `valid:"required"` struct tag from KubeVirt API types across multiple packages, including:

- core
- snapshot (v1alpha1, v1beta1)
- clone (v1alpha1, v1beta1)
- pool (v1alpha1, v1beta1)
- migrations (v1alpha1)

These tags appear to be remnants of the deprecated govalidator package and are not used for runtime validation in KubeVirt. Their presence can be misleading to contributors, especially in cases where fields also use `omitempty`, which conflicts with the idea of being "required".

Removing these unused tags improves API clarity, reduces confusion, and avoids divergence from the actual validation logic enforced by admission webhooks and the API server.

No functional changes are introduced by this PR.

Partially addresses #17234

### Release note
```release-note
NONE