### PR TITLE
cleanup: short-circuit executeVMICommands on console failure

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1559,6 +1559,11 @@ func (r *KubernetesReporter) executeContainerCommands(virtCli kubecli.KubevirtCl
 	}
 }
 
+func isConsoleTimeout(err error) bool {
+	_, ok := err.(expect.TimeoutError)
+	return ok
+}
+
 func (r *KubernetesReporter) executeVMICommands(vmi v12.VirtualMachineInstance, logsdir string, vmiType string) {
 	cmds := []commands{
 		{command: ipAddrName, fileNameSuffix: "ipaddress"},
@@ -1589,7 +1594,7 @@ func (r *KubernetesReporter) executeVMICommands(vmi v12.VirtualMachineInstance, 
 		}, 10)
 		if err != nil {
 			printError("Not collecting logs from %s (%v)", vmi.ObjectMeta.Name, err)
-			if strings.Contains(err.Error(), "timer expired") {
+			if isConsoleTimeout(err) {
 				break
 			}
 			continue
@@ -1644,7 +1649,7 @@ func (r *KubernetesReporter) executeCloudInitCommands(vmi v12.VirtualMachineInst
 		}, 10)
 		if err != nil {
 			printError("failed console vmi %s/%s: %v", vmi.Namespace, vmi.Name, err)
-			if strings.Contains(err.Error(), "timer expired") {
+			if isConsoleTimeout(err) {
 				break
 			}
 			continue

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1589,6 +1589,9 @@ func (r *KubernetesReporter) executeVMICommands(vmi v12.VirtualMachineInstance, 
 		}, 10)
 		if err != nil {
 			printError("Not collecting logs from %s (%v)", vmi.ObjectMeta.Name, err)
+			if strings.Contains(err.Error(), "timer expired") {
+				break
+			}
 			continue
 		}
 
@@ -1641,6 +1644,9 @@ func (r *KubernetesReporter) executeCloudInitCommands(vmi v12.VirtualMachineInst
 		}, 10)
 		if err != nil {
 			printError("failed console vmi %s/%s: %v", vmi.Namespace, vmi.Name, err)
+			if strings.Contains(err.Error(), "timer expired") {
+				break
+			}
 			continue
 		}
 


### PR DESCRIPTION
# cleanup: short-circuit executeVMICommands on console failure

### What this PR does
#### Before this PR:
The test reporter in `executeVMICommands` and `executeCloudInitCommands` would continue attempting to run a full batch of diagnostic commands even if the VMI console was unresponsive. This resulted in 8–10 consecutive 10-second "timer expired" timeouts, wasting approximately 80–100 seconds of CI time per failed test.

#### After this PR:
The reporter now detects a "timer expired" error (console timeout) and immediately `break`s the command execution loop. This short-circuits the redundant attempts while still allowing the reporter to proceed with other non-console diagnostic tasks.

### References
- Fixes #17279

### Why we need it and why it was done in this way
We need this to improve CI efficiency and reduce logs noise in Prow. By stopping the reporter from hanging on dead consoles, we free up CI executors faster. 

The following tradeoffs were made:
Used a `break` within the command loop rather than a full `return`. This ensures that if the console is dead, we stop trying console commands, but the `KubernetesReporter` can still potentially finish other cleanup or logging tasks defined later in the function.

### Special notes for your reviewer
This is an infrastructure cleanup identified during flake investigation. Logic was reviewed conceptually with @oshoval.

### Checklist
- [x] Design: Not required (Cleanup)
- [x] PR: The PR description is expressive enough
- [x] Code: Keep it simple
- [x] Refactor: Boy Scout Rule applied
- [x] Testing: Verified against existing timeout logs.
- [x] Documentation: Not required.
- [x] Community: Discussed in #17279.
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
None