### PR TITLE
log debug information when KUBEVIRT_CRI stop fails in cleanup

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -91,8 +91,22 @@ function finish() {
     # avoid container cleanup affecting the exit code of the build
     local exit_code=$?
     set +e
-    $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
-    $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
+
+    if [ -n "${RSYNC_CID}" ]; then
+        if ! output=$($KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} 2>&1); then
+            echo "ERROR: Failed to stop container ${RSYNC_CID} with KUBEVIRT_CRI" >&2
+            echo "Command output: ${output}" >&2
+
+            echo "Container state for debugging:" >&2
+            $KUBEVIRT_CRI ps -a >&2 || true
+        fi
+
+        if ! rm_output=$($KUBEVIRT_CRI rm -f ${RSYNC_CID} 2>&1); then
+            echo "WARNING: Failed to remove container ${RSYNC_CID}" >&2
+            echo "Command output: ${rm_output}" >&2
+        fi
+    fi
+
     set -e
     return ${exit_code}
 }


### PR DESCRIPTION
## What this PR does

Improves observability when KUBEVIRT_CRI stop fails in the cleanup logic by logging command output and container state.

## Problem

Currently, stdout and stderr from the stop command are suppressed, making it difficult to diagnose intermittent failures.

## Solution

- Capture and log command output when stop fails
- Print container list for additional debugging context
- Preserve existing behavior (no failure propagation)

## Notes

This change only affects logging and does not modify control flow.

Fixes: #16867