### PR TITLE
virtctl: add HTTP debug logging via rest config hook

### DIFF
--- a/pkg/virtctl/debug/debug.go
+++ b/pkg/virtctl/debug/debug.go
@@ -1,0 +1,39 @@
+package debug
+
+import (
+	"net/http"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+func RegisterDebugHook() {
+	kubecli.RegisterRestConfigHook(addDebugLogging)
+}
+
+func addDebugLogging(config *rest.Config) {
+	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		// chain wrapper safely
+		return &DebugRoundTripper{rt: rt}
+	})
+}
+
+type DebugRoundTripper struct {
+	rt http.RoundTripper
+}
+
+func (d *DebugRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if klog.V(9).Enabled() {
+		klog.Infof("Request: %s %s", req.Method, req.URL)
+	}
+
+	resp, err := d.rt.RoundTrip(req)
+
+	if err == nil && klog.V(9).Enabled() {
+		klog.Infof("Response: %s", resp.Status)
+	}
+
+	return resp, err
+}

--- a/pkg/virtctl/debug/debug.go
+++ b/pkg/virtctl/debug/debug.go
@@ -14,24 +14,25 @@ func RegisterDebugHook() {
 }
 
 func addDebugLogging(config *rest.Config) {
+	if !klog.V(9).Enabled() {
+		return
+	}
+
 	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		// chain wrapper safely
-		return &DebugRoundTripper{rt: rt}
+		return &debugRoundTripper{rt: rt}
 	})
 }
 
-type DebugRoundTripper struct {
+type debugRoundTripper struct {
 	rt http.RoundTripper
 }
 
-func (d *DebugRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if klog.V(9).Enabled() {
-		klog.Infof("Request: %s %s", req.Method, req.URL)
-	}
+func (d *debugRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	klog.Infof("Request: %s %s", req.Method, req.URL)
 
 	resp, err := d.rt.RoundTrip(req)
 
-	if err == nil && klog.V(9).Enabled() {
+	if err == nil {
 		klog.Infof("Response: %s", resp.Status)
 	}
 

--- a/pkg/virtctl/debug/debug.go
+++ b/pkg/virtctl/debug/debug.go
@@ -28,6 +28,8 @@ type debugRoundTripper struct {
 }
 
 func (d *debugRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	klog.Infof("DEBUG HIT BEFORE REQUEST") // 👈 ADD THIS
+
 	klog.Infof("Request: %s %s", req.Method, req.URL)
 
 	resp, err := d.rt.RoundTrip(req)

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -156,9 +156,10 @@ func addVerbosityFlag(fs *pflag.FlagSet) {
 }
 
 func Execute() int {
-	debug.RegisterDebugHook()
-	log.InitializeLogging(programName)
 	cmd := NewVirtctlCommand()
+	log.InitializeLogging(programName)
+	debug.RegisterDebugHook()
+	
 	if err := cmd.Execute(); err != nil {
 		if versionErr := checkClientServerVersion(cmd.Context()); versionErr != nil {
 			cmd.PrintErrln(versionErr)

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -22,6 +22,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/create"
 	"kubevirt.io/kubevirt/pkg/virtctl/credentials"
+	"kubevirt.io/kubevirt/pkg/virtctl/debug"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 	"kubevirt.io/kubevirt/pkg/virtctl/guestfs"
 	"kubevirt.io/kubevirt/pkg/virtctl/imageupload"
@@ -155,6 +156,7 @@ func addVerbosityFlag(fs *pflag.FlagSet) {
 }
 
 func Execute() int {
+	debug.RegisterDebugHook()
 	log.InitializeLogging(programName)
 	cmd := NewVirtctlCommand()
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
## What this PR does

This PR adds HTTP-level debug logging to virtctl when high verbosity
levels (e.g., -v=9) are enabled.

Previously, virtctl did not provide visibility into HTTP requests and
responses sent to the Kubernetes API server, unlike kubectl.

## Changes

- Introduced a `DebugRoundTripper` to log HTTP requests and responses
- Registered the debug logger using `kubecli.RegisterRestConfigHook`
- Enabled logging conditionally based on verbosity level (-v=9)
- Ensured compatibility with existing transport wrappers (e.g., metrics)

## Why

This improves debugging capabilities for virtctl users by allowing
inspection of API interactions, similar to kubectl's verbose mode.

## Testing

- Built virtctl locally
- Verified HTTP logs appear when running commands with `-v=9`
- Verified no logs appear for lower verbosity levels
- Ensured existing functionality (metrics, commands) remains unaffected

Fixes: #17313

## Notes

- Logging is only enabled at high verbosity levels to avoid noise
- Existing transport wrappers are preserved by chaining, not overriding