### PR TITLE
net, nadswap: Preserve auto injected pod network in syncNetworks

### DIFF
--- a/pkg/network/controllers/vm.go
+++ b/pkg/network/controllers/vm.go
@@ -191,19 +191,16 @@ func applyDynamicIfaceRequestOnVMI(
 
 func syncNetworks(vmNets, vmiNets []v1.Network) []v1.Network {
 	vmIndexedNets := vmispec.IndexNetworkSpecByName(vmNets)
-	var updatedVMINets []v1.Network
-	for _, vmiNet := range vmiNets {
+	updatedVMINets := make([]v1.Network, len(vmiNets))
+	for i := range vmiNets {
+		updatedVMINets[i] = *vmiNets[i].DeepCopy()
+	}
+
+	for i, vmiNet := range updatedVMINets {
 		vmNet, exists := vmIndexedNets[vmiNet.Name]
-		if !exists {
-			continue
-		}
-		switch {
-		case vmiNet.Multus == nil:
-			updatedVMINets = append(updatedVMINets, vmiNet)
-		case vmiNet.Multus.NetworkName == vmNet.Multus.NetworkName:
-			updatedVMINets = append(updatedVMINets, vmiNet)
-		default:
-			updatedVMINets = append(updatedVMINets, *vmNet.DeepCopy())
+
+		if exists && vmNet.Multus != nil && vmiNet.Multus != nil {
+			updatedVMINets[i].Multus.NetworkName = vmNet.Multus.NetworkName
 		}
 	}
 	return updatedVMINets

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -747,6 +747,38 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(Equal(expectedIfaces))
 		Expect(updatedVMI.Spec.Networks).To(Equal(expectedNets))
 	})
+
+	It("sync preserves auto-injected Pod network", func() {
+		clientset := fake.NewSimpleClientset()
+		c := controllers.NewVMController(clientset, stubClusterConfigurer{isLiveUpdateNADRefEnabled: true})
+
+		expectedIfaces := []v1.Interface{libvmi.InterfaceDeviceWithMasqueradeBinding()}
+		expectedNets := []v1.Network{*v1.DefaultPodNetwork()}
+
+		vmi := libvmi.New(
+			libvmi.WithInterface(expectedIfaces[0]),
+			libvmi.WithNetwork(&expectedNets[0]),
+		)
+
+		vm := libvmi.NewVirtualMachine(libvmi.New())
+
+		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedVM, err := c.Sync(vm, vmi)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updatedVM.Spec.Template.Spec.Networks).To(BeEmpty())
+		Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces).To(BeEmpty())
+
+		updatedVMI, err := clientset.KubevirtV1().
+			VirtualMachineInstances(vmi.Namespace).
+			Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(Equal(expectedIfaces))
+		Expect(updatedVMI.Spec.Networks).To(Equal(expectedNets))
+	})
 })
 
 type syncError interface {


### PR DESCRIPTION
When a VM is defined without networks or interfaces, the VM controller
creates a VMI with an auto-injected pod network using the cluster-wide
default binding. However, the VM spec remains empty.

With the NADRefLiveUpdate feature enabled, syncNetworks() iterates over
VM networks and drops any VMI network not found in the VM spec. This
removes the auto-injected pod network, causing "failed to find network
default" errors when virt-launcher tries to configure the domain.

This commit fixes the issue by cloning VMI networks upfront as the base
and only updating entries where the Multus NAD reference differs. Since
syncNetworks() exists solely to sync NAD references during live updates,
this approach ensures networks are never dropped - only their NAD refs
are updated when needed.

Also adds a unit test verifying that auto-injected pod networks are
preserved through the sync operation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/140
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes bug in Live NAD Ref Update feature where a VM with no interfaces/networks is unable to start when LiveNADRefUpdate FG is enabled.
```

