### PR TITLE
[release-1.8] net, nadswap: Preserve auto injected pod network in syncNetworks

### DIFF
--- a/pkg/network/controllers/vm.go
+++ b/pkg/network/controllers/vm.go
@@ -195,6 +195,7 @@ func syncNetworks(vmNets, vmiNets []v1.Network) []v1.Network {
 	for _, vmiNet := range vmiNets {
 		vmNet, exists := vmIndexedNets[vmiNet.Name]
 		if !exists {
+			updatedVMINets = append(updatedVMINets, vmiNet)
 			continue
 		}
 		switch {

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -747,6 +747,41 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(Equal(expectedIfaces))
 		Expect(updatedVMI.Spec.Networks).To(Equal(expectedNets))
 	})
+
+	DescribeTable("sync preserves auto-injected Pod network", func(isFGEnabled bool) {
+		clientset := fake.NewSimpleClientset()
+		c := controllers.NewVMController(clientset, stubClusterConfigurer{isLiveUpdateNADRefEnabled: isFGEnabled})
+
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+
+		vm := libvmi.NewVirtualMachine(
+			libvmi.New(),
+		)
+
+		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = c.Sync(vm, vmi)
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedVMI, err := clientset.KubevirtV1().
+			VirtualMachineInstances(vmi.Namespace).
+			Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updatedVMI.Spec.Networks).To(HaveLen(1), "auto-injected Pod network should not be removed")
+		Expect(updatedVMI.Spec.Networks[0].Name).To(Equal(defaultNetName))
+		Expect(updatedVMI.Spec.Networks[0].Pod).NotTo(BeNil())
+
+		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
+		Expect(updatedVMI.Spec.Domain.Devices.Interfaces[0].Name).To(Equal(defaultNetName))
+	},
+		Entry("when FG LiveUpdateNADRefEnabled is enabled", true),
+		Entry("when FG LiveUpdateNADRefEnabled is disabled", false),
+	)
 })
 
 type syncError interface {


### PR DESCRIPTION
syncNetworks() was removing networks from VMI that don't exist in VM template, breaking auto-injected Pod networks and causing "failed to find network default" errors.

This commit makes syncNetworks preserves the networks on the VMI even if they are not present on the VMI, as the goal of the NAD swap feature is not unplugging networks.
It also adds a unit test for the auto injection scenario because it tests both that auto injected pod interfaces are preserved as well as networks are
not unplugged.

[1] https://github.com/kubevirt/kubevirt/blob/25d115dc989a93b05a31979ff546f0dbf323dcb0/pkg/virt-controller/watch/vm/vm.go#L1310

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/140
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

