### PR TITLE
 virt-controller: timeout decentralized migrations stuck in sync phases

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -43,6 +43,7 @@ const (
 	MigrationProgressTimeout                 int64  = 150
 	MigrationCompletionTimeoutPerGiB         int64  = 150
 	MigrationUtilityVolumesTimeoutSeconds    int64  = 150
+	MigrationSyncTimeoutSeconds              int64  = 150
 	DefaultAMD64MachineType                         = "q35"
 	DefaultAARCH64MachineType                       = "virt"
 	DefaultS390XMachineType                         = "s390-ccw-virtio"

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -782,11 +782,15 @@ func (c *Controller) processMigrationPhase(
 	case virtv1.MigrationWaitingForSync:
 		if vmi.IsMigrationSourceSynchronized() {
 			migrationCopy.Status.Phase = virtv1.MigrationPending
+		} else if err := c.checkSyncPhaseTimeout(migration, migrationCopy, virtv1.MigrationWaitingForSync); err != nil {
+			return err
 		}
 	case virtv1.MigrationSynchronizing:
 		if vmi.IsMigrationSynchronized(migration) {
 			// Sync happened, switch to MigrationPendingTargetVMI
 			migrationCopy.Status.Phase = virtv1.MigrationPending
+		} else if err := c.checkSyncPhaseTimeout(migration, migrationCopy, virtv1.MigrationSynchronizing); err != nil {
+			return err
 		}
 	case virtv1.MigrationScheduling:
 		if conditionManager.HasCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota) {
@@ -1528,6 +1532,60 @@ func timeSinceCreationSeconds(objectMeta *metav1.ObjectMeta) int64 {
 	}
 
 	return seconds
+}
+
+// timeSincePhaseTransitionSeconds returns the number of seconds that have elapsed
+func timeSincePhaseTransitionSeconds(migration *virtv1.VirtualMachineInstanceMigration, phase virtv1.VirtualMachineInstanceMigrationPhase) int64 {
+	for _, ts := range migration.Status.PhaseTransitionTimestamps {
+		if ts.Phase == phase {
+			now := time.Now().UTC().Unix()
+			enteredAt := ts.PhaseTransitionTimestamp.Time.UTC().Unix()
+			seconds := now - enteredAt
+			if seconds < 0 {
+				return 0
+			}
+			return seconds
+		}
+	}
+	return 0
+}
+
+// checkSyncPhaseTimeout enforces a deadline on decentralized migration phases that wait for
+// virt-handler synchronization 
+func (c *Controller) checkSyncPhaseTimeout(
+	migration *virtv1.VirtualMachineInstanceMigration,
+	migrationCopy *virtv1.VirtualMachineInstanceMigration,
+	phase virtv1.VirtualMachineInstanceMigrationPhase,
+) error {
+	timeout := virtconfig.MigrationSyncTimeoutSeconds
+	elapsed := timeSincePhaseTransitionSeconds(migration, phase)
+
+	if elapsed == 0 {
+		// Phase transition timestamp not yet persisted
+		return nil
+	}
+
+	if elapsed >= timeout {
+		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, controller.FailedMigrationReason,
+			"Migration stuck in %s phase for %d seconds (timeout: %d seconds). "+
+				"virt-handler may have crashed or encountered a network partition.",
+			phase, elapsed, timeout)
+		log.Log.Object(migration).Warningf(
+			"Migration stuck in %s phase for %d seconds, exceeding sync timeout of %d seconds.",
+			phase, elapsed, timeout)
+		return c.failMigration(migrationCopy)
+	}
+
+	migrationKey, err := controller.KeyFunc(migration)
+	if err != nil {
+		return err
+	}
+	remaining := time.Duration(timeout-elapsed) * time.Second
+	c.Queue.AddWithOpts(priorityqueue.AddOpts{
+		Priority: pointer.P(migrationsutil.QueuePriorityRunning),
+		After:    remaining,
+	}, migrationKey)
+	return nil
 }
 
 func (c *Controller) deleteTimedOutTargetPod(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, message string) error {

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -3078,6 +3078,70 @@ var _ = Describe("Migration watcher", func() {
 			Expect(conditionManager.HasCondition(migration, v1.VirtualMachineInstanceDecentralizedMigrationBlocked)).To(BeFalse(), "Condition should not be set when VMI does not have the condition")
 		})
 	})
+
+	Context("Decentralized migration sync phase timeout", func() {
+		It("should fail a WaitingForSync migration that has exceeded the sync timeout", func() {
+			vmi := newReceiverVirtualMachine("testvmi", v1.WaitingForSync, "testmigration")
+			migration := newDecentralizedReceiverMigration("testmigration", vmi.Name, v1.MigrationWaitingForSync)
+			migration.Status.PhaseTransitionTimestamps = []v1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
+				{
+					Phase:                    v1.MigrationWaitingForSync,
+					PhaseTransitionTimestamp: metav1.NewTime(time.Now().Add(-151 * time.Second)),
+				},
+			}
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+
+			sanityExecute()
+
+			testutils.ExpectEvent(recorder, virtcontroller.FailedMigrationReason)
+			expectMigrationFailedState(migration.Namespace, migration.Name)
+		})
+
+		It("should fail a Synchronizing migration that has exceeded the sync timeout", func() {
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			migration := newMigration("testmigration", vmi.Name, v1.MigrationSynchronizing)
+			migration.Spec.SendTo = &v1.VirtualMachineInstanceMigrationSource{
+				MigrationID: "testmigration",
+			}
+			migration.Status.PhaseTransitionTimestamps = []v1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
+				{
+					Phase:                    v1.MigrationSynchronizing,
+					PhaseTransitionTimestamp: metav1.NewTime(time.Now().Add(-151 * time.Second)),
+				},
+			}
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+
+			sanityExecute()
+
+			testutils.ExpectEvent(recorder, virtcontroller.FailedMigrationReason)
+			expectMigrationFailedState(migration.Namespace, migration.Name)
+		})
+
+		It("should not fail a WaitingForSync migration within the sync timeout", func() {
+			vmi := newReceiverVirtualMachine("testvmi", v1.WaitingForSync, "testmigration")
+			migration := newDecentralizedReceiverMigration("testmigration", vmi.Name, v1.MigrationWaitingForSync)
+			migration.Status.PhaseTransitionTimestamps = []v1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
+				{
+					Phase:                    v1.MigrationWaitingForSync,
+					PhaseTransitionTimestamp: metav1.NewTime(time.Now().Add(-60 * time.Second)),
+				},
+			}
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+
+			sanityExecute()
+
+			// Migration should remain in WaitingForSync, not failed.
+			updatedVMIM, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMIM.Status.Phase).NotTo(Equal(v1.MigrationFailed))
+		})
+	})
 })
 
 func newMigration(name string, vmiName string, phase v1.VirtualMachineInstanceMigrationPhase) *v1.VirtualMachineInstanceMigration {


### PR DESCRIPTION


### What this PR does

  Decentralized (live) migrations stuck in `WaitingForSync` or `Synchronizing` had no deadline. The controller only advanced the phase when virt-handler updated the VMI's MigrationState; if virt-handler crashed or a network partition occurred the migration would hang forever — no event, no condition, no re-queue.

### What was done 

  * Added `MigrationSyncTimeoutSeconds = 150` constant.
  * Added `timeSincePhaseTransitionSeconds` helper that reads the existing `PhaseTransitionTimestamps` slice (already populated on every phase transition) without touching the API types.
  * Added `checkSyncPhaseTimeout` controller method called from both stuck-phase branches: fails the migration with a Warning event when elapsed ≥ timeout; otherwise re-enqueues after the remaining time so the deadline is enforced even with no object updates.
  * Added 3 unit tests: timeout exceeded for WaitingForSync, timeout xceeded for Synchronizing, and within-timeout no-fail check.


- Fixes #17317 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@0xFelix 