### PR TITLE
Cleanup/remove podman workaround

### DIFF
--- a/hack/push-container-manifest.sh
+++ b/hack/push-container-manifest.sh
@@ -29,7 +29,6 @@ fail_if_cri_bin_missing
 
 function podman_push_manifest() {
     image=$1
-    # FIXME: Workaround https://github.com/containers/podman/issues/18360 and remove once https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f is released
     echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
     ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
     for ARCH in ${BUILD_ARCH//,/ }; do
@@ -41,7 +40,7 @@ function podman_push_manifest() {
             echo "Warning: Image ${TAGGED_IMAGE} does not exist, skipping"
         fi
     done
-    ${KUBEVIRT_CRI} manifest push --all ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+    ${KUBEVIRT_CRI} manifest push --all ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
 }
 
 function docker_push_manifest() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The `podman_push_manifest` function in `hack/push-container-manifest.sh` included a workaround for an old Podman bug ([containers/podman#18360](https://github.com/containers/podman/issues/18360)). This bug required explicitly providing the destination image argument alongside the source image during a `manifest push` because Podman failed to use the source as the destination by default.

#### After this PR:
The obsolete workaround and its corresponding `FIXME` comment are removed. The script now uses the standard shorter syntax (`manifest push --all <image>`), as the upstream Podman issue was resolved and merged in May 2023 ([containers/podman#18395](https://github.com/containers/podman/pull/18395)).

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Upstream fix reference: https://github.com/containers/podman/pull/18395
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
We need this to clean up stale and obsolete workarounds in our build/release scripts. Removing dead workarounds reduces confusion for future contributors and keeps the shell scripts as simple as possible. It was done by reverting the command to its standard form.

The following tradeoffs were made:
None. The underlying tooling (Podman) has supported the standard behavior for over a year, so there is no risk of breaking modern build environments.

The following alternatives were considered:
Leaving the codebase as is. This was rejected because keeping the `FIXME` comment falsely indicates that there is pending upstream action required, which adds unnecessary cognitive load for maintainers.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
N/A

### Special notes for your reviewer

<!-- optional -->
Simple cleanup/refactoring only. No logical changes to standard pipeline outcomes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```