### PR TITLE
cleanup: adopt %w error wrapping in clone package

### DIFF
--- a/pkg/virt-controller/watch/clone/clone.go
+++ b/pkg/virt-controller/watch/clone/clone.go
@@ -410,7 +410,7 @@ func (ctrl *VMCloneController) createSnapshotFromVm(vmClone *clone.VirtualMachin
 	createdSnapshot, err := ctrl.client.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, v1.CreateOptions{})
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
-			syncInfo.setError(fmt.Errorf("failed creating snapshot %s for clone %s: %v", snapshot.Name, vmClone.Name, err))
+			syncInfo.setError(fmt.Errorf("failed creating snapshot %s for clone %s: %w", snapshot.Name, vmClone.Name, err))
 			return syncInfo
 		}
 		syncInfo.snapshotName = snapshot.Name
@@ -428,7 +428,7 @@ func (ctrl *VMCloneController) createSnapshotFromVm(vmClone *clone.VirtualMachin
 func (ctrl *VMCloneController) verifySnapshotReady(vmClone *clone.VirtualMachineClone, name, namespace string, syncInfo syncInfoType) (*snapshotv1.VirtualMachineSnapshot, syncInfoType) {
 	obj, exists, err := ctrl.snapshotStore.GetByKey(getKey(name, namespace))
 	if err != nil {
-		syncInfo.setError(fmt.Errorf("error getting snapshot %s from cache for clone %s: %v", name, vmClone.Name, err))
+		syncInfo.setError(fmt.Errorf("error getting snapshot %s from cache for clone %s: %w", name, vmClone.Name, err))
 		return nil, syncInfo
 	} else if !exists {
 		syncInfo.setError(fmt.Errorf("snapshot %s is not created yet for clone %s", name, vmClone.Name))
@@ -527,7 +527,7 @@ func (ctrl *VMCloneController) getSnapshot(snapshotName string, sourceNamespace 
 		return nil, syncInfo
 	}
 	if err != nil {
-		syncInfo.setError(fmt.Errorf("error getting snapshot %s from cache: %v", snapshotName, err))
+		syncInfo.setError(fmt.Errorf("error getting snapshot %s from cache: %w", snapshotName, err))
 		return nil, syncInfo
 	}
 	snapshot := obj.(*snapshotv1.VirtualMachineSnapshot)
@@ -538,7 +538,7 @@ func (ctrl *VMCloneController) getSnapshot(snapshotName string, sourceNamespace 
 func (ctrl *VMCloneController) createRestoreFromVm(vmClone *clone.VirtualMachineClone, vm *k6tv1.VirtualMachine, snapshotName string, syncInfo syncInfoType) syncInfoType {
 	patches, err := generatePatches(vm, &vmClone.Spec)
 	if err != nil {
-		retErr := fmt.Errorf("error generating patches for clone %s: %v", vmClone.Name, err)
+		retErr := fmt.Errorf("error generating patches for clone %s: %w", vmClone.Name, err)
 		ctrl.recorder.Event(vmClone, corev1.EventTypeWarning, string(RestoreCreationFailed), retErr.Error())
 		syncInfo.setError(retErr)
 		return syncInfo
@@ -548,7 +548,7 @@ func (ctrl *VMCloneController) createRestoreFromVm(vmClone *clone.VirtualMachine
 	createdRestore, err := ctrl.client.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, v1.CreateOptions{})
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
-			retErr := fmt.Errorf("failed creating restore %s for clone %s: %v", restore.Name, vmClone.Name, err)
+			retErr := fmt.Errorf("failed creating restore %s for clone %s: %w", restore.Name, vmClone.Name, err)
 			ctrl.recorder.Event(vmClone, corev1.EventTypeWarning, string(RestoreCreationFailed), retErr.Error())
 			syncInfo.setError(retErr)
 			return syncInfo
@@ -570,7 +570,7 @@ func (ctrl *VMCloneController) verifyRestoreReady(vmClone *clone.VirtualMachineC
 		syncInfo.setError(fmt.Errorf("restore %s is not created yet for clone %s", *vmClone.Status.RestoreName, vmClone.Name))
 		return syncInfo
 	} else if err != nil {
-		syncInfo.setError(fmt.Errorf("error getting restore %s from cache for clone %s: %v", *vmClone.Status.RestoreName, vmClone.Name, err))
+		syncInfo.setError(fmt.Errorf("error getting restore %s from cache for clone %s: %w", *vmClone.Status.RestoreName, vmClone.Name, err))
 		return syncInfo
 	}
 
@@ -597,7 +597,7 @@ func (ctrl *VMCloneController) verifyVmReady(vmClone *clone.VirtualMachineClone,
 		syncInfo.setError(fmt.Errorf("target VM %s is not created yet for clone %s", targetVMInfo.Name, vmClone.Name))
 		return syncInfo
 	} else if err != nil {
-		syncInfo.setError(fmt.Errorf("error getting VM %s from cache for clone %s: %v", targetVMInfo.Name, vmClone.Name, err))
+		syncInfo.setError(fmt.Errorf("error getting VM %s from cache for clone %s: %w", targetVMInfo.Name, vmClone.Name, err))
 		return syncInfo
 	}
 
@@ -613,7 +613,7 @@ func (ctrl *VMCloneController) verifyPVCBound(vmClone *clone.VirtualMachineClone
 		syncInfo.setError(fmt.Errorf("restore %s is not created yet for clone %s", *vmClone.Status.RestoreName, vmClone.Name))
 		return syncInfo
 	} else if err != nil {
-		syncInfo.setError(fmt.Errorf("error getting restore %s from cache for clone %s: %v", *vmClone.Status.SnapshotName, vmClone.Name, err))
+		syncInfo.setError(fmt.Errorf("error getting restore %s from cache for clone %s: %w", *vmClone.Status.SnapshotName, vmClone.Name, err))
 		return syncInfo
 	}
 
@@ -624,7 +624,7 @@ func (ctrl *VMCloneController) verifyPVCBound(vmClone *clone.VirtualMachineClone
 			syncInfo.setError(fmt.Errorf("PVC %s is not created yet for clone %s", volumeRestore.PersistentVolumeClaimName, vmClone.Name))
 			return syncInfo
 		} else if err != nil {
-			syncInfo.setError(fmt.Errorf("error getting PVC %s from cache for clone %s: %v", volumeRestore.PersistentVolumeClaimName, vmClone.Name, err))
+			syncInfo.setError(fmt.Errorf("error getting PVC %s from cache for clone %s: %w", volumeRestore.PersistentVolumeClaimName, vmClone.Name, err))
 			return syncInfo
 		}
 
@@ -679,7 +679,7 @@ func (ctrl *VMCloneController) getSource(vmClone *clone.VirtualMachineClone, nam
 	key := getKey(name, namespace)
 	obj, exists, err := store.GetByKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("error getting %s %s in namespace %s from cache: %v", sourceKind, name, namespace, err)
+		return nil, fmt.Errorf("error getting %s %s in namespace %s from cache: %w", sourceKind, name, namespace, err)
 	}
 	if !exists {
 		return nil, fmt.Errorf("%w: %s %s/%s", ErrSourceDoesntExist, sourceKind, namespace, name)

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -840,24 +840,24 @@ var _ = Describe("Clone", func() {
 
 			marshalledVM, err := json.Marshal(vm)
 			if err != nil {
-				return patchedVM, fmt.Errorf("cannot marshall VM %s: %v", vm.Name, err)
+				return patchedVM, fmt.Errorf("cannot marshall VM %s: %w", vm.Name, err)
 			}
 
 			jsonPatch := "[\n" + strings.Join(patches, ",\n") + "\n]"
 
 			patch, err := jsonpatch.DecodePatch([]byte(jsonPatch))
 			if err != nil {
-				return patchedVM, fmt.Errorf("cannot decode vm patches %s: %v", jsonPatch, err)
+				return patchedVM, fmt.Errorf("cannot decode vm patches %s: %w", jsonPatch, err)
 			}
 
 			modifiedMarshalledVM, err := patch.Apply(marshalledVM)
 			if err != nil {
-				return patchedVM, fmt.Errorf("failed to apply patch for VM %s: %v", jsonPatch, err)
+				return patchedVM, fmt.Errorf("failed to apply patch for VM %s: %w", jsonPatch, err)
 			}
 
 			err = json.Unmarshal(modifiedMarshalledVM, &patchedVM)
 			if err != nil {
-				return patchedVM, fmt.Errorf("cannot unmarshal modified marshalled vm %s: %v", string(modifiedMarshalledVM), err)
+				return patchedVM, fmt.Errorf("cannot unmarshal modified marshalled vm %s: %w", string(modifiedMarshalledVM), err)
 			}
 
 			return patchedVM, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
In `pkg/virt-controller/watch/clone/clone.go`, `fmt.Errorf` was using the `%v` verb to format nested errors. This breaks the error chain and prevents downstream error handlers from using `errors.Is()` or `errors.As()` to inspect the root cause.

#### After this PR:
Replaced `%v` with `%w` in `fmt.Errorf` calls within the `clone` package to ensure proper error chain wrapping.

### References

- Partially addresses #17332


### Why we need it and why it was done in this way
Proper error wrapping is a standard Go practice that allows callers to inspect the root cause of an error. Using `%w` instead of `%v` preserves the original error context.


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Issue #17332

### Special notes for your reviewer
This handles the `clone` package portion of the codebase wide cleanup tracked in the umbrella issue #17332.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```