### PR TITLE
Allow aggregating to kubevirt.io:migrate cluster role

### DIFF
--- a/pkg/virt-operator/resource/apply/rbac.go
+++ b/pkg/virt-operator/resource/apply/rbac.go
@@ -323,6 +323,10 @@ func changeRbacExistingByRequired(existing runtime.Object, required runtime.Obje
 		existingClusterRole := existing.(*rbacv1.ClusterRole)
 		requiredClusterRole := required.(*rbacv1.ClusterRole)
 		modified = changeExistingPolicyRulesByRequired(&existingClusterRole.Rules, &requiredClusterRole.Rules)
+		if existingClusterRole.AggregationRule == nil && requiredClusterRole.AggregationRule != nil {
+			existingClusterRole.AggregationRule = requiredClusterRole.AggregationRule
+			modified = true
+		}
 	case *rbacv1.RoleBinding:
 		existingRoleBinding := existing.(*rbacv1.RoleBinding)
 		requiredRoleBinding := required.(*rbacv1.RoleBinding)

--- a/pkg/virt-operator/resource/apply/rbac_test.go
+++ b/pkg/virt-operator/resource/apply/rbac_test.go
@@ -304,6 +304,33 @@ var _ = Describe("RBAC test", func() {
 			Entry("ClusterRole resource where resource had not changed", clusterRoleType, false),
 		)
 
+		DescribeTable("Check reconciliation of AggregationRule for ClusterRole", func(changeExisting bool) {
+			existing := newEmptyResource(clusterRoleType)
+			required := newEmptyResource(clusterRoleType)
+
+			getRbacMetaObject(required).OwnerReferences = []metav1.OwnerReference{}
+			addToCache(existing)
+
+			if changeExisting {
+				required.(*rbacv1.ClusterRole).AggregationRule = &rbacv1.AggregationRule{
+					ClusterRoleSelectors: []metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"rbac.kubevirt.io/aggregate-to-migrate": "true",
+							},
+						},
+					},
+				}
+				expectRbacUpdate(required)
+			}
+
+			err := updateResource(required)
+			Expect(err).ShouldNot(HaveOccurred())
+		},
+			Entry("where AggregationRule had changed", true),
+			Entry("where AggregationRule had not changed", false),
+		)
+
 		DescribeTable("Check reconciliation of Subjects and RoleRef for", func(resourceType string, changeExistingSubjects, changeExistingRoleRef bool) {
 
 			Expect(resourceType).To(Or(Equal(roleBindingType), Equal(clusterRoleBindingType)))

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -44,6 +44,8 @@ const (
 	// ClusterRoleView is the name of the ClusterRole that aggregates to the default view role
 	ClusterRoleView = "kubevirt.io:view"
 
+	// clusterRoleMigrate is the name of the aggregated ClusterRole for migrate permissions
+	clusterRoleMigrate              = "kubevirt.io:migrate"
 	defaultClusterRoleName          = "kubevirt.io:default"
 	instancetypeViewClusterRoleName = "instancetype.kubevirt.io:view"
 
@@ -111,6 +113,7 @@ func GetAllCluster() []runtime.Object {
 		newInstancetypeViewClusterRole(),
 		newInstancetypeViewClusterRoleBinding(),
 		newMigrateClusterRole(),
+		newMigrateBaseClusterRole(),
 	}
 }
 
@@ -624,9 +627,34 @@ func newMigrateClusterRole() *rbacv1.ClusterRole {
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt.io:migrate",
+			Name: clusterRoleMigrate,
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
+			},
+		},
+		AggregationRule: &rbacv1.AggregationRule{
+			ClusterRoleSelectors: []metav1.LabelSelector{
+				{
+					MatchLabels: map[string]string{
+						"rbac.kubevirt.io/aggregate-to-migrate": "true",
+					},
+				},
+			},
+		},
+	}
+}
+
+func newMigrateBaseClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: VersionNamev1,
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubevirt.io:migrate-base",
+			Labels: map[string]string{
+				virtv1.AppLabel:                         "",
+				"rbac.kubevirt.io/aggregate-to-migrate": "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -221,8 +221,27 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 
 		Context("migrate cluster role", func() {
 
+			It("should be an aggregated cluster role", func() {
+				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), clusterRoleMigrate).(*rbacv1.ClusterRole)
+				Expect(clusterRole).ToNot(BeNil())
+				Expect(clusterRole.AggregationRule).ToNot(BeNil())
+				Expect(clusterRole.AggregationRule.ClusterRoleSelectors).To(HaveLen(1))
+				Expect(clusterRole.AggregationRule.ClusterRoleSelectors[0].MatchLabels).To(
+					HaveKeyWithValue("rbac.kubevirt.io/aggregate-to-migrate", "true"),
+				)
+			})
+		})
+
+		Context("migrate base cluster role", func() {
+
+			It("should have the aggregate-to-migrate label", func() {
+				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), "kubevirt.io:migrate-base").(*rbacv1.ClusterRole)
+				Expect(clusterRole).ToNot(BeNil())
+				Expect(clusterRole.Labels).To(HaveKeyWithValue("rbac.kubevirt.io/aggregate-to-migrate", "true"))
+			})
+
 			DescribeTable("should contain rule to", func(apiGroup, resource string, verbs ...string) {
-				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), "kubevirt.io:migrate").(*rbacv1.ClusterRole)
+				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), "kubevirt.io:migrate-base").(*rbacv1.ClusterRole)
 				Expect(clusterRole).ToNot(BeNil())
 				expectExactRuleExists(clusterRole.Rules, apiGroup, resource, verbs...)
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This allows external projects to contribute additional rules to the
migrate role by creating ClusterRoles with the same label
(with the first consumer being kubevirt-migration-controller)

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow aggregating to kubevirt.io:migrate cluster role
```

