### PR TITLE
net: Backfill and persist default network interface on VM

### DIFF
--- a/pkg/network/controllers/vm.go
+++ b/pkg/network/controllers/vm.go
@@ -77,6 +77,9 @@ func (v *VMController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstanc
 		return vm, nil
 	}
 
+	vmCopy := vm.DeepCopy()
+	backfillDefaultPodNetwork(vmCopy, vmi)
+
 	var (
 		vmiIfacesByName        map[string]v1.Interface
 		vmiIfaceStatusesByName map[string]v1.VirtualMachineInstanceNetworkInterface
@@ -99,7 +102,6 @@ func (v *VMController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstanc
 		vmiIfacesByName = vmispec.IndexInterfaceSpecByName(updatedVMI.Spec.Domain.Devices.Interfaces)
 	}
 
-	vmCopy := vm.DeepCopy()
 	ifaces, networks := clearDetachedIfacesFromVM(
 		vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces,
 		vmCopy.Spec.Template.Spec.Networks,
@@ -223,6 +225,36 @@ func clearDetachedIfacesFromVMI(
 	}
 
 	return retainedIfaces, vmispec.FilterNetworksByInterfaces(specNets, retainedIfaces)
+}
+
+// backfillDefaultPodNetwork persists the default pod network and its interface
+// from a running VMI back to the VM spec. This handles VMs created before the
+// mutating webhook was updated to set network defaults at creation time.
+func backfillDefaultPodNetwork(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) {
+	if vmi == nil {
+		return
+	}
+	if autoAttach := vm.Spec.Template.Spec.Domain.Devices.AutoattachPodInterface; autoAttach != nil && !*autoAttach {
+		return
+	}
+	if len(vm.Spec.Template.Spec.Networks) != 0 || len(vm.Spec.Template.Spec.Domain.Devices.Interfaces) != 0 {
+		return
+	}
+	podNetwork := vmispec.LookupPodNetwork(vmi.Spec.Networks)
+	if podNetwork == nil {
+		return
+	}
+	iface := vmispec.LookupInterfaceByName(vmi.Spec.Domain.Devices.Interfaces, podNetwork.Name)
+	if iface == nil {
+		return
+	}
+	vm.Spec.Template.Spec.Networks = []v1.Network{*podNetwork.DeepCopy()}
+	vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{
+		{
+			Name:                   iface.Name,
+			InterfaceBindingMethod: *iface.InterfaceBindingMethod.DeepCopy(),
+		},
+	}
 }
 
 func clearDetachedIfacesFromVM(

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -95,6 +95,63 @@ var _ = Describe("VM Network Controller", func() {
 		),
 	)
 
+	DescribeTable("sync should backfill default pod network from VMI to VM when",
+		func(expectedIface v1.Interface) {
+			c := controllers.NewVMController(fake.NewSimpleClientset(), stubClusterConfigurer{})
+			vm := newEmptyVM()
+			vmi := libvmi.New(
+				libvmi.WithInterface(expectedIface),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+
+			updatedVM, err := c.Sync(vm, vmi)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces).To(Equal([]v1.Interface{expectedIface}))
+			Expect(updatedVM.Spec.Template.Spec.Networks).To(Equal([]v1.Network{*v1.DefaultPodNetwork()}))
+		},
+		Entry("VMI has default masquerade interface", *v1.DefaultMasqueradeNetworkInterface()),
+		Entry("VMI has default bridge interface", *v1.DefaultBridgeNetworkInterface()),
+	)
+
+	DescribeTable("sync should not backfill default pod network when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) {
+		c := controllers.NewVMController(fake.NewSimpleClientset(), stubClusterConfigurer{})
+		originalVM := vm.DeepCopy()
+		updatedVM, err := c.Sync(vm, vmi)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces).To(Equal(originalVM.Spec.Template.Spec.Domain.Devices.Interfaces))
+		Expect(updatedVM.Spec.Template.Spec.Networks).To(Equal(originalVM.Spec.Template.Spec.Networks))
+	},
+		Entry("VMI is nil",
+			newEmptyVM(),
+			nil,
+		),
+		Entry("VM already has networks and interfaces",
+			libvmi.NewVirtualMachine(libvmi.New(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)),
+			libvmi.New(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			),
+		),
+		Entry("AutoattachPodInterface is false",
+			libvmi.NewVirtualMachine(libvmi.New(
+				libvmi.WithAutoAttachPodInterface(false),
+			)),
+			libvmi.New(),
+		),
+		Entry("VMI has no pod network",
+			newEmptyVM(),
+			libvmi.New(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
+			),
+		),
+	)
+
 	It("sync fails when VMI patch returns an error", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset, stubClusterConfigurer{})

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/defaults:go_default_library",
         "//pkg/instancetype/webhooks/vm:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/webhooks:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/defaults"
 	instancetypeVMWebhooks "kubevirt.io/kubevirt/pkg/instancetype/webhooks/vm"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -88,6 +89,9 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	// race conditions with the VM controller.
 	if ar.Request.Operation == admissionv1.Create {
 		setFirmwareDefaultsIfEmpty(vm)
+		if err := netvmispec.SetDefaultNetworkInterface(mutator.ClusterConfig, &vm.Spec.Template.Spec); err != nil {
+			return webhookutils.ToAdmissionResponseError(err)
+		}
 	}
 
 	// Set VM defaults

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -48,6 +48,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	instancetypeVMWebhooks "kubevirt.io/kubevirt/pkg/instancetype/webhooks/vm"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 
@@ -185,6 +186,81 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		Entry("s390x", "s390x", "s390-ccw-virtio"),
 		Entry("amd64", "amd64", "q35"),
 	)
+
+	Context("default network interface", func() {
+		DescribeTable("should add the default network interface on VM creation when the cluster-wide default is",
+			func(defaultBinding string, isBridgeEnabledWithPodNet bool, expectedIface v1.Interface) {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+					Spec: v1.KubeVirtSpec{
+						Configuration: v1.KubeVirtConfiguration{
+							NetworkConfiguration: &v1.NetworkConfiguration{
+								NetworkInterface:                  defaultBinding,
+								PermitBridgeInterfaceOnPodNetwork: pointer.P(isBridgeEnabledWithPodNet),
+							},
+						},
+					},
+				})
+
+				vmSpec, _ := getVMSpecMetaFromResponseCreate()
+				Expect(vmSpec.Template.Spec.Domain.Devices.Interfaces).To(Equal([]v1.Interface{expectedIface}))
+				Expect(vmSpec.Template.Spec.Networks).To(Equal([]v1.Network{*v1.DefaultPodNetwork()}))
+			},
+			Entry("masquerade", string(v1.MasqueradeInterface), false, *v1.DefaultMasqueradeNetworkInterface()),
+			Entry("bridge", string(v1.BridgeInterface), true, *v1.DefaultBridgeNetworkInterface()),
+		)
+
+		DescribeTable("should not add default network interface on VM creation", func(mutateVM func(*v1.VirtualMachine), expectedIfaces []v1.Interface, expectedNets []v1.Network) {
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						NetworkConfiguration: &v1.NetworkConfiguration{
+							NetworkInterface: string(v1.MasqueradeInterface),
+						},
+					},
+				},
+			})
+
+			mutateVM(vm)
+			vmSpec, _ := getVMSpecMetaFromResponseCreate()
+			Expect(vmSpec.Template.Spec.Networks).To(Equal(expectedNets))
+			Expect(vmSpec.Template.Spec.Domain.Devices.Interfaces).To(Equal(expectedIfaces))
+		},
+			Entry("when autoattachPodInterface is false",
+				func(vm *v1.VirtualMachine) {
+					vm.Spec.Template.Spec.Domain.Devices.AutoattachPodInterface = pointer.P(false)
+				},
+				nil,
+				nil,
+			),
+			Entry("when interfaces and networks already exist",
+				func(vm *v1.VirtualMachine) {
+					vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "mynet"}}
+					vm.Spec.Template.Spec.Networks = []v1.Network{{Name: "mynet"}}
+				},
+				[]v1.Interface{{Name: "mynet"}},
+				[]v1.Network{{Name: "mynet"}},
+			),
+		)
+
+		It("should not add default network interface on VM update", func() {
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						NetworkConfiguration: &v1.NetworkConfiguration{
+							NetworkInterface: string(v1.MasqueradeInterface),
+						},
+					},
+				},
+			})
+
+			oldVM := vm.DeepCopy()
+			resp := getResponseFromVMUpdate(oldVM, vm)
+			Expect(resp.Allowed).To(BeTrue())
+			vmSpec, _ := getVMSpecMetaFromResponse(resp)
+			Expect(vmSpec.Template.Spec.Networks).To(BeEmpty())
+			Expect(vmSpec.Template.Spec.Domain.Devices.Interfaces).To(BeEmpty())
+		})
+	})
 
 	DescribeTable("should apply configurable defaults on VM create", func(arch string, amd64MachineType string, arm64MachineType string, s390xMachineType string, result string) {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -2838,6 +2838,17 @@ func (c *Controller) syncRestartRequired(lastSeenVMSpec *virtv1.VirtualMachineSp
 		lastSeenVM.Spec.Template.Spec.Networks = currentVM.Spec.Template.Spec.Networks
 	}
 
+	// Neutralize default network interface backfill if the VM had no networks/interfaces
+	// in the revision but now matches the VMI. This happens when the network synchronizer
+	// persists the default pod network to a VM that was created without one.
+	if vmi != nil &&
+		len(lastSeenVM.Spec.Template.Spec.Networks) == 0 &&
+		len(lastSeenVM.Spec.Template.Spec.Domain.Devices.Interfaces) == 0 &&
+		equality.Semantic.DeepEqual(currentVM.Spec.Template.Spec.Networks, vmi.Spec.Networks) {
+		lastSeenVM.Spec.Template.Spec.Networks = currentVM.Spec.Template.Spec.Networks
+		lastSeenVM.Spec.Template.Spec.Domain.Devices.Interfaces = currentVM.Spec.Template.Spec.Domain.Devices.Interfaces
+	}
+
 	// Neutralize firmware UUID changes if the VMI's UUID matches the VM's UUID.
 	// This happens when the firmware synchronizer persists the UUID to a VM that didn't have one.
 	if vmi != nil && vmi.Spec.Domain.Firmware != nil && currentVM.Spec.Template.Spec.Domain.Firmware != nil &&

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6115,6 +6115,38 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue), "restart required")
 			})
 
+			It("should not appear when the network synchronizer backfills default pod network", func() {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+
+				By("Creating a VM without networks/interfaces")
+				// VM has no networks/interfaces (simulates a pre-fix VM)
+
+				By("Creating a VMI with injected default pod network")
+				vmi = SetupVMIFromVM(vm)
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+				vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+				controller.vmiIndexer.Add(vmi)
+
+				By("Creating a Controller Revision without networks (as it was at start time)")
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Simulating backfill: adding the default network to the VM spec")
+				vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+				vm.Spec.Template.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+
+				addVirtualMachine(vm)
+
+				By("Executing the controller expecting no RestartRequired condition")
+				sanityExecute(vm)
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+
+				Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+			})
+
 			It("should appear when VM doesn't specify maxSockets and sockets go above cluster-wide maxSockets", func() {
 				var maxSockets uint32 = 8
 

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libpod"
@@ -50,6 +51,27 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
+	})
+
+	It("should persist default network interface on VM spec", func() {
+		vmiSpec := libvmifact.NewAlpine()
+		vm := libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+
+		var err error
+		vm, err = virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedBinding := defaultInterfaceBinding(libkubevirt.GetCurrentKv(virtClient))
+
+		Expect(vm.Spec.Template.Spec.Networks).To(Equal([]v1.Network{*v1.DefaultPodNetwork()}))
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces).To(Equal([]v1.Interface{
+			{Name: v1.DefaultPodNetwork().Name, InterfaceBindingMethod: expectedBinding},
+		}))
 	})
 
 	Describe("Status", func() {
@@ -166,6 +188,14 @@ func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance)
 	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 	return vmi
+}
+
+func defaultInterfaceBinding(kv *v1.KubeVirt) v1.InterfaceBindingMethod {
+	if kv.Spec.Configuration.NetworkConfiguration != nil &&
+		v1.NetworkInterfaceType(kv.Spec.Configuration.NetworkConfiguration.NetworkInterface) == v1.MasqueradeInterface {
+		return v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}
+	}
+	return v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}
 }
 
 func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.VirtualMachineInstance, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
When a VM is created without explicit networks/interfaces, the default pod network interface is only injected into the VMI at creation time (startVMI), leaving the VM spec.template empty. This causes:                                                                                                                                                                                          
  - Inconsistent networking across restarts if cluster defaults change.                                                                                                                            
  - False `RestartRequired` condition on NIC hotplug instead of live update.
#### After this PR:
The default pod network and interface are persisted in the VM spec:
- New VMs: The VM mutating webhook calls SetDefaultNetworkInterface on CREATE.
- Existing running VMs: The network controller backfills the default pod network from the VMI to the VM spec (only name and binding method, no runtime fields).
- Neutralization: Prevents false RestartRequired when the backfill causes a mismatch between the controller revision and the current VM spec.
### References
- Fixes #17331
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
`SetDefaultNetworkInterface` is intentionally kept in `startVMI()`. It handles old stopped VMs created before this fix that are started after upgrade: they have no defaults in their spec and no running VMI, so neither the webhook (CREATE-only) nor the backfill (needs a running VMI) can help. The `startVMI()` call injects defaults into the VMI, and the backfill then persists them to the VM spec on the next sync.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Persist default network interface in VM spec on creation and backfill for existing VMs, fixing crash loops with LiveUpdateNADRef and inconsistent networking across restarts.
```

