### PR TITLE
tests: remove flaky libvirtd logs e2e test

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -175,21 +175,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			}, 10*time.Second, 1*time.Second).Should(BeNil(), "Should not delete the Pod")
 		})
 
-		It("[test_id:1622]should log libvirtd logs", decorators.WgS390x, func() {
-			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
-
-			By("Getting virt-launcher logs")
-			logs := func() string { return getVirtLauncherLogs(kubevirt.Client(), vmi) }
-			Eventually(logs,
-				11*time.Second,
-				500*time.Millisecond).
-				Should(ContainSubstring("libvirt version: "))
-			Eventually(logs,
-				2*time.Second,
-				500*time.Millisecond).
-				Should(ContainSubstring("Connected to libvirt daemon"))
-		})
-
 		DescribeTable("log libvirtd debug logs should be", func(vmiLabels, vmiAnnotations map[string]string, expectDebugLogs bool) {
 			options := []libvmi.Option{libvmi.WithMemoryRequest("32Mi")}
 			for k, v := range vmiLabels {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `[test_id:1622] should log libvirtd logs` e2e test asserts that `"libvirt version: "` and `"Connected to libvirt daemon"` strings appear in virt-launcher pod logs within an 11 second timeout. This test is consistently flaky across multiple k8s versions.

#### After this PR:
The test is removed. The sibling `log libvirtd debug logs` table test remains and provides meaningful coverage.

### References

Recent CI failures caused by this test:
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17296/pull-kubevirt-e2e-k8s-1.34-sig-compute/2037420652071227392
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17251/pull-kubevirt-e2e-k8s-1.35-sig-compute/2037013641848426496
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17253/pull-kubevirt-e2e-k8s-1.33-sig-compute/2036172662752940032

### Why we need it and why it was done in this way
The test doesn't validate any KubeVirt functionality — it only checks that libvirt emits its own startup log messages, which is already guaranteed if the VMI launched successfully (verified by `RunVMIAndExpectLaunch`). The 11-second timeout races against Kubernetes pod log propagation via the API, which under load regularly exceeds this window.

The following tradeoffs were made:
- Removal over timeout increase: bumping the timeout would make the test slower while still not testing KubeVirt logic.

The following alternatives were considered:
- Increasing the timeout — rejected because the test still wouldn't validate KubeVirt behavior.

### Special notes for your reviewer

The `getVirtLauncherLogs` helper is still used by other tests and is retained.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```