### PR TITLE
tests: increase BeGone timeout in graceful shutdown test

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1658,7 +1658,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				event = watcher.New(vmi).Timeout(10*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "Deleted")
 				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
 
-				Eventually(matcher.ThisVMI(vmi)).WithTimeout(15 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
+				Eventually(matcher.ThisVMI(vmi)).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
 			})
 		})
 	})


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The graceful shutdown test `[test_id:1655]` waits only 15 seconds for the VMI object to be fully removed after deletion. Under CI load, virt-handler can be slow to remove the `foregroundDeleteVirtualMachine` finalizer, causing flaky timeouts even though the shutdown itself completed successfully.

#### After this PR:
The `BeGone` timeout is increased from 15s to 30s.

### References

Recent CI failures caused by this test:
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17042/pull-kubevirt-e2e-k8s-1.34-sig-compute/2037134241472450560
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17290/pull-kubevirt-e2e-k8s-1.35-sig-compute-1.8/2036845106719363072
- https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17270/pull-kubevirt-e2e-k8s-1.35-sig-compute/2036425362178576384

### Why we need it and why it was done in this way
The CI failure logs show the VMI has `DeletionTimestamp` set, `DeletionGracePeriodSeconds: 0`, and phase `Failed` — the shutdown completed — but the object persists because the `kubevirt.io/foregroundDeleteVirtualMachine` finalizer hasn't been removed yet by virt-handler. The 15s timeout (5s grace period + 10s buffer) is insufficient under load.

The following tradeoffs were made:
- Doubled the timeout rather than investigating virt-handler finalizer removal performance, since this is a test-side timing issue.

The following alternatives were considered:
- No alternatives — this is a straightforward timeout bump.

### Special notes for your reviewer

The `ShuttingDown` and `Deleted` events both fire successfully in the failing runs. The only issue is the VMI object lingering due to finalizer cleanup latency.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```