### PR TITLE
libvmi: use value types consistently for Interface helpers

### DIFF
--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -95,9 +95,9 @@ func InterfaceWithPasstBindingPlugin(ports ...kvirtv1.Port) kvirtv1.Interface {
 }
 
 // InterfaceWithMacvtapBindingPlugin returns an Interface named "default" with "macvtap" binding plugin.
-func InterfaceWithMacvtapBindingPlugin(name string) *kvirtv1.Interface {
+func InterfaceWithMacvtapBindingPlugin(name string) kvirtv1.Interface {
 	const macvtapBindingName = "macvtap"
-	return &kvirtv1.Interface{
+	return kvirtv1.Interface{
 		Name:    name,
 		Binding: &kvirtv1.PluginBinding{Name: macvtapBindingName},
 	}
@@ -112,7 +112,7 @@ func InterfaceWithBindingPlugin(name string, binding kvirtv1.PluginBinding, port
 }
 
 // InterfaceWithMac decorates an existing Interface with a MAC address.
-func InterfaceWithMac(iface *kvirtv1.Interface, macAddress string) *kvirtv1.Interface {
+func InterfaceWithMac(iface kvirtv1.Interface, macAddress string) kvirtv1.Interface {
 	iface.MacAddress = macAddress
 	return iface
 }

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Annotations Generator", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(defaultNetworkName)),
-				libvmi.WithInterface(*libvmi.InterfaceWithMac(&sriovNIC, customMACAddress)),
+				libvmi.WithInterface(libvmi.InterfaceWithMac(sriovNIC, customMACAddress)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(defaultNetworkName, defaultNetworkAttachmentDefinitionName)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 			)

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -137,7 +137,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			)
 			vmi = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(
-					*libvmi.InterfaceWithMac(&macvtapIface, chosenMAC)),
+					libvmi.InterfaceWithMac(macvtapIface, chosenMAC)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, macvtapNetworkName)))
 
 			namespace := testsuite.GetTestNamespace(nil)

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -90,7 +90,7 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 		nodeName := nodeList.Items[0].Name
 
 		opts := []libvmi.Option{
-			libvmi.WithInterface(*libvmi.InterfaceWithMacvtapBindingPlugin(macvtapNetworkName)),
+			libvmi.WithInterface(libvmi.InterfaceWithMacvtapBindingPlugin(macvtapNetworkName)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)),
 			libvmi.WithNodeAffinityFor(nodeName),
 		}
@@ -118,7 +118,7 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 
 		BeforeEach(func() {
 			clientVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(*libvmi.InterfaceWithMac(
+				libvmi.WithInterface(libvmi.InterfaceWithMac(
 					libvmi.InterfaceWithMacvtapBindingPlugin("test"), clientMAC)),
 				libvmi.WithNetwork(libvmi.MultusNetwork("test", macvtapNetworkName)),
 			)
@@ -149,7 +149,7 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 			BeforeEach(func() {
 				serverVMI = libvmifact.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithInterface(*libvmi.InterfaceWithMac(
+					libvmi.WithInterface(libvmi.InterfaceWithMac(
 						libvmi.InterfaceWithMacvtapBindingPlugin(macvtapNetworkName), serverMAC)),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)),

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -83,10 +83,10 @@ var _ = Describe(SIG("Infosource", func() {
 			secondaryLinuxBridgeInterface1 := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork1.Name)
 			secondaryLinuxBridgeInterface2 := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork2.Name)
 			vmiSpec := libvmifact.NewFedora(
-				libvmi.WithInterface(*libvmi.InterfaceWithMac(&defaultBridgeInterface, primaryInterfaceMac)),
+				libvmi.WithInterface(libvmi.InterfaceWithMac(defaultBridgeInterface, primaryInterfaceMac)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface1, secondaryInterface1Mac)),
-				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface2, secondaryInterface2Mac)),
+				libvmi.WithInterface(libvmi.InterfaceWithMac(secondaryLinuxBridgeInterface1, secondaryInterface1Mac)),
+				libvmi.WithInterface(libvmi.InterfaceWithMac(secondaryLinuxBridgeInterface2, secondaryInterface2Mac)),
 				libvmi.WithNetwork(secondaryNetwork1),
 				libvmi.WithNetwork(secondaryNetwork2),
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(manipulateGuestLinksScript(primaryInterfaceNewMac, dummyInterfaceMac))))

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -526,7 +526,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 					By("Creating a VM with custom MAC address on its Linux bridge CNI interface.")
 					linuxBridgeInterfaceWithCustomMac := linuxBridgeInterfaceWithMACSpoofCheck
-					libvmi.InterfaceWithMac(&linuxBridgeInterfaceWithCustomMac, initialMacAddressStr)
+					linuxBridgeInterfaceWithCustomMac = libvmi.InterfaceWithMac(linuxBridgeInterfaceWithCustomMac, initialMacAddressStr)
 
 					networkData, err := cloudinit.NewNetworkData(
 						cloudinit.WithEthernet(linuxBridgeInterfaceWithCustomMac.Name,

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -839,7 +839,7 @@ func runVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 
 func vmiWithCustomMacAddress(mac string) *v1.VirtualMachineInstance {
 	return libvmifact.NewCirros(
-		libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultBridgeNetworkInterface(), mac)),
+		libvmi.WithInterface(libvmi.InterfaceWithMac(*v1.DefaultBridgeNetworkInterface(), mac)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 }
 


### PR DESCRIPTION
`InterfaceWithMac` and `InterfaceWithMacvtapBindingPlugin` were the only Interface helpers using pointer types, while all other helpers (`InterfaceDeviceWithMasqueradeBinding`, `InterfaceDeviceWithBridgeBinding`, `InterfaceWithBindingPlugin`, etc.) and `WithInterface()` itself use value types. Switch to value types for consistency, simplifying call sites by removing &/* gymnastics.

/kind cleanup

```release-note
NONE
```

