### PR TITLE
Domainwatcher refactor

### DIFF
--- a/pkg/virt-handler/cache/BUILD.bazel
+++ b/pkg/virt-handler/cache/BUILD.bazel
@@ -50,6 +50,5 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )

--- a/pkg/virt-handler/cache/BUILD.bazel
+++ b/pkg/virt-handler/cache/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -20,6 +20,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -223,8 +224,8 @@ func (store *GhostRecordStore) Delete(namespace string, name string) error {
 }
 
 func NewSharedInformer(virtShareDir string, watchdogTimeout int, recorder record.EventRecorder, vmiStore cache.Store, resyncPeriod time.Duration) cache.SharedInformer {
-	lw := newListWatchFromNotify(func(stopChan chan struct{}, c chan watch.Event) error {
-		return notifyserver.RunServer(virtShareDir, stopChan, c, recorder, vmiStore)
+	lw := newListWatchFromNotify(func(ctx context.Context, c chan watch.Event) error {
+		return notifyserver.RunServer(virtShareDir, ctx.Done(), c, recorder, vmiStore)
 	}, watchdogTimeout, resyncPeriod, recorder)
 	return cache.NewSharedInformer(lw, &api.Domain{}, 0)
 }

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -29,6 +29,8 @@ import (
 
 	"k8s.io/client-go/tools/record"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -224,8 +226,28 @@ func (store *GhostRecordStore) Delete(namespace string, name string) error {
 }
 
 func NewSharedInformer(virtShareDir string, watchdogTimeout int, recorder record.EventRecorder, vmiStore cache.Store, resyncPeriod time.Duration) cache.SharedInformer {
-	lw := newListWatchFromNotify(func(ctx context.Context, c chan watch.Event) error {
+	consecutiveFails := new(int)
+	runServer := func(ctx context.Context, c chan watch.Event) error {
 		return notifyserver.RunServer(virtShareDir, ctx.Done(), c, recorder, vmiStore)
-	}, watchdogTimeout, resyncPeriod, recorder)
+	}
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(_ context.Context, _ metav1.ListOptions) (runtime.Object, error) {
+			log.Log.V(3).Info("Synchronizing domains")
+			domains, err := listAllKnownDomains()
+			if err != nil {
+				return nil, err
+			}
+			list := api.DomainList{
+				Items: []api.Domain{},
+			}
+			for _, domain := range domains {
+				list.Items = append(list.Items, *domain)
+			}
+			return &list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+			return newDomainWatcher(ctx, runServer, watchdogTimeout, resyncPeriod, recorder, consecutiveFails), nil
+		},
+	}
 	return cache.NewSharedInformer(lw, &api.Domain{}, 0)
 }

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -29,12 +29,15 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/checkpoint"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
+	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
 )
 
 type IterableCheckpointManager interface {
@@ -220,6 +223,8 @@ func (store *GhostRecordStore) Delete(namespace string, name string) error {
 }
 
 func NewSharedInformer(virtShareDir string, watchdogTimeout int, recorder record.EventRecorder, vmiStore cache.Store, resyncPeriod time.Duration) cache.SharedInformer {
-	lw := newListWatchFromNotify(virtShareDir, watchdogTimeout, recorder, vmiStore, resyncPeriod)
+	lw := newListWatchFromNotify(func(stopChan chan struct{}, c chan watch.Event) error {
+		return notifyserver.RunServer(virtShareDir, stopChan, c, recorder, vmiStore)
+	}, watchdogTimeout, resyncPeriod, recorder)
 	return cache.NewSharedInformer(lw, &api.Domain{}, 0)
 }

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -326,6 +326,7 @@ var _ = Describe("Domain informer", func() {
 			Expect(f.Close()).To(Succeed())
 
 			d := newDomainWatcher(
+				context.Background(),
 				func(ctx context.Context, c chan watch.Event) error {
 					return notifyserver.RunServer(shareDir, ctx.Done(), c, nil, nil)
 				},
@@ -368,6 +369,7 @@ var _ = Describe("Domain informer", func() {
 			}()
 
 			d := newDomainWatcher(
+				context.Background(),
 				func(ctx context.Context, c chan watch.Event) error {
 					return notifyserver.RunServer(shareDir, ctx.Done(), c, nil, nil)
 				},

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
@@ -438,6 +439,55 @@ var _ = Describe("Domain informer", func() {
 			err = client.SendDomainEvent(watch.Event{Type: watch.Deleted, Object: domain})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func(g Gomega) { verifyObj("default/test", nil, g) }, time.Second, 200*time.Millisecond).Should(Succeed())
+		})
+	})
+})
+
+var _ = Describe("Domain watcher ListerWatcher", func() {
+	Context("consecutive failure across watcher restarts", func() {
+		It("should accumulate failures across Watch() calls via ListerWatcher", func() {
+			origMax := notifyServerMaxConsecutiveFails
+			origHealthy := notifyServerHealthyRunTime
+			defer func() {
+				notifyServerMaxConsecutiveFails = origMax
+				notifyServerHealthyRunTime = origHealthy
+			}()
+			notifyServerMaxConsecutiveFails = 10
+			notifyServerHealthyRunTime = 1 * time.Hour
+
+			failCount := 3
+			consecutiveFails := new(int)
+			runServer := func(_ context.Context, _ chan watch.Event) error {
+				return fmt.Errorf("permanent failure")
+			}
+			lw := &cache.ListWatch{
+				WatchFuncWithContext: func(ctx context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+					return newDomainWatcher(ctx, runServer, 10, 1*time.Hour, nil, consecutiveFails), nil
+				},
+			}
+
+			// Simulate what SharedInformer does: call WatchWithContext(),
+			// drain the result channel, then call it again on failure.
+			// Each call creates a new domainWatcher; the counter
+			// must persist across all of them.
+			ctx := context.Background()
+			for range failCount {
+				w, err := lw.WatchWithContext(ctx, metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for range w.ResultChan() {
+				}
+			}
+
+			// Retrieve the shared counter from the next watcher.
+			w, err := lw.WatchWithContext(ctx, metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			dw := w.(*domainWatcher)
+			// Wait for this watcher to also finish (it will fail too).
+			for range dw.ResultChan() {
+			}
+			// The counter should reflect all failures, including the
+			// last watcher. If counters are not shared, this will be 1.
+			Expect(*dw.consecutiveFails).To(Equal(failCount + 1))
 		})
 	})
 })

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -227,7 +227,6 @@ var _ = Describe("Domain informer", func() {
 
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,
-				virtShareDir:             shareDir,
 			}
 
 			listResults, err := d.listAllKnownDomains()
@@ -256,7 +255,6 @@ var _ = Describe("Domain informer", func() {
 
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,
-				virtShareDir:             shareDir,
 			}
 
 			listResults, err := d.listAllKnownDomains()
@@ -336,11 +334,12 @@ var _ = Describe("Domain informer", func() {
 
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,
-				virtShareDir:             shareDir,
 				watchdogTimeout:          1,
 				unresponsiveSockets:      make(map[string]int64),
 				resyncPeriod:             1 * time.Hour,
-				runServer:                notifyserver.RunServer,
+				runServer: func(stopChan chan struct{}, c chan watch.Event) error {
+					return notifyserver.RunServer(shareDir, stopChan, c, nil, nil)
+				},
 			}
 
 			err = d.startBackground()
@@ -380,11 +379,12 @@ var _ = Describe("Domain informer", func() {
 
 			d := &domainWatcher{
 				backgroundWatcherStarted: false,
-				virtShareDir:             shareDir,
 				watchdogTimeout:          1,
 				unresponsiveSockets:      make(map[string]int64),
 				resyncPeriod:             time.Duration(1) * time.Hour,
-				runServer:                notifyserver.RunServer,
+				runServer: func(stopChan chan struct{}, c chan watch.Event) error {
+					return notifyserver.RunServer(shareDir, stopChan, c, nil, nil)
+				},
 			}
 
 			err = d.startBackground()

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -344,7 +344,7 @@ var _ = Describe("Domain informer", func() {
 			// before our own timeout.
 			timeout := time.After(10 * time.Second)
 			select {
-			case event := <-d.eventChan:
+			case event := <-d.result:
 				Expect(event.Type).To(Equal(watch.Modified))
 				Expect(event.Object.(*api.Domain).ObjectMeta.DeletionTimestamp).ToNot(BeNil())
 			case <-timeout:
@@ -387,7 +387,7 @@ var _ = Describe("Domain informer", func() {
 			timedOut := false
 			timeout := time.After(5 * time.Second)
 			select {
-			case _ = <-d.eventChan:
+			case _ = <-d.result:
 				// fall through
 			case <-timeout:
 				timedOut = true

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -20,6 +20,7 @@
 package cache
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net"
@@ -329,8 +330,8 @@ var _ = Describe("Domain informer", func() {
 				watchdogTimeout:          1,
 				unresponsiveSockets:      make(map[string]int64),
 				resyncPeriod:             1 * time.Hour,
-				runServer: func(stopChan chan struct{}, c chan watch.Event) error {
-					return notifyserver.RunServer(shareDir, stopChan, c, nil, nil)
+				runServer: func(ctx context.Context, c chan watch.Event) error {
+					return notifyserver.RunServer(shareDir, ctx.Done(), c, nil, nil)
 				},
 			}
 
@@ -374,8 +375,8 @@ var _ = Describe("Domain informer", func() {
 				watchdogTimeout:          1,
 				unresponsiveSockets:      make(map[string]int64),
 				resyncPeriod:             time.Duration(1) * time.Hour,
-				runServer: func(stopChan chan struct{}, c chan watch.Event) error {
-					return notifyserver.RunServer(shareDir, stopChan, c, nil, nil)
+				runServer: func(ctx context.Context, c chan watch.Event) error {
+					return notifyserver.RunServer(shareDir, ctx.Done(), c, nil, nil)
 				},
 			}
 

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -225,11 +225,7 @@ var _ = Describe("Domain informer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			client.Close()
 
-			d := &domainWatcher{
-				backgroundWatcherStarted: false,
-			}
-
-			listResults, err := d.listAllKnownDomains()
+			listResults, err := listAllKnownDomains()
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(listResults).To(HaveLen(1))
@@ -253,11 +249,7 @@ var _ = Describe("Domain informer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			client.Close()
 
-			d := &domainWatcher{
-				backgroundWatcherStarted: false,
-			}
-
-			listResults, err := d.listAllKnownDomains()
+			listResults, err := listAllKnownDomains()
 			Expect(err).ToNot(HaveOccurred())
 
 			// includes both the domain with an active socket and the ghost record with deleted socket

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -325,18 +325,15 @@ var _ = Describe("Domain informer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(f.Close()).To(Succeed())
 
-			d := &domainWatcher{
-				backgroundWatcherStarted: false,
-				watchdogTimeout:          1,
-				unresponsiveSockets:      make(map[string]int64),
-				resyncPeriod:             1 * time.Hour,
-				runServer: func(ctx context.Context, c chan watch.Event) error {
+			d := newDomainWatcher(
+				func(ctx context.Context, c chan watch.Event) error {
 					return notifyserver.RunServer(shareDir, ctx.Done(), c, nil, nil)
 				},
-			}
-
-			err = d.startBackground()
-			Expect(err).ToNot(HaveOccurred())
+				1,
+				1*time.Hour,
+				nil,
+				new(int),
+			)
 			defer d.Stop()
 
 			timedOut := false
@@ -370,18 +367,15 @@ var _ = Describe("Domain informer", func() {
 				}
 			}()
 
-			d := &domainWatcher{
-				backgroundWatcherStarted: false,
-				watchdogTimeout:          1,
-				unresponsiveSockets:      make(map[string]int64),
-				resyncPeriod:             time.Duration(1) * time.Hour,
-				runServer: func(ctx context.Context, c chan watch.Event) error {
+			d := newDomainWatcher(
+				func(ctx context.Context, c chan watch.Event) error {
 					return notifyserver.RunServer(shareDir, ctx.Done(), c, nil, nil)
 				},
-			}
-
-			err = d.startBackground()
-			Expect(err).ToNot(HaveOccurred())
+				1,
+				1*time.Hour,
+				nil,
+				new(int),
+			)
 			defer d.Stop()
 
 			timedOut := false

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -287,7 +287,7 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 	return nil
 }
 
-func (d *domainWatcher) listAllKnownDomains() ([]*api.Domain, error) {
+func listAllKnownDomains() ([]*api.Domain, error) {
 	var domains []*api.Domain
 
 	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
@@ -351,7 +351,7 @@ func (d *domainWatcher) List(_ metav1.ListOptions) (runtime.Object, error) {
 		return nil, err
 	}
 
-	domains, err := d.listAllKnownDomains()
+	domains, err := listAllKnownDomains()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -28,10 +28,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
 	"kubevirt.io/client-go/log"
@@ -71,29 +68,6 @@ func newDomainWatcher(ctx context.Context, runNotifyServer runServerFunc, watchd
 	d.wg.Add(1)
 	go d.worker(ctx, runNotifyServer, resyncPeriod, watchdogTimeout)
 	return d
-}
-
-func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder) *cache.ListWatch {
-	consecutiveFails := new(int)
-	return &cache.ListWatch{
-		ListWithContextFunc: func(_ context.Context, _ metav1.ListOptions) (runtime.Object, error) {
-			log.Log.V(3).Info("Synchronizing domains")
-			domains, err := listAllKnownDomains()
-			if err != nil {
-				return nil, err
-			}
-			list := api.DomainList{
-				Items: []api.Domain{},
-			}
-			for _, domain := range domains {
-				list.Items = append(list.Items, *domain)
-			}
-			return &list, nil
-		},
-		WatchFuncWithContext: func(ctx context.Context, _ metav1.ListOptions) (watch.Interface, error) {
-			return newDomainWatcher(ctx, runNotifyServer, watchdogTimeout, resyncPeriod, recorder, consecutiveFails), nil
-		},
-	}
 }
 
 func (d *domainWatcher) worker(ctx context.Context, runServer runServerFunc, resyncPeriod time.Duration, watchdogTimeout int) {

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -42,7 +43,7 @@ import (
 
 const socketDialTimeout = 5
 
-type runServerFunc func(stopChan chan struct{}, c chan watch.Event) error
+type runServerFunc func(ctx context.Context, c chan watch.Event) error
 
 var (
 	notifyServerMaxConsecutiveFails = 10
@@ -52,7 +53,8 @@ var (
 type domainWatcher struct {
 	sync.Mutex
 	wg                       sync.WaitGroup
-	stopChan                 chan struct{}
+	ctx                      context.Context
+	cancel                   context.CancelFunc
 	eventChan                chan watch.Event
 	backgroundWatcherStarted bool
 	watchdogTimeout          int
@@ -119,7 +121,7 @@ func (d *domainWatcher) worker() {
 	srvErr := make(chan error)
 	go func() {
 		defer close(srvErr)
-		err := d.runServer(d.stopChan, d.eventChan)
+		err := d.runServer(d.ctx, d.eventChan)
 		srvErr <- err
 	}()
 
@@ -187,7 +189,7 @@ func (d *domainWatcher) startBackground() error {
 		return nil
 	}
 
-	d.stopChan = make(chan struct{}, 1)
+	d.ctx, d.cancel = context.WithCancel(context.Background())
 	d.eventChan = make(chan watch.Event, 100)
 
 	d.wg.Add(1)
@@ -365,22 +367,14 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 }
 
 func (d *domainWatcher) Stop() {
-	shouldWait := func() bool {
-		d.Lock()
-		defer d.Unlock()
-		if !d.backgroundWatcherStarted {
-			return false
-		}
-		select {
-		case <-d.stopChan:
-		default:
-			close(d.stopChan)
-		}
-		return true
-	}()
-	if shouldWait {
-		d.wg.Wait()
+	d.Lock()
+	if !d.backgroundWatcherStarted {
+		d.Unlock()
+		return
 	}
+	d.cancel()
+	d.Unlock()
+	d.wg.Wait()
 }
 
 func (d *domainWatcher) ResultChan() <-chan watch.Event {

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -66,16 +66,37 @@ type domainWatcher struct {
 }
 
 func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder) cache.ListerWatcher {
-	d := &domainWatcher{
-		backgroundWatcherStarted: false,
-		watchdogTimeout:          watchdogTimeout,
-		recorder:                 recorder,
-		unresponsiveSockets:      make(map[string]int64),
-		resyncPeriod:             resyncPeriod,
-		runServer:                runNotifyServer,
+	return &cache.ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			log.Log.V(3).Info("Synchronizing domains")
+			domains, err := listAllKnownDomains()
+			if err != nil {
+				return nil, err
+			}
+			list := api.DomainList{
+				Items: []api.Domain{},
+			}
+			for _, domain := range domains {
+				list.Items = append(list.Items, *domain)
+			}
+			return &list, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			d := &domainWatcher{
+				backgroundWatcherStarted: false,
+				watchdogTimeout:          watchdogTimeout,
+				recorder:                 recorder,
+				unresponsiveSockets:      make(map[string]int64),
+				resyncPeriod:             resyncPeriod,
+				runServer:                runNotifyServer,
+			}
+			err := d.startBackground()
+			if err != nil {
+				return nil, err
+			}
+			return d, nil
+		},
 	}
-
-	return d
 }
 
 func (d *domainWatcher) worker() {
@@ -341,33 +362,6 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 		}
 	}
 	return domains, nil
-}
-
-func (d *domainWatcher) List(_ metav1.ListOptions) (runtime.Object, error) {
-
-	log.Log.V(3).Info("Synchronizing domains")
-	err := d.startBackground()
-	if err != nil {
-		return nil, err
-	}
-
-	domains, err := listAllKnownDomains()
-	if err != nil {
-		return nil, err
-	}
-
-	list := api.DomainList{
-		Items: []api.Domain{},
-	}
-
-	for _, domain := range domains {
-		list.Items = append(list.Items, *domain)
-	}
-	return &list, nil
-}
-
-func (d *domainWatcher) Watch(_ metav1.ListOptions) (watch.Interface, error) {
-	return d, nil
 }
 
 func (d *domainWatcher) Stop() {

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -55,7 +55,7 @@ type domainWatcher struct {
 	wg                       sync.WaitGroup
 	ctx                      context.Context
 	cancel                   context.CancelFunc
-	eventChan                chan watch.Event
+	result                   chan watch.Event
 	backgroundWatcherStarted bool
 	watchdogTimeout          int
 	recorder                 record.EventRecorder
@@ -121,7 +121,7 @@ func (d *domainWatcher) worker() {
 	srvErr := make(chan error)
 	go func() {
 		defer close(srvErr)
-		err := d.runServer(d.ctx, d.eventChan)
+		err := d.runServer(d.ctx, d.result)
 		srvErr <- err
 	}()
 
@@ -135,7 +135,7 @@ func (d *domainWatcher) worker() {
 			if err != nil {
 				log.Log.Reason(err).Errorf("Domain notify server exited unexpectedly")
 				d.panicOnConsecutiveFailures(err, startedAt)
-				d.eventChan <- watch.Event{
+				d.result <- watch.Event{
 					Type: watch.Error,
 					Object: &metav1.Status{
 						Status:  metav1.StatusFailure,
@@ -152,7 +152,7 @@ func (d *domainWatcher) onWorkerExit() {
 	d.Lock()
 	defer d.Unlock()
 	d.backgroundWatcherStarted = false
-	close(d.eventChan)
+	close(d.result)
 }
 
 func (d *domainWatcher) panicOnConsecutiveFailures(err error, startedAt time.Time) {
@@ -190,7 +190,7 @@ func (d *domainWatcher) startBackground() error {
 	}
 
 	d.ctx, d.cancel = context.WithCancel(context.Background())
-	d.eventChan = make(chan watch.Event, 100)
+	d.result = make(chan watch.Event, 100)
 
 	d.wg.Add(1)
 	go d.worker()
@@ -229,7 +229,7 @@ func (d *domainWatcher) handleResync() {
 			continue
 		}
 
-		d.eventChan <- watch.Event{Type: watch.Modified, Object: domain}
+		d.result <- watch.Event{Type: watch.Modified, Object: domain}
 	}
 }
 
@@ -297,7 +297,7 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 				now := metav1.Now()
 				domain.ObjectMeta.DeletionTimestamp = &now
 				log.Log.Object(domain).Warningf("detected unresponsive virt-launcher command socket (%s) for domain", key)
-				d.eventChan <- watch.Event{Type: watch.Modified, Object: domain}
+				d.result <- watch.Event{Type: watch.Modified, Object: domain}
 
 				err := cmdclient.MarkSocketUnresponsive(key)
 				if err != nil {
@@ -378,7 +378,7 @@ func (d *domainWatcher) Stop() {
 }
 
 func (d *domainWatcher) ResultChan() <-chan watch.Event {
-	return d.eventChan
+	return d.result
 }
 
 func listSockets(ghostRecords []ghostRecord) ([]string, error) {

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -37,13 +37,12 @@ import (
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
-	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 const socketDialTimeout = 5
 
-type runServerFunc func(virtShareDir string, stopChan chan struct{}, c chan watch.Event, recorder record.EventRecorder, vmiStore cache.Store, watchInterval ...time.Duration) error
+type runServerFunc func(stopChan chan struct{}, c chan watch.Event) error
 
 var (
 	notifyServerMaxConsecutiveFails = 10
@@ -56,10 +55,8 @@ type domainWatcher struct {
 	stopChan                 chan struct{}
 	eventChan                chan watch.Event
 	backgroundWatcherStarted bool
-	virtShareDir             string
 	watchdogTimeout          int
 	recorder                 record.EventRecorder
-	vmiStore                 cache.Store
 	resyncPeriod             time.Duration
 	runServer                runServerFunc
 	consecutiveFails         int
@@ -68,16 +65,14 @@ type domainWatcher struct {
 	unresponsiveSockets map[string]int64
 }
 
-func newListWatchFromNotify(virtShareDir string, watchdogTimeout int, recorder record.EventRecorder, vmiStore cache.Store, resyncPeriod time.Duration) cache.ListerWatcher {
+func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder) cache.ListerWatcher {
 	d := &domainWatcher{
 		backgroundWatcherStarted: false,
-		virtShareDir:             virtShareDir,
 		watchdogTimeout:          watchdogTimeout,
 		recorder:                 recorder,
-		vmiStore:                 vmiStore,
 		unresponsiveSockets:      make(map[string]int64),
 		resyncPeriod:             resyncPeriod,
-		runServer:                notifyserver.RunServer,
+		runServer:                runNotifyServer,
 	}
 
 	return d
@@ -103,7 +98,7 @@ func (d *domainWatcher) worker() {
 	srvErr := make(chan error)
 	go func() {
 		defer close(srvErr)
-		err := d.runServer(d.virtShareDir, d.stopChan, d.eventChan, d.recorder, d.vmiStore)
+		err := d.runServer(d.stopChan, d.eventChan)
 		srvErr <- err
 	}()
 

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -50,7 +50,7 @@ var (
 )
 
 type domainWatcher struct {
-	lock                     sync.Mutex
+	sync.Mutex
 	wg                       sync.WaitGroup
 	stopChan                 chan struct{}
 	eventChan                chan watch.Event
@@ -147,8 +147,8 @@ func (d *domainWatcher) worker() {
 }
 
 func (d *domainWatcher) onWorkerExit() {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+	d.Lock()
+	defer d.Unlock()
 	d.backgroundWatcherStarted = false
 	close(d.eventChan)
 }
@@ -180,8 +180,8 @@ func (d *domainWatcher) recordNotifyServerFailureEvent(err error) {
 }
 
 func (d *domainWatcher) startBackground() error {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+	d.Lock()
+	defer d.Unlock()
 
 	if d.backgroundWatcherStarted {
 		return nil
@@ -366,8 +366,8 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 
 func (d *domainWatcher) Stop() {
 	shouldWait := func() bool {
-		d.lock.Lock()
-		defer d.lock.Unlock()
+		d.Lock()
+		defer d.Unlock()
 		if !d.backgroundWatcherStarted {
 			return false
 		}

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -59,8 +59,8 @@ type domainWatcher struct {
 	unresponsiveSockets map[string]int64
 }
 
-func newDomainWatcher(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder, consecutiveFails *int) *domainWatcher {
-	ctx, cancel := context.WithCancel(context.Background())
+func newDomainWatcher(ctx context.Context, runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder, consecutiveFails *int) *domainWatcher {
+	ctx, cancel := context.WithCancel(ctx)
 	d := &domainWatcher{
 		recorder:            recorder,
 		unresponsiveSockets: make(map[string]int64),
@@ -73,10 +73,10 @@ func newDomainWatcher(runNotifyServer runServerFunc, watchdogTimeout int, resync
 	return d
 }
 
-func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder) cache.ListerWatcher {
+func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder) *cache.ListWatch {
 	consecutiveFails := new(int)
 	return &cache.ListWatch{
-		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(_ context.Context, _ metav1.ListOptions) (runtime.Object, error) {
 			log.Log.V(3).Info("Synchronizing domains")
 			domains, err := listAllKnownDomains()
 			if err != nil {
@@ -90,8 +90,8 @@ func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, 
 			}
 			return &list, nil
 		},
-		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
-			return newDomainWatcher(runNotifyServer, watchdogTimeout, resyncPeriod, recorder, consecutiveFails), nil
+		WatchFuncWithContext: func(ctx context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+			return newDomainWatcher(ctx, runNotifyServer, watchdogTimeout, resyncPeriod, recorder, consecutiveFails), nil
 		},
 	}
 }

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -51,36 +51,25 @@ var (
 )
 
 type domainWatcher struct {
-	sync.Mutex
-	wg               sync.WaitGroup
-	ctx              context.Context
-	cancel           context.CancelFunc
-	result           chan watch.Event
-	watchdogTimeout  int
-	recorder         record.EventRecorder
-	resyncPeriod     time.Duration
-	runServer        runServerFunc
-	consecutiveFails *int
-
-	watchDogLock        sync.Mutex
+	wg                  sync.WaitGroup
+	cancel              context.CancelFunc
+	result              chan watch.Event
+	recorder            record.EventRecorder
+	consecutiveFails    *int
 	unresponsiveSockets map[string]int64
 }
 
 func newDomainWatcher(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder, consecutiveFails *int) *domainWatcher {
 	ctx, cancel := context.WithCancel(context.Background())
 	d := &domainWatcher{
-		watchdogTimeout:     watchdogTimeout,
 		recorder:            recorder,
 		unresponsiveSockets: make(map[string]int64),
-		resyncPeriod:        resyncPeriod,
-		runServer:           runNotifyServer,
 		consecutiveFails:    consecutiveFails,
 		result:              make(chan watch.Event, 100),
-		ctx:                 ctx,
 		cancel:              cancel,
 	}
 	d.wg.Add(1)
-	go d.worker()
+	go d.worker(ctx, runNotifyServer, resyncPeriod, watchdogTimeout)
 	return d
 }
 
@@ -107,36 +96,32 @@ func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, 
 	}
 }
 
-func (d *domainWatcher) worker() {
+func (d *domainWatcher) worker(ctx context.Context, runServer runServerFunc, resyncPeriod time.Duration, watchdogTimeout int) {
 	defer d.wg.Done()
 	defer close(d.result)
 
-	resyncTicker := time.NewTicker(d.resyncPeriod)
-	resyncTickerChan := resyncTicker.C
+	resyncTicker := time.NewTicker(resyncPeriod)
 	defer resyncTicker.Stop()
 
 	// Divide the watchdogTimeout by 3 for our ticker.
 	// This ensures we always have at least 2 response failures
 	// in a row before we mark the socket as unavailable (which results in shutdown of VMI)
-	expiredWatchdogTicker := time.NewTicker(time.Duration((d.watchdogTimeout/3)+1) * time.Second)
+	expiredWatchdogTicker := time.NewTicker(time.Duration((watchdogTimeout/3)+1) * time.Second)
 	defer expiredWatchdogTicker.Stop()
-
-	expiredWatchdogTickerChan := expiredWatchdogTicker.C
 
 	startedAt := time.Now()
 	srvErr := make(chan error)
 	go func() {
 		defer close(srvErr)
-		err := d.runServer(d.ctx, d.result)
-		srvErr <- err
+		srvErr <- runServer(ctx, d.result)
 	}()
 
 	for {
 		select {
-		case <-resyncTickerChan:
+		case <-resyncTicker.C:
 			d.handleResync()
-		case <-expiredWatchdogTickerChan:
-			d.handleStaleSocketConnections()
+		case <-expiredWatchdogTicker.C:
+			d.handleStaleSocketConnections(watchdogTimeout)
 		case err := <-srvErr:
 			if err != nil {
 				log.Log.Reason(err).Errorf("Domain notify server exited unexpectedly")
@@ -214,7 +199,7 @@ func (d *domainWatcher) handleResync() {
 	}
 }
 
-func (d *domainWatcher) handleStaleSocketConnections() error {
+func (d *domainWatcher) handleStaleSocketConnections(watchdogTimeout int) error {
 	var unresponsive []string
 
 	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
@@ -232,9 +217,6 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 		}
 		unresponsive = append(unresponsive, socket)
 	}
-
-	d.watchDogLock.Lock()
-	defer d.watchDogLock.Unlock()
 
 	now := time.Now().UTC().Unix()
 
@@ -263,7 +245,7 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 
 		diff := now - timeStamp
 
-		if diff > int64(d.watchdogTimeout) {
+		if diff > int64(watchdogTimeout) {
 
 			record, exists := GhostRecordGlobalStore.findBySocket(key)
 

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -52,19 +52,36 @@ var (
 
 type domainWatcher struct {
 	sync.Mutex
-	wg                       sync.WaitGroup
-	ctx                      context.Context
-	cancel                   context.CancelFunc
-	result                   chan watch.Event
-	backgroundWatcherStarted bool
-	watchdogTimeout          int
-	recorder                 record.EventRecorder
-	resyncPeriod             time.Duration
-	runServer                runServerFunc
-	consecutiveFails         *int
+	wg               sync.WaitGroup
+	ctx              context.Context
+	cancel           context.CancelFunc
+	result           chan watch.Event
+	watchdogTimeout  int
+	recorder         record.EventRecorder
+	resyncPeriod     time.Duration
+	runServer        runServerFunc
+	consecutiveFails *int
 
 	watchDogLock        sync.Mutex
 	unresponsiveSockets map[string]int64
+}
+
+func newDomainWatcher(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder, consecutiveFails *int) *domainWatcher {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &domainWatcher{
+		watchdogTimeout:     watchdogTimeout,
+		recorder:            recorder,
+		unresponsiveSockets: make(map[string]int64),
+		resyncPeriod:        resyncPeriod,
+		runServer:           runNotifyServer,
+		consecutiveFails:    consecutiveFails,
+		result:              make(chan watch.Event, 100),
+		ctx:                 ctx,
+		cancel:              cancel,
+	}
+	d.wg.Add(1)
+	go d.worker()
+	return d
 }
 
 func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder) cache.ListerWatcher {
@@ -85,27 +102,14 @@ func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, 
 			return &list, nil
 		},
 		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
-			d := &domainWatcher{
-				backgroundWatcherStarted: false,
-				watchdogTimeout:          watchdogTimeout,
-				recorder:                 recorder,
-				unresponsiveSockets:      make(map[string]int64),
-				resyncPeriod:             resyncPeriod,
-				runServer:                runNotifyServer,
-				consecutiveFails:         consecutiveFails,
-			}
-			err := d.startBackground()
-			if err != nil {
-				return nil, err
-			}
-			return d, nil
+			return newDomainWatcher(runNotifyServer, watchdogTimeout, resyncPeriod, recorder, consecutiveFails), nil
 		},
 	}
 }
 
 func (d *domainWatcher) worker() {
 	defer d.wg.Done()
-	defer d.onWorkerExit()
+	defer close(d.result)
 
 	resyncTicker := time.NewTicker(d.resyncPeriod)
 	resyncTickerChan := resyncTicker.C
@@ -150,13 +154,6 @@ func (d *domainWatcher) worker() {
 	}
 }
 
-func (d *domainWatcher) onWorkerExit() {
-	d.Lock()
-	defer d.Unlock()
-	d.backgroundWatcherStarted = false
-	close(d.result)
-}
-
 func (d *domainWatcher) panicOnConsecutiveFailures(err error, startedAt time.Time) {
 	if time.Since(startedAt) >= notifyServerHealthyRunTime {
 		*d.consecutiveFails = 0
@@ -181,24 +178,6 @@ func (d *domainWatcher) recordNotifyServerFailureEvent(err error) {
 	node := &k8sv1.Node{ObjectMeta: metav1.ObjectMeta{Name: hostname}}
 	d.recorder.Eventf(node, k8sv1.EventTypeWarning, "NotifyServerFailure",
 		"Domain notify server exited unexpectedly: %v", err)
-}
-
-func (d *domainWatcher) startBackground() error {
-	d.Lock()
-	defer d.Unlock()
-
-	if d.backgroundWatcherStarted {
-		return nil
-	}
-
-	d.ctx, d.cancel = context.WithCancel(context.Background())
-	d.result = make(chan watch.Event, 100)
-
-	d.wg.Add(1)
-	go d.worker()
-
-	d.backgroundWatcherStarted = true
-	return nil
 }
 
 func (d *domainWatcher) handleResync() {
@@ -369,13 +348,7 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 }
 
 func (d *domainWatcher) Stop() {
-	d.Lock()
-	if !d.backgroundWatcherStarted {
-		d.Unlock()
-		return
-	}
 	d.cancel()
-	d.Unlock()
 	d.wg.Wait()
 }
 

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -61,13 +61,14 @@ type domainWatcher struct {
 	recorder                 record.EventRecorder
 	resyncPeriod             time.Duration
 	runServer                runServerFunc
-	consecutiveFails         int
+	consecutiveFails         *int
 
 	watchDogLock        sync.Mutex
 	unresponsiveSockets map[string]int64
 }
 
 func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, resyncPeriod time.Duration, recorder record.EventRecorder) cache.ListerWatcher {
+	consecutiveFails := new(int)
 	return &cache.ListWatch{
 		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
 			log.Log.V(3).Info("Synchronizing domains")
@@ -91,6 +92,7 @@ func newListWatchFromNotify(runNotifyServer runServerFunc, watchdogTimeout int, 
 				unresponsiveSockets:      make(map[string]int64),
 				resyncPeriod:             resyncPeriod,
 				runServer:                runNotifyServer,
+				consecutiveFails:         consecutiveFails,
 			}
 			err := d.startBackground()
 			if err != nil {
@@ -157,13 +159,13 @@ func (d *domainWatcher) onWorkerExit() {
 
 func (d *domainWatcher) panicOnConsecutiveFailures(err error, startedAt time.Time) {
 	if time.Since(startedAt) >= notifyServerHealthyRunTime {
-		d.consecutiveFails = 0
+		*d.consecutiveFails = 0
 	}
-	d.consecutiveFails++
+	*d.consecutiveFails++
 
 	d.recordNotifyServerFailureEvent(err)
 
-	if d.consecutiveFails >= notifyServerMaxConsecutiveFails {
+	if *d.consecutiveFails >= notifyServerMaxConsecutiveFails {
 		log.Log.Reason(err).Criticalf("Domain notify server reached max consecutive failures (%d)",
 			notifyServerMaxConsecutiveFails)
 		panic(fmt.Sprintf("domain notify server reached max consecutive failures (%d): %v",

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -78,6 +79,49 @@ var _ = Describe("Domain Watcher", func() {
 
 			Expect(d.worker).To(PanicWith(
 				ContainSubstring("domain notify server reached max consecutive failures")))
+		})
+	})
+
+	Context("consecutive failure across watcher restarts", func() {
+		It("should accumulate failures across Watch() calls via ListerWatcher", func() {
+			origMax := notifyServerMaxConsecutiveFails
+			origHealthy := notifyServerHealthyRunTime
+			defer func() {
+				notifyServerMaxConsecutiveFails = origMax
+				notifyServerHealthyRunTime = origHealthy
+			}()
+			notifyServerMaxConsecutiveFails = 5
+			notifyServerHealthyRunTime = 1 * time.Hour
+
+			failCount := 3
+			lw := newListWatchFromNotify(
+				func(_ context.Context, _ chan watch.Event) error {
+					return fmt.Errorf("permanent failure")
+				},
+				10,
+				1*time.Hour,
+				nil,
+			)
+
+			// Simulate what SharedInformer does: call Watch(), drain the
+			// result channel, then call Watch() again on failure.
+			for range failCount {
+				w, err := lw.Watch(metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				// Drain until channel closes (worker exited)
+				for range w.ResultChan() {
+				}
+			}
+
+			// After failCount Watch() restarts, the next watcher should
+			// have the accumulated counter. If each Watch() creates a
+			// fresh domainWatcher without sharing the counter, this
+			// will be 0 instead of failCount.
+			w, err := lw.Watch(metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			dw := w.(*domainWatcher)
+			Expect(dw.consecutiveFails).To(Equal(failCount))
+			dw.Stop()
 		})
 	})
 

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -26,8 +26,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/watch"
-	k8scache "k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 )
 
 var _ = Describe("Domain Watcher", func() {
@@ -63,11 +61,10 @@ var _ = Describe("Domain Watcher", func() {
 			notifyServerHealthyRunTime = 1 * time.Hour
 
 			d := &domainWatcher{
-				virtShareDir:        GinkgoT().TempDir(),
 				watchdogTimeout:     10,
 				unresponsiveSockets: make(map[string]int64),
 				resyncPeriod:        1 * time.Hour,
-				runServer: func(string, chan struct{}, chan watch.Event, record.EventRecorder, k8scache.Store, ...time.Duration) error {
+				runServer: func(_ chan struct{}, _ chan watch.Event) error {
 					return fmt.Errorf("permanent failure")
 				},
 				eventChan: make(chan watch.Event, 100),
@@ -83,11 +80,10 @@ var _ = Describe("Domain Watcher", func() {
 	Context("Stop() idempotency", func() {
 		It("should not panic when Stop is called twice", func() {
 			d := &domainWatcher{
-				virtShareDir:        GinkgoT().TempDir(),
 				watchdogTimeout:     1,
 				unresponsiveSockets: make(map[string]int64),
 				resyncPeriod:        1 * time.Hour,
-				runServer: func(string, chan struct{}, chan watch.Event, record.EventRecorder, k8scache.Store, ...time.Duration) error {
+				runServer: func(chan struct{}, chan watch.Event) error {
 					return fmt.Errorf("injected error")
 				},
 			}

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -90,8 +90,8 @@ var _ = Describe("Domain Watcher", func() {
 
 			Expect(d.startBackground()).To(Succeed())
 			Eventually(func() bool {
-				d.lock.Lock()
-				defer d.lock.Unlock()
+				d.Lock()
+				defer d.Unlock()
 				return !d.backgroundWatcherStarted
 			}, 5*time.Second).Should(BeTrue())
 

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -71,9 +71,10 @@ var _ = Describe("Domain Watcher", func() {
 				runServer: func(_ context.Context, _ chan watch.Event) error {
 					return fmt.Errorf("permanent failure")
 				},
-				result: make(chan watch.Event, 100),
-				ctx:    ctx,
-				cancel: cancel,
+				consecutiveFails: new(int),
+				result:           make(chan watch.Event, 100),
+				ctx:              ctx,
+				cancel:           cancel,
 			}
 			d.wg.Add(1)
 
@@ -90,7 +91,7 @@ var _ = Describe("Domain Watcher", func() {
 				notifyServerMaxConsecutiveFails = origMax
 				notifyServerHealthyRunTime = origHealthy
 			}()
-			notifyServerMaxConsecutiveFails = 5
+			notifyServerMaxConsecutiveFails = 10
 			notifyServerHealthyRunTime = 1 * time.Hour
 
 			failCount := 3
@@ -105,23 +106,25 @@ var _ = Describe("Domain Watcher", func() {
 
 			// Simulate what SharedInformer does: call Watch(), drain the
 			// result channel, then call Watch() again on failure.
+			// Each Watch() creates a new domainWatcher; the counter
+			// must persist across all of them.
 			for range failCount {
 				w, err := lw.Watch(metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				// Drain until channel closes (worker exited)
 				for range w.ResultChan() {
 				}
 			}
 
-			// After failCount Watch() restarts, the next watcher should
-			// have the accumulated counter. If each Watch() creates a
-			// fresh domainWatcher without sharing the counter, this
-			// will be 0 instead of failCount.
+			// Retrieve the shared counter from the next watcher.
 			w, err := lw.Watch(metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			dw := w.(*domainWatcher)
-			Expect(dw.consecutiveFails).To(Equal(failCount))
-			dw.Stop()
+			// Wait for this watcher to also finish (it will fail too).
+			for range dw.ResultChan() {
+			}
+			// The counter should reflect all failures, including the
+			// last watcher. If counters are not shared, this will be 1.
+			Expect(*dw.consecutiveFails).To(Equal(failCount + 1))
 		})
 	})
 
@@ -130,6 +133,7 @@ var _ = Describe("Domain Watcher", func() {
 			d := &domainWatcher{
 				watchdogTimeout:     1,
 				unresponsiveSockets: make(map[string]int64),
+				consecutiveFails:    new(int),
 				resyncPeriod:        1 * time.Hour,
 				runServer: func(context.Context, chan watch.Event) error {
 					return fmt.Errorf("injected error")

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -20,6 +20,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -60,15 +61,18 @@ var _ = Describe("Domain Watcher", func() {
 			notifyServerMaxConsecutiveFails = 1
 			notifyServerHealthyRunTime = 1 * time.Hour
 
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			d := &domainWatcher{
 				watchdogTimeout:     10,
 				unresponsiveSockets: make(map[string]int64),
 				resyncPeriod:        1 * time.Hour,
-				runServer: func(_ chan struct{}, _ chan watch.Event) error {
+				runServer: func(_ context.Context, _ chan watch.Event) error {
 					return fmt.Errorf("permanent failure")
 				},
 				eventChan: make(chan watch.Event, 100),
-				stopChan:  make(chan struct{}),
+				ctx:       ctx,
+				cancel:    cancel,
 			}
 			d.wg.Add(1)
 
@@ -83,7 +87,7 @@ var _ = Describe("Domain Watcher", func() {
 				watchdogTimeout:     1,
 				unresponsiveSockets: make(map[string]int64),
 				resyncPeriod:        1 * time.Hour,
-				runServer: func(chan struct{}, chan watch.Event) error {
+				runServer: func(context.Context, chan watch.Event) error {
 					return fmt.Errorf("injected error")
 				},
 			}

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -65,20 +65,17 @@ var _ = Describe("Domain Watcher", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			d := &domainWatcher{
-				watchdogTimeout:     10,
 				unresponsiveSockets: make(map[string]int64),
-				resyncPeriod:        1 * time.Hour,
-				runServer: func(_ context.Context, _ chan watch.Event) error {
-					return fmt.Errorf("permanent failure")
-				},
-				consecutiveFails: new(int),
-				result:           make(chan watch.Event, 100),
-				ctx:              ctx,
-				cancel:           cancel,
+				consecutiveFails:    new(int),
+				result:              make(chan watch.Event, 100),
+				cancel:              cancel,
 			}
 			d.wg.Add(1)
 
-			Expect(d.worker).To(PanicWith(
+			runServer := func(_ context.Context, _ chan watch.Event) error {
+				return fmt.Errorf("permanent failure")
+			}
+			Expect(func() { d.worker(ctx, runServer, 1*time.Hour, 10) }).To(PanicWith(
 				ContainSubstring("domain notify server reached max consecutive failures")))
 		})
 	})

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -26,7 +26,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -77,52 +76,6 @@ var _ = Describe("Domain Watcher", func() {
 			}
 			Expect(func() { d.worker(ctx, runServer, 1*time.Hour, 10) }).To(PanicWith(
 				ContainSubstring("domain notify server reached max consecutive failures")))
-		})
-	})
-
-	Context("consecutive failure across watcher restarts", func() {
-		It("should accumulate failures across Watch() calls via ListerWatcher", func() {
-			origMax := notifyServerMaxConsecutiveFails
-			origHealthy := notifyServerHealthyRunTime
-			defer func() {
-				notifyServerMaxConsecutiveFails = origMax
-				notifyServerHealthyRunTime = origHealthy
-			}()
-			notifyServerMaxConsecutiveFails = 10
-			notifyServerHealthyRunTime = 1 * time.Hour
-
-			failCount := 3
-			lw := newListWatchFromNotify(
-				func(_ context.Context, _ chan watch.Event) error {
-					return fmt.Errorf("permanent failure")
-				},
-				10,
-				1*time.Hour,
-				nil,
-			)
-
-			// Simulate what SharedInformer does: call WatchWithContext(),
-			// drain the result channel, then call it again on failure.
-			// Each call creates a new domainWatcher; the counter
-			// must persist across all of them.
-			ctx := context.Background()
-			for range failCount {
-				w, err := lw.WatchWithContext(ctx, metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for range w.ResultChan() {
-				}
-			}
-
-			// Retrieve the shared counter from the next watcher.
-			w, err := lw.WatchWithContext(ctx, metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			dw := w.(*domainWatcher)
-			// Wait for this watcher to also finish (it will fail too).
-			for range dw.ResultChan() {
-			}
-			// The counter should reflect all failures, including the
-			// last watcher. If counters are not shared, this will be 1.
-			Expect(*dw.consecutiveFails).To(Equal(failCount + 1))
 		})
 	})
 

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -130,22 +130,17 @@ var _ = Describe("Domain Watcher", func() {
 
 	Context("Stop() idempotency", func() {
 		It("should not panic when Stop is called twice", func() {
-			d := &domainWatcher{
-				watchdogTimeout:     1,
-				unresponsiveSockets: make(map[string]int64),
-				consecutiveFails:    new(int),
-				resyncPeriod:        1 * time.Hour,
-				runServer: func(context.Context, chan watch.Event) error {
+			d := newDomainWatcher(
+				func(context.Context, chan watch.Event) error {
 					return fmt.Errorf("injected error")
 				},
-			}
+				1,
+				1*time.Hour,
+				nil,
+				new(int),
+			)
 
-			Expect(d.startBackground()).To(Succeed())
-			Eventually(func() bool {
-				d.Lock()
-				defer d.Unlock()
-				return !d.backgroundWatcherStarted
-			}, 5*time.Second).Should(BeTrue())
+			Eventually(d.result).Should(BeClosed())
 
 			Expect(func() { d.Stop() }).ShouldNot(Panic())
 			Expect(func() { d.Stop() }).ShouldNot(Panic())

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -101,19 +101,20 @@ var _ = Describe("Domain Watcher", func() {
 				nil,
 			)
 
-			// Simulate what SharedInformer does: call Watch(), drain the
-			// result channel, then call Watch() again on failure.
-			// Each Watch() creates a new domainWatcher; the counter
+			// Simulate what SharedInformer does: call WatchWithContext(),
+			// drain the result channel, then call it again on failure.
+			// Each call creates a new domainWatcher; the counter
 			// must persist across all of them.
+			ctx := context.Background()
 			for range failCount {
-				w, err := lw.Watch(metav1.ListOptions{})
+				w, err := lw.WatchWithContext(ctx, metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for range w.ResultChan() {
 				}
 			}
 
 			// Retrieve the shared counter from the next watcher.
-			w, err := lw.Watch(metav1.ListOptions{})
+			w, err := lw.WatchWithContext(ctx, metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			dw := w.(*domainWatcher)
 			// Wait for this watcher to also finish (it will fail too).
@@ -128,6 +129,7 @@ var _ = Describe("Domain Watcher", func() {
 	Context("Stop() idempotency", func() {
 		It("should not panic when Stop is called twice", func() {
 			d := newDomainWatcher(
+				context.Background(),
 				func(context.Context, chan watch.Event) error {
 					return fmt.Errorf("injected error")
 				},

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -70,9 +70,9 @@ var _ = Describe("Domain Watcher", func() {
 				runServer: func(_ context.Context, _ chan watch.Event) error {
 					return fmt.Errorf("permanent failure")
 				},
-				eventChan: make(chan watch.Event, 100),
-				ctx:       ctx,
-				cancel:    cancel,
+				result: make(chan watch.Event, 100),
+				ctx:    ctx,
+				cancel: cancel,
 			}
 			d.wg.Add(1)
 

--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -123,7 +123,7 @@ func (n *Notify) HandleK8SEvent(_ context.Context, request *notifyv1.K8SEventReq
 	return response, nil
 }
 
-func RunServer(virtShareDir string, stopChan chan struct{}, c chan watch.Event, recorder record.EventRecorder, vmiStore cache.Store, watchInterval ...time.Duration) error {
+func RunServer(virtShareDir string, stopChan <-chan struct{}, c chan watch.Event, recorder record.EventRecorder, vmiStore cache.Store, watchInterval ...time.Duration) error {
 	interval := socketCheckInterval
 	if len(watchInterval) > 0 {
 		interval = watchInterval[0]


### PR DESCRIPTION
### What this PR does
Simplifies the domain watcher by dropping most of the state from it and by better aligning to list/watcher (informer) pattern. 

It also enables the use case of watchlist

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Note that on crash of the notify server and following restart will reset all the unresponsive socket tracking

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

