### PR TITLE
logger: suppress spurious /dev/kvm permission denied erro

### DIFF
--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -345,6 +345,10 @@ func LogLibvirtLogLine(logger *FilteredLogger, line string) {
 		return
 	}
 
+	if strings.Contains(line, "Unable to open /dev/kvm: Permission denied") {
+		return
+	}
+
 	fragments := strings.SplitN(line, ": ", 5)
 	if len(fragments) < 4 {
 		now := time.Now()


### PR DESCRIPTION
### What this PR does
#### Before this PR:
During `virt-launcher` startup, `virtqemud` attempts to access `/dev/kvm` before `virt-handler` has successfully updated the device permissions. This race condition causes a harmless but highly noisy `Unable to open /dev/kvm: Permission denied` error to be emitted to the user's logs.

#### After this PR:
The libvirt logging wrapper (`LogLibvirtLogLine`) now intercepts and suppresses this specific spurious error message, significantly reducing log spam and customer confusion.

### References
- Fixes #16369
- Related to #16259

### Why we need it and why it was done in this way
Customers frequently report this error as a potential issue, creating unnecessary noise. 

**Why it was done this way:**
Architecturally synchronizing `virt-launcher` and `virt-handler` to prevent the race condition entirely (e.g., via blocking sockets or polling) is complex and fragile given `virt-launcher`'s unprivileged security model. Since the race condition itself is harmless and resolves immediately, filtering the specific string in the log stream is the most direct, maintainable, and upstream-aligned solution. (as discussed in issue #16369)

The following alternatives were considered:
- Making `virt-launcher` run `chown` on `/dev/kvm` directly. Rejected because it violates the unprivileged container security model.

### Special notes for your reviewer
This is a straightforward string match addition at the top of the `LogLibvirtLogLine` function to drop the message before further processing. 

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
none