### PR TITLE
[release-1.8] automation: Pin release-1.8 to CDI v1.65.0

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -56,6 +56,7 @@ add_feature_gate() {
 }
 
 export KUBEVIRT_DEPLOY_CDI=true
+export KUBEVIRT_CUSTOM_CDI_VERSION=v1.65.0
 if [[ ! $TARGET =~ .*kind.* ]]; then
   add_feature_gate "NodeRestriction"
   export KUBEVIRT_PSA="true"


### PR DESCRIPTION
### What this PR does
As discussed in #16472 `KUBEVIRTCI_TAG` on release-1.8 currently provides a version of gocli that bundles an older version of CDI. As we cannot bump this tag this commit exports the KUBEVIRT_CUSTOM_CDI_VERSION env var allowing us to provide a specific version for gocli to use instead.

### References

- Partially addresses #16472

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place:
- https://groups.google.com/g/kubevirt-dev/c/IIUXHUOlivY

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```