### PR TITLE
[release-1.7] s390x: Fix VM failures by skipping v3 PCI topology changes

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -377,3 +377,16 @@ func setDefaultArchitectureFromDataSource(clusterConfig *virtconfig.ClusterConfi
 		return
 	}
 }
+
+// SupportsPCIeHotplug reports whether the architecture uses PCIe bus
+// topology and requires pcie-root-port controllers for hotplug capacity.
+// Architectures like s390x (CCW) and ppc64le (SPAPR) use flat bus
+// topologies and do not support pcie-root-port controllers.
+func SupportsPCIeHotplug(arch string) bool {
+	switch arch {
+	case "amd64", "arm64", "":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -88,13 +88,18 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	// race conditions with the VM controller.
 	if ar.Request.Operation == admissionv1.Create {
 		setFirmwareDefaultsIfEmpty(vm)
-		setDefaultPciTopologyVersion(&vm.Spec.Template.ObjectMeta)
 	}
 
 	// Set VM defaults
 	log.Log.Object(vm).V(4).Info("Apply defaults")
 
 	defaults.SetVirtualMachineDefaults(vm, mutator.ClusterConfig, mutator.virtClient)
+
+	if ar.Request.Operation == admissionv1.Create {
+		if defaults.SupportsPCIeHotplug(vm.Spec.Template.Spec.Architecture) {
+			setDefaultPciTopologyVersion(&vm.Spec.Template.ObjectMeta)
+		}
+	}
 
 	patchBytes, err := patch.New(
 		patch.WithReplace("/spec", vm.Spec),

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -186,10 +186,19 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		Entry("amd64", "amd64", "q35"),
 	)
 
-	It("should set PCI topology version v3 annotation on new VM template", func() {
-		vmSpec, _ := getVMSpecMetaFromResponseCreate()
-		Expect(vmSpec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV3))
-	})
+	DescribeTable("should set PCI topology version based on architecture", func(arch string, expectAnnotation bool) {
+		vmSpec, _ := getVMSpecMetaFromResponseCreateWithArch(arch)
+		if expectAnnotation {
+			Expect(vmSpec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV3))
+		} else {
+			Expect(vmSpec.Template.ObjectMeta.Annotations).ToNot(HaveKey(v1.PciTopologyVersionAnnotation))
+		}
+	},
+		Entry("amd64 gets v3", "amd64", true),
+		Entry("arm64 gets v3", "arm64", true),
+		Entry("s390x skipped", "s390x", false),
+		Entry("ppc64le skipped", "ppc64le", false),
+	)
 
 	It("should not override existing PCI topology version annotation on VM template", func() {
 		vm.Spec.Template.ObjectMeta.Annotations = map[string]string{

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -57,7 +57,9 @@ func ApplyNewVMIMutations(newVMI *v1.VirtualMachineInstance, clusterConfig *virt
 		return err
 	}
 
-	setDefaultPciTopologyVersion(&newVMI.ObjectMeta)
+	if defaults.SupportsPCIeHotplug(newVMI.Spec.Architecture) {
+		setDefaultPciTopologyVersion(&newVMI.ObjectMeta)
+	}
 
 	if newVMI.Spec.Domain.CPU.IsolateEmulatorThread {
 		_, emulatorThreadCompleteToEvenParityAnnotationExists := clusterConfig.GetConfigFromKubeVirtCR().Annotations[v1.EmulatorThreadCompleteToEvenParity]

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -623,10 +623,19 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(exist).To(BeTrue())
 	})
 
-	It("should set PCI topology version v3 annotation on new VMI", func() {
-		vmiMeta, _, _ := getMetaSpecStatusFromAdmit()
-		Expect(vmiMeta.Annotations).To(HaveKeyWithValue(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV3))
-	})
+	DescribeTable("should set PCI topology version based on architecture", func(arch string, expectAnnotation bool) {
+		vmiMeta, _, _ := getMetaSpecStatusFromAdmitWithArch(arch)
+		if expectAnnotation {
+			Expect(vmiMeta.Annotations).To(HaveKeyWithValue(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV3))
+		} else {
+			Expect(vmiMeta.Annotations).NotTo(HaveKey(v1.PciTopologyVersionAnnotation))
+		}
+	},
+		Entry("amd64 gets v3", "amd64", true),
+		Entry("arm64 gets v3", "arm64", true),
+		Entry("s390x skipped", "s390x", false),
+		Entry("ppc64le skipped", "ppc64le", false),
+	)
 
 	It("should not override existing PCI topology version annotation", func() {
 		vmi.Annotations = map[string]string{

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/defaults:go_default_library",
         "//pkg/dra:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/executor:go_default_library",

--- a/pkg/virt-handler/pci_topology.go
+++ b/pkg/virt-handler/pci_topology.go
@@ -33,6 +33,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/defaults"
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -42,6 +43,10 @@ import (
 // accordingly. This is only needed during the upgrade window.
 func (c *VirtualMachineController) detectPCITopologyAndAnnotate(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	if domain == nil {
+		return nil
+	}
+
+	if !defaults.SupportsPCIeHotplug(vmi.Spec.Architecture) {
 		return nil
 	}
 

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/config:go_default_library",
         "//pkg/container-disk:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/defaults:go_default_library",
         "//pkg/downwardmetrics:go_default_library",
         "//pkg/emptydisk:go_default_library",
         "//pkg/ephemeral-disk:go_default_library",

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -43,6 +43,7 @@ import (
 	"syscall"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/defaults"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/dra"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
 
@@ -1514,6 +1515,11 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 	domainSpec *api.DomainSpec,
 ) (cli.VirDomain, error) {
 	logger := log.Log.Object(vmi)
+
+	if !defaults.SupportsPCIeHotplug(vmi.Spec.Architecture) {
+		logger.Infof("Skipping hotplug port allocation: architecture %s does not use PCIe topology", vmi.Spec.Architecture)
+		return l.setDomainSpecWithHooks(vmi, domainSpec)
+	}
 
 	placeholderCount, err := calculatePlaceholderCount(vmi)
 	if err != nil {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR skips all v3 PCI topology logic for s390x, where PCIe hierarchy is not supported. The v3 PCI topology changes (PR https://github.com/kubevirt/kubevirt/pull/17059) unconditionally add pcie-root-port controllers which are incompatible with the s390x that uses a flat zPCI/CCW topology.

#### Before this PR:
On s390x, the v3 PCI topology logic in allocateHotplugPorts() attempts to add pcie-root-port controllers via placeholder interfaces and appendPCIeRootPortControllers(). This causes VM creation to fail with:

```
"a PCI slot is needed to connect a PCI controller model='pcie-root-port', but none is available"
```

#### After this PR:

s390x VMs start normally. All v3 PCI topology logic introduced by PR https://github.com/kubevirt/kubevirt/pull/17059 is skipped for s390x.

#### Fixes: https://github.com/kubevirt/kubevirt/issues/17269

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix s390x VM creation failure caused by unsupported pcie-root-port controllers from v3 PCI topology changes
```

