### PR TITLE
rbac: add resourceclaims/driver associated-node verbs for SR-IOV DRA …

### DIFF
--- a/kubevirtci/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
+++ b/kubevirtci/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
@@ -115,6 +115,10 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims/status"]
   verbs: ["get","list","update","patch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  resourceNames: ["sriovnetwork.k8snetworkplumbingwg.io"]
+  verbs: ["associated-node:update", "associated-node:patch"]
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]  # Cluster-scoped resource, needs cluster permissions


### PR DESCRIPTION
…driver
### What this PR does
#### Before this PR:
The vendored SR-IOV DRA manifest only granted `resourceclaims/status` access.

#### After this PR:
The manifest also grants `resourceclaims/driver` permissions with
`associated-node:update` and `associated-node:patch` for the node-local SR-IOV DRA driver.

### References
- Partially addresses kubernetes/kubernetes#138149

### Why we need it and why it was done in this way
Kubernetes v1.36 introduces granular authorization for ResourceClaim status updates.
Node-local DRA drivers now require additional permissions on the synthetic
`resourceclaims/driver` subresource for associated-node access.

This PR updates the vendored SR-IOV DRA manifest accordingly while keeping the
existing `resourceclaims/status` permissions unchanged.

The following tradeoffs were made:
- Keep the change minimal and limited to RBAC in the vendored manifest.

The following alternatives were considered:
- No functional alternatives were needed beyond updating the RBAC rules to match
  the new authorization model.

Links to places where the discussion took place:
- kubernetes/kubernetes#138149

### Special notes for your reviewer
This is a manifest-only RBAC update for Kubernetes v1.36 compatibility.

### Checklist

- [x] Design: not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Keep it simple
- [x] Refactor: not applicable
- [x] Upgrade: Impact of this change on upgrade flows was considered and no additional action is required
- [ ] Testing: New code requires new unit tests
- [ ] Documentation: A user-guide update is present
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy
### Release note
```release-note
NONE