### PR TITLE
tests/libmonitoring: Fix query escaping and refactor prometheus helpers

### DIFF
--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -36,12 +37,21 @@ import (
 )
 
 const (
-	statusSuccess           = "success"
-	defaultGomegaOffset     = 2
-	readBufferSize          = 1024
-	defaultAlertTimeout     = 120 * time.Second
-	defaultAlertWaitTimeout = 5 * time.Minute
-	defaultMetricsPort      = 8443
+	statusSuccess                   = "success"
+	defaultGomegaOffset             = 2
+	readBufferSize                  = 1024
+	defaultAlertTimeout             = 120 * time.Second
+	defaultAlertWaitTimeout         = 5 * time.Minute
+	defaultMetricsPort              = 8443
+	prometheusPortForwardTargetPort = 9090
+)
+
+var (
+	portForwardRe = regexp.MustCompile(
+		fmt.Sprintf(`Forwarding from 127\.0\.0\.1:(\d+) -> %d`, prometheusPortForwardTargetPort),
+	)
+
+	alertRangeVectorRe = regexp.MustCompile(`\[\d+m\]`)
 )
 
 type AlertRequestResult struct {
@@ -94,8 +104,8 @@ func WaitForMetricValueWithLabels(
 		return i
 	}, 3*time.Minute, 1*time.Second).Should(
 		Equal(expectedValue),
-		"Metric %s with labels %v has value %f, not the expected %f",
-		metric, labels, expectedValue, expectedValue,
+		"Metric %s with labels %v did not reach the expected value %f",
+		metric, labels, expectedValue,
 	)
 }
 
@@ -164,7 +174,7 @@ func labelsMatch(pr testing.PromResult, labels map[string]string) bool {
 }
 
 func fetchMetric(cli kubecli.KubevirtClient, query string) (*QueryRequestResult, error) {
-	bodyBytes := DoPrometheusHTTPRequest(cli, fmt.Sprintf("/query?query=%s", query))
+	bodyBytes := DoPrometheusHTTPRequest(cli, fmt.Sprintf("/query?query=%s", url.QueryEscape(query)))
 
 	var result QueryRequestResult
 	err := json.Unmarshal(bodyBytes, &result)
@@ -187,7 +197,7 @@ func QueryRange(
 ) (*QueryRequestResult, error) {
 	endpoint := fmt.Sprintf(
 		"/query_range?query=%s&start=%d&end=%d&step=%d",
-		query, start.Unix(), end.Unix(), int(step.Seconds()),
+		url.QueryEscape(query), start.Unix(), end.Unix(), int(step.Seconds()),
 	)
 	bodyBytes := DoPrometheusHTTPRequest(cli, endpoint)
 
@@ -205,18 +215,17 @@ func QueryRange(
 }
 
 func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte {
-	monitoringNs := getMonitoringNs(cli)
+	monitoringNs := getMonitoringNs()
 	token := getAuthorizationToken(cli, monitoringNs)
 
 	var result []byte
 	if checks.IsOpenShift() {
-		url := getPrometheusURLForOpenShift()
-		result = doHTTPRequest(url, endpoint, token)
+		promURL := getPrometheusURLForOpenShift()
+		result = doHTTPRequest(promURL, endpoint, token)
 	} else {
-		const targetPort = 9090
 		Eventually(func() error {
 			_, cmd, cmdErr := clientcmd.CreateCommandWithNS(monitoringNs, "kubectl",
-				"port-forward", "service/prometheus-k8s", fmt.Sprintf(":%d", targetPort))
+				"port-forward", "service/prometheus-k8s", fmt.Sprintf(":%d", prometheusPortForwardTargetPort))
 			if cmdErr != nil {
 				return cmdErr
 			}
@@ -227,11 +236,11 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 			if startErr := cmd.Start(); startErr != nil {
 				return startErr
 			}
-			sourcePort := WaitForPortForwardCmd(stdout, targetPort)
 			defer func() { _ = KillPortForwardCommand(cmd) }()
+			sourcePort := WaitForPortForwardCmd(stdout)
 
-			url := fmt.Sprintf("http://localhost:%d", sourcePort)
-			result = doHTTPRequest(url, endpoint, token)
+			promURL := fmt.Sprintf("http://localhost:%d", sourcePort)
+			result = doHTTPRequest(promURL, endpoint, token)
 			return nil
 		}, 10*time.Second, time.Second).ShouldNot(HaveOccurred())
 	}
@@ -251,7 +260,7 @@ func getPrometheusURLForOpenShift() string {
 	return fmt.Sprintf("https://%s", route.Spec.Host)
 }
 
-func doHTTPRequest(url, endpoint, token string) []byte {
+func doHTTPRequest(promURL, endpoint, token string) []byte {
 	var result []byte
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -262,7 +271,7 @@ func doHTTPRequest(url, endpoint, token string) []byte {
 		req, err := http.NewRequestWithContext(
 			context.Background(),
 			"GET",
-			fmt.Sprintf("%s/api/v1/%s", url, endpoint),
+			fmt.Sprintf("%s/api/v1/%s", promURL, endpoint),
 			http.NoBody,
 		)
 		if err != nil {
@@ -317,7 +326,7 @@ func getAuthorizationToken(cli kubecli.KubevirtClient, monitoringNs string) stri
 	return token
 }
 
-func getMonitoringNs(cli kubecli.KubevirtClient) string {
+func getMonitoringNs() string {
 	if checks.IsOpenShift() {
 		return "openshift-monitoring"
 	}
@@ -327,15 +336,14 @@ func getMonitoringNs(cli kubecli.KubevirtClient) string {
 
 // WaitForPortForwardCmd reads kubectl's stdout until it sees the "Forwarding from"
 // readiness line, then returns the OS-assigned local port number.
-// kubectl prints "Forwarding from 127.0.0.1:<localPort> -> <dst>" once the tunnel is ready.
-func WaitForPortForwardCmd(stdout io.ReadCloser, dst int) int {
-	re := regexp.MustCompile(fmt.Sprintf(`Forwarding from 127\.0\.0\.1:(\d+) -> %d`, dst))
+// kubectl prints "Forwarding from 127.0.0.1:<localPort> -> <targetPort>" once the tunnel is ready.
+func WaitForPortForwardCmd(stdout io.ReadCloser) int {
 	var m []string
 	Eventually(func() []string {
 		tmp := make([]byte, readBufferSize)
 		_, err := stdout.Read(tmp)
 		Expect(err).NotTo(HaveOccurred())
-		m = re.FindStringSubmatch(string(tmp))
+		m = portForwardRe.FindStringSubmatch(string(tmp))
 		return m
 	}, 30*time.Second, 1*time.Second).ShouldNot(BeEmpty())
 	port, err := strconv.Atoi(m[1])
@@ -395,7 +403,6 @@ func WaitUntilAlertDoesNotExist(virtClient kubecli.KubevirtClient, alertNames ..
 
 func ReduceAlertPendingTime(virtClient kubecli.KubevirtClient) {
 	newRules := getPrometheusAlerts(virtClient)
-	re := regexp.MustCompile(`\[\d+m\]`)
 
 	var gs []promv1.RuleGroup
 	zeroMinutes := promv1.Duration("0m")
@@ -406,7 +413,7 @@ func ReduceAlertPendingTime(virtClient kubecli.KubevirtClient) {
 			rule.DeepCopyInto(&r)
 			if r.Alert != "" {
 				r.For = &zeroMinutes
-				r.Expr = intstr.FromString(re.ReplaceAllString(r.Expr.String(), `[1m]`))
+				r.Expr = intstr.FromString(alertRangeVectorRe.ReplaceAllString(r.Expr.String(), `[1m]`))
 				r.Expr = intstr.FromString(strings.ReplaceAll(r.Expr.String(), ">= 300", ">= 0"))
 			}
 			rs = append(rs, r)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

no url query espace on prometheus queries
inefficient response parsing

#### After this PR:

prometheus metric queries via http are correctly escaped
regex are parsed only once

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

