### PR TITLE
decentralized live migration: fix target VMI incorrectly transitioning to Failed

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1114,29 +1114,43 @@ func (c *Controller) handleMigrationBackoff(key string, vmi *virtv1.VirtualMachi
 }
 
 func (c *Controller) handleMarkMigrationFailedOnVMI(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
+	now := v1.Now()
 
-	vmiCopy := vmi.DeepCopy()
-
-	now := v1.NewTime(time.Now())
-	if vmiCopy.Status.MigrationState.StartTimestamp == nil {
-		vmiCopy.Status.MigrationState.StartTimestamp = &now
+	// Use field-level "add" patches instead of whole-object test+replace.
+	// The RFC 6902 "add" operation creates the member when absent (omitempty
+	// fields like "failed" and "completed" are absent when false) and
+	// replaces it when present, making the patch idempotent and free from
+	// conflicts with concurrent sync-controller field-level patches.
+	// A test on migrationUid ensures the patch is rejected if a new
+	// migration has replaced the MigrationState since we read it.
+	patchSet := patch.New(
+		patch.WithTest("/status/migrationState/migrationUid", string(migration.UID)),
+		patch.WithAdd("/status/migrationState/failed", true),
+		patch.WithAdd("/status/migrationState/completed", true),
+	)
+	if vmi.Status.MigrationState.EndTimestamp == nil {
+		patchSet.AddOption(patch.WithAdd("/status/migrationState/endTimestamp", now))
 	}
-	vmiCopy.Status.MigrationState.EndTimestamp = &now
-	vmiCopy.Status.MigrationState.Failed = true
-	vmiCopy.Status.MigrationState.Completed = true
+	if vmi.Status.MigrationState.StartTimestamp == nil {
+		patchSet.AddOption(patch.WithAdd("/status/migrationState/startTimestamp", now))
+	}
+	if vmi.Status.MigrationState.FailureReason == "" {
+		failureReason := "Target pod is down"
+		patchSet.AddOption(patch.WithAdd("/status/migrationState/failureReason", failureReason))
+	}
 
-	err := c.patchVMI(vmi, vmiCopy)
+	patchBytes, err := patchSet.GeneratePayload()
 	if err != nil {
+		return err
+	}
+	log.Log.Object(vmi).V(4).Infof("patch VMI with %s", string(patchBytes))
+	if _, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{}); err != nil {
 		log.Log.Reason(err).Object(vmi).Errorf("Failed to patch VMI status to indicate migration %s/%s failed.", migration.Namespace, migration.Name)
 		return err
 	}
+
 	log.Log.Object(vmi).Infof("Marked Migration %s/%s failed on vmi due to target pod disappearing before migration kicked off.", migration.Namespace, migration.Name)
-	failureReason := "Target pod is down"
-	c.recorder.Event(vmi, k8sv1.EventTypeWarning, controller.FailedMigrationReason, fmt.Sprintf("VirtualMachineInstance migration uid %s failed. reason: %s", string(migration.UID), failureReason))
-	if vmiCopy.Status.MigrationState.FailureReason == "" {
-		// Only set the failure reason if empty, as virt-handler may already have provided a better one
-		vmiCopy.Status.MigrationState.FailureReason = failureReason
-	}
+	c.recorder.Event(vmi, k8sv1.EventTypeWarning, controller.FailedMigrationReason, fmt.Sprintf("VirtualMachineInstance migration uid %s failed. reason: Target pod is down", string(migration.UID)))
 
 	return nil
 }
@@ -1916,7 +1930,7 @@ func (c *Controller) sync(key string, migration *virtv1.VirtualMachineInstanceMi
 	case virtv1.MigrationFailed:
 		if migration.IsLocalOrDecentralizedTarget() &&
 			vmi.IsMigrationSynchronized(migration) &&
-			vmi.Status.MigrationState.EndTimestamp == nil {
+			!vmi.Status.MigrationState.Failed {
 
 			err = c.handleMarkMigrationFailedOnVMI(migration, vmi)
 			if err != nil {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -445,12 +445,21 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 					}
 				}
 			} else if controller.IsPodDownOrGoingDown(pod) {
-				vmiCopy.Status.Phase = virtv1.Failed
+				if vmiCopy.IsMigrationTarget() {
+					log.Log.Object(vmi).V(2).Infof("setting VMI to WaitingForSync while scheduling because pod is down")
+					vmiCopy.Status.Phase = virtv1.WaitingForSync
+				} else {
+					vmiCopy.Status.Phase = virtv1.Failed
+				}
 			}
 		} else {
-			log.Log.Object(vmi).V(5).Infof("setting VMI to failed during scheduling because pod does not exist")
-			// someone other than the controller deleted the pod unexpectedly
-			vmiCopy.Status.Phase = virtv1.Failed
+			if vmiCopy.IsMigrationTarget() {
+				log.Log.Object(vmi).V(2).Infof("setting VMI to WaitingForSync while scheduling because pod does not exist")
+				vmiCopy.Status.Phase = virtv1.WaitingForSync
+			} else {
+				log.Log.Object(vmi).V(5).Infof("setting VMI to failed during scheduling because pod does not exist")
+				vmiCopy.Status.Phase = virtv1.Failed
+			}
 		}
 	case vmi.IsFinal():
 		allDeleted, err := c.allPodsDeleted(vmi)

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -4476,6 +4476,74 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				sanityExecute()
 				expectVMIBeInPhase(vmi.Namespace, vmi.Name, virtv1.Failed)
 			})
+
+			DescribeTable("should not let migration target escape WaitingForSync via Scheduling", func(podPhase k8sv1.PodPhase) {
+				vmi := newPendingVirtualMachine("testvmi")
+				vmi.Status.Phase = virtv1.WaitingForSync
+				vmi.Status.NodeName = "targetnode"
+				if vmi.Annotations == nil {
+					vmi.Annotations = make(map[string]string)
+				}
+				vmi.Annotations[virtv1.CreateMigrationTarget] = "true"
+
+				pod := newPodForVirtualMachine(vmi, podPhase)
+				pod.Spec.NodeName = "targetnode"
+
+				addVirtualMachine(vmi)
+				addActivePods(vmi, pod.UID, "targetnode")
+				addPod(pod)
+
+				sanityExecute()
+
+				updatedVmi, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedVmi.Status.Phase).To(Equal(virtv1.WaitingForSync))
+			},
+				Entry("pod in Failed phase", k8sv1.PodFailed),
+				Entry("pod in Succeeded phase", k8sv1.PodSucceeded),
+			)
+
+			DescribeTable("should transition scheduling migration target to WaitingForSync when pod is down", func(podPhase k8sv1.PodPhase) {
+				vmi := newPendingVirtualMachine("testvmi")
+				vmi.Status.Phase = virtv1.Scheduling
+				vmi.Status.NodeName = "targetnode"
+				if vmi.Annotations == nil {
+					vmi.Annotations = make(map[string]string)
+				}
+				vmi.Annotations[virtv1.CreateMigrationTarget] = "true"
+
+				pod := newPodForVirtualMachine(vmi, podPhase)
+				pod.Spec.NodeName = "targetnode"
+
+				addVirtualMachine(vmi)
+				addPod(pod)
+
+				sanityExecute()
+
+				updatedVmi, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedVmi.Status.Phase).To(Equal(virtv1.WaitingForSync))
+			},
+				Entry("pod in Failed phase", k8sv1.PodFailed),
+				Entry("pod in Succeeded phase", k8sv1.PodSucceeded),
+			)
+
+			It("should transition scheduling migration target to WaitingForSync when pod disappears", func() {
+				vmi := newPendingVirtualMachine("testvmi")
+				vmi.Status.Phase = virtv1.Scheduling
+				if vmi.Annotations == nil {
+					vmi.Annotations = make(map[string]string)
+				}
+				vmi.Annotations[virtv1.CreateMigrationTarget] = "true"
+
+				addVirtualMachine(vmi)
+
+				sanityExecute()
+
+				updatedVmi, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedVmi.Status.Phase).To(Equal(virtv1.WaitingForSync))
+			})
 		})
 	})
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2206,6 +2206,9 @@ func (c *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 				c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 				return vmi.Status.Phase, err
 			} else if isUnresponsive {
+				if vmi.IsMigrationTarget() {
+					return v1.WaitingForSync, nil
+				}
 				// virt-launcher is gone and VirtualMachineInstance never transitioned
 				// from scheduled to Running.
 				return v1.Failed, nil
@@ -2214,6 +2217,9 @@ func (c *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 		case !vmi.IsRunning() && !vmi.IsFinal():
 			return v1.Scheduled, nil
 		case !vmi.IsFinal():
+			if vmi.IsMigrationTarget() {
+				return v1.WaitingForSync, nil
+			}
 			// That is unexpected. We should not be able to delete a VirtualMachineInstance before we stop it.
 			// However, if someone directly interacts with libvirt it is possible
 			return v1.Failed, nil


### PR DESCRIPTION
### What this PR does
When a decentralized (cross-namespace) migration is cancelled, multiple controllers race to update the target VMI's phase. Both the virt-controller lifecycle handler and the virt-handler's main VMI controller can independently set the phase to `Failed`, ignoring that a migration target should return to `WaitingForSync` for cleanup. This causes the "delete source/target migration" functional tests to intermittently fail.

The first commit adds `IsMigrationTarget()` guards in two places: the lifecycle handler's `IsScheduling` and `IsWaitingForSync` cases (preventing the VMI from bouncing through `Scheduling` into `Failed`), and `calculateVmPhaseForStatusReason` in virt-handler (returning `WaitingForSync` instead of `Failed` when the domain disappears or the launcher becomes unresponsive on a migration target).

The second commit fixes a race in `handleMarkMigrationFailedOnVMI` where `MigrationState.Failed` was never set if `ackMigrationCompletion` wrote `EndTimestamp` first. It changes the guard from `EndTimestamp == nil` to `!Failed` and switches from whole-object `test+replace` to field-level RFC 6902 `add` operations, making the patch idempotent and conflict-free with concurrent sync-controller updates.

With both fixes in place, the third commit de-quarantines the two cross-namespace migration cancellation tests.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
