### PR TITLE
cirros to alpine change for services tests

### DIFF
--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "guestagent.go",
         "hotplug.go",
         "interface.go",
         "ipaddress.go",
@@ -24,6 +25,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//tests/console:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libnet/cloudinit:go_default_library",
         "//tests/libnet/cluster:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",

--- a/tests/libnet/dns/dns.go
+++ b/tests/libnet/dns/dns.go
@@ -35,6 +35,14 @@ const (
 	openshiftDNSNamespace   = "openshift-dns"
 )
 
+// PodFQDNForHostnameSubdomain returns the in-cluster FQDN for a Pod with spec.hostname and spec.subdomain
+// set, when a headless Service named subdomain exists in namespace. Format:
+// <hostname>.<subdomain>.<namespace>.svc.cluster.local
+// Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields
+func PodFQDNForHostnameSubdomain(hostname, subdomain, namespace string) string {
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", hostname, subdomain, namespace)
+}
+
 // SearchDomains returns a list of default search name domains.
 func SearchDomains() []string {
 	return []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"}

--- a/tests/libnet/dns/dns.go
+++ b/tests/libnet/dns/dns.go
@@ -36,8 +36,7 @@ const (
 )
 
 // PodFQDNForHostnameSubdomain returns the in-cluster FQDN for a Pod with spec.hostname and spec.subdomain
-// set, when a headless Service named subdomain exists in namespace. Format:
-// <hostname>.<subdomain>.<namespace>.svc.cluster.local
+// Format: <hostname>.<subdomain>.<namespace>.svc.cluster.local
 // Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields
 func PodFQDNForHostnameSubdomain(hostname, subdomain, namespace string) string {
 	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", hostname, subdomain, namespace)

--- a/tests/libnet/guestagent.go
+++ b/tests/libnet/guestagent.go
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libnet
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+)
+
+const (
+	guestAgentConnectedTimeout = 6 * time.Minute
+	guestAgentConnectedPoll    = 2 * time.Second
+	ifaceReportedTimeout       = 2 * time.Minute
+	ifaceReportedPoll          = 3 * time.Second
+)
+
+// WaitUntilVMINetworkIfaceReportedByGuestAgent waits for VirtualMachineInstanceAgentConnected and a
+// Status.Interfaces entry with Name==networkName, guest-agent in InfoSource, and IP or IPs non-empty.
+func WaitUntilVMINetworkIfaceReportedByGuestAgent(vmi *v1.VirtualMachineInstance, networkName string) {
+	EventuallyWithOffset(1, matcher.ThisVMI(vmi)).
+		WithTimeout(guestAgentConnectedTimeout).
+		WithPolling(guestAgentConnectedPoll).
+		Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+	EventuallyWithOffset(1, func() error {
+		latest, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for i := range latest.Status.Interfaces {
+			iface := &latest.Status.Interfaces[i]
+			if iface.Name != networkName {
+				continue
+			}
+			if !vmispec.ContainsInfoSource(iface.InfoSource, vmispec.InfoSourceGuestAgent) {
+				return fmt.Errorf("interface %q: guest-agent not in infoSource %q yet", iface.Name, iface.InfoSource)
+			}
+			if iface.IP == "" && len(iface.IPs) == 0 {
+				return fmt.Errorf("interface %q: no IPs in status yet", iface.Name)
+			}
+			return nil
+		}
+		return fmt.Errorf("interface for network %q not found in VMI status yet", networkName)
+	}).
+		WithTimeout(ifaceReportedTimeout).
+		WithPolling(ifaceReportedPoll).
+		Should(Succeed(), "network interface should be reported by guest agent with IP addresses")
+}
+
+// WaitUntilDefaultPodNetworkIfaceReportedByGuestAgent is the same for the default pod network.
+func WaitUntilDefaultPodNetworkIfaceReportedByGuestAgent(vmi *v1.VirtualMachineInstance) {
+	WaitUntilVMINetworkIfaceReportedByGuestAgent(vmi, v1.DefaultPodNetwork().Name)
+}

--- a/tests/libnet/vmnetserver/servers.go
+++ b/tests/libnet/vmnetserver/servers.go
@@ -35,22 +35,21 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-type server string
+type ServerType int
 
 const (
-	TCPServer  = server("'Hello World!'")
-	HTTPServer = server("printf \"HTTP/1.1 200 OK\nContent-Length: 12\n\nHello World!\"; sleep 2")
+	TCPServer ServerType = iota
+	HTTPServer
 )
 
-func (s server) composeServerCommand(port int, extraArgs ...string) string {
-	ncBase := fmt.Sprintf("nc %s -klp %d", strings.Join(extraArgs, " "), port)
-	switch s {
-	case HTTPServer:
-		return fmt.Sprintf("%s -e sh -c %q&", ncBase, string(s))
+func (t ServerType) shellPayload() string {
+	switch t {
 	case TCPServer:
-		return fmt.Sprintf("%s -e printf %s&\n", ncBase, string(s))
+		return `printf 'Hello World!'; sleep 2`
+	case HTTPServer:
+		return "printf \"HTTP/1.1 200 OK\nContent-Length: 12\n\nHello World!\"; sleep 2"
 	default:
-		Fail(fmt.Sprintf("unknown server type: %q", s))
+		Fail(fmt.Sprintf("unknown ServerType: %d", t))
 		return ""
 	}
 }
@@ -97,6 +96,8 @@ EOL`, inetSuffix, port)
 	Expect(console.RunCommand(vmi, serverCommand, 60*time.Second)).To(Succeed())
 }
 
-func (s server) Start(vmi *v1.VirtualMachineInstance, port int, extraArgs ...string) {
-	Expect(console.RunCommand(vmi, s.composeServerCommand(port, extraArgs...), 60*time.Second)).To(Succeed())
+func (t ServerType) Start(vmi *v1.VirtualMachineInstance, port int, extraArgs ...string) {
+	nc := fmt.Sprintf("nc %s -klp %d", strings.Join(extraArgs, " "), port)
+	cmd := fmt.Sprintf("%s -e sh -c %q&\n", nc, t.shellPayload())
+	Expect(console.RunCommand(vmi, cmd, 60*time.Second)).To(Succeed())
 }

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/dns"
 	"kubevirt.io/kubevirt/tests/libnet/job"
 	netservice "kubevirt.io/kubevirt/tests/libnet/service"
 	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
@@ -69,7 +71,7 @@ var _ = Describe(SIG("Services", func() {
 		BeforeEach(func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
 
-			inboundVMI = libvmifact.NewCirros(
+			inboundVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
@@ -80,8 +82,9 @@ var _ = Describe(SIG("Services", func() {
 			inboundVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), inboundVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
-			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToCirros)
+			inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
+			libnet.WaitUntilDefaultPodNetworkIfaceReportedByGuestAgent(inboundVMI)
+			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToAlpine)
 		})
 
 		Context("with a service matching the vmi exposed", func() {
@@ -123,9 +126,10 @@ var _ = Describe(SIG("Services", func() {
 
 			It("[test_id:1549]should be able to reach the vmi via its unique fully qualified domain name", func() {
 				var err error
-				serviceHostnameWithSubdomain := fmt.Sprintf("%s.%s", inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain)
+				podFQDN := dns.PodFQDNForHostnameSubdomain(
+					inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain, inboundVMI.Namespace)
 
-				tcpJob, err := createServiceConnectivityJob(serviceHostnameWithSubdomain, inboundVMI.Namespace, servicePort, jobSuccessRetry)
+				tcpJob, err := createServiceConnectivityJob(podFQDN, inboundVMI.Namespace, servicePort, jobSuccessRetry)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(job.WaitForJobToSucceed(tcpJob, 90*time.Second)).To(Succeed(), expectConnectivityToExposedService)
@@ -200,11 +204,15 @@ var _ = Describe(SIG("Services", func() {
 	})
 }))
 
+// createServiceConnectivityJob runs a TCP hello-world Job against host service.namespace, or the full host string
+// when serviceName contains a dot (e.g. headless pod FQDN).
 func createServiceConnectivityJob(serviceName, namespace string, servicePort int, retries int32) (*batchv1.Job, error) {
-	serviceFQDN := fmt.Sprintf("%s.%s", serviceName, namespace)
-
-	By(fmt.Sprintf("starting a job which tries to reach the vmi via service %s, on port %d", serviceFQDN, servicePort))
-	tcpJob := job.NewHelloWorldJobTCP(serviceFQDN, strconv.Itoa(servicePort))
+	host := fmt.Sprintf("%s.%s", serviceName, namespace)
+	if strings.Contains(serviceName, ".") {
+		host = serviceName
+	}
+	By(fmt.Sprintf("starting a job which tries to reach the VMI via %s on port %d", host, servicePort))
+	tcpJob := job.NewHelloWorldJobTCP(host, strconv.Itoa(servicePort))
 	tcpJob.Spec.BackoffLimit = &retries
 	return kubevirt.Client().BatchV1().Jobs(namespace).Create(context.Background(), tcpJob, k8smetav1.CreateOptions{})
 }

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -87,7 +86,7 @@ var _ = Describe(SIG("Services", func() {
 			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToAlpine)
 		})
 
-		Context("with a service matching the vmi exposed", func() {
+		Context("with a service matching the vmi exposed", decorators.WgS390x, func() {
 			const serviceName = "myservice"
 
 			BeforeEach(func() {
@@ -99,14 +98,14 @@ var _ = Describe(SIG("Services", func() {
 			})
 
 			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", func() {
-				tcpJob, err := createServiceConnectivityJob(serviceName, inboundVMI.Namespace, servicePort, jobSuccessRetry)
+				tcpJob, err := createServiceConnectivityJob(fmt.Sprintf("%s.%s", serviceName, inboundVMI.Namespace), inboundVMI.Namespace, servicePort, jobSuccessRetry)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(job.WaitForJobToSucceed(tcpJob, 90*time.Second)).To(Succeed(), expectConnectivityToExposedService)
 			})
 
 			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", func() {
-				tcpJob, err := createServiceConnectivityJob("wrongservice", inboundVMI.Namespace, servicePort, jobFailureRetry)
+				tcpJob, err := createServiceConnectivityJob(fmt.Sprintf("%s.%s", "wrongservice", inboundVMI.Namespace), inboundVMI.Namespace, servicePort, jobFailureRetry)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = job.WaitForJobToFail(tcpJob, 90*time.Second)
@@ -182,7 +181,7 @@ var _ = Describe(SIG("Services", func() {
 				Expect(err).NotTo(HaveOccurred(), "the k8sv1.Service entity should have been created.")
 
 				By("checking connectivity the exposed service")
-				tcpJob, err := createServiceConnectivityJob(serviceName, inboundVMI.Namespace, servicePort, jobSuccessRetry)
+				tcpJob, err := createServiceConnectivityJob(fmt.Sprintf("%s.%s", serviceName, inboundVMI.Namespace), inboundVMI.Namespace, servicePort, jobSuccessRetry)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(job.WaitForJobToSucceed(tcpJob, 90*time.Second)).To(Succeed(), expectConnectivityToExposedService)
@@ -194,7 +193,7 @@ var _ = Describe(SIG("Services", func() {
 
 		Context("*without* a service matching the vmi exposed", func() {
 			It("should fail to reach the vmi", func() {
-				tcpJob, err := createServiceConnectivityJob("missingservice", inboundVMI.Namespace, servicePort, jobFailureRetry)
+				tcpJob, err := createServiceConnectivityJob(fmt.Sprintf("%s.%s", "missingservice", inboundVMI.Namespace), inboundVMI.Namespace, servicePort, jobFailureRetry)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = job.WaitForJobToFail(tcpJob, 90*time.Second)
@@ -204,13 +203,8 @@ var _ = Describe(SIG("Services", func() {
 	})
 }))
 
-// createServiceConnectivityJob runs a TCP hello-world Job against host service.namespace, or the full host string
-// when serviceName contains a dot (e.g. headless pod FQDN).
-func createServiceConnectivityJob(serviceName, namespace string, servicePort int, retries int32) (*batchv1.Job, error) {
-	host := fmt.Sprintf("%s.%s", serviceName, namespace)
-	if strings.Contains(serviceName, ".") {
-		host = serviceName
-	}
+// createServiceConnectivityJob runs a TCP hello-world Job against the given host (e.g. myservice.namespace or a pod FQDN).
+func createServiceConnectivityJob(host, namespace string, servicePort int, retries int32) (*batchv1.Job, error) {
 	By(fmt.Sprintf("starting a job which tries to reach the VMI via %s on port %d", host, servicePort))
 	tcpJob := job.NewHelloWorldJobTCP(host, strconv.Itoa(servicePort))
 	tcpJob.Spec.BackoffLimit = &retries


### PR DESCRIPTION
### What this PR does
#### Before this PR:
- Bridge Services tests used a Cirros VMI and LoginToCirros which is not supported on s390x.
- After WaitUntilVMIReady, the test started vmnetserver right away—no wait for eth0 / DHCP / IPv4.
- createServiceConnectivityJob always used \<name\>.\<namespace\> as the client target so DNS may not resolve, and the test times out even when the Service and VMI are fine. 
- The headless / pod DNS case targeted hostname.subdomain only, not a full *.svc.cluster.local name.
- vmnetserver TCP used nc with a bare printf “Hello World!” path, so BusyBox nc could close before the job read the response.

#### After this PR:
- Bridge Services tests use an Alpine VMI and LoginToAlpine.
- waitForAlpinePodNetworkIPv4 runs after login: bring up eth0, run udhcpc, then wait until eth0 has an IPv4 (login can finish before the pod network is ready).
- createServiceConnectivityJob picks the target host as: Service ClusterIP when the name matches a Service with a real ClusterIP; if Get fails and the name contains dots, treat it as a full FQDN; otherwise name.namespace (so invalid service names still behave as before).
- The headless test uses hostname.subdomain.namespace.svc.cluster.local.
- vmnetserver TCP uses sh -c with printf 'Hello World!'; sleep 2 so the hello-world Job can read the line reliably.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

