### PR TITLE
fix: correct typos 'succesfully' -> 'successfully'

### DIFF
--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Guestfs shell", func() {
 			guestfs.CreateClientFunc = guestfs.CreateClient
 		})
 
-		It("Succesfully attach to PVC", func() {
+		It("Successfully attach to PVC", func() {
 			guestfs.CreateClientFunc = fakeCreateClientPVC
 			Expect(testing.NewRepeatableVirtctlCommand(commandName, pvcName)()).To(Succeed())
 		})

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -468,7 +468,7 @@ var _ = Describe("MemoryDump", func() {
 			Expect(outputData).To(HaveLen(length))
 		})
 
-		It("should call download memory dump and decompress succesfully", func() {
+		It("should call download memory dump and decompress successfully", func() {
 			server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				_, err := w.Write([]byte{
 					0x1f, 0x8b, 0x08, 0x08, 0xc8, 0x58, 0x13, 0x4a,
@@ -528,7 +528,7 @@ var _ = Describe("MemoryDump", func() {
 			Entry("with port-forward specifying default number on local port", setFlag(memorydump.LocalPortFlag, "0")),
 		)
 
-		It("should fail download memory dump if not completed succesfully", func() {
+		It("should fail download memory dump if not completed successfully", func() {
 			const errMsg = "memory dump failed: test err"
 			memorydump.WaitForMemoryDumpCompleteFn = func(_ kubecli.KubevirtClient, _, _ string, _, _ time.Duration) (string, error) {
 				return pvcName, errors.New(errMsg)

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -459,7 +459,7 @@ func CreateVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExport
 		return err
 	}
 
-	printToOutput("VirtualMachineExport '%s/%s' created succesfully\n", vmeInfo.Namespace, vmeInfo.Name)
+	printToOutput("VirtualMachineExport '%s/%s' created successfully\n", vmeInfo.Namespace, vmeInfo.Name)
 	return nil
 }
 
@@ -473,7 +473,7 @@ func DeleteVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExport
 		return nil
 	}
 
-	printToOutput("VirtualMachineExport '%s/%s' deleted succesfully\n", vmeInfo.Namespace, vmeInfo.Name)
+	printToOutput("VirtualMachineExport '%s/%s' deleted successfully\n", vmeInfo.Namespace, vmeInfo.Name)
 	return nil
 }
 
@@ -492,7 +492,7 @@ func DownloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExpo
 			time.Sleep(2 * time.Second)
 		}
 	}
-	return fmt.Errorf("retry count reached, exiting unsuccesfully")
+	return fmt.Errorf("retry count reached, exiting unsuccessfully")
 }
 
 func downloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExportInfo) (bool, error) {
@@ -606,7 +606,7 @@ func downloadVolume(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMac
 		return false, err
 	}
 
-	printToOutput("Download finished succesfully\n")
+	printToOutput("Download finished successfully\n")
 
 	return true, nil
 }

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -326,7 +326,7 @@ var _ = Describe("vmexport", func() {
 				setFlag(vmexport.OUTPUT_FLAG, outputPath),
 				setFlag(vmexport.RETRY_FLAG, "2"),
 			)
-			Expect(err).To(MatchError("retry count reached, exiting unsuccesfully"))
+			Expect(err).To(MatchError("retry count reached, exiting unsuccessfully"))
 		})
 
 		It("VirtualMachineExport succeeds after retrying due to bad status", func() {
@@ -429,7 +429,7 @@ var _ = Describe("vmexport", func() {
 			Expect(runDeleteCmd()).To(Succeed())
 		})
 
-		It("Succesfully download from an already existing VirtualMachineExport", func() {
+		It("Successfully download from an already existing VirtualMachineExport", func() {
 			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
 				Name: volumeName,
 				Formats: []exportv1.VirtualMachineExportVolumeFormat{{
@@ -451,7 +451,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("Succesfully create and download a VirtualMachineExport in different steps", func(expected bool, extraArgs ...string) {
+		DescribeTable("Successfully create and download a VirtualMachineExport in different steps", func(expected bool, extraArgs ...string) {
 			err := runCreateCmd(setFlag(vmexport.PVC_FLAG, pvcName))
 			Expect(err).ToNot(HaveOccurred())
 
@@ -581,7 +581,7 @@ var _ = Describe("vmexport", func() {
 			})
 		})
 
-		It("Succesfully download a VirtualMachineExport with just 'raw' links", func() {
+		It("Successfully download a VirtualMachineExport with just 'raw' links", func() {
 			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
 				Name: volumeName,
 				Formats: []exportv1.VirtualMachineExportVolumeFormat{{
@@ -644,7 +644,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Succesfully create VirtualMachineExport with TTL", func() {
+		It("Successfully create VirtualMachineExport with TTL", func() {
 			ttl := metav1.Duration{Duration: 2 * time.Minute}
 			err := runCreateCmd(
 				setFlag(vmexport.PVC_FLAG, pvcName),
@@ -657,7 +657,7 @@ var _ = Describe("vmexport", func() {
 			Expect(*vme.Spec.TTLDuration).To(Equal(ttl))
 		})
 
-		It("Succesfully create VirtualMachineExport with custom labels and annotations", func() {
+		It("Successfully create VirtualMachineExport with custom labels and annotations", func() {
 			const (
 				labelKey        = "label-key"
 				labelValue      = "label-value"
@@ -802,7 +802,7 @@ var _ = Describe("vmexport", func() {
 				vmexport.MANIFEST_FLAG,
 				setFlag(vmexport.VM_FLAG, "test"),
 			)
-			Expect(err).To(MatchError("retry count reached, exiting unsuccesfully"))
+			Expect(err).To(MatchError("retry count reached, exiting unsuccessfully"))
 		})
 	})
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Several user-facing output strings and test descriptions contained the misspelling `succesfully` (missing an 's') and `unsuccesfully`.

#### After this PR:
All occurrences of `succesfully` and `unsuccesfully` are corrected to `successfully` and `unsuccessfully` across production code and test files.

### References
- Fixes #17368

### Special notes for your reviewer
This is a spelling-only change. No logic, behavior, or API contracts are modified.

### Checklist
- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```