### PR TITLE
virtwrap, cbt, fix: channel priority race in runOverlayQMPSession

### DIFF
--- a/pkg/virt-launcher/virtwrap/storage/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/storage/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",
+        "//vendor/golang.org/x/sync/errgroup:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
         "//vendor/google.golang.org/grpc/keepalive:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/storage/cbt.go
+++ b/pkg/virt-launcher/virtwrap/storage/cbt.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
@@ -152,13 +153,13 @@ func runOverlayQMPSession(ctx context.Context, stdin io.WriteCloser, stdout io.R
 	quit := `{"execute": "quit"}`
 
 	var outputBuf bytes.Buffer
-	var jobErr, scanErr error
 	concludedChan := make(chan struct{})
-	scanDone := make(chan struct{})
-	go func() {
-		defer close(scanDone)
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
 		scanner := bufio.NewScanner(stdout)
 		concluded := false
+		var jobErr error
 		for scanner.Scan() {
 			line := scanner.Text()
 			outputBuf.WriteString(line + "\n")
@@ -166,37 +167,46 @@ func runOverlayQMPSession(ctx context.Context, stdin io.WriteCloser, stdout io.R
 			if !concluded && resp.isJobConcluded() {
 				close(concludedChan)
 				concluded = true
+				continue
 			}
 			if concluded && jobErr == nil {
 				jobErr = resp.jobError()
 			}
 		}
-		scanErr = scanner.Err()
-	}()
+
+		var errs []error
+		if scanner.Err() != nil {
+			errs = append(errs, fmt.Errorf("error reading qemu-storage-daemon output for overlay %s: %w", overlayPath, scanner.Err()))
+		}
+		if !concluded {
+			errs = append(errs, fmt.Errorf("qemu-storage-daemon exited without job concluding for overlay %s", overlayPath))
+		}
+		if jobErr != nil {
+			errs = append(errs, fmt.Errorf("blockdev-create job failed for overlay %s: %w", overlayPath, jobErr))
+		}
+		return errors.Join(errs...)
+	})
 
 	fmt.Fprintf(stdin, "%s\n%s\n", qmpCapabilities, blockdevCreate)
 
-	var err error
 	select {
 	case <-concludedChan:
 		fmt.Fprintf(stdin, "%s\n%s\n%s\n", queryJobs, jobDismiss, quit)
-	case <-scanDone:
-		err = fmt.Errorf("qemu-storage-daemon exited without job concluding for overlay %s", overlayPath)
-	case <-ctx.Done():
-		err = fmt.Errorf("timed out waiting for qemu-storage-daemon to create overlay %s", overlayPath)
+	case <-egCtx.Done():
+		select {
+		case <-concludedChan:
+			fmt.Fprintf(stdin, "%s\n%s\n%s\n", queryJobs, jobDismiss, quit)
+		default:
+		}
 	}
 
 	stdin.Close()
-	<-scanDone
+	egErr := eg.Wait()
 
-	if scanErr != nil {
-		err = errors.Join(err, fmt.Errorf("error reading qemu-storage-daemon output for overlay %s: %w", overlayPath, scanErr))
+	if ctx.Err() != nil {
+		return outputBuf.String(), fmt.Errorf("timed out waiting for qemu-storage-daemon to create overlay %s", overlayPath)
 	}
-	if jobErr != nil {
-		err = errors.Join(err, fmt.Errorf("blockdev-create job failed for overlay %s: %w", overlayPath, jobErr))
-	}
-
-	return outputBuf.String(), err
+	return outputBuf.String(), egErr
 }
 
 type jobInfo struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The select in `runOverlayQMPSession` treated `concludedChan` and `scanDone` as mutually exclusive outcomes but both can fire on every successful run. When the scanner finishes before the select observes `concludedChan`, cleanup commands are never sent and a false error is reported.

#### After this PR:
This PR replaces the goroutine with `errgroup` to consolidate scan error handling and adds a priority check so `concludedChan` is always observed when the job does conclude.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
See effect in: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17354/pull-kubevirt-unit-test/2039451317658718208

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

