### PR TITLE
[Meta-VEP 229]: Enable Beta features by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,10 @@ gofumpt:
 update-generated-api-testdata:
 	./hack/update-generated-api-testdata.sh
 
+feature-gate-report:
+	hack/dockerized "bazel build //tools/feature-gate-report && \
+		./bazel-bin/tools/feature-gate-report/feature-gate-report_/feature-gate-report"
+
 vmlog-checker:
 	@echo "Building vmlog-checker..."
 	@CGO_ENABLED=0 go build -o tools/vmlog-checker/vmlog-checker tools/vmlog-checker/main.go
@@ -297,5 +301,6 @@ vmlog-checker:
 	rpm-deps-cs9 \
 	rpm-deps-cs10 \
 	rpm-deps-all \
+	feature-gate-report \
 	vmlog-checker \
 	$(NULL)

--- a/hack/perftests.sh
+++ b/hack/perftests.sh
@@ -51,6 +51,19 @@ mkdir -p ${TESTS_OUT_DIR}/performance
 echo 'ARTIFACTS ' ${ARTIFACTS}
 echo 'TESTS_OUT_DIR ' ${TESTS_OUT_DIR}
 
+# ImageVolume requires kubelet support (k8s 1.35+). Disable on older clusters
+# before the test binary starts so virt-operator reconciliation completes
+# well before any tests run.
+k8s_minor=$(${kubectl} --kubeconfig "${kubeconfig}" version -o json | sed -n 's/.*"minor": "\([^"]*\)".*/\1/p' | tail -1 | tr -d '+')
+if [ "${k8s_minor}" -lt 35 ]; then
+    echo "Disabling ImageVolume feature gate (k8s ${k8s_minor} < 1.35)"
+    ${kubectl} --kubeconfig "${kubeconfig}" patch kv kubevirt -n kubevirt --type=merge \
+        -p '{"spec":{"configuration":{"developerConfiguration":{"disabledFeatureGates":["ImageVolume"]}}}}'
+    ${kubectl} --kubeconfig "${kubeconfig}" wait kv kubevirt -n kubevirt --for condition=Available --timeout 5m
+    trap '${kubectl} --kubeconfig "${kubeconfig}" patch kv kubevirt -n kubevirt --type=merge \
+      -p '"'"'{"spec":{"configuration":{"developerConfiguration":{"disabledFeatureGates":[]}}}}'"'"' 2>/dev/null || true' EXIT
+fi
+
 function perftest() {
     _out/tests/ginkgo -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -kubectl-path=${kubectl} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
 }

--- a/pkg/storage/admitters/vmrestore_test.go
+++ b/pkg/storage/admitters/vmrestore_test.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
@@ -77,8 +78,18 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 	config, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
-	Context("Without feature gate enabled", func() {
+	Context("With a disabled feature gate", func() {
 		It("should reject anything", func() {
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						DeveloperConfiguration: &v1.DeveloperConfiguration{
+							DisabledFeatureGates: []string{featuregate.SnapshotGate},
+						},
+					},
+				},
+			})
+
 			restore := &snapshotv1.VirtualMachineRestore{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "restore",
@@ -111,7 +122,8 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
-							FeatureGates: make([]string, 0),
+							FeatureGates:         make([]string, 0),
+							DisabledFeatureGates: []string{featuregate.SnapshotGate},
 						},
 					},
 				},

--- a/pkg/storage/admitters/vmsnapshot_test.go
+++ b/pkg/storage/admitters/vmsnapshot_test.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
@@ -50,8 +51,18 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 
 	config, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
-	Context("Without feature gate enabled", func() {
+	Context("With a disabled feature gate", func() {
 		It("should reject anything", func() {
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						DeveloperConfiguration: &v1.DeveloperConfiguration{
+							DisabledFeatureGates: []string{featuregate.SnapshotGate},
+						},
+					},
+				},
+			})
+
 			snapshot := &snapshotv1.VirtualMachineSnapshot{
 				Spec: snapshotv1.VirtualMachineSnapshotSpec{},
 			}
@@ -80,7 +91,8 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
-							FeatureGates: make([]string, 0),
+							FeatureGates:         make([]string, 0),
+							DisabledFeatureGates: []string{featuregate.SnapshotGate},
 						},
 					},
 				},

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -292,7 +292,9 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 	Context("handling priority field", func() {
 		When("MigrationPriorityQueue feature gate is disabled", func() {
 			BeforeEach(func() {
-				disableFeatureGates()
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.MigrationPriorityQueue}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			})
 
 			DescribeTable("should reject the", func(user string) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -48,6 +48,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("Validating VirtualMachineClone Admitter", func() {
@@ -78,7 +79,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						FeatureGates: make([]string, 0),
+						DisabledFeatureGates: []string{featuregate.SnapshotGate},
 					},
 				},
 			},

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2739,7 +2739,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject when the feature gate is disabled", func() {
-
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.SecureExecution}
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.SecureExecution)))
@@ -3746,7 +3748,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject when the feature gate is disabled", func() {
-			disableFeatureGates()
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.VideoConfig}
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -219,6 +219,9 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 		})
 
 		DescribeTable("with Node Restriction feature gate disabled should allow different handler", func(migrationState *v1.VirtualMachineInstanceMigrationState) {
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.NodeRestrictionGate}
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Status.NodeName = "got"
 			vmi.Status.MigrationState = migrationState
@@ -337,6 +340,9 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 	DescribeTable(
 		"Should allow VMI upon modification of kubevirt.io/ labels by kubevirt internal service account",
 		func(originalVmiLabels map[string]string, updateVmiLabels map[string]string, serviceAccount string) {
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.NodeRestrictionGate}
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			vmi := api.NewMinimalVMI("testvmi")
 			updateVmi := vmi.DeepCopy() // Don't need to copy the labels
 			vmi.Labels = originalVmiLabels

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -20,8 +20,6 @@
 package virtconfig
 
 import (
-	"slices"
-
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
@@ -29,20 +27,8 @@ import (
  This module is intended for determining whether an optional feature is enabled or not at the cluster-level.
 */
 
-func (config *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
-	if fg := featuregate.FeatureGateInfo(featureGate); fg != nil && fg.State == featuregate.GA {
-		return true
-	}
-
-	if isExplicitlyEnabled := slices.Contains(config.GetConfig().DeveloperConfiguration.FeatureGates, featureGate); isExplicitlyEnabled {
-		return true
-	}
-
-	if isExplicitlyDisabled := slices.Contains(config.GetConfig().DeveloperConfiguration.DisabledFeatureGates, featureGate); isExplicitlyDisabled {
-		return false
-	}
-
-	return false
+func (config *ClusterConfig) isFeatureGateEnabled(fg string) bool {
+	return featuregate.IsEnabled(fg, config.GetConfig().DeveloperConfiguration)
 }
 
 func (config *ClusterConfig) CPUManagerEnabled() bool {

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -251,6 +251,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: PCINUMAAwareTopologyEnabled, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DecentralizedLiveMigration, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DeclarativeHotplugVolumesGate, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: ObjectGraph, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: UtilityVolumesGate, State: Alpha})

--- a/pkg/virt-config/featuregate/feature-gates.go
+++ b/pkg/virt-config/featuregate/feature-gates.go
@@ -21,6 +21,8 @@ package featuregate
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	v1 "kubevirt.io/api/core/v1"
 )
@@ -32,7 +34,7 @@ const (
 	// The feature is disabled by default and can be enabled explicitly through the FG.
 	Alpha State = "Alpha"
 	// Beta represents features that are under evaluation.
-	// The feature is disabled by default and can be enabled explicitly through the FG.
+	// The feature is enabled by default and can be disabled explicitly through DisabledFeatureGates.
 	Beta State = "Beta"
 	// GA represents features that reached General Availability.
 	// GA features are considered feature-gate enabled, with no option to disable them by an FG.
@@ -77,4 +79,34 @@ func FeatureGateInfo(featureGate string) *FeatureGate {
 		return &fg
 	}
 	return nil
+}
+
+// GetRegisteredFeatureGates returns a copy of all registered feature gates.
+func GetRegisteredFeatureGates() map[string]FeatureGate {
+	return maps.Clone(featureGates)
+}
+
+// IsEnabled evaluates whether a feature gate is active.
+// Precedence: GA (always on) > explicit enable > explicit disable > Beta (on by default) > off.
+func IsEnabled(gate string, devConfig *v1.DeveloperConfiguration) bool {
+	fg := FeatureGateInfo(gate)
+	if fg == nil {
+		return false
+	}
+
+	if fg.State == GA {
+		return true
+	}
+
+	if devConfig != nil {
+		if slices.Contains(devConfig.FeatureGates, gate) {
+			return true
+		}
+
+		if slices.Contains(devConfig.DisabledFeatureGates, gate) {
+			return false
+		}
+	}
+
+	return fg.State == Beta
 }

--- a/pkg/virt-config/featuregate/feature-gates_test.go
+++ b/pkg/virt-config/featuregate/feature-gates_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
@@ -67,6 +69,53 @@ var _ = Describe("Feature Gate", func() {
 
 		Expect(featuregate.FeatureGateInfo(fg1.Name)).To(Equal(&fg1))
 		Expect(featuregate.FeatureGateInfo(fg2.Name)).To(Equal(&fg2))
+	})
+
+	Context("IsEnabled", func() {
+		const (
+			testGAGate         = "test-ga-gate"
+			testBetaGate       = "test-beta-gate"
+			testAlphaGate      = "test-alpha-gate"
+			testDeprecatedGate = "test-deprecated-gate"
+			testUnknownGate    = "test-unknown-unregistered-gate"
+		)
+
+		BeforeEach(func() {
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: testGAGate, State: featuregate.GA})
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: testBetaGate, State: featuregate.Beta})
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: testAlphaGate, State: featuregate.Alpha})
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: testDeprecatedGate, State: featuregate.Deprecated})
+		})
+
+		AfterEach(func() {
+			featuregate.UnregisterFeatureGate(testGAGate)
+			featuregate.UnregisterFeatureGate(testBetaGate)
+			featuregate.UnregisterFeatureGate(testAlphaGate)
+			featuregate.UnregisterFeatureGate(testDeprecatedGate)
+		})
+
+		DescribeTable("should return the expected result",
+			func(gate string, devConfig *v1.DeveloperConfiguration, expected bool) {
+				Expect(featuregate.IsEnabled(gate, devConfig)).To(Equal(expected))
+			},
+			Entry("GA gate with nil config", testGAGate, nil, true),
+			Entry("GA gate in disabled list is still enabled",
+				testGAGate, &v1.DeveloperConfiguration{DisabledFeatureGates: []string{testGAGate}}, true),
+			Entry("Beta gate with nil config defaults to on", testBetaGate, nil, true),
+			Entry("Beta gate explicitly disabled",
+				testBetaGate, &v1.DeveloperConfiguration{DisabledFeatureGates: []string{testBetaGate}}, false),
+			Entry("Beta gate explicitly enabled",
+				testBetaGate, &v1.DeveloperConfiguration{FeatureGates: []string{testBetaGate}}, true),
+			Entry("Alpha gate with nil config defaults to off", testAlphaGate, nil, false),
+			Entry("Alpha gate explicitly enabled",
+				testAlphaGate, &v1.DeveloperConfiguration{FeatureGates: []string{testAlphaGate}}, true),
+			Entry("Alpha gate explicitly disabled",
+				testAlphaGate, &v1.DeveloperConfiguration{DisabledFeatureGates: []string{testAlphaGate}}, false),
+			Entry("Deprecated gate with nil config defaults to off", testDeprecatedGate, nil, false),
+			Entry("Unregistered gate with nil config defaults to off", testUnknownGate, nil, false),
+			Entry("Unregistered gate explicitly disabled",
+				testUnknownGate, &v1.DeveloperConfiguration{FeatureGates: []string{testUnknownGate}}, false),
+		)
 	})
 
 	It("register FG that overrides an existing one", func() {

--- a/pkg/virt-controller/services/container_disk_test.go
+++ b/pkg/virt-controller/services/container_disk_test.go
@@ -26,6 +26,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,9 +36,7 @@ import (
 var _ = Describe("Container disk", func() {
 	Context("image pull policy", func() {
 
-		var svc *TemplateService
-
-		BeforeEach(func() {
+		DescribeTable("should", func(image string, policy k8sv1.PullPolicy) {
 			ctrl := gomock.NewController(GinkgoT())
 			config, _, _ := testutils.NewFakeClusterConfigUsingKVWithCPUArch(&v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -46,11 +45,13 @@ var _ = Describe("Container disk", func() {
 				},
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
-						DeveloperConfiguration: &v1.DeveloperConfiguration{},
+						DeveloperConfiguration: &v1.DeveloperConfiguration{
+							DisabledFeatureGates: []string{featuregate.ImageVolume},
+						},
 					},
 				},
 			}, "amd64")
-			svc = NewTemplateService("kubevirt/virt-launcher",
+			svc := NewTemplateService("kubevirt/virt-launcher",
 				240,
 				"/var/run/kubevirt",
 				"/var/run/kubevirt-ephemeral-disks",
@@ -65,9 +66,6 @@ var _ = Describe("Container disk", func() {
 				cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil),
 				cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil),
 			)
-		})
-
-		DescribeTable("should", func(image string, policy k8sv1.PullPolicy) {
 			vmi := &v1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testvmi", Namespace: "namespace1", UID: "1234",

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -114,8 +114,10 @@ var _ = Describe("Template", func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 
-	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+	disableFeatureGate := func(featureGates ...string) {
+		kvConfig := kv.DeepCopy()
+		kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = featureGates
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 
 	BeforeEach(func() {
@@ -190,7 +192,7 @@ var _ = Describe("Template", func() {
 	})
 
 	AfterEach(func() {
-		disableFeatureGates()
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	})
 
 	Describe("Rendering", func() {
@@ -442,6 +444,7 @@ var _ = Describe("Template", func() {
 
 			DescribeTable("should work", func(arch string, ovmfPath string) {
 				config, kvStore, svc = configFactory(arch)
+				disableFeatureGate(featuregate.ImageVolume, featuregate.PodSecondaryInterfaceNamingUpgrade)
 				trueVar := true
 				annotations := map[string]string{
 					hooks.HookSidecarListAnnotationName: `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
@@ -972,6 +975,7 @@ var _ = Describe("Template", func() {
 
 			It("should add init containers to inject binary and pre-pull container disks", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				volumes := []v1.Volume{
 					{
 						Name: "containerdisk1",
@@ -1063,6 +1067,7 @@ var _ = Describe("Template", func() {
 		Context("with node selectors", func() {
 			DescribeTable("should add node selectors to template", func(arch string, ovmfPath string) {
 				config, kvStore, svc = configFactory(arch)
+				disableFeatureGate(featuregate.ImageVolume, featuregate.PodSecondaryInterfaceNamingUpgrade)
 
 				nodeSelector := map[string]string{
 					k8sv1.LabelHostname: "master",
@@ -2411,6 +2416,7 @@ var _ = Describe("Template", func() {
 		Context("with hugepages constraints", func() {
 			DescribeTable("should add to the template constraints ", func(arch, pagesize string, memorySize int) {
 				config, kvStore, svc = configFactory(arch)
+				disableFeatureGate(featuregate.ImageVolume)
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -2486,6 +2492,7 @@ var _ = Describe("Template", func() {
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvStore, svc = configFactory(arch)
+				disableFeatureGate(featuregate.ImageVolume)
 				guestMem := resource.MustParse("64M")
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2566,6 +2573,7 @@ var _ = Describe("Template", func() {
 		Context("with file mode pvc source", func() {
 			It("should add volume to template", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				namespace := "testns"
 				pvcName := "pvcFile"
 				pvc := k8sv1.PersistentVolumeClaim{
@@ -2621,6 +2629,7 @@ var _ = Describe("Template", func() {
 		Context("with blockdevice mode pvc source", func() {
 			It("should add device to template", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				namespace := "testns"
 				pvcName := "pvcDevice"
 				mode := k8sv1.PersistentVolumeBlock
@@ -2862,6 +2871,7 @@ var _ = Describe("Template", func() {
 
 			It("should have compute as first container in the pod", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Image).To(Equal("kubevirt/virt-launcher"))
@@ -3171,6 +3181,7 @@ var _ = Describe("Template", func() {
 
 			It("Should add an empytDir backed by Memory", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				vmi.Spec.Volumes = []v1.Volume{
 					{
 						Name: "downardMetrics",
@@ -3224,6 +3235,7 @@ var _ = Describe("Template", func() {
 		Context("with a configMap volume source", func() {
 			It("Should add the ConfigMap to template", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				volumes := []v1.Volume{
 					{
 						Name: "configmap-volume",
@@ -3267,6 +3279,7 @@ var _ = Describe("Template", func() {
 			Context("with a ConfigMap", func() {
 				It("Should add the Sysprep ConfigMap to template", func() {
 					config, kvStore, svc = configFactory(defaultArch)
+					disableFeatureGate(featuregate.ImageVolume)
 					volumes := []v1.Volume{
 						{
 							Name: "sysprep-configmap-volume",
@@ -3304,6 +3317,7 @@ var _ = Describe("Template", func() {
 			Context("with a Secret", func() {
 				It("Should add the Sysprep SecretRef to template", func() {
 					config, kvStore, svc = configFactory(defaultArch)
+					disableFeatureGate(featuregate.ImageVolume)
 					volumes := []v1.Volume{
 						{
 							Name: "sysprep-configmap-volume",
@@ -3344,6 +3358,7 @@ var _ = Describe("Template", func() {
 		Context("with a secret volume source", func() {
 			It("should add the Secret to template", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				volumes := []v1.Volume{
 					{
 						Name: "secret-volume",
@@ -3830,6 +3845,7 @@ var _ = Describe("Template", func() {
 
 			It("should define containers and volumes properly", func() {
 				config, kvStore, svc = configFactory(defaultArch)
+				disableFeatureGate(featuregate.ImageVolume)
 				vmi := utils.GetVMIKernelBootWithRandName()
 				vmi.ObjectMeta = metav1.ObjectMeta{
 					Name: "testvmi-kernel-boot", Namespace: "default", UID: "1234",

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -101,9 +101,9 @@ var _ = Describe("Evacuation", func() {
 	}
 
 	Context("migration object creation", func() {
-		DescribeTable("should have expected values, annotations and priority", func(fgs []string, annotations map[string]string, matcher types.GomegaMatcher) {
+		DescribeTable("should have expected values, annotations and priority", func(devConfig *v1.DeveloperConfiguration, annotations map[string]string, matcher types.GomegaMatcher) {
 			config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-				DeveloperConfiguration: &v1.DeveloperConfiguration{FeatureGates: fgs},
+				DeveloperConfiguration: devConfig,
 			})
 			vmi := newVirtualMachine("my-vmi", "somenode")
 			vmi.Annotations = annotations
@@ -112,13 +112,14 @@ var _ = Describe("Evacuation", func() {
 			Expect(migration.Annotations[v1.EvacuationMigrationAnnotation]).To(Equal("somenode"))
 			Expect(migration.Spec.Priority).To(matcher)
 		},
-			Entry("with MigrationPriorityQueue feature gate disabled", nil, nil, BeNil()),
+			Entry("with MigrationPriorityQueue feature gate disabled",
+				&v1.DeveloperConfiguration{DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue}},
+				nil, BeNil()),
 			Entry("with MigrationPriorityQueue feature gate enabled",
-				[]string{featuregate.MigrationPriorityQueue},
-				nil,
+				nil, nil,
 				gstruct.PointTo(BeEquivalentTo("system-critical"))),
 			Entry("with MigrationPriorityQueue feature gate enabled, and descheduler annotation",
-				[]string{featuregate.MigrationPriorityQueue},
+				nil,
 				map[string]string{v1.EvictionSourceAnnotation: "descheduler"},
 				gstruct.PointTo(BeEquivalentTo("system-maintenance"))),
 		)
@@ -170,6 +171,11 @@ var _ = Describe("Evacuation", func() {
 		})
 
 		It("should ignore VMIs which are not migratable", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
 			node := newNode("testnode")
 			addNode(newNode("anothernode"))
 			node.Spec.Taints = append(node.Spec.Taints, *newTaint())
@@ -194,6 +200,11 @@ var _ = Describe("Evacuation", func() {
 		})
 
 		It("should not evict VMIs if 5 migrations are in progress", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
 			node := newNode("testnode")
 			node.Spec.Taints = append(node.Spec.Taints, *newTaint())
 			addNode(node)
@@ -217,6 +228,11 @@ var _ = Describe("Evacuation", func() {
 		})
 
 		It("should start another migration if one completes and we have a free spot", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
 			node := newNode("testnode")
 			node.Spec.Taints = append(node.Spec.Taints, *newTaint())
 			addNode(node)
@@ -265,6 +281,11 @@ var _ = Describe("Evacuation", func() {
 		})
 
 		It("Should record a warning on a not migratable VMI", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
 			node := newNode("foo")
 			addNode(node)
 			enqueue(node)
@@ -437,6 +458,11 @@ var _ = Describe("Evacuation", func() {
 		})
 
 		It("Should create new evictions up to the configured maximum migrations per outbound node", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
 			var maxParallelMigrationsPerCluster uint32 = 10
 			var maxParallelMigrationsPerOutboundNode uint32 = 5
 			var activeMigrationsFromThisSourceNode = 4

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -2733,6 +2733,11 @@ var _ = Describe("Migration watcher", func() {
 
 	Context("Priority queue", func() {
 		It("should properly re-enqueue pending migrations as low priority when no new migration can start", func() {
+			setConfig(&v1.KubeVirtConfiguration{
+				DeveloperConfiguration: &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				},
+			})
 			By("Creating 1 pending migration. It will be picked up by the call to Execute()")
 			vmi := newVirtualMachine("testvmipending", v1.Running)
 			migration := newMigration("testmigrationpending", vmi.Name, v1.MigrationPending)

--- a/pkg/virt-handler/container-disk/BUILD.bazel
+++ b/pkg/virt-handler/container-disk/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -30,6 +30,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/checkpoint"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -94,6 +95,14 @@ var _ = Describe("ContainerDisk", func() {
 	}
 
 	Context("checking if containerDisks are ready", func() {
+
+		BeforeEach(func() {
+			m.clusterConfig, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+				DeveloperConfiguration: &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.ImageVolume},
+				},
+			})
+		})
 
 		DescribeTable("should", func(
 			pathGetter containerdisk.SocketPathGetter,

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1256,6 +1256,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 			})
 
 			It("should compute checksums for the specified containerDisks and kernelboot containers", func() {
+				config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+					DeveloperConfiguration: &v1.DeveloperConfiguration{
+						DisabledFeatureGates: []string{featuregate.ImageVolume},
+					},
+				})
+				controller.clusterConfig = config
 				vmi := NewScheduledVMIWithContainerDisk(vmiTestUUID, podTestUUID, host)
 				vmi.Status.Phase = v1.Running
 				vmi.Status.VolumeStatus = []v1.VolumeStatus{

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1244,31 +1244,19 @@ func enableContainerPathVolumesFeatureGate(kv *v1.KubeVirt) {
 }
 
 func containerPathVolumesEnabled(kv *v1.KubeVirt) bool {
-	return isFeatureGateEnabled(kv, featuregate.ContainerPathVolumesGate)
+	return featuregate.IsEnabled(featuregate.ContainerPathVolumesGate, kv.Spec.Configuration.DeveloperConfiguration)
 }
 
 func synchronizationControllerEnabled(kv *v1.KubeVirt) bool {
-	return isFeatureGateEnabled(kv, featuregate.DecentralizedLiveMigration)
+	return featuregate.IsEnabled(featuregate.DecentralizedLiveMigration, kv.Spec.Configuration.DeveloperConfiguration)
 }
 
 func virtTemplateDeploymentEnabled(kv *v1.KubeVirt) bool {
-	if !isFeatureGateEnabled(kv, featuregate.Template) {
+	if !featuregate.IsEnabled(featuregate.Template, kv.Spec.Configuration.DeveloperConfiguration) {
 		return false
 	}
 	virtTemplateDeployment := kv.Spec.Configuration.VirtTemplateDeployment
 	return virtTemplateDeployment == nil || virtTemplateDeployment.Enabled == nil || *virtTemplateDeployment.Enabled
-}
-
-func isFeatureGateEnabled(kv *v1.KubeVirt, fg string) bool {
-	if kv.Spec.Configuration.DeveloperConfiguration == nil {
-		return false
-	}
-	for _, enabledFg := range kv.Spec.Configuration.DeveloperConfiguration.FeatureGates {
-		if enabledFg == fg {
-			return true
-		}
-	}
-	return false
 }
 
 func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt, exclusionMap map[string]bool) {

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -1228,18 +1228,8 @@ func (r *Reconciler) deleteObjectsNotInInstallStrategy() error {
 	return nil
 }
 
-func (r *Reconciler) isFeatureGateEnabled(featureGate string) bool {
-	if r.kv.Spec.Configuration.DeveloperConfiguration == nil {
-		return false
-	}
-
-	for _, fg := range r.kv.Spec.Configuration.DeveloperConfiguration.FeatureGates {
-		if fg == featureGate {
-			return true
-		}
-	}
-
-	return false
+func (r *Reconciler) isFeatureGateEnabled(fg string) bool {
+	return featuregate.IsEnabled(fg, r.kv.Spec.Configuration.DeveloperConfiguration)
 }
 
 func (r *Reconciler) commonInstancetypesDeploymentEnabled() bool {

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -28,7 +28,6 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -210,11 +209,8 @@ func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVa
 		envVarManager)
 }
 
-func isFeatureGateEnabledInKvConfig(kvConfig *v1.KubeVirtConfiguration, featureGate string) bool {
-	if kvConfig.DeveloperConfiguration != nil && len(kvConfig.DeveloperConfiguration.FeatureGates) > 0 {
-		return slices.Contains(kvConfig.DeveloperConfiguration.FeatureGates, featureGate)
-	}
-	return false
+func isFeatureGateEnabledInKvConfig(kvConfig *v1.KubeVirtConfiguration, fg string) bool {
+	return featuregate.IsEnabled(fg, kvConfig.DeveloperConfiguration)
 }
 
 func getKVMapFromSpec(spec v1.KubeVirtSpec) map[string]string {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -528,7 +528,7 @@ func validateFeatureGates(devConfig *v1.DeveloperConfiguration) (causes []metav1
 }
 
 func hasFeatureGateEnabled(config *v1.KubeVirtConfiguration, gate string) bool {
-	return config.DeveloperConfiguration != nil && slices.Contains(config.DeveloperConfiguration.FeatureGates, gate)
+	return featuregate.IsEnabled(gate, config.DeveloperConfiguration)
 }
 
 func validateVirtTemplateDeployment(config *v1.KubeVirtConfiguration) []metav1.StatusCause {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -202,7 +202,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -21,7 +21,6 @@ package tests_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -33,7 +32,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sversion "k8s.io/apimachinery/pkg/version"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -45,6 +43,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
@@ -208,7 +207,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	Describe("Simulate an upgrade from a version where ImageVolume was disabled to a version where it is enabled", Serial, decorators.ImageVolume, decorators.NoFlakeCheck, func() {
 		BeforeEach(func() {
-			v, err := getKubernetesVersion()
+			v, err := checks.GetKubernetesVersion()
 			Expect(err).ToNot(HaveOccurred())
 			if v < "1.35" {
 				// Fail the test if the Kubernetes version is lower than 1.33
@@ -281,22 +280,4 @@ func newAlpineWithKernelBoot() *v1.VirtualMachineInstance {
 	)
 	utils.AddKernelBootToVMI(vmi)
 	return vmi
-}
-
-func getKubernetesVersion() (string, error) {
-	var info k8sversion.Info
-	virtClient, err := kubecli.GetKubevirtClient()
-	if err != nil {
-		return "", err
-	}
-	response, err := virtClient.RestClient().Get().AbsPath("/version").DoRaw(context.Background())
-	if err != nil {
-		return "", err
-	}
-	if err := json.Unmarshal(response, &info); err != nil {
-		return "", err
-	}
-	curVersion := strings.Split(info.GitVersion, "+")[0]
-	curVersion = strings.Trim(curVersion, "v")
-	return curVersion, nil
 }

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -169,7 +169,12 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	Describe("[rfe_id:4052][crit:high][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", decorators.WgS390x, decorators.WgArm64, func() {
 		Context("with ephemeral registry disk", func() {
-			It("[test_id:4299]should not have world write permissions", func() {
+			It("[test_id:4299]should not have world write permissions", Serial, func() {
+				if checks.HasFeature(featuregate.ImageVolume) {
+					config.DisableFeatureGate(featuregate.ImageVolume)
+					DeferCleanup(config.EnableFeatureGate, featuregate.ImageVolume)
+				}
+
 				vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), libvmops.StartupTimeoutSecondsSmall)
 
 				By("Ensuring VMI is running by logging in")

--- a/tests/framework/checks/BUILD.bazel
+++ b/tests/framework/checks/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/cluster:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
@@ -20,5 +21,6 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
     ],
 )

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -1,6 +1,8 @@
 package checks
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -9,10 +11,13 @@ import (
 	"github.com/onsi/gomega"
 
 	k8sv1 "k8s.io/api/core/v1"
+	k8sversion "k8s.io/apimachinery/pkg/version"
 
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/util/cluster"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
@@ -51,19 +56,26 @@ func Has2MiHugepages(node *k8sv1.Node) bool {
 func HasFeature(feature string) bool {
 	virtClient := kubevirt.Client()
 
-	var featureGates []string
 	kv := libkubevirt.GetCurrentKv(virtClient)
-	if kv.Spec.Configuration.DeveloperConfiguration != nil {
-		featureGates = kv.Spec.Configuration.DeveloperConfiguration.FeatureGates
-	}
+	return featuregate.IsEnabled(feature, kv.Spec.Configuration.DeveloperConfiguration)
+}
 
-	for _, fg := range featureGates {
-		if fg == feature {
-			return true
-		}
+func GetKubernetesVersion() (string, error) {
+	var info k8sversion.Info
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return "", err
 	}
-
-	return false
+	response, err := virtClient.RestClient().Get().AbsPath("/version").DoRaw(context.Background())
+	if err != nil {
+		return "", err
+	}
+	if err := json.Unmarshal(response, &info); err != nil {
+		return "", err
+	}
+	curVersion := strings.Split(info.GitVersion, "+")[0]
+	curVersion = strings.Trim(curVersion, "v")
+	return curVersion, nil
 }
 
 func IsSEVCapable(node *k8sv1.Node, sevLabel string) bool {

--- a/tests/libkubevirt/config/featuregate.go
+++ b/tests/libkubevirt/config/featuregate.go
@@ -20,6 +20,8 @@
 package config
 
 import (
+	"slices"
+
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -35,22 +37,19 @@ func DisableFeatureGate(feature string) {
 
 	kv := libkubevirt.GetCurrentKv(virtClient)
 	if kv.Spec.Configuration.DeveloperConfiguration == nil {
-		kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
-			FeatureGates: []string{},
-		}
+		kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
 	}
 
-	var newArray []string
-	featureGates := kv.Spec.Configuration.DeveloperConfiguration.FeatureGates
-	for _, fg := range featureGates {
-		if fg == feature {
-			continue
-		}
+	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = slices.DeleteFunc(
+		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+		func(fg string) bool { return fg == feature },
+	)
 
-		newArray = append(newArray, fg)
+	if !slices.Contains(kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates, feature) {
+		kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = append(
+			kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates, feature,
+		)
 	}
-
-	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = newArray
 
 	UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 }
@@ -64,12 +63,19 @@ func EnableFeatureGate(feature string) *v1.KubeVirt {
 	}
 
 	if kv.Spec.Configuration.DeveloperConfiguration == nil {
-		kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
-			FeatureGates: []string{},
-		}
+		kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
 	}
 
-	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, feature)
+	kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = slices.DeleteFunc(
+		kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates,
+		func(fg string) bool { return fg == feature },
+	)
+
+	if !slices.Contains(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, feature) {
+		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(
+			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, feature,
+		)
+	}
 
 	return UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 }

--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//tests/operator/resourcefiles:go_default_library",
         "//tests/operator/version:go_default_library",
         "//tests/testsuite:go_default_library",
+        "//vendor/github.com/coreos/go-semver/semver:go_default_library",
         "//vendor/github.com/google/go-github/v83/github:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -770,6 +770,12 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 				)
 			}
 
+			// No external net resource injection controller in the test environment.
+			kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = append(
+				kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates,
+				featuregate.ExternalNetResourceInjection,
+			)
+
 			// Now create the kubevirt CR
 			createKv(kv)
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -43,6 +43,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-github/v83/github"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 
@@ -751,7 +752,24 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					updatedFeatureGates = append(updatedFeatureGates, fg)
 				}
 			}
+			// Old releases don't support Beta-on-by-default, so Snapshot must be
+			// explicitly listed for the previous release's webhook to accept
+			// snapshot creation.
+			updatedFeatureGates = append(updatedFeatureGates, featuregate.SnapshotGate)
 			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = updatedFeatureGates
+
+			// ImageVolume requires k8s 1.35+ (kubelet image volume support).
+			// Disable it on older clusters so the new virt-launcher doesn't
+			// panic looking for image-volume paths after the upgrade.
+			k8sVersion, err := checks.GetKubernetesVersion()
+			Expect(err).ToNot(HaveOccurred())
+			if semver.New(k8sVersion).LessThan(*semver.New("1.35.0")) {
+				kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = append(
+					kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates,
+					featuregate.ImageVolume,
+				)
+			}
+
 			// Now create the kubevirt CR
 			createKv(kv)
 

--- a/tests/performance/density-kwok.go
+++ b/tests/performance/density-kwok.go
@@ -59,7 +59,6 @@ var _ = Describe(KWOK("Control Plane Performance Density Testing using kwok", fu
 		if !flags.DeployFakeKWOKNodesFlag {
 			Skip("Skipping test as KWOK flag is not enabled") //nolint:forbidigo
 		}
-
 		virtClient = kubevirt.Client()
 
 		if !primed {

--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//tests/libsecret:go_default_library",
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",
+        "//vendor/github.com/coreos/go-semver/semver:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -108,23 +109,29 @@ func AdjustKubeVirtResource() {
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
 		featuregate.IgnitionGate,
 		featuregate.SidecarGate,
-		featuregate.SnapshotGate,
 		featuregate.IncrementalBackupGate,
 		featuregate.HostDiskGate,
 		featuregate.VirtIOFSStorageVolumeGate,
 		featuregate.DownwardMetricsFeatureGate,
 		featuregate.WorkloadEncryptionSEV,
-		featuregate.KubevirtSeccompProfile,
 		featuregate.ObjectGraph,
 		featuregate.DeclarativeHotplugVolumesGate,
-		featuregate.NodeRestrictionGate,
 		featuregate.DecentralizedLiveMigration,
-		featuregate.VideoConfig,
 		featuregate.UtilityVolumesGate,
-		featuregate.MigrationPriorityQueue,
 		featuregate.RebootPolicy,
 		featuregate.ContainerPathVolumesGate,
 	)
+
+	// ImageVolume is enabled by default for k8s 1.35+ (image volume feature gate in kubelet).
+	// Disable it on older clusters to avoid CI failures.
+	k8sVersion, err := checks.GetKubernetesVersion()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	if semver.New(k8sVersion).LessThan(*semver.New("1.35.0")) {
+		kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = append(
+			kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates,
+			featuregate.ImageVolume,
+		)
+	}
 	kv.Spec.Configuration.ChangedBlockTrackingLabelSelectors = &v1.ChangedBlockTrackingSelectors{
 		VirtualMachineLabelSelector: &metav1.LabelSelector{
 			MatchLabels: cbt.CBTLabel,

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -50,10 +50,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/libdv"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
@@ -505,7 +507,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			),
 		)
 
-		It("[test_id:6869]should report an error status when image pull error occurs", decorators.Conformance, decorators.WgS390x, func() {
+		It("[test_id:6869]should report an error status when image pull error occurs", Serial, decorators.Conformance, decorators.WgS390x, func() {
+			if checks.HasFeature(featuregate.ImageVolume) {
+				config.DisableFeatureGate(featuregate.ImageVolume)
+				DeferCleanup(config.EnableFeatureGate, featuregate.ImageVolume)
+			}
+
 			vmi := libvmi.New(
 				libvmi.WithContainerDisk("disk0", "no-such-image"),
 				libvmi.WithMemoryRequest("128Mi"),

--- a/tools/feature-gate-report/BUILD.bazel
+++ b/tools/feature-gate-report/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["feature-gate-report.go"],
+    importpath = "kubevirt.io/kubevirt/tools/feature-gate-report",
+    visibility = ["//visibility:private"],
+    deps = ["//pkg/virt-config/featuregate:go_default_library"],
+)
+
+go_binary(
+    name = "feature-gate-report",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["feature-gate-report_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//pkg/virt-config/featuregate:go_default_library"],
+)

--- a/tools/feature-gate-report/README.md
+++ b/tools/feature-gate-report/README.md
@@ -1,0 +1,21 @@
+# Feature Gate Report
+
+Prints a JSON summary of all registered KubeVirt feature gates (excluding GA and Discontinued).
+
+## Usage
+
+```bash
+make feature-gate-report
+```
+
+## Output
+
+JSON array sorted by state then name:
+
+```json
+[
+  {"name": "MyAlphaFeature", "state": "Alpha"},
+  {"name": "MyBetaFeature", "state": "Beta"},
+  {"name": "MyDeprecatedFeature", "state": "Deprecated"}
+]
+```

--- a/tools/feature-gate-report/feature-gate-report.go
+++ b/tools/feature-gate-report/feature-gate-report.go
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+)
+
+type featureGateEntry struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+func main() {
+	gates := featuregate.GetRegisteredFeatureGates()
+
+	var entries []featureGateEntry
+	for _, fg := range gates {
+		if fg.State == featuregate.GA || fg.State == featuregate.Discontinued {
+			continue
+		}
+		entries = append(entries, featureGateEntry{
+			Name:  fg.Name,
+			State: string(fg.State),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].State != entries[j].State {
+			return entries[i].State < entries[j].State
+		}
+		return entries[i].Name < entries[j].Name
+	})
+
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(data))
+}

--- a/tools/feature-gate-report/feature-gate-report_test.go
+++ b/tools/feature-gate-report/feature-gate-report_test.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"testing"
+
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+)
+
+func TestFeatureGateReport(t *testing.T) {
+	gates := featuregate.GetRegisteredFeatureGates()
+	if len(gates) == 0 {
+		t.Fatal("expected registered feature gates, got none")
+	}
+
+	for name, fg := range gates {
+		if fg.State == featuregate.GA || fg.State == featuregate.Discontinued {
+			continue
+		}
+		if name == "" {
+			t.Error("found feature gate with empty name")
+		}
+		if fg.State != featuregate.Alpha && fg.State != featuregate.Beta && fg.State != featuregate.Deprecated {
+			t.Errorf("feature gate %q has unexpected state %q", name, fg.State)
+		}
+	}
+}


### PR DESCRIPTION
### What this PR does
#### Before this PR:
All Beta feature gates in KubeVirt are disabled by default. Users must explicitly enable each Beta feature via `FeatureGates` in the KubeVirt CR's `DeveloperConfiguration`.

#### After this PR:
All Beta feature gates are enabled by default. 
Users can opt out of individual Beta features by adding them to `DisabledFeatureGates`.

In addition, adds a feature gate summary tool to expose the registered feature gates map.

### References
- Implements VEP 229: https://github.com/kubevirt/enhancements/blob/main/veps/meta-VEPs/229-beta-features-on-by-default/vep.md.
- VEP Tracking issue: https://github.com/kubevirt/enhancements/issues/229.

### Note for the reviewer

The feature gate report JSON looks like the following:
```json
[
  {"name": "AlignCPUs", "state": "Alpha"},
  {"name": "CPUManager", "state": "Alpha"},
  {"name": "ConfigurableHypervisor", "state": "Alpha"},
  {"name": "ContainerPathVolumes", "state": "Alpha"},
  {"name": "DecentralizedLiveMigration", "state": "Alpha"},
  {"name": "DeclarativeHotplugVolumes", "state": "Alpha"},
  {"name": "DownwardMetrics", "state": "Alpha"},
  {"name": "EnableVirtioFsStorageVolumes", "state": "Alpha"},
  {"name": "ExperimentalIgnitionSupport", "state": "Alpha"},
  {"name": "GPUsWithDRA", "state": "Alpha"},
  {"name": "HostDevices", "state": "Alpha"},
  {"name": "HostDevicesWithDRA", "state": "Alpha"},
  {"name": "HostDisk", "state": "Alpha"},
  {"name": "HotplugVolumes", "state": "Alpha"},
  {"name": "HypervStrictCheck", "state": "Alpha"},
  {"name": "IncrementalBackup", "state": "Alpha"},
  {"name": "LibvirtHooksServerAndClient", "state": "Alpha"},
  {"name": "OptOutRoleAggregation", "state": "Alpha"},
  {"name": "PCINUMAAwareTopology", "state": "Alpha"},
  {"name": "PersistentReservation", "state": "Alpha"},
  {"name": "RebootPolicy", "state": "Alpha"},
  {"name": "ReservedOverheadMemlock", "state": "Alpha"},
  {"name": "Root", "state": "Alpha"},
  {"name": "Sidecar", "state": "Alpha"},
  {"name": "Template", "state": "Alpha"},
  {"name": "UtilityVolumes", "state": "Alpha"},
  {"name": "VGPULiveMigration", "state": "Alpha"},
  {"name": "VSOCK", "state": "Alpha"},
  {"name": "VmiMemoryOverheadReport", "state": "Alpha"},
  {"name": "WorkloadEncryptionSEV", "state": "Alpha"},
  {"name": "WorkloadEncryptionTDX", "state": "Alpha"},
  {"name": "ExternalNetResourceInjection", "state": "Beta"},
  {"name": "ImageVolume", "state": "Beta"},
  {"name": "KubevirtSeccompProfile", "state": "Beta"},
  {"name": "LiveUpdateNADRef", "state": "Beta"},
  {"name": "MigrationPriorityQueue", "state": "Beta"},
  {"name": "NodeRestriction", "state": "Beta"},
  {"name": "PasstBinding", "state": "Beta"},
  {"name": "PodSecondaryInterfaceNamingUpgrade", "state": "Beta"},
  {"name": "SecureExecution", "state": "Beta"},
  {"name": "Snapshot", "state": "Beta"},
  {"name": "VideoConfig", "state": "Beta"},
  {"name": "DisableMDEVConfiguration", "state": "Deprecated"},
  {"name": "DockerSELinuxMCSWorkaround", "state": "Deprecated"},
  {"name": "MultiArchitecture", "state": "Deprecated"}
]
```

### Checklist
- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Enable all Beta feature gates by default. Users can opt out of individual Beta features by adding them to `spec.configuration.developerConfiguration.disabledFeatureGates` in the KubeVirt CR. A feature gate report with all non-GA feature gates will be added to each release's artifacts.
```