### PR TITLE
release-1.6: fix long vm name bug

### DIFF
--- a/pkg/libvmi/BUILD.bazel
+++ b/pkg/libvmi/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -20,8 +20,11 @@
 package libvmi
 
 import (
+	"strings"
+
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	v1 "kubevirt.io/api/core/v1"
 )
@@ -49,9 +52,14 @@ func RegisterDefaultOption(opt Option) {
 }
 
 // randName returns a random name for a virtual machine
+// the name is made long in order to tickle would-be bugs that are related to
+// long names. Use a long xxxxxxxxx suffix for a lesser disturbance to human
+// log viewers.
 func randName() string {
 	const randomPostfixLen = 5
-	return "testvmi" + "-" + rand.String(randomPostfixLen)
+	const prefix = "testvmi-"
+	const xLen = validation.DNS1035LabelMaxLength - randomPostfixLen - len(prefix) - 1
+	return prefix + rand.String(randomPostfixLen) + "-" + strings.Repeat("x", xLen)
 }
 
 func baseVmi(name string) *v1.VirtualMachineInstance {

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -47,8 +47,9 @@ import (
 )
 
 const (
-	PVCPrefix = "persistent-state-for"
-	PVCSize   = "10Mi"
+	PVCPrefix  = "persistent-state-for"
+	PVCSize    = "10Mi"
+	VolumeName = PVCPrefix + "-this-vm"
 
 	// LabelApplyStorageProfile is a label used by the CDI mutating webhook
 	// to modify the PVC according to the storage profile.
@@ -262,9 +263,15 @@ func (bs *BackendStorage) labelLegacyPVC(pvc *v1.PersistentVolumeClaim, name str
 	}
 }
 
+func IsBackendStorageVolume(v corev1.VolumeStatus) bool {
+	// TODO https://github.com/kubevirt/kubevirt/issues/17369
+	// simplify to volume.Name == VolumeName
+	return strings.HasPrefix(v.Name, PVCPrefix)
+}
+
 func CurrentPVCName(vmi *corev1.VirtualMachineInstance) string {
 	for _, volume := range vmi.Status.VolumeStatus {
-		if strings.Contains(volume.Name, basePVC(vmi)) {
+		if IsBackendStorageVolume(volume) {
 			return volume.PersistentVolumeClaimInfo.ClaimName
 		}
 	}
@@ -470,7 +477,8 @@ func (bs *BackendStorage) UpdateVolumeStatus(vmi *corev1.VirtualMachineInstance,
 		vmi.Status.VolumeStatus = []corev1.VolumeStatus{}
 	}
 	for i := range vmi.Status.VolumeStatus {
-		if vmi.Status.VolumeStatus[i].Name == pvc.Name {
+		if IsBackendStorageVolume(vmi.Status.VolumeStatus[i]) {
+			vmi.Status.VolumeStatus[i].Name = VolumeName
 			if vmi.Status.VolumeStatus[i].PersistentVolumeClaimInfo == nil {
 				vmi.Status.VolumeStatus[i].PersistentVolumeClaimInfo = &corev1.PersistentVolumeClaimInfo{}
 			}
@@ -480,7 +488,7 @@ func (bs *BackendStorage) UpdateVolumeStatus(vmi *corev1.VirtualMachineInstance,
 		}
 	}
 	vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, corev1.VolumeStatus{
-		Name: pvc.Name,
+		Name: VolumeName,
 		PersistentVolumeClaimInfo: &corev1.PersistentVolumeClaimInfo{
 			ClaimName:   pvc.Name,
 			AccessModes: pvc.Spec.AccessModes,

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/controller/testing:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -179,7 +179,16 @@ func (c *Controller) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, virt
 
 	backendStoragePVC := backendstorage.PVCForVMI(c.pvcIndexer, vmi)
 	if backendStoragePVC != nil {
-		if backendStorage, ok := oldStatusMap[backendStoragePVC.Name]; ok {
+		backendStorage, ok := oldStatusMap[backendstorage.VolumeName]
+		if !ok {
+			// TODO https://github.com/kubevirt/kubevirt/issues/17369
+			// Fall back to the legacy volume name (the PVC name itself) used by older VMIs
+			backendStorage, ok = oldStatusMap[backendStoragePVC.Name]
+			if ok {
+				backendStorage.Name = backendstorage.VolumeName
+			}
+		}
+		if ok {
 			newStatus = append(newStatus, backendStorage)
 		}
 	}

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -52,6 +52,8 @@ import (
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
@@ -3190,6 +3192,40 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("should return global fs overhead if the storageClassName is invalid", k8sv1.PersistentVolumeFilesystem, "nonValid", virtv1.Percent("0.5")),
 			Entry("should return the appropiate overhead when using a valid storageClassName", k8sv1.PersistentVolumeFilesystem, "default", virtv1.Percent("0.8")),
 		)
+
+		// TODO drop test with legacy code https://github.com/kubevirt/kubevirt/issues/17369
+		It("Should normalize legacy backend storage volume name on upgrade", func() {
+			vmi := newPendingVirtualMachine("testvmi")
+			legacyPVCName := "persistent-state-for-testvmi"
+			// Simulate a VMI whose status was written by an older controller:
+			// the volume status entry uses the PVC name as the Name field.
+			vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				{
+					Name: legacyPVCName,
+					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
+						ClaimName: legacyPVCName,
+					},
+				},
+			}
+
+			pvc := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      legacyPVCName,
+					Namespace: k8sv1.NamespaceDefault,
+					Labels:    map[string]string{backendstorage.PVCPrefix: "testvmi"},
+				},
+			}
+			Expect(controller.pvcIndexer.Add(pvc)).To(Succeed())
+
+			virtlauncherPod := newPodForVirtualMachine(vmi, k8sv1.PodRunning)
+			Expect(controller.updateVolumeStatus(vmi, virtlauncherPod)).To(Succeed())
+
+			// The legacy entry must be carried forward under the new static name,
+			// so that UpdateVolumeStatus can update it in-place on the same reconcile.
+			Expect(vmi.Status.VolumeStatus).To(HaveLen(1))
+			Expect(vmi.Status.VolumeStatus[0].Name).To(Equal(backendstorage.VolumeName))
+			Expect(vmi.Status.VolumeStatus[0].PersistentVolumeClaimInfo.ClaimName).To(Equal(legacyPVCName))
+		})
 
 		It("Should properly create attachmentpod, if correct volume and disk are added", func() {
 			vmi := newPendingVirtualMachine("testvmi")

--- a/pkg/virt-controller/watch/volume-migration/volume-migration.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration.go
@@ -463,13 +463,12 @@ func ValidateVolumesUpdateMigration(vmi *virtv1.VirtualMachineInstance, vm *virt
 	for _, v := range migVolsInfo {
 		volMigMap[v.VolumeName] = true
 	}
-	persistBackendVolName := backendstorage.CurrentPVCName(vmi)
 	for _, v := range vmi.Status.VolumeStatus {
 		if v.PersistentVolumeClaimInfo == nil {
 			continue
 		}
 		// Skip the check for the persistent VM state, this is handled differently then the other PVCs
-		if v.Name == persistBackendVolName {
+		if backendstorage.IsBackendStorageVolume(v) {
 			continue
 		}
 		_, ok := volMigMap[v.Name]

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -442,7 +442,7 @@ var _ = Describe("Volume Migration", func() {
 						},
 					},
 				})), fmt.Errorf("cannot migrate the VM. The volume disk1 is RWO and not included in the migration volumes")),
-			Entry("with valid migrated volumes and persistent storage", libvmi.New(libvmi.WithName("test"), libvmi.WithTPM(true),
+			Entry("with valid migrated volumes and persistent storage (legacy volume name)", libvmi.New(libvmi.WithName("test"), libvmi.WithTPM(true),
 				libvmistatus.WithStatus(
 					v1.VirtualMachineInstanceStatus{
 						MigratedVolumes: []v1.StorageMigratedVolumeInfo{
@@ -468,9 +468,45 @@ var _ = Describe("Volume Migration", func() {
 								},
 							},
 							{
+								// Legacy: volume status name equals the PVC claim name
 								Name: "persistent-state-for-test",
 								PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
 									ClaimName:   "persistent-state-for-test",
+									AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+								},
+							},
+						},
+					})), nil),
+			Entry("with valid migrated volumes and persistent storage (static volume name)", libvmi.New(libvmi.WithTPM(true),
+				libvmistatus.WithStatus(
+					v1.VirtualMachineInstanceStatus{
+						MigratedVolumes: []v1.StorageMigratedVolumeInfo{
+							{
+								VolumeName:         "disk0",
+								SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: "src"},
+								DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: "dst"},
+							},
+						},
+						Conditions: []v1.VirtualMachineInstanceCondition{
+							v1.VirtualMachineInstanceCondition{
+								Type:   v1.VirtualMachineInstanceIsMigratable,
+								Status: k8sv1.ConditionFalse,
+								Reason: v1.VirtualMachineInstanceReasonDisksNotMigratable,
+							},
+						},
+						VolumeStatus: []v1.VolumeStatus{
+							{
+								Name: "disk0",
+								PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+									ClaimName:   "src",
+									AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+								},
+							},
+							{
+								// New style: static Name (backendstorage.VolumeName) differs from the actual PVC ClaimName
+								Name: "persistent-state-for-this-vm",
+								PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+									ClaimName:   "persistent-state-for-abc123",
 									AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
 								},
 							},

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -376,6 +376,7 @@ var _ = Describe("MemoryDump", func() {
 							}},
 						},
 					},
+					ServiceName:    "virt-export-" + fmt.Sprintf("export-%s-%s", vmName, pvcName),
 					TokenSecretRef: &secret.Name,
 				},
 			}

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -1071,7 +1071,6 @@ func translateServicePortToTargetPort(localPort string, remotePort string, svc k
 // waitForExportServiceToBeReady waits until the vmexport service is ready for port-forwarding
 func waitForExportServiceToBeReady(client kubecli.KubevirtClient, vmeInfo *VMExportInfo, interval, timeout time.Duration) (*k8sv1.Service, error) {
 	service := &k8sv1.Service{}
-	serviceName := fmt.Sprintf("virt-export-%s", vmeInfo.Name)
 	err := virtwait.PollImmediately(interval, timeout, func(ctx context.Context) (bool, error) {
 		vmexport, err := getVirtualMachineExport(client, vmeInfo)
 		if err != nil || vmexport == nil {
@@ -1080,6 +1079,12 @@ func waitForExportServiceToBeReady(client kubecli.KubevirtClient, vmeInfo *VMExp
 
 		if vmexport.Status == nil || vmexport.Status.Phase != exportv1.Ready {
 			printToOutput("waiting for VM Export %s status to be ready...\n", vmeInfo.Name)
+			return false, nil
+		}
+
+		serviceName := vmexport.Status.ServiceName
+		if serviceName == "" {
+			printToOutput("waiting for VM Export %s service name to be set...\n", vmeInfo.Name)
 			return false, nil
 		}
 

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -824,6 +824,7 @@ var _ = Describe("vmexport", func() {
 					}}},
 				}),
 			}
+			vme.Status.ServiceName = "virt-export-" + vmeName
 			_, err := virtClient.ExportV1beta1().VirtualMachineExports(metav1.NamespaceDefault).Create(context.Background(), vme, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -92,6 +92,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -45,6 +45,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -233,8 +234,9 @@ var _ = Describe(SIG("Export", func() {
 	}
 
 	createExportTokenSecret := func(name, namespace string) *k8sv1.Secret {
+		const prefix = "export-token-"
 		var err error
-		secret := libsecret.New(fmt.Sprintf("export-token-%s", name), libsecret.DataString{"token": name})
+		secret := libsecret.New(fmt.Sprintf("%s%s", prefix, name[:min(len(name), validation.DNS1035LabelMaxLength-len(prefix))]), libsecret.DataString{"token": name})
 		token, err = virtClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return token

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	clone "kubevirt.io/api/clone/v1beta1"
 	"kubevirt.io/api/core"
@@ -1641,9 +1642,10 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			})
 
 			It("should restore an already cloned virtual machine", func() {
+				const cloneSuffix = "-clone"
 				vm, vmi = createAndStartVM(renderVMWithRegistryImportDataVolume(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass))
 
-				targetVMName := vm.Name + "-clone"
+				targetVMName := vm.Name[:min(len(vm.Name), validation.DNS1035LabelMaxLength-len(cloneSuffix))] + cloneSuffix
 				cloneVM(vm.Name, targetVMName)
 
 				By(fmt.Sprintf("Getting the cloned VM %s", targetVMName))

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1468,7 +1468,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes).Should(HaveLen(2))
 				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes[0]).Should(Equal("snapshotablevolume"))
-				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes[1]).Should(Equal(fmt.Sprintf("persistent-state-for-%s", vm.Name)))
+				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes[1]).To(HavePrefix("persistent-state-for-"))
 			})
 		})
 


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/17404

/kind bug

```release-note
VMs with backend storage volume use and report the volume name as `persistent-state-for-this-vm` rather than trying to embed the vm name in the volume name.
Persistent TPM, EFI, snapshot, export and CBT features now work with VM names of all lengths up to 63 chars.
```