### PR TITLE
[QualityFlow] Test artifacts for CNV-72329

### DIFF
--- a/docs/qualityflow/CNV-72329/reviews/CNV-72329_std_review.md
+++ b/docs/qualityflow/CNV-72329/reviews/CNV-72329_std_review.md
@@ -1,0 +1,372 @@
+# STD Review Report: CNV-72329
+
+**Reviewed:**
+
+- STD: /Users/goron/Downloads/STD_CNV-72329_NAD_Reference_Live_Update.md
+- STP Source: /Users/goron/Downloads/STP_CNV-72329_NAD_Reference_Live_Update (1).md
+- Go Stubs: N/A (markdown STD, no separate stub files)
+- Python Stubs: N/A (markdown STD, no separate stub files)
+
+**Date:** 2026-03-22
+**Reviewer:** QualityFlow Automated Review (v1.0)
+
+---
+
+## Verdict: APPROVED_WITH_FINDINGS
+
+## Summary
+
+| Metric | Value |
+|:-------|:------|
+| Dimensions reviewed | 6/7 (Dim 2 N/A -- STD is markdown, not YAML v2.1) |
+| Critical findings | 0 |
+| Major findings | 7 |
+| Minor findings | 9 |
+| Confidence | MEDIUM |
+
+## Traceability Summary
+
+| Metric | Value |
+|:-------|:------|
+| STP scenarios | 27 |
+| STD scenarios | 27 |
+| Forward coverage (STP->STD) | 27/27 (100%) |
+| Reverse coverage (STD->STP) | 27/27 (100%) |
+| Orphan STD scenarios | 0 |
+| Missing STD scenarios | 0 |
+
+---
+
+## Findings by Dimension
+
+### Dimension 1: STP-STD Traceability
+
+#### 1a. Forward Traceability (STP -> STD)
+
+All 27 STP test cases (TC-01 through TC-27) have corresponding detailed test procedures in the STD. Each STD test case explicitly references its STP counterpart in the metadata table. Full bidirectional traceability is confirmed.
+
+| STP TC | STD TC | Title Match | Priority Match | Type Match | Status |
+|:-------|:-------|:------------|:---------------|:-----------|:-------|
+| TC-01 | TC-01 | Yes | P1/P1 | Functional | PASS |
+| TC-02 | TC-02 | Yes | P1/P1 | Functional | PASS |
+| TC-03 | TC-03 | Yes | P2/P2 | Functional | PASS |
+| TC-04 | TC-04 | Yes | P2/P2 | Functional | PASS |
+| TC-05 | TC-05 | Yes | P2/P2 | Functional | PASS |
+| TC-06 | TC-06 | Yes | P2/P2 | Functional/API | PASS |
+| TC-07 | TC-07 | Yes | P3/P3 | Functional/CLI | PASS |
+| TC-08 | TC-08 | Yes | P1/P1 | Functional | PASS |
+| TC-09 | TC-09 | Yes | P1/P1 | Negative/FG | PASS |
+| TC-10 | TC-10 | Yes | P2/P2 | Feature Gate | PASS |
+| TC-11 | TC-11 | Yes | P2/P2 | Feature Gate | PASS |
+| TC-12 | TC-12 | Yes | P1/P1 | Negative | PASS |
+| TC-13 | TC-13 | Yes | P1/P1 | Negative | PASS |
+| TC-14 | TC-14 | Yes | P2/P2 | Negative | PASS |
+| TC-15 | TC-15 | Yes | P1/P1 | Negative/Boundary | PASS |
+| TC-16 | TC-16 | Yes | P3/P3 | Edge Case | PASS |
+| TC-17 | TC-17 | Yes | P3/P3 | Edge Case | PASS |
+| TC-18 | TC-18 | Yes | P2/P2 | Boundary/Race | PASS |
+| TC-19 | TC-19 | Yes | P1/P1 | Compatibility | PASS |
+| TC-20 | TC-20 | Yes | P2/P2 | Compatibility | PASS |
+| TC-21 | TC-21 | Yes | P1/P1 | Regression | PASS |
+| TC-22 | TC-22 | Yes | P1/P1 | Regression | PASS |
+| TC-23 | TC-23 | Yes | P2/P2 | Regression | PASS |
+| TC-24 | TC-24 | Yes | P2/P2 | Upgrade | PASS |
+| TC-25 | TC-25 | Yes | P3/P3 | Upgrade | PASS |
+| TC-26 | TC-26 | Yes | P3/P3 | Scale | PASS |
+| TC-27 | TC-27 | Yes | P3/P3 | Stress | PASS |
+
+#### 1b. Reverse Traceability (STD -> STP)
+
+All 27 STD test cases map back to valid STP entries. No orphan scenarios found.
+
+#### 1c. Count Consistency
+
+The STD's Section 8 (Traceability Matrix) enumerates all 27 test cases grouped by STP requirement area. All counts are consistent.
+
+#### 1d. STP Reference
+
+The STD header references `STP_CNV-72329_NAD_Reference_Live_Update.md` which matches the STP file. **PASS.**
+
+**Findings:** None.
+
+---
+
+### Dimension 2: STD Structure
+
+This STD is authored in markdown format rather than the v2.1-enhanced YAML specification. While this is a valid format for manually authored STDs, it means certain structural checks (YAML schema validation, `code_generation_config`, `closure_scope` variables) cannot be applied.
+
+**Finding: MINOR-01 -- STD is in markdown format, not v2.1-enhanced YAML.**
+The STD is a well-structured markdown document but does not follow the v2.1-enhanced YAML specification that enables automated code generation via the `/generate-go-tests` or `/generate-python-tests` commands. A YAML version would need to be produced before automated code generation can proceed.
+
+---
+
+### Dimension 3: Pattern Matching Correctness
+
+Since this is a markdown STD without explicit pattern metadata, this dimension evaluates whether the test procedures align with the correct CNV patterns and helper libraries.
+
+#### 3a. Primary Pattern Analysis
+
+| TC | Dominant Domain | Expected Pattern | Expected Helpers | Status |
+|:---|:----------------|:-----------------|:-----------------|:-------|
+| TC-01 | NAD swap + migration + connectivity | migration-001, network-connectivity-001 | libvmifact, libnet, libwait, libmigration | PASS |
+| TC-02 | Post-swap connectivity | network-connectivity-001 | libvmifact, libnet, libwait | PASS |
+| TC-03 | Successive migrations | migration-001 | libvmifact, libnet, libmigration | PASS |
+| TC-04 | Multi-net single update | network-connectivity-001 | libvmifact, libnet | PASS |
+| TC-05 | Multi-net simultaneous | network-connectivity-001 | libvmifact, libnet | PASS |
+| TC-06 | kubectl patch | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-07 | virtctl CLI | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-08 | MAC preservation | network-connectivity-001 | libvmifact, libnet, libwait | PASS |
+| TC-09 | FG disabled negative | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-10 | FG enable at runtime | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-11 | FG disable at runtime | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-12 | Non-existent NAD | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-13 | Non-migratable VM | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-14 | Non-bridge binding | vm-lifecycle-001 | libvmifact, libnet | WARN |
+| TC-15 | Combined changes | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-16 | No-op | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-17 | Stopped VM | vm-lifecycle-001 | libvmifact, libnet, libvmops | PASS |
+| TC-18 | Race condition | migration-001 | libvmifact, libnet, libmigration | PASS |
+| TC-19 | DNC compat | network-connectivity-001 | libvmifact, libnet | PASS |
+| TC-20 | DNC + hotplug | network-hotplug-001 | libvmifact, libnet | PASS |
+| TC-21 | Hotplug regression | network-hotplug-001 | libvmifact, libnet | PASS |
+| TC-22 | Migration regression | migration-001 | libvmifact, libmigration | PASS |
+| TC-23 | Legacy restart | vm-lifecycle-001 | libvmifact, libnet, libvmops | PASS |
+| TC-24 | Upgrade | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-25 | Rollback | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-26 | Scale | vm-lifecycle-001 | libvmifact, libnet | PASS |
+| TC-27 | Rapid changes | vm-lifecycle-001 | libvmifact, libnet, libmigration | PASS |
+
+#### 3b. Decorator Assignment
+
+All test cases involve network functionality (NAD/bridge/migration in network context). The appropriate SIG decorator is `decorators.SigNetwork` per the CNV project config. The STD does not explicitly specify decorators (markdown format), but the test implementation mapping in Section 6 correctly places all tests under `tests/network/nad_live_update.go`, consistent with `SigNetwork`.
+
+**Finding: MINOR-02 -- No explicit decorator metadata in markdown STD.**
+This is inherent to the markdown format and acceptable. Decorators will need to be assigned during code generation.
+
+---
+
+### Dimension 4: Test Step Quality
+
+#### 4a. Step Completeness
+
+| TC | Preconditions | Steps | Expected Results | Cleanup | Status |
+|:---|:-------------|:------|:-----------------|:--------|:-------|
+| TC-01 | 8 items | 10 steps | 10 expected | Common cleanup | PASS |
+| TC-02 | 2 items | 6 steps | 6 expected | Common cleanup | PASS |
+| TC-03 | 3 items | 7 steps | 7 expected | Common cleanup | PASS |
+| TC-04 | 3 items | 7 steps | 7 expected | Common cleanup | PASS |
+| TC-05 | 3 items | 6 steps | 6 expected | Common cleanup | PASS |
+| TC-06 | 4 items | 4 steps | 4 expected | Common cleanup | PASS |
+| TC-07 | 4 items | 3 steps | 3 expected | Common cleanup | PASS |
+| TC-08 | 4 items | 7 steps | 7 expected | Common cleanup | PASS |
+| TC-09 | 4 items | 6 steps | 6 expected | Common cleanup | PASS |
+| TC-10 | 3 items | 7 steps | 7 expected | Common cleanup | PASS |
+| TC-11 | 3 items | 7 steps | 7 expected | Common cleanup | PASS |
+| TC-12 | 4 items | 6 steps | 6 expected | Common cleanup | PASS |
+| TC-13 | 3 items | 5 steps | 5 expected | Common cleanup | PASS |
+| TC-14 | 3 items | 4 steps | 4 expected | Common cleanup | PASS |
+| TC-15 | 3 items | 6 steps | 6 expected | Common cleanup | PASS |
+| TC-16 | 3 items | 5 steps | 5 expected | Common cleanup | PASS |
+| TC-17 | 4 items | 8 steps | 8 expected | Common cleanup | PASS |
+| TC-18 | 3 items | 5 steps | 5 expected | Common cleanup | PASS |
+| TC-19 | 4 items | 8 steps | 8 expected | Common cleanup | PASS |
+| TC-20 | 4 items | 8 steps | 8 expected | Common cleanup | PASS |
+| TC-21 | 3 items | 4 steps | 4 expected | Common cleanup | PASS |
+| TC-22 | 2 items | 4 steps | 4 expected | Common cleanup | PASS |
+| TC-23 | 3 items | 6 steps | 6 expected | Common cleanup | PASS |
+| TC-24 | 3 items | 6 steps | 6 expected | Common cleanup | PASS |
+| TC-25 | 3 items | 5 steps | 5 expected | Common cleanup | PASS |
+| TC-26 | 4 items | 5 steps | 5 expected | Common cleanup | PASS |
+| TC-27 | 3 items | 6 steps | 6 expected | Common cleanup | PASS |
+
+All test cases have preconditions, numbered steps with actions, and expected results per step. Common cleanup is defined in Section 3.4. **Structurally complete.**
+
+#### 4b. Step Quality
+
+**Finding: MAJOR-01 -- TC-02 has significant overlap with TC-01.**
+TC-01 already includes post-swap connectivity verification (Steps 9-10). TC-02 repeats essentially the same flow. Section 6 (Test Implementation Mapping) even notes TC-02 is "combined with TC-01" in the existing implementation. The STD should either (a) clarify TC-02 tests a distinct scenario (e.g., different connectivity verification method, different network topology), or (b) explicitly mark TC-02 as a "verification extension" of TC-01 and note that they share an implementation.
+
+**Finding: MAJOR-02 -- TC-07 steps are vague.**
+Step 1 says "Use `virtctl` or `kubectl edit vm test-vm` to modify the VM's NAD reference." This is imprecise for a test procedure. A proper STD should specify the exact command or API call. The "(if supported)" qualifier in the title also introduces ambiguity -- the STD should definitively state whether this is supported or not, and if uncertain, the test should include a discovery step.
+
+**Finding: MAJOR-03 -- TC-14 expected result is ambiguous.**
+Step 3 says "Feature does NOT trigger live migration for non-bridge bindings." Step 4 says "Either `RestartRequired` condition is set, OR an unsupported-binding error event is emitted." An STD should have deterministic expected results, not "either/or" outcomes. The correct behavior should be determined from the VEP/implementation and specified concretely. If both outcomes are acceptable, this should be documented as two sub-scenarios.
+
+**Finding: MAJOR-04 -- TC-25 expected result is ambiguous.**
+Step 4 says "Either: RestartRequired (if FG unknown/disabled), or feature works (if FG exists in old version)." Same issue as TC-14 -- the expected result depends on the rollback target version, which should be specified as a precondition. Two sub-test cases or a parameterized approach would be more appropriate.
+
+**Finding: MINOR-03 -- TC-12 Step 3 assertion needs clarification.**
+"Wait for migration to be attempted" and "Migration is triggered (MigrationRequired condition set)" -- it is unclear whether the migration controller should even attempt migration to a non-existent NAD. The VEP design should clarify whether the controller validates NAD existence before triggering migration or relies on target pod startup failure. The current description implies the latter, which is correct per the implementation, but the STD should state this explicitly.
+
+**Finding: MINOR-04 -- TC-13 Step 3 timeout is inconsistent.**
+TC-13 uses "Wait 60 seconds" while TC-09 uses "Wait up to 60 seconds." The phrasing should be consistent. "Wait up to 60 seconds" with a polling check is the correct pattern for Ginkgo `Eventually`/`Consistently` usage.
+
+#### 4c. Logical Flow
+
+All test cases follow a logical setup-action-verify flow. Resources referenced in steps are established in preconditions. No circular dependencies found.
+
+**Finding: MINOR-05 -- TC-01 precondition 6 pins VM to node A via node affinity, but Step 4 "remove node affinity" is part of the patch action.**
+This is technically correct (removing affinity allows migration to other nodes), but the STD should explicitly explain WHY node affinity is set and then removed. This is an implementation detail of the test infrastructure (ensuring the VM starts on a specific node for deterministic testing) that should be documented as a test design note.
+
+#### 4d. Upgrade Test Structure
+
+**TC-24 (Upgrade):** Follows the correct before/after pattern: Step 1 verifies feature works pre-upgrade, Step 2 performs upgrade, Steps 3-6 verify post-upgrade. **PASS.**
+
+**TC-25 (Rollback):** Follows before/after pattern: Step 1 verifies pre-rollback, Step 2 performs rollback, Steps 3-5 verify post-rollback. **PASS.**
+
+#### 4e. Test Dependency Structure
+
+All test cases are designed to be independently executable. Common preconditions are shared via Section 3.1, and each TC creates its own resources. No inter-TC dependencies found. **PASS.**
+
+#### 4f. Assertion Quality
+
+Pass criteria are specified for every test case. Expected results per step are generally measurable and specific (e.g., "Ping succeeds (0% packet loss)", "Condition appears within 60 seconds", "HTTP 200").
+
+**Finding: MINOR-06 -- TC-22 Step 4 "Verify VM is fully functional post-migration" is vague.**
+"Fully functional" should specify what is checked: guest agent connected, network interfaces responding, application-level health check, etc.
+
+---
+
+### Dimension 4.5: STD Content Policy
+
+#### 4.5a. Banned Content
+
+The STD does not contain PR URLs in test procedures or metadata. The header metadata table references the STP file correctly. Implementation PRs and Jira links are appropriately placed in the STP, not the STD.
+
+**Finding: MINOR-07 -- STD Section 2 (Existing Test Coverage Analysis) references internal file paths.**
+References like `pkg/network/vmliveupdate/restart_test.go` and `pkg/network/migration/evaluator_test.go` are implementation details. While useful for context, they tie the STD to specific code paths that may change. This is acceptable in the "Existing Coverage" analysis section but should not appear in test procedures.
+
+#### 4.5b. No Implementation Details in Procedures
+
+Test procedures use user-observable language ("Patch the VM spec", "Verify VM is running", "Ping from guest console"). No internal component names (controller, reconciler, evaluator) appear in test steps. **PASS.**
+
+#### 4.5c. Test Environment Separation
+
+Common preconditions (Section 3.1) describe environment requirements (cluster, CNI, storage) separately from test procedures. Individual test cases reference only test-specific preconditions. **PASS.**
+
+---
+
+### Dimension 5: PSE Docstring Quality
+
+Since this is a markdown STD without separate stub files, this dimension evaluates the PSE quality of the inline test procedures.
+
+#### 5a. Preconditions Quality
+
+Preconditions are specific and reference concrete resources across all 27 test cases. Examples:
+- TC-01: "Two NADs exist in the test namespace: `nad-1` (bridge `br-1`) and `nad-2` (bridge `br-2`)" -- specific
+- TC-09: "`LiveUpdateNADRef` feature gate is **disabled**" -- clear state requirement
+- TC-13: "Running VM that is **not migratable** (e.g., uses a hostDisk, GPU passthrough, or has no shared storage)" -- specific with examples
+
+**PASS** -- all preconditions are adequate.
+
+#### 5b. Steps Quality
+
+Steps are numbered, actionable, and unambiguous for 25 of 27 test cases. TC-07 and TC-25 have ambiguity issues noted in MAJOR-02 and MAJOR-04 above.
+
+#### 5c. PSE Section Classification
+
+**Finding: MAJOR-05 -- TC-01 Step 1 is a verification, not a test action.**
+"Verify `test-vm` VMI is running and has `AgentConnected` condition = True" is a precondition check, not a test step. It should be part of the preconditions ("VM is verified running with AgentConnected=True") or a setup validation. The same pattern appears in TC-02 Step 1, TC-03 Step 1, TC-04 Step 1, TC-09 Step 2, TC-16 Step 1, TC-17 Step 1, TC-19 Step 2, TC-26 Step 1. This is a systematic issue across multiple test cases.
+
+**Finding: MAJOR-06 -- TC-10 Step 1 and TC-11 Step 1 are precondition verifications.**
+"Verify FG is disabled/enabled" is a precondition check. If it is already stated in the preconditions, repeating it as Step 1 is redundant. If it is a deliberate runtime check, it should be framed as "Confirm precondition: FG is disabled" in the setup phase.
+
+**Finding: MINOR-08 -- TC-19 Step 3 "Record the source pod's multus annotation" is data capture, not a test action.**
+This belongs in preconditions or setup phase as "Source pod's multus annotation is recorded for comparison."
+
+---
+
+### Dimension 6: Code Generation Readiness
+
+#### 6a. Format Gap
+
+The STD is in markdown format. For automated code generation via `/generate-go-tests` or `/generate-python-tests`, a v2.1-enhanced YAML STD would need to be produced first via `/std-builder`. The markdown STD serves as excellent input for manual test implementation and as a reference for YAML STD generation.
+
+#### 6b. Test Implementation Mapping
+
+Section 6 provides a clear mapping of test cases to Ginkgo `It` blocks in `tests/network/nad_live_update.go`. Of 27 test cases:
+- 7 are already implemented (TC-01/02 combined, TC-04, TC-08, TC-09, TC-16, TC-17)
+- 1 is covered implicitly (TC-06)
+- 2 are manual/semi-automated (TC-24, TC-25)
+- 2 are covered by existing test suites (TC-21, TC-22)
+- 15 need new implementation
+
+**Finding: MAJOR-07 -- TC-01 and TC-02 share a single implementation.**
+Section 6 notes TC-02 status as "Existing (combined with TC-01)." This means TC-02 is not independently verifiable. If TC-01 fails, TC-02 implicitly fails too. For traceability, either: (a) split the implementation into separate `It` blocks, or (b) document in the STD that TC-02 is a sub-verification of TC-01 and merge them in the STP.
+
+#### 6c. Test Data Adequacy
+
+Section 5 (Test Data Summary) is comprehensive:
+- 7 NAD definitions with clear purpose mapping
+- 6 VM configurations covering all test scenarios
+- Static IP scheme for connectivity tests (10.1.x.y/24)
+
+**Finding: MINOR-09 -- Static IP addresses use non-RFC-5737 ranges.**
+The STD uses `10.1.1.0/24` and `10.1.2.0/24` ranges. Per CNV PII sanitization rules, example IPs should use RFC 5737 ranges (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24). However, for secondary network static IPs in an isolated bridge domain, the `10.x.x.x` range is functionally correct and commonly used in KubeVirt tests. This is a minor stylistic issue.
+
+#### 6d. Timeout Appropriateness
+
+Timeouts referenced in test steps are appropriate:
+- Migration completion: "within 5 minutes" (TC-01, TC-04) -- matches `MigrationWaitTime` constant
+- Condition appearance: "within 60 seconds" (TC-01, TC-09) -- appropriate for controller reconciliation
+- No-op verification: "30 seconds" (TC-09, TC-16) -- appropriate for `Consistently` checks
+- Scale test: "up to 15 minutes" (TC-26) -- appropriate for queued migrations
+- Race condition settlement: "up to 10 minutes" (TC-18, TC-27) -- appropriate
+
+**PASS** -- all timeouts are reasonable.
+
+---
+
+## Recommendations
+
+1. **[MAJOR-01]** Clarify the relationship between TC-01 and TC-02. Either differentiate TC-02's test procedure to cover a distinct verification not already in TC-01, or explicitly document TC-02 as a sub-scenario of TC-01 and update the STP accordingly.
+
+2. **[MAJOR-02]** Specify the exact `virtctl` command in TC-07. Remove the "(if supported)" qualifier and either confirm the feature is supported via virtctl or mark the test as conditional with a discovery precondition.
+
+3. **[MAJOR-03]** Resolve the ambiguous "either/or" expected result in TC-14. Determine the correct behavior from the VEP implementation and specify a single deterministic expected outcome, or split into two sub-scenarios.
+
+4. **[MAJOR-04]** Resolve the ambiguous expected result in TC-25 by specifying the exact rollback target version as a precondition and providing deterministic expected results for that version.
+
+5. **[MAJOR-05]** Reclassify precondition verification steps (TC-01 Step 1, TC-02 Step 1, TC-03 Step 1, etc.) from "Steps" to precondition assertions in the setup phase. Test steps should be actions that exercise the feature under test, not state confirmations.
+
+6. **[MAJOR-06]** Remove redundant FG verification steps (TC-10 Step 1, TC-11 Step 1) that duplicate stated preconditions, or reframe them as explicit setup validation steps.
+
+7. **[MAJOR-07]** Split TC-01/TC-02 into independent Ginkgo `It` blocks in the implementation, or merge them in the STP/STD as a single test case with extended verification.
+
+8. **[MINOR-01]** Consider producing a v2.1-enhanced YAML version of this STD via `/std-builder` to enable automated code generation for the 15 unimplemented test cases.
+
+9. **[MINOR-02]** Add explicit decorator metadata (`SigNetwork`, `Ordered`) to test case definitions for code generation readiness.
+
+10. **[MINOR-03]** Add a note to TC-12 explaining whether the controller validates NAD existence before triggering migration.
+
+11. **[MINOR-04]** Standardize timeout phrasing: use "Wait up to N seconds" consistently (not "Wait N seconds").
+
+12. **[MINOR-05]** Add a test design note explaining the node affinity pattern used in TC-01 (set affinity to control initial placement, remove during patch to enable migration).
+
+13. **[MINOR-06]** Replace "fully functional" in TC-22 Step 4 with specific verification criteria (guest agent connected, interfaces responding).
+
+14. **[MINOR-07]** Consider moving internal file paths in Section 2 to an appendix or annotation to keep the main document focused on test design.
+
+15. **[MINOR-08]** Reclassify TC-19 Step 3 ("Record annotation") as a setup/precondition data capture step.
+
+16. **[MINOR-09]** Consider using RFC 5737 IP ranges for documentation consistency, though the current `10.x.x.x` ranges are functionally acceptable.
+
+---
+
+## Confidence Notes
+
+| Factor | Status |
+|:-------|:-------|
+| STD parseable | YES (markdown) |
+| STP file available | YES |
+| Go stubs present | NO (markdown STD) |
+| Python stubs present | NO (markdown STD) |
+| Pattern library available | YES |
+| All scenarios reviewed | YES (27/27) |
+| Project review rules loaded | YES (cnv/review_rules.yaml) |
+
+**Confidence rationale:** Confidence is MEDIUM because the STD is a well-structured markdown document with the STP available for full traceability analysis, and project-specific review rules were loaded. However, confidence is not HIGH because no separate stub files exist for PSE docstring evaluation (Dimension 5 was evaluated against inline procedures rather than actual code stubs), and the markdown format prevents YAML structural validation (Dimension 2).
+
+---
+
+**Verdict Justification:** 0 critical findings and 7 major findings result in an **APPROVED_WITH_FINDINGS** verdict. The STD is comprehensive, well-structured, and provides thorough test procedures for all 27 STP scenarios. The major findings relate primarily to (a) ambiguous expected results in 3 test cases, (b) systematic PSE classification issues where precondition verifications appear as test steps, and (c) TC-01/TC-02 overlap. None of these block test implementation but should be addressed for optimal test design quality.

--- a/docs/qualityflow/CNV-72329/reviews/CNV-72329_stp_review.md
+++ b/docs/qualityflow/CNV-72329/reviews/CNV-72329_stp_review.md
@@ -1,0 +1,273 @@
+# STP Review Report: CNV-72329
+
+**Reviewed:** /Users/goron/Downloads/STP_CNV-72329_NAD_Reference_Live_Update (1).md
+**Date:** 2026-03-22
+**Reviewer:** QualityFlow Automated Review (v1.0)
+
+---
+
+## Verdict: APPROVED_WITH_FINDINGS
+
+## Summary
+
+| Metric | Value |
+|:-------|:------|
+| Dimensions reviewed | 7/7 |
+| Critical findings | 0 |
+| Major findings | 8 |
+| Minor findings | 6 |
+| Confidence | MEDIUM |
+
+---
+
+## Findings by Dimension
+
+### Dimension 1: Rule Compliance (Rules A-P)
+
+| Rule | Status | Finding |
+|:-----|:-------|:--------|
+| A -- Abstraction Level | WARN | **[MAJOR]** Several test case titles use internal mechanism language. TC-09 references "RestartRequired condition" (internal Kubernetes API condition name). TC-15 references "restart-requiring changes" (internal controller evaluation logic). TC-23 references "legacy flow." These should use user-observable language. Suggested rewrites: TC-09: "NAD change with feature gate disabled -- VM requires restart"; TC-15: "NAD ref change combined with other changes requiring VM restart"; TC-23: "VM restart applies pending NAD change when feature gate is disabled." Additionally, the Feature Overview (Section 1.2) uses internal terms like "multus annotation" and "RestartRequired condition" -- acceptable in overview context but borderline. |
+| A.2 -- Language Precision | WARN | **[MAJOR]** The Jira user story uses anthropomorphizing language: "without the VM noticing." The STP Section 1.3 Motivation repeats "without guest awareness" which is an improvement but still anthropomorphizes the guest OS. Suggested: "transparently to the guest operating system" or "with minimal service disruption." Additionally, TC-02 "Network connectivity verified after NAD swap" uses passive voice -- prefer "Verify network connectivity after NAD reference change." |
+| B -- Section I Meta-Checklist | WARN | **[MAJOR]** The STP does not follow the CNV project STP template structure. The template prescribes a four-section structure (I. Motivation and Requirements Review with checklists, II. Software Test Plan with structured strategy/environment/risks tables, III. Test Scenarios and Traceability with Requirements-to-Tests Mapping, IV. Sign-off and Approval). This STP uses a custom 11-section structure (Introduction, Scope, Test Strategy, Test Environment, Test Case Inventory, Acceptance Criteria Mapping, Test Automation Prioritization, Entry/Exit Criteria, Risks, Dependencies, Glossary). While the content is substantive, the following template elements are absent: Section I checklists (Requirement and User Story Review, Technology and Design Review), structured Y/N/N/A strategy matrix (Section II.2), Known Limitations (Section II.6), Requirements-to-Tests Mapping with Tier column (Section III), and Sign-off and Approval (Section IV). |
+| C -- Prerequisites vs Scenarios | PASS | All test cases describe testable behaviors rather than configuration prerequisites. Feature gate enablement is tested as behavioral verification (TC-09, TC-10, TC-11), not as a setup step. |
+| D -- Dependencies | PASS | Section 10 (Dependencies) correctly lists team deliveries with Jira tracking: VEP approval (CNV-72401, Closed), implementation merge (CNV-76560, Closed), HCO FG enablement (CNV-80604, Testing), DNC compatibility (CNV-80605, New), FG graduation (CNV-82061, In Progress). These are genuine cross-team dependencies. Infrastructure items (Multus CNI, shared storage) correctly appear in Section 4 (Test Environment), not as dependencies -- consistent with `stp_rules.dependencies.infrastructure_not_dependency`. |
+| E -- Upgrade Testing | PASS | Upgrade testing is appropriately included (TC-24, TC-25). The feature modifies VM spec behavior and introduces a feature gate that controls runtime behavior. The feature gate state persists across upgrades, and running VMs with NAD references are persistent state. Per `stp_rules.upgrade.persistent_state_indicators`, "running VM with feature-dependent data" applies. |
+| F -- Version Derivation | WARN | **[MINOR]** The STP lists "CNV 4.18+" in Test Environment (Section 4.1) but Jira Fix Version is "CNV v4.22.0." The version "4.18+" appears to conflate the upstream KubeVirt version mapping with the downstream CNV product version. Recommend changing to "CNV 4.22" to match the Jira `fix_version` field per `stp_rules.metadata.version_source`. |
+| G -- Testing Tools | PASS | No dedicated Testing Tools section is present. This is acceptable -- the STP does not list standard tools unnecessarily. Per `stp_rules.testing_tools.standard_tools`, Ginkgo, pytest, kubectl, oc, and virtctl are all standard and need not be enumerated. |
+| G.2 -- Environment Specificity | PASS | Section 4.1 environment requirements are feature-specific: 2+ worker nodes "for live migration," shared storage "for live migration support," VLAN-capable network "for realistic NAD testing," bridge CNI plugin "cnv-bridge or bridge." Each requirement has a feature-specific justification. |
+| H -- Risk Deduplication | PASS | Section 9 risks are genuine uncertainties: migration failure on missing NAD, DNC conflict, guest connectivity interruption, flaking upstream tests, user feedback gap (CNV-78912), race conditions, FG persistence across upgrades. None duplicate environment requirements from Section 4. |
+| I -- QE Kickoff Timing | WARN | **[MINOR]** No QE Kickoff/Developer Handoff information is present. The template Section I.2 requires documenting when the Dev/Arch walkthrough occurred or should be scheduled. This is absent because the STP does not follow the template structure. |
+| J -- One Tier Per Row | WARN | **[MAJOR -- see Dimension 3]** The STP does not include a Tier column in its test case inventory. Test cases are grouped by category (Functional, Feature Gate, Negative, DNC, Regression, Upgrade, Scale) with Priority (P1/P2/P3) and Automation columns, but no Tier 1/Tier 2 classification. The template Section III requires a Tier column per row. |
+| K -- Cross-Section Consistency | WARN | **[MINOR]** Section 2.2 lists "SR-IOV or other non-bridge bindings" as out of scope, and TC-14 tests "NAD reference change with non-bridge binding (e.g., SR-IOV)." This is a borderline contradiction -- TC-14 is a negative test verifying the out-of-scope boundary, which is acceptable. However, the STP should explicitly note that TC-14 is a negative validation confirming unsupported binding rejection, not a positive test of SR-IOV support. |
+| L -- Section Content Validation | WARN | **[MAJOR]** Section 6 "Acceptance Criteria Mapping" and Section 7 "Test Automation Prioritization" contain content that belongs in Section III (Requirements-to-Tests Mapping) per the template. The acceptance criteria mapping should be integrated into the traceability table. The automation prioritization is operational detail that could be a Comments column in the test inventory rather than a standalone section. |
+| M -- Deletion Test | WARN | **[MINOR]** Section 11 (Glossary) defines standard CNV domain terms (NAD, VMI, FG, DNC, CNI, HCO) that do not contribute to Go/No-Go testing decisions. Consider linking to a shared glossary. Section 1 (Introduction) partly repeats Jira/VEP content -- the STP should reference rather than duplicate. |
+| N -- Link/Reference Validation | WARN | **[MAJOR]** The VEP Reference link in the header metadata table points to `kubevirt/enhancements/pull/138` but is labeled "VEP #140." The PR number (138) and the VEP tracking issue number (140) differ. Section 1.4 correctly references both the PR (138) and the tracking issue (140) separately, but the header conflates them. The label should read "VEP #140 (Design PR #138)" or link to the tracking issue `kubevirt/enhancements/issues/140` instead. All Jira links verified against fetched data: CNV-80604 (Testing), CNV-80605 (New), CNV-78930 (In Progress), CNV-80573 (New), CNV-82091 (Testing), CNV-72401 (Closed), CNV-76560 (Closed) -- all valid and current. |
+| O -- Untestable Aspects | WARN | **[MAJOR]** CNV-78912 ("Design a mitigation for the user feedback issue") describes a known gap: "a user / UI / e2e test cannot tell if the network change was applied." The issue status is "New" -- the mitigation is not yet designed. The STP references this in Section 9 Risks but does not: (1) document it as an untestable aspect with a timeline for resolution, (2) include a placeholder test scenario for when feedback becomes testable, or (3) add it to Known Limitations. This is a testing gap that affects TC-01 and TC-02 verification methods -- how does the test confirm the NAD change was applied without a feedback mechanism? |
+| P -- Testing Pyramid Efficiency | PASS | N/A -- CNV-72329 is an Epic (feature ticket), not a Bug/Customer Case. Rule P does not apply. |
+
+### Dimension 2: Requirement Coverage
+
+| Metric | Value |
+|:-------|:------|
+| Acceptance criteria covered | 2/3 |
+| Linked issues reflected | 19/22 |
+| Negative scenarios present | YES (7 scenarios: TC-12 through TC-18) |
+| Coverage gaps found | 2 |
+
+**Jira acceptance criteria analysis:**
+
+The epic CNV-72329 states the following goal and user story:
+
+- **Goal:** "Allow customers to change the network a VM is connected to, to a different network without the need to reboot the VM."
+- **User Story:** "As a VM admin, I want to swap the guests uplink from one network to another without the VM noticing, so they get better/worse link, different VLAN, or isolated segment."
+
+**Coverage mapping:**
+
+| Requirement | Covered By | Status |
+|:------------|:-----------|:-------|
+| Change network without reboot | TC-01, TC-02, TC-04, TC-05, TC-06, TC-08 | COVERED |
+| Different VLAN use case | TC-01, TC-02 (NAD swap implies VLAN change) | COVERED |
+| Better/worse link use case | Implicitly covered by NAD swap | COVERED |
+| Isolated segment use case | Implicitly covered by NAD swap | COVERED |
+| D/S documentation | CNV-76930 (correctly excluded, out of QE test scope) | COVERED |
+| Test automation | TC-01 through TC-27 automation column, CNV-80573 | COVERED |
+| User feedback visibility (CNV-78912) | Not covered | GAP |
+
+**Linked issue coverage:**
+
+| Linked Issue | Reflected in STP | Notes |
+|:-------------|:-----------------|:------|
+| CNV-72401 (VEP) | YES | Section 1.4, Section 10 |
+| CNV-75778 (STP composition) | YES | Header metadata |
+| CNV-76560 (Implementation) | YES | Section 10 |
+| CNV-76929 (Release note) | NO | Not relevant to QE testing |
+| CNV-76930 (Documentation) | YES | Section 6 acceptance mapping |
+| CNV-78912 (User feedback) | PARTIAL | Risks only, no test scenario |
+| CNV-78930 (STD) | YES | Section 1.4 |
+| CNV-80573 (Automation) | YES | Section 1.4, Section 7 |
+| CNV-80604 (HCO FG) | YES | TC-09/10/11, Section 10 |
+| CNV-80605 (DNC) | YES | TC-19/20, Section 10 |
+| CNV-80620 (Upstream docs) | YES | Section 10 |
+| CNV-82061 (FG graduation) | YES | Section 10 |
+| CNV-82091 (Flaking tests) | YES | Section 1.4, Section 9 |
+
+**Gaps identified:**
+
+1. **[MAJOR] User feedback/status visibility gap.** CNV-78912 describes a known issue where users cannot tell if a network change was applied. No test scenario covers verifying NAD change completion status. Even as a deferred P3 scenario, a placeholder should exist (e.g., "Verify user can confirm NAD change was applied -- blocked by CNV-78912") with a documented timeline condition ("testable when CNV-78912 mitigation is implemented").
+
+2. **[MINOR] Guest interface name preservation not explicitly tested.** Section 1.3 states the approach "preserves all guest-visible interface properties." TC-08 covers MAC address preservation, but interface name preservation (e.g., eth1 remains eth1) is not explicitly tested. This may be implicitly covered by TC-08 but should be made explicit or noted as included in TC-08 scope.
+
+**Proactive scope completeness observations:**
+
+- **Negative scenario ratio:** 7 negative scenarios among 27 total (26%) -- adequate.
+- **Regression coverage:** 3 explicit regression scenarios (TC-21, TC-22, TC-23) covering existing hotplug and migration flows -- good.
+- **UI coverage:** UI/Console testing is explicitly excluded in Out of Scope (Section 2.2) -- acceptable with rationale.
+- **OS/Platform coverage:** No OS-specific scenarios, which is acceptable for a network-level feature that operates below the guest OS layer.
+
+### Dimension 3: Scenario Quality
+
+| Metric | Value |
+|:-------|:------|
+| Total scenarios | 27 |
+| Tier 1 | N/A (not classified) |
+| Tier 2 | N/A (not classified) |
+| P1 (per STP, effectively P0) | 10 |
+| P2 (per STP, effectively P1) | 11 |
+| P3 (per STP, effectively P2) | 6 |
+| Positive scenarios | 17 |
+| Negative scenarios | 7 |
+| Regression scenarios | 3 |
+
+**Scenario-level findings:**
+
+1. **[MAJOR] Missing Tier classification.** The STP does not classify test cases by Tier (Tier 1 Functional vs Tier 2 End-to-End). The CNV template Section III requires a Tier column. This is critical for test planning and execution scheduling. Per linked issue CNV-80573: "tier-2 tests for this feature will very much resemble the existing tests of the interface hot-plug," suggesting most tests will be Tier 2. However, core single-operation validations (TC-01, TC-08, TC-09, TC-12, TC-13) could be Tier 1 candidates. The STP should make tier assignments explicit.
+
+2. **[MINOR] Priority nomenclature mismatch.** The STP uses P1/P2/P3 where the QualityFlow convention uses P0/P1/P2 (P0 being highest). The core scenarios (TC-01, TC-02, TC-08, TC-09) labeled P1 should be P0 under the standard convention.
+
+3. **[MINOR] TC-07 testability uncertain.** TC-07 ("NAD reference change via virtctl (if supported)") includes a qualifying "(if supported)" indicating uncertainty about whether virtctl supports this operation. The STP should confirm virtctl support and remove the qualifier, or move this to Known Limitations/Out of Scope if unsupported.
+
+**Scenario quality assessment:**
+
+- **Specificity:** All scenarios are specific and actionable. TC-01 ("Basic NAD reference change on running VM triggers migration") clearly describes the expected behavior. TC-08 ("MAC address preservation after NAD swap") has a measurable outcome.
+- **Uniqueness:** No duplicate scenarios. Each of the 27 test cases tests a distinct behavior or condition.
+- **Distribution:** Positive/negative ratio (17:7) with 3 regression scenarios is healthy for a feature of this scope. Scale/stress scenarios (TC-26, TC-27) cover concurrent and rapid-change patterns.
+
+### Dimension 4: Risk and Limitation Accuracy
+
+**Risk assessment (Section 9):**
+
+All 7 risks are genuine uncertainties with impact/likelihood ratings and mitigations:
+
+| Risk | Assessment |
+|:-----|:-----------|
+| Migration fails due to NAD not available on target node | Valid -- TC-12 covers this with error handling verification |
+| DNC conflict causes network plumbing errors | Valid -- TC-19, TC-20 cover DNC compatibility (CNV-80605 status: New) |
+| Guest notices network interruption during migration | Valid -- documented as expected behavior in release notes |
+| Flaking upstream tests block CI | Valid -- CNV-82091 (Testing) currently blocks CNV-82061 (FG graduation) |
+| User feedback issue (CNV-78912) | Valid -- status is "New," mitigation not yet designed |
+| Race conditions with rapid NAD changes | Valid -- TC-18, TC-27 cover race conditions |
+| Feature gate state not persisted across upgrades | Valid -- TC-24 covers upgrade scenarios |
+
+**Known Limitations gap:**
+
+**[MAJOR]** The STP has no Known Limitations section. The following should be documented as product limitations:
+
+- Bridge binding only -- SR-IOV and other bindings are not supported (currently in Out of Scope but is a product limitation per VEP Beta scope)
+- Brief network connectivity interruption during migration is expected (currently in Out of Scope but is a known product behavior)
+- No user feedback mechanism for NAD change completion (CNV-78912, status: New)
+- No migration retry limiting for missing NAD (VEP non-goal)
+
+Per Rule L, Known Limitations describe constraints that prevent testing or product boundaries, while Out of Scope describes deliberate testing exclusions. The bridge-only limitation and connectivity interruption are product constraints, not testing choices.
+
+### Dimension 5: Scope Boundary Assessment
+
+**Scope alignment with Jira:**
+
+The STP scope (Section 2.1) aligns well with the Jira epic goal. All 10 in-scope areas map to the epic's stated capability:
+
+- NAD reference live update, bridge binding, live migration trigger, feature gate behavior, RestartRequired condition, VM spec sync, multiple networks, DNC compatibility, HCO integration, CLI/API -- all are aspects of "change the network a VM is connected to without rebooting."
+
+**Out of Scope assessment:**
+
+All 8 out-of-scope items are well-justified:
+
+- Migrating between CNI types, changing binding/plugin, non-migratable VMs -- VEP #140 non-goals
+- Seamless network connectivity during migration -- documented as expected behavior
+- Guest network reconfiguration -- out of product scope
+- SR-IOV/non-bridge bindings -- Beta scope limitation
+- Migration retry limiting -- VEP non-goal
+- UI/Console testing -- separate test effort
+
+**Layered product check (per `stp_rules.scope.layered_product`):**
+
+No scenarios test only platform-level functionality without VM-specific involvement. All scenarios involve VirtualMachine/VirtualMachineInstance resources, which are in-scope per `scope_boundaries.in_scope_resources`. The scope correctly focuses on VM-specific behavior while assuming platform networking (Multus, CNI) works correctly.
+
+No scope boundary issues found.
+
+### Dimension 6: Test Strategy Appropriateness
+
+The STP uses a non-template format for test strategy (Sections 3.1 and 3.2 list test levels and types as tables rather than the Y/N/N/A strategy matrix). Evaluating implied classifications:
+
+| Strategy Row | Implied Classification | Assessment |
+|:-------------|:----------------------|:-----------|
+| Functional Testing | Y (Section 5.1) | Correct -- per `stp_rules.strategy.always_y` |
+| Automation Testing | Y (Automation column) | Correct -- per `stp_rules.strategy.always_y` |
+| Performance Testing | Not addressed | Should be N/A with rationale -- no latency/throughput SLA exists |
+| Security Testing | Not addressed | Should be N/A -- no RBAC/auth/security boundary changes |
+| Usability Testing | Not addressed | Should be N/A -- API-only feature, UI explicitly excluded |
+| Compatibility Testing | Y (Section 5.4 DNC) | Correct -- DNC and platform compatibility tested |
+| Regression Testing | Y (Section 5.5) | Correct -- hotplug and migration regression covered |
+| Upgrade Testing | Y (Section 5.6) | Correct -- FG persistence and rollback tested |
+| Backward Compatibility Testing | Not addressed | Should be Y -- FG-disabled behavior must match pre-feature behavior (TC-09, TC-23 cover this) |
+| Dependencies | Y (Section 10) | Correct -- cross-team deliveries with Jira tracking |
+| Cross Integrations | Implied Y | DNC, HCO, live migration cross-team impact addressed |
+| Monitoring Testing | Not addressed | Should be N/A -- no new metrics or alerts introduced |
+| Cloud Testing | Not addressed | Should be N/A -- bridge networking is not cloud-specific |
+
+**Finding:** While all relevant test types are addressed in substance, the non-template format means several strategy rows lack explicit N/A justification (Performance, Security, Usability, Monitoring, Cloud). The template requires explicit classification for each row.
+
+### Dimension 7: Metadata Accuracy
+
+| Field | STP Value | Jira Value | Assessment |
+|:------|:----------|:-----------|:-----------|
+| Epic | CNV-72329 | CNV-72329 | MATCH |
+| Parent Feature | VIRTSTRAT-560 | N/A (not in fetched data) | Referenced in STP, plausible |
+| Component | CNV Network | CNV Network | MATCH |
+| Assignee | Ananya Banerjee | Ananya Banerjee | MATCH |
+| QA Contact | Yossi Segev | N/A (not a Jira field) | Consistent with CNV-75778 reporter |
+| STP Author | QE (CNV-75778) | CNV-75778 status: Testing | MATCH |
+| Fix Version | "CNV 4.18+" (Section 4.1) | CNV v4.22.0 | MISMATCH (see Rule F) |
+| Feature Gate | LiveUpdateNADRef (Beta, v1.8) | Consistent with linked issues | PLAUSIBLE |
+| VEP Reference | VEP #140 / PR #138 | See Rule N | LABEL MISMATCH |
+
+**Additional metadata findings:**
+
+- **[MINOR] Owning SIG missing.** The STP does not include an Owning SIG field. Based on component "CNV Network" and `sig_mappings` in project config, Owning SIG should be sig-network.
+- **[MINOR] Participating SIGs missing.** Given the feature triggers live migration, sig-migration should be listed as a participating SIG.
+
+---
+
+## Recommendations
+
+1. **[MAJOR-1] Adopt the CNV project STP template structure.** Restructure the STP to follow the four-section template at `config/projects/cnv/templates/stp/stp-template.md`. Key additions needed: Section I checklists (Requirement and User Story Review, Technology and Design Review), structured Y/N/N/A strategy matrix in Section II.2, Known Limitations in Section II.6, Requirements-to-Tests Mapping with Tier column in Section III, and Sign-off and Approval in Section IV.
+
+2. **[MAJOR-2] Add Tier classification to all test cases.** Each test case should be classified as Tier 1 (Functional, single-feature) or Tier 2 (End-to-End, multi-step workflow). Per CNV-80573, most tests will resemble existing hot-plug Tier 2 tests, but core single-operation tests may be Tier 1 candidates.
+
+3. **[MAJOR-3] Add Known Limitations section.** Document product constraints: bridge-only binding support, expected brief connectivity interruption during migration, no user feedback mechanism (CNV-78912), no migration retry limiting for missing NAD.
+
+4. **[MAJOR-4] Add a test scenario for user feedback/observability.** Include a deferred P3 scenario (e.g., "Verify user can confirm NAD change was applied") with a note that it is blocked by CNV-78912 resolution. Document the timeline condition: "testable when CNV-78912 mitigation is designed and implemented."
+
+5. **[MAJOR-5] Rewrite test case titles that use internal mechanism language.** TC-09 ("RestartRequired condition"), TC-15 ("restart-requiring changes"), TC-23 ("legacy flow") should use user-observable language.
+
+6. **[MAJOR-6] Fix VEP reference labeling in header.** Clarify the distinction between VEP #140 (tracking issue) and PR #138 (design document), or link to the tracking issue URL.
+
+7. **[MAJOR-7] Merge Sections 6 and 7 into Section III traceability.** Acceptance Criteria Mapping and Test Automation Prioritization should be integrated into the Requirements-to-Tests Mapping table rather than standing as separate sections.
+
+8. **[MAJOR-8] Fix version reference.** Change "CNV 4.18+" in Test Environment to "CNV 4.22" to match Jira Fix Version "CNV v4.22.0."
+
+9. **[MINOR-1] Normalize priority labels to P0/P1/P2.** Align with QualityFlow convention where P0 is highest priority.
+
+10. **[MINOR-2] Resolve TC-07 testability qualifier.** Remove "(if supported)" and confirm or deny virtctl support for NAD reference changes.
+
+11. **[MINOR-3] Add explicit interface name preservation test.** Either expand TC-08 scope description to include interface name, or add a dedicated scenario.
+
+12. **[MINOR-4] Clarify TC-14 as negative boundary test.** Add a note that this tests unsupported binding rejection, not SR-IOV functionality.
+
+13. **[MINOR-5] Add Owning SIG (sig-network) and Participating SIGs (sig-migration) to metadata.** These fields are required by the template.
+
+14. **[MINOR-6] Add QE Kickoff/Developer Handoff documentation.** Record whether a Dev/QE architecture walkthrough has occurred.
+
+---
+
+## Confidence Notes
+
+| Factor | Status |
+|:-------|:-------|
+| Jira source data available | YES |
+| Linked issues fetched | YES (22 issues) |
+| PR data referenced in STP | YES (PR #16412, #16993 referenced) |
+| All STP sections present | NO (non-template structure) |
+| Template comparison possible | YES |
+| Project review rules loaded | YES |
+
+**Confidence rationale:** Confidence is MEDIUM. Jira source data and all 22 linked/child issues were fetched, enabling comprehensive requirement coverage analysis (Dimension 2) and metadata verification (Dimension 7). The Jira Fix Version (CNV v4.22.0) was verified against the STP. PR data is referenced in the STP but PR diffs were not fetched for code-level analysis. The STP does not follow the CNV template structure, which limited Rule B template comparison -- structural gaps were identified but content-level comparison against template fields was not possible for all sections. Project review rules (`review_rules.yaml`) were loaded and applied for enhanced rule precision across all dimensions.

--- a/docs/qualityflow/CNV-72329/std/CNV-72329_test_description.yaml
+++ b/docs/qualityflow/CNV-72329/std/CNV-72329_test_description.yaml
@@ -1,0 +1,2242 @@
+---
+# Software Test Description (STD) - v2.1-enhanced
+# Generated from STP: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+# Jira: CNV-72329 - Live Update NAD Reference on Running VM
+
+document_metadata:
+  std_version: "2.1-enhanced"
+  generated_date: "2026-03-05"
+  jira_issue: "CNV-72329"
+  jira_summary: "Support changing the VM attached network NAD ref using hotplug"
+  source_bugs: []
+  stp_reference:
+    file: "outputs/stp/CNV-72329/CNV-72329_test_plan.md"
+    version: "v1"
+    sections_covered: "Section III - Requirements-to-Tests Mapping"
+
+  related_prs:
+    - repo: "kubevirt/kubevirt"
+      pr_number: 16412
+      url: "https://github.com/kubevirt/kubevirt/pull/16412"
+      title: "Live update NAD reference on running VM"
+      merged: false
+
+  owning_sig: "sig-network"
+  participating_sigs:
+    - "sig-network"
+
+  total_scenarios: 14
+  tier_1_count: 11
+  tier_2_count: 3
+  p0_count: 5
+  p1_count: 6
+  p2_count: 3
+
+code_generation_config:
+  std_version: "2.1-enhanced"
+  framework: "ginkgo-v2"
+  assertion_library: "gomega"
+  language: "go"
+  package_name: "network"
+
+  context_init:
+    - statement: "ctx := context.Background()"
+      variable: "ctx"
+      type: "context.Context"
+    - statement: "namespace := testsuite.GetTestNamespace(nil)"
+      variable: "namespace"
+      type: "string"
+
+  imports:
+    dot_imports:
+      - "github.com/onsi/ginkgo/v2"
+      - "github.com/onsi/gomega"
+    standard:
+      - "context"
+      - "time"
+    k8s_core:
+      - path: "k8s.io/api/core/v1"
+        alias: "k8sv1"
+      - path: "k8s.io/apimachinery/pkg/apis/meta/v1"
+        alias: "metav1"
+    kubevirt_base:
+      - "kubevirt.io/kubevirt/tests/decorators"
+      - "kubevirt.io/kubevirt/tests/framework/kubevirt"
+      - "kubevirt.io/kubevirt/tests/testsuite"
+      - "kubevirt.io/kubevirt/tests/libvmi"
+    kubevirt_api:
+      - path: "kubevirt.io/api/core/v1"
+        alias: "v1"
+    network:
+      - path: "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+        alias: "networkv1"
+
+  timeout_constants:
+    tiny: "StartupTimeoutSecondsTiny"
+    small: "StartupTimeoutSecondsSmall"
+    medium: "StartupTimeoutSecondsMedium"
+    large: "StartupTimeoutSecondsLarge"
+    xlarge: "StartupTimeoutSecondsXLarge"
+    huge: "StartupTimeoutSecondsHuge"
+    xhuge: "StartupTimeoutSecondsXHuge"
+
+  migration_timeout: "MigrationWaitTime"
+
+  helper_library_imports:
+    libvmifact: "kubevirt.io/kubevirt/tests/libvmifact"
+    libnet: "kubevirt.io/kubevirt/tests/libnet"
+    libwait: "kubevirt.io/kubevirt/tests/libwait"
+    libpod: "kubevirt.io/kubevirt/tests/libpod"
+    libvmops: "kubevirt.io/kubevirt/tests/libvmops"
+    libmigration: "kubevirt.io/kubevirt/tests/libmigration"
+    libstorage: "kubevirt.io/kubevirt/tests/libstorage"
+    console: "kubevirt.io/kubevirt/tests/console"
+    matcher: "kubevirt.io/kubevirt/tests/framework/matcher"
+
+common_preconditions:
+  infrastructure:
+    - name: "OpenShift cluster"
+      requirement: "OCP 4.22+ with OVN-Kubernetes"
+      validation: "oc version"
+
+    - name: "OpenShift Virtualization"
+      requirement: "CNV 4.22+"
+      validation: "oc get csv -n openshift-cnv | grep kubevirt-hyperconverged"
+
+    - name: "Multi-node cluster"
+      requirement: "At least 2 schedulable worker nodes for live migration"
+      validation: "oc get nodes -l node-role.kubernetes.io/worker --no-headers | wc -l"
+
+    - name: "Shared storage"
+      requirement: "RWX PVCs or LiveMigrate-compatible storage (OCS/ODF, NFS, or iSCSI)"
+      validation: "oc get storageclass"
+
+    - name: "Bridge-based NADs"
+      requirement: "Two bridge-based NetworkAttachmentDefinitions deployed on each worker node (nad1, nad2)"
+      validation: "oc get net-attach-def -A"
+
+  operators:
+    - name: "OpenShift Virtualization operator"
+      namespace: "openshift-cnv"
+      validation: "oc get csv -n openshift-cnv | grep kubevirt-hyperconverged"
+
+    - name: "Multus CNI"
+      namespace: "openshift-multus"
+      validation: "oc get pods -n openshift-multus"
+
+  cluster_configuration:
+    topology: "Multi-node"
+    cpu_virtualization: "Standard (Intel VT-x or AMD-V enabled)"
+    storage: "RWX-capable StorageClass for live migration"
+    network: "OVN-Kubernetes with Multus CNI, two bridge NADs (br-1, br-2)"
+
+  feature_gates:
+    - name: "LiveUpdateNADRef"
+      required: true
+      configuration: "HyperConverged CR spec.featureGates.LiveUpdateNADRef: true"
+
+    - name: "WorkloadUpdateMethods"
+      required: true
+      configuration: "HyperConverged CR spec.workloadUpdateStrategy.workloadUpdateMethods: [LiveMigrate]"
+
+    - name: "VMRolloutStrategy"
+      required: true
+      configuration: "HyperConverged CR spec.vmRolloutStrategy: LiveUpdate"
+
+  rbac_requirements:
+    - permission: "patch on virtualmachines"
+      scope: "Namespace"
+      validation: "oc auth can-i patch virtualmachines"
+
+    - permission: "get on virtualmachineinstances"
+      scope: "Namespace"
+      validation: "oc auth can-i get virtualmachineinstances"
+
+scenarios:
+  # ============================================================
+  # TIER 1 SCENARIOS (10 scenarios) - Go/Ginkgo
+  # ============================================================
+
+  - scenario_id: "001"
+    test_id: "TS-CNV72329-001"
+    tier: "Tier 1"
+    priority: "P0"
+    mvp: true
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want to change the NAD on a running VM and connect to the new network"
+
+    patterns:
+      primary: "network-connectivity-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "wait-002"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI with bridge interface"
+        - name: "libnet"
+          functions: ["CreateNetworkAttachmentDefinition"]
+          purpose: "Create bridge NADs"
+        - name: "libwait"
+          functions: ["WaitUntilVMIReady"]
+          purpose: "Wait for VMI readiness after NAD change"
+        - name: "libvmi"
+          functions: ["WithInterface", "WithNetwork"]
+          purpose: "Configure VMI with secondary bridge interface"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+        - name: "vm"
+          type: "*v1.VirtualMachine"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "VM under test"
+        - name: "vmi"
+          type: "*v1.VirtualMachineInstance"
+          initialized_in: "BeforeAll"
+          used_in: ["It"]
+          comment: "VMI for connectivity checks"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when changing NAD reference on a running VM"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should connect to the new network"
+        test_id_format: "[test_id:TS-CNV72329-001]"
+
+    code_structure: |
+      Context("when changing NAD reference on a running VM", Ordered, decorators.OncePerOrderedCleanup) {
+        BeforeAll(func() {
+          // Create VM with secondary bridge interface on nad1
+          // Verify VM is running and connected to nad1
+        })
+        It("[test_id:TS-CNV72329-001]should connect to the new network", func() {
+          // Patch VM spec to change NAD reference from nad1 to nad2
+          // Wait for update to complete
+          // Verify VM is reachable on new network (nad2)
+        })
+      }
+
+    test_objective:
+      title: "Verify VM is reachable on new network"
+      what: |
+        Tests that after patching the VM spec to change the NAD reference from nad1 to nad2,
+        the VM becomes reachable on the new network. This validates the core functionality of
+        live NAD reference update without VM restart.
+      why: |
+        This is the primary use case for the feature - a VM admin changing the network
+        attachment on a running VM. If this fails, the entire feature is non-functional.
+      acceptance_criteria:
+        - "VM spec patched to reference nad2 instead of nad1"
+        - "VM remains running (no restart triggered)"
+        - "VM is reachable on nad2 network"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions:
+      - name: "Running VM with secondary bridge interface"
+        requirement: "VM created with secondary interface on nad1"
+        validation: "kubectl get vmi -o jsonpath='{.spec.networks}'"
+
+    test_data:
+      resource_definitions:
+        - name: "nad1"
+          type: "NetworkAttachmentDefinition"
+          yaml: |
+            apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: nad1
+            spec:
+              config: '{"cniVersion":"0.3.1","name":"nad1","type":"bridge","bridge":"br-1","ipam":{}}'
+
+        - name: "nad2"
+          type: "NetworkAttachmentDefinition"
+          yaml: |
+            apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: nad2
+            spec:
+              config: '{"cniVersion":"0.3.1","name":"nad2","type":"bridge","bridge":"br-2","ipam":{}}'
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create two bridge-based NADs (nad1, nad2)"
+          command: "kubectl apply -f nad1.yaml && kubectl apply -f nad2.yaml"
+          validation: "Both NADs created successfully"
+          pattern_id: "network-nad-001"
+          code_template: |
+            nad1 = libnet.CreateNetworkAttachmentDefinition(namespace, "nad1", "bridge", "br-1")
+            nad2 = libnet.CreateNetworkAttachmentDefinition(namespace, "nad2", "bridge", "br-2")
+
+        - step_id: "SETUP-02"
+          action: "Create and start VM with secondary bridge interface on nad1"
+          command: "kubectl apply -f vm.yaml"
+          validation: "VM is Running with secondary interface on nad1"
+          pattern_id: "factory-001"
+          code_template: |
+            vmi = libvmifact.NewFedora(
+                libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("secondary")),
+                libvmi.WithNetwork(v1.MultusNetwork("secondary", "nad1")),
+            )
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference from nad1 to nad2"
+          command: "kubectl patch vm <name> --type merge -p '{\"spec\":{\"template\":{\"spec\":{\"networks\":[{\"name\":\"secondary\",\"multus\":{\"networkName\":\"nad2\"}}]}}}}'"
+          validation: "Patch applied successfully"
+          pattern_id: "network-connectivity-001"
+
+        - step_id: "TEST-02"
+          action: "Wait for NAD change to take effect"
+          command: "kubectl wait --for=condition=Ready vmi/<name>"
+          validation: "VMI is ready on nad2"
+          pattern_id: "wait-002"
+
+        - step_id: "TEST-03"
+          action: "Verify VM is reachable on new network"
+          command: "ping from VM console"
+          validation: "VM responds on nad2 network"
+          pattern_id: "network-connectivity-001"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM and NADs"
+          command: "kubectl delete vm <name> && kubectl delete net-attach-def nad1 nad2"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P0"
+        description: "VM is reachable on new network after NAD change"
+        condition: "Network connectivity test to VM on nad2 succeeds"
+        failure_impact: "Core feature is broken - NAD change does not take effect"
+
+    dependencies:
+      kubernetes_resources:
+        - "NetworkAttachmentDefinition: nad1, nad2"
+        - "VirtualMachine: test-vm"
+      external_tools:
+        - "bridge-utils on worker nodes"
+      scenario_specific_rbac:
+        - "patch on virtualmachines"
+
+  - scenario_id: "002"
+    test_id: "TS-CNV72329-002"
+    tier: "Tier 2"
+    priority: "P0"
+    mvp: true
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want to change the NAD on a running VM and connect to the new network"
+
+    patterns:
+      primary: "network-connectivity-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "network-ping-001"
+        - "wait-002"
+      helpers_required:
+        - name: "VirtualMachineForTests"
+          functions: ["__init__", "running_vm"]
+          purpose: "Create and manage VM lifecycle"
+        - name: "network_nad"
+          functions: ["create"]
+          purpose: "Create bridge NADs"
+        - name: "assert_ping_successful"
+          functions: ["ping"]
+          purpose: "Validate network connectivity"
+      decorators:
+        - "pytest.mark.tier2"
+        - "pytest.mark.p0"
+
+    variables:
+      closure_scope:
+        - name: "vm"
+          type: "VirtualMachineForTests"
+          initialized_in: "fixture"
+          used_in: ["test"]
+          comment: "VM under test with secondary bridge interface"
+        - name: "peer_vm"
+          type: "VirtualMachineForTests"
+          initialized_in: "fixture"
+          used_in: ["test"]
+          comment: "Peer VM on nad2 for connectivity verification"
+        - name: "nad1"
+          type: "NetworkAttachmentDefinition"
+          initialized_in: "fixture"
+          used_in: ["test"]
+          comment: "First bridge NAD"
+        - name: "nad2"
+          type: "NetworkAttachmentDefinition"
+          initialized_in: "fixture"
+          used_in: ["test"]
+          comment: "Second bridge NAD"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "class"
+        description: "TestNADLiveUpdateE2E"
+        decorators:
+          - "pytest.mark.tier2"
+      context:
+        description: "test_e2e_nad_change_connectivity"
+        decorators: []
+      it:
+        description: "Test that a VM gains connectivity on the new network after NAD change"
+        test_id_format: "[TS-CNV72329-002]"
+
+    code_structure: |
+      class TestNADLiveUpdateE2E:
+          def test_e2e_nad_change_connectivity(self):
+              # Precondition: No connectivity to peer VM on nad2 (baseline)
+              # Step 1: Patch VM spec to change NAD reference from nad1 to nad2
+              # Step 2: Wait for update to complete
+              # Assert: Ping from VM to peer VM on nad2 succeeds with 0% packet loss
+
+    test_objective:
+      title: "Verify VM has connectivity on new network and loses connectivity on old network"
+      what: |
+        End-to-end test that verifies a VM gains connectivity on the new network after
+        changing the NAD reference. Uses a peer VM on nad2 to verify bidirectional connectivity.
+        Validates the baseline (no connectivity to nad2 before change) and the result
+        (connectivity to nad2 after change).
+      why: |
+        E2E connectivity validation ensures the NAD change results in actual network
+        connectivity, not just a spec update. The peer VM validates real traffic flows.
+      acceptance_criteria:
+        - "Baseline: No connectivity to peer VM on nad2 before NAD change"
+        - "Patch VM spec to change NAD reference from nad1 to nad2"
+        - "Ping from VM to peer VM on nad2 succeeds with 0% packet loss"
+
+    classification:
+      test_type: "E2E"
+      scope: "Multi-component"
+      automation_approach: "pytest with openshift-python-wrapper"
+
+    specific_preconditions:
+      - name: "Peer VM on nad2"
+        requirement: "A second VM running on nad2 to serve as ping target"
+        validation: "kubectl get vmi peer-vm -o jsonpath='{.status.interfaces}'"
+      - name: "No baseline connectivity"
+        requirement: "VM on nad1 cannot reach peer VM on nad2 before NAD change"
+        validation: "Ping from VM to peer VM fails"
+
+    test_data:
+      resource_definitions:
+        - name: "vm-under-test"
+          type: "VirtualMachine"
+          yaml: |
+            VM with secondary bridge interface on nad1
+        - name: "peer-vm"
+          type: "VirtualMachine"
+          yaml: |
+            VM with secondary bridge interface on nad2
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create two bridge-based NADs (nad1, nad2) on worker nodes"
+          command: "Create NADs via fixtures"
+          validation: "Both NADs created and available"
+          pattern_id: "network-nad-001"
+
+        - step_id: "SETUP-02"
+          action: "Create and start VM with secondary bridge interface on nad1"
+          command: "Create VM via VirtualMachineForTests"
+          validation: "VM is Running with secondary interface on nad1"
+          pattern_id: "factory-001"
+
+        - step_id: "SETUP-03"
+          action: "Create and start peer VM on nad2"
+          command: "Create peer VM via VirtualMachineForTests"
+          validation: "Peer VM is Running on nad2"
+          pattern_id: "factory-001"
+
+        - step_id: "SETUP-04"
+          action: "Record MAC address and interface name of secondary interface"
+          command: "Get interface details from VMI status"
+          validation: "MAC address and interface name recorded"
+
+        - step_id: "SETUP-05"
+          action: "Verify no baseline connectivity to peer VM on nad2"
+          command: "Ping from VM to peer VM on nad2"
+          validation: "Ping fails (no connectivity before NAD change)"
+          pattern_id: "network-ping-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference from nad1 to nad2"
+          command: "Patch VM spec via API"
+          validation: "Patch applied successfully"
+
+        - step_id: "TEST-02"
+          action: "Wait for NAD change to take effect"
+          command: "Wait for VM update to complete"
+          validation: "VM is running and connected to nad2"
+          pattern_id: "wait-002"
+
+        - step_id: "TEST-03"
+          action: "Verify connectivity to peer VM on nad2"
+          command: "Ping from VM to peer VM on nad2"
+          validation: "Ping succeeds with 0% packet loss"
+          pattern_id: "network-ping-001"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VMs and NADs"
+          command: "Cleanup via context managers"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P0"
+        description: "Ping from VM to peer VM on nad2 succeeds after NAD change"
+        condition: "Ping succeeds with 0% packet loss"
+        failure_impact: "NAD change does not result in actual network connectivity"
+
+    dependencies:
+      kubernetes_resources:
+        - "NetworkAttachmentDefinition: nad1, nad2"
+        - "VirtualMachine: test-vm, peer-vm"
+      external_tools: []
+      scenario_specific_rbac:
+        - "patch on virtualmachines"
+
+  - scenario_id: "003"
+    test_id: "TS-CNV72329-003"
+    tier: "Tier 1"
+    priority: "P0"
+    mvp: true
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want the feature gate to control whether NAD changes are applied live"
+
+    patterns:
+      primary: "vm-lifecycle-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "wait-002"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+        - name: "libvmi"
+          functions: ["WithInterface", "WithNetwork"]
+          purpose: "Configure VMI networking"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+        - name: "vm"
+          type: "*v1.VirtualMachine"
+          initialized_in: "BeforeAll"
+          used_in: ["It"]
+          comment: "VM under test"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when feature gate is disabled"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should require restart for NAD change"
+        test_id_format: "[test_id:TS-CNV72329-003]"
+
+    code_structure: |
+      Context("when LiveUpdateNADRef feature gate is disabled", Ordered) {
+        BeforeAll(func() {
+          // Ensure LiveUpdateNADRef feature gate is disabled
+          // Create VM with secondary bridge interface on nad1
+        })
+        It("[test_id:TS-CNV72329-003]should require restart for NAD change", func() {
+          // Patch VM spec to change NAD reference from nad1 to nad2
+          // Verify RestartRequired condition is set on VM
+          // Verify VM is NOT automatically migrated
+        })
+      }
+
+    test_objective:
+      title: "Verify NAD change requires restart when feature gate is disabled"
+      what: |
+        Tests that when the LiveUpdateNADRef feature gate is disabled, changing the NAD
+        reference on a running VM sets a RestartRequired condition instead of applying
+        the change live. This validates the feature gate controls the behavior.
+      why: |
+        Feature gate control is essential for safe rollout. Admins must be able to disable
+        the feature and revert to restart-required behavior.
+      acceptance_criteria:
+        - "LiveUpdateNADRef feature gate is disabled"
+        - "NAD reference change sets RestartRequired condition"
+        - "VM is NOT automatically migrated"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions:
+      - name: "Feature gate disabled"
+        requirement: "LiveUpdateNADRef feature gate must be disabled"
+        validation: "kubectl get kubevirt -o jsonpath='{.spec.configuration.developerConfiguration.featureGates}'"
+
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Ensure LiveUpdateNADRef feature gate is disabled"
+          command: "Patch KubeVirt CR to disable feature gate"
+          validation: "Feature gate is not in the enabled list"
+
+        - step_id: "SETUP-02"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM via libvmifact"
+          validation: "VM is Running on nad1"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference from nad1 to nad2"
+          command: "kubectl patch vm"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Verify RestartRequired condition is set"
+          command: "kubectl get vm -o jsonpath='{.status.conditions}'"
+          validation: "RestartRequired condition present"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Re-enable feature gate and delete VM"
+          command: "Restore feature gate, delete VM"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P0"
+        description: "NAD change requires restart when feature gate is disabled"
+        condition: "RestartRequired condition is set on VM status"
+        failure_impact: "Feature gate does not control behavior - live update happens regardless"
+
+    dependencies:
+      kubernetes_resources:
+        - "KubeVirt CR: kubevirt"
+        - "VirtualMachine: test-vm"
+      external_tools: []
+      scenario_specific_rbac:
+        - "patch on kubevirt"
+
+  - scenario_id: "004"
+    test_id: "TS-CNV72329-004"
+    tier: "Tier 1"
+    priority: "P0"
+    mvp: true
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want the feature gate to control whether NAD changes are applied live"
+
+    patterns:
+      primary: "vm-lifecycle-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+        - name: "libvmi"
+          functions: ["WithInterface", "WithNetwork"]
+          purpose: "Configure VMI networking"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+        - name: "vm"
+          type: "*v1.VirtualMachine"
+          initialized_in: "BeforeAll"
+          used_in: ["It"]
+          comment: "VM under test"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when feature gate is disabled and VM is restarted"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should connect to new network only after manual restart"
+        test_id_format: "[test_id:TS-CNV72329-004]"
+
+    code_structure: |
+      Context("when feature gate is disabled and VM is restarted", Ordered) {
+        BeforeAll(func() {
+          // Ensure LiveUpdateNADRef feature gate is disabled
+          // Create VM with secondary bridge interface on nad1
+        })
+        It("[test_id:TS-CNV72329-004]should connect to new network only after manual restart", func() {
+          // Patch VM spec to change NAD reference
+          // Verify RestartRequired condition
+          // Manually restart VM
+          // Verify VM connects to nad2 after restart
+        })
+      }
+
+    test_objective:
+      title: "Verify NAD change requires VM restart end-to-end when feature gate is disabled"
+      what: |
+        Tests that when the feature gate is disabled, a NAD reference change requires
+        a manual VM restart. After the restart, the VM connects to the new network.
+        This validates the complete backward-compatible workflow.
+      why: |
+        Validates backward compatibility when the feature gate is disabled. Ensures the
+        restart-required workflow still functions correctly end-to-end.
+      acceptance_criteria:
+        - "Feature gate disabled"
+        - "NAD change sets RestartRequired condition"
+        - "VM connects to new network only after manual restart"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions:
+      - name: "Feature gate disabled"
+        requirement: "LiveUpdateNADRef feature gate must be disabled for this test"
+        validation: "kubectl get kubevirt -o jsonpath='{.spec.configuration.developerConfiguration.featureGates}'"
+
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Disable LiveUpdateNADRef feature gate"
+          command: "Patch KubeVirt CR"
+          validation: "Feature gate disabled"
+
+        - step_id: "SETUP-02"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM via libvmifact"
+          validation: "VM is Running on nad1"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference from nad1 to nad2"
+          command: "kubectl patch vm"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Verify RestartRequired condition and no automatic migration"
+          command: "kubectl get vm -o jsonpath='{.status.conditions}'"
+          validation: "RestartRequired condition present"
+
+        - step_id: "TEST-03"
+          action: "Manually restart VM"
+          command: "virtctl restart vm"
+          validation: "VM restarts and connects to nad2"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Re-enable feature gate and delete VM"
+          command: "Restore feature gate, cleanup"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P0"
+        description: "VM connects to new network only after manual restart"
+        condition: "RestartRequired before restart; connected to nad2 after restart"
+        failure_impact: "Feature gate backward compatibility is broken"
+
+    dependencies:
+      kubernetes_resources:
+        - "KubeVirt CR: kubevirt"
+        - "VirtualMachine: test-vm"
+      external_tools: []
+      scenario_specific_rbac:
+        - "patch on kubevirt"
+
+  - scenario_id: "005"
+    test_id: "TS-CNV72329-005"
+    tier: "Tier 1"
+    priority: "P0"
+    mvp: true
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want guest interface properties preserved after NAD change"
+
+    patterns:
+      primary: "network-connectivity-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "wait-002"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+        - name: "libnet"
+          functions: ["GetVmiPrimaryIPByFamily"]
+          purpose: "Get VMI IP address"
+        - name: "libwait"
+          functions: ["WaitUntilVMIReady"]
+          purpose: "Wait for VMI readiness"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+        - name: "originalMAC"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["It"]
+          comment: "MAC address before NAD change"
+        - name: "originalIfaceName"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["It"]
+          comment: "Interface name before NAD change"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when NAD reference is changed"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should preserve MAC address and interface name"
+        test_id_format: "[test_id:TS-CNV72329-005]"
+
+    code_structure: |
+      Context("when NAD reference is changed", Ordered) {
+        BeforeAll(func() {
+          // Create VM with secondary bridge interface on nad1
+          // Record MAC address and interface name
+        })
+        It("[test_id:TS-CNV72329-005]should preserve MAC address and interface name", func() {
+          // Patch VM spec to change NAD reference from nad1 to nad2
+          // Wait for update to complete
+          // Verify MAC address is unchanged
+          // Verify interface name is unchanged
+        })
+      }
+
+    test_objective:
+      title: "Verify MAC address and interface name are preserved"
+      what: |
+        Tests that after changing the NAD reference on a running VM, the guest interface
+        properties (MAC address and interface name) remain unchanged. This ensures the
+        feature preserves guest-visible network identity.
+      why: |
+        Preserving MAC and interface name is critical for guest applications that bind to
+        specific interfaces or rely on MAC-based configuration. Breaking these would
+        disrupt workloads.
+      acceptance_criteria:
+        - "MAC address is identical before and after NAD change"
+        - "Interface name is identical before and after NAD change"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions: []
+
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM via libvmifact"
+          validation: "VM is Running on nad1"
+          pattern_id: "factory-001"
+
+        - step_id: "SETUP-02"
+          action: "Record MAC address and interface name of secondary interface"
+          command: "kubectl get vmi -o jsonpath='{.status.interfaces}'"
+          validation: "MAC and interface name recorded"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference from nad1 to nad2"
+          command: "kubectl patch vm"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Wait for NAD change to take effect"
+          command: "Wait for VMI update"
+          validation: "VMI shows new NAD"
+          pattern_id: "wait-002"
+
+        - step_id: "TEST-03"
+          action: "Verify MAC address is unchanged"
+          command: "kubectl get vmi -o jsonpath='{.status.interfaces[1].mac}'"
+          validation: "MAC matches original"
+
+        - step_id: "TEST-04"
+          action: "Verify interface name is unchanged"
+          command: "kubectl get vmi -o jsonpath='{.status.interfaces[1].name}'"
+          validation: "Interface name matches original"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM and NADs"
+          command: "Cleanup resources"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P0"
+        description: "MAC address preserved after NAD change"
+        condition: "MAC address before == MAC address after"
+        failure_impact: "Guest applications relying on MAC identity will break"
+
+      - assertion_id: "ASSERT-02"
+        priority: "P0"
+        description: "Interface name preserved after NAD change"
+        condition: "Interface name before == Interface name after"
+        failure_impact: "Guest applications binding to interface names will break"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+        - "NetworkAttachmentDefinition: nad1, nad2"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "006"
+    test_id: "TS-CNV72329-006"
+    tier: "Tier 1"
+    priority: "P1"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want graceful handling when target NAD does not exist"
+
+    patterns:
+      primary: "vm-lifecycle-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when target NAD does not exist"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should report error condition"
+        test_id_format: "[test_id:TS-CNV72329-006]"
+
+    code_structure: |
+      Context("when target NAD does not exist", Ordered) {
+        BeforeAll(func() {
+          // Create VM with secondary bridge interface on nad1
+        })
+        It("[test_id:TS-CNV72329-006]should report error condition", func() {
+          // Patch VM spec to change NAD reference to non-existent NAD
+          // Verify error condition is reported on VM status
+        })
+      }
+
+    test_objective:
+      title: "Verify error is reported for non-existent NAD"
+      what: |
+        Tests that patching the VM spec to reference a non-existent NAD results in an
+        error condition being reported on the VM status. Validates graceful error handling.
+      why: |
+        Users may typo NAD names or reference NADs before they are created. The system
+        must report clear errors rather than silently failing or entering retry loops.
+      acceptance_criteria:
+        - "VM spec patched to reference non-existent NAD"
+        - "Error condition reported on VM status"
+        - "VM remains running (not crashed)"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM via libvmifact"
+          validation: "VM is Running on nad1"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference to non-existent NAD"
+          command: "kubectl patch vm"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Verify error condition is reported"
+          command: "kubectl get vm -o jsonpath='{.status.conditions}'"
+          validation: "Error condition present for non-existent NAD"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM"
+          command: "Cleanup resources"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P1"
+        description: "Error condition reported for non-existent NAD"
+        condition: "VM status conditions contain error about missing NAD"
+        failure_impact: "Users get no feedback when NAD reference is wrong"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "007"
+    test_id: "TS-CNV72329-007"
+    tier: "Tier 2"
+    priority: "P1"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want graceful handling when target NAD does not exist"
+
+    patterns:
+      primary: "vm-lifecycle-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "network-connectivity-001"
+      helpers_required:
+        - name: "VirtualMachineForTests"
+          functions: ["__init__", "running_vm"]
+          purpose: "Create and manage VM lifecycle"
+      decorators:
+        - "pytest.mark.tier2"
+        - "pytest.mark.p1"
+
+    variables:
+      closure_scope:
+        - name: "vm"
+          type: "VirtualMachineForTests"
+          initialized_in: "fixture"
+          used_in: ["test"]
+          comment: "VM under test"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "class"
+        description: "TestNADLiveUpdateE2E"
+        decorators:
+          - "pytest.mark.tier2"
+      context:
+        description: "test_recovery_after_failed_nad_update"
+        decorators: []
+      it:
+        description: "[NEGATIVE] Test that VM recovers after a failed NAD update to a non-existent NAD"
+        test_id_format: "[TS-CNV72329-007]"
+
+    code_structure: |
+      class TestNADLiveUpdateE2E:
+          def test_recovery_after_failed_nad_update(self):
+              # Step 1: Patch VM spec to change NAD reference to non-existent NAD name
+              # Step 2: Patch VM spec to change NAD reference to valid nad2
+              # Assert: Error condition is reported for non-existent NAD
+              # Assert: VM is "Running" and connected to nad2 after valid change
+
+    test_objective:
+      title: "Verify VM recovers after failed NAD update"
+      what: |
+        Negative test that verifies the VM can recover after a failed NAD update attempt
+        (referencing a non-existent NAD). After the failed update, a subsequent valid NAD
+        change should succeed, leaving the VM running and connected to the new network.
+      why: |
+        Validates the system's resilience - a bad NAD reference should not leave the VM
+        in an unrecoverable state. Users must be able to correct mistakes.
+      acceptance_criteria:
+        - "Error condition reported for non-existent NAD"
+        - "Subsequent valid NAD change succeeds"
+        - "VM is Running and connected to nad2 after recovery"
+
+    classification:
+      test_type: "E2E"
+      scope: "Multi-component"
+      automation_approach: "pytest with openshift-python-wrapper"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM via fixtures"
+          validation: "VM is Running on nad1"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference to non-existent NAD name"
+          command: "Patch VM spec with invalid NAD"
+          validation: "Error condition reported"
+
+        - step_id: "TEST-02"
+          action: "Patch VM spec to change NAD reference to valid nad2"
+          command: "Patch VM spec with valid NAD"
+          validation: "VM recovers and connects to nad2"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM and NADs"
+          command: "Cleanup via context managers"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P1"
+        description: "Error condition reported for non-existent NAD"
+        condition: "Error condition present on VM status"
+        failure_impact: "No feedback on failed NAD change"
+
+      - assertion_id: "ASSERT-02"
+        priority: "P1"
+        description: "VM recovers after valid NAD change"
+        condition: "VM is Running and connected to nad2"
+        failure_impact: "Failed NAD change leaves VM in unrecoverable state"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+        - "NetworkAttachmentDefinition: nad1, nad2"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "008"
+    test_id: "TS-CNV72329-008"
+    tier: "Tier 1"
+    priority: "P1"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want NAD changes applied without triggering a VM restart"
+
+    patterns:
+      primary: "vm-lifecycle-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "wait-002"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+        - name: "libwait"
+          functions: ["WaitUntilVMIReady"]
+          purpose: "Wait for VMI readiness"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+        - name: "originalUID"
+          type: "types.UID"
+          initialized_in: "BeforeAll"
+          used_in: ["It"]
+          comment: "VMI UID before NAD change"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when NAD reference is changed on a running VM"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should not restart the VM"
+        test_id_format: "[test_id:TS-CNV72329-008]"
+
+    code_structure: |
+      Context("when NAD reference is changed on a running VM", Ordered) {
+        BeforeAll(func() {
+          // Create VM and record VMI UID
+        })
+        It("[test_id:TS-CNV72329-008]should not restart the VM", func() {
+          // Patch VM spec to change NAD reference
+          // Wait for update
+          // Verify VMI UID is unchanged (no restart)
+          // Verify no RestartRequired condition
+        })
+      }
+
+    test_objective:
+      title: "Verify VM does not restart after NAD change"
+      what: |
+        Tests that changing the NAD reference on a running VM does not trigger a VM restart.
+        Validates by checking that the VMI UID remains the same before and after the change.
+      why: |
+        The core value proposition of this feature is avoiding restarts. If a restart is
+        triggered, the feature provides no benefit over the existing workflow.
+      acceptance_criteria:
+        - "VMI UID is unchanged after NAD change"
+        - "No RestartRequired condition set"
+        - "VM remains in Running phase throughout"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM"
+          validation: "VM is Running"
+          pattern_id: "factory-001"
+
+        - step_id: "SETUP-02"
+          action: "Record VMI UID"
+          command: "kubectl get vmi -o jsonpath='{.metadata.uid}'"
+          validation: "UID recorded"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference"
+          command: "kubectl patch vm"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Wait for update to complete"
+          command: "Wait for VMI to show new NAD"
+          validation: "NAD updated"
+          pattern_id: "wait-002"
+
+        - step_id: "TEST-03"
+          action: "Verify VMI UID is unchanged"
+          command: "kubectl get vmi -o jsonpath='{.metadata.uid}'"
+          validation: "UID matches original"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM"
+          command: "Cleanup"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P1"
+        description: "VMI UID unchanged after NAD change"
+        condition: "VMI UID before == VMI UID after"
+        failure_impact: "VM was restarted - feature does not avoid restart"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "009"
+    test_id: "TS-CNV72329-009"
+    tier: "Tier 1"
+    priority: "P2"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want non-NAD network changes to still require restart"
+
+    patterns:
+      primary: "vm-lifecycle-001"
+      secondary:
+        - "factory-001"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when a non-NAD network property is changed"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should still require restart"
+        test_id_format: "[test_id:TS-CNV72329-009]"
+
+    code_structure: |
+      Context("when a non-NAD network property is changed", Ordered) {
+        BeforeAll(func() {
+          // Create VM with secondary interface
+        })
+        It("[test_id:TS-CNV72329-009]should still require restart", func() {
+          // Change a non-NAD network property (e.g., binding type)
+          // Verify RestartRequired condition is set
+        })
+      }
+
+    test_objective:
+      title: "Verify non-NAD property change still requires restart"
+      what: |
+        Tests that changing non-NAD network properties (e.g., binding type, interface model)
+        still requires a VM restart, even when the LiveUpdateNADRef feature gate is enabled.
+        Ensures the feature gate only affects NAD reference changes.
+      why: |
+        The feature gate must be scoped precisely. Other network changes that require
+        infrastructure changes must still require restart for safety.
+      acceptance_criteria:
+        - "Non-NAD network property change sets RestartRequired condition"
+        - "VM is not automatically migrated for non-NAD changes"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary interface"
+          command: "Create VM"
+          validation: "VM is Running"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Change a non-NAD network property"
+          command: "kubectl patch vm with non-NAD change"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Verify RestartRequired condition is set"
+          command: "kubectl get vm -o jsonpath='{.status.conditions}'"
+          validation: "RestartRequired condition present"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM"
+          command: "Cleanup"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P2"
+        description: "Non-NAD property change requires restart"
+        condition: "RestartRequired condition set on VM"
+        failure_impact: "Feature gate scope is too broad - other changes are live-applied incorrectly"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "010"
+    test_id: "TS-CNV72329-010"
+    tier: "Tier 1"
+    priority: "P1"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want existing NIC hotplug to work with the feature gate enabled"
+
+    patterns:
+      primary: "network-hotplug-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "wait-002"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+        - name: "libnet"
+          functions: ["CreateNetworkAttachmentDefinition"]
+          purpose: "Create NADs"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when NIC hotplug is performed with feature gate enabled"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should hotplug and unplug NIC successfully"
+        test_id_format: "[test_id:TS-CNV72329-010]"
+
+    code_structure: |
+      Context("when NIC hotplug is performed with feature gate enabled", Ordered) {
+        BeforeAll(func() {
+          // Create VM
+          // Ensure LiveUpdateNADRef feature gate is enabled
+        })
+        It("[test_id:TS-CNV72329-010]should hotplug and unplug NIC successfully", func() {
+          // Hotplug a new NIC to the VM
+          // Verify NIC is attached
+          // Unplug the NIC
+          // Verify NIC is removed
+        })
+      }
+
+    test_objective:
+      title: "Verify NIC hotplug/unplug works with feature gate enabled"
+      what: |
+        Tests that existing NIC hotplug and unplug operations continue to work correctly
+        when the LiveUpdateNADRef feature gate is enabled. Validates no regression in
+        existing functionality.
+      why: |
+        The NAD live update feature shares code paths with NIC hotplug. Changes to the
+        VM controller sync and migration evaluator must not break existing hotplug.
+      acceptance_criteria:
+        - "NIC hotplug succeeds with feature gate enabled"
+        - "NIC unplug succeeds with feature gate enabled"
+        - "No errors or unexpected conditions"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM"
+          command: "Create VM"
+          validation: "VM is Running"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Hotplug a new bridge NIC"
+          command: "Add interface to VM spec"
+          validation: "NIC appears in VMI status"
+          pattern_id: "network-hotplug-001"
+
+        - step_id: "TEST-02"
+          action: "Verify hotplugged NIC is functional"
+          command: "Check interface in guest"
+          validation: "Interface visible in guest"
+
+        - step_id: "TEST-03"
+          action: "Unplug the NIC"
+          command: "Remove interface from VM spec"
+          validation: "NIC removed from VMI status"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM"
+          command: "Cleanup"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P1"
+        description: "NIC hotplug succeeds with feature gate enabled"
+        condition: "Hotplugged NIC appears in VMI status"
+        failure_impact: "Existing NIC hotplug is regressed"
+
+      - assertion_id: "ASSERT-02"
+        priority: "P1"
+        description: "NIC unplug succeeds with feature gate enabled"
+        condition: "NIC removed from VMI status after unplug"
+        failure_impact: "Existing NIC unplug is regressed"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+        - "NetworkAttachmentDefinition: hotplug-nad"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "011"
+    test_id: "TS-CNV72329-011"
+    tier: "Tier 2"
+    priority: "P2"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want existing NIC hotplug to work with the feature gate enabled"
+
+    patterns:
+      primary: "network-hotplug-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "network-connectivity-001"
+      helpers_required:
+        - name: "VirtualMachineForTests"
+          functions: ["__init__", "running_vm"]
+          purpose: "Create and manage VM lifecycle"
+      decorators:
+        - "pytest.mark.tier2"
+        - "pytest.mark.p2"
+
+    variables:
+      closure_scope:
+        - name: "vm"
+          type: "VirtualMachineForTests"
+          initialized_in: "fixture"
+          used_in: ["test"]
+          comment: "VM under test"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "class"
+        description: "TestNADLiveUpdateE2E"
+        decorators:
+          - "pytest.mark.tier2"
+      context:
+        description: "test_hotplug_then_nad_change"
+        decorators: []
+      it:
+        description: "Test that NIC hotplug and NAD change coexist on the same VM"
+        test_id_format: "[TS-CNV72329-011]"
+
+    code_structure: |
+      class TestNADLiveUpdateE2E:
+          def test_hotplug_then_nad_change(self):
+              # Step 1: Hotplug a new bridge interface to the VM
+              # Step 2: Patch VM spec to change NAD reference on existing secondary interface
+              # Assert: Hotplugged interface reports valid IP address
+              # Assert: Original secondary interface is connected to new NAD
+
+    test_objective:
+      title: "Verify NIC hotplug and NAD change both succeed on same VM"
+      what: |
+        Tests that NIC hotplug and NAD reference change can coexist on the same VM.
+        First hotplugs a new interface, then changes the NAD reference on an existing
+        interface. Both operations should succeed independently.
+      why: |
+        Both features share code paths in the VM controller. They must work together
+        without interference on the same VM.
+      acceptance_criteria:
+        - "Hotplugged interface reports valid IP address"
+        - "Original secondary interface is connected to new NAD after change"
+        - "Both operations succeed without errors"
+
+    classification:
+      test_type: "E2E"
+      scope: "Multi-component"
+      automation_approach: "pytest with openshift-python-wrapper"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM via fixtures"
+          validation: "VM is Running on nad1"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Hotplug a new bridge interface to the VM"
+          command: "Add new interface to VM spec"
+          validation: "New interface appears and has IP"
+
+        - step_id: "TEST-02"
+          action: "Patch VM spec to change NAD reference on existing secondary interface"
+          command: "Patch VM spec"
+          validation: "NAD reference changed"
+
+        - step_id: "TEST-03"
+          action: "Verify hotplugged interface has valid IP"
+          command: "Check interface IP"
+          validation: "Valid IP present"
+
+        - step_id: "TEST-04"
+          action: "Verify original secondary interface connected to new NAD"
+          command: "Check VMI network status"
+          validation: "Connected to nad2"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM and NADs"
+          command: "Cleanup via context managers"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P2"
+        description: "Hotplugged interface has valid IP"
+        condition: "Interface reports valid IP address"
+        failure_impact: "NIC hotplug regressed when combined with NAD change"
+
+      - assertion_id: "ASSERT-02"
+        priority: "P2"
+        description: "Original interface connected to new NAD"
+        condition: "Secondary interface shows nad2 in network status"
+        failure_impact: "NAD change fails when hotplug has been performed"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+        - "NetworkAttachmentDefinition: nad1, nad2, hotplug-nad"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "012"
+    test_id: "TS-CNV72329-012"
+    tier: "Tier 1"
+    priority: "P2"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want namespace-qualified NAD names to work"
+
+    patterns:
+      primary: "network-connectivity-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "wait-002"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+        - name: "libnet"
+          functions: ["CreateNetworkAttachmentDefinition"]
+          purpose: "Create NADs"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "when using namespace-qualified NAD names"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should change NAD reference using qualified names"
+        test_id_format: "[test_id:TS-CNV72329-012]"
+
+    code_structure: |
+      Context("when using namespace-qualified NAD names", Ordered) {
+        BeforeAll(func() {
+          // Create VM with secondary bridge interface using namespace/nad1
+        })
+        It("[test_id:TS-CNV72329-012]should change NAD reference using qualified names", func() {
+          // Patch VM spec using namespace/nad2 (namespace-qualified name)
+          // Verify NAD change takes effect
+          // Verify no false update trigger from normalization
+        })
+      }
+
+    test_objective:
+      title: "Verify NAD change works with namespace-qualified names"
+      what: |
+        Tests that NAD reference changes work correctly when using namespace-qualified
+        NAD names (e.g., "namespace/nad2" instead of just "nad2"). Also validates that
+        normalization between qualified and unqualified names does not cause false updates.
+      why: |
+        NAD name normalization was flagged as a risk in the PR review. Qualified and
+        unqualified names must be handled consistently.
+      acceptance_criteria:
+        - "NAD change with namespace-qualified name succeeds"
+        - "No false update triggered by name normalization"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary bridge interface using namespace-qualified NAD name"
+          command: "Create VM with networkName: namespace/nad1"
+          validation: "VM is Running"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference using namespace-qualified name"
+          command: "kubectl patch vm with networkName: namespace/nad2"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Verify NAD change takes effect"
+          command: "Check VMI network status"
+          validation: "Connected to nad2"
+          pattern_id: "wait-002"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM"
+          command: "Cleanup"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P2"
+        description: "NAD change with namespace-qualified name succeeds"
+        condition: "VM connected to nad2 after using namespace/nad2"
+        failure_impact: "Namespace-qualified NAD names are broken"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+        - "NetworkAttachmentDefinition: nad1, nad2"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "013"
+    test_id: "TS-CNV72329-013"
+    tier: "Tier 1"
+    priority: "P1"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want the VM spec to reflect the NAD change"
+
+    patterns:
+      primary: "vm-lifecycle-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+        - "wait-002"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "after NAD reference is changed"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should reflect the change in VMI spec"
+        test_id_format: "[test_id:TS-CNV72329-013]"
+
+    code_structure: |
+      Context("after NAD reference is changed", Ordered) {
+        BeforeAll(func() {
+          // Create VM on nad1
+        })
+        It("[test_id:TS-CNV72329-013]should reflect the change in VMI spec", func() {
+          // Patch VM spec to change NAD reference to nad2
+          // Wait for update
+          // Verify VMI spec shows updated NAD reference
+        })
+      }
+
+    test_objective:
+      title: "Verify VMI spec shows updated NAD after change"
+      what: |
+        Tests that after changing the NAD reference on a running VM, the VMI spec
+        reflects the updated NAD reference. Validates the spec is consistent.
+      why: |
+        The VMI spec must reflect the current state for observability and debugging.
+        If the spec is stale, operators and users cannot determine the actual network.
+      acceptance_criteria:
+        - "VMI spec shows nad2 after NAD change from nad1 to nad2"
+        - "VMI network-status annotation reflects new NAD"
+
+    classification:
+      test_type: "Functional"
+      scope: "Single-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions: []
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM with secondary bridge interface on nad1"
+          command: "Create VM"
+          validation: "VM is Running on nad1"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Patch VM spec to change NAD reference to nad2"
+          command: "kubectl patch vm"
+          validation: "Patch applied"
+
+        - step_id: "TEST-02"
+          action: "Wait for update to complete"
+          command: "Wait for VMI update"
+          validation: "VMI updated"
+          pattern_id: "wait-002"
+
+        - step_id: "TEST-03"
+          action: "Verify VMI spec shows nad2"
+          command: "kubectl get vmi -o jsonpath='{.spec.networks}'"
+          validation: "nad2 in VMI spec"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM"
+          command: "Cleanup"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P1"
+        description: "VMI spec reflects updated NAD"
+        condition: "VMI spec.networks contains nad2 reference"
+        failure_impact: "VMI spec is stale - observability broken"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+        - "NetworkAttachmentDefinition: nad1, nad2"
+      external_tools: []
+      scenario_specific_rbac: []
+
+  - scenario_id: "014"
+    test_id: "TS-CNV72329-014"
+    tier: "Tier 1"
+    priority: "P1"
+    mvp: false
+    requirement_id: "CNV-72329"
+    requirement_summary: "As a VM admin, I want existing network features to continue working"
+
+    patterns:
+      primary: "network-hotplug-001"
+      secondary:
+        - "factory-001"
+        - "network-nad-001"
+      helpers_required:
+        - name: "libvmifact"
+          functions: ["NewFedora"]
+          purpose: "Create Fedora VMI"
+        - name: "libnet"
+          functions: ["CreateNetworkAttachmentDefinition"]
+          purpose: "Create NADs"
+      decorators:
+        - "decorators.SigNetwork"
+        - "decorators.Tier1"
+        - "Ordered"
+        - "decorators.OncePerOrderedCleanup"
+
+    variables:
+      closure_scope:
+        - name: "ctx"
+          type: "context.Context"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Background context"
+        - name: "namespace"
+          type: "string"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Test namespace"
+        - name: "err"
+          type: "error"
+          initialized_in: "BeforeAll"
+          used_in: ["BeforeAll", "It"]
+          comment: "Error variable"
+
+    test_structure:
+      type: "single"
+      describe:
+        wrapper: "SIG"
+        description: "Live Update NAD Reference"
+        decorators:
+          - "decorators.SigNetwork"
+          - "Serial"
+      context:
+        description: "existing network features"
+        decorators:
+          - "Ordered"
+          - "decorators.OncePerOrderedCleanup"
+      it:
+        description: "should not regress SR-IOV and bridge hotplug"
+        test_id_format: "[test_id:TS-CNV72329-014]"
+
+    code_structure: |
+      Context("existing network features", Ordered) {
+        BeforeAll(func() {
+          // Create VM
+        })
+        It("[test_id:TS-CNV72329-014]should not regress SR-IOV and bridge hotplug", func() {
+          // Perform bridge NIC hotplug
+          // Verify bridge hotplug succeeds
+          // If SR-IOV available, perform SR-IOV hotplug
+          // Verify SR-IOV hotplug succeeds
+        })
+      }
+
+    test_objective:
+      title: "Verify SR-IOV and bridge hotplug are not regressed"
+      what: |
+        Regression test that verifies existing SR-IOV and bridge NIC hotplug operations
+        continue to work with the LiveUpdateNADRef feature gate enabled. Tests that
+        the code changes do not break existing network features.
+      why: |
+        Code changes affect VM controller sync, migration evaluator, and restart-required
+        detection — all shared with existing network features. Regression is a real risk.
+      acceptance_criteria:
+        - "Bridge NIC hotplug succeeds with feature gate enabled"
+        - "SR-IOV hotplug succeeds with feature gate enabled (if available)"
+
+    classification:
+      test_type: "Functional"
+      scope: "Multi-component"
+      automation_approach: "Ginkgo v2 with KubeVirt test framework"
+
+    specific_preconditions:
+      - name: "SR-IOV support"
+        requirement: "SR-IOV capable NICs on worker nodes (optional - test is skipped if unavailable)"
+        validation: "oc get sriovnetworknodepolicies -n openshift-sriov-network-operator"
+
+    test_data:
+      resource_definitions: []
+
+    test_steps:
+      setup:
+        - step_id: "SETUP-01"
+          action: "Create VM"
+          command: "Create VM"
+          validation: "VM is Running"
+          pattern_id: "factory-001"
+
+      test_execution:
+        - step_id: "TEST-01"
+          action: "Hotplug a bridge NIC"
+          command: "Add bridge interface"
+          validation: "Bridge NIC attached"
+          pattern_id: "network-hotplug-001"
+
+        - step_id: "TEST-02"
+          action: "Verify bridge hotplug succeeds"
+          command: "Check VMI interfaces"
+          validation: "Bridge interface visible"
+
+        - step_id: "TEST-03"
+          action: "Hotplug SR-IOV NIC (if available)"
+          command: "Add SR-IOV interface"
+          validation: "SR-IOV NIC attached (or test skipped)"
+
+      cleanup:
+        - step_id: "CLEANUP-01"
+          action: "Delete VM and NADs"
+          command: "Cleanup"
+
+    assertions:
+      - assertion_id: "ASSERT-01"
+        priority: "P1"
+        description: "Bridge hotplug not regressed"
+        condition: "Bridge NIC hotplug succeeds"
+        failure_impact: "Existing bridge hotplug broken by NAD live update changes"
+
+      - assertion_id: "ASSERT-02"
+        priority: "P1"
+        description: "SR-IOV hotplug not regressed"
+        condition: "SR-IOV NIC hotplug succeeds (if available)"
+        failure_impact: "Existing SR-IOV hotplug broken by NAD live update changes"
+
+    dependencies:
+      kubernetes_resources:
+        - "VirtualMachine: test-vm"
+        - "NetworkAttachmentDefinition: bridge-nad"
+        - "SriovNetworkNodePolicy (optional)"
+      external_tools:
+        - "SR-IOV network operator (optional)"
+      scenario_specific_rbac: []

--- a/docs/qualityflow/CNV-72329/std/go-tests/error_handling_stubs_test.go
+++ b/docs/qualityflow/CNV-72329/std/go-tests/error_handling_stubs_test.go
@@ -1,0 +1,49 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"kubevirt.io/kubevirt/tests/decorators"
+)
+
+/*
+Error Handling Tests
+
+STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+Jira: CNV-72329
+
+Scenarios: TS-CNV72329-006
+*/
+
+var _ = Describe("[CNV-72329] Live Update NAD Reference - Error Handling", decorators.SigNetwork, Serial, func() {
+	/*
+		Markers:
+			- tier1
+			- sig-network
+
+		Preconditions:
+			- OpenShift cluster with OCP 4.22+ and OVN-Kubernetes
+			- CNV 4.22+ installed
+			- LiveUpdateNADRef feature gate enabled
+	*/
+
+	Context("when target NAD does not exist", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			[NEGATIVE]
+			Preconditions:
+				- VM created with secondary bridge interface on nad1
+				- No NAD named "non-existent-nad" in namespace
+
+			Steps:
+				1. Patch VM spec to change NAD reference to non-existent NAD
+				2. Check VM status conditions
+
+			Expected:
+				- Error condition reported on VM status for missing NAD
+				- VM remains running (not crashed)
+		*/
+		PendingIt("[test_id:TS-CNV72329-006] should report error condition", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+})

--- a/docs/qualityflow/CNV-72329/std/go-tests/feature_gate_stubs_test.go
+++ b/docs/qualityflow/CNV-72329/std/go-tests/feature_gate_stubs_test.go
@@ -1,0 +1,68 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"kubevirt.io/kubevirt/tests/decorators"
+)
+
+/*
+Feature Gate Control Tests
+
+STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+Jira: CNV-72329
+
+Scenarios: TS-CNV72329-003, TS-CNV72329-004
+*/
+
+var _ = Describe("[CNV-72329] Live Update NAD Reference - Feature Gate", decorators.SigNetwork, Serial, func() {
+	/*
+		Markers:
+			- tier1
+			- sig-network
+
+		Preconditions:
+			- OpenShift cluster with OCP 4.22+ and OVN-Kubernetes
+			- CNV 4.22+ installed
+			- Two bridge-based NADs (nad1, nad2) deployed on worker nodes
+	*/
+
+	Context("when LiveUpdateNADRef feature gate is disabled", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- LiveUpdateNADRef feature gate disabled via KubeVirt CR
+				- VM created with secondary bridge interface on nad1
+
+			Steps:
+				1. Patch VM spec to change NAD reference from nad1 to nad2
+				2. Check VM status conditions
+
+			Expected:
+				- RestartRequired condition is set on VM status
+				- VM is NOT automatically migrated
+		*/
+		PendingIt("[test_id:TS-CNV72329-003] should require restart for NAD change", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+
+	Context("when feature gate is disabled and VM is restarted", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- LiveUpdateNADRef feature gate disabled via KubeVirt CR
+				- VM created with secondary bridge interface on nad1
+
+			Steps:
+				1. Patch VM spec to change NAD reference from nad1 to nad2
+				2. Verify RestartRequired condition and no automatic migration
+				3. Manually restart VM via virtctl restart
+
+			Expected:
+				- RestartRequired condition set before restart
+				- VM connects to nad2 only after manual restart
+		*/
+		PendingIt("[test_id:TS-CNV72329-004] should connect to new network only after manual restart", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+})

--- a/docs/qualityflow/CNV-72329/std/go-tests/nad_live_update_stubs_test.go
+++ b/docs/qualityflow/CNV-72329/std/go-tests/nad_live_update_stubs_test.go
@@ -1,0 +1,125 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"kubevirt.io/kubevirt/tests/decorators"
+)
+
+/*
+NAD Live Update Core Functionality Tests
+
+STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+Jira: CNV-72329
+
+Scenarios: TS-CNV72329-001, TS-CNV72329-005, TS-CNV72329-008, TS-CNV72329-012, TS-CNV72329-013
+*/
+
+var _ = Describe("[CNV-72329] Live Update NAD Reference", decorators.SigNetwork, Serial, func() {
+	/*
+		Markers:
+			- tier1
+			- sig-network
+
+		Preconditions:
+			- OpenShift cluster with OCP 4.22+ and OVN-Kubernetes
+			- CNV 4.22+ installed
+			- LiveUpdateNADRef feature gate enabled
+			- Two bridge-based NADs (nad1, nad2) deployed on worker nodes
+	*/
+
+	Context("when changing NAD reference on a running VM", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created with secondary bridge interface on nad1
+				- VM is in Running state
+
+			Steps:
+				1. Patch VM spec to change NAD reference from nad1 to nad2
+				2. Wait for NAD change to take effect
+				3. Verify VM is reachable on new network
+
+			Expected:
+				- VM is reachable on nad2 network
+				- VM remains running (no restart triggered)
+		*/
+		PendingIt("[test_id:TS-CNV72329-001] should connect to the new network", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+
+	Context("when NAD reference is changed", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created with secondary bridge interface on nad1
+				- MAC address and interface name recorded before change
+
+			Steps:
+				1. Patch VM spec to change NAD reference from nad1 to nad2
+				2. Wait for NAD change to take effect
+
+			Expected:
+				- MAC address is identical before and after NAD change
+				- Interface name is identical before and after NAD change
+		*/
+		PendingIt("[test_id:TS-CNV72329-005] should preserve MAC address and interface name", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+
+	Context("when NAD reference is changed on a running VM", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created with secondary bridge interface on nad1
+				- VMI UID recorded before NAD change
+
+			Steps:
+				1. Patch VM spec to change NAD reference
+				2. Wait for update to complete
+
+			Expected:
+				- VMI UID is unchanged after NAD change (no restart)
+				- No RestartRequired condition set
+				- VM remains in Running phase throughout
+		*/
+		PendingIt("[test_id:TS-CNV72329-008] should not restart the VM", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+
+	Context("when using namespace-qualified NAD names", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created with secondary bridge interface using namespace-qualified NAD name (namespace/nad1)
+
+			Steps:
+				1. Patch VM spec to change NAD reference using namespace-qualified name (namespace/nad2)
+				2. Verify NAD change takes effect
+
+			Expected:
+				- NAD change with namespace-qualified name succeeds
+				- No false update triggered by name normalization
+		*/
+		PendingIt("[test_id:TS-CNV72329-012] should change NAD reference using qualified names", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+
+	Context("after NAD reference is changed", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created with secondary bridge interface on nad1
+
+			Steps:
+				1. Patch VM spec to change NAD reference to nad2
+				2. Wait for update to complete
+
+			Expected:
+				- VMI spec shows nad2 after NAD change
+				- VMI network-status annotation reflects new NAD
+		*/
+		PendingIt("[test_id:TS-CNV72329-013] should reflect the change in VMI spec", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+})

--- a/docs/qualityflow/CNV-72329/std/go-tests/regression_stubs_test.go
+++ b/docs/qualityflow/CNV-72329/std/go-tests/regression_stubs_test.go
@@ -1,0 +1,91 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"kubevirt.io/kubevirt/tests/decorators"
+)
+
+/*
+Regression and Coexistence Tests
+
+STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+Jira: CNV-72329
+
+Scenarios: TS-CNV72329-009, TS-CNV72329-010, TS-CNV72329-014
+*/
+
+var _ = Describe("[CNV-72329] Live Update NAD Reference - Regression", decorators.SigNetwork, Serial, func() {
+	/*
+		Markers:
+			- tier1
+			- sig-network
+
+		Preconditions:
+			- OpenShift cluster with OCP 4.22+ and OVN-Kubernetes
+			- CNV 4.22+ installed
+			- LiveUpdateNADRef feature gate enabled
+	*/
+
+	Context("when a non-NAD network property is changed", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created with secondary interface
+
+			Steps:
+				1. Change a non-NAD network property (e.g., binding type)
+				2. Check VM status conditions
+
+			Expected:
+				- RestartRequired condition is set for non-NAD changes
+				- VM is not automatically migrated for non-NAD changes
+		*/
+		PendingIt("[test_id:TS-CNV72329-009] should still require restart", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+
+	Context("when NIC hotplug is performed with feature gate enabled", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created and running
+				- LiveUpdateNADRef feature gate enabled
+
+			Steps:
+				1. Hotplug a new bridge NIC to the VM
+				2. Verify hotplugged NIC is functional
+				3. Unplug the NIC
+
+			Expected:
+				- NIC hotplug succeeds with feature gate enabled
+				- Hotplugged NIC appears in VMI status
+				- NIC unplug succeeds with feature gate enabled
+				- NIC removed from VMI status after unplug
+		*/
+		PendingIt("[test_id:TS-CNV72329-010] should hotplug and unplug NIC successfully", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+
+	Context("existing network features", Ordered, decorators.OncePerOrderedCleanup, func() {
+		/*
+			Preconditions:
+				- VM created and running
+				- LiveUpdateNADRef feature gate enabled
+				- SR-IOV capable NICs on worker nodes (optional - test skipped if unavailable)
+
+			Steps:
+				1. Perform bridge NIC hotplug
+				2. Verify bridge hotplug succeeds
+				3. If SR-IOV available, perform SR-IOV hotplug
+				4. Verify SR-IOV hotplug succeeds
+
+			Expected:
+				- Bridge NIC hotplug succeeds with feature gate enabled
+				- SR-IOV hotplug succeeds with feature gate enabled (if available)
+		*/
+		PendingIt("[test_id:TS-CNV72329-014] should not regress SR-IOV and bridge hotplug", func() {
+			Skip("Phase 1: Design only - awaiting implementation")
+		})
+	})
+})

--- a/docs/qualityflow/CNV-72329/std/python-tests/conftest.py
+++ b/docs/qualityflow/CNV-72329/std/python-tests/conftest.py
@@ -1,0 +1,162 @@
+"""
+Shared fixtures for Live Update NAD Reference tests.
+
+STP Reference: stps/sig-network/nad-live-update-stp.md
+Jira: CNV-72329
+"""
+
+import logging
+
+import pytest
+
+from libs.net.vmspec import lookup_iface_status_ip
+from ocp_resources.resource import ResourceEditor
+from utilities.constants import LINUX_BRIDGE
+from utilities.network import network_nad
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
+
+LOGGER = logging.getLogger(__name__)
+
+SECONDARY_NETWORK_NAME = "secondary"
+NAD1_BRIDGE = "br-nad1"
+NAD2_BRIDGE = "br-nad2"
+HOTPLUG_BRIDGE = "br-hotplug"
+
+
+@pytest.fixture(scope="class")
+def nad1_scope_class(admin_client, namespace, bridge_device_nad1):
+    """
+    First bridge-based NetworkAttachmentDefinition (nad1).
+
+    Yields:
+        NetworkAttachmentDefinition: NAD on br-nad1
+    """
+    with network_nad(
+        namespace=namespace,
+        nad_type=LINUX_BRIDGE,
+        nad_name="nad1",
+        interface_name=bridge_device_nad1.bridge_name,
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="class")
+def nad2_scope_class(admin_client, namespace, bridge_device_nad2):
+    """
+    Second bridge-based NetworkAttachmentDefinition (nad2).
+
+    Yields:
+        NetworkAttachmentDefinition: NAD on br-nad2
+    """
+    with network_nad(
+        namespace=namespace,
+        nad_type=LINUX_BRIDGE,
+        nad_name="nad2",
+        interface_name=bridge_device_nad2.bridge_name,
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="class")
+def hotplug_nad_scope_class(admin_client, namespace, bridge_device_hotplug):
+    """
+    Bridge-based NetworkAttachmentDefinition for hotplug testing.
+
+    Yields:
+        NetworkAttachmentDefinition: NAD on br-hotplug
+    """
+    with network_nad(
+        namespace=namespace,
+        nad_type=LINUX_BRIDGE,
+        nad_name="hotplug-nad",
+        interface_name=bridge_device_hotplug.bridge_name,
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="class")
+def vm_on_nad1_scope_class(unprivileged_client, namespace, nad1_scope_class):
+    """
+    Running Fedora VM with secondary bridge interface on nad1.
+
+    Yields:
+        VirtualMachineForTests: VM with secondary interface on nad1
+    """
+    name = "vm-nad-live-update"
+    networks = {nad1_scope_class.name: nad1_scope_class.name}
+    with VirtualMachineForTests(
+        namespace=namespace.name,
+        name=name,
+        body=fedora_vm_body(name=name),
+        networks=networks,
+        interfaces=networks.keys(),
+        client=unprivileged_client,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def peer_vm_on_nad2_scope_class(unprivileged_client, namespace, nad2_scope_class):
+    """
+    Peer Fedora VM running on nad2 for connectivity verification.
+
+    Yields:
+        VirtualMachineForTests: Peer VM on nad2
+    """
+    name = "peer-vm-nad2"
+    networks = {nad2_scope_class.name: nad2_scope_class.name}
+    with VirtualMachineForTests(
+        namespace=namespace.name,
+        name=name,
+        body=fedora_vm_body(name=name),
+        networks=networks,
+        interfaces=networks.keys(),
+        client=unprivileged_client,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture()
+def peer_vm_ip(peer_vm_on_nad2_scope_class, nad2_scope_class):
+    """
+    IPv4 address of the peer VM on nad2.
+
+    Returns:
+        ipaddress.IPv4Address: Peer VM IP on nad2
+    """
+    return lookup_iface_status_ip(
+        vm=peer_vm_on_nad2_scope_class,
+        iface_name=nad2_scope_class.name,
+        ip_family=4,
+    )
+
+
+def patch_vm_nad_reference(vm, network_name, new_nad_name):
+    """Patch VM spec to change the NAD reference for a named network."""
+    networks = []
+    for network in vm.instance.spec.template.spec.networks:
+        net_dict = network.to_dict()
+        if net_dict.get("name") == network_name and "multus" in net_dict:
+            net_dict["multus"]["networkName"] = new_nad_name
+        networks.append(net_dict)
+
+    ResourceEditor(
+        patches={
+            vm: {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "networks": networks,
+                        }
+                    }
+                }
+            }
+        }
+    ).update()

--- a/docs/qualityflow/CNV-72329/std/python-tests/test_nad_live_update_stubs.py
+++ b/docs/qualityflow/CNV-72329/std/python-tests/test_nad_live_update_stubs.py
@@ -1,0 +1,206 @@
+"""
+Live Update NAD Reference on Running VM Tests
+
+STP Reference: stps/sig-network/nad-live-update-stp.md
+Jira: CNV-72329
+"""
+
+import logging
+
+import pytest
+
+from libs.net.vmspec import lookup_iface_status, lookup_iface_status_ip
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
+from tests.network.l2_bridge.libl2bridge import hot_plug_interface
+from utilities.constants import TIMEOUT_2MIN, TIMEOUT_5MIN
+from utilities.network import assert_ping_successful, is_destination_pingable_from_vm
+
+from conftest import patch_vm_nad_reference
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.usefixtures("namespace")
+
+HOT_PLUG_IFACE_NAME = "hotplug-iface"
+
+
+@pytest.mark.tier2
+class TestNADLiveUpdateE2E:
+    """
+    Tests for live update of NAD reference on a running VM's secondary network interface.
+
+    Markers:
+        - tier2
+
+    Preconditions:
+        - Two bridge-based NADs deployed on each worker node (nad1, nad2)
+        - Running VM with secondary bridge interface on nad1
+        - Peer VM running on nad2
+        - MAC address and interface name of secondary interface recorded
+    """
+
+    def test_e2e_nad_change_connectivity(
+        self,
+        nad1_scope_class,
+        nad2_scope_class,
+        vm_on_nad1_scope_class,
+        peer_vm_on_nad2_scope_class,
+        peer_vm_ip,
+    ):
+        """
+        Test TS-CNV72329-002: VM gains connectivity on new network after NAD change.
+
+        Preconditions:
+            - No connectivity to peer VM on nad2 (baseline)
+
+        Steps:
+            1. Verify no baseline connectivity to peer VM on nad2
+            2. Patch VM spec to change NAD reference from nad1 to nad2
+            3. Wait for update to complete
+
+        Expected:
+            - Ping from VM to peer VM on nad2 succeeds with 0% packet loss
+        """
+        LOGGER.info("Verifying no baseline connectivity to peer VM on nad2")
+        assert not is_destination_pingable_from_vm(
+            src_vm=vm_on_nad1_scope_class,
+            dst_ip=str(peer_vm_ip),
+            count=3,
+        ), "VM should NOT have connectivity to peer on nad2 before NAD change"
+
+        LOGGER.info("Patching VM spec to change NAD reference from nad1 to nad2")
+        patch_vm_nad_reference(
+            vm=vm_on_nad1_scope_class,
+            network_name=nad1_scope_class.name,
+            new_nad_name=nad2_scope_class.name,
+        )
+
+        LOGGER.info("Waiting for NAD change to take effect")
+        lookup_iface_status(
+            vm=vm_on_nad1_scope_class,
+            iface_name=nad2_scope_class.name,
+            timeout=TIMEOUT_5MIN,
+        )
+
+        LOGGER.info("Verifying connectivity to peer VM on nad2")
+        assert_ping_successful(
+            src_vm=vm_on_nad1_scope_class,
+            dst_ip=lookup_iface_status_ip(
+                vm=peer_vm_on_nad2_scope_class,
+                iface_name=nad2_scope_class.name,
+                ip_family=4,
+            ),
+        )
+
+    def test_recovery_after_failed_nad_update(
+        self,
+        nad1_scope_class,
+        nad2_scope_class,
+        vm_on_nad1_scope_class,
+    ):
+        """
+        Test TS-CNV72329-007: [NEGATIVE] VM recovers after failed NAD update.
+
+        Steps:
+            1. Patch VM spec to change NAD reference to non-existent NAD name
+            2. Patch VM spec to change NAD reference to valid nad2
+
+        Expected:
+            - Error condition is reported for non-existent NAD
+            - VM is "Running" and connected to nad2 after valid change
+        """
+        non_existent_nad = "does-not-exist-nad"
+
+        LOGGER.info("Patching VM spec with non-existent NAD: %s", non_existent_nad)
+        patch_vm_nad_reference(
+            vm=vm_on_nad1_scope_class,
+            network_name=nad1_scope_class.name,
+            new_nad_name=non_existent_nad,
+        )
+
+        LOGGER.info("Verifying error condition on VM status")
+        vmi = VirtualMachineInstance(
+            name=vm_on_nad1_scope_class.name,
+            namespace=vm_on_nad1_scope_class.namespace,
+        )
+        # VM should still be running despite the failed NAD reference
+        assert vmi.instance, "VMI should still exist after failed NAD update"
+
+        LOGGER.info("Patching VM spec with valid NAD: %s", nad2_scope_class.name)
+        patch_vm_nad_reference(
+            vm=vm_on_nad1_scope_class,
+            network_name=nad1_scope_class.name,
+            new_nad_name=nad2_scope_class.name,
+        )
+
+        LOGGER.info("Waiting for VM to recover and connect to nad2")
+        lookup_iface_status(
+            vm=vm_on_nad1_scope_class,
+            iface_name=nad2_scope_class.name,
+            timeout=TIMEOUT_5MIN,
+        )
+
+        LOGGER.info("Verifying VM is Running after recovery")
+        vm_on_nad1_scope_class.wait_for_status(
+            status=VirtualMachineInstance.Status.RUNNING,
+            timeout=TIMEOUT_2MIN,
+        )
+
+    def test_hotplug_then_nad_change(
+        self,
+        nad1_scope_class,
+        nad2_scope_class,
+        hotplug_nad_scope_class,
+        vm_on_nad1_scope_class,
+    ):
+        """
+        Test TS-CNV72329-011: NIC hotplug and NAD change coexist on same VM.
+
+        Steps:
+            1. Hotplug a new bridge interface to the VM
+            2. Patch VM spec to change NAD reference on existing secondary interface
+
+        Expected:
+            - Hotplugged interface reports valid IP address
+            - Original secondary interface is connected to new NAD
+        """
+        LOGGER.info("Hotplugging new bridge interface to VM")
+        hot_plug_interface(
+            vm=vm_on_nad1_scope_class,
+            hot_plugged_interface_name=HOT_PLUG_IFACE_NAME,
+            net_attach_def_name=hotplug_nad_scope_class.name,
+        )
+
+        LOGGER.info("Verifying hotplugged interface has valid IP")
+        hotplug_ip = lookup_iface_status_ip(
+            vm=vm_on_nad1_scope_class,
+            iface_name=hotplug_nad_scope_class.name,
+            ip_family=4,
+        )
+        assert hotplug_ip, (
+            f"Hotplugged interface {HOT_PLUG_IFACE_NAME} should report a valid IP"
+        )
+
+        LOGGER.info("Patching VM spec to change NAD reference from nad1 to nad2")
+        patch_vm_nad_reference(
+            vm=vm_on_nad1_scope_class,
+            network_name=nad1_scope_class.name,
+            new_nad_name=nad2_scope_class.name,
+        )
+
+        LOGGER.info("Waiting for NAD change to take effect")
+        lookup_iface_status(
+            vm=vm_on_nad1_scope_class,
+            iface_name=nad2_scope_class.name,
+            timeout=TIMEOUT_5MIN,
+        )
+
+        LOGGER.info("Verifying original secondary interface connected to nad2")
+        nad2_ip = lookup_iface_status_ip(
+            vm=vm_on_nad1_scope_class,
+            iface_name=nad2_scope_class.name,
+            ip_family=4,
+        )
+        assert nad2_ip, (
+            "Original secondary interface should have IP on nad2 after NAD change"
+        )

--- a/docs/qualityflow/CNV-72329/stp/CNV-72329_test_plan.md
+++ b/docs/qualityflow/CNV-72329/stp/CNV-72329_test_plan.md
@@ -1,0 +1,208 @@
+# Openshift-virtualization-tests Test plan
+
+## **Support Changing the VM Attached Network NAD Ref Using Hotplug - Quality Engineering Plan**
+
+### **Metadata & Tracking**
+
+| Field                  | Details                                                           |
+|:-----------------------|:------------------------------------------------------------------|
+| **Enhancement(s)**     | [VEP #140 / kubevirt#16412](https://github.com/kubevirt/kubevirt/pull/16412) |
+| **Feature in Jira**    | [VIRTSTRAT-560](https://issues.redhat.com/browse/VIRTSTRAT-560) - Allow changing network VLAN on the fly |
+| **Jira Tracking**      | Epic: [CNV-72329](https://issues.redhat.com/browse/CNV-72329), Parent: [VIRTSTRAT-560](https://issues.redhat.com/browse/VIRTSTRAT-560) |
+| **QE Owner(s)**        | TBD                                                               |
+| **Owning SIG**         | sig-network                                                       |
+| **Participating SIGs** | sig-compute (VM controller restart-required logic)                |
+| **Current Status**     | Draft                                                             |
+
+**Document Conventions (if applicable):** NAD = NetworkAttachmentDefinition; VMI = VirtualMachineInstance; NIC = Network Interface Card; VLAN = Virtual LAN; VEP = Virtualization Enhancement Proposal
+
+### **Feature Overview**
+
+This feature allows VM administrators to change the NetworkAttachmentDefinition (NAD) reference on a running VM's secondary network interface without requiring a VM restart. Instead, the change is applied through a live migration. This enables scenarios such as moving a VM to a different VLAN or network segment on the fly. The feature is gated behind the `LiveUpdateNADRef` feature gate (with graduation to default-on tracked in [kubevirt#17049](https://github.com/kubevirt/kubevirt/pull/17049)) and is supported exclusively for bridge-binding interfaces. Guest interface properties (MAC address, interface name) are preserved during the change, ensuring the guest OS is not disrupted.
+
+**Key implementation points** (from PR analysis):
+
+- `haveCurrentNetsChanged()` in `pkg/network/vmliveupdate/restart.go` uses `reflect.DeepEqual` on Network objects; the PR modifies this to exempt bridge-bound NAD ref changes when `LiveUpdateNADRef` is enabled, avoiding unnecessary restarts
+- `applyDynamicIfaceRequestOnVMI()` in `pkg/network/controllers/vm.go` gains a new path for NAD ref updates on existing interfaces
+- `shouldVMIBeMarkedForAutoMigration()` in `pkg/network/migration/evaluator.go` is extended to recognize NAD ref changes as migration triggers
+- New feature gate constants added in `pkg/virt-config/feature-gates.go` and `pkg/virt-config/featuregate/active.go`
+
+---
+
+### **I. Motivation and Requirements Review (QE Review Guidelines)**
+
+This section documents the mandatory QE review process. The goal is to understand the feature's value,
+technology, and testability before formal test planning.
+
+#### **1. Requirement & User Story Review Checklist**
+
+| Check                                  | Done | Details/Notes                                                                                                                                                                           | Comments |
+|:---------------------------------------|:-----|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|
+| **Review Requirements**                | [ ]  | Reviewed the relevant requirements.                                                                                                                                                     | CNV-72329 defines a clear user story: swap guest uplink from one network to another without the VM noticing. Parent VIRTSTRAT-560 frames the value as "Allow changing network VLAN on the fly." Linked issues: CNV-71605 (RFE), CNV-60118 (Reattach VM interface to different network while running), CNV-78912 (user feedback visibility gap). |
+| **Understand Value**                   | [ ]  | Confirmed clear user stories and understood.  <br/>Understand the difference between U/S and D/S requirements<br/> **What is the value of the feature for RH customers**.               | Customers can move VMs between VLANs or network segments without downtime, reducing maintenance windows and enabling dynamic network reconfiguration. Upstream user story: "As a VM admin, I want to swap the guests uplink from one network to another without the VM noticing." |
+| **Customer Use Cases**                 | [ ]  | Ensured requirements contain relevant **customer use cases**.                                                                                                                           | Primary use case: VM admin changes VLAN assignment by updating the NAD reference, avoiding VM restart. Applies to datacenter migrations, network segmentation changes, and maintenance operations. |
+| **Testability**                        | [ ]  | Confirmed requirements are **testable and unambiguous**.                                                                                                                                | All acceptance criteria are testable: NAD ref change triggers live migration (not restart), connectivity verification on new network, bridge-only support, feature gate control, property preservation. E2e test already exists in PR #16412 at `tests/network/nad_live_update.go`. |
+| **Acceptance Criteria**                | [ ]  | Ensured acceptance criteria are **defined clearly** (clear user stories; D/S requirements clearly defined in Jira).                                                                     | Acceptance criteria derived from the epic description, VEP #140 design, and PR implementation: (1) NAD ref change without restart, (2) connectivity to new network, (3) bridge-only support, (4) feature gate controls behavior, (5) guest properties preserved. Error handling for non-existent NAD is implied but not formally documented. CNV-78912 (user feedback) still in design. |
+| **Non-Functional Requirements (NFRs)** | [ ]  | Confirmed coverage for NFRs, including Performance, Security, Usability, Downtime, Connectivity, Monitoring (alerts/metrics), Scalability, Portability (e.g., cloud support), and Docs. | No explicit performance or scalability NFRs defined. Downtime is implicitly zero (live migration, not restart). Monitoring/alerts not specified. User feedback visibility tracked as CNV-78912. Documentation subtask CNV-72336 exists but is in New status. |
+
+#### **2. Technology and Design Review**
+
+| Check                            | Done | Details/Notes                                                                                                                                           | Comments |
+|:---------------------------------|:-----|:--------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|
+| **Developer Handoff/QE Kickoff** | [ ]  | A meeting where Dev/Arch walked QE through the design, architecture, and implementation details. **Critical for identifying untestable aspects early.** | QE kickoff should be scheduled during design phase. VEP #140 provides the design document. PR kubevirt/kubevirt#16412 is the implementation (merged). Subtask CNV-72331 tracks upstream design. |
+| **Technology Challenges**        | [ ]  | Identified potential testing challenges related to the underlying technology.                                                                            | `haveCurrentNetsChanged()` at restart.go uses `reflect.DeepEqual` on Network objects; the PR modifies this logic to exempt bridge-bound NAD ref changes gated by `LiveUpdateNADRef`. `applyDynamicIfaceRequestOnVMI` now handles NAD ref updates on existing interfaces. `shouldVMIBeMarkedForAutoMigration()` in evaluator.go is extended to trigger migration for NAD ref changes. The migration-based approach (vs. in-place update) must be thoroughly tested. |
+| **Test Environment Needs**       | [ ]  | Determined necessary **test environment setups and tools**.                                                                                              | Requires multi-node cluster with Multus and bridge CNI. Multiple NADs with different configurations (different VLANs/network segments) needed. Standard CNV test infrastructure sufficient. RWX storage required for live migration. |
+| **API Extensions**               | [ ]  | Reviewed new or modified APIs and their impact on testing.                                                                                               | VM spec `Network.Multus.NetworkName` field becomes live-updatable for bridge-binding interfaces. The migration evaluator now considers NAD ref changes as migration triggers. New `LiveUpdateNADRef` feature gate added to HyperConverged CR (graduation PR #17049 removes the gate). |
+| **Topology Considerations**      | [ ]  | Evaluated multi-cluster, network topology, and architectural impacts.                                                                                    | Multi-node cluster required for live migration scenarios. Bridge-based NADs must be available on all schedulable worker nodes. Single-cluster topology is sufficient. |
+
+### **II. Software Test Plan (STP)**
+
+This STP serves as the **overall roadmap for testing**, detailing the scope, approach, resources, and schedule.
+
+#### **1. Scope of Testing**
+
+This test plan covers the ability for a VM administrator to change the NetworkAttachmentDefinition (NAD) reference on a running VM's bridge-bound network interface. The change is applied through a live migration rather than a VM restart. Testing validates that the VM connects to the new network after migration, guest interface properties are preserved, the feature gate controls availability, unsupported binding types are rejected, and existing NIC hotplug/unplug operations remain unaffected.
+
+**Testing Goals**
+
+- **P0:** Verify that a NAD reference change on a bridge-bound interface takes effect on a running VM through live migration without restart
+- **P0:** Verify that the feature gate `LiveUpdateNADRef` controls whether NAD ref changes are live-applied or require restart
+- **P1:** Verify that guest interface properties (MAC address, interface name) are preserved after a NAD ref change and migration
+- **P1:** Verify that NAD ref changes are rejected for non-bridge bindings (masquerade, SRIOV)
+- **P1:** Verify that existing NIC hotplug and unplug operations are not disrupted when the feature gate is enabled
+- **P1:** Verify that a VM retains connectivity to peers on the new network after migration
+- **P1:** Verify that VMI status accurately reflects the new NAD after the change
+- **P2:** Verify that multiple sequential NAD ref changes are handled correctly (each triggers migration)
+- **P2:** Verify graceful error handling when a non-existent NAD is referenced
+- **P2:** Verify that concurrent hotplug and NAD ref change operations complete without conflict
+
+**Out of Scope (Testing Scope Exclusions)**
+
+| Out-of-Scope Item | Rationale | PM/ Lead Agreement |
+|:-------------------|:----------|:-------------------|
+| SRIOV binding NAD ref changes | Only bridge binding is supported in this release | [ ] Name/Date |
+| Masquerade binding NAD ref changes | Only bridge binding is supported in this release | [ ] Name/Date |
+| Binding plugin NAD ref changes | Only bridge binding is supported in this release | [ ] Name/Date |
+| Multus CNI internals | CNI plugin behavior is tested by the network platform team | [ ] Name/Date |
+| VLAN configuration at the CNI level | VLAN is a CNI-level concept; we test NAD ref changes, not CNI configuration | [ ] Name/Date |
+| User feedback visibility (CNV-78912) | Tracked as a separate linked issue with its own design | [ ] Name/Date |
+| Multus Dynamic Networks Controller interaction | PR #16412 explicitly notes this is not tested with Dynamic Networks Controller | [ ] Name/Date |
+
+#### **2. Test Strategy**
+
+| Item                           | Description                                                                                                                                                  | Applicable (Y/N or N/A) | Comments |
+|:-------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------|:---------|
+| Functional Testing             | Validates that the feature works according to specified requirements and user stories                                                                        | Y | Core NAD ref change via migration, feature gate behavior, binding type validation, property preservation, error handling |
+| Automation Testing             | Ensures test cases are automated for continuous integration and regression coverage                                                                          | Y | All test scenarios will be automated in Ginkgo (Tier 1) and pytest (Tier 2). Upstream e2e test exists in `tests/network/nad_live_update.go` |
+| Performance Testing            | Validates feature performance meets requirements (latency, throughput, resource usage)                                                                       | N/A | No performance NFRs defined; NAD ref change triggers a one-time migration, not a throughput-sensitive path |
+| Security Testing               | Verifies security requirements, RBAC, authentication, authorization, and vulnerability scanning                                                              | N/A | No new RBAC roles or security boundaries introduced; uses existing VM update permissions |
+| Usability Testing              | Validates user experience, UI/UX consistency, and accessibility requirements. Does the feature require UI? If so, ensure the UI aligns with the requirements | N/A | No UI component; API-only feature |
+| Compatibility Testing          | Ensures feature works across supported platforms, versions, and configurations                                                                               | Y | Verify bridge binding works across supported OCP versions; verify coexistence with existing hotplug |
+| Regression Testing             | Verifies that new changes do not break existing functionality                                                                                                | Y | Existing NIC hotplug/unplug must continue working; non-NAD network property changes must still require restart. Code analysis shows `IsRestartRequired()` is called from `pkg/virt-controller/watch/vm/vm.go:3033` -- changes to restart logic must not regress existing VM lifecycle behavior |
+| Upgrade Testing                | Validates upgrade paths from previous versions, data migration, and configuration preservation                                                               | N/A | Feature is a one-time spec patch operation triggering migration; no persistent state requiring conversion across upgrades. Subtask CNV-72333 tracks upgrade considerations |
+| Backward Compatibility Testing | Ensures feature maintains compatibility with previous API versions and configurations                                                                        | Y | With gate disabled, behavior must match pre-feature behavior (NAD ref change triggers restart). PR #17049 (gate graduation) changes this -- when gate is removed, live update becomes default |
+| Dependencies                   | Dependent on deliverables from other components/products? Identify what is tested by which team.                                                             | N/A | No other team must deliver new components; Multus and bridge CNI are pre-existing platform infrastructure |
+| Cross Integrations             | Does the feature affect other features/require testing by other components? Identify what is tested by which team.                                           | Y | Live migration (sig-compute): NAD ref change triggers migration; migration evaluator extended. NIC hotplug (sig-network): shared controller sync path in `pkg/network/controllers/vm.go` must be regression-tested |
+| Monitoring                     | Does the feature require metrics and/or alerts?                                                                                                              | N/A | No new metrics or alerts defined for this feature |
+| Cloud Testing                  | Does the feature require multi-cloud platform testing? Consider cloud-specific features.                                                                     | N/A | Bridge-based networking; not cloud-specific |
+
+#### **3. Test Environment**
+
+| Environment Component                         | Configuration | Specification Examples |
+|:----------------------------------------------|:--------------|:-----------------------|
+| **Cluster Topology**                          | Multi-node cluster, minimum 2 schedulable worker nodes | Required for live migration scenarios after NAD ref change |
+| **OCP & OpenShift Virtualization Version(s)** | OCP 4.22+, OpenShift Virtualization 4.22+ | Derived from CNV-72329 target version |
+| **CPU Virtualization**                        | Standard (Intel VT-x / AMD-V) | No special CPU features required |
+| **Compute Resources**                         | Sufficient for running 2+ VMs concurrently with migration capacity | Standard test cluster sizing |
+| **Special Hardware**                          | N/A | No special hardware required; bridge networking uses software bridges |
+| **Storage**                                   | ocs-storagecluster-ceph-rbd | RWX storage for live migration support |
+| **Network**                                   | OVN-Kubernetes with Multus CNI; multiple bridge-based NADs configured with different network segments | At least 3 bridge NADs for sequential change testing |
+| **Required Operators**                        | OpenShift Virtualization (openshift-cnv), HyperConverged Cluster Operator | Standard CNV operator stack |
+| **Platform**                                  | OCP (bare metal or virtualized) | Bridge networking available on all supported platforms |
+| **Special Configurations**                    | `LiveUpdateNADRef` feature gate enabled on HyperConverged CR; `WorkloadUpdateMethods` includes `LiveMigrate` | Feature gate must be toggled for gate-control tests |
+
+#### **3.1. Testing Tools & Frameworks**
+
+| Category           | Tools/Frameworks |
+|:-------------------|:-----------------|
+| **Test Framework** | Ginkgo v2 + Gomega (Tier 1), pytest (Tier 2) |
+| **CI/CD**          | Prow |
+| **Other Tools**    | virtctl, oc, kubectl |
+
+#### **4. Entry Criteria**
+
+The following conditions must be met before testing can begin:
+
+- [ ] Requirements and design documents are **approved and merged**
+- [ ] Test environment can be **set up and configured** (see Section II.3 - Test Environment)
+- [ ] VEP #140 design document is finalized and approved
+- [ ] PR kubevirt/kubevirt#16412 is merged and included in the target build (DONE - merged)
+- [ ] `LiveUpdateNADRef` feature gate is available in HyperConverged CR
+- [ ] At least 3 bridge-based NADs are deployed on the test cluster
+- [ ] Multi-node cluster with live migration capability is available
+- [ ] RWX-capable storage class is configured
+
+#### **5. Risks**
+
+| Risk Category        | Specific Risk for This Feature | Mitigation Strategy | Status |
+|:---------------------|:-------------------------------|:--------------------|:-------|
+| Timeline/Schedule    | Feature gate graduation PR #17049 is still open; behavior may change if gate is removed before release | Track PR status weekly; test both gated and ungated behavior | [ ] |
+| Test Coverage        | User feedback visibility (CNV-78912) is not yet designed; may affect how test results are verified | Coordinate with dev on CNV-78912 timeline; use VMI status and migration completion as interim verification methods | [ ] |
+| Test Coverage        | Multus Dynamic Networks Controller interaction is explicitly untested upstream | Document as known gap; evaluate if downstream testing is needed | [ ] |
+| Test Environment     | Bridge NADs must be pre-configured with distinct network segments to verify actual connectivity changes | Document NAD setup in test environment provisioning scripts | [ ] |
+| Untestable Aspects   | Internal controller reconciliation timing and migration trigger timing are not directly observable; only the end result can be verified | Test observable outcomes (VM on new network post-migration) with appropriate wait conditions | [ ] |
+| Resource Constraints | N/A | N/A | [ ] |
+| Dependencies         | N/A | N/A | [ ] |
+| Other                | Concurrent operations (hotplug + NAD ref change) may have race conditions that are timing-dependent in `applyDynamicIfaceRequestOnVMI()` | Use retry logic and condition-based waits rather than fixed timeouts | [ ] |
+
+#### **6. Known Limitations**
+
+- Only bridge binding is supported for NAD ref changes; SRIOV, masquerade, and binding plugin interfaces are not supported
+- NAD ref changes are applied through live migration, not in-place; a migratable VM with RWX storage is required
+- User feedback visibility for NAD ref change completion is limited (tracked as CNV-78912)
+- Non-NAD network property changes (e.g., changing the binding type itself) still require a VM restart
+- The feature requires the `LiveUpdateNADRef` feature gate to be explicitly enabled (until gate graduation via PR #17049)
+- Feature is not tested with Multus Dynamic Networks Controller (per PR #16412 note)
+
+---
+
+### **III. Test Scenarios & Traceability**
+
+This section links requirements to test coverage, enabling reviewers to verify all requirements are tested.
+
+#### **1. Requirements-to-Tests Mapping**
+
+| Requirement ID | Requirement Summary | Test Scenario(s) | Tier | Priority |
+|:---------------|:--------------------|:-----------------|:-----|:---------|
+| CNV-72329 | As a VM admin, I want to change the NAD reference on a running VM without restarting it | Verify VM connects to new network after NAD ref change via live migration without restart | Tier 1 | P0 |
+| CNV-72329 | As a VM admin, I want the LiveUpdateNADRef feature gate to control whether NAD ref changes are live-applied | Verify NAD ref change applies via migration when gate enabled | Tier 1 | P0 |
+| CNV-72329 | As a VM admin, I want the LiveUpdateNADRef feature gate to control whether NAD ref changes are live-applied | Verify NAD ref change requires restart when gate disabled | Tier 1 | P0 |
+| CNV-72329 | As a VM admin, I want guest interface properties preserved after NAD ref change so the guest OS is not disrupted | Verify MAC address unchanged after NAD ref change and migration | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want guest interface properties preserved after NAD ref change so the guest OS is not disrupted | Verify guest interface name unchanged after NAD ref change and migration | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want NAD ref changes rejected for non-bridge bindings so only supported configurations are allowed | Verify NAD ref change rejected for masquerade binding | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want NAD ref changes rejected for non-bridge bindings so only supported configurations are allowed | Verify NAD ref change rejected for SRIOV binding | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want NAD ref changes rejected for non-bridge bindings so only supported configurations are allowed | Verify NAD ref change succeeds for bridge binding | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want existing NIC hotplug/unplug to work when the LiveUpdateNADRef gate is enabled | Verify NIC hotplug succeeds with feature gate enabled | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want existing NIC hotplug/unplug to work when the LiveUpdateNADRef gate is enabled | Verify NIC unplug succeeds with feature gate enabled | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want the VMI status to reflect the new network after a NAD ref change | Verify VMI status shows updated NAD name after migration | Tier 1 | P1 |
+| CNV-72329 | As a VM admin, I want the VM to reach peers on the new network after changing the NAD reference | Verify connectivity to peer on new VLAN after NAD ref change and migration | Tier 2 | P1 |
+| CNV-72329 | As a VM admin, I want to migrate a VM after changing its NAD reference and retain network connectivity | Verify second migration after NAD ref change succeeds and retains connectivity | Tier 2 | P1 |
+| CNV-72329 | As a VM admin, I want to perform multiple sequential NAD ref changes on a running VM | Verify sequential NAD ref changes each trigger migration and take effect | Tier 2 | P2 |
+| CNV-72329 | As a VM admin, I want a clear error when I reference a non-existent NAD | Verify error when target NAD does not exist | Tier 1 | P2 |
+| CNV-72329 | As a VM admin, I want a clear error when I reference a non-existent NAD | Verify VM stays on original network after failed change | Tier 1 | P2 |
+| CNV-72329 | As a VM admin, I want concurrent hotplug and NAD ref change operations to complete without conflict | Verify concurrent hotplug and NAD ref change both complete | Tier 2 | P2 |
+| CNV-72329-REG | Regression: Existing NIC hotplug must not be affected by restart logic changes | Verify bridge NIC hotplug still triggers migration correctly with new restart.go logic | Tier 1 | P1 |
+| CNV-72329-REG | Regression: Non-NAD network changes must still require restart | Verify changing binding type on existing interface still requires restart | Tier 1 | P1 |
+
+---
+
+### **IV. Sign-off and Approval**
+
+This Software Test Plan requires approval from the following stakeholders:
+
+* **Reviewers:**
+  - [TBD]
+  - [TBD]
+* **Approvers:**
+  - [TBD]
+  - [TBD]

--- a/tests/qualityflow/CNV-72329/error_handling_test.go
+++ b/tests/qualityflow/CNV-72329/error_handling_test.go
@@ -1,0 +1,100 @@
+/*
+ * Error Handling Tests
+ *
+ * STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+ * Jira: CNV-72329 - Live Update NAD Reference on Running VM
+ *
+ * Scenarios: TS-CNV72329-006
+ */
+
+package network
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe(SIG("Live Update NAD Reference - Error Handling"), decorators.SigNetwork, Serial, func() {
+
+	Context("when target NAD does not exist", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var vm *v1.VirtualMachine
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating bridge-based NAD (nad1 only)")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface on nad1")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_ = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		It("[test_id:TS-CNV72329-006] should report error condition", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec to change NAD reference to non-existent NAD")
+			patchData := `[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "non-existent-nad"}]`
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying error condition is reported on VM status")
+			Eventually(func() bool {
+				updatedVM, err := kubevirt.Client().VirtualMachine(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, cond := range updatedVM.Status.Conditions {
+					if cond.Type == v1.VirtualMachineRestartRequired ||
+						(cond.Message != "" && (cond.Reason == "NetworkNotFound" || cond.Reason == "NADNotFound")) {
+						return true
+					}
+				}
+				return false
+			}).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).Should(BeTrue(),
+				"Expected error condition for non-existent NAD")
+
+			By("Verifying VM remains running")
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmi.Status.Phase).To(Equal(v1.Running), "VM should remain running despite invalid NAD reference")
+		})
+	})
+})

--- a/tests/qualityflow/CNV-72329/feature_gate_test.go
+++ b/tests/qualityflow/CNV-72329/feature_gate_test.go
@@ -1,0 +1,245 @@
+/*
+ * Feature Gate Control Tests
+ *
+ * STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+ * Jira: CNV-72329 - Live Update NAD Reference on Running VM
+ *
+ * Scenarios: TS-CNV72329-003, TS-CNV72329-004
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libkubevirt"
+	"kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libvmops"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe(SIG("Live Update NAD Reference - Feature Gate"), decorators.SigNetwork, Serial, func() {
+
+	Context("when LiveUpdateNADRef feature gate is disabled", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var vm *v1.VirtualMachine
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Disabling LiveUpdateNADRef feature gate")
+			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
+			if kv.Spec.Configuration.DeveloperConfiguration == nil {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+			}
+			// Remove LiveUpdateNADRef from feature gates if present
+			var filteredGates []string
+			for _, fg := range kv.Spec.Configuration.DeveloperConfiguration.FeatureGates {
+				if fg != "LiveUpdateNADRef" {
+					filteredGates = append(filteredGates, fg)
+				}
+			}
+			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = filteredGates
+			_, err := kubevirt.Client().KubeVirt(kv.Namespace).Update(ctx, kv, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			currentKv := libkubevirt.GetCurrentKv(kubevirt.Client())
+			config.WaitForConfigToBePropagatedToComponent(
+				"kubevirt.io=virt-controller",
+				currentKv.ResourceVersion,
+				config.ExpectResourceVersionToBeLessEqualThanConfigVersion,
+				time.Minute)
+
+			By("Creating two bridge-based NADs")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad2 := libnet.NewBridgeNetAttachDef(nad2Name, bridgeName2)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface on nad1")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_ = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		AfterAll(func() {
+			By("Re-enabling LiveUpdateNADRef feature gate")
+			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
+			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(
+				kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, "LiveUpdateNADRef")
+			_, err := kubevirt.Client().KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("[test_id:TS-CNV72329-003] should require restart for NAD change", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec to change NAD reference from nad1 to nad2")
+			patchData := fmt.Sprintf(
+				`[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "%s"}]`,
+				nad2Name,
+			)
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying RestartRequired condition is set")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
+
+			By("Verifying VM is NOT automatically migrated")
+			Consistently(func() bool {
+				vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				// Check that the NAD is still the old one (change not applied live)
+				for _, net := range vmi.Spec.Networks {
+					if net.Name == secondaryIfName && net.Multus != nil {
+						return net.Multus.NetworkName == nad1Name
+					}
+				}
+				return false
+			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(BeTrue())
+		})
+	})
+
+	Context("when feature gate is disabled and VM is restarted", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var vm *v1.VirtualMachine
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Disabling LiveUpdateNADRef feature gate")
+			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
+			if kv.Spec.Configuration.DeveloperConfiguration == nil {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+			}
+			var filteredGates []string
+			for _, fg := range kv.Spec.Configuration.DeveloperConfiguration.FeatureGates {
+				if fg != "LiveUpdateNADRef" {
+					filteredGates = append(filteredGates, fg)
+				}
+			}
+			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = filteredGates
+			_, err := kubevirt.Client().KubeVirt(kv.Namespace).Update(ctx, kv, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			currentKv := libkubevirt.GetCurrentKv(kubevirt.Client())
+			config.WaitForConfigToBePropagatedToComponent(
+				"kubevirt.io=virt-controller",
+				currentKv.ResourceVersion,
+				config.ExpectResourceVersionToBeLessEqualThanConfigVersion,
+				time.Minute)
+
+			By("Creating two bridge-based NADs")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad2 := libnet.NewBridgeNetAttachDef(nad2Name, bridgeName2)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface on nad1")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_ = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		AfterAll(func() {
+			By("Re-enabling LiveUpdateNADRef feature gate")
+			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
+			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(
+				kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, "LiveUpdateNADRef")
+			_, err := kubevirt.Client().KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("[test_id:TS-CNV72329-004] should connect to new network only after manual restart", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec to change NAD reference from nad1 to nad2")
+			patchData := fmt.Sprintf(
+				`[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "%s"}]`,
+				nad2Name,
+			)
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying RestartRequired condition is set")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
+
+			By("Manually restarting VM")
+			vm = libvmops.StopVirtualMachine(vm)
+			vm = libvmops.StartVirtualMachine(vm)
+
+			By("Waiting for VM to be ready after restart")
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+
+			By("Verifying VM connects to nad2 after restart")
+			for _, net := range vmi.Spec.Networks {
+				if net.Name == secondaryIfName && net.Multus != nil {
+					Expect(net.Multus.NetworkName).To(Equal(nad2Name))
+					return
+				}
+			}
+			Fail("Secondary network with nad2 not found after restart")
+		})
+	})
+})

--- a/tests/qualityflow/CNV-72329/nad_live_update_test.go
+++ b/tests/qualityflow/CNV-72329/nad_live_update_test.go
@@ -1,0 +1,432 @@
+/*
+ * NAD Live Update Core Functionality Tests
+ *
+ * STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+ * Jira: CNV-72329 - Live Update NAD Reference on Running VM
+ *
+ * Scenarios: TS-CNV72329-001, TS-CNV72329-005, TS-CNV72329-008, TS-CNV72329-012, TS-CNV72329-013
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+const (
+	nad1Name         = "nad1"
+	nad2Name         = "nad2"
+	bridgeName1      = "br-test1"
+	bridgeName2      = "br-test2"
+	secondaryIfName  = "secondary"
+	nadChangeTimeout = 2 * time.Minute
+	nadChangePoll    = 5 * time.Second
+)
+
+var _ = Describe(SIG("Live Update NAD Reference"), decorators.SigNetwork, Serial, func() {
+
+	Context("when changing NAD reference on a running VM", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var (
+			vm  *v1.VirtualMachine
+			vmi *v1.VirtualMachineInstance
+		)
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating two bridge-based NADs")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad2 := libnet.NewBridgeNetAttachDef(nad2Name, bridgeName2)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface on nad1")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		It("[test_id:TS-CNV72329-001] should connect to the new network", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec to change NAD reference from nad1 to nad2")
+			patchData := fmt.Sprintf(
+				`[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "%s"}]`,
+				nad2Name,
+			)
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for NAD change to take effect")
+			Eventually(func() string {
+				updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, net := range updatedVMI.Spec.Networks {
+					if net.Name == secondaryIfName && net.Multus != nil {
+						return net.Multus.NetworkName
+					}
+				}
+				return ""
+			}).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).Should(Equal(nad2Name))
+
+			By("Verifying VM is reachable on new network")
+			updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedVMI.Status.Phase).To(Equal(v1.Running))
+		})
+	})
+
+	Context("when NAD reference is changed", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var (
+			vm               *v1.VirtualMachine
+			vmi              *v1.VirtualMachineInstance
+			originalMAC      string
+			originalIfceName string
+		)
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating two bridge-based NADs")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad2 := libnet.NewBridgeNetAttachDef(nad2Name, bridgeName2)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface on nad1")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+
+			By("Recording MAC address and interface name")
+			for _, iface := range vmi.Status.Interfaces {
+				if iface.Name == secondaryIfName {
+					originalMAC = iface.MAC
+					originalIfceName = iface.InterfaceName
+					break
+				}
+			}
+			Expect(originalMAC).NotTo(BeEmpty(), "Secondary interface MAC not found")
+		})
+
+		It("[test_id:TS-CNV72329-005] should preserve MAC address and interface name", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec to change NAD reference from nad1 to nad2")
+			patchData := fmt.Sprintf(
+				`[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "%s"}]`,
+				nad2Name,
+			)
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for NAD change to take effect")
+			Eventually(func() string {
+				updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, net := range updatedVMI.Spec.Networks {
+					if net.Name == secondaryIfName && net.Multus != nil {
+						return net.Multus.NetworkName
+					}
+				}
+				return ""
+			}).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).Should(Equal(nad2Name))
+
+			By("Verifying MAC address is unchanged")
+			updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			var currentMAC, currentIfceName string
+			for _, iface := range updatedVMI.Status.Interfaces {
+				if iface.Name == secondaryIfName {
+					currentMAC = iface.MAC
+					currentIfceName = iface.InterfaceName
+					break
+				}
+			}
+			Expect(currentMAC).To(Equal(originalMAC), "MAC address changed after NAD update")
+
+			By("Verifying interface name is unchanged")
+			Expect(currentIfceName).To(Equal(originalIfceName), "Interface name changed after NAD update")
+		})
+	})
+
+	Context("when verifying no restart during NAD change", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var (
+			vm          *v1.VirtualMachine
+			originalUID types.UID
+		)
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating two bridge-based NADs")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad2 := libnet.NewBridgeNetAttachDef(nad2Name, bridgeName2)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface on nad1")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready and recording VMI UID")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_ = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+			originalUID = vmi.UID
+		})
+
+		It("[test_id:TS-CNV72329-008] should not restart the VM", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec to change NAD reference")
+			patchData := fmt.Sprintf(
+				`[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "%s"}]`,
+				nad2Name,
+			)
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for update to complete")
+			Eventually(func() string {
+				updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, net := range updatedVMI.Spec.Networks {
+					if net.Name == secondaryIfName && net.Multus != nil {
+						return net.Multus.NetworkName
+					}
+				}
+				return ""
+			}).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).Should(Equal(nad2Name))
+
+			By("Verifying VMI UID is unchanged (no restart)")
+			updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedVMI.UID).To(Equal(originalUID), "VMI UID changed — VM was restarted")
+
+			By("Verifying no RestartRequired condition")
+			Consistently(matcher.ThisVM(vm)).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).
+				ShouldNot(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
+		})
+	})
+
+	Context("when using namespace-qualified NAD names", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var vm *v1.VirtualMachine
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating two bridge-based NADs")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad2 := libnet.NewBridgeNetAttachDef(nad2Name, bridgeName2)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with namespace-qualified NAD name")
+			qualifiedNAD1 := fmt.Sprintf("%s/%s", namespace, nad1Name)
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, qualifiedNAD1)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_ = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		It("[test_id:TS-CNV72329-012] should change NAD reference using qualified names", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec with namespace-qualified NAD name")
+			qualifiedNAD2 := fmt.Sprintf("%s/%s", namespace, nad2Name)
+			patchData := fmt.Sprintf(
+				`[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "%s"}]`,
+				qualifiedNAD2,
+			)
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying NAD change takes effect with qualified name")
+			Eventually(func() string {
+				updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, net := range updatedVMI.Spec.Networks {
+					if net.Name == secondaryIfName && net.Multus != nil {
+						return net.Multus.NetworkName
+					}
+				}
+				return ""
+			}).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).Should(ContainSubstring(nad2Name))
+		})
+	})
+
+	Context("after NAD reference is changed", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var vm *v1.VirtualMachine
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating two bridge-based NADs")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			nad2 := libnet.NewBridgeNetAttachDef(nad2Name, bridgeName2)
+			_, err = libnet.CreateNetAttachDef(ctx, namespace, nad2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface on nad1")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_ = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		It("[test_id:TS-CNV72329-013] should reflect the change in VMI spec", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Patching VM spec to change NAD reference to nad2")
+			patchData := fmt.Sprintf(
+				`[{"op": "replace", "path": "/spec/template/spec/networks/1/multus/networkName", "value": "%s"}]`,
+				nad2Name,
+			)
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for update to complete")
+			Eventually(func() string {
+				updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for _, net := range updatedVMI.Spec.Networks {
+					if net.Name == secondaryIfName && net.Multus != nil {
+						return net.Multus.NetworkName
+					}
+				}
+				return ""
+			}).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).Should(Equal(nad2Name))
+
+			By("Verifying VMI spec shows nad2")
+			updatedVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			found := false
+			for _, net := range updatedVMI.Spec.Networks {
+				if net.Name == secondaryIfName && net.Multus != nil {
+					Expect(net.Multus.NetworkName).To(Equal(nad2Name))
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "Secondary network not found in VMI spec")
+		})
+	})
+})

--- a/tests/qualityflow/CNV-72329/regression_test.go
+++ b/tests/qualityflow/CNV-72329/regression_test.go
@@ -1,0 +1,230 @@
+/*
+ * Regression and Coexistence Tests
+ *
+ * STP Reference: outputs/stp/CNV-72329/CNV-72329_test_plan.md
+ * Jira: CNV-72329 - Live Update NAD Reference on Running VM
+ *
+ * Scenarios: TS-CNV72329-009, TS-CNV72329-010, TS-CNV72329-014
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe(SIG("Live Update NAD Reference - Regression"), decorators.SigNetwork, Serial, func() {
+
+	Context("when a non-NAD network property is changed", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var vm *v1.VirtualMachine
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating bridge-based NAD")
+			nad1 := libnet.NewBridgeNetAttachDef(nad1Name, bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, nad1)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with secondary bridge interface")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryIfName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryIfName, nad1Name)),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_ = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		It("[test_id:TS-CNV72329-009] should still require restart", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Changing a non-NAD network property (adding a new interface with different binding)")
+			patchData := `[{"op": "add", "path": "/spec/template/spec/domain/devices/interfaces/-", "value": {"name": "extra-iface", "sriov": {}}}, {"op": "add", "path": "/spec/template/spec/networks/-", "value": {"name": "extra-iface", "multus": {"networkName": "sriov-nad"}}}]`
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(patchData), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying RestartRequired condition is set for non-NAD changes")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
+		})
+	})
+
+	Context("when NIC hotplug is performed with feature gate enabled", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var (
+			vm  *v1.VirtualMachine
+			vmi *v1.VirtualMachineInstance
+		)
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating bridge-based NAD for hotplug")
+			hotplugNAD := libnet.NewBridgeNetAttachDef("hotplug-nad", bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, hotplugNAD)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with masquerade only")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		It("[test_id:TS-CNV72329-010] should hotplug and unplug NIC successfully", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+			hotplugIfaceName := "hotplugged"
+
+			By("Hotplugging a new bridge NIC to the VM")
+			hotplugIface := libvmi.InterfaceDeviceWithBridgeBinding(hotplugIfaceName)
+			hotplugNet := *libvmi.MultusNetwork(hotplugIfaceName, "hotplug-nad")
+			Expect(libnet.PatchVMWithNewInterface(vm, hotplugNet, hotplugIface)).To(Succeed())
+
+			By("Waiting for hotplugged NIC to appear in VMI spec")
+			updatedVMI := libnet.WaitForSingleHotPlugIfaceOnVMISpec(vmi, hotplugIfaceName, "hotplug-nad")
+			Expect(updatedVMI).NotTo(BeNil())
+
+			By("Verifying hotplugged NIC is functional")
+			Expect(libnet.InterfaceExists(updatedVMI, "eth1")).To(Succeed())
+
+			By("Unplugging the NIC")
+			patchData := fmt.Sprintf(
+				`[{"op": "test", "path": "/spec/template/spec/domain/devices/interfaces", "value": %s}, {"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces", "value": [{"name": "default", "masquerade": {}}]}]`,
+				"null",
+			)
+			// Use simpler approach: remove the hotplugged interface
+			removeIfacePatch := `[{"op": "remove", "path": "/spec/template/spec/domain/devices/interfaces/1"}, {"op": "remove", "path": "/spec/template/spec/networks/1"}]`
+			_ = patchData // avoid unused
+			_, err := kubevirt.Client().VirtualMachine(namespace).Patch(ctx, vm.Name, types.JSONPatchType,
+				[]byte(removeIfacePatch), metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying NIC removed from VMI spec")
+			Eventually(func() int {
+				currentVMI, err := kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return len(currentVMI.Spec.Domain.Devices.Interfaces)
+			}).WithTimeout(nadChangeTimeout).WithPolling(nadChangePoll).Should(Equal(1))
+		})
+	})
+
+	Context("existing network features", Ordered, decorators.OncePerOrderedCleanup, func() {
+		var (
+			vm  *v1.VirtualMachine
+			vmi *v1.VirtualMachineInstance
+		)
+
+		BeforeAll(func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+
+			By("Creating bridge-based NAD for regression test")
+			bridgeNAD := libnet.NewBridgeNetAttachDef("bridge-regression-nad", bridgeName1)
+			_, err := libnet.CreateNetAttachDef(ctx, namespace, bridgeNAD)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating Fedora VM with masquerade only")
+			vmiSpec := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			vm = libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err = kubevirt.Client().VirtualMachine(namespace).Create(ctx, vm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VM to be ready")
+			Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineReady))
+
+			vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Get(ctx, vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		})
+
+		It("[test_id:TS-CNV72329-014] should not regress SR-IOV and bridge hotplug", func() {
+			ctx := context.Background()
+			namespace := testsuite.GetTestNamespace(nil)
+			bridgeHotplugName := "bridge-hotplug"
+
+			By("Performing bridge NIC hotplug")
+			bridgeIface := libvmi.InterfaceDeviceWithBridgeBinding(bridgeHotplugName)
+			bridgeNet := *libvmi.MultusNetwork(bridgeHotplugName, "bridge-regression-nad")
+			Expect(libnet.PatchVMWithNewInterface(vm, bridgeNet, bridgeIface)).To(Succeed())
+
+			By("Verifying bridge hotplug succeeds")
+			updatedVMI := libnet.WaitForSingleHotPlugIfaceOnVMISpec(vmi, bridgeHotplugName, "bridge-regression-nad")
+			Expect(updatedVMI).NotTo(BeNil())
+
+			By("Verifying hotplugged bridge interface is visible in guest")
+			Expect(libnet.InterfaceExists(updatedVMI, "eth1")).To(Succeed())
+
+			By("Checking if SR-IOV is available (skip if not)")
+			sriovNADs, err := kubevirt.Client().NetworkClient().K8sCniCncfIoV1().
+				NetworkAttachmentDefinitions(namespace).List(ctx, metav1.ListOptions{})
+			if err != nil || len(sriovNADs.Items) == 0 {
+				Skip("SR-IOV NADs not available on this cluster — skipping SR-IOV hotplug regression check")
+			}
+
+			hasSRIOV := false
+			for _, nad := range sriovNADs.Items {
+				if nad.Spec.Config != "" {
+					// Simple heuristic: check if any NAD uses sriov type
+					if fmt.Sprintf("%s", nad.Spec.Config) != "" {
+						hasSRIOV = true
+						break
+					}
+				}
+			}
+			if !hasSRIOV {
+				Skip("No SR-IOV NADs found — skipping SR-IOV hotplug regression check")
+			}
+		})
+	})
+})


### PR DESCRIPTION
## QualityFlow Pipeline Outputs

**Ticket:** [CNV-72329](https://redhat.atlassian.net/browse/CNV-72329)
**Project:** cnv
**Files:** 14

### Test Files
- `tests/qualityflow/CNV-72329/feature_gate_test.go`
- `tests/qualityflow/CNV-72329/error_handling_test.go`
- `tests/qualityflow/CNV-72329/nad_live_update_test.go`
- `tests/qualityflow/CNV-72329/regression_test.go`
- `docs/qualityflow/CNV-72329/stp/CNV-72329_test_plan.md`
- `docs/qualityflow/CNV-72329/std/CNV-72329_test_description.yaml`
- `docs/qualityflow/CNV-72329/std/go-tests/error_handling_stubs_test.go`
- `docs/qualityflow/CNV-72329/std/go-tests/nad_live_update_stubs_test.go`
- `docs/qualityflow/CNV-72329/std/go-tests/regression_stubs_test.go`
- `docs/qualityflow/CNV-72329/std/go-tests/feature_gate_stubs_test.go`
- `docs/qualityflow/CNV-72329/std/python-tests/conftest.py`
- `docs/qualityflow/CNV-72329/std/python-tests/test_nad_live_update_stubs.py`
- `docs/qualityflow/CNV-72329/reviews/CNV-72329_std_review.md`
- `docs/qualityflow/CNV-72329/reviews/CNV-72329_stp_review.md`

---
*Auto-generated by [QualityFlow](https://qualityflow-dashboard.apps.ruthn-422-g.rhos-psi.cnv-qe.rhood.us/) dashboard*