### PR TITLE
virt-operator: use domain-qualified KubeVirt CR finalizer

### DIFF
--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -1059,7 +1059,7 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 	}
 
 	// add finalizer to prevent deletion of CR before KubeVirt was undeployed
-	util.AddFinalizer(kv)
+	util.SetFinalizer(kv)
 
 	//  delete old install strategies to ensure a clean re-creation
 	err = c.deleteAllOldInstallStrategies(config.GetKubeVirtVersion())
@@ -1196,7 +1196,7 @@ func (c *KubeVirtController) syncDeletion(kv *v1.KubeVirt) error {
 		kv.Status.Phase = v1.KubeVirtPhaseDeleted
 
 		// remove finalizer
-		kv.Finalizers = nil
+		util.UnsetFinalizer(kv)
 
 		logger.Info("KubeVirt deleted")
 

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2676,6 +2676,42 @@ var _ = Describe("KubeVirt Operator", func() {
 
 		})
 
+		It("should replace deprecated finalizer with domain-qualified one on reconcile", func() {
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Finalizers: []string{"foregroundDeleteKubeVirt"},
+				},
+			}
+			enableTemplateFeatureGate(kv)
+			enableContainerPathVolumesFeatureGate(kv)
+			kubecontroller.SetLatestApiVersionAnnotation(kv)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+
+			job, err := kvTestData.controller.generateInstallStrategyJob(kv.Spec.Infra, util.GetTargetConfigFromKV(kv))
+			Expect(err).ToNot(HaveOccurred())
+
+			job.Status.CompletionTime = now()
+			kvTestData.addInstallStrategyJob(job)
+
+			kvTestData.deleteFromCache = false
+			kvTestData.shouldExpectJobDeletion()
+			kvTestData.shouldExpectKubeVirtFinalizersPatch(1)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectCreations()
+
+			kvTestData.controller.Execute()
+
+			kv = kvTestData.getLatestKubeVirt(kv)
+			Expect(kv.ObjectMeta.Finalizers).To(ConsistOf(util.KubeVirtFinalizer))
+		})
+
 		It("should pause rollback until api server is rolled over.", func() {
 			defer GinkgoRecover()
 

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -173,19 +173,22 @@ func SetConditionTimestamps(kvOrig *virtv1.KubeVirt, kvUpdated *virtv1.KubeVirt)
 	}
 }
 
-func AddFinalizer(kv *virtv1.KubeVirt) {
-	if !hasFinalizer(kv) {
-		kv.Finalizers = append(kv.Finalizers, KubeVirtFinalizer)
-	}
+func SetFinalizer(kv *virtv1.KubeVirt) {
+	kv.Finalizers = append(withoutKubeVirtFinalizers(kv.Finalizers), KubeVirtFinalizer)
 }
 
-func hasFinalizer(kv *virtv1.KubeVirt) bool {
-	for _, f := range kv.GetFinalizers() {
-		if f == KubeVirtFinalizer {
-			return true
+func UnsetFinalizer(kv *virtv1.KubeVirt) {
+	kv.Finalizers = withoutKubeVirtFinalizers(kv.Finalizers)
+}
+
+func withoutKubeVirtFinalizers(finalizers []string) []string {
+	var result []string
+	for _, f := range finalizers {
+		if f != KubeVirtFinalizer {
+			result = append(result, f)
 		}
 	}
-	return false
+	return result
 }
 
 func SetOperatorVersion(kv *virtv1.KubeVirt) {

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -36,7 +36,10 @@ import (
 )
 
 const (
-	KubeVirtFinalizer string = "foregroundDeleteKubeVirt"
+	KubeVirtFinalizer string = "kubevirt.io/foregroundDeleteKubeVirt"
+	// TODO drop the code handling the deprecated finalizer after release
+	// of kubevirt-1.11
+	deprecatedKubeVirtFinalizer string = "foregroundDeleteKubeVirt"
 
 	ConditionReasonDeploymentFailedExisting = "ExistingDeployment"
 	ConditionReasonDeploymentFailedError    = "DeploymentFailed"
@@ -184,7 +187,7 @@ func UnsetFinalizer(kv *virtv1.KubeVirt) {
 func withoutKubeVirtFinalizers(finalizers []string) []string {
 	var result []string
 	for _, f := range finalizers {
-		if f != KubeVirtFinalizer {
+		if f != KubeVirtFinalizer && f != deprecatedKubeVirtFinalizer {
 			result = append(result, f)
 		}
 	}

--- a/pkg/virt-operator/util/client_test.go
+++ b/pkg/virt-operator/util/client_test.go
@@ -118,17 +118,31 @@ var _ = Describe("Operator Client", func() {
 		Describe("Adding a finalizer", func() {
 			Context("When another one already exists", func() {
 				It("Should add it", func() {
-					AddFinalizer(kv)
+					SetFinalizer(kv)
 					Expect(kv.Finalizers).To(HaveLen(2), "should have 2 finalizers")
 					Expect(kv.Finalizers[0]).To(Equal("oldFinalizer"), "should keep first old finalizer")
 					Expect(kv.Finalizers[1]).To(Equal(KubeVirtFinalizer), "should add new finalizer")
 				})
 				It("Should not add it again", func() {
-					AddFinalizer(kv)
+					SetFinalizer(kv)
+					SetFinalizer(kv)
 					Expect(kv.Finalizers).To(HaveLen(2), "should still have 2 finalizers")
 					Expect(kv.Finalizers[0]).To(Equal("oldFinalizer"), "should keep first old finalizer")
 					Expect(kv.Finalizers[1]).To(Equal(KubeVirtFinalizer), "should keep second old finalizer")
 				})
+			})
+		})
+
+		Describe("UnsetFinalizer", func() {
+			It("Should remove the current finalizer", func() {
+				kv.Finalizers = []string{KubeVirtFinalizer}
+				UnsetFinalizer(kv)
+				Expect(kv.Finalizers).To(BeEmpty())
+			})
+			It("Should preserve finalizers from other controllers should they exist", func() {
+				kv.Finalizers = []string{"otherFinalizer", KubeVirtFinalizer}
+				UnsetFinalizer(kv)
+				Expect(kv.Finalizers).To(ConsistOf("otherFinalizer"))
 			})
 		})
 

--- a/pkg/virt-operator/util/client_test.go
+++ b/pkg/virt-operator/util/client_test.go
@@ -130,12 +130,22 @@ var _ = Describe("Operator Client", func() {
 					Expect(kv.Finalizers[0]).To(Equal("oldFinalizer"), "should keep first old finalizer")
 					Expect(kv.Finalizers[1]).To(Equal(KubeVirtFinalizer), "should keep second old finalizer")
 				})
+				It("Should replace the deprecated finalizer on upgrade", func() {
+					kv.Finalizers = []string{deprecatedKubeVirtFinalizer}
+					SetFinalizer(kv)
+					Expect(kv.Finalizers).To(ConsistOf(KubeVirtFinalizer))
+				})
 			})
 		})
 
 		Describe("UnsetFinalizer", func() {
 			It("Should remove the current finalizer", func() {
 				kv.Finalizers = []string{KubeVirtFinalizer}
+				UnsetFinalizer(kv)
+				Expect(kv.Finalizers).To(BeEmpty())
+			})
+			It("Should remove the deprecated finalizer", func() {
+				kv.Finalizers = []string{deprecatedKubeVirtFinalizer}
 				UnsetFinalizer(kv)
 				Expect(kv.Finalizers).To(BeEmpty())
 			})


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The KubeVirt CR carried the finalizer `foregroundDeleteKubeVirt`, a bare
name that triggers the following API server warning:

```
metadata.finalizers: "foregroundDeleteKubeVirt": prefer a domain-qualified finalizer name to avoid accidental conflicts with other finalizer writers
```

#### After this PR:

The finalizer is named `kubevirt.io/foregroundDeleteKubeVirt`.

### References

- Fixes #12342

### Why we need it and why it was done in this way

The constant `KubeVirtFinalizer` is renamed to a domain-qualified form.  The 
`deprecatedKubeVirtFinalizer` constant is kept for the upgrade transition: a 
cluster upgraded from a previous release will have a KubeVirt CR carrying the 
old bare string, which would be replaced by the first reconcile. 
 
`AddFinalizer`/`hasFinalizer` are replaced with `SetFinalizer`/ 
`UnsetFinalizer`, backed by a `withoutKubeVirtFinalizers` helper that 
strips both the old and new strings. This code is simpler than alternatives 
and has the benefit of making the deletion path more careful. Previously it set 
`kv.Finalizers = nil`, wiping all finalizers indiscriminately. `UnsetFinalizer` 
replaces that with a surgical removal of only the kubevirt-owned finalizers, 
preserving any finalizers may have been set by foreign controllers. 

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```