### PR TITLE
tests: enhance failure messages in storage test files (3)

### DIFF
--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -84,17 +84,17 @@ var _ = Describe(SIG("Memory dump", func() {
 		By("Creating VirtualMachine")
 		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine %s", vm.Name)
 		Eventually(func() bool {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
 				return false
 			}
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VMI %s/%s", vm.Namespace, vm.Name)
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VirtualMachine %s/%s", vm.Namespace, vm.Name)
 			return vm.Status.Ready && vmi.Status.Phase == v1.Running
-		}, 180*time.Second, time.Second).Should(BeTrue())
+		}, 180*time.Second, time.Second).Should(BeTrue(), "VM %s did not become ready and running in time", vm.Name)
 
 		return vm
 	}
@@ -149,7 +149,7 @@ var _ = Describe(SIG("Memory dump", func() {
 			}
 
 			if updatedVM.Status.MemoryDumpRequest.Phase != v1.MemoryDumpCompleted {
-				return fmt.Errorf(fmt.Sprintf(waitMemoryDumpCompletion, updatedVM.Status.MemoryDumpRequest.Phase))
+				return fmt.Errorf(waitMemoryDumpCompletion, updatedVM.Status.MemoryDumpRequest.Phase)
 			}
 
 			foundPvc := false
@@ -168,8 +168,8 @@ var _ = Describe(SIG("Memory dump", func() {
 			if err != nil {
 				return err
 			}
-			Expect(pvc.GetAnnotations()).ToNot(BeNil())
-			Expect(pvc.Annotations[v1.PVCMemoryDumpAnnotation]).To(Equal(*updatedVM.Status.MemoryDumpRequest.FileName))
+			Expect(pvc.GetAnnotations()).ToNot(BeNil(), "PVC %s/%s should have annotations set", pvc.Namespace, pvc.Name)
+			Expect(pvc.Annotations[v1.PVCMemoryDumpAnnotation]).To(Equal(*updatedVM.Status.MemoryDumpRequest.FileName), "PVC %s memory dump annotation should match the dump file name", pvc.Name)
 
 			return nil
 		}, 90*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
@@ -212,7 +212,7 @@ var _ = Describe(SIG("Memory dump", func() {
 		)
 		lsOutput = strings.TrimSpace(lsOutput)
 		log.Log.Infof("%s", lsOutput)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to list files in memory dump PVC %s", memoryDumpPVC.Name)
 		wcOutput, err := exec.ExecuteCommandOnPod(
 			executorPod,
 			executorPod.Spec.Containers[0].Name,
@@ -220,19 +220,19 @@ var _ = Describe(SIG("Memory dump", func() {
 		)
 		wcOutput = strings.TrimSpace(wcOutput)
 		log.Log.Infof("%s", wcOutput)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to count files in memory dump PVC %s", memoryDumpPVC.Name)
 
-		Expect(strings.Contains(lsOutput, "memory.dump")).To(BeTrue())
+		Expect(strings.Contains(lsOutput, "memory.dump")).To(BeTrue(), "expected 'memory.dump' file in PVC %s, got: %s", memoryDumpPVC.Name, lsOutput)
 		// Could be that a 'lost+found' directory is in it, check if the
 		// response is more then 1 then it is only 2 with `lost+found` directory
 		if strings.Compare("1", wcOutput) != 0 {
-			Expect(wcOutput).To(Equal("2"))
-			Expect(strings.Contains(lsOutput, "lost+found")).To(BeTrue())
+			Expect(wcOutput).To(Equal("2"), "expected at most 2 files in PVC %s (memory.dump + lost+found), got: %s", memoryDumpPVC.Name, wcOutput)
+			Expect(strings.Contains(lsOutput, "lost+found")).To(BeTrue(), "expected 'lost+found' directory in PVC %s when file count is 2, got: %s", memoryDumpPVC.Name, lsOutput)
 		}
 		if previousOutput != "" && shouldEqual {
-			Expect(lsOutput).To(Equal(previousOutput))
+			Expect(lsOutput).To(Equal(previousOutput), "expected PVC %s contents to remain unchanged after memory dump", memoryDumpPVC.Name)
 		} else {
-			Expect(lsOutput).ToNot(Equal(previousOutput))
+			Expect(lsOutput).ToNot(Equal(previousOutput), "expected PVC %s contents to change after new memory dump", memoryDumpPVC.Name)
 		}
 
 		deletePod(executorPod)
@@ -263,7 +263,7 @@ var _ = Describe(SIG("Memory dump", func() {
 		waitAndVerifyMemoryDumpCompletion(vm, pvcName)
 		verifyMemoryDumpNotOnVMI(vm, pvcName)
 		pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.NamespaceTestDefault).Get(context.Background(), pvcName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get memory dump PVC %s", pvcName)
 
 		return verifyMemoryDumpOutput(pvc, previousOutput, false)
 	}
@@ -273,7 +273,7 @@ var _ = Describe(SIG("Memory dump", func() {
 		removeMemoryDumpFunc(vm.Name, vm.Namespace)
 		waitAndVerifyMemoryDumpDissociation(vm, pvcName)
 		pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.NamespaceTestDefault).Get(context.Background(), pvcName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get memory dump PVC %s after dissociation", pvcName)
 		// Verify the content is still on the pvc
 		verifyMemoryDumpOutput(pvc, previousOutput, true)
 	}
@@ -381,7 +381,7 @@ var _ = Describe(SIG("Memory dump", func() {
 			memoryDumpPVC2 = libstorage.NewPVC(memoryDumpPVCName2, memoryDumpPVCSize, "no-exist")
 			memoryDumpPVC2.Namespace = vm.Namespace
 			memoryDumpPVC2, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Create(context.Background(), memoryDumpPVC2, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create PVC %s with non-existing storage class", memoryDumpPVC2.Name)
 			memoryDumpVMSubresource(vm.Name, vm.Namespace, memoryDumpPVC2.Name)
 
 			By("Wait memory dump in progress")
@@ -391,7 +391,7 @@ var _ = Describe(SIG("Memory dump", func() {
 					return err
 				}
 				if updatedVM.Status.MemoryDumpRequest == nil || updatedVM.Status.MemoryDumpRequest.Phase != v1.MemoryDumpInProgress {
-					return fmt.Errorf(fmt.Sprintf(waitMemoryDumpInProgress, updatedVM.Status.MemoryDumpRequest.Phase))
+					return fmt.Errorf(waitMemoryDumpInProgress, updatedVM.Status.MemoryDumpRequest.Phase)
 				}
 
 				return nil
@@ -401,9 +401,9 @@ var _ = Describe(SIG("Memory dump", func() {
 			removeMemoryDumpVMSubresource(vm.Name, vm.Namespace)
 			waitAndVerifyMemoryDumpDissociation(vm, memoryDumpPVCName)
 			memoryDumpPVC2, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), memoryDumpPVC2.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get PVC %s after memory dump removal", memoryDumpPVC2.Name)
 			if memoryDumpPVC2.Annotations != nil {
-				Expect(memoryDumpPVC2.Annotations[v1.PVCMemoryDumpAnnotation]).To(BeNil())
+				Expect(memoryDumpPVC2.Annotations[v1.PVCMemoryDumpAnnotation]).To(BeNil(), "PVC %s memory dump annotation should be cleared after removal", memoryDumpPVC2.Name)
 			}
 		})
 	})

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -83,8 +83,9 @@ var _ = Describe(SIG("Memory dump", func() {
 	createAndStartVM := func() *v1.VirtualMachine {
 		By("Creating VirtualMachine")
 		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		vmName := vm.Name
 		vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine %s", vm.Name)
+		Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine %s", vmName)
 		Eventually(func() bool {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			if errors.IsNotFound(err) {

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -73,7 +73,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 	executeTargetCli := func(podName string, args []string) {
 		cmd := append([]string{"/usr/bin/targetcli"}, args...)
 		pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get targetcli pod %s", podName)
 
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli", cmd)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("command='targetcli %v' stdout='%s' stderr='%s'", args, stdout, stderr))
@@ -91,7 +91,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 		// Create targetcli container
 		By("Create targetcli pod")
 		pod, err := libpod.Run(libpod.RenderTargetcliPod(podName, pvc), testsuite.NamespacePrivileged)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to run targetcli pod %s", podName)
 		node = pod.Spec.NodeName
 		// The vm-killer image is built with bazel and the /etc/ld.so.cache isn't built
 		// at the package installation. The targetcli utility relies on ctype python package that
@@ -99,7 +99,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 		// To fix this issue, we run ldconfig before targetcli
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli", []string{"ldconfig"})
 		By(fmt.Sprintf("ldconfig: stdout: %v stderr: %v", stdout, stderr))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to run ldconfig in pod %s: stdout=%s stderr=%s", podName, stdout, stderr)
 
 		// Create backend file. Let some room for metedata and create a
 		// slightly smaller backend image, we use 800M instead of 1G. In
@@ -124,7 +124,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 	findSCSIdisk := func(podName string, model string) string {
 		var device string
 		pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get pod %s when finding SCSI disk", podName)
 
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli",
 			[]string{"/bin/lsblk", "--scsi", "-o", "NAME,MODEL", "-p", "-n"})
@@ -150,20 +150,20 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 			&expect.BSnd{S: fmt.Sprintf("%s\n", cmd)},
 			&expect.BExp{R: ""},
 		}, 20)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to run command %q in VMI console", cmd)
 		return strings.Contains(res[0].Output, output)
 	}
 
 	waitForVirtHandlerWithPrHelperReadyOnNode := func(node string) {
 		ready := false
 		fieldSelector, err := fields.ParseSelector("spec.nodeName==" + string(node))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to parse field selector for node %s", node)
 		labelSelector, err := labels.Parse(fmt.Sprintf(v1.AppLabel + "=virt-handler"))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to parse label selector for virt-handler")
 		selector := metav1.ListOptions{FieldSelector: fieldSelector.String(), LabelSelector: labelSelector.String()}
 		Eventually(func() bool {
 			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), selector)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to list virt-handler pods on node %s", node)
 			if len(pods.Items) < 1 {
 				return false
 			}
@@ -181,12 +181,12 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 			}
 			return ready
 
-		}, 90*time.Second, 1*time.Second).Should(BeTrue())
+		}, 90*time.Second, 1*time.Second).Should(BeTrue(), "virt-handler with pr-helper container did not become ready on node %s in time", node)
 	}
 	BeforeEach(func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "failed to get KubeVirt client")
 		fgDisabled = !checks.HasFeature(featuregate.PersistentReservation)
 		if fgDisabled {
 			config.EnableFeatureGate(featuregate.PersistentReservation)
@@ -211,10 +211,10 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 			// Avoid races if there is some delay in the device creation
 			Eventually(findSCSIdisk, 20*time.Second, 1*time.Second).WithArguments(targetCliPod, backendDisk).ShouldNot(BeEmpty())
 			device = findSCSIdisk(targetCliPod, backendDisk)
-			Expect(device).ToNot(BeEmpty())
+			Expect(device).ToNot(BeEmpty(), "expected to find a SCSI device for backend disk %s on targetcli pod %s", backendDisk, targetCliPod)
 			By(fmt.Sprintf("Create PVC with SCSI disk %s", device))
 			pv, pvc, err = CreatePVandPVCwithSCSIDisk(node, device, testsuite.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create PV and PVC for SCSI disk %s on node %s", device, node)
 			waitForVirtHandlerWithPrHelperReadyOnNode(node)
 			// Switching the PersistentReservation feature gate on/off
 			// causes redeployment of all KubeVirt components.
@@ -228,7 +228,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				"loopback/", "delete", naa})
 			executeTargetCli(targetCliPod, []string{
 				"backstores/fileio", "delete", backendDisk})
-			Expect(virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+			Expect(virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred(), "failed to delete PersistentVolume %s", pv.Name)
 
 		})
 
@@ -240,7 +240,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				libvmi.WithNodeAffinityFor(node),
 			)
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create VMI with SCSI LUN disk")
 			libwait.WaitForSuccessfulVMIStart(vmi,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
@@ -263,11 +263,11 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 			// Restart virt-handler
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(),
 				vmi.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get VMI %s/%s before restarting virt-handler", vmi.Namespace, vmi.Name)
 			pod, err := libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to get virt-handler pod on node %s", vmi.Status.NodeName)
 			err = virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to delete virt-handler pod %s", pod.Name)
 			// Wait unti new handler pod is ready
 			oldPodName := pod.Name
 			Eventually(func(g Gomega) bool {
@@ -278,7 +278,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				}
 				pod, err = virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 				return pod.Name != oldPodName
-			}).WithTimeout(time.Minute).WithPolling(time.Second).Should(BeTrue())
+			}).WithTimeout(time.Minute).WithPolling(time.Second).Should(BeTrue(), "new virt-handler pod did not replace old pod %s on node %s in time", oldPodName, vmi.Status.NodeName)
 			Eventually(matcher.ThisPod(pod)).WithTimeout(30 * time.Second).
 				WithPolling(1 * time.Second).Should(matcher.HaveConditionTrue(k8sv1.PodReady))
 
@@ -296,7 +296,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				libvmi.WithNodeAffinityFor(node),
 			)
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create first VMI with shared SCSI LUN disk")
 			libwait.WaitForSuccessfulVMIStart(vmi,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
@@ -308,7 +308,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 				libvmi.WithNodeAffinityFor(node),
 			)
 			vmi2, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi2)).Create(context.Background(), vmi2, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create second VMI with shared SCSI LUN disk")
 			libwait.WaitForSuccessfulVMIStart(vmi2,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
@@ -373,7 +373,7 @@ var _ = Describe(SIG("SCSI persistent reservation", Serial, func() {
 						libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"touch", mpathSocket})
 						DeferCleanup(func() {
 							_, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"rm", "-f", mpathSocket})
-							Expect(err).ToNot(HaveOccurred())
+							Expect(err).ToNot(HaveOccurred(), "failed to remove fake multipathd socket on node %s", node.Name)
 						})
 					}
 				}

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -124,7 +124,7 @@ var _ = Describe(SIG("Storage", func() {
 
 		createAndWaitForVMIReady := func(vmi *v1.VirtualMachineInstance, dataVolume *cdiv1.DataVolume, timeoutSec int) *v1.VirtualMachineInstance {
 			vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachineInstance")
 			By("Waiting until the DataVolume is ready")
 			libstorage.EventuallyDV(dataVolume, timeoutSec, HaveSucceeded())
 			By("Waiting until the VirtualMachineInstance starts")
@@ -143,9 +143,9 @@ var _ = Describe(SIG("Storage", func() {
 				nodeName = libnode.GetNodeNameWithHandler()
 				address, device = CreateErrorDisk(nodeName)
 				pv, pvc, err = CreatePVandPVCwithFaultyDisk(nodeName, device, testsuite.GetTestNamespace(nil))
-				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for faulty disk")
+				Expect(err).NotTo(HaveOccurred(), "failed to create PV and PVC for faulty disk on node %s", nodeName)
 				DeferCleanup(func() {
-					Expect(virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+					Expect(virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred(), "failed to delete PersistentVolume %s", pv.Name)
 					RemoveSCSIDisk(nodeName, address)
 				})
 			})
@@ -276,8 +276,8 @@ var _ = Describe(SIG("Storage", func() {
 					}
 
 					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120*time.Second)).To(Succeed())
+					Expect(err).ToNot(HaveOccurred(), "failed to delete VMI %s/%s", vmi.Namespace, vmi.Name)
+					Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120*time.Second)).To(Succeed(), "VMI %s/%s did not disappear in time", vmi.Namespace, vmi.Name)
 				}
 			},
 				Entry("[test_id:3132]with Disk PVC", newRandomVMIWithPVC),
@@ -439,8 +439,8 @@ var _ = Describe(SIG("Storage", func() {
 
 				By("Killing a VirtualMachineInstance")
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(createdVMI, 120*time.Second)).To(Succeed())
+				Expect(err).ToNot(HaveOccurred(), "failed to delete VMI %s/%s", vmi.Namespace, vmi.Name)
+				Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(createdVMI, 120*time.Second)).To(Succeed(), "VMI %s/%s did not disappear in time", createdVMI.Namespace, createdVMI.Name)
 
 				By("Starting the VirtualMachineInstance again")
 				if isRunOnKindInfra {
@@ -499,8 +499,8 @@ var _ = Describe(SIG("Storage", func() {
 					}
 
 					err = virtClient.VirtualMachineInstance(obj.Namespace).Delete(context.Background(), obj.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Eventually(ThisVMI(obj), 120).Should(BeGone())
+					Expect(err).ToNot(HaveOccurred(), "failed to delete VMI %s/%s", obj.Namespace, obj.Name)
+					Eventually(ThisVMI(obj), 120).Should(BeGone(), "VMI %s/%s did not disappear in time", obj.Namespace, obj.Name)
 				}
 			})
 		})
@@ -598,8 +598,8 @@ var _ = Describe(SIG("Storage", func() {
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", hostdisk.GetMountedHostDiskDir("anotherdisk"), "-size", "1G", "-o", "-size", "+1G"},
 						)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(output).To(ContainSubstring(hostdisk.GetMountedHostDiskPath("anotherdisk", filepath.Join(hostDiskDir, "another.img"))))
+						Expect(err).ToNot(HaveOccurred(), "failed to find 'another.img' host disk for VMI %s", vmi.Name)
+						Expect(output).To(ContainSubstring(hostdisk.GetMountedHostDiskPath("anotherdisk", filepath.Join(hostDiskDir, "another.img"))), "expected mounted path of 'another.img' to be present in find output")
 
 						By("Checking if disk.img has been created")
 						output, err = exec.ExecuteCommandOnPod(
@@ -622,11 +622,11 @@ var _ = Describe(SIG("Storage", func() {
 						// create a disk image before test
 						pod := CreateHostDisk(diskPath)
 						pod, err = virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Create(context.Background(), pod, metav1.CreateOptions{})
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).ToNot(HaveOccurred(), "failed to create host disk creation pod")
 
 						Eventually(ThisPod(pod), 30*time.Second, 1*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
 						pod, err = ThisPod(pod)()
-						Expect(err).NotTo(HaveOccurred())
+						Expect(err).NotTo(HaveOccurred(), "failed to get host disk creation pod after completion")
 						nodeName = pod.Spec.NodeName
 					})
 
@@ -652,8 +652,8 @@ var _ = Describe(SIG("Storage", func() {
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", hostdisk.GetMountedHostDiskDir(hostDiskName), "-name", diskName},
 						)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(output).To(ContainSubstring(diskName))
+						Expect(err).ToNot(HaveOccurred(), "failed to find disk image %s for VMI %s", diskName, vmi.Name)
+						Expect(output).To(ContainSubstring(diskName), "expected disk image %s to be found in host disk directory", diskName)
 					})
 
 					It("[test_id:847]Should fail with a capacity option", func() {
@@ -739,10 +739,10 @@ var _ = Describe(SIG("Storage", func() {
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", "/var/run/kubevirt-private/vmi-disks/disk0/", "-name", diskImgName, "-size", "1G", "-o", "-size", "+1G"},
 						)
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).ToNot(HaveOccurred(), "failed to find disk.img in empty PVC for VMI %s", vmi.Name)
 
 						By("Checking if a disk image for PVC has been created")
-						Expect(strings.Contains(output, diskImgName)).To(BeTrue())
+						Expect(strings.Contains(output, diskImgName)).To(BeTrue(), "expected disk.img to be present in PVC for VMI %s", vmi.Name)
 					}
 				})
 			})
@@ -773,20 +773,20 @@ var _ = Describe(SIG("Storage", func() {
 						},
 					}
 					pod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred(), "failed to create hostPath preparator pod")
 
 					By("Waiting for hostPath pod to prepare the mounted directory")
 					Eventually(matcher.ThisPod(pod), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(k8sv1.PodReady))
 
 					pod, err = ThisPod(pod)()
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "failed to get hostPath preparator pod after readiness")
 
 					By("Determining the size of the mounted directory")
 					diskSizeStr, _, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, []string{"/bin/bash", "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "failed to determine size of mounted directory %s", mountDir)
 					diskSize, err = strconv.Atoi(strings.TrimSpace(diskSizeStr))
 					diskSize = diskSize * 1000 // byte to kilobyte
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "failed to parse disk size value %q from mounted directory %s", diskSizeStr, mountDir)
 				})
 
 				AfterEach(func() {
@@ -822,7 +822,7 @@ var _ = Describe(SIG("Storage", func() {
 					)
 					vmi.Spec.Volumes[0].HostDisk.Capacity = resource.MustParse(strconv.Itoa(int(float64(diskSize) * 1.2)))
 					vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "failed to create VMI with non-existing PVC")
 
 					By("Checking events")
 					objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(120) * time.Second)
@@ -877,7 +877,7 @@ var _ = Describe(SIG("Storage", func() {
 					libdv.WithStorage(libdv.StorageWithStorageClass(sc), libdv.StorageWithBlockVolumeMode()),
 				)
 				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to create DataVolume for block mode Cirros disk")
 				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 			})
 
@@ -918,7 +918,7 @@ var _ = Describe(SIG("Storage", func() {
 				)
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to create DataVolume for Alpine block volume test")
 
 				vmi := libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace)
 				createAndWaitForVMIReady(vmi, dv, 240)
@@ -937,7 +937,7 @@ var _ = Describe(SIG("Storage", func() {
 					libvmi.WithPersistentVolumeClaim("disk0", pvcName),
 				)
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to create VMI with host disk that is too small")
 
 				Eventually(func() bool {
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
@@ -1037,7 +1037,7 @@ var _ = Describe(SIG("Storage", func() {
 					libdv.WithStorage(libdv.StorageWithStorageClass(sc), libdv.StorageWithBlockVolumeMode()),
 				)
 				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to create DataVolume for block-backed ephemeral disk test")
 				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 				vmi = nil
 			})
@@ -1051,7 +1051,7 @@ var _ = Describe(SIG("Storage", func() {
 
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsLarge)
 				runningPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to get virt-launcher pod for VMI %s/%s", vmi.Namespace, vmi.Name)
 
 				By("Checking that the virt-launcher pod spec contains the volumeDevice")
 				Expect(runningPod.Spec.Containers[0].VolumeDevices).NotTo(BeEmpty())
@@ -1076,7 +1076,7 @@ var _ = Describe(SIG("Storage", func() {
 				)
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to create DataVolume for shareable disk test")
 				labelKey := "testshareablekey"
 
 				// give an affinity rule to ensure the vmi's get placed on the same node.
@@ -1256,7 +1256,7 @@ var _ = Describe(SIG("Storage", func() {
 
 			DescribeTable("should run the VMI using", func(addLunDisk func(*v1.VirtualMachineInstance, string, string)) {
 				pv, pvc, err = CreatePVandPVCwithSCSIDisk(nodeName, device, testsuite.GetTestNamespace(nil), "scsi-disks", "scsipv", "scsipvc")
-				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for scsi disk")
+				Expect(err).NotTo(HaveOccurred(), "failed to create PV and PVC for SCSI disk %s on node %s", device, nodeName)
 
 				By("Creating VMI with LUN disk")
 				vmi := libvmifact.NewAlpine()
@@ -1280,7 +1280,7 @@ var _ = Describe(SIG("Storage", func() {
 
 			It("should run the VMI created with a DataVolume source and use the LUN disk", func() {
 				pv, err = CreatePVwithSCSIDisk("scsi-disks", "scsipv", nodeName, device)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to create PersistentVolume for SCSI disk %s on node %s", device, nodeName)
 				dv := libdv.NewDataVolume(
 					libdv.WithBlankImageSource(),
 					libdv.WithStorage(libdv.StorageWithStorageClass(pv.Spec.StorageClassName),
@@ -1290,7 +1290,7 @@ var _ = Describe(SIG("Storage", func() {
 					),
 				)
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "failed to create DataVolume for LUN disk test")
 
 				By("Creating VMI with LUN disk")
 				vmi := libvmifact.NewCirros(libvmi.WithMemoryRequest("512M"))
@@ -1373,11 +1373,11 @@ func runPodAndExpectPhase(pod *k8sv1.Pod, phase k8sv1.PodPhase) *k8sv1.Pod {
 
 	var err error
 	pod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	Eventually(ThisPod(pod), 120).Should(BeInPhase(phase))
+	Expect(err).ToNot(HaveOccurred(), "failed to create pod %s", pod.Name)
+	Eventually(ThisPod(pod), 120).Should(BeInPhase(phase), "pod %s did not reach phase %s in time", pod.Name, phase)
 
 	pod, err = ThisPod(pod)()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(pod).ToNot(BeNil())
+	Expect(err).ToNot(HaveOccurred(), "failed to get pod %s after reaching phase %s", pod.Name, phase)
+	Expect(pod).ToNot(BeNil(), "pod %s should not be nil after reaching phase %s", pod.Name, phase)
 	return pod
 }

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -742,7 +742,7 @@ var _ = Describe(SIG("Storage", func() {
 						Expect(err).ToNot(HaveOccurred(), "failed to find disk.img in empty PVC for VMI %s", vmi.Name)
 
 						By("Checking if a disk image for PVC has been created")
-						Expect(strings.Contains(output, diskImgName)).To(BeTrue(), "expected disk.img to be present in PVC for VMI %s", vmi.Name)
+						Expect(output).To(ContainSubstring(diskImgName), "expected disk.img to be present in PVC for VMI %s", vmi.Name)
 					}
 				})
 			})
@@ -822,7 +822,7 @@ var _ = Describe(SIG("Storage", func() {
 					)
 					vmi.Spec.Volumes[0].HostDisk.Capacity = resource.MustParse(strconv.Itoa(int(float64(diskSize) * 1.2)))
 					vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred(), "failed to create VMI with non-existing PVC")
+					Expect(err).ToNot(HaveOccurred(), "failed to create hostDisk-backed VMI %s/%s (host disk too small / toleration scenario)", vmi.Namespace, vmi.Name)
 
 					By("Checking events")
 					objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(120) * time.Second)


### PR DESCRIPTION

### What this PR does
#### Before this PR:
Many assertions in the storage test suite were bare. When these tests failed in CI, the logs only showed generic Gomega output (e.g., `Expected <nil> to not have occurred`), making it difficult to identify exactly which step of the test failed without cross-referencing line numbers.

#### After this PR:
Descriptive failure messages have been added to all bare assertions in the following files:
- `tests/storage/memorydump.go`
- `tests/storage/reservation.go`
- `tests/storage/storage.go`

### References
- Partially addresses #10347

### Why we need it and why it was done in this way
Standardizing failure messages in the KubeVirt test suite follows the project's best practices for debuggability. By providing the resource name and the action that failed (e.g., `"failed to create VirtualMachine %s"`) directly in the assertion, developers can quickly diagnose CI failures without deep diving into the source code.

The following tradeoffs were made:

### Special notes for your reviewer
This is part of a broader effort to clean bare assertions in test files.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: Verified locally that `go build ./tests/storage/...`, `go vet ./tests/storage/...`, and `go fmt ./tests/storage/...` pass.
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. 
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE

