### PR TITLE
virt-controller: migrate deprecated VMI finalizer during updateStatus

### DIFF
--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -280,6 +280,16 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 	podConditionManager := controller.NewPodConditionManager()
 
 	vmiCopy := vmi.DeepCopy()
+
+	// Migrate the deprecated non-domain-qualified VMI finalizer
+	// ("foregroundDeleteVirtualMachine") to the current domain-qualified form
+	// ("kubevirt.io/foregroundDeleteVirtualMachine"). This handles VMIs created
+	// before PR #15096 and silences the API server warning from issue #12342.
+	if controller.HasFinalizer(vmiCopy, virtv1.DeprecatedVirtualMachineInstanceFinalizer) {
+		controller.RemoveFinalizer(vmiCopy, virtv1.DeprecatedVirtualMachineInstanceFinalizer)
+		controller.AddFinalizer(vmiCopy, virtv1.VirtualMachineInstanceFinalizer)
+	}
+
 	vmiPodExists := controller.PodExists(pod) && !isTempPod(pod)
 	tempPodExists := controller.PodExists(pod) && isTempPod(pod)
 
@@ -692,6 +702,17 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 			patchSet.AddOption(
 				patch.WithTest("/metadata/annotations", oldVMI.Annotations),
 				patch.WithReplace("/metadata/annotations", newVMI.Annotations),
+			)
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(oldVMI.Finalizers, newVMI.Finalizers) {
+		if oldVMI.Finalizers == nil {
+			patchSet.AddOption(patch.WithAdd("/metadata/finalizers", newVMI.Finalizers))
+		} else {
+			patchSet.AddOption(
+				patch.WithTest("/metadata/finalizers", oldVMI.Finalizers),
+				patch.WithReplace("/metadata/finalizers", newVMI.Finalizers),
 			)
 		}
 	}

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -1742,6 +1742,24 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			sanityExecute()
 			expectVMIFailedState(vmi)
 		})
+		It("should replace the deprecated finalizer with the domain-qualified one during reconciliation", func() {
+			vmi := newPendingVirtualMachine("testvmi")
+			vmi.Status.Phase = virtv1.Running
+			vmi.Finalizers = []string{virtv1.DeprecatedVirtualMachineInstanceFinalizer}
+
+			pod := newPodForVirtualMachine(vmi, k8sv1.PodRunning)
+			addActivePods(vmi, pod.UID, "")
+
+			addVirtualMachine(vmi)
+			addPod(pod)
+
+			sanityExecute()
+
+			updatedVmi, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVmi.Finalizers).ToNot(ContainElement(virtv1.DeprecatedVirtualMachineInstanceFinalizer))
+			Expect(updatedVmi.Finalizers).To(ContainElement(virtv1.VirtualMachineInstanceFinalizer))
+		})
 		DescribeTable("should remove the fore ground finalizer if no pod is present and the vmi is in ", func(phase virtv1.VirtualMachineInstancePhase, finalizer string) {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = phase


### PR DESCRIPTION
### What this PR does
#### Before this PR:

After the finalizer rename in PR #15096, existing running VMIs created before
an upgrade retain the old non-domain-qualified `foregroundDeleteVirtualMachine`
finalizer indefinitely. The VMI controller only adds the finalizer via the
mutating webhook on CREATE and only removes it during deletion, so there is no
path to proactively replace the old string on live VMIs. This causes the
Kubernetes API server warning from #12342 to persist on every VMI update until
the VMI terminates.

#### After this PR:

The deprecated finalizer is replaced with the domain-qualified
`kubevirt.io/foregroundDeleteVirtualMachine` form on `vmiCopy` at the start of
`updateStatus()`, so existing VMIs are migrated on their next reconciliation
after an upgrade. The change is persisted by the existing patch
(Running/Scheduled) or update (other phases) at the end of `updateStatus()`.

### References

- Partially addresses #12342
- Follows the principle from #16497 of avoiding direct API calls during the
  sync loop, instead modifying the local copy and letting the controller persist
  changes at the end.

### Why we need it and why it was done in this way

Two changes were needed:

1. **Finalizer migration in `updateStatus()`**: After the `DeepCopy`, the
   deprecated finalizer is swapped for the domain-qualified one on `vmiCopy`.
   This avoids making a separate `Patch()` call mid-loop (per #16497) and
   instead piggybacks on the existing patch/update at the end of the function.

2. **Finalizer diff in `prepareVMIPatch()`**: For Running/Scheduled VMIs the
   controller uses JSON Patch (not Update) since virt-handler owns the object.
   The existing `prepareVMIPatch` did not include finalizers in the patch set.
   Added finalizer diff handling to the patch builder so the migration (and any
   other finalizer changes) are correctly serialized.

The following alternatives were considered:

- Doing nothing and relying on VMI termination to clean up: rejected because
  long-running VMIs would emit the API server warning for their entire lifetime.
- A separate `legacyMigrateDeprecatedFinalizer()` function calling `Patch()`
  directly from `execute()` before `sync()`: rejected because it adds an extra
  API call per reconciliation and violates the principle from #16497 of not
  making direct API calls during the sync loop.

### Special notes for your reviewer

PR #17437 proposes a similar rename for the KubeVirt CR finalizer
(`foregroundDeleteKubeVirt`) but has the same gap - it does not handle the
upgrade path. That PR would also benefit from proactive migration since the
KubeVirt CR is rarely deleted.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```