### PR TITLE
Quarantine sig-scale density instancetype preference test

### DIFF
--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -40,6 +40,7 @@ import (
 	audit_api "kubevirt.io/kubevirt/tools/perfscale-audit/api"
 	metric_client "kubevirt.io/kubevirt/tools/perfscale-audit/metric-client"
 
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	instancetypeBuilder "kubevirt.io/kubevirt/tests/libinstancetype/builder"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -109,7 +110,7 @@ var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 		})
 
 		Context(fmt.Sprintf("[small] create a batch of %d running VMs using a single instancetype and preference", vmCount), func() {
-			It("should successfully create all VMS with instancetype and preference", func() {
+			It("[QUARANTINE]should successfully create all VMS with instancetype and preference", decorators.Quarantine, func() {
 				By("Creating an instancetype and preference for the test")
 				instancetype := createInstancetype(virtClient)
 				preference := createPreference(virtClient)


### PR DESCRIPTION
What this PR does
Before this PR:
One flaky tests on sig-scale lane

After this PR:
Quarantine density instancetype preference test

<img width="1580" height="99" alt="Screenshot From 2026-04-10 14-01-12" src="https://github.com/user-attachments/assets/132ef165-61f6-442c-890a-5b780b1176b5" />

References
Special notes for your reviewer
Checklist
This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

 Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
 PR: The PR description is expressive enough and will help future contributors
 Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
 Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
 Upgrade: Impact of this change on upgrade flows was considered and addressed if required
 Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
 Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
 Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
 AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).
Release note