### PR TITLE
WIP

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -225,7 +225,8 @@ func NewExpecter(
 		})
 	}()
 
-	opts = append(opts, expect.SendTimeout(timeout), expect.Verbose(true), expect.VerboseWriter(ginkgo.GinkgoWriter))
+	opts = append(opts, expect.SendTimeout(timeout), expect.Verbose(true), expect.VerboseWriter(ginkgo.GinkgoWriter)) // expect.CheckDuration(time.Millisecond*200),
+
 	return expect.SpawnGeneric(&expect.GenOptions{
 		In:  vmiWriter,
 		Out: expecterReader,


### PR DESCRIPTION
### What this PR does
Trying to reproduce failure where expector doesn't seem to read whole buffer from console and therefore never matching new promt, such as https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17340/pull-kubevirt-e2e-k8s-1.35-sig-network/2042545922222592000

### Why we need it and why it was done in this way

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

