### PR TITLE
tests/network: use libvmi helper functions

### DIFF
--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -75,8 +75,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			const (
 				macAddress = "02:00:00:00:00:02"
 			)
-			passtIface := libvmi.InterfaceWithPasstBindingPlugin()
-			passtIface.MacAddress = macAddress
+			passtIface := libvmi.InterfaceWithMac(libvmi.InterfaceWithPasstBindingPlugin(), macAddress)
 			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(passtIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -225,21 +224,16 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 					},
 				},
 			}
-			primaryIface.MacAddress = "de:ad:00:00:be:af"
-			opts := []libvmi.Option{
-				libvmi.WithInterface(primaryIface),
+			serverVMI := libvmifact.NewAlpineWithTestTooling(
+				libvmi.WithInterface(libvmi.InterfaceWithMac(primaryIface, "de:ad:00:00:be:af")),
 				libvmi.WithNetwork(&primaryNetwork),
 				libvmi.WithNodeAffinityFor(nodeName),
-			}
-			serverVMI := libvmifact.NewAlpineWithTestTooling(opts...)
-
-			primaryIface.MacAddress = "de:ad:00:00:be:aa"
-			opts = []libvmi.Option{
-				libvmi.WithInterface(primaryIface),
+			)
+			clientVMI := libvmifact.NewAlpineWithTestTooling(
+				libvmi.WithInterface(libvmi.InterfaceWithMac(primaryIface, "de:ad:00:00:be:aa")),
 				libvmi.WithNetwork(&primaryNetwork),
 				libvmi.WithNodeAffinityFor(nodeName),
-			}
-			clientVMI := libvmifact.NewAlpineWithTestTooling(opts...)
+			)
 
 			ns := testsuite.GetTestNamespace(nil)
 			serverVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Create(context.Background(), serverVMI, metav1.CreateOptions{})

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -225,8 +225,10 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			secondIfaceMac, err := libnet.GenerateRandomMac()
 			Expect(err).NotTo(HaveOccurred())
 
-			secondHotpluggedIface := libvmi.InterfaceDeviceWithBridgeBinding(secondHotpluggedIfaceName)
-			secondHotpluggedIface.MacAddress = secondIfaceMac.String()
+			secondHotpluggedIface := libvmi.InterfaceWithMac(
+				libvmi.InterfaceDeviceWithBridgeBinding(secondHotpluggedIfaceName),
+				secondIfaceMac.String(),
+			)
 			secondHotpluggedIface.State = v1.InterfaceStateLinkDown
 
 			Expect(

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -187,8 +187,7 @@ func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName string) err
 	if err != nil {
 		return err
 	}
-	newIface.MacAddress = mac.String()
-	return libnet.PatchVMWithNewInterface(vm, newNetwork, newIface)
+	return libnet.PatchVMWithNewInterface(vm, newNetwork, libvmi.InterfaceWithMac(newIface, mac.String()))
 }
 
 func verifySriovDynamicInterfaceChange(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -65,9 +65,11 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", Seria
 	It("should apply the interface configuration", func() {
 		const testMACAddr = "02:02:02:02:02:02"
 		const testPCIAddr = "0000:01:00.0"
-		passtIface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
+		passtIface := libvmi.InterfaceWithMac(
+			libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name),
+			testMACAddr,
+		)
 		passtIface.Ports = []v1.Port{{Port: 1234, Protocol: "TCP"}}
-		passtIface.MacAddress = testMACAddr
 		passtIface.PciAddress = testPCIAddr
 		vmi := libvmifact.NewAlpineWithTestTooling(
 			libvmi.WithInterface(passtIface),

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -111,11 +111,11 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 
 		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
-			vmi := newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())))
-			vmi.Spec.Domain.CPU = &v1.CPU{
-				Cores:                 4,
-				DedicatedCPUPlacement: true,
-			}
+			vmi := newSRIOVVmi([]string{sriovnet1},
+				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())),
+				libvmi.WithCPUCount(4, 0, 0),
+				libvmi.WithDedicatedCPUPlacement(),
+			)
 
 			for idx, iface := range vmi.Spec.Domain.Devices.Interfaces {
 				if iface.Name == sriovnet1 {
@@ -195,10 +195,10 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 
 		It("[test_id:1754]should create a virtual machine with sriov interface with all pci devices on the root bus", func() {
-			vmi := newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
-			vmi.Annotations = map[string]string{
-				v1.PlacePCIDevicesOnRootComplex: "true",
-			}
+			vmi := newSRIOVVmi([]string{sriovnet1},
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
+				libvmi.WithAnnotation(v1.PlacePCIDevicesOnRootComplex, "true"),
+			)
 			vmi, err := createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
@@ -217,11 +217,11 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
 			// In addition to verifying that we can start a VMI with CPU pinning
 			// this also tests if we've correctly calculated the overhead for VFIO devices.
-			vmi := newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
-			vmi.Spec.Domain.CPU = &v1.CPU{
-				Cores:                 2,
-				DedicatedCPUPlacement: true,
-			}
+			vmi := newSRIOVVmi([]string{sriovnet1},
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
+				libvmi.WithCPUCount(2, 0, 0),
+				libvmi.WithDedicatedCPUPlacement(),
+			)
 			vmi, err := createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
@@ -351,11 +351,9 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 				)
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithGuestMemory(initialGuestMemory),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(sriovNetworkLogicalName)),
+					libvmi.WithInterface(libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(sriovNetworkLogicalName), mac)),
 					libvmi.WithNetwork(libvmi.MultusNetwork(sriovNetworkLogicalName, sriovnet1)),
 				)
-
-				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = mac
 				vmi.Spec.Domain.Resources.Requests = nil
 
 				vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -367,8 +367,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", decorators.WgS390x, func() {
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
-				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
-				linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress
+				linuxBridgeInterfaceWithCustomMac := libvmi.InterfaceWithMac(linuxBridgeInterface, customMacAddress)
 
 				networkData, err := cloudinit.NewNetworkData(
 					cloudinit.WithEthernet("eth1",

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -526,8 +526,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					linuxBridgeInterfaceWithMACSpoofCheck := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeWithMACSpoofCheckNetwork)
 
 					By("Creating a VM with custom MAC address on its Linux bridge CNI interface.")
-					linuxBridgeInterfaceWithCustomMac := linuxBridgeInterfaceWithMACSpoofCheck
-					linuxBridgeInterfaceWithCustomMac = libvmi.InterfaceWithMac(linuxBridgeInterfaceWithCustomMac, initialMacAddressStr)
+					linuxBridgeInterfaceWithCustomMac := libvmi.InterfaceWithMac(linuxBridgeInterfaceWithMACSpoofCheck, initialMacAddressStr)
 
 					networkData, err := cloudinit.NewNetworkData(
 						cloudinit.WithEthernet(linuxBridgeInterfaceWithCustomMac.Name,

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -275,55 +275,72 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				return "", fmt.Errorf("couldn't find iface %s on vmi %s", networkName, vmiName)
 			}
 
-			DescribeTable("should be able to ping between two vms", func(interfaces []v1.Interface,
-				networks []v1.Network, ifaceName, staticIPVm1, staticIPVm2 string) {
-				if staticIPVm2 == "" || staticIPVm1 == "" {
-					ipam := map[string]string{"type": "host-local", "subnet": ptpSubnet}
-					Expect(createBridgeNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), linuxBridgeVlan100WithIPAMNetwork, bridge10Name, 0, ipam, bridge10MacSpoofCheck)).To(Succeed())
-				}
-
+			DescribeTable("should be able to ping between two vms", func(interfaces []v1.Interface, networks []v1.Network, ifaceName string) {
 				vmiOne := createVMIOnNode(interfaces, networks)
 				vmiTwo := createVMIOnNode(interfaces, networks)
 
 				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToAlpine)
 
-				Expect(configureAlpineInterfaceIP(vmiOne, ifaceName, staticIPVm1)).To(Succeed())
+				Expect(configureAlpineInterfaceIP(vmiOne, ifaceName, ptpSubnetIP1+ptpSubnetMask)).To(Succeed())
 				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
 				Expect(libnet.InterfaceExists(vmiOne, ifaceName)).To(Succeed())
 
-				Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, staticIPVm2)).To(Succeed())
+				Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, ptpSubnetIP2+ptpSubnetMask)).To(Succeed())
 				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
 				Expect(libnet.InterfaceExists(vmiTwo, ifaceName)).To(Succeed())
-				ipAddr := ""
-				if staticIPVm2 != "" {
-					ipAddr, err = libnet.CidrToIP(staticIPVm2)
-				} else {
-					const secondaryNetworkIndex = 1
-					ipAddr, err = getIfaceIPByNetworkName(vmiTwo.Name, networks[secondaryNetworkIndex].Name)
-				}
+
+				ipAddr, err := libnet.CidrToIP(ptpSubnetIP2 + ptpSubnetMask)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ipAddr).ToNot(BeEmpty())
 
 				By("ping between virtual machines")
 				Expect(libnet.PingFromVMConsole(vmiOne, ipAddr)).To(Succeed())
 			},
-				Entry("[test_id:1577]with secondary network only", []v1.Interface{linuxBridgeInterface}, []v1.Network{linuxBridgeNetwork}, "eth0", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
+				Entry("[test_id:1577]with secondary network only",
+					[]v1.Interface{linuxBridgeInterface},
+					[]v1.Network{linuxBridgeNetwork},
+					"eth0",
+				),
 				Entry("[test_id:1578]with default network and secondary network", decorators.WgS390x,
 					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterface},
 					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeNetwork},
 					"eth1",
-					ptpSubnetIP1+ptpSubnetMask,
-					ptpSubnetIP2+ptpSubnetMask,
-				),
-				Entry("with default network and secondary network with IPAM",
-					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterfaceWithIPAM},
-					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeWithIPAMNetwork},
-					"eth1",
-					"",
-					"",
 				),
 			)
+
+			It("should be able to ping between two vms via IPAM-assigned addresses", func() {
+				ipam := map[string]string{"type": "host-local", "subnet": ptpSubnet}
+				Expect(createBridgeNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), linuxBridgeVlan100WithIPAMNetwork, bridge10Name, 0, ipam, bridge10MacSpoofCheck)).To(Succeed())
+
+				const ifaceName = "eth1"
+				vmiOne := createVMIOnNode(
+					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterfaceWithIPAM},
+					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeWithIPAMNetwork},
+				)
+				vmiTwo := createVMIOnNode(
+					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterfaceWithIPAM},
+					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeWithIPAMNetwork},
+				)
+
+				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
+				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToAlpine)
+
+				Expect(configureAlpineInterfaceIP(vmiOne, ifaceName, "")).To(Succeed())
+				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
+				Expect(libnet.InterfaceExists(vmiOne, ifaceName)).To(Succeed())
+
+				Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, "")).To(Succeed())
+				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
+				Expect(libnet.InterfaceExists(vmiTwo, ifaceName)).To(Succeed())
+
+				ipAddr, err := getIfaceIPByNetworkName(vmiTwo.Name, linuxBridgeWithIPAMNetwork.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ipAddr).ToNot(BeEmpty())
+
+				By("ping between virtual machines")
+				Expect(libnet.PingFromVMConsole(vmiOne, ipAddr)).To(Succeed())
+			})
 		})
 
 		Context("VirtualMachineInstance with Linux bridge CNI plugin interface and custom MAC address.", func() {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -93,19 +93,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 	var nodes *k8sv1.NodeList
 
-	linuxBridgeInterface := v1.Interface{
-		Name: linuxBridgeIfaceName,
-		InterfaceBindingMethod: v1.InterfaceBindingMethod{
-			Bridge: &v1.InterfaceBridge{},
-		},
-	}
-
-	linuxBridgeInterfaceWithIPAM := v1.Interface{
-		Name: linuxBridgeWithIPAMIfaceName,
-		InterfaceBindingMethod: v1.InterfaceBindingMethod{
-			Bridge: &v1.InterfaceBridge{},
-		},
-	}
+	linuxBridgeInterface := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeIfaceName)
+	linuxBridgeInterfaceWithIPAM := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeWithIPAMIfaceName)
 
 	linuxBridgeNetwork := v1.Network{
 		Name: linuxBridgeIfaceName,

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -167,13 +167,9 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("ptp")),
+					libvmi.WithNetwork(libvmi.MultusNetwork("ptp", fmt.Sprintf("%s/%s", testsuite.NamespaceTestAlternative, ptpConf2))),
 				)
-				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
-				detachedVMI.Spec.Networks = []v1.Network{
-					{Name: "ptp", NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: fmt.Sprintf("%s/%s", testsuite.NamespaceTestAlternative, ptpConf2)},
-					}},
-				}
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), detachedVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -227,16 +223,17 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				Expect(err).NotTo(HaveOccurred())
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
-				)
-				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
-				detachedVMI.Spec.Networks = []v1.Network{
-					{Name: "ptp", NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{
-							NetworkName: fmt.Sprintf("%s/%s", testsuite.GetTestNamespace(nil), ptpConf1),
-							Default:     true,
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("ptp")),
+					libvmi.WithNetwork(&v1.Network{
+						Name: "ptp",
+						NetworkSource: v1.NetworkSource{
+							Multus: &v1.MultusNetwork{
+								NetworkName: fmt.Sprintf("%s/%s", testsuite.GetTestNamespace(nil), ptpConf1),
+								Default:     true,
+							},
 						},
-					}},
-				}
+					}),
+				)
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), detachedVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -32,7 +32,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -609,11 +608,13 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
                     ip addr add %s dev ep1
                     ip addr add %s dev ep2
                 `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
-				agentVMI := libvmifact.NewFedora(libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userdata)))
+				agentVMI := libvmifact.NewFedora(
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userdata)),
+					libvmi.WithMemoryRequest("1024M"),
+				)
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
 				agentVMI.Spec.Networks = networks
-				agentVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 
 				By("Starting a VirtualMachineInstance")
 				agentVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), agentVMI, metav1.CreateOptions{})

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -207,8 +207,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			By("checking the device vendor in /sys/class")
 			// Create a machine with e1000 interface model
 			// Use alpine because cirros dhcp client starts prematurely before link is ready
-			e1000ModelIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
-			e1000ModelIface.Model = "e1000"
+			e1000ModelIface := libvmi.InterfaceWithModel(libvmi.InterfaceDeviceWithMasqueradeBinding(), "e1000")
 			e1000ModelIface.PciAddress = "0000:02:01.0"
 
 			const secondaryNetName = "secondary-net"

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -28,7 +28,6 @@ import (
 
 	expect "github.com/google/goexpect"
 	k8sv1 "k8s.io/api/core/v1"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -70,47 +69,52 @@ var _ = Describe(SIG("Subdomain", func() {
 		BeforeEach(func() {
 			serviceName := subdomain
 			service := netservice.BuildHeadlessSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
-			_, err := virtClient.CoreV1().Services(testsuite.NamespaceTestDefault).Create(context.Background(), service, k8smetav1.CreateOptions{})
+			_, err := virtClient.CoreV1().Services(testsuite.NamespaceTestDefault).Create(context.Background(), service, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("VMI should have the expected FQDN", decorators.WgS390x, func(f func(...libvmi.Option) *v1.VirtualMachineInstance, subdom, hostname string) {
-			opts := []libvmi.Option{libvmi.WithLabel(selectorLabelKey, selectorLabelValue)}
-			if subdom != "" {
-				opts = append(opts, libvmi.WithSubdomain(subdom))
-				if hostname != "" {
-					opts = append(opts, libvmi.WithHostname(hostname))
-				}
-			}
-			vmiSpec := f(opts...)
-			var expectedFQDN string
-			if subdom != "" {
-				domain := hostname
-				if domain == "" {
-					domain = vmiSpec.Name
-				}
-				expectedFQDN = fmt.Sprintf("%s.%s.%s.svc.cluster.local", domain, subdom, testsuite.NamespaceTestDefault)
-			} else {
-				expectedFQDN = vmiSpec.Name
-			}
-
-			vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmiSpec, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
-
-			Expect(assertFQDNinGuest(vmi, expectedFQDN)).To(Succeed(), "failed to get expected FQDN")
-		},
-			Entry("with Masquerade binding and subdomain and hostname", fedoraMasqueradeVMI, subdomain, hostname),
-			Entry("with Bridge binding and subdomain", fedoraBridgeBindingVMI, subdomain, ""),
-			Entry("with Masquerade binding without subdomain", fedoraMasqueradeVMI, "", ""),
-			Entry("with Bridge binding without subdomain", fedoraBridgeBindingVMI, "", ""),
+		DescribeTable("VMI should have the expected FQDN", decorators.WgS390x,
+			func(vmi *v1.VirtualMachineInstance, expectedFQDN func(string) string) {
+				vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+				Expect(assertFQDNinGuest(vmi, expectedFQDN(vmi.Name))).To(Succeed(), "failed to get expected FQDN")
+			},
+			Entry("masquerade with subdomain and hostname uses hostname in FQDN",
+				fedoraMasqueradeVMI(
+					libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+					libvmi.WithSubdomain(subdomain),
+					libvmi.WithHostname(hostname),
+				),
+				func(_ string) string { return fqdnForVMI(hostname, subdomain) },
+			),
+			Entry("bridge with subdomain uses VMI name in FQDN",
+				fedoraBridgeBindingVMI(
+					libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+					libvmi.WithSubdomain(subdomain),
+				),
+				func(name string) string { return fqdnForVMI(name, subdomain) },
+			),
+			Entry("masquerade without subdomain uses VMI name as FQDN",
+				fedoraMasqueradeVMI(
+					libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+				),
+				func(name string) string { return name },
+			),
+			Entry("bridge without subdomain uses VMI name as FQDN",
+				fedoraBridgeBindingVMI(
+					libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+				),
+				func(name string) string { return name },
+			),
 		)
 
 		It("VMI with custom DNSPolicy should have the expected FQDN", func() {
-			vmiSpec := fedoraBridgeBindingVMI()
-			vmiSpec.Spec.Subdomain = subdomain
+			vmiSpec := fedoraBridgeBindingVMI(
+				libvmi.WithSubdomain(subdomain),
+				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+			)
 			expectedFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", vmiSpec.Name, subdomain, testsuite.NamespaceTestDefault)
-			vmiSpec.Labels = map[string]string{selectorLabelKey: selectorLabelValue}
 
 			dnsServerIP, err := dns.ClusterDNSServiceIP()
 			Expect(err).ToNot(HaveOccurred())
@@ -169,6 +173,10 @@ func fedoraBridgeBindingVMI(opts ...libvmi.Option) *v1.VirtualMachineInstance {
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	}, opts...)...)
+}
+
+func fqdnForVMI(name, subdomain string) string {
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", name, subdomain, testsuite.NamespaceTestDefault)
 }
 
 func assertFQDNinGuest(vmi *v1.VirtualMachineInstance, expectedFQDN string) error {

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -74,22 +74,25 @@ var _ = Describe(SIG("Subdomain", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("VMI should have the expected FQDN", decorators.WgS390x, func(f func() *v1.VirtualMachineInstance, subdom, hostname string) {
-			vmiSpec := f()
-			var expectedFQDN, domain string
+		DescribeTable("VMI should have the expected FQDN", decorators.WgS390x, func(f func(...libvmi.Option) *v1.VirtualMachineInstance, subdom, hostname string) {
+			opts := []libvmi.Option{libvmi.WithLabel(selectorLabelKey, selectorLabelValue)}
 			if subdom != "" {
-				vmiSpec.Spec.Subdomain = subdom
+				opts = append(opts, libvmi.WithSubdomain(subdom))
 				if hostname != "" {
-					domain = hostname
-					vmiSpec.Spec.Hostname = domain
-				} else {
+					opts = append(opts, libvmi.WithHostname(hostname))
+				}
+			}
+			vmiSpec := f(opts...)
+			var expectedFQDN string
+			if subdom != "" {
+				domain := hostname
+				if domain == "" {
 					domain = vmiSpec.Name
 				}
 				expectedFQDN = fmt.Sprintf("%s.%s.%s.svc.cluster.local", domain, subdom, testsuite.NamespaceTestDefault)
 			} else {
 				expectedFQDN = vmiSpec.Name
 			}
-			vmiSpec.Labels = map[string]string{selectorLabelKey: selectorLabelValue}
 
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmiSpec, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -130,10 +133,11 @@ var _ = Describe(SIG("Subdomain", func() {
 	})
 
 	It("VMI with custom DNSPolicy, a subdomain and no service entry, should not include the subdomain in the searchlist", func() {
-		vmiSpec := fedoraBridgeBindingVMI()
-		vmiSpec.Spec.Subdomain = subdomain
+		vmiSpec := fedoraBridgeBindingVMI(
+			libvmi.WithSubdomain(subdomain),
+			libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+		)
 		expectedFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", vmiSpec.Name, subdomain, testsuite.NamespaceTestDefault)
-		vmiSpec.Labels = map[string]string{selectorLabelKey: selectorLabelValue}
 
 		dnsServerIP, err := dns.ClusterDNSServiceIP()
 		Expect(err).ToNot(HaveOccurred())
@@ -153,16 +157,18 @@ var _ = Describe(SIG("Subdomain", func() {
 	})
 }))
 
-func fedoraMasqueradeVMI() *v1.VirtualMachineInstance {
-	return libvmifact.NewFedora(
+func fedoraMasqueradeVMI(opts ...libvmi.Option) *v1.VirtualMachineInstance {
+	return libvmifact.NewFedora(append([]libvmi.Option{
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-		libvmi.WithNetwork(v1.DefaultPodNetwork()))
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+	}, opts...)...)
 }
 
-func fedoraBridgeBindingVMI() *v1.VirtualMachineInstance {
-	return libvmifact.NewFedora(
+func fedoraBridgeBindingVMI(opts ...libvmi.Option) *v1.VirtualMachineInstance {
+	return libvmifact.NewFedora(append([]libvmi.Option{
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
-		libvmi.WithNetwork(v1.DefaultPodNetwork()))
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+	}, opts...)...)
 }
 
 func assertFQDNinGuest(vmi *v1.VirtualMachineInstance, expectedFQDN string) error {

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -114,7 +114,7 @@ var _ = Describe(SIG("Subdomain", func() {
 				libvmi.WithSubdomain(subdomain),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
 			)
-			expectedFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", vmiSpec.Name, subdomain, testsuite.NamespaceTestDefault)
+			expectedFQDN := fqdnForVMI(vmiSpec.Name, subdomain)
 
 			dnsServerIP, err := dns.ClusterDNSServiceIP()
 			Expect(err).ToNot(HaveOccurred())
@@ -141,7 +141,7 @@ var _ = Describe(SIG("Subdomain", func() {
 			libvmi.WithSubdomain(subdomain),
 			libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
 		)
-		expectedFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", vmiSpec.Name, subdomain, testsuite.NamespaceTestDefault)
+		expectedFQDN := fqdnForVMI(vmiSpec.Name, subdomain)
 
 		dnsServerIP, err := dns.ClusterDNSServiceIP()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Replace direct assignments with proper `libvmi` helper functions, to make the code more tidy. While at it, refactor an over-complicated Table.

/kind cleanup

```release-note
NONE
```

