### PR TITLE
fix:handling race condition of virt-api and virt-controller using single writer via annotation

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -50,6 +50,10 @@ const (
 	BurstReplicas uint = 250
 )
 
+const (
+	GracePeriodOverrideAnnotation = "kubevirt.io/grace-period-override"
+)
+
 // Reasons for vmi events
 const (
 	// FailedCreatePodReason is added in an event and in a vmi controller condition

--- a/pkg/virt-api/rest/lifecycle.go
+++ b/pkg/virt-api/rest/lifecycle.go
@@ -40,7 +40,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
-	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, response *restful.Response) {
@@ -436,6 +435,14 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 			writeError(errors.NewBadRequest(fmt.Sprintf("gracePeriod has to be greater or equal to 0")), response)
 			return
 		}
+
+		// Patch the VMI directly with the grace period annotation
+		patchData := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%d"}}}`, controller.GracePeriodOverrideAnnotation, *bodyStruct.GracePeriodSeconds))
+		_, err := app.virtCli.VirtualMachineInstance(namespace).Patch(context.Background(), name, types.MergePatchType, patchData, metav1.PatchOptions{})
+		if err != nil {
+			writeError(errors.NewInternalError(err), response)
+			return
+		}
 	}
 
 	vm, statusErr := app.fetchVirtualMachine(name, namespace)
@@ -486,30 +493,6 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 			writeError(errors.NewInternalError(err), response)
 		}
 		return
-	}
-
-	// Only force restart with GracePeriodSeconds=0 is supported for now
-	// Here we are deleting the Pod because CRDs don't support gracePeriodSeconds at the moment
-	if bodyStruct.GracePeriodSeconds != nil {
-		if *bodyStruct.GracePeriodSeconds == 0 {
-			vmiPodname, err := app.findPod(namespace, vmi)
-			if err != nil {
-				writeError(errors.NewInternalError(err), response)
-				return
-			}
-			if vmiPodname == "" {
-				response.WriteHeader(http.StatusAccepted)
-				return
-			}
-			// set terminationGracePeriod to 1 (which is the shorted safe restart period) and delete the VMI pod to trigger a swift restart.
-			err = app.virtCli.CoreV1().Pods(namespace).Delete(context.Background(), vmiPodname, metav1.DeleteOptions{GracePeriodSeconds: pointer.P(int64(1))})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					writeError(errors.NewInternalError(err), response)
-					return
-				}
-			}
-		}
 	}
 
 	response.WriteHeader(http.StatusAccepted)
@@ -624,6 +607,15 @@ func (app *SubresourceAPIApp) findPod(namespace string, vmi *v1.VirtualMachineIn
 }
 
 func (app *SubresourceAPIApp) patchVMStatusStopped(vmi *v1.VirtualMachineInstance, vm *v1.VirtualMachine, response *restful.Response, bodyStruct *v1.StopOptions) (error, error) {
+	if bodyStruct.GracePeriod != nil && vmi != nil {
+		patchData := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%d"}}}`, controller.GracePeriodOverrideAnnotation, *bodyStruct.GracePeriod))
+		_, err := app.virtCli.VirtualMachineInstance(vm.Namespace).Patch(context.Background(), vmi.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			log.Log.Object(vm).Reason(err).Errorf("Failed to patch VMI with grace period override")
+			writeError(errors.NewInternalError(err), response)
+			return nil, err
+		}
+	}
 	patchBytes, err := getChangeRequestJson(vm,
 		v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
 	if err != nil {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -65,6 +65,7 @@ import (
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
@@ -1540,9 +1541,29 @@ func (c *Controller) stopVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachi
 		return vm, nil
 	}
 
+	var gracePeriod *int64
+	if vmi != nil && vmi.Annotations != nil {
+		if overrideStr, exists := vmi.Annotations[controller.GracePeriodOverrideAnnotation]; exists {
+			if parsed, err := strconv.ParseInt(overrideStr, 10, 64); err == nil {
+				gracePeriod = &parsed
+			}
+
+			// Clean up the annotation immediately so it doesn't linger
+			patchData := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":null}}}`, controller.GracePeriodOverrideAnnotation))
+			_, patchErr := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+			if patchErr != nil && !k8serrors.IsNotFound(patchErr) {
+				log.Log.Object(vm).Reason(patchErr).Errorf("Failed to clear grace period annotation on VMI")
+			}
+		}
+	}
+
+	deleteOptions := metav1.DeleteOptions{
+		GracePeriodSeconds: gracePeriod,
+	}
+
 	// stop it
 	c.expectations.ExpectDeletions(vmKey, []string{controller.VirtualMachineInstanceKey(vmi)})
-	err = c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Delete(context.Background(), vmi.ObjectMeta.Name, metav1.DeleteOptions{})
+	err = c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Delete(context.Background(), vmi.ObjectMeta.Name, deleteOptions)
 
 	// Don't log an error if it is already deleted
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
During a force restart/stop (`gracePeriod=0`), `virt-api` directly deleted the `virt-launcher` pod. This created a race condition with `virt-controller`, which also attempted to delete the pod. When both requests hit `kubelet` simultaneously, `kubelet` safely locked in the longer default grace period, causing the pod to hang in `Terminating` for up to 10 minutes instead of dying instantly.

#### After this PR:
We enforce the Single Writer principle. `virt-api` no longer deletes pods directly. Instead, it applies a temporary `kubevirt.io/grace-period-override` annotation to the VMI. `virt-controller` acts as the sole authoritative pod deleter, reading this annotation, applying it to the VMI `DeleteOptions`, and safely clearing the annotation.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
Fixes #17388 
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
We needed a way to pass a transient operational parameter (the grace period) from the API to the Controller without polluting the declarative API schema or abusing the `Status` field.

The following tradeoffs were made:

The following alternatives were considered:
1. **Adding a new field to `VirtualMachineStateChangeRequest`:** Rejected as it requires modifying the core API schema for a transient runtime parameter.
2. **Injecting into the `StateChangeRequest.Data` map:** Rejected because it abuses the `Status` field to pass stringly-typed operational instructions, which is an anti-pattern. The temporary annotation on the VMI is the cleanest, most Kubernetes-native path.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Manually verified on a local `kubevirtci` cluster. Sending a force restart now results in the `virt-launcher` pod terminating cleanly in under 3 seconds with no overlapping kubelet timeouts.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a race condition during VM force restart/stop that caused the virt-launcher pod to hang in termination by enforcing single-writer pod deletion via virt-controller.
```

