### PR TITLE
api: validate VMI checksum status fields as uint32 range

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -14765,7 +14765,9 @@ var CRDsValidation map[string]string = map[string]string{
               properties:
                 checksum:
                   description: Checksum is the checksum of the initrd file
-                  format: int32
+                  format: int64
+                  maximum: 4294967295
+                  minimum: 0
                   type: integer
               type: object
             kernelInfo:
@@ -14773,7 +14775,9 @@ var CRDsValidation map[string]string = map[string]string{
               properties:
                 checksum:
                   description: Checksum is the checksum of the kernel image
-                  format: int32
+                  format: int64
+                  maximum: 4294967295
+                  minimum: 0
                   type: integer
               type: object
           type: object
@@ -15333,7 +15337,9 @@ var CRDsValidation map[string]string = map[string]string{
                   checksum:
                     description: Checksum is the checksum of the rootdisk or kernel
                       artifacts inside the containerdisk
-                    format: int32
+                    format: int64
+                    maximum: 4294967295
+                    minimum: 0
                     type: integer
                 type: object
               hotplugVolume:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -404,12 +404,18 @@ type VolumeStatus struct {
 
 // KernelInfo show info about the kernel image
 type KernelInfo struct {
+	// +kubebuilder:validation:Format:=int64
+	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Maximum:=4294967295
 	// Checksum is the checksum of the kernel image
 	Checksum uint32 `json:"checksum,omitempty"`
 }
 
 // InitrdInfo show info about the initrd file
 type InitrdInfo struct {
+	// +kubebuilder:validation:Format:=int64
+	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Maximum:=4294967295
 	// Checksum is the checksum of the initrd file
 	Checksum uint32 `json:"checksum,omitempty"`
 }
@@ -444,6 +450,9 @@ type HotplugVolumeStatus struct {
 
 // ContainerDiskInfo shows info about the containerdisk
 type ContainerDiskInfo struct {
+	// +kubebuilder:validation:Format:=int64
+	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Maximum:=4294967295
 	// Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk
 	Checksum uint32 `json:"checksum,omitempty"`
 }

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -130,14 +130,14 @@ func (VolumeStatus) SwaggerDoc() map[string]string {
 func (KernelInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "KernelInfo show info about the kernel image",
-		"checksum": "Checksum is the checksum of the kernel image",
+		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\nChecksum is the checksum of the kernel image",
 	}
 }
 
 func (InitrdInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "InitrdInfo show info about the initrd file",
-		"checksum": "Checksum is the checksum of the initrd file",
+		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\nChecksum is the checksum of the initrd file",
 	}
 }
 
@@ -170,7 +170,7 @@ func (HotplugVolumeStatus) SwaggerDoc() map[string]string {
 func (ContainerDiskInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "ContainerDiskInfo shows info about the containerdisk",
-		"checksum": "Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
+		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\nChecksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
 	}
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
- VMI checksum status fields were validated as `int32` in generated CRD schema.
- Valid checksum values above `2147483647` could be rejected during status updates.

#### After this PR:
- Checksum validation is defined on API fields (`kernelInfo`, `initrdInfo`, `containerDiskVolume`) using kubebuilder markers.
- Generated schema validates these fields as `int64` with explicit uint32 bounds (`0..4294967295`).

### Why we need it and why it was done in this way
Without it, VMs failed to start locally, due to checksum being bigger than max int32.
```
{"component":"virt-handler","controller":"vm","kind":"","level":"error","msg":"Updating the VirtualMachineInstance status failed.","name":"testvmi-txhzt-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","namespace":"kubevirt-test-default1","pos":"vm.go:1531","reason":"VirtualMachineInstance.kubevirt.io \"testvmi-txhzt-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\" is invalid: <nil>: Invalid value: \"\": Checked value must be of type integer with format int32 in status.volumeStatus[1].containerDiskVolume.checksum","timestamp":"2026-04-12T07:21:26.636683Z","uid":"3cdb6cfd-6186-4916-9548-2d32de8395ab"}
```

### Release note
```release-note
None
```