### PR TITLE
Fix Missing return before denied in pod eviction admitter.

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -171,7 +171,7 @@ func (admitter *PodEvictionAdmitter) admitLauncherPod(ctx context.Context, ar *a
 	}
 	evictionObject := policyv1.Eviction{}
 	if err := json.Unmarshal(ar.Request.Object.Raw, &evictionObject); err != nil {
-		denied(fmt.Sprintf("failed to parse the eviction object: %v", err))
+		return denied(fmt.Sprintf("failed to parse the eviction object: %v", err))
 	}
 	descEviction := isDeschedulerEviction(&evictionObject)
 	err = admitter.markVMI(ctx, vmi, pod.Spec.NodeName, isDryRun(ar, &evictionObject), descEviction)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

In `admitLauncherPod`, when `json.Unmarshal` failed to parse the eviction object, the result of `denied()` was not returned. Execution silently fell through, continuing with a zero-value `policyv1.Eviction{}`. This caused `markVMI` to be called, potentially triggering an unintended VMI live migration despite the malformed eviction request.

#### After this PR:

The `denied()` call on unmarshal failure is now properly returned, short-circuiting execution before any side effects (VMI marking/evacuation) can occur. This is consistent with every other `denied()` call in the function.

### References

### Why we need it and why it was done in this way

A missing `return` before `denied()` meant that a malformed eviction request could silently mark a VMI for evacuation (triggering a live migration) while still ultimately denying the pod eviction. This is the worst of both worlds: the eviction is rejected, but the side effect of marking the VMI for evacuation is already committed.

The fix is a single-line addition of `return` to match the existing pattern used by every other error path in the same function. No alternative approaches were considered since this is the idiomatic and correct way to handle early exits in Go admission webhooks.

### Special notes for your reviewer

All other calls to `denied()` in `pod-eviction-admitter.go` already use `return`. This was the only instance missing it.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
NONE
```