### PR TITLE
tests, storage, backup: dequarantine tests

### DIFF
--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -118,7 +118,7 @@ var _ = Describe(SIG("Backup", func() {
 		Entry("2 backups to the same PVC should succeed", getDoubleTargetPVCSize(cd.AlpineVolumeSize), 2),
 	)
 
-	It("[QUARANTINE]Full and Incremental Backup with BackupTracker", decorators.Quarantine, func() {
+	It("Full and Incremental Backup with BackupTracker", func() {
 		const (
 			testDataSizeMB    = 50
 			testDataSizeBytes = testDataSizeMB * 1024 * 1024
@@ -196,7 +196,7 @@ var _ = Describe(SIG("Backup", func() {
 		verifyBackupTargetPVCOutput(virtClient, incrementalBackupPVC, vm.Name, 1, []int64{testDataSizeBytes})
 	})
 
-	It("[QUARANTINE]Full and Incremental Backup with 2 disks", decorators.Quarantine, func() {
+	It("Full and Incremental Backup with 2 disks", func() {
 		const (
 			testDataSizeMB    = 50
 			testDataSizeBytes = testDataSizeMB * 1024 * 1024
@@ -490,7 +490,7 @@ var _ = Describe(SIG("Backup", func() {
 		verifyBackupTargetPVCOutput(virtClient, secondBackupPVC, vm.Name, 1, []int64{expectedDiskSize.Value()})
 	})
 
-	It("[QUARANTINE] Checkpoint redefinition succeeds after hotplug volume removal", decorators.Quarantine, func() {
+	It("Checkpoint redefinition succeeds after hotplug volume removal", func() {
 		const (
 			testDataSizeMB    = 50
 			testDataSizeBytes = testDataSizeMB * 1024 * 1024

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -134,6 +134,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
 			libvmi.WithLabels(cbt.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			withCloudInitNoCloudDummy(),
 		)
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
@@ -222,6 +223,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(bootDv,
 			libvmi.WithLabels(cbt.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			withCloudInitNoCloudDummy(),
 		)
 
 		libstorage.AddDataVolumeTemplate(vm, blankDv)
@@ -276,7 +278,7 @@ var _ = Describe(SIG("Backup", func() {
 
 		By("Writing data directly to second disk")
 		// Write random data directly to the raw block device (no formatting needed)
-		err = console.RunCommand(vmi, fmt.Sprintf("dd if=/dev/urandom of=/dev/vdb bs=1M count=%d && sync", testDataSizeMB), 2*time.Minute)
+		err = console.RunCommand(vmi, fmt.Sprintf("dd if=/dev/urandom of=/dev/vdc bs=1M count=%d && sync", testDataSizeMB), 2*time.Minute)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Creating second incremental backup with same tracker reference")
@@ -314,6 +316,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
 			libvmi.WithLabels(cbt.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			withCloudInitNoCloudDummy(),
 		)
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
@@ -512,6 +515,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(bootDv,
 			libvmi.WithLabels(cbt.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			withCloudInitNoCloudDummy(),
 		)
 
 		vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
@@ -581,6 +585,9 @@ var _ = Describe(SIG("Backup", func() {
 			}
 			if volStatus.Name == bootDiskName {
 				bootDiskTarget = volStatus.Target
+			}
+			if volStatus.Name == libvmi.CloudInitDiskName {
+				continue
 			}
 			allDiskTargets = append(allDiskTargets, volStatus.Target)
 		}
@@ -814,6 +821,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
 			libvmi.WithLabels(backup.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			withCloudInitNoCloudDummy(),
 		)
 
 		By(fmt.Sprintf("Creating VM %s", vm.Name))
@@ -908,6 +916,7 @@ var _ = Describe(SIG("Backup", func() {
 		vm = libstorage.RenderVMWithDataVolumeTemplate(bootDv,
 			libvmi.WithLabels(backup.CBTLabel),
 			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+			withCloudInitNoCloudDummy(),
 		)
 		libstorage.AddDataVolumeTemplate(vm, blankDv)
 		libstorage.AddDataVolume(vm, "disk1", blankDv)
@@ -923,7 +932,7 @@ var _ = Describe(SIG("Backup", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(console.LoginToAlpine(vmi)).To(Succeed(), "Should be able to login to Alpine VM")
 
-		writeCmdA := fmt.Sprintf("printf '%%0512s' '%s' | dd of=/dev/vdb bs=1 count=%d seek=%d && sync", patternA, testLength, testOffset)
+		writeCmdA := fmt.Sprintf("printf '%%0512s' '%s' | dd of=/dev/vdc bs=1 count=%d seek=%d && sync", patternA, testLength, testOffset)
 		err = console.RunCommand(vmi, writeCmdA, 2*time.Minute)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -966,7 +975,7 @@ var _ = Describe(SIG("Backup", func() {
 		verifyPullEndpointsWithDataCheck(virtClient, fullBackup, backupv1.Full, tokenValue, "disk1", testOffset, testLength, patternA)
 
 		By("Writing Pattern B to the exact same offset in the live VM")
-		writeCmdB := fmt.Sprintf("printf '%%0512s' '%s' | dd of=/dev/vdb bs=1 count=%d seek=%d && sync", patternB, testLength, testOffset)
+		writeCmdB := fmt.Sprintf("printf '%%0512s' '%s' | dd of=/dev/vdc bs=1 count=%d seek=%d && sync", patternB, testLength, testOffset)
 		err = console.RunCommand(vmi, writeCmdB, 2*time.Minute)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1787,4 +1796,23 @@ func verifyPullEndpointsWithDataCheck(virtClient kubecli.KubevirtClient, vmbacku
 
 	err = virtClient.CoreV1().ConfigMaps(caConfigMap.Namespace).Delete(context.Background(), caConfigMap.Name, metav1.DeleteOptions{})
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func withCloudInitNoCloudDummy() libvmi.VMOption {
+	return func(vm *v1.VirtualMachine) {
+		source := &v1.CloudInitNoCloudSource{}
+		libvmifact.WithDummyCloudForFastBoot()(source)
+
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+			Name:         libvmi.CloudInitDiskName,
+			VolumeSource: v1.VolumeSource{CloudInitNoCloud: source},
+		})
+
+		vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: libvmi.CloudInitDiskName,
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{Bus: v1.DiskBusVirtio},
+			},
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Overlay resolution logic has been fixed, therefore the dequarantined tests no longer flake.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

