### PR TITLE
Remove bidirectional mount propagation from kubelet volume in virt-handler

### DIFF
--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "apiservices_test.go",
         "components_suite_test.go",
         "crds_test.go",
+        "daemonsets_test.go",
         "deployments_test.go",
         "instancetypes_test.go",
         "routes_test.go",

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -306,6 +306,7 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 	attachProfileVolume(pod)
 
 	bidi := corev1.MountPropagationBidirectional
+	hostToContainer := corev1.MountPropagationHostToContainer
 	// NOTE: the 'kubelet-pods' volume mount exists because that path holds unix socket files.
 	// Socket files fail when their path is longer than 108 characters,
 	//   so that shortened volume path is to allow domain socket connections.
@@ -315,7 +316,7 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 		{"virt-share-dir", util.VirtShareDir, util.VirtShareDir, &bidi},
 		{"virt-private-dir", util.VirtPrivateDir, util.VirtPrivateDir, nil},
 		{"kubelet-pods", kubeletPodsPath, "/pods", nil},
-		{"kubelet", util.KubeletRoot, util.KubeletRoot, &bidi},
+		{"kubelet", util.KubeletRoot, util.KubeletRoot, &hostToContainer},
 		{"node-labeller", nodeLabellerVolumePath, nodeLabellerVolumePath, nil},
 	}
 

--- a/pkg/virt-operator/resource/generate/components/daemonsets_test.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets_test.go
@@ -1,0 +1,34 @@
+package components
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
+)
+
+var _ = Describe("Handler DaemonSet", func() {
+	var config *operatorutil.KubeVirtDeploymentConfig
+
+	BeforeEach(func() {
+		config = &operatorutil.KubeVirtDeploymentConfig{}
+	})
+
+	It("should not use bidirectional mount propagation for the kubelet volume", func() {
+		ds := NewHandlerDaemonSet(config, "", "", "")
+		container := ds.Spec.Template.Spec.Containers[0]
+
+		var kubeletMount *corev1.VolumeMount
+		for i := range container.VolumeMounts {
+			if container.VolumeMounts[i].Name == "kubelet" {
+				kubeletMount = &container.VolumeMounts[i]
+				break
+			}
+		}
+		Expect(kubeletMount).NotTo(BeNil(), "kubelet volume mount should exist")
+		Expect(kubeletMount.MountPropagation).NotTo(BeNil())
+		Expect(*kubeletMount.MountPropagation).To(Equal(corev1.MountPropagationHostToContainer))
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
virt-handler currently mounts /var/lib/kubelet with MountPropagationBidirectional. When other components on the node (e.g. CSI pods) also mount child directories such as /var/lib/kubelet/plugins or /var/lib/kubelet/pods as bidirectional, each restart of virt-handler doubles the mount count on the node due to the bidirectional propagation preserving old mounts while creating new ones. After 10-12 restarts this causes the node to become unusable with "device or resource busy" errors from kubelet/containerd.

Bidirectional propagation on this volume is unnecessary because:

Hotplug disk operations use virt-chroot with /proc/1/root to operate directly in the host mount namespace
Device plugin registration only needs read/write socket access
Seccomp profile installation only writes files
cpu_manager_state is read-only

#### After this PR:
Change the kubelet volume mount propagation from Bidirectional to HostToContainer, which still allows virt-handler to see new mounts created by kubelet on the host, while preventing mount explosion from container-to-host propagation.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- [Fixes #](https://github.com/kubevirt/kubevirt/issues/17423)
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
change /var/lib/kubelet mount from Bidirectional to HostToContainer
```

