### PR TITLE
PCIe NUMA topology: support cross-NUMA device placement

### DIFF
--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -199,11 +199,18 @@ func PCIAddressToString(pciBusID *api.Address) string {
 // LookupDevicesNumaNodes looks up the NUMA nodes of multiple devices based on
 // their PCI addresses and the domain spec of the virtual machine.
 //
-// It returns a map of PCI addresses to their corresponding NUMA node IDs.
-func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) map[string]uint32 {
-	results := make(map[string]uint32)
+// It returns two maps:
+//   - aligned: PCI addresses mapped to guest NUMA cell IDs where the device's
+//     host NUMA node has vCPUs pinned to it.
+//   - unaligned: PCI addresses mapped to host NUMA node IDs where the device's
+//     host NUMA node has no pinned vCPUs. The caller can use this to create
+//     CPU-less guest NUMA cells for cross-NUMA device placement (e.g., NVIDIA
+//     GB200 where the GPU is on a separate NUMA node from all CPUs).
+func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) (aligned map[string]uint32, unaligned map[string]uint32) {
+	aligned = make(map[string]uint32)
+	unaligned = make(map[string]uint32)
 	if len(pciAddresses) == 0 || domainSpec == nil || domainSpec.CPU.NUMA == nil || domainSpec.CPUTune == nil {
-		return results
+		return
 	}
 
 	// pcpu -> vcpu mapping
@@ -244,6 +251,12 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 		if err != nil {
 			continue
 		}
+
+		// Skip devices that report no NUMA affinity (-1 wraps to max uint32)
+		if int32(*deviceNuma) == -1 {
+			continue
+		}
+
 		var pcpus []uint32
 		// if another device is already on this NUMA node, use the same pcpu set
 		if res, exists := pNumaToPCPUSetMap[*deviceNuma]; exists {
@@ -251,21 +264,33 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 		} else {
 			pcpusNuma, err := GetNumaNodeCPUList(int(*deviceNuma))
 			if err != nil {
-				continue
+				// NUMA node may have no CPUs (e.g., GPU-only NUMA node)
+				pNumaToPCPUSetMap[*deviceNuma] = nil
+				pcpus = nil
+			} else {
+				for _, pcpu := range pcpusNuma {
+					pcpus = append(pcpus, uint32(pcpu))
+				}
+				pNumaToPCPUSetMap[*deviceNuma] = pcpus
 			}
-			for _, pcpu := range pcpusNuma {
-				pcpus = append(pcpus, uint32(pcpu))
-			}
-			pNumaToPCPUSetMap[*deviceNuma] = pcpus
 		}
 
+		found := false
 		for _, pcpu := range pcpus {
 			if vCPU, exist := p2vCPUMap[pcpu]; exist {
 				cellID := vCPUToCellMap[vCPU]
-				results[pciAddress] = cellID
+				aligned[pciAddress] = cellID
+				found = true
 				break
 			}
 		}
+
+		// Device is on a host NUMA node with no pinned vCPUs.
+		// Record the host NUMA node so the caller can create a
+		// CPU-less guest NUMA cell for it.
+		if !found {
+			unaligned[pciAddress] = *deviceNuma
+		}
 	}
-	return results
+	return
 }

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -33,7 +33,8 @@ import (
 
 var _ = Describe("Hardware utils test", func() {
 	const (
-		testPCIAddress = "0000:00:01.0"
+		testPCIAddress  = "0000:00:01.0"
+		testPCIAddress2 = "0000:00:02.0"
 	)
 
 	var (
@@ -52,13 +53,22 @@ var _ = Describe("Hardware utils test", func() {
 		fakeNodeBasePath, err = os.MkdirTemp("", "numa_nodes")
 		Expect(err).ToNot(HaveOccurred())
 
-		// Create test PCI device with NUMA node
+		// Create test PCI device on NUMA node 0
 		pciDevicePath := filepath.Join(fakePciBasePath, testPCIAddress)
 		err = os.MkdirAll(pciDevicePath, 0o755)
 		Expect(err).ToNot(HaveOccurred())
 
 		numaNodeFile := filepath.Join(pciDevicePath, "numa_node")
 		err = os.WriteFile(numaNodeFile, []byte("0\n"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create test PCI device on NUMA node 1
+		pciDevicePath2 := filepath.Join(fakePciBasePath, testPCIAddress2)
+		err = os.MkdirAll(pciDevicePath2, 0o755)
+		Expect(err).ToNot(HaveOccurred())
+
+		numaNodeFile2 := filepath.Join(pciDevicePath2, "numa_node")
+		err = os.WriteFile(numaNodeFile2, []byte("1\n"), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create NUMA node 0 with cpulist
@@ -276,26 +286,29 @@ var _ = Describe("Hardware utils test", func() {
 	})
 
 	Context("devices NUMA affinity", func() {
-		It("should return an empty result for no PCI addresses", func() {
+		It("should return empty results for no PCI addresses", func() {
 			domainSpec := &api.DomainSpec{}
-			devicesNumaNodes := LookupDevicesNumaNodes([]string{}, domainSpec)
-			Expect(devicesNumaNodes).To(BeEmpty())
+			aligned, unaligned := LookupDevicesNumaNodes([]string{}, domainSpec)
+			Expect(aligned).To(BeEmpty())
+			Expect(unaligned).To(BeEmpty())
 		})
 
-		It("should return an empty result for nil domain spec", func() {
-			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, nil)
-			Expect(devicesNumaNodes).To(BeEmpty())
+		It("should return empty results for nil domain spec", func() {
+			aligned, unaligned := LookupDevicesNumaNodes([]string{testPCIAddress}, nil)
+			Expect(aligned).To(BeEmpty())
+			Expect(unaligned).To(BeEmpty())
 		})
 
-		It("should return an empty result when domain spec has no NUMA info", func() {
+		It("should return empty results when domain spec has no NUMA info", func() {
 			domainSpec := &api.DomainSpec{
 				CPU: api.CPU{},
 			}
-			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
-			Expect(devicesNumaNodes).To(BeEmpty())
+			aligned, unaligned := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
+			Expect(aligned).To(BeEmpty())
+			Expect(unaligned).To(BeEmpty())
 		})
 
-		It("should handle domain spec with NUMA cells but no vCPU affinity", func() {
+		It("should return device as unaligned when NUMA cells exist but no vCPU affinity", func() {
 			domainSpec := &api.DomainSpec{
 				CPU: api.CPU{
 					NUMA: &api.NUMA{
@@ -310,8 +323,12 @@ var _ = Describe("Hardware utils test", func() {
 				},
 			}
 
-			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
-			Expect(devicesNumaNodes).To(BeEmpty())
+			// Device is on NUMA 0 but no vCPUs are pinned anywhere,
+			// so it should be reported as unaligned with its host NUMA node
+			aligned, unaligned := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
+			Expect(aligned).To(BeEmpty())
+			Expect(unaligned).To(HaveKey(testPCIAddress))
+			Expect(unaligned[testPCIAddress]).To(Equal(uint32(0)))
 		})
 
 		It("should return devices vCPU NUMA nodes for their aligned vCPUs", func() {
@@ -333,10 +350,40 @@ var _ = Describe("Hardware utils test", func() {
 			}
 
 			// Device is on host NUMA node 0, and vCPU 0 is on guest NUMA cell 0
-			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
-			Expect(devicesNumaNodes).ToNot(BeEmpty())
-			Expect(devicesNumaNodes).To(HaveKey(testPCIAddress))
-			Expect(devicesNumaNodes[testPCIAddress]).To(Equal(uint32(0)))
+			aligned, unaligned := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
+			Expect(aligned).ToNot(BeEmpty())
+			Expect(aligned).To(HaveKey(testPCIAddress))
+			Expect(aligned[testPCIAddress]).To(Equal(uint32(0)))
+			Expect(unaligned).To(BeEmpty())
+		})
+
+		It("should return unaligned devices when device is on NUMA node without vCPUs", func() {
+			// Simulate GB200: vCPUs on NUMA 0, device on NUMA 1
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0-1", Memory: 2048, Unit: "MiB"},
+						},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{VCPU: 0, CPUSet: "0"},
+						{VCPU: 1, CPUSet: "1"},
+					},
+				},
+			}
+
+			// testPCIAddress (0000:00:01.0) is on NUMA node 0,
+			// use a device on NUMA node 1
+			aligned, unaligned := LookupDevicesNumaNodes([]string{testPCIAddress, testPCIAddress2}, domainSpec)
+			// testPCIAddress is on NUMA 0 with vCPUs -> aligned
+			Expect(aligned).To(HaveKey(testPCIAddress))
+			Expect(aligned[testPCIAddress]).To(Equal(uint32(0)))
+			// testPCIAddress2 is on NUMA 1 with no vCPUs -> unaligned
+			Expect(unaligned).To(HaveKey(testPCIAddress2))
+			Expect(unaligned[testPCIAddress2]).To(Equal(uint32(1)))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -183,6 +183,11 @@ type expanderBusAssigner struct {
 	devices          map[string]*api.HostDevice
 	devicesNUMANodes map[string]uint32
 
+	// hostNUMAToCellMap tracks CPU-less guest NUMA cells created for host
+	// NUMA nodes that have passthrough devices but no pinned vCPUs (e.g.,
+	// NVIDIA GB200 where the GPU is on a separate NUMA node from all CPUs).
+	hostNUMAToCellMap map[uint32]uint32
+
 	// lastAssignedBusNr tracks the last assigned bus number for expander buses.
 	// It starts from maxExpanderBusNr and decreases as expander buses are assigned
 	// to ensure controller indices don't conflict with expander bus number space.
@@ -213,6 +218,7 @@ func newExpanderBusAssigner(domainSpec *api.DomainSpec) *expanderBusAssigner {
 		topologyMap:       make(map[uint32]*numaAwareTopology),
 		devices:           make(map[string]*api.HostDevice),
 		devicesNUMANodes:  make(map[string]uint32),
+		hostNUMAToCellMap: make(map[uint32]uint32),
 		controllerIndex:   currentControllerIndex,
 		controllerCount:   0,
 		lastAssignedBusNr: maxExpanderBusNr,
@@ -277,16 +283,65 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 		devicesByAddress[address] = &devices[i]
 	}
 
-	numaNodes := hardware.LookupDevicesNumaNodes(pciAddresses, a.domainSpec)
+	aligned, unaligned := hardware.LookupDevicesNumaNodes(pciAddresses, a.domainSpec)
 
 	for address, device := range devicesByAddress {
-		if numaNode, exists := numaNodes[address]; exists {
+		if numaNode, exists := aligned[address]; exists {
 			a.devices[address] = device
 			a.devicesNUMANodes[address] = numaNode
+		} else if hostNUMANode, exists := unaligned[address]; exists {
+			// Device is on a host NUMA node with no pinned vCPUs (e.g.,
+			// NVIDIA GB200 where the GPU is on a separate NUMA node from
+			// all CPUs). Create a CPU-less guest NUMA cell for this host
+			// NUMA node so the device can be placed under an expander bus
+			// targeting it.
+			guestCellID := a.getOrCreateCPULessNUMACell(hostNUMANode)
+			a.devices[address] = device
+			a.devicesNUMANodes[address] = guestCellID
 		} else {
 			log.Log.Infof("device %s has no NUMA affinity information, skipping for pcie-expander-bus assignment", address)
 		}
 	}
+}
+
+// getOrCreateCPULessNUMACell returns the guest NUMA cell ID for a host NUMA
+// node that has no pinned vCPUs. If a CPU-less cell has already been created
+// for this host NUMA node, it returns the existing cell ID. Otherwise, it
+// creates a new CPU-less NUMA cell in the domain spec.
+func (a *expanderBusAssigner) getOrCreateCPULessNUMACell(hostNUMANode uint32) uint32 {
+	// Check if we already created a cell for this host NUMA node
+	if cellID, exists := a.hostNUMAToCellMap[hostNUMANode]; exists {
+		return cellID
+	}
+
+	// Find the next available cell ID
+	nextCellID := uint32(0)
+	if a.domainSpec.CPU.NUMA != nil {
+		for _, cell := range a.domainSpec.CPU.NUMA.Cells {
+			id, err := strconv.Atoi(cell.ID)
+			if err != nil {
+				continue
+			}
+			if uint32(id) >= nextCellID {
+				nextCellID = uint32(id) + 1
+			}
+		}
+	}
+
+	newCell := api.NUMACell{
+		ID:   strconv.Itoa(int(nextCellID)),
+		CPUs: "",
+	}
+
+	if a.domainSpec.CPU.NUMA == nil {
+		a.domainSpec.CPU.NUMA = &api.NUMA{}
+	}
+	a.domainSpec.CPU.NUMA.Cells = append(a.domainSpec.CPU.NUMA.Cells, newCell)
+	a.hostNUMAToCellMap[hostNUMANode] = nextCellID
+
+	log.Log.Infof("created CPU-less guest NUMA cell %d for host NUMA node %d", nextCellID, hostNUMANode)
+
+	return nextCellID
 }
 
 // numaDeviceGroups represents a mapping of NUMA nodes to host devices.

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -217,6 +217,33 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 				expectedDevices: 2,
 				description:     "should accept all valid PCI devices with NUMA affinity",
 			}),
+			Entry("accepts cross-NUMA device by creating CPU-less NUMA cell", addDevicesTestCase{
+				name: "device on NUMA node without vCPUs (cross-NUMA)",
+				devices: []api.HostDevice{
+					createPCIDevice("gpu1", "0x02"), // NUMA 1, no vCPUs pinned there
+				},
+				numaCells: []api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				vcpuPins: []api.CPUTuneVCPUPin{
+					{VCPU: 0, CPUSet: "0"},
+					{VCPU: 1, CPUSet: "1"},
+				},
+				expectedDevices: 1,
+				description:     "should accept cross-NUMA device by creating a CPU-less guest NUMA cell",
+			}),
+			Entry("accepts both co-located and cross-NUMA devices", addDevicesTestCase{
+				name: "mixed NUMA alignment",
+				devices: []api.HostDevice{
+					createPCIDevice("gpu_numa0", "0x01"), // NUMA 0, vCPUs present
+					createPCIDevice("gpu_numa1", "0x02"), // NUMA 1, no vCPUs
+				},
+				numaCells: []api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				vcpuPins: []api.CPUTuneVCPUPin{
+					{VCPU: 0, CPUSet: "0"},
+					{VCPU: 1, CPUSet: "1"},
+				},
+				expectedDevices: 2,
+				description:     "should accept both co-located and cross-NUMA devices",
+			}),
 		)
 
 		DescribeTable("PlaceNumaAlignedDevices",
@@ -307,6 +334,33 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 				devices:             []api.HostDevice{createPCIDevice("device1", "0x01")},
 				expectedControllers: 0,
 			}),
+			Entry("places cross-NUMA device with CPU-less NUMA cell", devicePlacementTestCase{
+				name: "cross-NUMA: device on NUMA 1, vCPUs only on NUMA 0",
+				numaCells: []api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				vcpuPins: []api.CPUTuneVCPUPin{
+					{VCPU: 0, CPUSet: "0"},
+					{VCPU: 1, CPUSet: "1"},
+				},
+				devices:               []api.HostDevice{createPCIDevice("gpu1", "0x02")},
+				expectedControllers:   2,
+				expectedExpanderBuses: 1,
+				expectedRootPorts:     1,
+			}),
+			Entry("places both co-located and cross-NUMA devices", devicePlacementTestCase{
+				name: "mixed: one device co-located, one cross-NUMA",
+				numaCells: []api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				vcpuPins: []api.CPUTuneVCPUPin{
+					{VCPU: 0, CPUSet: "0"},
+					{VCPU: 1, CPUSet: "1"},
+				},
+				devices: []api.HostDevice{
+					createPCIDevice("gpu_numa0", "0x01"), // NUMA 0, vCPUs present
+					createPCIDevice("gpu_numa1", "0x02"), // NUMA 1, no vCPUs
+				},
+				expectedControllers:   4,
+				expectedExpanderBuses: 2,
+				expectedRootPorts:     2,
+			}),
 		)
 	})
 
@@ -382,6 +436,55 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 				Expect(device.Address.Bus).ToNot(BeEmpty())
 				Expect(device.Address.Slot).To(Equal("0x00"))
 			}
+		})
+
+		It("should place cross-NUMA device under expander bus with CPU-less NUMA cell", func() {
+			// Simulate a topology like NVIDIA GB200 where the GPU is on a
+			// different NUMA node (1) than the vCPUs (all on NUMA 0).
+			domainSpec = createDomainSpecWithNUMA(
+				[]api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				[]api.CPUTuneVCPUPin{
+					{VCPU: 0, CPUSet: "0"},
+					{VCPU: 1, CPUSet: "1"},
+				},
+			)
+
+			coLocatedDevice := createPCIDevice("nic_numa0", "0x01")   // NUMA 0, vCPUs present
+			crossNUMADevice := createPCIDevice("gpu_numa1", "0x02")   // NUMA 1, no vCPUs
+
+			domainSpec.Devices.HostDevices = []api.HostDevice{coLocatedDevice, crossNUMADevice}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Both devices should be placed under expander buses
+			for i, device := range domainSpec.Devices.HostDevices {
+				Expect(device.Address).ToNot(BeNil(), "device %d should have an address assigned", i)
+				Expect(device.Address.Type).To(Equal(api.AddressPCI))
+				Expect(device.Address.Slot).To(Equal("0x00"))
+			}
+
+			// Verify two expander buses were created (one per NUMA node)
+			expanderBuses := make(map[uint32]*api.Controller)
+			for i := range domainSpec.Devices.Controllers {
+				ctrl := &domainSpec.Devices.Controllers[i]
+				if ctrl.Model == api.ControllerModelPCIeExpanderBus {
+					Expect(ctrl.Target).ToNot(BeNil())
+					Expect(ctrl.Target.NUMANode).ToNot(BeNil())
+					expanderBuses[*ctrl.Target.NUMANode] = ctrl
+				}
+			}
+			Expect(expanderBuses).To(HaveLen(2), "expected 2 expander buses (one per NUMA node)")
+			Expect(expanderBuses).To(HaveKey(uint32(0)), "expected expander bus for vNUMA 0")
+			Expect(expanderBuses).To(HaveKey(uint32(1)), "expected expander bus for CPU-less vNUMA 1")
+
+			// Verify a CPU-less NUMA cell was created for host NUMA node 1
+			Expect(domainSpec.CPU.NUMA).ToNot(BeNil())
+			Expect(domainSpec.CPU.NUMA.Cells).To(HaveLen(2), "expected 2 NUMA cells (original + CPU-less)")
+
+			cpuLessCell := domainSpec.CPU.NUMA.Cells[1]
+			Expect(cpuLessCell.ID).To(Equal("1"))
+			Expect(cpuLessCell.CPUs).To(Equal(""), "CPU-less NUMA cell should have no CPUs")
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does
#### Before this PR:

VEP 115's PCIe NUMA-aware topology discovers the host NUMA node for each
passthrough device but discards it when no vCPUs are pinned to that node.
On hardware like NVIDIA GB200 where the GPU is architecturally on a separate
NUMA node from all CPUs, this means the GPU falls back to the default `pci.0`
bus without NUMA affinity and VEP 115 provides no benefit.

#### After this PR:

`LookupDevicesNumaNodes` returns both aligned devices (host NUMA node has
pinned vCPUs) and unaligned devices (host NUMA node has no pinned vCPUs).
When the expander bus assigner encounters an unaligned device, it creates a
CPU-less guest NUMA cell for the device's host NUMA node and places the device
under a `pcie-expander-bus` targeting that cell. The guest sees the correct
topology (e.g., vCPUs on vNUMA 0, GPU on vNUMA 1).

Also adds an explicit check for NUMA node `-1` in `GetDeviceNumaNode` to avoid
relying on uint32 overflow for devices without NUMA affinity.

### References

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/115
- VEP design update: https://github.com/kubevirt/enhancements/pull/264

### Why we need it and why it was done in this way
The following tradeoffs were made:
- CPU-less NUMA cells have no memory assigned. The minimum memory needed for the
  guest kernel to recognize the node needs to be determined and is tracked as an
  open question in the VEP.

The following alternatives were considered:
- A new `guestMappingPassthroughWithDevices` policy was considered but extending
  the existing `guestMappingPassthrough` behaviour within the VEP 115 feature gate
  is simpler and keeps the API unchanged.

### Special notes for your reviewer

This is a draft exploring cross-NUMA device placement for VEP 115. The design
update PR is at https://github.com/kubevirt/enhancements/pull/264.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present ([VEP 115](https://github.com/kubevirt/enhancements/issues/115)) 
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```