### PR TITLE
tests: fix density test primer VMI flakiness

### DIFF
--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -53,6 +53,7 @@ const (
 	updateVMICountToPodCreateCountThreshold = 10
 	vmiCreationToRunningSecondsP50Threshold = 45
 	vmiCreationToRunningSecondsP95Threshold = 60
+	primerVMITimeout                        = 3 * time.Minute
 )
 
 var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
@@ -71,7 +72,7 @@ var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 			createBatchVMIWithRateControl(virtClient, 1)
 
 			By("Waiting for primer VMI to be Running")
-			waitRunningVMI(virtClient, 1, 1*time.Minute)
+			waitRunningVMI(virtClient, 1, primerVMITimeout)
 
 			// Leave a two scrape buffer between tests
 			time.Sleep(2 * PrometheusScrapeInterval)
@@ -92,7 +93,7 @@ var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 				createBatchVMIWithRateControl(virtClient, vmCount)
 
 				By("Waiting a batch of VMIs")
-				waitRunningVMI(virtClient, vmCount+1, vmBatchStartupLimit)
+				waitRunningVMI(virtClient, vmCount, vmBatchStartupLimit)
 				collectMetrics(startTime, filepath.Join(artifactsDir, "VMI-perf-audit-results.json"))
 			})
 		})


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The density test primer VMI has two issues causing flaky failures across all density tests in the sig-performance lane:

1. The primer VMI timeout of 60 seconds is too tight for the CI environment. When the primer can't boot within 60s, all 3 density tests fail in `BeforeEach` with `Expected <int>: 0 to equal <int>: 1` at `density.go:65`.

2. The first VMI batch test expects `vmCount+1` (101) running VMIs to account for the primer, but the primer may have been evicted under resource pressure, leaving exactly 100 running. This causes a 5-minute timeout that consumes the entire 1-hour suite budget, preventing the other density tests from running.

#### After this PR:
1. Primer VMI timeout increased from 1 minute to 3 minutes, giving the CI environment more time to boot the initial VMI.
2. The first VMI batch test now expects `vmCount` (100) running VMIs, matching the behavior of the other two density tests. The primer's purpose is to warm caches, not to be counted in the batch.

### References
- Partially addresses #17456

### Why we need it and why it was done in this way

Analysis of recent CI failures ([search results](https://search.ci.kubevirt.io/?context=1&groupBy=job&maxAge=336h&maxBytes=20971520&maxMatches=100&search=should+successfully+create+all+VMS+with+instancetype+and+preference&type=junit)) shows 11 failures across `pull-kubevirt-e2e-k8s-1.34-sig-performance` and `periodic-kubevirt-e2e-k8s-1.34-sig-performance` in the last 14 days.

Two distinct failure patterns exist:
- **Pattern 1** (`density.go:65`): Primer VMI can't reach Running within 60s → all 3 density tests fail
- **Pattern 2** (`density.go:90`): First VMI test gets 100/101 running VMIs → times out after 300s, consuming the suite's 1-hour budget

Both are addressed by this PR without needing to quarantine any tests.

### Special notes for your reviewer

The quarantine approach in #17456 only targets the instancetype test, but the failures are not specific to that test. In Pattern 1 all 3 tests fail, and in Pattern 2 it's the first VMI test that fails (the instancetype test is never reached). This PR fixes the root causes instead.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```