### PR TITLE
Extend dynamic label/annotation propagation to support prefix wildcards

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -1087,11 +1087,10 @@ func (vca *VirtControllerApp) AddFlags() {
 		"Number of goroutines to run for clone controller")
 
 	flag.StringSliceVar(&vca.additionalLauncherAnnotationsSync, "additional-launcher-annotations-sync", []string{},
-		"Comma separated list of annotation keys which if present on the VM template and so VMI, will be sync to the virt-launcher pod. Note, it is unidirectional from VM.spec.template.metadata -> VMI and VMI -> virt-launcher pod")
+		"Comma separated list of annotation keys which if present on the VM template and so VMI, will be sync to the virt-launcher pod. Supports prefix wildcards via the '*' suffix (for example 'vendor.io/*'). Note, it is unidirectional from VM.spec.template.metadata -> VMI and VMI -> virt-launcher pod")
 
 	flag.StringSliceVar(&vca.additionalLauncherLabelsSync, "additional-launcher-labels-sync", []string{},
-		"Comma separated list of labels keys which if present on the VM template and so VMI, will be sync to the virt-launcher pod. Note, it is unidirectional from VM.spec.template.metadata -> VMI and VMI -> virt-launcher pod")
-
+		"Comma separated list of labels keys which if present on the VM template and so VMI, will be sync to the virt-launcher pod. Supports prefix wildcards via the '*' suffix (for example 'vendor.io/*'). Note, it is unidirectional from VM.spec.template.metadata -> VMI and VMI -> virt-launcher pod")
 	flag.IntVar(&vca.backupControllerThreads, "backup-controller-threads", defaultBackupControllerThreads,
 		"Number of goroutines to run for backup controller")
 }

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -2872,19 +2872,26 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToVMI(vm *virtv1.VirtualMach
 
 	patchSet := patch.New()
 	newVmiAnnotations := maps.Clone(vmi.Annotations)
+	if newVmiAnnotations == nil {
+		newVmiAnnotations = map[string]string{}
+	}
 	newVmiLabels := maps.Clone(vmi.Labels)
+	if newVmiLabels == nil {
+		newVmiLabels = map[string]string{}
+	}
 
-	syncMap := func(keys []string, vmMap, vmiMap, vmiOrigMap map[string]string, subPath string) {
+	syncMap := func(patterns []string, vmMap, vmiMap, vmiOrigMap map[string]string, subPath string) {
 		changed := false
 		if _, ok := vmiMap[virtv1.DeprecatedVirtualMachineGenerationAnnotation]; ok {
 			delete(vmiMap, virtv1.DeprecatedVirtualMachineGenerationAnnotation)
 			changed = true
 		}
-		for _, key := range keys {
+
+		syncKey := func(key string) {
 			vmVal, vmExists := vmMap[key]
 			vmiVal, vmiExists := vmiMap[key]
 			if vmExists == vmiExists && vmVal == vmiVal {
-				continue
+				return
 			}
 			changed = true
 			if vmExists {
@@ -2892,6 +2899,36 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToVMI(vm *virtv1.VirtualMach
 			} else {
 				delete(vmiMap, key)
 			}
+		}
+
+		syncPrefix := func(prefix string) {
+			visited := map[string]struct{}{}
+			for key := range vmMap {
+				if strings.HasPrefix(key, prefix) {
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+			for key := range vmiMap {
+				if strings.HasPrefix(key, prefix) {
+					if _, ok := visited[key]; ok {
+						continue
+					}
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+		}
+
+		for _, pattern := range patterns {
+			if pattern == "" {
+				continue
+			}
+			if strings.HasSuffix(pattern, "*") {
+				syncPrefix(strings.TrimSuffix(pattern, "*"))
+				continue
+			}
+			syncKey(pattern)
 		}
 
 		if !changed {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3070,15 +3070,21 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToVMI(vm *virtv1.VirtualMach
 
 	patchSet := patch.New()
 	newVmiAnnotations := maps.Clone(vmi.Annotations)
+	if newVmiAnnotations == nil {
+		newVmiAnnotations = map[string]string{}
+	}
 	newVmiLabels := maps.Clone(vmi.Labels)
+	if newVmiLabels == nil {
+		newVmiLabels = map[string]string{}
+	}
 
-	syncMap := func(keys []string, vmMap, vmiMap, vmiOrigMap map[string]string, subPath string) {
+	syncMap := func(patterns []string, vmMap, vmiMap, vmiOrigMap map[string]string, subPath string) {
 		changed := false
-		for _, key := range keys {
+		syncKey := func(key string) {
 			vmVal, vmExists := vmMap[key]
 			vmiVal, vmiExists := vmiMap[key]
 			if vmExists == vmiExists && vmVal == vmiVal {
-				continue
+				return
 			}
 			changed = true
 			if vmExists {
@@ -3086,6 +3092,41 @@ func (c *Controller) syncDynamicAnnotationsAndLabelsToVMI(vm *virtv1.VirtualMach
 			} else {
 				delete(vmiMap, key)
 			}
+		}
+
+		syncPrefix := func(prefix string) {
+			visited := map[string]struct{}{}
+			for key := range vmMap {
+				if strings.HasPrefix(key, prefix) {
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+			for key := range vmiMap {
+				if strings.HasPrefix(key, prefix) {
+					if _, ok := visited[key]; ok {
+						continue
+					}
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+		}
+
+		for _, pattern := range patterns {
+			if pattern == "" {
+				continue
+			}
+			if strings.HasSuffix(pattern, "*") {
+				prefix := strings.TrimSuffix(pattern, "*")
+				// Reject bare "*" to prevent accidental sync-all. Only prefix wildcards like "vendor.io/*" are supported.
+				if prefix == "" {
+					continue
+				}
+				syncPrefix(prefix)
+				continue
+			}
+			syncKey(pattern)
 		}
 
 		if !changed {

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -3213,7 +3213,9 @@ var _ = Describe("VirtualMachine", func() {
 		Context("dynamic annotations and labels", func() {
 			const selectedAnnotationKey = descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction
 			const customSyncAnnotation = "custom/annotation"
+			const customSyncAnnotationPrefix = "custom/annotation-prefix/"
 			const customSyncLabel = "custom/label"
+			const customSyncLabelPrefix = "custom/label-prefix/"
 			const ignoredKey = "anotherKey"
 			const intitialValue = "initialValue"
 			const updatedValue = "updatedValue"
@@ -3305,10 +3307,48 @@ var _ = Describe("VirtualMachine", func() {
 					map[string]string{selectedAnnotationKey: intitialValue, customSyncAnnotation: customSyncAnnotation},
 					1,
 				),
+				Entry("should sync annotations matching wildcard prefixes",
+					[]string{customSyncAnnotationPrefix + "*"},
+					map[string]string{selectedAnnotationKey: intitialValue, customSyncAnnotationPrefix + "one": intitialValue},
+					map[string]string{
+						selectedAnnotationKey:              intitialValue,
+						customSyncAnnotationPrefix + "one": updatedValue,
+						customSyncAnnotationPrefix + "two": updatedValue,
+						ignoredKey:                         anotherValue,
+					},
+					map[string]string{
+						selectedAnnotationKey:              intitialValue,
+						customSyncAnnotationPrefix + "one": updatedValue,
+						customSyncAnnotationPrefix + "two": updatedValue,
+					},
+					1,
+				),
+				Entry("should remove annotations matching wildcard prefixes when absent in VM template",
+					[]string{customSyncAnnotationPrefix + "*"},
+					map[string]string{
+						selectedAnnotationKey:              intitialValue,
+						customSyncAnnotationPrefix + "one": intitialValue,
+						customSyncAnnotationPrefix + "two": intitialValue,
+					},
+					map[string]string{
+						selectedAnnotationKey: intitialValue,
+					},
+					map[string]string{
+						selectedAnnotationKey: intitialValue,
+					},
+					1,
+				),
+				Entry("should ignore bare '*' pattern and not sync any annotations",
+					[]string{"*"},
+					map[string]string{selectedAnnotationKey: intitialValue},
+					map[string]string{selectedAnnotationKey: intitialValue, ignoredKey: updatedValue},
+					map[string]string{selectedAnnotationKey: intitialValue},
+					0,
+				),
 			)
 
-			DescribeTable("should sync selected dynamic labels from spec.template to vmi", func(existingLabels, updatedVMLabels, expectedVMILabels map[string]string, numExpectedPatches int) {
-				controller.additionalLauncherLabelsSync = []string{customSyncLabel}
+			DescribeTable("should sync selected dynamic labels from spec.template to vmi", func(additionalLauncherLabelsSync []string, existingLabels, updatedVMLabels, expectedVMILabels map[string]string, numExpectedPatches int) {
+				controller.additionalLauncherLabelsSync = additionalLauncherLabelsSync
 
 				vm, vmi := watchtesting.DefaultVirtualMachine(true)
 				vm.Spec.Template.ObjectMeta.Labels = existingLabels
@@ -3337,32 +3377,75 @@ var _ = Describe("VirtualMachine", func() {
 
 			},
 				Entry("should copy selected custom labels from VM.spec.template.metadata.labels to VMI",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue},
 					map[string]string{customSyncLabel: updatedValue},
 					map[string]string{customSyncLabel: updatedValue},
 					1,
 				),
 				Entry("should remove selected custom labels from VMI if missing in VM.spec.template.metadata.labels",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should do nothing if selected custom labels are already equal",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					0,
 				),
 				Entry("should update only custom selected labels",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{customSyncLabel: updatedValue, ignoredKey: updatedValue},
 					map[string]string{customSyncLabel: updatedValue, ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should ignore other labels on VM.spec.template.metadata.labels",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: updatedValue},
+					map[string]string{customSyncLabel: intitialValue},
+					0,
+				),
+				Entry("should sync labels matching wildcard prefixes",
+					[]string{customSyncLabelPrefix + "*"},
+					map[string]string{
+						customSyncLabelPrefix + "one": intitialValue,
+					},
+					map[string]string{
+						customSyncLabelPrefix + "one": updatedValue,
+						customSyncLabelPrefix + "two": updatedValue,
+						ignoredKey:                    anotherValue,
+					},
+					map[string]string{
+						customSyncLabelPrefix + "one": updatedValue,
+						customSyncLabelPrefix + "two": updatedValue,
+					},
+					1,
+				),
+				Entry("should remove labels matching wildcard prefixes when absent in VM template",
+					[]string{customSyncLabelPrefix + "*"},
+					map[string]string{
+						customSyncLabelPrefix + "one": intitialValue,
+						customSyncLabelPrefix + "two": intitialValue,
+						ignoredKey:                    anotherValue,
+					},
+					map[string]string{
+						ignoredKey: anotherValue,
+					},
+					map[string]string{
+						ignoredKey: anotherValue,
+					},
+					1,
+				),
+				Entry("should ignore bare '*' pattern and not sync any labels",
+					[]string{"*"},
+					map[string]string{customSyncLabel: intitialValue},
+					map[string]string{customSyncLabel: updatedValue, ignoredKey: updatedValue},
 					map[string]string{customSyncLabel: intitialValue},
 					0,
 				),

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -3014,7 +3014,9 @@ var _ = Describe("VirtualMachine", func() {
 		Context("dynamic annotations and labels", func() {
 			const selectedAnnotationKey = descheduler.EvictPodAnnotationKeyAlphaPreferNoEviction
 			const customSyncAnnotation = "custom/annotation"
+			const customSyncAnnotationPrefix = "custom/annotation-prefix/"
 			const customSyncLabel = "custom/label"
+			const customSyncLabelPrefix = "custom/label-prefix/"
 			const ignoredKey = "anotherKey"
 			const intitialValue = "initialValue"
 			const updatedValue = "updatedValue"
@@ -3106,10 +3108,41 @@ var _ = Describe("VirtualMachine", func() {
 					map[string]string{selectedAnnotationKey: intitialValue, customSyncAnnotation: customSyncAnnotation},
 					1,
 				),
+				Entry("should sync annotations matching wildcard prefixes",
+					[]string{customSyncAnnotationPrefix + "*"},
+					map[string]string{selectedAnnotationKey: intitialValue, customSyncAnnotationPrefix + "one": intitialValue},
+					map[string]string{
+						selectedAnnotationKey:              intitialValue,
+						customSyncAnnotationPrefix + "one": updatedValue,
+						customSyncAnnotationPrefix + "two": updatedValue,
+						ignoredKey:                         anotherValue,
+					},
+					map[string]string{
+						selectedAnnotationKey:              intitialValue,
+						customSyncAnnotationPrefix + "one": updatedValue,
+						customSyncAnnotationPrefix + "two": updatedValue,
+					},
+					1,
+				),
+				Entry("should remove annotations matching wildcard prefixes when absent in VM template",
+					[]string{customSyncAnnotationPrefix + "*"},
+					map[string]string{
+						selectedAnnotationKey:              intitialValue,
+						customSyncAnnotationPrefix + "one": intitialValue,
+						customSyncAnnotationPrefix + "two": intitialValue,
+					},
+					map[string]string{
+						selectedAnnotationKey: intitialValue,
+					},
+					map[string]string{
+						selectedAnnotationKey: intitialValue,
+					},
+					1,
+				),
 			)
 
-			DescribeTable("should sync selected dynamic labels from spec.template to vmi", func(existingLabels, updatedVMLabels, expectedVMILabels map[string]string, numExpectedPatches int) {
-				controller.additionalLauncherLabelsSync = []string{customSyncLabel}
+			DescribeTable("should sync selected dynamic labels from spec.template to vmi", func(additionalLauncherLabelsSync []string, existingLabels, updatedVMLabels, expectedVMILabels map[string]string, numExpectedPatches int) {
+				controller.additionalLauncherLabelsSync = additionalLauncherLabelsSync
 
 				vm, vmi := watchtesting.DefaultVirtualMachine(true)
 				vm.Spec.Template.ObjectMeta.Labels = existingLabels
@@ -3138,34 +3171,70 @@ var _ = Describe("VirtualMachine", func() {
 
 			},
 				Entry("should copy selected custom labels from VM.spec.template.metadata.labels to VMI",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue},
 					map[string]string{customSyncLabel: updatedValue},
 					map[string]string{customSyncLabel: updatedValue},
 					1,
 				),
 				Entry("should remove selected custom labels from VMI if missing in VM.spec.template.metadata.labels",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					map[string]string{ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should do nothing if selected custom labels are already equal",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					0,
 				),
 				Entry("should update only custom selected labels",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: anotherValue},
 					map[string]string{customSyncLabel: updatedValue, ignoredKey: updatedValue},
 					map[string]string{customSyncLabel: updatedValue, ignoredKey: anotherValue},
 					1,
 				),
 				Entry("should ignore other labels on VM.spec.template.metadata.labels",
+					[]string{customSyncLabel},
 					map[string]string{customSyncLabel: intitialValue},
 					map[string]string{customSyncLabel: intitialValue, ignoredKey: updatedValue},
 					map[string]string{customSyncLabel: intitialValue},
 					0,
+				),
+				Entry("should sync labels matching wildcard prefixes",
+					[]string{customSyncLabelPrefix + "*"},
+					map[string]string{
+						customSyncLabelPrefix + "one": intitialValue,
+					},
+					map[string]string{
+						customSyncLabelPrefix + "one": updatedValue,
+						customSyncLabelPrefix + "two": updatedValue,
+						ignoredKey:                    anotherValue,
+					},
+					map[string]string{
+						customSyncLabelPrefix + "one": updatedValue,
+						customSyncLabelPrefix + "two": updatedValue,
+					},
+					1,
+				),
+				Entry("should remove labels matching wildcard prefixes when absent in VM template",
+					[]string{customSyncLabelPrefix + "*"},
+					map[string]string{
+						customSyncLabelPrefix + "one": intitialValue,
+						customSyncLabelPrefix + "two": intitialValue,
+						ignoredKey:                    anotherValue,
+					},
+					map[string]string{
+						ignoredKey: anotherValue,
+					},
+					map[string]string{
+						ignoredKey: anotherValue,
+					},
+					1,
 				),
 			)
 

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -720,26 +720,59 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 func (c *Controller) syncDynamicAnnotationsAndLabelsToPod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) (*k8sv1.Pod, error) {
 	patchSet := patch.New()
 	newPodAnnotations := maps.Clone(pod.Annotations)
+	if newPodAnnotations == nil {
+		newPodAnnotations = map[string]string{}
+	}
 	newPodLabels := maps.Clone(pod.Labels)
+	if newPodLabels == nil {
+		newPodLabels = map[string]string{}
+	}
 
-	syncMap := func(keys []string, vmiMap, podNewMap, podOrigMap map[string]string, subPath string) {
-		if podNewMap == nil {
-			podNewMap = map[string]string{}
-		}
-
+	syncMap := func(patterns []string, vmiMap, podNewMap, podOrigMap map[string]string, subPath string) {
 		changed := false
-		for _, key := range keys {
+
+		syncKey := func(key string) {
 			vmiVal, vmiExists := vmiMap[key]
 			podVal, podExists := podNewMap[key]
 			if vmiExists == podExists && vmiVal == podVal {
-				continue
+				return
 			}
 			changed = true
 			if !vmiExists {
 				delete(podNewMap, key)
-			} else {
-				podNewMap[key] = vmiVal
+				return
 			}
+			podNewMap[key] = vmiVal
+		}
+
+		syncPrefix := func(prefix string) {
+			visited := map[string]struct{}{}
+			for key := range vmiMap {
+				if strings.HasPrefix(key, prefix) {
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+			for key := range podNewMap {
+				if strings.HasPrefix(key, prefix) {
+					if _, ok := visited[key]; ok {
+						continue
+					}
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+		}
+
+		for _, pattern := range patterns {
+			if pattern == "" {
+				continue
+			}
+			if strings.HasSuffix(pattern, "*") {
+				syncPrefix(strings.TrimSuffix(pattern, "*"))
+				continue
+			}
+			syncKey(pattern)
 		}
 
 		if !changed {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -753,26 +753,64 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 func (c *Controller) syncDynamicAnnotationsAndLabelsToPod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) (*k8sv1.Pod, error) {
 	patchSet := patch.New()
 	newPodAnnotations := maps.Clone(pod.Annotations)
+	if newPodAnnotations == nil {
+		newPodAnnotations = map[string]string{}
+	}
 	newPodLabels := maps.Clone(pod.Labels)
+	if newPodLabels == nil {
+		newPodLabels = map[string]string{}
+	}
 
-	syncMap := func(keys []string, vmiMap, podNewMap, podOrigMap map[string]string, subPath string) {
-		if podNewMap == nil {
-			podNewMap = map[string]string{}
-		}
-
+	syncMap := func(patterns []string, vmiMap, podNewMap, podOrigMap map[string]string, subPath string) {
 		changed := false
-		for _, key := range keys {
+
+		syncKey := func(key string) {
 			vmiVal, vmiExists := vmiMap[key]
 			podVal, podExists := podNewMap[key]
 			if vmiExists == podExists && vmiVal == podVal {
-				continue
+				return
 			}
 			changed = true
 			if !vmiExists {
 				delete(podNewMap, key)
-			} else {
-				podNewMap[key] = vmiVal
+				return
 			}
+			podNewMap[key] = vmiVal
+		}
+
+		syncPrefix := func(prefix string) {
+			visited := map[string]struct{}{}
+			for key := range vmiMap {
+				if strings.HasPrefix(key, prefix) {
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+			for key := range podNewMap {
+				if strings.HasPrefix(key, prefix) {
+					if _, ok := visited[key]; ok {
+						continue
+					}
+					visited[key] = struct{}{}
+					syncKey(key)
+				}
+			}
+		}
+
+		for _, pattern := range patterns {
+			if pattern == "" {
+				continue
+			}
+			if strings.HasSuffix(pattern, "*") {
+				prefix := strings.TrimSuffix(pattern, "*")
+				// Reject bare "*" to prevent accidental sync-all. Only prefix wildcards like "vendor.io/*" are supported.
+				if prefix == "" {
+					continue
+				}
+				syncPrefix(prefix)
+				continue
+			}
+			syncKey(pattern)
 		}
 
 		if !changed {

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -2125,6 +2125,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				additionalLauncherAnnotationsSync []string
 				additionalLauncherLabelsSync      []string
 			}
+			const (
+				wildcardAnnotationPrefix = "custom/wildcard-annotation/"
+				wildcardLabelPrefix      = "custom/wildcard-label/"
+			)
 			DescribeTable("when VMI dynamic annotations and label sets changes", func(td *testData) {
 				vmi := newPendingVirtualMachine("testvmi")
 				vmi.Status.Phase = virtv1.Running
@@ -2399,6 +2403,99 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						},
 						expectedPatch:                true,
 						additionalLauncherLabelsSync: []string{"custom/label"},
+					},
+				),
+				Entry("when VMI and pod wildcard annotations differ",
+					&testData{
+						vmiAnnotations: map[string]string{
+							wildcardAnnotationPrefix + "one": "value-one",
+							wildcardAnnotationPrefix + "two": "value-two",
+						},
+						podAnnotations: map[string]string{
+							wildcardAnnotationPrefix + "one": "stale",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":             "testvmi",
+							descheduler.EvictOnlyAnnotation:  "",
+							wildcardAnnotationPrefix + "one": "value-one",
+							wildcardAnnotationPrefix + "two": "value-two",
+						},
+						expectedPatch:                     true,
+						additionalLauncherAnnotationsSync: []string{wildcardAnnotationPrefix + "*"},
+					},
+				),
+				Entry("when pod has wildcard annotations missing on VMI",
+					&testData{
+						vmiAnnotations: map[string]string{
+							"kubevirt.io/domain": "testvmi",
+						},
+						podAnnotations: map[string]string{
+							"kubevirt.io/domain":             "testvmi",
+							descheduler.EvictOnlyAnnotation:  "",
+							wildcardAnnotationPrefix + "one": "stale",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedPatch:                     true,
+						additionalLauncherAnnotationsSync: []string{wildcardAnnotationPrefix + "*"},
+					},
+				),
+				Entry("when VMI and pod wildcard labels differ",
+					&testData{
+						vmiLabels: map[string]string{
+							wildcardLabelPrefix + "one": "nodeA",
+							wildcardLabelPrefix + "two": "nodeB",
+						},
+						podLabels: map[string]string{
+							wildcardLabelPrefix + "one": "nodeOld",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":               "virt-launcher",
+							"kubevirt.io/created-by":    "1234",
+							wildcardLabelPrefix + "one": "nodeA",
+							wildcardLabelPrefix + "two": "nodeB",
+						},
+						expectedPatch:                true,
+						additionalLauncherLabelsSync: []string{wildcardLabelPrefix + "*"},
+					},
+				),
+				Entry("when pod has wildcard labels missing on VMI",
+					&testData{
+						vmiLabels: map[string]string{
+							"kubevirt.io":        "virt-launcher",
+							virtv1.NodeNameLabel: "node1",
+						},
+						podLabels: map[string]string{
+							"kubevirt.io":               "virt-launcher",
+							wildcardLabelPrefix + "one": "nodeOld",
+							virtv1.NodeNameLabel:        "node1",
+							"kubevirt.io/created-by":    "1234",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+							virtv1.NodeNameLabel:     "node1",
+						},
+						expectedPatch:                true,
+						additionalLauncherLabelsSync: []string{wildcardLabelPrefix + "*"},
 					},
 				),
 			)

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -2143,6 +2143,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				additionalLauncherAnnotationsSync []string
 				additionalLauncherLabelsSync      []string
 			}
+			const (
+				wildcardAnnotationPrefix = "custom/wildcard-annotation/"
+				wildcardLabelPrefix      = "custom/wildcard-label/"
+			)
 			DescribeTable("when VMI dynamic annotations and label sets changes", func(td *testData) {
 				vmi := newPendingVirtualMachine("testvmi")
 				vmi.Status.Phase = virtv1.Running
@@ -2417,6 +2421,145 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						},
 						expectedPatch:                true,
 						additionalLauncherLabelsSync: []string{"custom/label"},
+					},
+				),
+				Entry("when VMI and pod wildcard annotations differ",
+					&testData{
+						vmiAnnotations: map[string]string{
+							wildcardAnnotationPrefix + "one": "value-one",
+							wildcardAnnotationPrefix + "two": "value-two",
+						},
+						podAnnotations: map[string]string{
+							wildcardAnnotationPrefix + "one": "stale",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":             "testvmi",
+							descheduler.EvictOnlyAnnotation:  "",
+							wildcardAnnotationPrefix + "one": "value-one",
+							wildcardAnnotationPrefix + "two": "value-two",
+						},
+						expectedPatch:                     true,
+						additionalLauncherAnnotationsSync: []string{wildcardAnnotationPrefix + "*"},
+					},
+				),
+				Entry("when pod has wildcard annotations missing on VMI",
+					&testData{
+						vmiAnnotations: map[string]string{
+							"kubevirt.io/domain": "testvmi",
+						},
+						podAnnotations: map[string]string{
+							"kubevirt.io/domain":             "testvmi",
+							descheduler.EvictOnlyAnnotation:  "",
+							wildcardAnnotationPrefix + "one": "stale",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedPatch:                     true,
+						additionalLauncherAnnotationsSync: []string{wildcardAnnotationPrefix + "*"},
+					},
+				),
+				Entry("when VMI and pod wildcard labels differ",
+					&testData{
+						vmiLabels: map[string]string{
+							wildcardLabelPrefix + "one": "nodeA",
+							wildcardLabelPrefix + "two": "nodeB",
+						},
+						podLabels: map[string]string{
+							wildcardLabelPrefix + "one": "nodeOld",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":               "virt-launcher",
+							"kubevirt.io/created-by":    "1234",
+							wildcardLabelPrefix + "one": "nodeA",
+							wildcardLabelPrefix + "two": "nodeB",
+						},
+						expectedPatch:                true,
+						additionalLauncherLabelsSync: []string{wildcardLabelPrefix + "*"},
+					},
+				),
+				Entry("when pod has wildcard labels missing on VMI",
+					&testData{
+						vmiLabels: map[string]string{
+							"kubevirt.io":        "virt-launcher",
+							virtv1.NodeNameLabel: "node1",
+						},
+						podLabels: map[string]string{
+							"kubevirt.io":               "virt-launcher",
+							wildcardLabelPrefix + "one": "nodeOld",
+							virtv1.NodeNameLabel:        "node1",
+							"kubevirt.io/created-by":    "1234",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+							virtv1.NodeNameLabel:     "node1",
+						},
+						expectedPatch:                true,
+						additionalLauncherLabelsSync: []string{wildcardLabelPrefix + "*"},
+					},
+				),
+				Entry("when bare '*' annotation pattern is used it should be ignored",
+					&testData{
+						vmiAnnotations: map[string]string{
+							"custom/something": "value",
+						},
+						podAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedPatch:                     false,
+						additionalLauncherAnnotationsSync: []string{"*"},
+					},
+				),
+				Entry("when bare '*' label pattern is used it should be ignored",
+					&testData{
+						vmiLabels: map[string]string{
+							"kubevirt.io":        "virt-launcher",
+							"custom/some-label":  "value",
+							virtv1.NodeNameLabel: "node1",
+						},
+						podLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							virtv1.NodeNameLabel:     "node1",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedAnnotations: map[string]string{
+							"kubevirt.io/domain":            "testvmi",
+							descheduler.EvictOnlyAnnotation: "",
+						},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+							virtv1.NodeNameLabel:     "node1",
+						},
+						expectedPatch:                false,
+						additionalLauncherLabelsSync: []string{"*"},
 					},
 				),
 			)


### PR DESCRIPTION
The existing dynamic label/annotation propagation system (--additional-launcher-annotations-sync and
--additional-launcher-labels-sync flags) requires listing every key individually.

Prefix wildcards (vendor.io/*) are a natural extension that by honoring prefix-style wildcards (e.g. vendor.com/*), so that all matching labels/annotations on the VM template are propagated to the VMI and then to the virt-launcher Pod.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
With #14902, cluster admins can configure `--additional-launcher-annotations-sync` and `--additional-launcher-labels-sync` flags on virt-controller to propagate selected annotations/labels from VM.spec.template.metadata → VMI → virt-launcher Pod at runtime without a VM restart.
However, every key must be listed individually. When a vendor uses a common prefix for a group of labels (e.g. `vendor.io/gpu-model`, `vendor.io/gpu-count`, …), the admin must enumerate each one and keep the list in sync with new keys over time.

#### After this PR:
Entries in `--additional-launcher-annotations-sync` and `--additional-launcher-labels-sync` now accept a trailing `*` as a prefix wildcard. For example, `vendor.io/*` matches all keys under the `vendor.io/` prefix.

Exact-key behavior is fully preserved — the wildcard is opt-in via the `*` suffix and `*` is an illegal character in Kubernetes label/annotation keys, so there is no ambiguity.

The wildcard propagation is bidirectional within each sync direction:
- Keys present on the source but missing on the target are **added**.
- Keys present on the target but missing on the source are **removed**.
- Keys present on both with different values are **updated**.

### References

- Follows: #14902
- Related community request: #16832

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Wildcards are restricted to suffix-only (`prefix/*`). Full glob or regex was considered but adds complexity with minimal benefit — Kubernetes labels/annotations follow a `domain/key` convention that maps naturally to prefix matching.
- The sync logic is refactored into `syncKey` and `syncPrefix` inner functions within the existing `syncMap` closure rather than extracting to a shared utility package. This keeps the change minimal and self-contained while avoiding code duplication between `vm.go` and `lifecycle.go` by applying the same pattern in both locations.
- Nil-map guards for `newVmiAnnotations`/`newVmiLabels` (and the pod equivalents) are moved before the `syncMap` closure. This prevents potential nil-map panics when a VMI or Pod has no annotations/labels yet — a defensive fix unrelated to wildcards but required for correctness once `syncPrefix` may write to the map for keys not explicitly listed.


### Special notes for your reviewer

- The `syncMap` closure parameter was renamed from `keys` to `patterns` to reflect that entries can now be either exact keys or prefix patterns.
- The existing `DeprecatedVirtualMachineGenerationAnnotation` cleanup block inside `syncMap` (added by upstream commit a2f20abc40) is preserved and runs before pattern dispatch. It is positionally correct and functionally independent of the iteration strategy.
- Both `vm.go` (VM→VMI sync) and `lifecycle.go` (VMI→Pod sync) are updated with the same structural change.
- Tests cover: prefix match add, prefix match update, prefix match removal (keys on target but absent from source), and no-op when nothing matches.


<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The --additional-launcher-annotations-sync and --additional-launcher-labels-sync flags now support prefix wildcards via a trailing '*' suffix (e.g. 'vendor.io/*'), allowing all matching labels/annotations to be propagated from VM template to VMI and virt-launcher pod without enumerating each key individually.
```

