### PR TITLE
fix: guard VCPU hotplug topology adjustment against nil VCPUs

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -458,7 +458,7 @@ func AdjustDomainForTopologyAndCPUSet(domain *api.Domain, vmi *v12.VirtualMachin
 		Threads: domain.Spec.CPU.Topology.Threads,
 	}
 
-	if vmi.Spec.Domain.CPU.MaxSockets != 0 {
+	if vmi.Spec.Domain.CPU.MaxSockets != 0 && domain.Spec.VCPUs != nil {
 		disabledVCPUs := 0
 		for _, vcpu := range domain.Spec.VCPUs.VCPU {
 			if vcpu.Enabled != "yes" {

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	v12 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
 	v1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
@@ -176,6 +177,38 @@ var _ = Describe("VCPU pinning", func() {
 			[]uint32{7, 6, 2, 8, 3, 9, 4, 10, 5, 11},
 		),
 	)
+
+	Describe("AdjustDomainForTopologyAndCPUSet", func() {
+		It("skips disabled socket adjustments when VCPU metadata is absent", func() {
+			domain := &api.Domain{
+				Spec: api.DomainSpec{
+					CPU: api.CPU{
+						Topology: &api.CPUTopology{
+							Sockets: 1,
+							Cores:   1,
+							Threads: 1,
+						},
+					},
+				},
+			}
+			vmi := &v12.VirtualMachineInstance{
+				Spec: v12.VirtualMachineInstanceSpec{
+					Domain: v12.DomainSpec{
+						CPU: &v12.CPU{
+							Sockets:               1,
+							Cores:                 1,
+							Threads:               1,
+							MaxSockets:            2,
+							DedicatedCPUPlacement: true,
+						},
+					},
+				},
+			}
+			topology := hostTopology(1, 1, 0)
+			err := AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, []int{0}, false)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })
 
 func shuffleCPUSet(cpuSet ...int) []int {

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
 	v1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
@@ -176,6 +177,43 @@ var _ = Describe("VCPU pinning", func() {
 			[]uint32{7, 6, 2, 8, 3, 9, 4, 10, 5, 11},
 		),
 	)
+
+	Describe("AdjustDomainForTopologyAndCPUSet", func() {
+		It("should succeed without modifying topology when VCPU metadata is absent", func() {
+			domain := &api.Domain{
+				Spec: api.DomainSpec{
+					CPU: api.CPU{
+						Topology: &api.CPUTopology{
+							Sockets: 1,
+							Cores:   1,
+							Threads: 1,
+						},
+					},
+				},
+			}
+			vmi := &corev1.VirtualMachineInstance{
+				Spec: corev1.VirtualMachineInstanceSpec{
+					Domain: corev1.DomainSpec{
+						CPU: &corev1.CPU{
+							Sockets:               1,
+							Cores:                 1,
+							Threads:               1,
+							MaxSockets:            2,
+							DedicatedCPUPlacement: true,
+						},
+					},
+				},
+			}
+			topology := hostTopology(1, 1, 0)
+			err := AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, []int{0}, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domain.Spec.CPU.Topology).ToNot(BeNil())
+			Expect(domain.Spec.CPU.Topology.Sockets).To(Equal(uint32(1)))
+			Expect(domain.Spec.CPU.Topology.Cores).To(Equal(uint32(1)))
+			Expect(domain.Spec.CPU.Topology.Threads).To(Equal(uint32(1)))
+			Expect(domain.Spec.VCPUs).To(BeNil())
+		})
+	})
 })
 
 func shuffleCPUSet(cpuSet ...int) []int {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`AdjustDomainForTopologyAndCPUSet` dereferences `domain.Spec.VCPUs.VCPU` when `vmi.Spec.Domain.CPU.MaxSockets != 0`, without checking whether `domain.Spec.VCPUs` is nil first.

`domain.Spec.VCPUs` is a `*VCPUs` pointer (populated by `domainVCPUTopologyForHotplug` only when hotplug is supported) and is **not set** in at least one call path:

- `cpudedicated.go:AdjustCPUDedicated` builds a `domain` with `CPU.Topology` and `VCPU` (singular), but never initializes `VCPUs` (plural). When called for a VMI with `MaxSockets > 0`, virt-launcher panics with a nil pointer dereference.

The same risk exists when `AdjustDomainForTopologyAndCPUSet` is called from `manager.go` during live vCPU hotplug if the libvirt domain XML lacks a `<vcpus>` element.

#### After this PR:

The condition is extended to `MaxSockets != 0 && domain.Spec.VCPUs != nil`, so the disabled-socket adjustment is skipped when VCPU metadata is absent.
This is safe because if `VCPUs` is nil, there are no disabled VCPUs to subtract from the requested topology.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

### Why we need it and why it was done in this way

The fix is a single nil guard added to the existing condition.
Alternatives considered:

- Initializing `VCPUs` in `cpudedicated.go` before calling `AdjustDomainForTopologyAndCPUSet` — rejected because populating dummy VCPU entries would be incorrect and couple the caller to internal hotplug logic.
- Moving the nil check inside the loop body — rejected because skipping the entire block when there is no VCPU metadata is the correct semantic (no VCPUs metadata = no disabled VCPUs = nothing to adjust).

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

