### PR TITLE
docs: fix 'occured' typo in comments

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -105,9 +105,9 @@ const (
 	PVCNotReadyReason = "PVCNotReady"
 	// FailedHotplugSyncReason is set when a hotplug specific failure occurs during sync
 	FailedHotplugSyncReason = "FailedHotplugSync"
-	// ErrImagePullReason is set when an error has occured while pulling an image for a containerDisk VM volume.
+	// ErrImagePullReason is set when an error has occurred while pulling an image for a containerDisk VM volume.
 	ErrImagePullReason = "ErrImagePull"
-	// ImagePullBackOffReason is set when an error has occured while pulling an image for a containerDisk VM volume,
+	// ImagePullBackOffReason is set when an error has occurred while pulling an image for a containerDisk VM volume,
 	// and that kubelet is backing off before retrying.
 	ImagePullBackOffReason = "ImagePullBackOff"
 	// NoSuitableNodesForHostModelMigration is set when a VMI with host-model CPU mode tries to migrate but no node
@@ -115,7 +115,7 @@ const (
 	NoSuitableNodesForHostModelMigration = "NoSuitableNodesForHostModelMigration"
 	// FailedPodPatchReason is set when a pod patch error occurs during sync
 	FailedPodPatchReason = "FailedPodPatch"
-	// MigrationBackoffReason is set when an error has occured while migrating
+	// MigrationBackoffReason is set when an error has occurred while migrating
 	// and virt-controller is backing off before retrying.
 	MigrationBackoffReason = "MigrationBackoff"
 )

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -933,7 +933,7 @@ func (c *Controller) syncPausedConditionToPod(vmi *virtv1.VirtualMachineInstance
 	return nil
 }
 
-// checkForContainerImageError checks if an error has occured while handling the image of any of the pod's containers
+// checkForContainerImageError checks if an error has occurred while handling the image of any of the pod's containers
 // (including init containers), and returns a syncErr with the details of the error, or nil otherwise.
 func checkForContainerImageError(pod *k8sv1.Pod) common.SyncError {
 	containerStatuses := append(append([]k8sv1.ContainerStatus{}, pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...)

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -768,7 +768,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 
 		updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		// Update occured for labels but not spec
+		// Update occurred for labels but not spec
 		Expect(updatedVMI.Spec.Volumes).To(Equal(originalVMI.Spec.Volumes))
 		Expect(updatedVMI.Labels).To(Not(HaveKey(v1.MigrationTargetNodeNameLabel)))
 	})

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -40,7 +40,7 @@ var _ = Describe("virtctl", func() {
 		Entry("shorthand flag", "-v=2"),
 	)
 
-	It("Execute should print a message if and error occurred and server and client virtctl versions are different", func() {
+	It("Execute should print a message if an error occurred and server and client virtctl versions are different", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		serverVersionInterface := kubecli.NewMockServerVersionInterface(ctrl)
 		serverVersionInterface.EXPECT().Get().Return(&version.Info{

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -40,7 +40,7 @@ var _ = Describe("virtctl", func() {
 		Entry("shorthand flag", "-v=2"),
 	)
 
-	It("Execute should print a message if and error occured and server and client virtctl versions are different", func() {
+	It("Execute should print a message if and error occurred and server and client virtctl versions are different", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		serverVersionInterface := kubecli.NewMockServerVersionInterface(ctrl)
 		serverVersionInterface.EXPECT().Get().Return(&version.Info{

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2003,10 +2003,10 @@ const (
 	// VirtualMachineStatusUnschedulable indicates that an error has occurred while scheduling the virtual machine,
 	// e.g. due to unsatisfiable resource requests or unsatisfiable scheduling constraints.
 	VirtualMachineStatusUnschedulable VirtualMachinePrintableStatus = "ErrorUnschedulable"
-	// VirtualMachineStatusErrImagePull indicates that an error has occured while pulling an image for
+	// VirtualMachineStatusErrImagePull indicates that an error has occurred while pulling an image for
 	// a containerDisk VM volume.
 	VirtualMachineStatusErrImagePull VirtualMachinePrintableStatus = "ErrImagePull"
-	// VirtualMachineStatusImagePullBackOff indicates that an error has occured while pulling an image for
+	// VirtualMachineStatusImagePullBackOff indicates that an error has occurred while pulling an image for
 	// a containerDisk VM volume, and that kubelet is backing off before retrying.
 	VirtualMachineStatusImagePullBackOff VirtualMachinePrintableStatus = "ImagePullBackOff"
 	// VirtualMachineStatusPvcNotFound indicates that the virtual machine references a PVC volume which doesn't exist.


### PR DESCRIPTION
Small typo fix in various comments/docstrings: `occured` → `occurred`.

Files touched:

- `pkg/controller/controller.go` (3 occurrences)
- `pkg/virt-controller/watch/vmi/lifecycle.go`
- `staging/src/kubevirt.io/api/core/v1/types.go` (2 occurrences)
- `pkg/virtctl/root_test.go` (test description)
- `pkg/virt-handler/migration-target_test.go` (comment)

Comment-only change, no behavior change.

/kind cleanup
Release note: `NONE`
```release-note
NONE
```