### PR TITLE
vmitrait: Add unit tests and linter coverage

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -69,6 +69,7 @@ pkg/virt-launcher/virtwrap/converter/storage
 pkg/virt-launcher/virtwrap/converter/virtio
 pkg/virt-launcher/virtwrap/network
 pkg/virt-launcher/virtwrap/statsconv/util
+pkg/vmitrait
 tests/conformance
 tests/console
 tests/decorators

--- a/pkg/vmitrait/BUILD.bazel
+++ b/pkg/vmitrait/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,4 +6,20 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/vmitrait",
     visibility = ["//visibility:public"],
     deps = ["//staging/src/kubevirt.io/api/core/v1:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "vmitrait_suite_test.go",
+        "vmitrait_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )

--- a/pkg/vmitrait/vmitrait_suite_test.go
+++ b/pkg/vmitrait/vmitrait_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vmitrait_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVMITrait(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/vmitrait/vmitrait_test.go
+++ b/pkg/vmitrait/vmitrait_test.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vmitrait_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/vmitrait"
+)
+
+var _ = Describe("VMI traits", func() {
+	Context("IsNonRoot", func() {
+		It("should return false when annotation is absent and RuntimeUser is 0", func() {
+			Expect(vmitrait.IsNonRoot(&v1.VirtualMachineInstance{})).To(BeFalse())
+		})
+
+		DescribeTable("should return true", func(annotations map[string]string, runtimeUser uint64) {
+			vmi := &v1.VirtualMachineInstance{}
+			vmi.Annotations = annotations
+			vmi.Status.RuntimeUser = runtimeUser
+			Expect(vmitrait.IsNonRoot(vmi)).To(BeTrue())
+		},
+			Entry("when the deprecated non-root annotation is present",
+				map[string]string{v1.DeprecatedNonRootVMIAnnotation: ""},
+				uint64(0),
+			),
+			Entry("when RuntimeUser is non-zero",
+				nil,
+				uint64(107),
+			),
+			Entry("when both annotation and non-zero RuntimeUser are present",
+				map[string]string{v1.DeprecatedNonRootVMIAnnotation: ""},
+				uint64(107),
+			),
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
  Add unit tests for `IsNonRoot` in `pkg/vmitrait` and add the package to the linter paths. 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This is a follow-up for https://github.com/kubevirt/kubevirt/pull/17155.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

