### PR TITLE
migration compression

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15133,6 +15133,10 @@
     "description": "ExperimentalMigrationOptions is an alpha API for experimental migration tunables. It is intended for experimental purposes only and will be removed in the future.",
     "type": "object",
     "properties": {
+     "compression": {
+      "description": "Compression selects the algorithm for compressing the live migration data stream. When omitted (nil) or set to \"none\", compression is disabled.",
+      "type": "string"
+     },
      "stallDetector": {
       "$ref": "#/definitions/v1.StallDetectorOptions"
      }

--- a/pkg/virt-controller/watch/migration/migrationpolicy.go
+++ b/pkg/virt-controller/watch/migration/migrationpolicy.go
@@ -156,6 +156,7 @@ func applyExperimentalMigrationOptions(base, spec *k6tv1.ExperimentalMigrationOp
 	if spec.StallDetector != nil {
 		result.StallDetector = applyStallDetectorOptions(result.StallDetector, spec.StallDetector)
 	}
+	setIfNotNil(&result.Compression, spec.Compression)
 
 	return result
 }

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -90,6 +90,7 @@ type MigrationOptions struct {
 	AllowWorkloadDisruption  bool
 	StallDetectionEnabled    bool
 	StallDetectorOptions     StallDetectorOptions
+	Compression              *string
 }
 
 type LauncherClient interface {

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -574,6 +574,10 @@ func (c *MigrationSourceController) migrateVMI(vmi *v1.VirtualMachineInstance, d
 		},
 	}
 
+	if exp := migrationConfiguration.ExperimentalMigrationOptions; exp != nil && exp.Compression != nil {
+		options.Compression = pointer.P(string(*exp.Compression))
+	}
+
 	configureParallelMigrationThreads(options, vmi)
 
 	marshalledOptions, err := json.Marshal(options)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -100,6 +100,22 @@ type migrationMonitor struct {
 	progressTimeout    int64
 }
 
+var libvirtCompressionMethods = map[v1.MigrationCompression]string{
+	v1.MigrationCompressionZstd: "zstd",
+}
+
+func shouldCompressMigration(options *cmdclient.MigrationOptions) (bool, string) {
+	if options.Compression == nil || *options.Compression == "" || *options.Compression == string(v1.MigrationCompressionNone) {
+		return false, ""
+	}
+	method, ok := libvirtCompressionMethods[v1.MigrationCompression(*options.Compression)]
+	if !ok {
+		log.Log.Warningf("Unsupported migration compression method %q, compression will be disabled", *options.Compression)
+		return false, ""
+	}
+	return true, method
+}
+
 func generateMigrationFlags(isBlockMigration, migratePaused bool, options *cmdclient.MigrationOptions) libvirt.DomainMigrateFlags {
 	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
@@ -120,6 +136,9 @@ func generateMigrationFlags(isBlockMigration, migratePaused bool, options *cmdcl
 	}
 	if shouldConfigureParallel, _ := shouldConfigureParallelMigration(options); shouldConfigureParallel {
 		migrateFlags |= libvirt.MIGRATE_PARALLEL
+	}
+	if shouldCompress, _ := shouldCompressMigration(options); shouldCompress {
+		migrateFlags |= libvirt.MIGRATE_COMPRESSED
 	}
 
 	return migrateFlags
@@ -938,14 +957,20 @@ func LogMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.D
 		downtimeInfo = fmt.Sprintf("Downtime:%dms DowntimeNet:%dms", info.Downtime, info.DowntimeNet)
 	}
 
+	compressionInfo := ""
+	if info.DataProcessed > 0 && info.MemNormalBytes > info.DataProcessed {
+		ratio := float64(info.MemNormalBytes) / float64(info.DataProcessed)
+		compressionInfo = fmt.Sprintf(" CompressionRatio:%.2fx", ratio)
+	}
+
 	logger.V(2).Info(fmt.Sprintf(`Migration info for %s: TimeElapsed:%dms DataProcessed:%dMiB DataRemaining:%dMiB DataTotal:%dMiB `+
 		`MemoryProcessed:%dMiB MemoryRemaining:%dMiB MemoryTotal:%dMiB MemoryBandwidth:%dMbps DirtyRate:%dMbps `+
 		`Iteration:%d PostcopyRequests:%d ConstantPages:%d NormalPages:%d NormalData:%dMiB %s `+
-		`DiskMbps:%d`,
+		`DiskMbps:%d%s`,
 		uid, info.TimeElapsed, bToMiB(info.DataProcessed), bToMiB(info.DataRemaining), bToMiB(info.DataTotal),
 		bToMiB(info.MemProcessed), bToMiB(info.MemRemaining), bToMiB(info.MemTotal), bpsToMbps(info.MemBps), bpsToMbps(info.MemDirtyRate*info.MemPageSize),
 		info.MemIteration, info.MemPostcopyReqs, info.MemConstant, info.MemNormal, bToMiB(info.MemNormalBytes), downtimeInfo,
-		bpsToMbps(info.DiskBps),
+		bpsToMbps(info.DiskBps), compressionInfo,
 	))
 }
 
@@ -1088,6 +1113,12 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 		params.DisksURISet = true
 		params.MigrateDisksDetectZeroesList = copyDisks
 		params.MigrateDisksDetectZeroesSet = true
+	}
+
+	if shouldCompress, method := shouldCompressMigration(options); shouldCompress {
+		params.CompressionSet = true
+		params.Compression = method
+		log.Log.Object(vmi).Infof("Migration compression enabled: method=%s", method)
 	}
 
 	log.Log.Object(vmi).Infof("generated migration parameters: %+v", params)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -4140,6 +4140,15 @@ var CRDsValidation map[string]string = map[string]string{
             ExperimentalMigrationOptions is an alpha API. It is intended for experimental
             purposes only and will be removed in the future.
           properties:
+            compression:
+              description: |-
+                Compression selects the algorithm for compressing the live migration
+                data stream. When omitted (nil) or set to "none", compression is
+                disabled.
+              enum:
+              - none
+              - zstd
+              type: string
             stallDetector:
               properties:
                 completionTimeoutFactor:
@@ -15559,6 +15568,15 @@ var CRDsValidation map[string]string = map[string]string{
                     ExperimentalMigrationOptions is an alpha API. It is intended for experimental
                     purposes only and will be removed in the future.
                   properties:
+                    compression:
+                      description: |-
+                        Compression selects the algorithm for compressing the live migration
+                        data stream. When omitted (nil) or set to "none", compression is
+                        disabled.
+                      enum:
+                      - none
+                      - zstd
+                      type: string
                     stallDetector:
                       properties:
                         completionTimeoutFactor:
@@ -16238,6 +16256,15 @@ var CRDsValidation map[string]string = map[string]string{
                     ExperimentalMigrationOptions is an alpha API. It is intended for experimental
                     purposes only and will be removed in the future.
                   properties:
+                    compression:
+                      description: |-
+                        Compression selects the algorithm for compressing the live migration
+                        data stream. When omitted (nil) or set to "none", compression is
+                        disabled.
+                      enum:
+                      - none
+                      - zstd
+                      type: string
                     stallDetector:
                       properties:
                         completionTimeoutFactor:

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -1028,7 +1028,8 @@
             "patienceWindowDecayFactor": "patienceWindowDecayFactorValue",
             "searchLocalMinima": true,
             "completionTimeoutFactor": "completionTimeoutFactorValue"
-          }
+          },
+          "compression": "compressionValue"
         }
       },
       "targetCPUSet": [

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -728,6 +728,7 @@ status:
       completionTimeoutPerGiB: -23
       disableTLS: true
       experimental:
+        compression: compressionValue
         stallDetector:
           completionTimeoutFactor: completionTimeoutFactorValue
           ewmaAlpha: ewmaAlphaValue

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -1662,6 +1662,11 @@ func (in *ExperimentalMigrationOptions) DeepCopyInto(out *ExperimentalMigrationO
 		*out = new(StallDetectorOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Compression != nil {
+		in, out := &in.Compression, &out.Compression
+		*out = new(MigrationCompression)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -3451,11 +3451,27 @@ type StallDetectorOptions struct {
 	CompletionTimeoutFactor *string `json:"completionTimeoutFactor,omitempty"`
 }
 
+// MigrationCompression represents the compression method for live migration.
+type MigrationCompression string
+
+const (
+	// MigrationCompressionNone disables compression.
+	MigrationCompressionNone MigrationCompression = "none"
+	// MigrationCompressionZstd enables zstd compression on multifd channels.
+	MigrationCompressionZstd MigrationCompression = "zstd"
+)
+
 // ExperimentalMigrationOptions is an alpha API for experimental migration tunables.
 // It is intended for experimental purposes only and will be removed in the future.
 type ExperimentalMigrationOptions struct {
 	//+optional
 	StallDetector *StallDetectorOptions `json:"stallDetector,omitempty"`
+	// Compression selects the algorithm for compressing the live migration
+	// data stream. When omitted (nil) or set to "none", compression is
+	// disabled.
+	// +kubebuilder:validation:Enum=none;zstd
+	//+optional
+	Compression *MigrationCompression `json:"compression,omitempty"`
 }
 
 // VMIMConfigurationOptions holds the resolved migration options for a single migration.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -1035,6 +1035,7 @@ func (ExperimentalMigrationOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":              "ExperimentalMigrationOptions is an alpha API for experimental migration tunables.\nIt is intended for experimental purposes only and will be removed in the future.",
 		"stallDetector": "+optional",
+		"compression":   "Compression selects the algorithm for compressing the live migration\ndata stream. When omitted (nil) or set to \"none\", compression is\ndisabled.\n+kubebuilder:validation:Enum=none;zstd\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21029,6 +21029,13 @@ func schema_kubevirtio_api_core_v1_ExperimentalMigrationOptions(ref common.Refer
 							Ref: ref("kubevirt.io/api/core/v1.StallDetectorOptions"),
 						},
 					},
+					"compression": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Compression selects the algorithm for compressing the live migration data stream. When omitted (nil) or set to \"none\", compression is disabled.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2147,6 +2147,99 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 		})
 
+		Context("with migration compression", Serial, func() {
+			It("should migrate with zstd compression and confirm via API and logs", func() {
+				vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+
+				By("Creating a migration policy with compression enabled")
+				policy := GeneratePolicyAndAlignVMI(vmi)
+				policy.Spec.ExperimentalMigrationOptions = &v1.ExperimentalMigrationOptions{
+					Compression: pointer.P(v1.MigrationCompressionZstd),
+				}
+				policy = CreateMigrationPolicy(virtClient, policy)
+
+				By("Starting the VirtualMachineInstance")
+				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+
+				By("Starting the Migration")
+				migration := libmigration.New(vmi.Name, vmi.Namespace)
+				migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+				By("Confirming migration completed successfully")
+				vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+
+				By("Verifying the migration policy was applied")
+				Expect(vmi.Status.MigrationState.MigrationPolicyName).ToNot(BeNil())
+				Expect(*vmi.Status.MigrationState.MigrationPolicyName).To(Equal(policy.Name))
+
+				By("Verifying compression is set in the migration configuration")
+				Expect(vmi.Status.MigrationState.VMIMConfigurationOptions).ToNot(BeNil())
+				Expect(vmi.Status.MigrationState.VMIMConfigurationOptions.ExperimentalMigrationOptions).ToNot(BeNil())
+				Expect(vmi.Status.MigrationState.VMIMConfigurationOptions.ExperimentalMigrationOptions.Compression).ToNot(BeNil())
+				Expect(*vmi.Status.MigrationState.VMIMConfigurationOptions.ExperimentalMigrationOptions.Compression).To(Equal(v1.MigrationCompressionZstd))
+
+				By("Verifying compression was applied via launcher logs")
+				logs := getSourceLauncherLogs(virtClient, vmi)
+				Expect(logs).To(ContainSubstring("Migration compression enabled: method=zstd"))
+			})
+
+			It("should migrate with compression, autoconverge, and postcopy combined", func() {
+				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), libvmi.WithMemoryRequest(fedoraVMSize))
+				vmi.Namespace = testsuite.NamespacePrivileged
+
+				By("Creating a migration policy with compression + postcopy + autoconverge")
+				policyName := fmt.Sprintf("testpolicy-combo-%s", rand.String(5))
+				policy := kubecli.NewMinimalMigrationPolicy(policyName)
+				policy.Spec.AllowAutoConverge = pointer.P(true)
+				policy.Spec.AllowPostCopy = pointer.P(true)
+				policy.Spec.CompletionTimeoutPerGiB = pointer.P(int64(1))
+				policy.Spec.BandwidthPerMigration = pointer.P(resource.MustParse("5Mi"))
+				policy.Spec.ExperimentalMigrationOptions = &v1.ExperimentalMigrationOptions{
+					Compression: pointer.P(v1.MigrationCompressionZstd),
+				}
+				AlignPolicyAndVmi(vmi, policy)
+				policy = CreateMigrationPolicy(virtClient, policy)
+
+				By("Starting the VirtualMachineInstance")
+				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Running stress test to generate memory pressure for postcopy")
+				runStressTest(vmi, stressLargeVMSize)
+
+				By("Starting the Migration")
+				migration := libmigration.New(vmi.Name, vmi.Namespace)
+				migration = libmigration.RunMigrationAndExpectToComplete(virtClient, migration, 180)
+
+				By("Confirming migration completed successfully")
+				vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+				libmigration.ConfirmMigrationMode(virtClient, vmi, v1.MigrationPostCopy)
+
+				By("Verifying the migration policy was applied")
+				Expect(vmi.Status.MigrationState.MigrationPolicyName).ToNot(BeNil())
+				Expect(*vmi.Status.MigrationState.MigrationPolicyName).To(Equal(policy.Name))
+
+				By("Verifying the migration configuration contains all settings")
+				mc := vmi.Status.MigrationState.VMIMConfigurationOptions
+				Expect(mc).ToNot(BeNil())
+				Expect(mc.AllowAutoConverge).ToNot(BeNil())
+				Expect(*mc.AllowAutoConverge).To(BeTrue())
+				Expect(mc.AllowPostCopy).ToNot(BeNil())
+				Expect(*mc.AllowPostCopy).To(BeTrue())
+				Expect(mc.ExperimentalMigrationOptions).ToNot(BeNil())
+				Expect(mc.ExperimentalMigrationOptions.Compression).ToNot(BeNil())
+				Expect(*mc.ExperimentalMigrationOptions.Compression).To(Equal(v1.MigrationCompressionZstd))
+
+				By("Verifying compression via launcher logs")
+				logs := getSourceLauncherLogs(virtClient, vmi)
+				Expect(logs).To(ContainSubstring("Migration compression enabled: method=zstd"))
+			})
+		})
+
 		Context(" with freePageReporting", Serial, decorators.WgS390x, func() {
 
 			BeforeEach(func() {
@@ -3210,4 +3303,18 @@ func withSubdomain(subdomain string) libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Subdomain = subdomain
 	}
+}
+
+func getSourceLauncherLogs(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
+	GinkgoHelper()
+	Expect(vmi.Status.MigrationState).ToNot(BeNil())
+	sourcePod := vmi.Status.MigrationState.SourcePod
+	Expect(sourcePod).ToNot(BeEmpty(), "source pod name must be populated after migration")
+
+	logsRaw, err := virtClient.CoreV1().
+		Pods(vmi.Namespace).
+		GetLogs(sourcePod, &k8sv1.PodLogOptions{Container: "compute"}).
+		DoRaw(context.Background())
+	Expect(err).ToNot(HaveOccurred(), "should get virt-launcher source pod logs")
+	return string(logsRaw)
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:
KubeVirt has no mechanism for compressing live migration data streams. Bandwidth-constrained environments or large-memory VMs frequently hit migration timeouts when the dirty rate exceeds available bandwidth. There is also no generic infrastructure for exposing experimental migration knobs via MigrationPolicy.

#### After this PR:
Introduces ExperimentalMigrationConfiguration and the AdvancedLiveMigration feature gate, providing a scalable infrastructure for gating advanced migration knobs in MigrationPolicy under spec.experimental.

As the first use of this infrastructure, adds optional zstd compression for live migration data streams. When enabled via MigrationPolicy, virt-launcher sets libvirt's VIR_MIGRATE_COMPRESSED flag with VIR_MIGRATE_PARAM_COMPRESSION = "zstd", compressing memory pages on multifd channels.

### References
VEP tracking issue: https://github.com/kubevirt/enhancements/issues/246

### Why we need it and why it was done in this way
The following tradeoffs were made:

Compression is opt-in via MigrationPolicy only (not cluster-wide in KubeVirt CR), since it trades CPU for bandwidth and is not universally beneficial.
The spec.experimental section is gated behind a single AdvancedLiveMigration feature gate rather than per-knob gates, to avoid gate proliferation as more experimental knobs are added.
API enum uses explicit values ("none", "zstd") rather than empty string for clarity.
virt-launcher uses an explicit mapping table from API enums to libvirt method names rather than passing strings through directly.
The following alternatives were considered:

Boolean toggle: simpler but no room for additional algorithms.
Cluster-wide default in KubeVirt CR: risks regressions for CPU-constrained workloads.
Always-on compression: CPU overhead makes this unsuitable as a universal default.
Annotation-based configuration: tested in prototyping but does not integrate with MigrationPolicy.

### Special notes for your reviewer

The infrastructure commit (ExperimentalMigrationConfiguration, feature gate, plumbing) is deliberately separated from the compression commit to allow clean review and reuse for future experimental knobs (e.g., downtime tuning).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
Live migration data stream can be compressed now by using .spec.experimental.compression field in MigrationPolicy applied to a set of VMs. Currently only "zstd" algorithm is supported.
```

