### PR TITLE
skip dirty rate calculation for non-running and migrating VMIs

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_collector.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_collector.go
@@ -51,8 +51,10 @@ func domainDirtyRateStatsCollectorCallback() []operatormetrics.CollectorResult {
 func execDomainDirtyRateStatsCollector(
 	concCollector collector.Collector, vmis []*k6tv1.VirtualMachineInstance,
 ) []operatormetrics.CollectorResult {
-	scraper := NewDomainsDirtyRateStatsScraper(len(vmis))
-	go concCollector.Collect(vmis, scraper, PrometheusCollectionTimeout)
+	eligible := filterDirtyRateEligible(vmis)
+
+	scraper := NewDomainsDirtyRateStatsScraper(len(eligible))
+	go concCollector.Collect(eligible, scraper, PrometheusCollectionTimeout)
 
 	var crs []operatormetrics.CollectorResult
 
@@ -62,4 +64,21 @@ func execDomainDirtyRateStatsCollector(
 	}
 
 	return crs
+}
+
+// StartDirtyRateCalc requires a running guest and conflicts with an active
+// migration (which already provides MemDirtyRate via DomainJobInfo).
+// StartTimestamp distinguishes an active migration from pending/scheduling.
+func filterDirtyRateEligible(vmis []*k6tv1.VirtualMachineInstance) []*k6tv1.VirtualMachineInstance {
+	var eligible []*k6tv1.VirtualMachineInstance
+	for _, vmi := range vmis {
+		if vmi.Status.Phase != k6tv1.Running {
+			continue
+		}
+		if ms := vmi.Status.MigrationState; ms != nil && ms.StartTimestamp != nil && !ms.Completed && !ms.Failed {
+			continue
+		}
+		eligible = append(eligible, vmi)
+	}
+	return eligible
 }

--- a/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_metrics_test.go
@@ -20,12 +20,17 @@
 package domainstats
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k6tv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/testing"
+	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/collector"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
 
@@ -63,4 +68,34 @@ var _ = Describe("dirty rate metrics", func() {
 			Expect(crs).To(BeEmpty())
 		})
 	})
+
+	Context("dirty rate collector filtering", func() {
+		It("should only collect from running, non-migrating VMIs", func() {
+			running := api.NewMinimalVMI("running")
+			running.Status.Phase = k6tv1.Running
+
+			scheduled := api.NewMinimalVMI("scheduled")
+			scheduled.Status.Phase = k6tv1.Scheduled
+
+			migrating := api.NewMinimalVMI("migrating")
+			migrating.Status.Phase = k6tv1.Running
+			now := metav1.Now()
+			migrating.Status.MigrationState = &k6tv1.VirtualMachineInstanceMigrationState{StartTimestamp: &now}
+
+			rc := &recCollector{}
+			execDomainDirtyRateStatsCollector(rc, []*k6tv1.VirtualMachineInstance{running, scheduled, migrating})
+			Expect(rc.collected).To(ConsistOf(HaveField("Name", "running")))
+		})
+	})
 })
+
+type recCollector struct {
+	collector.Collector
+	collected []*k6tv1.VirtualMachineInstance
+}
+
+func (rc *recCollector) Collect(vmis []*k6tv1.VirtualMachineInstance, scraper collector.MetricsScraper, _ time.Duration) ([]string, bool) {
+	rc.collected = vmis
+	scraper.Complete()
+	return nil, true
+}


### PR DESCRIPTION
Fixes: https://github.com/kubevirt/kubevirt/issues/17504

### What this PR does
#### Before this PR:
The DomainDirtyRateStatsCollector triggers `StartDirtyRateCalc` for every VMI on the node on every Prometheus scrape, including non-running and actively migrating VMs. This fails for migrating VMs (contending with migration's memory tracking) and is pointless for non-running ones.

#### After this PR:
VMIs are filtered before dispatching dirty rate scrapes — only running, non-migrating VMs are included. (the migration job already provides its own `MemDirtyRate` through `DomainJobInfo`, though they are not collected, just logged).

### References
- Fixes https://github.com/kubevirt/kubevirt/issues/17504

### Why we need it and why it was done in this way
The following tradeoffs were made:
The filter is applied in `execDomainDirtyRateStatsCollector` (before the collector dispatches goroutines) using VMI status from the informer cache. This avoids the gRPC round-trip to virt-launcher and the libvirt `StartDirtyRateCalc` call entirely for ineligible VMIs.

The following alternatives were considered:


### Special notes for your reviewer

### Checklist
- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).


### Release note
```release-note
Fixed DomainDirtyRateStatsCollector to skip non-running and actively migrating VMIs, avoiding failed StartDirtyRateCalc calls during live migration.