### PR TITLE
[release-1.8] net, networkpolicy: Fix network policy for IPv4/IPv6

### DIFF
--- a/tests/libnet/cloudinit/BUILD.bazel
+++ b/tests/libnet/cloudinit/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnet/cloudinit",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
+        "//tests/libnet/cluster:go_default_library",
         "//tests/libnet/dns:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/tests/libnet/cloudinit/cloudinit.go
+++ b/tests/libnet/cloudinit/cloudinit.go
@@ -22,6 +22,8 @@ package cloudinit
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
 	"kubevirt.io/kubevirt/tests/libnet/dns"
 
 	"sigs.k8s.io/yaml"
@@ -81,16 +83,28 @@ func WithAddresses(addresses ...string) NetworkDataInterfaceOption {
 
 func WithDHCP4Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		enabled := true
-		networkDataInterface.DHCP4 = &enabled
+		networkDataInterface.DHCP4 = pointer.P(true)
 		return nil
 	}
 }
 
 func WithDHCP6Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		enabled := true
-		networkDataInterface.DHCP6 = &enabled
+		networkDataInterface.DHCP6 = pointer.P(true)
+		return nil
+	}
+}
+
+func WithDHCP4Disabled() NetworkDataInterfaceOption {
+	return func(networkDataInterface *CloudInitInterface) error {
+		networkDataInterface.DHCP4 = pointer.P(false)
+		return nil
+	}
+}
+
+func WithDHCP6Disabled() NetworkDataInterfaceOption {
+	return func(networkDataInterface *CloudInitInterface) error {
+		networkDataInterface.DHCP6 = pointer.P(false)
 		return nil
 	}
 }
@@ -176,18 +190,44 @@ const (
 	DefaultIPv6Gateway = "fd10:0:2::1"
 )
 
-// CreateDefaultCloudInitNetworkData generates a default configuration
-// for the Cloud-Init Network Data, in version 2 format.
-// The default configuration sets dynamic IPv4 (DHCP) and static IPv6 addresses,
-// including DNS settings of the cluster nameserver IP and search domains.
+// CreateDefaultCloudInitNetworkData returns cloud-init v2 network-config for eth0 from cluster IP family probes.
 func CreateDefaultCloudInitNetworkData() string {
-	data, err := NewNetworkData(
-		WithEthernet("eth0",
+	supportsIPv4, errV4 := cluster.SupportsIpv4()
+	if errV4 != nil {
+		panic(errV4)
+	}
+	supportsIPv6, errV6 := cluster.SupportsIpv6()
+	if errV6 != nil {
+		panic(errV6)
+	}
+
+	var ifaceOpts []NetworkDataInterfaceOption
+	switch {
+	case supportsIPv4 && supportsIPv6: // DHCPv4 + static IPv6 + gateway6
+		ifaceOpts = []NetworkDataInterfaceOption{
 			WithDHCP4Enabled(),
 			WithAddresses(DefaultIPv6CIDR),
 			WithGateway6(DefaultIPv6Gateway),
 			WithNameserverFromCluster(),
-		))
+		}
+	case supportsIPv4: // DHCPv4 only
+		ifaceOpts = []NetworkDataInterfaceOption{
+			WithDHCP4Enabled(),
+			WithDHCP6Disabled(),
+			WithNameserverFromCluster(),
+		}
+	case supportsIPv6: // static IPv6 + gateway6
+		ifaceOpts = []NetworkDataInterfaceOption{
+			WithDHCP4Disabled(),
+			WithAddresses(DefaultIPv6CIDR),
+			WithGateway6(DefaultIPv6Gateway),
+			WithNameserverFromCluster(),
+		}
+	default: // probes ok but neither family — should not happen
+		panic(fmt.Errorf("cluster IPv4/IPv6 probes succeeded but neither family is supported"))
+	}
+
+	data, err := NewNetworkData(WithEthernet("eth0", ifaceOpts...))
 	if err != nil {
 		panic(err)
 	}

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -23,6 +23,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	libvmi "kubevirt.io/kubevirt/pkg/libvmi"
+
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -392,9 +394,13 @@ func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
 }
 
 func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {
-	clientVMI := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
-	var err error
-	clientVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
+	clientVMI := libvmifact.NewAlpineWithTestTooling(
+		libvmi.WithCloudInitNoCloud(
+			libvmifact.WithDummyCloudForFastBoot(),
+		),
+		libnet.WithMasqueradeNetworking(),
+	)
+	clientVMI, err := virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -405,6 +411,9 @@ func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.V
 
 func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, serverVMILabels map[string]string) (*v1.VirtualMachineInstance, error) {
 	serverVMI := libvmifact.NewAlpineWithTestTooling(
+		libvmi.WithCloudInitNoCloud(
+			libvmifact.WithDummyCloudForFastBoot(),
+		),
 		libnet.WithMasqueradeNetworking(
 			v1.Port{
 				Name:     "http80",


### PR DESCRIPTION

Backport of #17067 to release-1.8 by manual cherry pick of commit 2ac1c29. 

**Note:** https://github.com/kubevirt/kubevirt/pull/17067/changes/71acedd88b9ff55ebca62486d411092de65a8e21 is not being backported because it adds a decorator for s390 which is not required in older versions.

The reason for backporting is to fix NetworkPolicy test failures occurring in single IP family setups running older releases.


### What this PR does
Fixes network policy test behaviour across IPv4-only, IPv6-only, and dual-stack clusters by aligning guest cloud-init network config with the cluster IP families when creating the test VMIs.

Previously, guest network config could be mismatched with the cluster's supported IP families, which could make network policy tests fail/flaky even when policy behaviour was correct.

By making cloud-init match cluster IP-family support at VM creation time, test behaviour becomes consistent across stack types without introducing per-family branching in ping/HTTP assertions.

### Changes
- Extended `CreateDefaultCloudInitNetworkData` to probe cluster IP family support (`SupportsIpv4`/`SupportsIpv6`)
- Emit dual-stack, IPv4-only, or IPv6-only eth0 config based on cluster capabilities
- Updated network policy test VMIs to use the IP-family-aware cloud-init configuration

Signed-off-by: Nir Dothan <ndothan@redhat.com>
Assisted by: Claude Sonnet 4.5 <noreply@anthropic.com>

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```