### PR TITLE
hack: Fix cluster-clean stuck on webhook errors and CRD finalizer races

### DIFF
--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -34,6 +34,10 @@ function delete_kubevirt_cr() {
     set +e
     _kubectl -n ${namespace} delete kv kubevirt --timeout=10s --ignore-not-found || true
     _kubectl -n cdi delete service cdi-uploadproxy-nodeport || true
+    # Remove webhook registrations so they don't block the finalizer patch
+    # (the backing service may already be gone after the graceful delete above)
+    _kubectl delete validatingwebhookconfiguration,mutatingwebhookconfiguration -l operator.kubevirt.io --ignore-not-found
+    _kubectl delete validatingwebhookconfiguration,mutatingwebhookconfiguration -l kubevirt.io --ignore-not-found
     patch_remove_finalizers -n ${namespace} kv kubevirt
     set -e
 }
@@ -98,7 +102,7 @@ function delete_resources() {
             local name="${arr[0]}"
             patch_remove_finalizers customresourcedefinitions ${name}
         done
-        _kubectl delete apiservices,clusterroles,clusterrolebinding,customresourcedefinitions,pv,validatingwebhookconfiguration -l ${label}
+        _kubectl delete apiservices,clusterroles,clusterrolebinding,customresourcedefinitions,pv -l ${label}
     done
 
     _kubectl delete priorityclass kubevirt-cluster-critical --ignore-not-found


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR Fixes two issues in hack/cluster-clean.sh that cause the cleanup to hang or fail.
The s390x periodic E2E Test lane is failing at the cluster-cleanup 
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-test-S390X/2045963218697850880
```
20:40:45: + echo 'waiting for cluster-clean to finish'
20:40:45: waiting for cluster-clean to finish
20:40:45: + wait 11864
```
The cluster clean is not able to clean up the left over kubevirt resources. The  Kubevirt's validatingwebhookconfiguration and mutatingwebhookconfiguration are blocking the kubevirt from deleting it.
This is the state of the kubevirt during the time of the error.
```
root@kubevirtci-s390x-external-controlplane:~# kubectl get all -n kubevirt
NAME                            AGE   PHASE
kubevirt.kubevirt.io/kubevirt   10h   Deleting
root@kubevirtci-s390x-external-controlplane:~# kubectl get kv kubevirt -n kubevirt -o jsonpath='{.metadata.finalizers}'
["kubevirt.io/foregroundDeleteKubeVirt"]root@kubevirtci-s390x-external-controlplane:~# 
root@kubevirtci-s390x-external-controlplane:~# 
root@kubevirtci-s390x-external-controlplane:~# kubectl patch kv kubevirt -n kubevirt --type=json -p '[{"op":"remove","path":"/metadata/finalizers"}]'
Error from server (Internal Error): Internal error occurred: failed calling webhook "kubevirt-update-validator.kubevirt.io": failed to call webhook: Post "[https://kubevirt-operator-webhook.kubevirt.svc:443/kubevirt-validate-update?timeout=10s](https://kubevirt-operator-webhook.kubevirt.svc/kubevirt-validate-update?timeout=10s)": service "kubevirt-operator-webhook" not foundDue to the validating webhook the finalizer removal on kubevirt is failed. 
```

Later the script proceeds to the step to delete the pods,crds etc and there it hung. So, it waited for the cluster-clean to finish and eventually the prow job timed out.

#### Before this PR:

- The KubeVirt CR gets stuck in Deleting because the validating webhook blocks finalizer removal after the backing service is already gone.

#### After this PR:

- Webhook registrations (validating and mutating) are deleted after the graceful KV CR delete attempt but before the finalizer patch, so the patch is no longer blocked.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.
```

