### PR TITLE
VEP 160: Add RBAC role aggregation upgrade e2e test

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -885,6 +885,31 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Verifying infrastructure Is Updated")
 			allKvInfraPodsAreReady(kv)
 
+			By("Verifying RBAC aggregate labels are preserved after upgrade")
+			verifyAggregateLabels(virtClient, "true")
+
+			By("Setting RoleAggregationStrategy to Manual after upgrade")
+			currentKV := libkubevirt.GetCurrentKv(virtClient)
+			savedConfig := currentKV.Spec.Configuration.DeepCopy()
+			if currentKV.Spec.Configuration.DeveloperConfiguration == nil {
+				currentKV.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+			}
+			currentKV.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(
+				currentKV.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+				featuregate.OptOutRoleAggregation,
+			)
+			currentKV.Spec.Configuration.RoleAggregationStrategy = pointer.P(v1.RoleAggregationStrategyManual)
+			kvconfig.UpdateKubeVirtConfigValueAndWait(currentKV.Spec.Configuration)
+
+			By("Verifying aggregate labels are set to false after upgrade with Manual strategy")
+			verifyAggregateLabels(virtClient, "false")
+
+			By("Restoring RoleAggregationStrategy to default after upgrade verification")
+			kvconfig.UpdateKubeVirtConfigValueAndWait(*savedConfig)
+
+			By("Verifying aggregate labels are restored after upgrade")
+			verifyAggregateLabels(virtClient, "true")
+
 			// Verify console connectivity to VMI still works and stop VM
 			for _, vmYaml := range vmYamls {
 				By(fmt.Sprintf("Ensuring vm %s is ready and latest API annotation is set", vmYaml.apiVersion))
@@ -2511,22 +2536,11 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 	})
 
 	Context("RoleAggregationStrategy", func() {
-		clusterRolesWithAggregateLabels := map[string]string{
-			rbac.ClusterRoleAdmin: "rbac.authorization.k8s.io/aggregate-to-admin",
-			rbac.ClusterRoleEdit:  "rbac.authorization.k8s.io/aggregate-to-edit",
-			rbac.ClusterRoleView:  "rbac.authorization.k8s.io/aggregate-to-view",
-		}
-
 		It("should disable aggregate labels when set to Manual and restore them when set to AggregateToDefault", func() {
 			By("Verifying aggregate labels are present by default")
-			for name, labelKey := range clusterRolesWithAggregateLabels {
-				clusterRole, err := kubevirt.Client().RbacV1().ClusterRoles().Get(context.Background(), name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(clusterRole.Labels).To(HaveKeyWithValue(labelKey, "true"),
-					"ClusterRole %s should have label %s", name, labelKey)
-			}
+			verifyAggregateLabels(kubevirt.Client(), "true")
 
-			By("Setting RoleAggregationStrategy to Manual with OptOutRoleAggregation feature gate")
+			By("Setting RoleAggregationStrategy to Manual")
 			currentKV := libkubevirt.GetCurrentKv(kubevirt.Client())
 			if currentKV.Spec.Configuration.DeveloperConfiguration == nil {
 				currentKV.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
@@ -2539,24 +2553,14 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			kv := kvconfig.UpdateKubeVirtConfigValueAndWait(currentKV.Spec.Configuration)
 
 			By("Verifying aggregate labels are set to false")
-			for name, labelKey := range clusterRolesWithAggregateLabels {
-				clusterRole, err := kubevirt.Client().RbacV1().ClusterRoles().Get(context.Background(), name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(clusterRole.Labels).To(HaveKeyWithValue(labelKey, "false"),
-					"ClusterRole %s should have label %s set to false when RoleAggregationStrategy is Manual", name, labelKey)
-			}
+			verifyAggregateLabels(kubevirt.Client(), "false")
 
 			By("Setting RoleAggregationStrategy to AggregateToDefault")
 			kv.Spec.Configuration.RoleAggregationStrategy = pointer.P(v1.RoleAggregationStrategyAggregateToDefault)
 			kvconfig.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 
 			By("Verifying aggregate labels are restored")
-			for name, labelKey := range clusterRolesWithAggregateLabels {
-				clusterRole, err := kubevirt.Client().RbacV1().ClusterRoles().Get(context.Background(), name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(clusterRole.Labels).To(HaveKeyWithValue(labelKey, "true"),
-					"ClusterRole %s should have label %s when RoleAggregationStrategy is AggregateToDefault", name, labelKey)
-			}
+			verifyAggregateLabels(kubevirt.Client(), "true")
 		})
 	})
 })
@@ -3255,4 +3259,18 @@ func verifyVMIsUpdated(vmis []*v1.VirtualMachineInstance) {
 			g.Expect(count).To(Equal(1), "vmi [%s] returned %d successful migrations", vmi.Name, count)
 		}
 	}).WithTimeout(10*time.Second).WithPolling(time.Second).Should(Succeed(), "Expects only a single successful migration per workload update")
+}
+
+func verifyAggregateLabels(virtClient kubecli.KubevirtClient, expectedValue string) {
+	clusterRolesWithAggregateLabels := map[string]string{
+		rbac.ClusterRoleAdmin: "rbac.authorization.k8s.io/aggregate-to-admin",
+		rbac.ClusterRoleEdit:  "rbac.authorization.k8s.io/aggregate-to-edit",
+		rbac.ClusterRoleView:  "rbac.authorization.k8s.io/aggregate-to-view",
+	}
+	for name, labelKey := range clusterRolesWithAggregateLabels {
+		clusterRole, err := virtClient.RbacV1().ClusterRoles().Get(context.Background(), name, metav1.GetOptions{})
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		ExpectWithOffset(1, clusterRole.Labels).To(HaveKeyWithValue(labelKey, expectedValue),
+			"ClusterRole %s should have label %s=%s", name, labelKey, expectedValue)
+	}
 }


### PR DESCRIPTION
- Add upgrade test coverage for the `RoleAggregationStrategy` feature
  (VEP 160) as part of Beta graduation requirements
- Verify that RBAC aggregate labels on `kubevirt.io:admin`, `kubevirt.io:edit`,
  and `kubevirt.io:view` ClusterRoles are preserved after upgrading from a
  previous release (backward compatibility)
- Verify that enabling `Manual` strategy works correctly on an upgraded cluster
  and that toggling back to `AggregateToDefault` restores the labels

The new checks are added to the existing `from previous release to target
tested release` upgrade test, running after the upgrade completes and before
VM lifecycle verification.

## Test plan

- [ ] Existing `from previous release to target tested release` upgrade test
      passes with the new RBAC verification steps
- [ ] Aggregate labels are confirmed present after upgrade (default behavior)
- [ ] Manual strategy correctly sets labels to `"false"` on upgraded cluster
- [ ] Restoring default strategy correctly sets labels back to "true"
- [ ] Remaining upgrade test steps (VM lifecycle, migration) are unaffected

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
* VEP 160: https://github.com/kubevirt/enhancements/issues/160
* Beta Graduation VEP: https://github.com/kubevirt/enhancements/pull/276
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add RBAC role aggregation upgrade e2e test
```

