### PR TITLE
console tests: increase configureConsole timeout to 60s

### DIFF
--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -247,7 +247,7 @@ func configureConsole(expecter expect.Expecter, shouldSudo bool) error {
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: RetValueWithPrompt("0")},
 	}
-	const configureConsoleTimeout = 30 * time.Second
+	const configureConsoleTimeout = 60 * time.Second
 	resp, err := expecter.ExpectBatch(batch, configureConsoleTimeout)
 	if err != nil {
 		log.DefaultLogger().Infof("%v", resp)


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `configureConsole` timeout is 30s, which causes flakes in CI environments with parallel testing and resource constraints. `test_id:4599` (MultiQueue VMI) has been flaking at ~2-6% across multiple sig-network jobs.

#### After this PR:
The `configureConsoleTimeout` is increased from 30s to 60s, matching the rationale from #13486.

### References
- Follows the same approach as #13486 which increased similar console timeouts
- [CI search for test_id:4599 failures](https://search.ci.kubevirt.io/?search=test_id%3A4599&maxAge=720h&context=1&type=junit)

### Why we need it and why it was done in this way
Analysis of the `test_id:4599` flake shows the failure occurs in `configureConsole` (not during login or boot). After `echo $?` prints `0`, the shell prompt sometimes does not appear within 30s due to serial console I/O latency under CI load. The CI search confirms this hits many unrelated PRs and periodic jobs consistently.

The following alternatives were considered:
- Keeping 30s: too aggressive, as established by #13486 for similar timeouts

### Special notes for your reviewer
This is a one-line change (30 -> 60) in `tests/console/login.go`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```