### PR TITLE
libvmi: Move WithPasstInterfaceWithPort to its only consumer

### DIFF
--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -39,10 +39,6 @@ func WithNetwork(network *kvirtv1.Network) Option {
 	}
 }
 
-func WithPasstInterfaceWithPort() Option {
-	return WithInterface(InterfaceWithPasstBindingPlugin([]kvirtv1.Port{{Port: 1234, Protocol: "TCP"}}...))
-}
-
 // InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
 func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -129,7 +129,7 @@ var _ = Describe(
 					namespace := testsuite.GetTestNamespace(nil)
 
 					clientVMI = libvmifact.NewAlpineWithTestTooling(
-						libvmi.WithPasstInterfaceWithPort(),
+						withPasstInterfaceWithPort(),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
 					clientVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
@@ -249,7 +249,7 @@ var _ = Describe(
 
 				BeforeAll(func() {
 					vmi = libvmifact.NewAlpineWithTestTooling(
-						libvmi.WithPasstInterfaceWithPort(),
+						withPasstInterfaceWithPort(),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
 					namespace := testsuite.GetTestNamespace(nil)
@@ -352,6 +352,10 @@ var _ = Describe(
 		}),
 )
 
+func withPasstInterfaceWithPort() libvmi.Option {
+	return libvmi.WithInterface(libvmi.InterfaceWithPasstBindingPlugin(v1.Port{Port: 1234, Protocol: "TCP"}))
+}
+
 func assertSourcePodContainersTerminate(labelSelector, fieldSelector string, vmi *v1.VirtualMachineInstance) bool {
 	return Eventually(func() k8sv1.PodPhase {
 		pods, err := kubevirt.Client().CoreV1().Pods(vmi.Namespace).List(context.Background(),
@@ -388,7 +392,7 @@ func createClientServerPasstVMIsWithTCPServer(tcpPort int) (client, server *v1.V
 	namespace := testsuite.GetTestNamespace(nil)
 
 	clientVMI := libvmifact.NewAlpineWithTestTooling(
-		libvmi.WithPasstInterfaceWithPort(),
+		withPasstInterfaceWithPort(),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 	clientVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
WithPasstInterfaceWithPort is not generic enough to be a library function and is only used in the passt binding plugin e2e tests.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

