### PR TITLE
virt-api/rest: preserve deep subresource in SubjectAccessReview

### DIFF
--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -223,6 +223,9 @@ func addNamespacedResourceAttributes(pathSplit []string, requestMethod string, r
 	// SubjectAccessReview matches those resource names exactly; otherwise
 	// the authz decision runs against the first segment only ("vnc") and
 	// diverges from what the cluster role actually grants.
+	if len(pathSplit) <= 8 {
+		return fmt.Errorf("missing subresource in request path: %s", strings.Join(pathSplit, "/"))
+	}
 	group := pathSplit[2]
 	version := pathSplit[3]
 	namespace := pathSplit[5]

--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -212,14 +212,23 @@ func (a *authorizor) generateAccessReview(req *restful.Request) (*authv1.Subject
 }
 
 func addNamespacedResourceAttributes(pathSplit []string, requestMethod string, r *authv1.SubjectAccessReview) error {
-	// URL example
+	// URL examples:
 	// /apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvmi/console
+	// /apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvmi/vnc/screenshot
+	//
+	// #17337: virt-operator RBAC and tests reference deep subresources like
+	// "virtualmachineinstances/vnc/screenshot" and
+	// "virtualmachineinstances/sev/injectlaunchsecret". Preserve the full
+	// slash-delimited remainder after pathSplit[7] so the
+	// SubjectAccessReview matches those resource names exactly; otherwise
+	// the authz decision runs against the first segment only ("vnc") and
+	// diverges from what the cluster role actually grants.
 	group := pathSplit[2]
 	version := pathSplit[3]
 	namespace := pathSplit[5]
 	resource := pathSplit[6]
 	resourceName := pathSplit[7]
-	subresource := pathSplit[8]
+	subresource := strings.Join(pathSplit[8:], "/")
 
 	if resource != "virtualmachineinstances" && resource != "virtualmachines" {
 		return fmt.Errorf("unknown resource type %s", resource)


### PR DESCRIPTION
<!-- thanks for sending a pull request! -->

**What this PR does / why we need it**:

`addNamespacedResourceAttributes` only read `pathSplit[8]`, so deep subresource paths like

- `/vnc/screenshot`
- `/sev/querylaunchmeasurement`
- `/sev/injectlaunchsecret`
- `/evacuate/cancel`

were truncated to `vnc` / `sev` / `evacuate` in the constructed `SubjectAccessReview`. `virt-operator` RBAC (`pkg/virt-operator/resource/generate/rbac/cluster.go`) and the access tests reference the **full** slash-delimited resource names, so the authz decision diverged from what cluster roles actually grant (#17337).

Build the subresource by joining `pathSplit[8:]` with `/`. Non-deep paths still produce the single-segment string (`console`, `vnc`, etc.) because `strings.Join` on a one-element slice returns that element verbatim.

**Which issue(s) this PR fixes**:

Fixes #17337

**Release note**:
```release-note
virt-api: preserve deep subresource paths (e.g. `vnc/screenshot`, `sev/injectlaunchsecret`, `evacuate/cancel`) when building SubjectAccessReviews so authorization matches the resource names declared in virt-operator RBAC.
```
