### PR TITLE
VEP #287: Add TLS group preferences support

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17807,6 +17807,15 @@
       },
       "x-kubernetes-list-type": "set"
      },
+     "groups": {
+      "description": "Groups defines the set of TLS supported groups (key exchange curves) offered during TLS handshakes. Uses IANA names from the TLS Supported Groups registry. When empty, Go's default curve preferences apply. Requires the TLSGroupPreferences feature gate to be enabled.",
+      "type": "array",
+      "items": {
+       "type": "string",
+       "default": ""
+      },
+      "x-kubernetes-list-type": "set"
+     },
      "minTLSVersion": {
       "description": "MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections. Protocol versions are based on the following most common TLS configurations:\n\n  https://ssl-config.mozilla.org/\n\nNote that SSLv3.0 is not a supported protocol version due to well known vulnerabilities such as POODLE: https://en.wikipedia.org/wiki/POODLE",
       "type": "string"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17830,6 +17830,15 @@
       },
       "x-kubernetes-list-type": "set"
      },
+     "groups": {
+      "description": "Groups defines the ordered list of TLS supported groups (key exchange curves) offered during TLS handshakes, using IANA names from the TLS Supported Groups registry (e.g. X25519, secp256r1, X25519MLKEM768). The order is significant: it is applied verbatim as the curve preference order during negotiation. When empty, Go's default curve preferences apply. Unrecognised groups are ignored. Requires the TLSGroupPreferences feature gate to be enabled.\n\nThis is an open string list rather than a hard enum, in line with the KubeVirt API design guidelines (kubevirt/kubevirt#18612, §3.2), so that newly-standardised groups do not break rolling upgrades.",
+      "type": "array",
+      "items": {
+       "type": "string",
+       "default": ""
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "minTLSVersion": {
       "description": "MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections. Protocol versions are based on the following most common TLS configurations:\n\n  https://ssl-config.mozilla.org/\n\nNote that SSLv3.0 is not a supported protocol version due to well known vulnerabilities such as POODLE: https://en.wikipedia.org/wiki/POODLE",
       "type": "string"

--- a/cmd/virt-exportserver/virt-exportserver.go
+++ b/cmd/virt-exportserver/virt-exportserver.go
@@ -44,14 +44,15 @@ func main() {
 
 	certFile, keyFile := getCert()
 	config := exportServer.ExportServerConfig{
-		CertFile:        certFile,
-		KeyFile:         keyFile,
-		Deadline:        getDeadline(),
-		ListenAddr:      getListenAddr(),
-		TokenFile:       getTokenFile(),
-		Paths:           export.CreateServerPaths(export.EnvironToMap()),
-		TLSMinVersion:   getTLSMinVersion(),
-		TLSCipherSuites: getTLSCipherSuites(),
+		CertFile:            certFile,
+		KeyFile:             keyFile,
+		Deadline:            getDeadline(),
+		ListenAddr:          getListenAddr(),
+		TokenFile:           getTokenFile(),
+		Paths:               export.CreateServerPaths(export.EnvironToMap()),
+		TLSMinVersion:       getTLSMinVersion(),
+		TLSCipherSuites:     getTLSCipherSuites(),
+		TLSCurvePreferences: getTLSCurvePreferences(),
 	}
 	if len(config.Paths.Backups) > 0 {
 		config.BackupUID = getBackupUID()
@@ -151,6 +152,19 @@ func getTLSCipherSuites() []uint16 {
 	var ids []uint16
 	if err := json.Unmarshal([]byte(env), &ids); err != nil {
 		log.Log.Warningf("Failed to parse TLS_CIPHER_SUITES: %v", err)
+		return nil
+	}
+	return ids
+}
+
+func getTLSCurvePreferences() []tls.CurveID {
+	env := os.Getenv("TLS_CURVE_PREFERENCES")
+	if env == "" {
+		return nil
+	}
+	var ids []tls.CurveID
+	if err := json.Unmarshal([]byte(env), &ids); err != nil {
+		log.Log.Warningf("Failed to parse TLS_CURVE_PREFERENCES: %v", err)
 		return nil
 	}
 	return ids

--- a/cmd/virt-exportserver/virt-exportserver.go
+++ b/cmd/virt-exportserver/virt-exportserver.go
@@ -44,14 +44,15 @@ func main() {
 
 	certFile, keyFile := getCert()
 	config := exportServer.ExportServerConfig{
-		CertFile:        certFile,
-		KeyFile:         keyFile,
-		Deadline:        getDeadline(),
-		ListenAddr:      getListenAddr(),
-		TokenFile:       getTokenFile(),
-		Paths:           export.CreateServerPaths(export.EnvironToMap()),
-		TLSMinVersion:   getTLSMinVersion(),
-		TLSCipherSuites: getTLSCipherSuites(),
+		CertFile:            certFile,
+		KeyFile:             keyFile,
+		Deadline:            getDeadline(),
+		ListenAddr:          getListenAddr(),
+		TokenFile:           getTokenFile(),
+		Paths:               export.CreateServerPaths(export.EnvironToMap()),
+		TLSMinVersion:       getTLSMinVersion(),
+		TLSCipherSuites:     getTLSCipherSuites(),
+		TLSCurvePreferences: getTLSCurvePreferences(),
 	}
 	if len(config.Paths.Backups) > 0 {
 		config.BackupUID = getBackupUID()
@@ -154,6 +155,19 @@ func getTLSCipherSuites() []uint16 {
 	var ids []uint16
 	if err := json.Unmarshal([]byte(env), &ids); err != nil {
 		log.Log.Warningf("Failed to parse TLS_CIPHER_SUITES: %v", err)
+		return nil
+	}
+	return ids
+}
+
+func getTLSCurvePreferences() []tls.CurveID {
+	env := os.Getenv("TLS_CURVE_PREFERENCES")
+	if env == "" {
+		return nil
+	}
+	var ids []tls.CurveID
+	if err := json.Unmarshal([]byte(env), &ids); err != nil {
+		log.Log.Warningf("Failed to parse TLS_CURVE_PREFERENCES: %v", err)
 		return nil
 	}
 	return ids

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -1140,6 +1140,25 @@ spec:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
+                      groups:
+                        description: |-
+                          Groups defines the set of TLS supported groups (key exchange curves)
+                          offered during TLS handshakes. Uses IANA names from the TLS Supported
+                          Groups registry. When empty, Go's default curve preferences apply.
+                          Requires the TLSGroupPreferences feature gate to be enabled.
+                        items:
+                          description: |-
+                            TLSGroup defines a TLS supported group (key exchange curve) using IANA
+                            names from the TLS Supported Groups registry.
+                          enum:
+                          - X25519
+                          - secp256r1
+                          - secp384r1
+                          - secp521r1
+                          - X25519MLKEM768
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
                       minTLSVersion:
                         description: |-
                           MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.
@@ -4610,6 +4629,25 @@ spec:
                     properties:
                       ciphers:
                         items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      groups:
+                        description: |-
+                          Groups defines the set of TLS supported groups (key exchange curves)
+                          offered during TLS handshakes. Uses IANA names from the TLS Supported
+                          Groups registry. When empty, Go's default curve preferences apply.
+                          Requires the TLSGroupPreferences feature gate to be enabled.
+                        items:
+                          description: |-
+                            TLSGroup defines a TLS supported group (key exchange curve) using IANA
+                            names from the TLS Supported Groups registry.
+                          enum:
+                          - X25519
+                          - secp256r1
+                          - secp384r1
+                          - secp521r1
+                          - X25519MLKEM768
                           type: string
                         type: array
                         x-kubernetes-list-type: set

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -1167,6 +1167,23 @@ spec:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
+                      groups:
+                        description: |-
+                          Groups defines the ordered list of TLS supported groups (key exchange
+                          curves) offered during TLS handshakes, using IANA names from the TLS
+                          Supported Groups registry (e.g. X25519, secp256r1, X25519MLKEM768). The
+                          order is significant: it is applied verbatim as the curve preference
+                          order during negotiation. When empty, Go's default curve preferences
+                          apply. Unrecognised groups are ignored. Requires the TLSGroupPreferences
+                          feature gate to be enabled.
+
+                          This is an open string list rather than a hard enum, in line with the
+                          KubeVirt API design guidelines (kubevirt/kubevirt#18612, §3.2), so that
+                          newly-standardised groups do not break rolling upgrades.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       minTLSVersion:
                         description: |-
                           MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.
@@ -1183,6 +1200,13 @@ spec:
                         - VersionTLS13
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: at least one classical group (e.g. X25519, secp256r1,
+                        secp384r1 or secp521r1) is required in groups when minTLSVersion
+                        is below VersionTLS13
+                      rule: '!has(self.groups) || size(self.groups) == 0 || (has(self.minTLSVersion)
+                        && self.minTLSVersion == ''VersionTLS13'') || self.groups.exists(g,
+                        !(g in [''X25519MLKEM768'',''SecP256r1MLKEM768'',''SecP384r1MLKEM1024'']))'
                   virtTemplateDeployment:
                     description: VirtTemplateDeployment controls the deployment of
                       virt-template components
@@ -4673,6 +4697,23 @@ spec:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
+                      groups:
+                        description: |-
+                          Groups defines the ordered list of TLS supported groups (key exchange
+                          curves) offered during TLS handshakes, using IANA names from the TLS
+                          Supported Groups registry (e.g. X25519, secp256r1, X25519MLKEM768). The
+                          order is significant: it is applied verbatim as the curve preference
+                          order during negotiation. When empty, Go's default curve preferences
+                          apply. Unrecognised groups are ignored. Requires the TLSGroupPreferences
+                          feature gate to be enabled.
+
+                          This is an open string list rather than a hard enum, in line with the
+                          KubeVirt API design guidelines (kubevirt/kubevirt#18612, §3.2), so that
+                          newly-standardised groups do not break rolling upgrades.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       minTLSVersion:
                         description: |-
                           MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.
@@ -4689,6 +4730,13 @@ spec:
                         - VersionTLS13
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: at least one classical group (e.g. X25519, secp256r1,
+                        secp384r1 or secp521r1) is required in groups when minTLSVersion
+                        is below VersionTLS13
+                      rule: '!has(self.groups) || size(self.groups) == 0 || (has(self.minTLSVersion)
+                        && self.minTLSVersion == ''VersionTLS13'') || self.groups.exists(g,
+                        !(g in [''X25519MLKEM768'',''SecP256r1MLKEM768'',''SecP384r1MLKEM1024'']))'
                   virtTemplateDeployment:
                     description: VirtTemplateDeployment controls the deployment of
                       virt-template components

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1744,4 +1744,15 @@ func (ctrl *VMExportController) appendTLSEnvVars(podManifest *corev1.Pod) {
 			})
 		}
 	}
+	if len(tlsConfig.Groups) > 0 && ctrl.clusterConfig.TLSGroupPreferencesEnabled() {
+		curveJSON, err := json.Marshal(kvtls.CurvePreferenceIds(tlsConfig.Groups))
+		if err != nil {
+			log.Log.Warningf("Failed to marshal TLS curve preference IDs: %v", err)
+		} else {
+			podManifest.Spec.Containers[0].Env = append(podManifest.Spec.Containers[0].Env, corev1.EnvVar{
+				Name:  "TLS_CURVE_PREFERENCES",
+				Value: string(curveJSON),
+			})
+		}
+	}
 }

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1851,4 +1851,15 @@ func (ctrl *VMExportController) appendTLSEnvVars(podManifest *corev1.Pod) {
 			})
 		}
 	}
+	if len(tlsConfig.Groups) > 0 && ctrl.clusterConfig.TLSGroupPreferencesEnabled() {
+		curveJSON, err := json.Marshal(kvtls.CurvePreferenceIds(tlsConfig.Groups))
+		if err != nil {
+			log.Log.Warningf("Failed to marshal TLS curve preference IDs: %v", err)
+		} else {
+			podManifest.Spec.Containers[0].Env = append(podManifest.Spec.Containers[0].Env, corev1.EnvVar{
+				Name:  "TLS_CURVE_PREFERENCES",
+				Value: string(curveJSON),
+			})
+		}
+	}
 }

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -97,10 +97,11 @@ type ExportServerConfig struct {
 
 	ListenAddr string
 
-	CertFile, KeyFile string
-	BackupCACert      []byte
-	TLSMinVersion     uint16
-	TLSCipherSuites   []uint16
+	CertFile, KeyFile   string
+	BackupCACert        []byte
+	TLSMinVersion       uint16
+	TLSCipherSuites     []uint16
+	TLSCurvePreferences []tls.CurveID
 
 	TokenFile string
 
@@ -260,9 +261,10 @@ func (s *exportServer) Run() {
 
 func (s *exportServer) buildServer() *http.Server {
 	tlsConfig := &tls.Config{
-		MinVersion:   s.TLSMinVersion,
-		CipherSuites: s.TLSCipherSuites,
-		NextProtos:   []string{"h2", "http/1.1"},
+		MinVersion:       s.TLSMinVersion,
+		CipherSuites:     s.TLSCipherSuites,
+		CurvePreferences: s.TLSCurvePreferences,
+		NextProtos:       []string{"h2", "http/1.1"},
 	}
 
 	rootHandler := s.handler

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -100,10 +100,11 @@ type ExportServerConfig struct {
 
 	ListenAddr string
 
-	CertFile, KeyFile string
-	BackupCACert      []byte
-	TLSMinVersion     uint16
-	TLSCipherSuites   []uint16
+	CertFile, KeyFile   string
+	BackupCACert        []byte
+	TLSMinVersion       uint16
+	TLSCipherSuites     []uint16
+	TLSCurvePreferences []tls.CurveID
 
 	TokenFile string
 
@@ -278,9 +279,10 @@ func (s *exportServer) Run() {
 
 func (s *exportServer) buildServer(ctx context.Context) *http.Server {
 	tlsConfig := &tls.Config{
-		MinVersion:   s.TLSMinVersion,
-		CipherSuites: s.TLSCipherSuites,
-		NextProtos:   []string{"h2", "http/1.1"},
+		MinVersion:       s.TLSMinVersion,
+		CipherSuites:     s.TLSCipherSuites,
+		CurvePreferences: s.TLSCurvePreferences,
+		NextProtos:       []string{"h2", "http/1.1"},
 	}
 
 	rootHandler := s.handler

--- a/pkg/util/tls/BUILD.bazel
+++ b/pkg/util/tls/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/util/tls/tls.go
+++ b/pkg/util/tls/tls.go
@@ -16,6 +16,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 const noSrvCertMessage = "No server certificate, server is not yet ready to receive traffic"
@@ -46,11 +47,16 @@ func SetupPromTLS(certManager certificate.Manager, clusterConfig *virtconfig.Clu
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if clusterConfig.TLSGroupPreferencesEnabled() {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config := &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				Certificates: []tls.Certificate{*crt},
-				ClientAuth:   tls.VerifyClientCertIfGiven,
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				Certificates:     []tls.Certificate{*crt},
+				ClientAuth:       tls.VerifyClientCertIfGiven,
 			}
 
 			config.BuildNameToCertificate()
@@ -81,10 +87,15 @@ func SetupExportProxyTLS(certManager certificate.Manager, kubeVirtStore cache.St
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if isFeatureGateEnabledInKubeVirt(kv, featuregate.TLSGroupPreferences) {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config := &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				Certificates: []tls.Certificate{*crt},
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				Certificates:     []tls.Certificate{*crt},
 			}
 
 			config.BuildNameToCertificate()
@@ -119,12 +130,17 @@ func SetupTLSWithCertManager(caManager KubernetesCAManager, certManager certific
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if clusterConfig.TLSGroupPreferencesEnabled() {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config := &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				Certificates: []tls.Certificate{*cert},
-				ClientCAs:    clientCAPool,
-				ClientAuth:   clientAuth,
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				Certificates:     []tls.Certificate{*cert},
+				ClientCAs:        clientCAPool,
+				ClientAuth:       clientAuth,
 				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 					if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
 						return nil
@@ -201,10 +217,15 @@ func SetupTLSForServer(caManager ClientCAManager, certManager certificate.Manage
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if clusterConfig.TLSGroupPreferencesEnabled() {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config = &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				ClientCAs:    certPool,
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				ClientCAs:        certPool,
 				GetCertificate: func(info *tls.ClientHelloInfo) (i *tls.Certificate, e error) {
 					return cert, nil
 				},
@@ -280,6 +301,16 @@ func InjectTLSConfigIntoDeployment(kv *v1.KubeVirt, deployment *appsv1.Deploymen
 		deployment.Spec.Template.Spec.Containers[idx].Args = append(
 			deployment.Spec.Template.Spec.Containers[idx].Args,
 			"--tls-min-version", string(tlsConfig.MinTLSVersion),
+		)
+	}
+	if len(tlsConfig.Groups) > 0 && isFeatureGateEnabledInKubeVirt(kv, featuregate.TLSGroupPreferences) {
+		groupStrs := make([]string, len(tlsConfig.Groups))
+		for i, g := range tlsConfig.Groups {
+			groupStrs[i] = string(g)
+		}
+		deployment.Spec.Template.Spec.Containers[idx].Args = append(
+			deployment.Spec.Template.Spec.Containers[idx].Args,
+			"--tls-groups", strings.Join(groupStrs, ","),
 		)
 	}
 	return nil
@@ -401,6 +432,48 @@ func createIntermediatePool(externallyManaged bool, rawIntermediates [][]byte) *
 		}
 	}
 	return intermediatePool
+}
+
+func CurvePreferenceIds(groups []v1.TLSGroup) []tls.CurveID {
+	if len(groups) == 0 {
+		return nil
+	}
+	ids := make([]tls.CurveID, 0, len(groups))
+	for _, group := range groups {
+		switch group {
+		case v1.TLSGroupX25519:
+			ids = append(ids, tls.X25519)
+		case v1.TLSGroupSecP256r1:
+			ids = append(ids, tls.CurveP256)
+		case v1.TLSGroupSecP384r1:
+			ids = append(ids, tls.CurveP384)
+		case v1.TLSGroupSecP521r1:
+			ids = append(ids, tls.CurveP521)
+		case v1.TLSGroupX25519MLKEM768:
+			ids = append(ids, tls.X25519MLKEM768)
+		}
+	}
+	return ids
+}
+
+func ValidTLSGroup(group v1.TLSGroup) bool {
+	switch group {
+	case v1.TLSGroupX25519, v1.TLSGroupSecP256r1, v1.TLSGroupSecP384r1, v1.TLSGroupSecP521r1, v1.TLSGroupX25519MLKEM768:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsTLS13OnlyGroup(group v1.TLSGroup) bool {
+	return group == v1.TLSGroupX25519MLKEM768
+}
+
+func isFeatureGateEnabledInKubeVirt(kv *v1.KubeVirt, fgName string) bool {
+	if kv == nil || kv.Spec.Configuration.DeveloperConfiguration == nil {
+		return false
+	}
+	return slices.Contains(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, fgName)
 }
 
 func getKubevirt(kubeVirtStore cache.Store) *v1.KubeVirt {

--- a/pkg/util/tls/tls.go
+++ b/pkg/util/tls/tls.go
@@ -16,6 +16,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 const noSrvCertMessage = "No server certificate, server is not yet ready to receive traffic"
@@ -46,11 +47,16 @@ func SetupPromTLS(certManager certificate.Manager, clusterConfig *virtconfig.Clu
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if clusterConfig.TLSGroupPreferencesEnabled() {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config := &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				Certificates: []tls.Certificate{*crt},
-				ClientAuth:   tls.VerifyClientCertIfGiven,
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				Certificates:     []tls.Certificate{*crt},
+				ClientAuth:       tls.VerifyClientCertIfGiven,
 			}
 
 			config.BuildNameToCertificate()
@@ -81,10 +87,15 @@ func SetupExportProxyTLS(certManager certificate.Manager, kubeVirtStore cache.St
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if isFeatureGateEnabledInKubeVirt(kv, featuregate.TLSGroupPreferences) {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config := &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				Certificates: []tls.Certificate{*crt},
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				Certificates:     []tls.Certificate{*crt},
 			}
 
 			config.BuildNameToCertificate()
@@ -119,12 +130,17 @@ func SetupTLSWithCertManager(caManager KubernetesCAManager, certManager certific
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if clusterConfig.TLSGroupPreferencesEnabled() {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config := &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				Certificates: []tls.Certificate{*cert},
-				ClientCAs:    clientCAPool,
-				ClientAuth:   clientAuth,
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				Certificates:     []tls.Certificate{*cert},
+				ClientCAs:        clientCAPool,
+				ClientAuth:       clientAuth,
 				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 					if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
 						return nil
@@ -201,10 +217,15 @@ func SetupTLSForServer(caManager ClientCAManager, certManager certificate.Manage
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
+			var curvePreferences []tls.CurveID
+			if clusterConfig.TLSGroupPreferencesEnabled() {
+				curvePreferences = CurvePreferenceIds(tlsConfig.Groups)
+			}
 			config = &tls.Config{
-				CipherSuites: ciphers,
-				MinVersion:   minTLSVersion,
-				ClientCAs:    certPool,
+				CipherSuites:     ciphers,
+				MinVersion:       minTLSVersion,
+				CurvePreferences: curvePreferences,
+				ClientCAs:        certPool,
 				GetCertificate: func(info *tls.ClientHelloInfo) (i *tls.Certificate, e error) {
 					return cert, nil
 				},
@@ -280,6 +301,12 @@ func InjectTLSConfigIntoDeployment(kv *v1.KubeVirt, deployment *appsv1.Deploymen
 		deployment.Spec.Template.Spec.Containers[idx].Args = append(
 			deployment.Spec.Template.Spec.Containers[idx].Args,
 			"--tls-min-version", string(tlsConfig.MinTLSVersion),
+		)
+	}
+	if len(tlsConfig.Groups) > 0 && isFeatureGateEnabledInKubeVirt(kv, featuregate.TLSGroupPreferences) {
+		deployment.Spec.Template.Spec.Containers[idx].Args = append(
+			deployment.Spec.Template.Spec.Containers[idx].Args,
+			"--tls-groups", strings.Join(tlsConfig.Groups, ","),
 		)
 	}
 	return nil
@@ -418,6 +445,43 @@ func createIntermediatePool(externallyManaged bool, rawIntermediates [][]byte) *
 		}
 	}
 	return intermediatePool
+}
+
+// CurvePreferenceIds maps the configured TLS group names to their crypto/tls
+// CurveID values. Groups is an open string set (see kubevirt/kubevirt#18612,
+// §3.2), so unrecognised group names are silently ignored rather than rejected,
+// keeping older components tolerant of groups added in newer releases.
+func CurvePreferenceIds(groups []string) []tls.CurveID {
+	if len(groups) == 0 {
+		return nil
+	}
+	ids := make([]tls.CurveID, 0, len(groups))
+	for _, group := range groups {
+		switch group {
+		case v1.TLSGroupX25519:
+			ids = append(ids, tls.X25519)
+		case v1.TLSGroupSecP256r1:
+			ids = append(ids, tls.CurveP256)
+		case v1.TLSGroupSecP384r1:
+			ids = append(ids, tls.CurveP384)
+		case v1.TLSGroupSecP521r1:
+			ids = append(ids, tls.CurveP521)
+		case v1.TLSGroupX25519MLKEM768:
+			ids = append(ids, tls.X25519MLKEM768)
+		case v1.TLSGroupSecP256r1MLKEM768:
+			ids = append(ids, tls.SecP256r1MLKEM768)
+		case v1.TLSGroupSecP384r1MLKEM1024:
+			ids = append(ids, tls.SecP384r1MLKEM1024)
+		}
+	}
+	return ids
+}
+
+func isFeatureGateEnabledInKubeVirt(kv *v1.KubeVirt, fgName string) bool {
+	if kv == nil || kv.Spec.Configuration.DeveloperConfiguration == nil {
+		return false
+	}
+	return slices.Contains(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, fgName)
 }
 
 func getKubevirt(kubeVirtStore cache.Store) *v1.KubeVirt {

--- a/pkg/util/tls/tls_test.go
+++ b/pkg/util/tls/tls_test.go
@@ -479,5 +479,104 @@ var _ = Describe("TLS", func() {
 			Expect(kvtls.InjectTLSConfigIntoDeployment(&v1.KubeVirt{}, deployment, "nonexistent")).
 				To(MatchError(ContainSubstring("not found in deployment")))
 		})
+
+		It("should inject TLS groups when feature gate is enabled", func() {
+			kv := &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						DeveloperConfiguration: &v1.DeveloperConfiguration{
+							FeatureGates: []string{"TLSGroupPreferences"},
+						},
+						TLSConfiguration: &v1.TLSConfiguration{
+							MinTLSVersion: v1.VersionTLS12,
+							Groups:        []v1.TLSGroup{v1.TLSGroupX25519, v1.TLSGroupSecP256r1},
+						},
+					},
+				},
+			}
+			Expect(kvtls.InjectTLSConfigIntoDeployment(kv, deployment, containerName)).To(Succeed())
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--tls-groups", "X25519,secp256r1"))
+		})
+
+		It("should not inject TLS groups when feature gate is disabled", func() {
+			kv := &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						TLSConfiguration: &v1.TLSConfiguration{
+							MinTLSVersion: v1.VersionTLS12,
+							Groups:        []v1.TLSGroup{v1.TLSGroupX25519},
+						},
+					},
+				},
+			}
+			Expect(kvtls.InjectTLSConfigIntoDeployment(kv, deployment, containerName)).To(Succeed())
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--tls-groups"))
+		})
+	})
+
+	Describe("CurvePreferenceIds", func() {
+		It("should return nil for empty input", func() {
+			Expect(kvtls.CurvePreferenceIds(nil)).To(BeNil())
+			Expect(kvtls.CurvePreferenceIds([]v1.TLSGroup{})).To(BeNil())
+		})
+
+		DescribeTable("should return correct CurveID for each group",
+			func(group v1.TLSGroup, expected tls.CurveID) {
+				ids := kvtls.CurvePreferenceIds([]v1.TLSGroup{group})
+				Expect(ids).To(HaveLen(1))
+				Expect(ids[0]).To(Equal(expected))
+			},
+			Entry("X25519", v1.TLSGroupX25519, tls.X25519),
+			Entry("secp256r1", v1.TLSGroupSecP256r1, tls.CurveP256),
+			Entry("secp384r1", v1.TLSGroupSecP384r1, tls.CurveP384),
+			Entry("secp521r1", v1.TLSGroupSecP521r1, tls.CurveP521),
+			Entry("X25519MLKEM768", v1.TLSGroupX25519MLKEM768, tls.X25519MLKEM768),
+		)
+
+		It("should skip unknown group names", func() {
+			ids := kvtls.CurvePreferenceIds([]v1.TLSGroup{"unknown", v1.TLSGroupX25519})
+			Expect(ids).To(HaveLen(1))
+			Expect(ids[0]).To(Equal(tls.X25519))
+		})
+
+		It("should preserve order", func() {
+			ids := kvtls.CurvePreferenceIds([]v1.TLSGroup{v1.TLSGroupSecP384r1, v1.TLSGroupX25519})
+			Expect(ids).To(Equal([]tls.CurveID{tls.CurveP384, tls.X25519}))
+		})
+	})
+
+	Describe("ValidTLSGroup", func() {
+		DescribeTable("should return true for valid groups",
+			func(group v1.TLSGroup) {
+				Expect(kvtls.ValidTLSGroup(group)).To(BeTrue())
+			},
+			Entry("X25519", v1.TLSGroupX25519),
+			Entry("secp256r1", v1.TLSGroupSecP256r1),
+			Entry("secp384r1", v1.TLSGroupSecP384r1),
+			Entry("secp521r1", v1.TLSGroupSecP521r1),
+			Entry("X25519MLKEM768", v1.TLSGroupX25519MLKEM768),
+		)
+
+		It("should return false for an invalid group", func() {
+			Expect(kvtls.ValidTLSGroup(v1.TLSGroup("invalid"))).To(BeFalse())
+		})
+	})
+
+	Describe("IsTLS13OnlyGroup", func() {
+		It("should return true for X25519MLKEM768", func() {
+			Expect(kvtls.IsTLS13OnlyGroup(v1.TLSGroupX25519MLKEM768)).To(BeTrue())
+		})
+
+		DescribeTable("should return false for classical groups",
+			func(group v1.TLSGroup) {
+				Expect(kvtls.IsTLS13OnlyGroup(group)).To(BeFalse())
+			},
+			Entry("X25519", v1.TLSGroupX25519),
+			Entry("secp256r1", v1.TLSGroupSecP256r1),
+			Entry("secp384r1", v1.TLSGroupSecP384r1),
+			Entry("secp521r1", v1.TLSGroupSecP521r1),
+		)
 	})
 })

--- a/pkg/util/tls/tls_test.go
+++ b/pkg/util/tls/tls_test.go
@@ -479,6 +479,74 @@ var _ = Describe("TLS", func() {
 			Expect(kvtls.InjectTLSConfigIntoDeployment(&v1.KubeVirt{}, deployment, "nonexistent")).
 				To(MatchError(ContainSubstring("not found in deployment")))
 		})
+
+		It("should inject TLS groups when feature gate is enabled", func() {
+			kv := &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						DeveloperConfiguration: &v1.DeveloperConfiguration{
+							FeatureGates: []string{"TLSGroupPreferences"},
+						},
+						TLSConfiguration: &v1.TLSConfiguration{
+							MinTLSVersion: v1.VersionTLS12,
+							Groups:        []string{v1.TLSGroupX25519, v1.TLSGroupSecP256r1},
+						},
+					},
+				},
+			}
+			Expect(kvtls.InjectTLSConfigIntoDeployment(kv, deployment, containerName)).To(Succeed())
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(ContainElements("--tls-groups", "X25519,secp256r1"))
+		})
+
+		It("should not inject TLS groups when feature gate is disabled", func() {
+			kv := &v1.KubeVirt{
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						TLSConfiguration: &v1.TLSConfiguration{
+							MinTLSVersion: v1.VersionTLS12,
+							Groups:        []string{v1.TLSGroupX25519},
+						},
+					},
+				},
+			}
+			Expect(kvtls.InjectTLSConfigIntoDeployment(kv, deployment, containerName)).To(Succeed())
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			Expect(args).NotTo(ContainElement("--tls-groups"))
+		})
+	})
+
+	Describe("CurvePreferenceIds", func() {
+		It("should return nil for empty input", func() {
+			Expect(kvtls.CurvePreferenceIds(nil)).To(BeNil())
+			Expect(kvtls.CurvePreferenceIds([]string{})).To(BeNil())
+		})
+
+		DescribeTable("should return correct CurveID for each group",
+			func(group string, expected tls.CurveID) {
+				ids := kvtls.CurvePreferenceIds([]string{group})
+				Expect(ids).To(HaveLen(1))
+				Expect(ids[0]).To(Equal(expected))
+			},
+			Entry("X25519", v1.TLSGroupX25519, tls.X25519),
+			Entry("secp256r1", v1.TLSGroupSecP256r1, tls.CurveP256),
+			Entry("secp384r1", v1.TLSGroupSecP384r1, tls.CurveP384),
+			Entry("secp521r1", v1.TLSGroupSecP521r1, tls.CurveP521),
+			Entry("X25519MLKEM768", v1.TLSGroupX25519MLKEM768, tls.X25519MLKEM768),
+			Entry("SecP256r1MLKEM768", v1.TLSGroupSecP256r1MLKEM768, tls.SecP256r1MLKEM768),
+			Entry("SecP384r1MLKEM1024", v1.TLSGroupSecP384r1MLKEM1024, tls.SecP384r1MLKEM1024),
+		)
+
+		It("should skip unknown group names", func() {
+			ids := kvtls.CurvePreferenceIds([]string{"unknown", v1.TLSGroupX25519})
+			Expect(ids).To(HaveLen(1))
+			Expect(ids[0]).To(Equal(tls.X25519))
+		})
+
+		It("should preserve order", func() {
+			ids := kvtls.CurvePreferenceIds([]string{v1.TLSGroupSecP384r1, v1.TLSGroupX25519})
+			Expect(ids).To(Equal([]tls.CurveID{tls.CurveP384, tls.X25519}))
+		})
 	})
 
 	Describe("ApplyTLSConfigurationFromKubeVirtStore", func() {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -240,3 +240,7 @@ func (config *ClusterConfig) LiveUpdateNADRefEnabled() bool {
 func (config *ClusterConfig) VGPULiveMigrationEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.VGPULiveMigration)
 }
+
+func (config *ClusterConfig) TLSGroupPreferencesEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.TLSGroupPreferences)
+}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -252,3 +252,7 @@ func (config *ClusterConfig) MigrationStallDetectionEnabled() bool {
 func (config *ClusterConfig) MigrationDowntimeTuningEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.MigrationDowntimeTuning)
 }
+
+func (config *ClusterConfig) TLSGroupPreferencesEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.TLSGroupPreferences)
+}

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -228,6 +228,14 @@ const (
 	// The VGPULiveMigration fg enables the vGPU hook to run for vGPU live migrations, allowing the
 	// target XML's mdev UUID to be mutated.
 	VGPULiveMigration = "VGPULiveMigration"
+
+	// Owner: @lyarwood
+	// Alpha: v1.9.0
+	//
+	// TLSGroupPreferences allows configuring TLS supported groups (elliptic
+	// curves) on all virt pod endpoints, enabling Post-Quantum Cryptography
+	// readiness.
+	TLSGroupPreferences = "TLSGroupPreferences"
 )
 
 func init() {
@@ -273,4 +281,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: OptOutRoleAggregation, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: LiveUpdateNADRef, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: VGPULiveMigration, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: TLSGroupPreferences, State: Alpha})
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -283,6 +283,14 @@ const (
 	// PortRangesSpec enables the portRanges field, initially only on masquerade interfaces,
 	// allowing compact specification of contiguous port intervals to forward to the VM guest.
 	PortRangesSpec = "PortRangesSpec"
+
+	// Owner: @Barakmor1
+	// Alpha: v1.10.0
+	//
+	// TLSGroupPreferences allows configuring TLS supported groups (elliptic
+	// curves) on all virt pod endpoints, enabling Post-Quantum Cryptography
+	// readiness.
+	TLSGroupPreferences = "TLSGroupPreferences"
 )
 
 func init() {
@@ -332,4 +340,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MigrationDowntimeTuning, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CrossArchitectureVirtualization, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PortRangesSpec, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: TLSGroupPreferences, State: Alpha})
 }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1742,6 +1742,25 @@ var CRDsValidation map[string]string = map[string]string{
                     type: string
                   type: array
                   x-kubernetes-list-type: set
+                groups:
+                  description: |-
+                    Groups defines the set of TLS supported groups (key exchange curves)
+                    offered during TLS handshakes. Uses IANA names from the TLS Supported
+                    Groups registry. When empty, Go's default curve preferences apply.
+                    Requires the TLSGroupPreferences feature gate to be enabled.
+                  items:
+                    description: |-
+                      TLSGroup defines a TLS supported group (key exchange curve) using IANA
+                      names from the TLS Supported Groups registry.
+                    enum:
+                    - X25519
+                    - secp256r1
+                    - secp384r1
+                    - secp521r1
+                    - X25519MLKEM768
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
                 minTLSVersion:
                   description: |-
                     MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1769,6 +1769,23 @@ var CRDsValidation map[string]string = map[string]string{
                     type: string
                   type: array
                   x-kubernetes-list-type: set
+                groups:
+                  description: |-
+                    Groups defines the ordered list of TLS supported groups (key exchange
+                    curves) offered during TLS handshakes, using IANA names from the TLS
+                    Supported Groups registry (e.g. X25519, secp256r1, X25519MLKEM768). The
+                    order is significant: it is applied verbatim as the curve preference
+                    order during negotiation. When empty, Go's default curve preferences
+                    apply. Unrecognised groups are ignored. Requires the TLSGroupPreferences
+                    feature gate to be enabled.
+
+                    This is an open string list rather than a hard enum, in line with the
+                    KubeVirt API design guidelines (kubevirt/kubevirt#18612, §3.2), so that
+                    newly-standardised groups do not break rolling upgrades.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
                 minTLSVersion:
                   description: |-
                     MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.
@@ -1785,6 +1802,13 @@ var CRDsValidation map[string]string = map[string]string{
                   - VersionTLS13
                   type: string
               type: object
+              x-kubernetes-validations:
+              - message: at least one classical group (e.g. X25519, secp256r1, secp384r1
+                  or secp521r1) is required in groups when minTLSVersion is below
+                  VersionTLS13
+                rule: '!has(self.groups) || size(self.groups) == 0 || (has(self.minTLSVersion)
+                  && self.minTLSVersion == ''VersionTLS13'') || self.groups.exists(g,
+                  !(g in [''X25519MLKEM768'',''SecP256r1MLKEM768'',''SecP384r1MLKEM1024'']))'
             virtTemplateDeployment:
               description: VirtTemplateDeployment controls the deployment of virt-template
                 components

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -275,8 +275,35 @@ func validateTLSConfiguration(tlsConfiguration *v1.TLSConfiguration) []metav1.St
 				})
 			}
 		}
+	}
 
-		return statuses
+	if len(tlsConfiguration.Groups) > 0 {
+		for index, group := range tlsConfiguration.Groups {
+			if !kvtls.ValidTLSGroup(group) {
+				statuses = append(statuses, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueNotSupported,
+					Message: fmt.Sprintf("%s is not a valid TLS group", group),
+					Field:   fmt.Sprintf("spec.configuration.tlsConfiguration.groups#%d", index),
+				})
+			}
+		}
+
+		if len(statuses) == 0 && tlsConfiguration.MinTLSVersion != v1.VersionTLS13 {
+			hasClassicalGroup := false
+			for _, group := range tlsConfiguration.Groups {
+				if !kvtls.IsTLS13OnlyGroup(group) {
+					hasClassicalGroup = true
+					break
+				}
+			}
+			if !hasClassicalGroup {
+				statuses = append(statuses, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: "At least one classical group (X25519, secp256r1, secp384r1, or secp521r1) is required when minTLSVersion is below VersionTLS13",
+					Field:   "spec.configuration.tlsConfiguration.groups",
+				})
+			}
+		}
 	}
 
 	return statuses

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -279,9 +279,14 @@ func validateTLSConfiguration(tlsConfiguration *v1.TLSConfiguration) []metav1.St
 				})
 			}
 		}
-
-		return statuses
 	}
+
+	// TLS groups are an open string set (see kubevirt/kubevirt#18612, §3.2):
+	// unrecognised group names are not rejected here but ignored at TLS setup
+	// time by CurvePreferenceIds. The cross-field constraint requiring a
+	// classical group when minTLSVersion is below VersionTLS13 is expressed as a
+	// CEL validation on TLSConfiguration per §4.2, not as an imperative webhook
+	// check.
 
 	return statuses
 }

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -241,6 +241,44 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 		)
 	})
 
+	Context("with TLSConfiguration groups", func() {
+		It("should reject unknown group name", func() {
+			causes := validateTLSConfiguration(&v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Groups:        []v1.TLSGroup{"INVALID_GROUP"},
+			})
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(Equal("INVALID_GROUP is not a valid TLS group"))
+			Expect(causes[0].Field).To(Equal("spec.configuration.tlsConfiguration.groups#0"))
+		})
+
+		It("should reject PQC-only groups when minTLSVersion is below TLS 1.3", func() {
+			causes := validateTLSConfiguration(&v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Groups:        []v1.TLSGroup{v1.TLSGroupX25519MLKEM768},
+			})
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("At least one classical group"))
+			Expect(causes[0].Field).To(Equal("spec.configuration.tlsConfiguration.groups"))
+		})
+
+		It("should accept PQC-only groups when minTLSVersion is TLS 1.3", func() {
+			causes := validateTLSConfiguration(&v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS13,
+				Groups:        []v1.TLSGroup{v1.TLSGroupX25519MLKEM768},
+			})
+			Expect(causes).To(BeEmpty())
+		})
+
+		It("should accept valid groups with classical curve", func() {
+			causes := validateTLSConfiguration(&v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Groups:        []v1.TLSGroup{v1.TLSGroupX25519, v1.TLSGroupX25519MLKEM768},
+			})
+			Expect(causes).To(BeEmpty())
+		})
+	})
+
 	Context("with AdditionalGuestMemoryOverheadRatio", func() {
 		DescribeTable("the ratio must be parsable to float", func(unparsableRatio string) {
 			causes := validateGuestToRequestHeadroom(&unparsableRatio)

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
@@ -321,6 +321,9 @@
         "minTLSVersion": "minTLSVersionValue",
         "ciphers": [
           "ciphersValue"
+        ],
+        "groups": [
+          "groupsValue"
         ]
       },
       "seccompConfiguration": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.json
@@ -322,6 +322,9 @@
         "minTLSVersion": "minTLSVersionValue",
         "ciphers": [
           "ciphersValue"
+        ],
+        "groups": [
+          "groupsValue"
         ]
       },
       "seccompConfiguration": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
@@ -258,6 +258,8 @@ spec:
     tlsConfiguration:
       ciphers:
       - ciphersValue
+      groups:
+      - groupsValue
       minTLSVersion: minTLSVersionValue
     virtTemplateDeployment:
       enabled: true

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.KubeVirt.yaml
@@ -261,6 +261,8 @@ spec:
     tlsConfiguration:
       ciphers:
       - ciphersValue
+      groups:
+      - groupsValue
       minTLSVersion: minTLSVersionValue
     virtTemplateDeployment:
       enabled: true

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -4985,6 +4985,11 @@ func (in *TLSConfiguration) DeepCopyInto(out *TLSConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Groups != nil {
+		in, out := &in.Groups, &out.Groups
+		*out = make([]TLSGroup, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -5154,6 +5154,11 @@ func (in *TLSConfiguration) DeepCopyInto(out *TLSConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Groups != nil {
+		in, out := &in.Groups, &out.Groups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -3266,6 +3266,19 @@ const (
 	VersionTLS13 TLSProtocolVersion = "VersionTLS13"
 )
 
+// TLSGroup defines a TLS supported group (key exchange curve) using IANA
+// names from the TLS Supported Groups registry.
+// +kubebuilder:validation:Enum=X25519;secp256r1;secp384r1;secp521r1;X25519MLKEM768
+type TLSGroup string
+
+const (
+	TLSGroupX25519         TLSGroup = "X25519"
+	TLSGroupSecP256r1      TLSGroup = "secp256r1"
+	TLSGroupSecP384r1      TLSGroup = "secp384r1"
+	TLSGroupSecP521r1      TLSGroup = "secp521r1"
+	TLSGroupX25519MLKEM768 TLSGroup = "X25519MLKEM768"
+)
+
 type CustomProfile struct {
 	LocalhostProfile      *string `json:"localhostProfile,omitempty"`
 	RuntimeDefaultProfile bool    `json:"runtimeDefaultProfile,omitempty"`
@@ -3313,6 +3326,13 @@ type TLSConfiguration struct {
 	MinTLSVersion TLSProtocolVersion `json:"minTLSVersion,omitempty"`
 	// +listType=set
 	Ciphers []string `json:"ciphers,omitempty"`
+	// Groups defines the set of TLS supported groups (key exchange curves)
+	// offered during TLS handshakes. Uses IANA names from the TLS Supported
+	// Groups registry. When empty, Go's default curve preferences apply.
+	// Requires the TLSGroupPreferences feature gate to be enabled.
+	// +optional
+	// +listType=set
+	Groups []TLSGroup `json:"groups,omitempty"`
 }
 
 // MigrationConfiguration holds migration options.

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -3367,6 +3367,21 @@ const (
 	VersionTLS13 TLSProtocolVersion = "VersionTLS13"
 )
 
+// TLS supported group (key exchange curve) names from the IANA TLS Supported
+// Groups registry, provided as named constants for the groups KubeVirt
+// recognises. The TLSConfiguration.Groups field is an open string set (see
+// kubevirt/kubevirt#18612, §3.2), so these are convenience constants rather
+// than an exhaustive, schema-enforced enumeration.
+const (
+	TLSGroupX25519             = "X25519"
+	TLSGroupSecP256r1          = "secp256r1"
+	TLSGroupSecP384r1          = "secp384r1"
+	TLSGroupSecP521r1          = "secp521r1"
+	TLSGroupX25519MLKEM768     = "X25519MLKEM768"
+	TLSGroupSecP256r1MLKEM768  = "SecP256r1MLKEM768"
+	TLSGroupSecP384r1MLKEM1024 = "SecP384r1MLKEM1024"
+)
+
 type CustomProfile struct {
 	LocalhostProfile      *string `json:"localhostProfile,omitempty"`
 	RuntimeDefaultProfile bool    `json:"runtimeDefaultProfile,omitempty"`
@@ -3402,6 +3417,7 @@ type DisableFreePageReporting struct{}
 type DisableSerialConsoleLog struct{}
 
 // TLSConfiguration holds TLS options
+// +kubebuilder:validation:XValidation:rule="!has(self.groups) || size(self.groups) == 0 || (has(self.minTLSVersion) && self.minTLSVersion == 'VersionTLS13') || self.groups.exists(g, !(g in ['X25519MLKEM768','SecP256r1MLKEM768','SecP384r1MLKEM1024']))",message="at least one classical group (e.g. X25519, secp256r1, secp384r1 or secp521r1) is required in groups when minTLSVersion is below VersionTLS13"
 type TLSConfiguration struct {
 	// MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.
 	// Protocol versions are based on the following most common TLS configurations:
@@ -3414,6 +3430,20 @@ type TLSConfiguration struct {
 	MinTLSVersion TLSProtocolVersion `json:"minTLSVersion,omitempty"`
 	// +listType=set
 	Ciphers []string `json:"ciphers,omitempty"`
+	// Groups defines the ordered list of TLS supported groups (key exchange
+	// curves) offered during TLS handshakes, using IANA names from the TLS
+	// Supported Groups registry (e.g. X25519, secp256r1, X25519MLKEM768). The
+	// order is significant: it is applied verbatim as the curve preference
+	// order during negotiation. When empty, Go's default curve preferences
+	// apply. Unrecognised groups are ignored. Requires the TLSGroupPreferences
+	// feature gate to be enabled.
+	//
+	// This is an open string list rather than a hard enum, in line with the
+	// KubeVirt API design guidelines (kubevirt/kubevirt#18612, §3.2), so that
+	// newly-standardised groups do not break rolling upgrades.
+	// +optional
+	// +listType=atomic
+	Groups []string `json:"groups,omitempty"`
 }
 
 type StallDetectorOptions struct {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -1003,6 +1003,7 @@ func (TLSConfiguration) SwaggerDoc() map[string]string {
 		"":              "TLSConfiguration holds TLS options",
 		"minTLSVersion": "MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.\nProtocol versions are based on the following most common TLS configurations:\n\n  https://ssl-config.mozilla.org/\n\nNote that SSLv3.0 is not a supported protocol version due to well known\nvulnerabilities such as POODLE: https://en.wikipedia.org/wiki/POODLE\n+kubebuilder:validation:Enum=VersionTLS10;VersionTLS11;VersionTLS12;VersionTLS13",
 		"ciphers":       "+listType=set",
+		"groups":        "Groups defines the set of TLS supported groups (key exchange curves)\noffered during TLS handshakes. Uses IANA names from the TLS Supported\nGroups registry. When empty, Go's default curve preferences apply.\nRequires the TLSGroupPreferences feature gate to be enabled.\n+optional\n+listType=set",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -1019,9 +1019,10 @@ func (DisableSerialConsoleLog) SwaggerDoc() map[string]string {
 
 func (TLSConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":              "TLSConfiguration holds TLS options",
+		"":              "TLSConfiguration holds TLS options\n+kubebuilder:validation:XValidation:rule=\"!has(self.groups) || size(self.groups) == 0 || (has(self.minTLSVersion) && self.minTLSVersion == 'VersionTLS13') || self.groups.exists(g, !(g in ['X25519MLKEM768','SecP256r1MLKEM768','SecP384r1MLKEM1024']))\",message=\"at least one classical group (e.g. X25519, secp256r1, secp384r1 or secp521r1) is required in groups when minTLSVersion is below VersionTLS13\"",
 		"minTLSVersion": "MinTLSVersion is a way to specify the minimum protocol version that is acceptable for TLS connections.\nProtocol versions are based on the following most common TLS configurations:\n\n  https://ssl-config.mozilla.org/\n\nNote that SSLv3.0 is not a supported protocol version due to well known\nvulnerabilities such as POODLE: https://en.wikipedia.org/wiki/POODLE\n+kubebuilder:validation:Enum=VersionTLS10;VersionTLS11;VersionTLS12;VersionTLS13",
 		"ciphers":       "+listType=set",
+		"groups":        "Groups defines the ordered list of TLS supported groups (key exchange\ncurves) offered during TLS handshakes, using IANA names from the TLS\nSupported Groups registry (e.g. X25519, secp256r1, X25519MLKEM768). The\norder is significant: it is applied verbatim as the curve preference\norder during negotiation. When empty, Go's default curve preferences\napply. Unrecognised groups are ignored. Requires the TLSGroupPreferences\nfeature gate to be enabled.\n\nThis is an open string list rather than a hard enum, in line with the\nKubeVirt API design guidelines (kubevirt/kubevirt#18612, §3.2), so that\nnewly-standardised groups do not break rolling upgrades.\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -26230,6 +26230,26 @@ func schema_kubevirtio_api_core_v1_TLSConfiguration(ref common.ReferenceCallback
 							},
 						},
 					},
+					"groups": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Groups defines the set of TLS supported groups (key exchange curves) offered during TLS handshakes. Uses IANA names from the TLS Supported Groups registry. When empty, Go's default curve preferences apply. Requires the TLSGroupPreferences feature gate to be enabled.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -26711,6 +26711,26 @@ func schema_kubevirtio_api_core_v1_TLSConfiguration(ref common.ReferenceCallback
 							},
 						},
 					},
+					"groups": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Groups defines the ordered list of TLS supported groups (key exchange curves) offered during TLS handshakes, using IANA names from the TLS Supported Groups registry (e.g. X25519, secp256r1, X25519MLKEM768). The order is significant: it is applied verbatim as the curve preference order during negotiation. When empty, Go's default curve preferences apply. Unrecognised groups are ignored. Requires the TLSGroupPreferences feature gate to be enabled.\n\nThis is an open string list rather than a hard enum, in line with the KubeVirt API design guidelines (kubevirt/kubevirt#18612, §3.2), so that newly-standardised groups do not break rolling upgrades.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -82,6 +82,100 @@ var _ = Describe(SIGSerial("tls configuration", func() {
 		const virtTemplatePodTLSPort = 9443
 		verifyTLSEnforcement(podsToTest, virtTemplatePodTLSPort, cipher)
 	})
+
+	Context("with TLSGroupPreferences feature gate", func() {
+		BeforeEach(func() {
+			config.EnableFeatureGate(featuregate.TLSGroupPreferences)
+		})
+
+		It("should enforce configured TLS groups on kubevirt pod endpoints", func() {
+			By("Configuring groups to X25519 and secp256r1")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+				Groups:        []v1.TLSGroup{v1.TLSGroupX25519, v1.TLSGroupSecP256r1},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections with a configured group succeed")
+			const kubevirtPodTLSPort = 8443
+			verifyTLSGroupEnforcement(podsToTest, kubevirtPodTLSPort, []tls.CurveID{tls.CurveP256})
+		})
+
+		It("should reject connections offering only a non-configured group", func() {
+			By("Configuring groups to only X25519")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+				Groups:        []v1.TLSGroup{v1.TLSGroupX25519},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections offering only secp384r1 fail")
+			const kubevirtPodTLSPort = 8443
+			for i := range podsToTest {
+				func(i int, pod *k8sv1.Pod) {
+					stopChan := make(chan struct{})
+					defer close(stopChan)
+					const expectTimeout = 10 * time.Second
+					localPort := 8460 + i
+					Expect(libpod.ForwardPorts(pod, []string{fmt.Sprintf("%d:%d", localPort, kubevirtPodTLSPort)}, stopChan, expectTimeout)).To(Succeed())
+
+					rejectedTLSConfig := &tls.Config{
+						//nolint:gosec
+						InsecureSkipVerify: true,
+						MaxVersion:         tls.VersionTLS12,
+						CipherSuites:       kvtls.CipherSuiteIds([]string{cipher.Name}),
+						CurvePreferences:   []tls.CurveID{tls.CurveP384},
+					}
+					conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", localPort), rejectedTLSConfig)
+					Expect(err).To(HaveOccurred(), "Pod %s should reject non-configured curve", pod.Name)
+					Expect(conn).To(BeNil())
+				}(i, &podsToTest[i])
+			}
+		})
+
+		It("should use Go defaults when groups field is empty", func() {
+			By("Configuring TLS without groups")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections with secp384r1 succeed (Go default includes it)")
+			const kubevirtPodTLSPort = 8443
+			verifyTLSGroupEnforcement(podsToTest, kubevirtPodTLSPort, []tls.CurveID{tls.CurveP384})
+		})
+	})
+
+	Context("without TLSGroupPreferences feature gate", func() {
+		It("should ignore groups field when feature gate is disabled", func() {
+			By("Configuring groups without enabling the feature gate")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+				Groups:        []v1.TLSGroup{v1.TLSGroupX25519},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections with secp384r1 succeed (groups ignored, Go defaults apply)")
+			const kubevirtPodTLSPort = 8443
+			verifyTLSGroupEnforcement(podsToTest, kubevirtPodTLSPort, []tls.CurveID{tls.CurveP384})
+		})
+	})
 }))
 
 func listPods(labelSelectors ...string) []k8sv1.Pod {
@@ -95,6 +189,28 @@ func listPods(labelSelectors ...string) []k8sv1.Pod {
 		pods = append(pods, podList.Items...)
 	}
 	return pods
+}
+
+func verifyTLSGroupEnforcement(pods []k8sv1.Pod, containerPort int, clientCurves []tls.CurveID) {
+	for i := range pods {
+		func(i int, pod *k8sv1.Pod) {
+			stopChan := make(chan struct{})
+			defer close(stopChan)
+			const expectTimeout = 10 * time.Second
+			localPort := 8470 + i
+			Expect(libpod.ForwardPorts(pod, []string{fmt.Sprintf("%d:%d", localPort, containerPort)}, stopChan, expectTimeout)).To(Succeed())
+
+			tlsConfig := &tls.Config{
+				//nolint:gosec
+				InsecureSkipVerify: true,
+				MaxVersion:         tls.VersionTLS12,
+				CurvePreferences:   clientCurves,
+			}
+			conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", localPort), tlsConfig)
+			Expect(err).ToNot(HaveOccurred(), "Pod %s should accept configured curve", pod.Name)
+			Expect(conn).ToNot(BeNil())
+		}(i, &pods[i])
+	}
 }
 
 func verifyTLSEnforcement(pods []k8sv1.Pod, containerPort int, cipher *tls.CipherSuite) {

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -34,6 +34,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -80,6 +81,100 @@ var _ = Describe(SIGSerial("tls configuration", func() {
 		const virtTemplatePodTLSPort = 9443
 		verifyTLSEnforcement(podsToTest, virtTemplatePodTLSPort, cipher)
 	})
+
+	Context("with TLSGroupPreferences feature gate", func() {
+		BeforeEach(func() {
+			config.EnableFeatureGate(featuregate.TLSGroupPreferences)
+		})
+
+		It("should enforce configured TLS groups on kubevirt pod endpoints", func() {
+			By("Configuring groups to X25519 and secp256r1")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+				Groups:        []string{v1.TLSGroupX25519, v1.TLSGroupSecP256r1},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections with a configured group succeed")
+			const kubevirtPodTLSPort = 8443
+			verifyTLSGroupEnforcement(podsToTest, kubevirtPodTLSPort, []tls.CurveID{tls.CurveP256})
+		})
+
+		It("should reject connections offering only a non-configured group", func() {
+			By("Configuring groups to only X25519")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+				Groups:        []string{v1.TLSGroupX25519},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections offering only secp384r1 fail")
+			const kubevirtPodTLSPort = 8443
+			for i := range podsToTest {
+				func(pod *k8sv1.Pod) {
+					stopChan := make(chan struct{})
+					defer close(stopChan)
+					const expectTimeout = 10 * time.Second
+					localPort, fwErr := libpod.ForwardPorts(pod, []string{fmt.Sprintf("0:%d", kubevirtPodTLSPort)}, stopChan, expectTimeout)
+					Expect(fwErr).ToNot(HaveOccurred())
+
+					rejectedTLSConfig := &tls.Config{
+						//nolint:gosec
+						InsecureSkipVerify: true,
+						MaxVersion:         tls.VersionTLS12,
+						CipherSuites:       kvtls.CipherSuiteIds([]string{cipher.Name}),
+						CurvePreferences:   []tls.CurveID{tls.CurveP384},
+					}
+					conn, err := (&tls.Dialer{Config: rejectedTLSConfig}).DialContext(context.Background(), "tcp", fmt.Sprintf("localhost:%d", localPort))
+					Expect(err).To(HaveOccurred(), "Pod %s should reject non-configured curve", pod.Name)
+					Expect(conn).To(BeNil())
+				}(&podsToTest[i])
+			}
+		})
+
+		It("should use Go defaults when groups field is empty", func() {
+			By("Configuring TLS without groups")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections with secp384r1 succeed (Go default includes it)")
+			const kubevirtPodTLSPort = 8443
+			verifyTLSGroupEnforcement(podsToTest, kubevirtPodTLSPort, []tls.CurveID{tls.CurveP384})
+		})
+	})
+
+	Context("without TLSGroupPreferences feature gate", func() {
+		It("should ignore groups field when feature gate is disabled", func() {
+			By("Configuring groups without enabling the feature gate")
+			kvConfig := libkubevirt.GetCurrentKv(kubevirt.Client()).Spec.Configuration.DeepCopy()
+			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS12,
+				Ciphers:       []string{cipher.Name},
+				Groups:        []string{v1.TLSGroupX25519},
+			}
+			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+
+			podsToTest := listPods("kubevirt.io=virt-api", "kubevirt.io=virt-handler", "kubevirt.io=virt-exportproxy")
+
+			By("Verifying connections with secp384r1 succeed (groups ignored, Go defaults apply)")
+			const kubevirtPodTLSPort = 8443
+			verifyTLSGroupEnforcement(podsToTest, kubevirtPodTLSPort, []tls.CurveID{tls.CurveP384})
+		})
+	})
 }))
 
 func listPods(labelSelectors ...string) []k8sv1.Pod {
@@ -93,6 +188,29 @@ func listPods(labelSelectors ...string) []k8sv1.Pod {
 		pods = append(pods, podList.Items...)
 	}
 	return pods
+}
+
+func verifyTLSGroupEnforcement(pods []k8sv1.Pod, containerPort int, clientCurves []tls.CurveID) {
+	for i := range pods {
+		func(pod *k8sv1.Pod) {
+			stopChan := make(chan struct{})
+			defer close(stopChan)
+			const expectTimeout = 10 * time.Second
+			localPort, fwErr := libpod.ForwardPorts(pod, []string{fmt.Sprintf("0:%d", containerPort)}, stopChan, expectTimeout)
+			Expect(fwErr).ToNot(HaveOccurred())
+
+			tlsConfig := &tls.Config{
+				//nolint:gosec
+				InsecureSkipVerify: true,
+				MaxVersion:         tls.VersionTLS12,
+				CurvePreferences:   clientCurves,
+			}
+			conn, err := (&tls.Dialer{Config: tlsConfig}).DialContext(context.Background(), "tcp", fmt.Sprintf("localhost:%d", localPort))
+			Expect(err).ToNot(HaveOccurred(), "Pod %s should accept configured curve", pod.Name)
+			Expect(conn).ToNot(BeNil())
+			defer conn.Close()
+		}(&pods[i])
+	}
 }
 
 func verifyTLSEnforcement(pods []k8sv1.Pod, containerPort int, cipher *tls.CipherSuite) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

KubeVirt's `TLSConfiguration` only supports `MinTLSVersion` and `Ciphers`. There is no way to configure which TLS key exchange groups (elliptic curves) are offered during TLS handshakes across virt pod endpoints.

#### After this PR:

Adds a `Groups` field to `TLSConfiguration` as an open string set of IANA-named groups (`X25519`, `secp256r1`, `secp384r1`, `secp521r1`, `X25519MLKEM768`, `SecP256r1MLKEM768`, `SecP384r1MLKEM1024`). When the `TLSGroupPreferences` feature gate is enabled, configured groups are applied as `CurvePreferences` on all virt pod TLS endpoints, enabling Post-Quantum Cryptography (PQC) readiness. When `Groups` is empty, `CurvePreferences` is left unset and Go's default curve preferences apply.

Implementation highlights:
- `Groups []string` field on `TLSConfiguration` (an open string set, not a hard enum — see below), with a `TLSGroupPreferences` feature gate (Alpha) and a `ClusterConfig.TLSGroupPreferencesEnabled()` helper. Recognised group names are exposed as convenience constants (`TLSGroupX25519`, …).
- `pkg/util/tls`: `CurvePreferenceIds([]string) []tls.CurveID` maps recognised names to `tls.CurveID` via an explicit switch and silently skips unrecognised names.
- `CurvePreferences` wired into every TLS server-config path: `SetupPromTLS`, `SetupExportProxyTLS`, `SetupTLSWithCertManager`, `SetupTLSForServer`, and the exportserver's `buildServer` — covering metrics/Prometheus, webhook/API, handler, exportproxy and exportserver endpoints.
- `InjectTLSConfigIntoDeployment` injects a `--tls-groups` flag for virt-template components (alongside the existing `--tls-cipher-suites`/`--tls-min-version`).
- `virt-exportserver` receives groups via the `TLS_CURVE_PREFERENCES` env var (it has no runtime access to the KubeVirt CR).
- TLS-version/group compatibility is enforced declaratively by a CEL `x-kubernetes-validations` rule on `TLSConfiguration` (not an imperative webhook check).

### References

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/287
- VEP PR (retarget to v1.10 + open string set): https://github.com/kubevirt/enhancements/pull/442
- KubeVirt API design guidelines: https://github.com/kubevirt/kubevirt/pull/18612

### Why we need it and why it was done in this way

PQC readiness requires configuring TLS key exchange groups across all endpoints. Go 1.24 natively supports `X25519MLKEM768` but KubeVirt had no API to control curve preferences. An explicit field is still needed even though Go negotiates PQC automatically, so administrators can restrict groups for compliance/FIPS, manage performance trade-offs, and participate in cluster-wide TLS profile rollouts driven by a meta-operator.

The following tradeoffs were made:
- Uses IANA registry names (`secp256r1`) rather than Go names (`P256`), aligning with the cluster-wide TLS profile APIs that meta-operators reconcile from.
- Models `Groups` as an open `[]string` set rather than a typed enum, per the KubeVirt API design guidelines (#18612, §3.2 "Open String Set (Avoiding Enums)"). A hard OpenAPI enum on an extensible-choice field is a rolling-upgrade hazard (a newer component writing a newly-standardised group name would be rejected by an older apiserver) and would force an API change for every new group. This also matches the existing `Ciphers []string` field.
- Unrecognised group names are ingested without error and ignored at TLS setup time (graceful handling, §3.2.3); the only cross-field constraint (a classical group is required when `MinTLSVersion` < TLS 1.3) is a CEL rule per §4.2, preferred over an imperative webhook.
- Feature-gated behind `TLSGroupPreferences` for controlled rollout and easy rollback.
- KubeVirt does not watch platform-specific TLS profile resources directly — a meta-operator handles that translation into `spec.configuration.tlsConfiguration.groups`.

The following alternatives were considered:
- Ungated field (rejected: the gate allows controlled rollout and lockstep enablement with a meta-operator).
- A typed `TLSGroup` enum with a hard kubebuilder enum (rejected: disallowed for extensible-choice fields by #18612 §3.2; a rolling-upgrade hazard and forces an API change per new group).

### Special notes for your reviewer

- The `virt-exportserver` uses a separate TLS path via the `TLS_CURVE_PREFERENCES` env var since it has no runtime access to the KubeVirt CR; `VMExportController.appendTLSEnvVars` injects it at pod creation time.
- The CEL rule rejects PQC-only groups when `MinTLSVersion` < TLS 1.3 (Go filters PQC groups for TLS 1.2, which would leave an empty curve list), requiring at least one classical group in that case.
- virt-template components receive groups via the injected `--tls-groups` flag; the flag parsing itself lives in the virt-template component repo.
- Generated artifacts (deepcopy, openapi/swagger, CRD validations, apitesting testdata) are included; the API compatibility test (`kubevirt.io/api/apitesting`) passes against these.
- This branch has been rebased onto the latest `main`.

### Checklist

- [X] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present ([VEP #287](https://github.com/kubevirt/enhancements/tree/main/veps/sig-compute/287-tls-group-preferences), retarget PR [#442](https://github.com/kubevirt/enhancements/pull/442))
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Add TLSGroupPreferences feature gate and Groups field to TLSConfiguration, enabling cluster administrators to configure TLS supported groups (elliptic curves) across all virt pod endpoints for Post-Quantum Cryptography readiness.
```
