### PR TITLE
fix: remove inProgress short-circuit from target-side prepareMigrationTarget

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -201,12 +201,10 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 	l.metadataCache.GracePeriod.Set(
 		api.GracePeriodMetadata{DeletionGracePeriodSeconds: converter.GracePeriodSeconds(vmi)},
 	)
-	inProgress, err := l.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)
-	if err != nil {
+	// inProgress is intentionally ignored: unlike the source side, target
+	// preparation must fully re-run on retries (sockets, hooks, etc.).
+	if _, err := l.initializeMigrationMetadata(vmi, v1.MigrationPreCopy); err != nil {
 		return err
-	}
-	if inProgress {
-		return nil
 	}
 
 	err = l.generateCloudInitEmptyISO(vmi, nil)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Commit e9107af007 ("fix: initialize migration cache on the target", PR #15888) added `initializeMigrationMetadata()` to `prepareMigrationTarget` to fix a `StartTimestamp` race. However, it also copied the `if inProgress { return nil }` guard from the source-side `startMigration`. On the target side, if `prepareMigrationTarget` fails *after* storing the metadata (e.g. at the functional-test annotation check, or any later step), the retry finds metadata already present, concludes "inProgress", and returns `nil` -- silently skipping the rest of preparation (cloud-init ISO, hooks, migration socket setup). This causes QEMU to crash on the target ("Failed to bind socket ... No such file or directory").

`test_id:6980` ("Migration should fail if target pod fails during target preparation") is flaky because of this -- the annotation block succeeds on the first call but the immediate retry bypasses it via the `inProgress` short-circuit.

#### After this PR:

The `inProgress` return value is ignored on the target side. The metadata is still initialized (preserving the `StartTimestamp` fix from #15888), but the full preparation always runs. Re-preparation is already guarded at the virt-handler level by `GetTargetListenerPorts` and `IsMigrating` checks in `processVMI`, so the `inProgress` guard is redundant here.

### References

- Root cause: commit e9107af007 merged via #15888
- Flake observed in: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt%5Fkubevirt/17546/pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations/2046555971689385984

### Why we need it and why it was done in this way

The `inProgress` guard in `initializeMigrationMetadata` is semantically correct on the **source** side: it prevents spawning a duplicate QEMU migration goroutine if `startMigration` is called multiple times. On the **target** side it has no such role -- `prepareMigrationTarget` is a synchronous RPC that must complete fully. If any step after `initializeMigrationMetadata` fails, virt-handler retries via `AddRateLimited`, which calls `prepareMigrationTarget` again within milliseconds. The retry then hits the `inProgress` early-return and silently succeeds without setting up migration sockets, causing QEMU to crash.

The fix simply ignores the `inProgress` return on the target path. No tradeoffs -- the metadata initialization is preserved, and higher-level guards prevent true double-preparation.

### Special notes for your reviewer

One-line change. The `initializeMigrationMetadata` call is preserved (its side effect of storing the metadata is still needed), only the `inProgress` early-return is removed.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: Existing `test_id:6980` covers this scenario -- it should stop flaking with this fix
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```
