### PR TITLE
Gated --vgpu-dedicated-hook behind LibvitHooksServerAndClient fg

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -453,7 +453,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if t.clusterConfig.PodSecondaryInterfaceNamingUpgradeEnabled() {
 			command = append(command, "--upgrade-ordinal-ifaces")
 		}
-		if t.clusterConfig.VGPULiveMigrationEnabled() {
+		if t.clusterConfig.LibvirtHooksServerAndClientEnabled() && t.clusterConfig.VGPULiveMigrationEnabled() {
 			command = append(command, "--vgpu-dedicated-hook")
 		}
 		if t.clusterConfig.VMStatsCollectorEnabled() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR gates`--vgpu-dedicated-hook` args from being exposed in virt-launcher if the neccesary required pre-requisite FG (i.e. LibvirtHooksServerAndClient) is not enabled.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
https://github.com/kubevirt/kubevirt/pull/16675#pullrequestreview-3909085466

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

