### PR TITLE
chore: typo sweep (occured -> occurred, enviroment -> environment)

### DIFF
--- a/docs/updating-dependencies.md
+++ b/docs/updating-dependencies.md
@@ -77,7 +77,7 @@ executing the `make verify-rpm-deps` command.
 * Adjust the select clauses on all container entries to choose the right
   target architecture and the right base image.
 * Add architecture specific entries to [.bazelrc](../.bazelrc)
-* Running `make rpm-deps` requires a sandbox enviroment, which is also updated from the previous command. You need to either run the command on an already onboarded architecture or updating the sandbox manually, by sourcing the variables from `hack/rpm-deps.sh` and running the bazeldnf command.
+* Running `make rpm-deps` requires a sandbox environment, which is also updated from the previous command. You need to either run the command on an already onboarded architecture or updating the sandbox manually, by sourcing the variables from `hack/rpm-deps.sh` and running the bazeldnf command.
 ```
 bazeldnf rpmtree \
         --public --nobest \

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -105,9 +105,9 @@ const (
 	PVCNotReadyReason = "PVCNotReady"
 	// FailedHotplugSyncReason is set when a hotplug specific failure occurs during sync
 	FailedHotplugSyncReason = "FailedHotplugSync"
-	// ErrImagePullReason is set when an error has occured while pulling an image for a containerDisk VM volume.
+	// ErrImagePullReason is set when an error has occurred while pulling an image for a containerDisk VM volume.
 	ErrImagePullReason = "ErrImagePull"
-	// ImagePullBackOffReason is set when an error has occured while pulling an image for a containerDisk VM volume,
+	// ImagePullBackOffReason is set when an error has occurred while pulling an image for a containerDisk VM volume,
 	// and that kubelet is backing off before retrying.
 	ImagePullBackOffReason = "ImagePullBackOff"
 	// NoSuitableNodesForHostModelMigration is set when a VMI with host-model CPU mode tries to migrate but no node
@@ -115,7 +115,7 @@ const (
 	NoSuitableNodesForHostModelMigration = "NoSuitableNodesForHostModelMigration"
 	// FailedPodPatchReason is set when a pod patch error occurs during sync
 	FailedPodPatchReason = "FailedPodPatch"
-	// MigrationBackoffReason is set when an error has occured while migrating
+	// MigrationBackoffReason is set when an error has occurred while migrating
 	// and virt-controller is backing off before retrying.
 	MigrationBackoffReason = "MigrationBackoff"
 )

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -966,7 +966,7 @@ func (c *Controller) syncPausedConditionToPod(vmi *virtv1.VirtualMachineInstance
 	return nil
 }
 
-// checkForContainerImageError checks if an error has occured while handling the image of any of the pod's containers
+// checkForContainerImageError checks if an error has occurred while handling the image of any of the pod's containers
 // (including init containers), and returns a syncErr with the details of the error, or nil otherwise.
 func checkForContainerImageError(pod *k8sv1.Pod) common.SyncError {
 	containerStatuses := append(append([]k8sv1.ContainerStatus{}, pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...)


### PR DESCRIPTION
Small sweep of comment/doc typos — no functional change:

- `pkg/virt-controller/watch/vmi/lifecycle.go:969` — `checkForContainerImageError` doc comment `has occured` -> `has occurred`
- `pkg/controller/controller.go:108,110,118` — three doc comments `is set when an error has occured` -> `has occurred`
- `docs/updating-dependencies.md:80` — `sandbox enviroment` -> `sandbox environment`