### PR TITLE
Quarantine SIG-scale density VMI batch test

### DIFF
--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -40,6 +40,7 @@ import (
 	audit_api "kubevirt.io/kubevirt/tools/perfscale-audit/api"
 	metric_client "kubevirt.io/kubevirt/tools/perfscale-audit/metric-client"
 
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	instancetypeBuilder "kubevirt.io/kubevirt/tests/libinstancetype/builder"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -88,7 +89,7 @@ var _ = Describe(SIG("Control Plane Performance Density Testing", func() {
 		vmBatchStartupLimit := 5 * time.Minute
 
 		Context(fmt.Sprintf("[small] create a batch of %d VMIs", vmCount), func() {
-			It("should successfully create all VMIS", func() {
+			It("[QUARANTINE] should successfully create all VMIS", decorators.Quarantine, func() {
 				By("Creating a batch of VMIs")
 				createBatchVMIWithRateControl(virtClient, vmCount)
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `[small] create a batch of 100 VMIs / should successfully create all VMIS` density test runs and is
failing at a 9-10% rate on `pull-kubevirt-e2e-k8s-1.34-sig-performance`.

<img width="1552" height="98" alt="Screenshot From 2026-04-22 12-04-52" src="https://github.com/user-attachments/assets/4f413db1-6c61-4161-927c-b5fa06ea69ad" />

#### After this PR:
This test is quarantined 

### Why we need it and why it was done in this way
The failure rate has increased since #17495 merged.

### Special notes for your reviewer
/cc @lyarwood 
