### PR TITLE
Target Migration Monitor: Simplify

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -735,7 +735,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 			domain: domain,
 			events: events,
 		}
-		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, domain, metadataCache, notifier)
+		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 	}
 	return false

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -735,7 +735,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 			domain: domain,
 			events: events,
 		}
-		monitor := virtwrap.NewTargetMigrationMonitor(c, events, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := virtwrap.NewTargetMigrationMonitor(c, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 	}
 	return false

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -735,7 +735,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 			domain: domain,
 			events: events,
 		}
-		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := virtwrap.NewTargetMigrationMonitor(c, events, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 	}
 	return false

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -130,6 +130,7 @@ go_test(
         "//pkg/virt-launcher/virtwrap/testing:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -355,6 +355,7 @@ func NewTargetMigrationMonitor(
 	c cli.Connection,
 	events chan watch.Event,
 	vmi *v1.VirtualMachineInstance,
+	logger *log.FilteredLogger,
 	domain *api.Domain,
 	metadataCache *metadata.Cache,
 	notifier MigrationEventNotifier,
@@ -362,7 +363,7 @@ func NewTargetMigrationMonitor(
 	return &TargetMigrationMonitor{
 		c:             c,
 		events:        events,
-		logger:        log.Log.Object(vmi),
+		logger:        logger,
 		vmi:           vmi,
 		domain:        domain,
 		metadataCache: metadataCache,

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -339,6 +339,7 @@ func getVMIHotplugCount(vmi *v1.VirtualMachineInstance) int {
 type TargetMigrationMonitor struct {
 	c             cli.Connection
 	events        chan watch.Event
+	logger        *log.FilteredLogger
 	vmi           *v1.VirtualMachineInstance
 	domain        *api.Domain
 	metadataCache *metadata.Cache
@@ -361,6 +362,7 @@ func NewTargetMigrationMonitor(
 	return &TargetMigrationMonitor{
 		c:             c,
 		events:        events,
+		logger:        log.Log.Object(vmi),
 		vmi:           vmi,
 		domain:        domain,
 		metadataCache: metadataCache,
@@ -382,7 +384,7 @@ func (m *TargetMigrationMonitor) StartMonitor() {
 				defer dom.Free()
 				jobInfo, err := dom.GetJobInfo()
 				if err != nil {
-					log.Log.Object(m.vmi).V(4).Reason(err).Info("Failed to get domain job info")
+					m.logger.V(4).Reason(err).Info("Failed to get domain job info")
 					// This can happen if the current job doesn't support `GetJobInfo()`, let's try again
 					return false, nil
 				}
@@ -390,19 +392,19 @@ func (m *TargetMigrationMonitor) StartMonitor() {
 					// No migration job is currently running
 					return true, nil
 				}
-				log.Log.Object(m.vmi).V(4).Infof("Incoming migration job active (type %d)", jobInfo.Type)
+				m.logger.V(4).Infof("Incoming migration job active (type %d)", jobInfo.Type)
 				return false, nil
 			})
 			if err == nil || attempt == len(retryDelays) {
 				break
 			}
-			log.Log.Object(m.vmi).Info("A migration job is still active, retrying after delay")
+			m.logger.Info("A migration job is still active, retrying after delay")
 			time.Sleep(retryDelays[attempt])
 		}
 		if err != nil {
-			log.Log.Object(m.vmi).Info("Error polling libvirt, setting EndTimestamp anyway to unblock migration")
+			m.logger.Info("Error polling libvirt, setting EndTimestamp anyway to unblock migration")
 		} else {
-			log.Log.Object(m.vmi).Info("Incoming migration job completed, setting EndTimestamp")
+			m.logger.Info("Incoming migration job completed, setting EndTimestamp")
 		}
 		setEndTimestamp(m.metadataCache)
 		event := watch.Event{Type: watch.Modified, Object: m.domain}

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -338,7 +338,6 @@ func getVMIHotplugCount(vmi *v1.VirtualMachineInstance) int {
 // See https://issues.redhat.com/browse/RHEL-117250
 type TargetMigrationMonitor struct {
 	c             cli.Connection
-	events        chan watch.Event
 	logger        *log.FilteredLogger
 	domain        *api.Domain
 	metadataCache *metadata.Cache
@@ -352,7 +351,6 @@ type MigrationEventNotifier interface {
 
 func NewTargetMigrationMonitor(
 	c cli.Connection,
-	events chan watch.Event,
 	logger *log.FilteredLogger,
 	domain *api.Domain,
 	metadataCache *metadata.Cache,
@@ -360,7 +358,6 @@ func NewTargetMigrationMonitor(
 ) *TargetMigrationMonitor {
 	return &TargetMigrationMonitor{
 		c:             c,
-		events:        events,
 		logger:        logger,
 		domain:        domain,
 		metadataCache: metadataCache,

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -340,7 +340,6 @@ type TargetMigrationMonitor struct {
 	c             cli.Connection
 	events        chan watch.Event
 	logger        *log.FilteredLogger
-	vmi           *v1.VirtualMachineInstance
 	domain        *api.Domain
 	metadataCache *metadata.Cache
 	notifier      MigrationEventNotifier
@@ -354,7 +353,6 @@ type MigrationEventNotifier interface {
 func NewTargetMigrationMonitor(
 	c cli.Connection,
 	events chan watch.Event,
-	vmi *v1.VirtualMachineInstance,
 	logger *log.FilteredLogger,
 	domain *api.Domain,
 	metadataCache *metadata.Cache,
@@ -364,7 +362,6 @@ func NewTargetMigrationMonitor(
 		c:             c,
 		events:        events,
 		logger:        logger,
-		vmi:           vmi,
 		domain:        domain,
 		metadataCache: metadataCache,
 		notifier:      notifier}
@@ -375,7 +372,7 @@ var retryDelays = []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Sec
 func (m *TargetMigrationMonitor) StartMonitor() {
 	go func() {
 		var err error
-		domName := api.VMINamespaceKeyFunc(m.vmi)
+		domName := m.domain.Spec.Name
 		for attempt := 0; attempt <= len(retryDelays); attempt++ {
 			err = virtwait.PollImmediately(100*time.Millisecond, 3*time.Second, func(context context.Context) (bool, error) {
 				dom, err := m.c.LookupDomainByName(domName)

--- a/pkg/virt-launcher/virtwrap/live-migration-target_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target_test.go
@@ -79,7 +79,7 @@ var _ = Describe("client", func() {
 		domain := api.NewMinimalDomain("test")
 		metadataCache := metadata.NewCache()
 		notifier := &eventNotifier{}
-		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 
 		By("Ensuring that nothing gets added to the metadata cache as long as the migration is running")

--- a/pkg/virt-launcher/virtwrap/live-migration-target_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target_test.go
@@ -74,12 +74,11 @@ var _ = Describe("client", func() {
 			}, domainJobError
 		}).AnyTimes()
 		mockLibvirt.DomainEXPECT().Free().Return(nil).AnyTimes()
-		eventChan := make(chan watch.Event, 100)
 		vmi := api2.NewMinimalVMI("fake-vmi")
 		domain := api.NewMinimalDomain("test")
 		metadataCache := metadata.NewCache()
 		notifier := &eventNotifier{}
-		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 
 		By("Ensuring that nothing gets added to the metadata cache as long as the migration is running")

--- a/pkg/virt-launcher/virtwrap/live-migration-target_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/watch"
 	api2 "kubevirt.io/client-go/api"
+	"kubevirt.io/client-go/log"
 	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
@@ -78,7 +79,7 @@ var _ = Describe("client", func() {
 		domain := api.NewMinimalDomain("test")
 		metadataCache := metadata.NewCache()
 		notifier := &eventNotifier{}
-		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, vmi, domain, metadataCache, notifier)
+		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 
 		By("Ensuring that nothing gets added to the metadata cache as long as the migration is running")


### PR DESCRIPTION
### What this PR does
Simplify the monitor. This is pure refactor, no logic should be changed. Following changes are present:
1. Introduces logger as a field of monitor in order to support passing it in and unifying the attributes we log.
2. Removing the need to pass in VMI as we can use the present domain for domain lookup and the logger can now be constructed at higher stack
3. Removes unused field `events`

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

