### PR TITLE
tests: density: use >= when waiting for running VMIs

### DIFF
--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -272,5 +272,5 @@ func waitRunningVMI(virtClient kubecli.KubevirtClient, vmiCount int, timeout tim
 			}
 		}
 		return running
-	}, timeout, 10*time.Second).Should(Equal(vmiCount))
+	}, timeout, 10*time.Second).Should(BeNumerically(">=", vmiCount))
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The `waitRunningVMI` helper used strict `Equal(vmiCount)` to assert the number of running VMIs. The primer VMI created in `BeforeEach` may or may not still be running when batch tests check the count. This caused flakes regardless of the expected count:

- With `vmCount+1` (101): failed when the primer was evicted → `"Expected 100 to equal 101"`
- With `vmCount` (100) (after #17495): failed when the primer survived → `"Expected 101 to equal 100"` (more common, making the flake rate worse)

#### After this PR:

Uses `BeNumerically(">=", vmiCount)` so the assertion passes whether the primer VMI is still running (101 >= 100) or has been evicted (100 >= 100).

### References

- Fixes #17560
- Follow-up to #17495

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Using `>=` rather than exact equality means we won't catch a hypothetical bug that creates extra VMIs, but the test's purpose is to verify density/performance (all batch VMIs reach Running), not exact VMI accounting.

The following alternatives were considered:
- Deleting the primer VMI before running batch tests — more invasive and changes the test's warm-up semantics.
- Filtering out the primer VMI by name when counting — adds complexity for no real benefit.

### Special notes for your reviewer

The fix in #17495 changed the expected count from `vmCount+1` to `vmCount`, which inverted the failure condition. Since the primer VMI surviving is more common than being evicted, the flake rate actually increased after that change. Periodic job data showed 4/5 post-fix runs failing vs 1/5 pre-fix.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```