### PR TITLE
Removed long deprecated isGuestAgentSupported fallback

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18884,7 +18884,7 @@
       "$ref": "#/definitions/v1.VirtualMachineInstanceFileSystemInfo"
      },
      "guestAgentVersion": {
-      "description": "GAVersion is a version of currently installed guest agent",
+      "description": "Deprecated: please use SupportedCommands to determine compatibility",
       "type": "string"
      },
      "hostname": {

--- a/cmd/virt-freezer/virt-freezer.go
+++ b/cmd/virt-freezer/virt-freezer.go
@@ -106,12 +106,10 @@ func run(config *FreezerConfig, client cmdclient.LauncherClient) error {
 		return err
 	}
 
-	if info.GAVersion == "" {
+	if len(info.SupportedCommands) == 0 {
 		log.Log.Info("No guest agent, exiting")
 		return nil
 	}
-
-	log.Log.Infof("Guest agent version is %s", info.GAVersion)
 
 	shouldFreeze, err := shouldFreezeVirtualMachine(client)
 	if err != nil {

--- a/cmd/virt-freezer/virt-freezer_test.go
+++ b/cmd/virt-freezer/virt-freezer_test.go
@@ -29,7 +29,19 @@ var _ = Describe("Freezer", func() {
 			Namespace: "default",
 		}
 		guestInfo = &v1.VirtualMachineInstanceGuestAgentInfo{
-			GAVersion: "1.0",
+			// Basic required commands from guestagent.go
+			SupportedCommands: []v1.GuestAgentCommandInfo{
+				{Name: "guest-ping", Enabled: true},
+				{Name: "guest-get-time", Enabled: true},
+				{Name: "guest-info", Enabled: true},
+				{Name: "guest-shutdown", Enabled: true},
+				{Name: "guest-network-get-interfaces", Enabled: true},
+				{Name: "guest-get-fsinfo", Enabled: true},
+				{Name: "guest-get-host-name", Enabled: true},
+				{Name: "guest-get-users", Enabled: true},
+				{Name: "guest-get-timezone", Enabled: true},
+				{Name: "guest-get-osinfo", Enabled: true},
+			},
 		}
 	})
 

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -334,19 +334,6 @@ var _ = Describe("test configuration", func() {
 		Entry("is unset, GetMaxHotplugRatio should return the default", 0, virtconfig.DefaultMaxHotplugRatio),
 	)
 
-	// deprecated
-	DescribeTable(" when supportedGuestAgentVersions", func(value []string, result []string) {
-		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-			SupportedGuestAgentVersions: value,
-		})
-		supportedGuestAgentVersions := clusterConfig.GetSupportedAgentVersions()
-		Expect(supportedGuestAgentVersions).To(ConsistOf(result))
-	},
-		Entry("when set, GetSupportedAgentVersions should return the value", []string{"5.*", "6.*"}, []string{"5.*", "6.*"}),
-		Entry("when unset, GetSupportedAgentVersions should return the defaults", nil, strings.Split(virtconfig.SupportedGuestAgentVersions, ",")),
-		Entry("when empty, GetSupportedAgentVersions should return the defaults", []string{}, strings.Split(virtconfig.SupportedGuestAgentVersions, ",")),
-	)
-
 	It("Should return migration config values", func() {
 
 		parallelOutboundMigrationsPerNode := uint32(10)

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -283,10 +283,6 @@ func (c *ClusterConfig) GetDefaultRuntimeClass() string {
 	return c.GetConfig().DefaultRuntimeClass
 }
 
-func (c *ClusterConfig) GetSupportedAgentVersions() []string {
-	return c.GetConfig().SupportedGuestAgentVersions
-}
-
 func (c *ClusterConfig) GetOVMFPath(arch string) string {
 	oldOvmfPath := c.GetConfig().OVMFPath
 	if oldOvmfPath != "" {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -810,21 +809,8 @@ func (c *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMac
 		var supported = false
 		var reason = ""
 
-		// For current versions, virt-launcher's supported commands will always contain data.
-		// For backwards compatibility: during upgrade from a previous version of KubeVirt,
-		// virt-launcher might not provide any supported commands. If the list of supported
-		// commands is empty, fall back to previous behavior.
-		if len(guestInfo.SupportedCommands) > 0 {
-			supported, reason = isGuestAgentSupported(vmi, guestInfo.SupportedCommands)
-			c.logger.V(3).Object(vmi).Info(reason)
-		} else {
-			for _, version := range c.clusterConfig.GetSupportedAgentVersions() {
-				supported = supported || regexp.MustCompile(version).MatchString(guestInfo.GAVersion)
-			}
-			if !supported {
-				reason = fmt.Sprintf("Guest agent version '%s' is not supported", guestInfo.GAVersion)
-			}
-		}
+		supported, reason = isGuestAgentSupported(vmi, guestInfo.SupportedCommands)
+		c.logger.V(3).Object(vmi).Info(reason)
 
 		if !supported {
 			if !condManager.HasCondition(vmi, v1.VirtualMachineInstanceUnsupportedAgent) {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -2622,7 +2622,6 @@ func (l *LibvirtDomainManager) GetGuestInfo() v1.VirtualMachineInstanceGuestAgen
 	gaInfo := l.agentData.GetGA()
 
 	guestInfo := v1.VirtualMachineInstanceGuestAgentInfo{
-		GAVersion:         gaInfo.Version,
 		SupportedCommands: gaInfo.SupportedCommands,
 		Hostname:          sysInfo.Hostname,
 		FSFreezeStatus:    fsFreezestatus.Status,

--- a/pkg/virtctl/vm/guestosinfo_test.go
+++ b/pkg/virtctl/vm/guestosinfo_test.go
@@ -87,9 +87,7 @@ var _ = Describe("Guest os info command", func() {
 
 	It("should return guest agent data", func() {
 		vm := kubecli.NewMinimalVM(vmName)
-		guestOSInfo := v1.VirtualMachineInstanceGuestAgentInfo{
-			GAVersion: "3.1.0",
-		}
+		guestOSInfo := v1.VirtualMachineInstanceGuestAgentInfo{}
 
 		kubecli.MockKubevirtClientInstance.
 			EXPECT().

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2901,7 +2901,7 @@ type EvacuateCancelOptions struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type VirtualMachineInstanceGuestAgentInfo struct {
 	metav1.TypeMeta `json:",inline"`
-	// GAVersion is a version of currently installed guest agent
+	// Deprecated: please use SupportedCommands to determine compatibility
 	GAVersion string `json:"guestAgentVersion,omitempty"`
 	// Return command list the guest agent supports
 	// +listType=atomic

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -760,7 +760,7 @@ func (EvacuateCancelOptions) SwaggerDoc() map[string]string {
 func (VirtualMachineInstanceGuestAgentInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                  "VirtualMachineInstanceGuestAgentInfo represents information from the installed guest agent\n\n+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object",
-		"guestAgentVersion": "GAVersion is a version of currently installed guest agent",
+		"guestAgentVersion": "Deprecated: please use SupportedCommands to determine compatibility",
 		"supportedCommands": "Return command list the guest agent supports\n+listType=atomic",
 		"hostname":          "Hostname represents FQDN of a guest",
 		"os":                "OS contains the guest operating system information",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -27583,7 +27583,7 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceGuestAgentInfo(ref comm
 					},
 					"guestAgentVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GAVersion is a version of currently installed guest agent",
+							Description: "Deprecated: please use SupportedCommands to determine compatibility",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
@@ -384,9 +384,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
 		Expect(err).ToNot(HaveOccurred())
 
-		osInfo := v1.VirtualMachineInstanceGuestAgentInfo{
-			GAVersion: "4.1.1",
-		}
+		osInfo := v1.VirtualMachineInstanceGuestAgentInfo{}
 
 		server.AppendHandlers(ghttp.CombineHandlers(
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, subVMIPath, "guestosinfo")),

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -44,8 +44,6 @@ import (
 	"kubevirt.io/kubevirt/tests/events"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libkubevirt"
-	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -417,8 +415,8 @@ var _ = Describe(SIG("GuestAgent info", func() {
 
 				return guestInfo.Hostname != "" &&
 					guestInfo.Timezone != "" &&
-					guestInfo.GAVersion != "" &&
 					guestInfo.OS.Name != "" &&
+					len(guestInfo.SupportedCommands) > 0 &&
 					len(guestInfo.FSInfo.Filesystems) > 0
 
 			}).WithTimeout(guestAgentConnectTimeout).
@@ -457,6 +455,39 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			}).WithTimeout(guestAgentConnectTimeout).
 				WithPolling(2*time.Second).
 				Should(BeTrue(), "Should have some filesystem")
+		})
+		It("[test_id:5267]VMI condition should signal unsupported agent presence", func() {
+			agentVMI := libvmifact.NewFedora(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithCloudInitNoCloud(
+					libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-shutdown")),
+				),
+			)
+			By("Starting a VirtualMachineInstance")
+			agentVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+			libwait.WaitForSuccessfulVMIStart(agentVMI)
+
+			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
+		})
+
+		It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", func() {
+			agentVMI := libvmifact.NewFedora(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithCloudInitNoCloud(
+					libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec,guest-set-password")),
+				),
+			)
+			By("Starting a VirtualMachineInstance")
+			agentVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+			libwait.WaitForSuccessfulVMIStart(agentVMI)
+
+			By("VMI has the guest agent connected condition")
+			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("fetching the VMI after agent has connected")
+			Expect(matcher.ThisVMI(agentVMI)()).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceUnsupportedAgent))
 		})
 	})
 
@@ -498,50 +529,6 @@ var _ = Describe(SIG("GuestAgent info", func() {
 			}).WithTimeout(guestAgentConnectTimeout).
 				WithPolling(2*time.Second).
 				Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
-		})
-	})
-
-	Context("with cluster config changes", Serial, func() {
-		BeforeEach(func() {
-			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
-
-			config := kv.Spec.Configuration
-			config.SupportedGuestAgentVersions = []string{"X.*"}
-			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
-		})
-
-		It("[test_id:5267]VMI condition should signal unsupported agent presence", func() {
-			agentVMI := libvmifact.NewFedora(
-				libnet.WithMasqueradeNetworking(),
-				libvmi.WithCloudInitNoCloud(
-					libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-shutdown")),
-				),
-			)
-			By("Starting a VirtualMachineInstance")
-			agentVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
-			libwait.WaitForSuccessfulVMIStart(agentVMI)
-
-			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
-		})
-
-		It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", func() {
-			agentVMI := libvmifact.NewFedora(
-				libnet.WithMasqueradeNetworking(),
-				libvmi.WithCloudInitNoCloud(
-					libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec,guest-set-password")),
-				),
-			)
-			By("Starting a VirtualMachineInstance")
-			agentVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
-			libwait.WaitForSuccessfulVMIStart(agentVMI)
-
-			By("VMI has the guest agent connected condition")
-			Eventually(matcher.ThisVMI(agentVMI), guestAgentConnectTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-
-			By("fetching the VMI after agent has connected")
-			Expect(matcher.ThisVMI(agentVMI)()).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceUnsupportedAgent))
 		})
 	})
 }))


### PR DESCRIPTION
The SupportedGuestAgentVersions api field has been deprecated for 5 years, since 07fe258222aa0cc3eeb63c4998ea31efdfa16914 introduced a better mechanism for guest agent compatibility checking. Removing the accessor function and related tests where possible

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Guest agent code unnecessarily references a deprecated field, as do tests.
#### After this PR:
References to SupportedGuestAgentVersions largely removed. IIUC this does not impact functionality as isGuestAgentSupported has replaced it for many years.

I preemptively want to remove this in support of #17406, since if this dead functionality gets moved to a new location it will become harder to trace back that it isn't used anymore.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #17406
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
No Action Required: Removed fallback guest-agent mechanism that relied on deprecated SupportedGuestAgentVersions. No functional change intended.
```

