### PR TITLE
cleanup:decouple sig-storage controllers

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -197,9 +197,6 @@ type VirtControllerApp struct {
 	caBackupConfigMapInformer    cache.SharedIndexInformer
 	exportRouteConfigMapInformer cache.SharedInformer
 	exportServiceInformer        cache.SharedIndexInformer
-	exportController             *export.VMExportController
-	snapshotController           *snapshot.VMSnapshotController
-	restoreController            *snapshot.VMRestoreController
 	vmExportInformer             cache.SharedIndexInformer
 	routeCache                   cache.Store
 	ingressCache                 cache.Store
@@ -210,17 +207,16 @@ type VirtControllerApp struct {
 	storageClassInformer         cache.SharedIndexInformer
 	allPodInformer               cache.SharedIndexInformer
 	resourceQuotaInformer        cache.SharedIndexInformer
+	storageControllers           []storageControllerRunner
 
 	crdInformer cache.SharedIndexInformer
 
 	migrationPolicyInformer cache.SharedIndexInformer
 
-	vmCloneInformer   cache.SharedIndexInformer
-	vmCloneController *clonecontroller.VMCloneController
+	vmCloneInformer cache.SharedIndexInformer
 
 	vmBackupInformer        cache.SharedIndexInformer
 	vmBackupTrackerInformer cache.SharedIndexInformer
-	vmBackupController      *backup.VMBackupController
 
 	instancetypeInformer        cache.SharedIndexInformer
 	clusterInstancetypeInformer cache.SharedIndexInformer
@@ -280,6 +276,15 @@ type VirtControllerApp struct {
 	leaderElector            *leaderelection.LeaderElector
 
 	onOpenshift bool
+}
+
+type runnableController interface {
+	Run(threadiness int, stopCh <-chan struct{}) error
+}
+type storageControllerRunner struct {
+	Name    string
+	Ctrl    runnableController
+	Threads int
 }
 
 var _ service.Service = &VirtControllerApp{}
@@ -483,12 +488,8 @@ func Execute() {
 	app.initVirtualMachines()
 	app.initDisruptionBudgetController()
 	app.initEvacuationController()
-	app.initSnapshotController()
-	app.initRestoreController()
-	app.initExportController()
 	app.initWorkloadUpdaterController()
-	app.initCloneController()
-	app.initBackupController()
+	app.buildStorageControllers()
 	go app.Run()
 
 	<-app.reInitChan
@@ -610,34 +611,15 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 		go vca.poolController.Run(vca.poolControllerThreads, stop)
 		go vca.vmController.Run(vca.vmControllerThreads, stop)
 		go vca.migrationController.Run(vca.migrationControllerThreads, stop)
-		go func() {
-			if err := vca.snapshotController.Run(vca.snapshotControllerThreads, stop); err != nil {
-				log.Log.Warningf("error running the snapshot controller: %v", err)
-			}
-		}()
-		go func() {
-			if err := vca.restoreController.Run(vca.restoreControllerThreads, stop); err != nil {
-				log.Log.Warningf("error running the restore controller: %v", err)
-			}
-		}()
-		go func() {
-			if err := vca.exportController.Run(vca.exportControllerThreads, stop); err != nil {
-				log.Log.Warningf("error running the export controller: %v", err)
-			}
-		}()
 		go vca.workloadUpdateController.Run(stop)
 		go vca.nodeTopologyUpdater.Run(vca.nodeTopologyUpdatePeriod, stop)
-		go func() {
-			if err := vca.vmCloneController.Run(vca.cloneControllerThreads, stop); err != nil {
-				log.Log.Warningf("error running the clone controller: %v", err)
-			}
-		}()
-		go func() {
-			if err := vca.vmBackupController.Run(vca.backupControllerThreads, stop); err != nil {
-				log.Log.Warningf("error running the backup controller: %v", err)
-			}
-		}()
-
+		for _, runner := range vca.storageControllers {
+			go func(r storageControllerRunner) {
+				if err := r.Ctrl.Run(r.Threads, stop); err != nil {
+					log.Log.Warningf("error running the %s controller: %v", r.Name, err)
+				}
+			}(runner)
+		}
 		cache.WaitForCacheSync(stop, vca.persistentVolumeClaimInformer.HasSynced, vca.namespaceInformer.HasSynced, vca.resourceQuotaInformer.HasSynced)
 		close(vca.readyChan)
 		metrics.SetVirtControllerLeading()
@@ -868,9 +850,12 @@ func (vca *VirtControllerApp) initEvacuationController() {
 	}
 }
 
-func (vca *VirtControllerApp) initSnapshotController() {
-	recorder := vca.newRecorder(k8sv1.NamespaceAll, "snapshot-controller")
-	vca.snapshotController = &snapshot.VMSnapshotController{
+func (vca *VirtControllerApp) buildStorageControllers() {
+	var controllers []storageControllerRunner
+
+	// Snapshot Controller
+	snapshotRecorder := vca.newRecorder(k8sv1.NamespaceAll, "snapshot-controller")
+	snapshotCtrl := &snapshot.VMSnapshotController{
 		Client:                    vca.clientSet,
 		VMSnapshotInformer:        vca.vmSnapshotInformer,
 		VMSnapshotContentInformer: vca.vmSnapshotContentInformer,
@@ -883,17 +868,17 @@ func (vca *VirtControllerApp) initSnapshotController() {
 		PodInformer:               vca.allPodInformer,
 		DVInformer:                vca.dataVolumeInformer,
 		CRInformer:                vca.controllerRevisionInformer,
-		Recorder:                  recorder,
+		Recorder:                  snapshotRecorder,
 		ResyncPeriod:              vca.snapshotControllerResyncPeriod,
 	}
-	if err := vca.snapshotController.Init(); err != nil {
+	if err := snapshotCtrl.Init(); err != nil {
 		panic(err)
 	}
-}
+	controllers = append(controllers, storageControllerRunner{Name: "snapshot", Ctrl: snapshotCtrl, Threads: vca.snapshotControllerThreads})
 
-func (vca *VirtControllerApp) initRestoreController() {
-	recorder := vca.newRecorder(k8sv1.NamespaceAll, "restore-controller")
-	vca.restoreController = &snapshot.VMRestoreController{
+	// Restore Controller
+	restoreRecorder := vca.newRecorder(k8sv1.NamespaceAll, "restore-controller")
+	restoreCtrl := &snapshot.VMRestoreController{
 		Client:                    vca.clientSet,
 		VMRestoreInformer:         vca.vmRestoreInformer,
 		VMSnapshotInformer:        vca.vmSnapshotInformer,
@@ -903,18 +888,18 @@ func (vca *VirtControllerApp) initRestoreController() {
 		DataVolumeInformer:        vca.dataVolumeInformer,
 		PVCInformer:               vca.persistentVolumeClaimInformer,
 		StorageClassInformer:      vca.storageClassInformer,
-		VolumeSnapshotProvider:    vca.snapshotController,
-		Recorder:                  recorder,
+		VolumeSnapshotProvider:    snapshotCtrl,
+		Recorder:                  restoreRecorder,
 		CRInformer:                vca.controllerRevisionInformer,
 	}
-	if err := vca.restoreController.Init(); err != nil {
+	if err := restoreCtrl.Init(); err != nil {
 		panic(err)
 	}
-}
+	controllers = append(controllers, storageControllerRunner{Name: "restore", Ctrl: restoreCtrl, Threads: vca.restoreControllerThreads})
 
-func (vca *VirtControllerApp) initExportController() {
-	recorder := vca.newRecorder(k8sv1.NamespaceAll, "export-controller")
-	vca.exportController = &export.VMExportController{
+	// Export Controller
+	exportRecorder := vca.newRecorder(k8sv1.NamespaceAll, "export-controller")
+	exportCtrl := &export.VMExportController{
 		ManifestRenderer:            vca.templateService,
 		Client:                      vca.clientSet,
 		VMExportInformer:            vca.vmExportInformer,
@@ -922,14 +907,14 @@ func (vca *VirtControllerApp) initExportController() {
 		PodInformer:                 vca.allPodInformer,
 		DataVolumeInformer:          vca.dataVolumeInformer,
 		ServiceInformer:             vca.exportServiceInformer,
-		Recorder:                    recorder,
+		Recorder:                    exportRecorder,
 		ConfigMapInformer:           vca.caExportConfigMapInformer,
 		IngressCache:                vca.ingressCache,
 		RouteCache:                  vca.routeCache,
 		KubevirtNamespace:           vca.kubevirtNamespace,
 		RouteConfigMapInformer:      vca.exportRouteConfigMapInformer,
 		SecretInformer:              vca.unmanagedSecretInformer,
-		VolumeSnapshotProvider:      vca.snapshotController,
+		VolumeSnapshotProvider:      snapshotCtrl,
 		VMSnapshotInformer:          vca.vmSnapshotInformer,
 		VMSnapshotContentInformer:   vca.vmSnapshotContentInformer,
 		VMInformer:                  vca.vmInformer,
@@ -944,40 +929,32 @@ func (vca *VirtControllerApp) initExportController() {
 		VMBackupInformer:            vca.vmBackupInformer,
 		BackupCAConfigMapInformer:   vca.caBackupConfigMapInformer,
 	}
-	if err := vca.exportController.Init(); err != nil {
+	if err := exportCtrl.Init(); err != nil {
 		panic(err)
 	}
-}
+	controllers = append(controllers, storageControllerRunner{Name: "export", Ctrl: exportCtrl, Threads: vca.exportControllerThreads})
 
-func (vca *VirtControllerApp) initCloneController() {
-	var err error
-	recorder := vca.newRecorder(k8sv1.NamespaceAll, "clone-controller")
-	vca.vmCloneController, err = clonecontroller.NewVmCloneController(
-		vca.clientSet, vca.vmCloneInformer, vca.vmSnapshotInformer, vca.vmRestoreInformer, vca.vmInformer, vca.vmSnapshotContentInformer, vca.persistentVolumeClaimInformer, recorder,
+	// Clone Controller
+	cloneRecorder := vca.newRecorder(k8sv1.NamespaceAll, "clone-controller")
+	cloneCtrl, err := clonecontroller.NewVmCloneController(
+		vca.clientSet, vca.vmCloneInformer, vca.vmSnapshotInformer, vca.vmRestoreInformer, vca.vmInformer, vca.vmSnapshotContentInformer, vca.persistentVolumeClaimInformer, cloneRecorder,
 	)
 	if err != nil {
 		panic(err)
 	}
-}
+	controllers = append(controllers, storageControllerRunner{Name: "clone", Ctrl: cloneCtrl, Threads: vca.cloneControllerThreads})
 
-func (vca *VirtControllerApp) initBackupController() {
-	var err error
-	recorder := vca.newRecorder(k8sv1.NamespaceAll, "backup-controller")
-	vca.vmBackupController, err = backup.NewVMBackupController(
-		vca.clientSet,
-		vca.vmBackupInformer,
-		vca.vmBackupTrackerInformer,
-		vca.vmInformer,
-		vca.vmiInformer,
-		vca.persistentVolumeClaimInformer,
-		vca.vmExportInformer,
-		vca.caExportConfigMapInformer,
-		recorder,
-		vca.kubevirtNamespace,
+	// Backup Controller
+	backupRecorder := vca.newRecorder(k8sv1.NamespaceAll, "backup-controller")
+	backupCtrl, err := backup.NewVMBackupController(
+		vca.clientSet, vca.vmBackupInformer, vca.vmBackupTrackerInformer, vca.vmInformer, vca.vmiInformer, vca.persistentVolumeClaimInformer, vca.vmExportInformer, vca.caExportConfigMapInformer, backupRecorder, vca.kubevirtNamespace,
 	)
 	if err != nil {
 		panic(err)
 	}
+	controllers = append(controllers, storageControllerRunner{Name: "backup", Ctrl: backupCtrl, Threads: vca.backupControllerThreads})
+
+	vca.storageControllers = controllers
 }
 
 func (vca *VirtControllerApp) leaderProbe(_ *restful.Request, response *restful.Response) {

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Application", func() {
 			config,
 			stubNetworkAnnotationsGenerator{},
 		)
-		app.snapshotController = &snapshot.VMSnapshotController{
+		snapshotCtrl := &snapshot.VMSnapshotController{
 			Client:                    virtClient,
 			VMSnapshotInformer:        vmSnapshotInformer,
 			VMSnapshotContentInformer: vmSnapshotContentInformer,
@@ -215,8 +215,10 @@ var _ = Describe("Application", func() {
 			Recorder:                  recorder,
 			ResyncPeriod:              60 * time.Second,
 		}
-		_ = app.snapshotController.Init()
-		app.restoreController = &snapshot.VMRestoreController{
+		_ = snapshotCtrl.Init()
+		app.storageControllers = append(app.storageControllers, storageControllerRunner{Name: "snapshot", Ctrl: snapshotCtrl, Threads: 6})
+
+		restoreCtrl := &snapshot.VMRestoreController{
 			Client:                    virtClient,
 			VMRestoreInformer:         vmRestoreInformer,
 			VMSnapshotInformer:        vmSnapshotInformer,
@@ -228,8 +230,10 @@ var _ = Describe("Application", func() {
 			DataVolumeInformer:        dataVolumeInformer,
 			Recorder:                  recorder,
 		}
-		_ = app.restoreController.Init()
-		app.exportController = &export.VMExportController{
+		_ = restoreCtrl.Init()
+		app.storageControllers = append(app.storageControllers, storageControllerRunner{Name: "restore", Ctrl: restoreCtrl, Threads: 3})
+
+		exportCtrl := &export.VMExportController{
 			Client:                      virtClient,
 			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			VMExportInformer:            vmExportInformer,
@@ -254,12 +258,15 @@ var _ = Describe("Application", func() {
 			ControllerRevisionInformer:  controllerRevisionInformer,
 			VMBackupInformer:            backupInformer,
 		}
-		_ = app.exportController.Init()
+		_ = exportCtrl.Init()
+		app.storageControllers = append(app.storageControllers, storageControllerRunner{Name: "export", Ctrl: exportCtrl, Threads: 3})
+
 		app.persistentVolumeClaimInformer = pvcInformer
 		app.nodeInformer = nodeInformer
 		app.resourceQuotaInformer = resourceQuotaInformer
 		app.namespaceInformer = namespaceInformer
-		app.vmCloneController, _ = clonecontroller.NewVmCloneController(
+
+		cloneCtrl, _ := clonecontroller.NewVmCloneController(
 			virtClient,
 			cloneInformer,
 			vmSnapshotInformer,
@@ -269,7 +276,9 @@ var _ = Describe("Application", func() {
 			pvcInformer,
 			recorder,
 		)
-		app.vmBackupController, _ = backup.NewVMBackupController(
+		app.storageControllers = append(app.storageControllers, storageControllerRunner{Name: "clone", Ctrl: cloneCtrl, Threads: 3})
+
+		backupCtrl, _ := backup.NewVMBackupController(
 			virtClient,
 			backupInformer,
 			backupTrackerInformer,
@@ -281,6 +290,7 @@ var _ = Describe("Application", func() {
 			recorder,
 			"",
 		)
+		app.storageControllers = append(app.storageControllers, storageControllerRunner{Name: "backup", Ctrl: backupCtrl, Threads: 6})
 
 		app.readyChan = make(chan bool)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The `VirtControllerApp` struct was tightly coupled with SIG-specific storage controllers (Snapshot, Restore, Export, Clone, Backup). Each controller was manually initialized via dedicated methods and held as explicit fields, leading to a monolithic startup flow.
#### After this PR:
Introduced a `RunnableController` interface and a decoupled `storageControllers` slice. All storage-specific logic is now consolidated into a single factory builder, and the core application executes them via a generic loop, reducing structural debt in `application.go`.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
Partially addresses #17226 
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
Better maintainability and code ownership boundaries between the core control plane and SIG Storage.
The interface + slice approach was chosen over keeping individual fields because it gives the core app a single, stable contract with SIG Storage controllers. The core only needs to know that something can Run() and not what it is specifically.
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

