### PR TITLE
tests: use matcher.HaveConditionTrue in test_id:1677

### DIFF
--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -26,7 +26,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
 	expect "github.com/google/goexpect"
 
@@ -254,14 +253,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 		})
 
 		It("[test_id:1677]VMI condition should signal agent presence", func() {
-			freshVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-			Expect(freshVMI.Status.Conditions).To(
-				ContainElement(
-					MatchFields(
-						IgnoreExtras,
-						Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
-				"agent should already be connected")
+			Expect(matcher.ThisVMI(agentVMI)()).To(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected), "agent should already be connected")
 		})
 
 		It("[test_id:4626]should have guestosinfo in status when agent is present", func() {


### PR DESCRIPTION
Replace the manual Get+ContainElement+MatchFields pattern with the existing matcher.HaveConditionTrue helper, which also verifies the condition status is True rather than just checking for its presence. Drop the now-unused gstruct dot-import.

/kind cleanup

```release-note
NONE
```

