### PR TITLE
Fix deep subresource truncation in SubjectAccessReview

### DIFF
--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -219,7 +219,15 @@ func addNamespacedResourceAttributes(pathSplit []string, requestMethod string, r
 	namespace := pathSplit[5]
 	resource := pathSplit[6]
 	resourceName := pathSplit[7]
-	subresource := pathSplit[8]
+
+	// portforward requires special handling since it encodes the protocol and port into the URI.
+	// Protocol and port should not be subject to RBAC.
+	var subresource string
+	if pathSplit[8] == "portforward" {
+		subresource = pathSplit[8]
+	} else {
+		subresource = strings.Join(pathSplit[8:], "/")
+	}
 
 	if resource != "virtualmachineinstances" && resource != "virtualmachines" {
 		return fmt.Errorf("unknown resource type %s", resource)

--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -227,6 +227,32 @@ var _ = Describe("Authorizer", func() {
 				Entry("subresource v1alpha3 dump profiler", "/apis/subresources.kubevirt.io/v1alpha3/dump-cluster-profiler"),
 			)
 
+			DescribeTable("should use correct subresource in SAR", func(pathSuffix, expectedSubresource string) {
+				allowedFn = func(sar *authv1.SubjectAccessReview) (*authv1.SubjectAccessReview, error) {
+					Expect(sar.Spec.ResourceAttributes).ToNot(BeNil())
+					Expect(sar.Spec.ResourceAttributes.Subresource).To(Equal(expectedSubresource))
+					sar.Status.Allowed = true
+					return sar, nil
+				}
+
+				req.Request.Method = http.MethodGet
+				req.Request.URL.Path = "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/testvmi/" + pathSuffix
+				result, _, err := app.Authorize(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			},
+				Entry("single-segment: console", "console", "console"),
+				Entry("single-segment: vnc", "vnc", "vnc"),
+				Entry("deep: vnc/screenshot", "vnc/screenshot", "vnc/screenshot"),
+				Entry("deep: sev/fetchcertchain", "sev/fetchcertchain", "sev/fetchcertchain"),
+				Entry("deep: sev/querylaunchmeasurement", "sev/querylaunchmeasurement", "sev/querylaunchmeasurement"),
+				Entry("deep: sev/setupsession", "sev/setupsession", "sev/setupsession"),
+				Entry("deep: sev/injectlaunchsecret", "sev/injectlaunchsecret", "sev/injectlaunchsecret"),
+				Entry("deep: evacuate/cancel", "evacuate/cancel", "evacuate/cancel"),
+				Entry("portforward with port", "portforward/8080", "portforward"),
+				Entry("portforward with port and protocol", "portforward/8080/tcp", "portforward"),
+			)
+
 			DescribeTable("should reject all users for unknown endpoint paths", func(path string) {
 				req.Request.URL.Path = path
 				result, _, err := app.Authorize(req)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`addNamespacedResourceAttributes()` uses `pathSplit[8]` to extract the subresource from the URL path, capturing only the first segment. Deep subresources like `vnc/screenshot`, `sev/fetchcertchain`, and `evacuate/cancel` are truncated to `vnc`, `sev`, `evacuate` - causing the SAR to check authorization against the wrong (broader) subresource name.

#### After this PR:

All remaining path segments are joined into the subresource name. For `portforward`, where trailing segments are dynamic parameters (port, protocol), only `portforward` is used. Single-segment subresources are unaffected.

### References

- Fixes #17337

### Why we need it and why it was done in this way

The SAR subresource must match the RBAC resource names defined in `pkg/virt-operator/resource/generate/rbac/cluster.go` (e.g. `virtualmachineinstances/vnc/screenshot`, `virtualmachineinstances/sev/fetchcertchain`). The truncation causes a mismatch between the authorization check and the actual RBAC rules.

The fix joins all remaining path segments with `strings.Join(pathSplit[8:], "/")`. `portforward` is special-cased because its trailing segments (`{port}`, `{protocol}`) are dynamic path parameters, not part of the subresource name.

### Special notes for your reviewer

The change is minimal and self-contained in two files for easy backporting.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fixed virt-api truncating deep subresources (vnc/screenshot, sev/*, evacuate/cancel) when constructing SubjectAccessReviews, causing authorization checks against incorrect subresource names.
```