### PR TITLE
virt-operator: replace %+v with resource name in error messages

### DIFF
--- a/pkg/virt-operator/resource/apply/admissionregistration.go
+++ b/pkg/virt-operator/resource/apply/admissionregistration.go
@@ -201,11 +201,12 @@ func (r *Reconciler) createOrUpdateValidatingWebhookConfiguration(webhook *admis
 
 	if !exists {
 		r.expectations.ValidationWebhook.RaiseExpectations(r.kvKey, 1, 0)
-		webhookName := webhook.Name
+		origWebhook := webhook
 		webhook, err := r.createValidatingWebhookConfiguration(webhook)
 		if err != nil {
 			r.expectations.ValidationWebhook.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create validatingwebhook %s: %v", webhookName, err)
+			log.Log.V(2).Infof("failed to create validatingwebhook %s: %+v", origWebhook.Name, origWebhook)
+			return fmt.Errorf("unable to create validatingwebhook %s: %v", origWebhook.Name, err)
 		}
 
 		SetGeneration(&r.kv.Status.Generations, webhook)
@@ -229,9 +230,11 @@ func (r *Reconciler) createOrUpdateValidatingWebhookConfiguration(webhook *admis
 	if err != nil {
 		return err
 	}
+	origWebhook := webhook
 	webhook, err = r.patchValidatingWebhookConfiguration(webhook, patchBytes)
 	if err != nil {
-		return fmt.Errorf("unable to update validatingwebhookconfiguration %s: %v", webhook.GetName(), err)
+		log.Log.V(2).Infof("failed to update validatingwebhookconfiguration %s: %+v", origWebhook.Name, origWebhook)
+		return fmt.Errorf("unable to update validatingwebhookconfiguration %s: %v", origWebhook.Name, err)
 	}
 
 	SetGeneration(&r.kv.Status.Generations, webhook)
@@ -344,11 +347,12 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 
 	if !exists {
 		r.expectations.MutatingWebhook.RaiseExpectations(r.kvKey, 1, 0)
-		webhookName := webhook.Name
+		origWebhook := webhook
 		webhook, err := r.createMutatingWebhookConfiguration(webhook)
 		if err != nil {
 			r.expectations.MutatingWebhook.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create mutatingwebhook %s: %v", webhookName, err)
+			log.Log.V(2).Infof("failed to create mutatingwebhook %s: %+v", origWebhook.Name, origWebhook)
+			return fmt.Errorf("unable to create mutatingwebhook %s: %v", origWebhook.Name, err)
 		}
 
 		SetGeneration(&r.kv.Status.Generations, webhook)
@@ -371,9 +375,11 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 	if err != nil {
 		return err
 	}
+	origWebhook := webhook
 	webhook, err = r.patchMutatingWebhookConfiguration(webhook, patchBytes)
 	if err != nil {
-		return fmt.Errorf("unable to update mutatingwebhookconfiguration %s: %v", webhook.GetName(), err)
+		log.Log.V(2).Infof("failed to update mutatingwebhookconfiguration %s: %+v", origWebhook.Name, origWebhook)
+		return fmt.Errorf("unable to update mutatingwebhookconfiguration %s: %v", origWebhook.Name, err)
 	}
 
 	SetGeneration(&r.kv.Status.Generations, webhook)
@@ -409,6 +415,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicyBinding(validatingAd
 		_, err := admissionRegistrationV1.ValidatingAdmissionPolicyBindings().Create(context.Background(), validatingAdmissionPolicyBinding, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ValidatingAdmissionPolicyBinding.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create validatingAdmissionPolicyBinding %s: %+v", validatingAdmissionPolicyBinding.Name, validatingAdmissionPolicyBinding)
 			return fmt.Errorf("unable to create validatingAdmissionPolicyBinding %s: %v", validatingAdmissionPolicyBinding.Name, err)
 		}
 
@@ -430,6 +437,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicyBinding(validatingAd
 	}
 	p, err := patchSet.GeneratePayload()
 	if err != nil {
+		log.Log.V(2).Infof("failed to generate validatingAdmissionPolicyBinding patch for %s: %+v", validatingAdmissionPolicyBinding.Name, validatingAdmissionPolicyBinding)
 		return fmt.Errorf("unable to generate validatingAdmissionPolicyBinding patch operations for %s: %v", validatingAdmissionPolicyBinding.Name, err)
 	}
 
@@ -439,6 +447,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicyBinding(validatingAd
 		p,
 		metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch validatingAdmissionPolicyBinding %s: %+v", validatingAdmissionPolicyBinding.Name, validatingAdmissionPolicyBinding)
 		return fmt.Errorf("unable to patch validatingAdmissionPolicyBinding %s: %v", validatingAdmissionPolicyBinding.Name, err)
 	}
 
@@ -474,6 +483,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicy(validatingAdmission
 		_, err := admissionRegistrationV1.ValidatingAdmissionPolicies().Create(context.Background(), validatingAdmissionPolicy, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ValidatingAdmissionPolicy.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create validatingAdmissionPolicy %s: %+v", validatingAdmissionPolicy.Name, validatingAdmissionPolicy)
 			return fmt.Errorf("unable to create validatingAdmissionPolicy %s: %v", validatingAdmissionPolicy.Name, err)
 		}
 
@@ -494,11 +504,13 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicy(validatingAdmission
 	}
 	p, err := patchSet.GeneratePayload()
 	if err != nil {
+		log.Log.V(2).Infof("failed to generate validatingAdmissionPolicy patch for %s: %+v", validatingAdmissionPolicy.Name, validatingAdmissionPolicy)
 		return fmt.Errorf("unable to generate validatingAdmissionPolicy patch operations for %s: %v", validatingAdmissionPolicy.Name, err)
 	}
 
 	_, err = admissionRegistrationV1.ValidatingAdmissionPolicies().Patch(context.Background(), validatingAdmissionPolicy.Name, types.JSONPatchType, p, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch validatingAdmissionPolicy %s: %+v", validatingAdmissionPolicy.Name, validatingAdmissionPolicy)
 		return fmt.Errorf("unable to patch validatingAdmissionPolicy %s: %v", validatingAdmissionPolicy.Name, err)
 	}
 

--- a/pkg/virt-operator/resource/apply/admissionregistration.go
+++ b/pkg/virt-operator/resource/apply/admissionregistration.go
@@ -204,7 +204,7 @@ func (r *Reconciler) createOrUpdateValidatingWebhookConfiguration(webhook *admis
 		webhook, err := r.createValidatingWebhookConfiguration(webhook)
 		if err != nil {
 			r.expectations.ValidationWebhook.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create validatingwebhook %+v: %v", webhook, err)
+			return fmt.Errorf("unable to create validatingwebhook %s: %v", webhook.GetName(), err)
 		}
 
 		SetGeneration(&r.kv.Status.Generations, webhook)
@@ -230,7 +230,7 @@ func (r *Reconciler) createOrUpdateValidatingWebhookConfiguration(webhook *admis
 	}
 	webhook, err = r.patchValidatingWebhookConfiguration(webhook, patchBytes)
 	if err != nil {
-		return fmt.Errorf("unable to update validatingwebhookconfiguration %+v: %v", webhook, err)
+		return fmt.Errorf("unable to update validatingwebhookconfiguration %s: %v", webhook.GetName(), err)
 	}
 
 	SetGeneration(&r.kv.Status.Generations, webhook)
@@ -346,7 +346,7 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 		webhook, err := r.createMutatingWebhookConfiguration(webhook)
 		if err != nil {
 			r.expectations.MutatingWebhook.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create mutatingwebhook %+v: %v", webhook, err)
+			return fmt.Errorf("unable to create mutatingwebhook %s: %v", webhook.GetName(), err)
 		}
 
 		SetGeneration(&r.kv.Status.Generations, webhook)
@@ -371,7 +371,7 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 	}
 	webhook, err = r.patchMutatingWebhookConfiguration(webhook, patchBytes)
 	if err != nil {
-		return fmt.Errorf("unable to update mutatingwebhookconfiguration %+v: %v", webhook, err)
+		return fmt.Errorf("unable to update mutatingwebhookconfiguration %s: %v", webhook.GetName(), err)
 	}
 
 	SetGeneration(&r.kv.Status.Generations, webhook)
@@ -407,7 +407,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicyBinding(validatingAd
 		_, err := admissionRegistrationV1.ValidatingAdmissionPolicyBindings().Create(context.Background(), validatingAdmissionPolicyBinding, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ValidatingAdmissionPolicyBinding.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create validatingAdmissionPolicyBinding %+v: %v", validatingAdmissionPolicyBinding, err)
+			return fmt.Errorf("unable to create validatingAdmissionPolicyBinding %s: %v", validatingAdmissionPolicyBinding.Name, err)
 		}
 
 		return nil
@@ -428,7 +428,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicyBinding(validatingAd
 	}
 	p, err := patchSet.GeneratePayload()
 	if err != nil {
-		return fmt.Errorf("unable to generate validatingAdmissionPolicyBinding patch operations for %+v: %v", validatingAdmissionPolicyBinding, err)
+		return fmt.Errorf("unable to generate validatingAdmissionPolicyBinding patch operations for %s: %v", validatingAdmissionPolicyBinding.Name, err)
 	}
 
 	_, err = admissionRegistrationV1.ValidatingAdmissionPolicyBindings().Patch(context.Background(),
@@ -437,7 +437,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicyBinding(validatingAd
 		p,
 		metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch validatingAdmissionPolicyBinding %+v: %v", validatingAdmissionPolicyBinding, err)
+		return fmt.Errorf("unable to patch validatingAdmissionPolicyBinding %s: %v", validatingAdmissionPolicyBinding.Name, err)
 	}
 
 	log.Log.V(2).Infof("validatingAdmissionPolicyBinding %v patched", validatingAdmissionPolicyBinding.GetName())
@@ -472,7 +472,7 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicy(validatingAdmission
 		_, err := admissionRegistrationV1.ValidatingAdmissionPolicies().Create(context.Background(), validatingAdmissionPolicy, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ValidatingAdmissionPolicy.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create validatingAdmissionPolicy %+v: %v", validatingAdmissionPolicy, err)
+			return fmt.Errorf("unable to create validatingAdmissionPolicy %s: %v", validatingAdmissionPolicy.Name, err)
 		}
 
 		return nil
@@ -492,12 +492,12 @@ func (r *Reconciler) createOrUpdateValidatingAdmissionPolicy(validatingAdmission
 	}
 	p, err := patchSet.GeneratePayload()
 	if err != nil {
-		return fmt.Errorf("unable to generate validatingAdmissionPolicy patch operations for %+v: %v", validatingAdmissionPolicy, err)
+		return fmt.Errorf("unable to generate validatingAdmissionPolicy patch operations for %s: %v", validatingAdmissionPolicy.Name, err)
 	}
 
 	_, err = admissionRegistrationV1.ValidatingAdmissionPolicies().Patch(context.Background(), validatingAdmissionPolicy.Name, types.JSONPatchType, p, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch validatingAdmissionPolicy %+v: %v", validatingAdmissionPolicy, err)
+		return fmt.Errorf("unable to patch validatingAdmissionPolicy %s: %v", validatingAdmissionPolicy.Name, err)
 	}
 
 	log.Log.V(2).Infof("validatingAdmissionPolicy %v patched", validatingAdmissionPolicy.GetName())

--- a/pkg/virt-operator/resource/apply/admissionregistration.go
+++ b/pkg/virt-operator/resource/apply/admissionregistration.go
@@ -201,10 +201,11 @@ func (r *Reconciler) createOrUpdateValidatingWebhookConfiguration(webhook *admis
 
 	if !exists {
 		r.expectations.ValidationWebhook.RaiseExpectations(r.kvKey, 1, 0)
+		webhookName := webhook.Name
 		webhook, err := r.createValidatingWebhookConfiguration(webhook)
 		if err != nil {
 			r.expectations.ValidationWebhook.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create validatingwebhook %s: %v", webhook.GetName(), err)
+			return fmt.Errorf("unable to create validatingwebhook %s: %v", webhookName, err)
 		}
 
 		SetGeneration(&r.kv.Status.Generations, webhook)
@@ -343,10 +344,11 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 
 	if !exists {
 		r.expectations.MutatingWebhook.RaiseExpectations(r.kvKey, 1, 0)
+		webhookName := webhook.Name
 		webhook, err := r.createMutatingWebhookConfiguration(webhook)
 		if err != nil {
 			r.expectations.MutatingWebhook.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create mutatingwebhook %s: %v", webhook.GetName(), err)
+			return fmt.Errorf("unable to create mutatingwebhook %s: %v", webhookName, err)
 		}
 
 		SetGeneration(&r.kv.Status.Generations, webhook)

--- a/pkg/virt-operator/resource/apply/apiservices.go
+++ b/pkg/virt-operator/resource/apply/apiservices.go
@@ -54,7 +54,7 @@ func (r *Reconciler) createOrUpdateAPIService(apiService *apiregv1.APIService, c
 		_, err := r.aggregatorclient.Create(context.Background(), apiService, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.APIService.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create apiservice %+v: %v", apiService, err)
+			return fmt.Errorf("unable to create apiservice %s: %v", apiService.Name, err)
 		}
 
 		return nil
@@ -80,7 +80,7 @@ func (r *Reconciler) createOrUpdateAPIService(apiService *apiregv1.APIService, c
 
 	_, err = r.aggregatorclient.Patch(context.Background(), apiService.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch apiservice %+v: %v", apiService, err)
+		return fmt.Errorf("unable to patch apiservice %s: %v", apiService.Name, err)
 	}
 	log.Log.V(4).Infof("apiservice %v updated", apiService.GetName())
 

--- a/pkg/virt-operator/resource/apply/apiservices.go
+++ b/pkg/virt-operator/resource/apply/apiservices.go
@@ -54,6 +54,7 @@ func (r *Reconciler) createOrUpdateAPIService(apiService *apiregv1.APIService, c
 		_, err := r.aggregatorclient.Create(context.Background(), apiService, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.APIService.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create apiservice %s: %+v", apiService.Name, apiService)
 			return fmt.Errorf("unable to create apiservice %s: %v", apiService.Name, err)
 		}
 
@@ -80,6 +81,7 @@ func (r *Reconciler) createOrUpdateAPIService(apiService *apiregv1.APIService, c
 
 	_, err = r.aggregatorclient.Patch(context.Background(), apiService.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch apiservice %s: %+v", apiService.Name, apiService)
 		return fmt.Errorf("unable to patch apiservice %s: %v", apiService.Name, err)
 	}
 	log.Log.V(4).Infof("apiservice %v updated", apiService.GetName())

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -89,10 +89,11 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 	obj, exists, _ := r.stores.DeploymentCache.Get(deployment)
 	if !exists {
 		r.expectations.Deployment.RaiseExpectations(r.kvKey, 1, 0)
+		deploymentName := deployment.Name
 		deployment, err := apps.Deployments(kv.Namespace).Create(context.Background(), deployment, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Deployment.LowerExpectations(r.kvKey, 1, 0)
-			return nil, fmt.Errorf("unable to create deployment %s: %v", deployment.Name, err)
+			return nil, fmt.Errorf("unable to create deployment %s: %v", deploymentName, err)
 		}
 
 		SetGeneration(&kv.Status.Generations, deployment)
@@ -389,10 +390,11 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 			unattachCertificateSecret(&daemonSet.Spec.Template.Spec, components.VirtHandlerCertSecretName)
 		}
 
+		daemonSetName := daemonSet.Name
 		daemonSet, err := apps.DaemonSets(kv.Namespace).Create(context.Background(), daemonSet, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.DaemonSet.LowerExpectations(r.kvKey, 1, 0)
-			return false, fmt.Errorf("unable to create daemonset %s: %v", daemonSet.Name, err)
+			return false, fmt.Errorf("unable to create daemonset %s: %v", daemonSetName, err)
 		}
 
 		SetGeneration(&kv.Status.Generations, daemonSet)
@@ -455,10 +457,11 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 
 	if !exists {
 		r.expectations.PodDisruptionBudget.RaiseExpectations(r.kvKey, 1, 0)
+		pdbName := podDisruptionBudget.Name
 		podDisruptionBudget, err := pdbClient.Create(context.Background(), podDisruptionBudget, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.PodDisruptionBudget.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create poddisruptionbudget %s: %v", podDisruptionBudget.Name, err)
+			return fmt.Errorf("unable to create poddisruptionbudget %s: %v", pdbName, err)
 		}
 		log.Log.V(2).Infof("poddisruptionbudget %v created", podDisruptionBudget.GetName())
 		SetGeneration(&kv.Status.Generations, podDisruptionBudget)

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -89,11 +89,12 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 	obj, exists, _ := r.stores.DeploymentCache.Get(deployment)
 	if !exists {
 		r.expectations.Deployment.RaiseExpectations(r.kvKey, 1, 0)
-		deploymentName := deployment.Name
+		origDeployment := deployment
 		deployment, err := apps.Deployments(kv.Namespace).Create(context.Background(), deployment, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Deployment.LowerExpectations(r.kvKey, 1, 0)
-			return nil, fmt.Errorf("unable to create deployment %s: %v", deploymentName, err)
+			log.Log.V(2).Infof("failed to create deployment %s: %+v", origDeployment.Name, origDeployment)
+			return nil, fmt.Errorf("unable to create deployment %s: %v", origDeployment.Name, err)
 		}
 
 		SetGeneration(&kv.Status.Generations, deployment)
@@ -131,9 +132,11 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 		return nil, err
 	}
 
+	prePatchDeployment := deployment
 	deployment, err = apps.Deployments(kv.Namespace).Patch(context.Background(), deployment.Name, types.JSONPatchType, ops, metav1.PatchOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to update deployment %s: %v", deployment.Name, err)
+		log.Log.V(2).Infof("failed to update deployment %s: %+v", prePatchDeployment.Name, prePatchDeployment)
+		return nil, fmt.Errorf("unable to update deployment %s: %v", prePatchDeployment.Name, err)
 	}
 
 	SetGeneration(&kv.Status.Generations, deployment)
@@ -168,6 +171,7 @@ func (r *Reconciler) patchDaemonSet(oldDs, newDs *appsv1.DaemonSet) (*appsv1.Dae
 		patch,
 		metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to update daemonset %s: %+v", oldDs.Name, oldDs)
 		return nil, fmt.Errorf("unable to update daemonset %s: %v", oldDs.Name, err)
 	}
 	return newDs, nil
@@ -232,6 +236,7 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 			setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
 			_, err := r.patchDaemonSet(cachedDaemonSet, newDS)
 			if err != nil {
+				log.V(2).Infof("failed to start canary upgrade for daemonset %s: %+v", newDS.Name, newDS)
 				return false, fmt.Errorf("unable to start canary upgrade for daemonset %s: %v", newDS.Name, err), CanaryUpgradeStatusFailed
 			}
 			log.V(2).Infof("daemonSet %v started upgrade", newDS.GetName())
@@ -253,6 +258,7 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 			// start rollout again
 			_, err := r.patchDaemonSet(cachedDaemonSet, newDS)
 			if err != nil {
+				log.V(2).Infof("failed to update daemonset %s: %+v", newDS.Name, newDS)
 				return false, fmt.Errorf("unable to update daemonset %s: %v", newDS.Name, err), CanaryUpgradeStatusFailed
 			}
 			log.V(2).Infof("daemonSet %v updated", newDS.GetName())
@@ -390,11 +396,12 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 			unattachCertificateSecret(&daemonSet.Spec.Template.Spec, components.VirtHandlerCertSecretName)
 		}
 
-		daemonSetName := daemonSet.Name
+		origDaemonSet := daemonSet
 		daemonSet, err := apps.DaemonSets(kv.Namespace).Create(context.Background(), daemonSet, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.DaemonSet.LowerExpectations(r.kvKey, 1, 0)
-			return false, fmt.Errorf("unable to create daemonset %s: %v", daemonSetName, err)
+			log.Log.V(2).Infof("failed to create daemonset %s: %+v", origDaemonSet.Name, origDaemonSet)
+			return false, fmt.Errorf("unable to create daemonset %s: %v", origDaemonSet.Name, err)
 		}
 
 		SetGeneration(&kv.Status.Generations, daemonSet)
@@ -457,11 +464,12 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 
 	if !exists {
 		r.expectations.PodDisruptionBudget.RaiseExpectations(r.kvKey, 1, 0)
-		pdbName := podDisruptionBudget.Name
+		origPDB := podDisruptionBudget
 		podDisruptionBudget, err := pdbClient.Create(context.Background(), podDisruptionBudget, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.PodDisruptionBudget.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create poddisruptionbudget %s: %v", pdbName, err)
+			log.Log.V(2).Infof("failed to create poddisruptionbudget %s: %+v", origPDB.Name, origPDB)
+			return fmt.Errorf("unable to create poddisruptionbudget %s: %v", origPDB.Name, err)
 		}
 		log.Log.V(2).Infof("poddisruptionbudget %v created", podDisruptionBudget.GetName())
 		SetGeneration(&kv.Status.Generations, podDisruptionBudget)
@@ -488,9 +496,11 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 		return err
 	}
 
+	prePatchPDB := podDisruptionBudget
 	podDisruptionBudget, err = pdbClient.Patch(context.Background(), podDisruptionBudget.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch/delete poddisruptionbudget %s: %v", podDisruptionBudget.Name, err)
+		log.Log.V(2).Infof("failed to patch/delete poddisruptionbudget %s: %+v", prePatchPDB.Name, prePatchPDB)
+		return fmt.Errorf("unable to patch/delete poddisruptionbudget %s: %v", prePatchPDB.Name, err)
 	}
 
 	SetGeneration(&kv.Status.Generations, podDisruptionBudget)

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -92,7 +92,7 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 		deployment, err := apps.Deployments(kv.Namespace).Create(context.Background(), deployment, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Deployment.LowerExpectations(r.kvKey, 1, 0)
-			return nil, fmt.Errorf("unable to create deployment %+v: %v", deployment, err)
+			return nil, fmt.Errorf("unable to create deployment %s: %v", deployment.Name, err)
 		}
 
 		SetGeneration(&kv.Status.Generations, deployment)
@@ -132,7 +132,7 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 
 	deployment, err = apps.Deployments(kv.Namespace).Patch(context.Background(), deployment.Name, types.JSONPatchType, ops, metav1.PatchOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to update deployment %+v: %v", deployment, err)
+		return nil, fmt.Errorf("unable to update deployment %s: %v", deployment.Name, err)
 	}
 
 	SetGeneration(&kv.Status.Generations, deployment)
@@ -167,7 +167,7 @@ func (r *Reconciler) patchDaemonSet(oldDs, newDs *appsv1.DaemonSet) (*appsv1.Dae
 		patch,
 		metav1.PatchOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to update daemonset %+v: %v", oldDs, err)
+		return nil, fmt.Errorf("unable to update daemonset %s: %v", oldDs.Name, err)
 	}
 	return newDs, nil
 }
@@ -231,7 +231,7 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 			setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
 			_, err := r.patchDaemonSet(cachedDaemonSet, newDS)
 			if err != nil {
-				return false, fmt.Errorf("unable to start canary upgrade for daemonset %+v: %v", newDS, err), CanaryUpgradeStatusFailed
+				return false, fmt.Errorf("unable to start canary upgrade for daemonset %s: %v", newDS.Name, err), CanaryUpgradeStatusFailed
 			}
 			log.V(2).Infof("daemonSet %v started upgrade", newDS.GetName())
 		} else {
@@ -252,7 +252,7 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 			// start rollout again
 			_, err := r.patchDaemonSet(cachedDaemonSet, newDS)
 			if err != nil {
-				return false, fmt.Errorf("unable to update daemonset %+v: %v", newDS, err), CanaryUpgradeStatusFailed
+				return false, fmt.Errorf("unable to update daemonset %s: %v", newDS.Name, err), CanaryUpgradeStatusFailed
 			}
 			log.V(2).Infof("daemonSet %v updated", newDS.GetName())
 			status = CanaryUpgradeStatusUpgradingDaemonSet
@@ -392,7 +392,7 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 		daemonSet, err := apps.DaemonSets(kv.Namespace).Create(context.Background(), daemonSet, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.DaemonSet.LowerExpectations(r.kvKey, 1, 0)
-			return false, fmt.Errorf("unable to create daemonset %+v: %v", daemonSet, err)
+			return false, fmt.Errorf("unable to create daemonset %s: %v", daemonSet.Name, err)
 		}
 
 		SetGeneration(&kv.Status.Generations, daemonSet)
@@ -458,7 +458,7 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 		podDisruptionBudget, err := pdbClient.Create(context.Background(), podDisruptionBudget, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.PodDisruptionBudget.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create poddisruptionbudget %+v: %v", podDisruptionBudget, err)
+			return fmt.Errorf("unable to create poddisruptionbudget %s: %v", podDisruptionBudget.Name, err)
 		}
 		log.Log.V(2).Infof("poddisruptionbudget %v created", podDisruptionBudget.GetName())
 		SetGeneration(&kv.Status.Generations, podDisruptionBudget)
@@ -487,7 +487,7 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 
 	podDisruptionBudget, err = pdbClient.Patch(context.Background(), podDisruptionBudget.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch/delete poddisruptionbudget %+v: %v", podDisruptionBudget, err)
+		return fmt.Errorf("unable to patch/delete poddisruptionbudget %s: %v", podDisruptionBudget.Name, err)
 	}
 
 	SetGeneration(&kv.Status.Generations, podDisruptionBudget)

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -114,7 +114,7 @@ func (r *Reconciler) createOrUpdateService(service *corev1.Service) (bool, error
 		_, err := core.Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Service.LowerExpectations(r.kvKey, 1, 0)
-			return false, fmt.Errorf("unable to create service %+v: %v", service, err)
+			return false, fmt.Errorf("unable to create service %s: %v", service.Name, err)
 		}
 
 		return false, nil
@@ -135,7 +135,7 @@ func (r *Reconciler) createOrUpdateService(service *corev1.Service) (bool, error
 
 	patchBytes, err := generateServicePatch(cachedService, service)
 	if err != nil {
-		return false, fmt.Errorf("unable to generate service endpoint patch operations for %+v: %v", service, err)
+		return false, fmt.Errorf("unable to generate service endpoint patch operations for %s: %v", service.Name, err)
 	}
 
 	if len(patchBytes) == 0 {
@@ -145,7 +145,7 @@ func (r *Reconciler) createOrUpdateService(service *corev1.Service) (bool, error
 
 	_, err = core.Services(service.Namespace).Patch(context.Background(), service.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return false, fmt.Errorf("unable to patch service %+v: %v", service, err)
+		return false, fmt.Errorf("unable to patch service %s: %v", service.Name, err)
 	}
 
 	log.Log.V(2).Infof("service %v patched", service.GetName())
@@ -260,7 +260,7 @@ func (r *Reconciler) createOrUpdateCertificateSecret(queue workqueue.TypedRateLi
 		_, err := r.clientset.CoreV1().Secrets(secret.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Secrets.LowerExpectations(r.kvKey, 1, 0)
-			return nil, fmt.Errorf("unable to create secret %+v: %v", secret, err)
+			return nil, fmt.Errorf("unable to create secret %s: %v", secret.Name, err)
 		}
 
 		return crt, nil
@@ -281,7 +281,7 @@ func (r *Reconciler) createOrUpdateCertificateSecret(queue workqueue.TypedRateLi
 
 	_, err = r.clientset.CoreV1().Secrets(secret.Namespace).Patch(context.Background(), secret.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to patch secret %+v: %v", secret, err)
+		return nil, fmt.Errorf("unable to patch secret %s: %v", secret.Name, err)
 	}
 
 	log.Log.V(2).Infof("secret %v updated", secret.GetName())
@@ -378,12 +378,12 @@ func (r *Reconciler) cleanupExternalCACerts(configMap *corev1.ConfigMap) error {
 	if !exists {
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create configMap %+v: %v", configMap, err)
+			return fmt.Errorf("unable to create configMap %s: %v", configMap.Name, err)
 		}
 	} else {
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to update configMap %+v: %v", configMap, err)
+			return fmt.Errorf("unable to update configMap %s: %v", configMap.Name, err)
 		}
 	}
 	return nil
@@ -554,7 +554,7 @@ func (r *Reconciler) createOrUpdateServiceAccount(sa *corev1.ServiceAccount) err
 		_, err := core.ServiceAccounts(r.kv.Namespace).Create(context.Background(), sa, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ServiceAccount.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create serviceaccount %+v: %v", sa, err)
+			return fmt.Errorf("unable to create serviceaccount %s: %v", sa.Name, err)
 		}
 		log.Log.V(2).Infof("serviceaccount %v created", sa.GetName())
 		return nil
@@ -578,7 +578,7 @@ func (r *Reconciler) createOrUpdateServiceAccount(sa *corev1.ServiceAccount) err
 
 	_, err = core.ServiceAccounts(r.kv.Namespace).Patch(context.Background(), sa.Name, types.JSONPatchType, labelAnnotationPatch, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch serviceaccount %+v: %v", sa, err)
+		return fmt.Errorf("unable to patch serviceaccount %s: %v", sa.Name, err)
 	}
 
 	log.Log.V(2).Infof("serviceaccount %v updated", sa.GetName())
@@ -704,7 +704,7 @@ func (r *Reconciler) createExternalKubeVirtCAConfigMap(configMap *corev1.ConfigM
 		configMap.Data = map[string]string{components.CABundleKey: ""}
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("unable to create configMap %+v: %v", configMap, err)
+			return fmt.Errorf("unable to create configMap %s: %v", configMap.Name, err)
 		}
 	}
 	return nil
@@ -732,7 +732,7 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRate
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ConfigMap.LowerExpectations(r.kvKey, 1, 0)
-			return nil, fmt.Errorf("unable to create configMap %+v: %v", configMap, err)
+			return nil, fmt.Errorf("unable to create configMap %s: %v", configMap.Name, err)
 		}
 
 		return []byte(configMap.Data[components.CABundleKey]), nil
@@ -764,7 +764,7 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRate
 
 	_, err = r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Patch(context.Background(), configMap.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to patch configMap %+v: %v", configMap, err)
+		return nil, fmt.Errorf("unable to patch configMap %s: %v", configMap.Name, err)
 	}
 
 	log.Log.V(2).Infof("configMap %v updated", configMap.GetName())

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -114,6 +114,7 @@ func (r *Reconciler) createOrUpdateService(service *corev1.Service) (bool, error
 		_, err := core.Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Service.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create service %s: %+v", service.Name, service)
 			return false, fmt.Errorf("unable to create service %s: %v", service.Name, err)
 		}
 
@@ -135,6 +136,7 @@ func (r *Reconciler) createOrUpdateService(service *corev1.Service) (bool, error
 
 	patchBytes, err := generateServicePatch(cachedService, service)
 	if err != nil {
+		log.Log.V(2).Infof("failed to generate service endpoint patch for %s: %+v", service.Name, service)
 		return false, fmt.Errorf("unable to generate service endpoint patch operations for %s: %v", service.Name, err)
 	}
 
@@ -145,6 +147,7 @@ func (r *Reconciler) createOrUpdateService(service *corev1.Service) (bool, error
 
 	_, err = core.Services(service.Namespace).Patch(context.Background(), service.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch service %s: %+v", service.Name, service)
 		return false, fmt.Errorf("unable to patch service %s: %v", service.Name, err)
 	}
 
@@ -260,6 +263,7 @@ func (r *Reconciler) createOrUpdateCertificateSecret(queue workqueue.TypedRateLi
 		_, err := r.clientset.CoreV1().Secrets(secret.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Secrets.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create secret %s: %+v", secret.Name, secret)
 			return nil, fmt.Errorf("unable to create secret %s: %v", secret.Name, err)
 		}
 
@@ -281,6 +285,7 @@ func (r *Reconciler) createOrUpdateCertificateSecret(queue workqueue.TypedRateLi
 
 	_, err = r.clientset.CoreV1().Secrets(secret.Namespace).Patch(context.Background(), secret.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch secret %s: %+v", secret.Name, secret)
 		return nil, fmt.Errorf("unable to patch secret %s: %v", secret.Name, err)
 	}
 
@@ -378,11 +383,13 @@ func (r *Reconciler) cleanupExternalCACerts(configMap *corev1.ConfigMap) error {
 	if !exists {
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
+			log.Log.V(2).Infof("failed to create configMap %s: %+v", configMap.Name, configMap)
 			return fmt.Errorf("unable to create configMap %s: %v", configMap.Name, err)
 		}
 	} else {
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
 		if err != nil {
+			log.Log.V(2).Infof("failed to update configMap %s: %+v", configMap.Name, configMap)
 			return fmt.Errorf("unable to update configMap %s: %v", configMap.Name, err)
 		}
 	}
@@ -554,6 +561,7 @@ func (r *Reconciler) createOrUpdateServiceAccount(sa *corev1.ServiceAccount) err
 		_, err := core.ServiceAccounts(r.kv.Namespace).Create(context.Background(), sa, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ServiceAccount.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create serviceaccount %s: %+v", sa.Name, sa)
 			return fmt.Errorf("unable to create serviceaccount %s: %v", sa.Name, err)
 		}
 		log.Log.V(2).Infof("serviceaccount %v created", sa.GetName())
@@ -578,6 +586,7 @@ func (r *Reconciler) createOrUpdateServiceAccount(sa *corev1.ServiceAccount) err
 
 	_, err = core.ServiceAccounts(r.kv.Namespace).Patch(context.Background(), sa.Name, types.JSONPatchType, labelAnnotationPatch, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch serviceaccount %s: %+v", sa.Name, sa)
 		return fmt.Errorf("unable to patch serviceaccount %s: %v", sa.Name, err)
 	}
 
@@ -704,6 +713,7 @@ func (r *Reconciler) createExternalKubeVirtCAConfigMap(configMap *corev1.ConfigM
 		configMap.Data = map[string]string{components.CABundleKey: ""}
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
+			log.Log.V(2).Infof("failed to create configMap %s: %+v", configMap.Name, configMap)
 			return fmt.Errorf("unable to create configMap %s: %v", configMap.Name, err)
 		}
 	}
@@ -732,6 +742,7 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRate
 		_, err := r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ConfigMap.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create configMap %s: %+v", configMap.Name, configMap)
 			return nil, fmt.Errorf("unable to create configMap %s: %v", configMap.Name, err)
 		}
 
@@ -764,6 +775,7 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.TypedRate
 
 	_, err = r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Patch(context.Background(), configMap.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch configMap %s: %+v", configMap.Name, configMap)
 		return nil, fmt.Errorf("unable to patch configMap %s: %v", configMap.Name, err)
 	}
 

--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -52,9 +52,11 @@ func patchCRD(client clientset.Interface, crd *extv1.CustomResourceDefinition, o
 	if err != nil {
 		return nil, err
 	}
+	origCrd := crd
 	crd, err = client.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to patch crd %s: %v", crd.Name, err)
+		log.Log.V(2).Infof("failed to patch crd %s: %+v", origCrd.Name, origCrd)
+		return nil, fmt.Errorf("unable to patch crd %s: %v", origCrd.Name, err)
 	}
 
 	log.Log.V(2).Infof("crd %v updated", name)
@@ -86,6 +88,7 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1.CustomResourceDefinition) erro
 		createdCRD, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), crd, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.OperatorCrd.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create crd %s: %+v", crd.Name, crd)
 			return fmt.Errorf("unable to create crd %s: %v", crd.Name, err)
 		}
 

--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -54,7 +54,7 @@ func patchCRD(client clientset.Interface, crd *extv1.CustomResourceDefinition, o
 	}
 	crd, err = client.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to patch crd %+v: %v", crd, err)
+		return nil, fmt.Errorf("unable to patch crd %s: %v", crd.Name, err)
 	}
 
 	log.Log.V(2).Infof("crd %v updated", name)
@@ -86,7 +86,7 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1.CustomResourceDefinition) erro
 		createdCRD, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), crd, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.OperatorCrd.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create crd %+v: %v", crd, err)
+			return fmt.Errorf("unable to create crd %s: %v", crd.Name, err)
 		}
 
 		SetGeneration(&r.kv.Status.Generations, createdCRD)

--- a/pkg/virt-operator/resource/apply/instancetypes.go
+++ b/pkg/virt-operator/resource/apply/instancetypes.go
@@ -49,7 +49,7 @@ func (r *Reconciler) createOrUpdateInstancetype(instancetype *instancetypev1beta
 
 	if errors.IsNotFound(err) {
 		if _, err := r.clientset.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("unable to create instancetype %+v: %v", instancetype, err)
+			return fmt.Errorf("unable to create instancetype %s: %v", instancetype.Name, err)
 		}
 		log.Log.V(2).Infof("instancetype %v created", instancetype.GetName())
 		return nil
@@ -64,7 +64,7 @@ func (r *Reconciler) createOrUpdateInstancetype(instancetype *instancetypev1beta
 
 	instancetype.ResourceVersion = foundObj.ResourceVersion
 	if _, err := r.clientset.VirtualMachineClusterInstancetype().Update(context.Background(), instancetype, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("unable to update instancetype %+v: %v", instancetype, err)
+		return fmt.Errorf("unable to update instancetype %s: %v", instancetype.Name, err)
 	}
 	log.Log.V(2).Infof("instancetype %v updated", instancetype.GetName())
 
@@ -136,7 +136,7 @@ func (r *Reconciler) createOrUpdatePreference(preference *instancetypev1beta1.Vi
 
 	if errors.IsNotFound(err) {
 		if _, err := r.clientset.VirtualMachineClusterPreference().Create(context.Background(), preference, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("unable to create preference %+v: %v", preference, err)
+			return fmt.Errorf("unable to create preference %s: %v", preference.Name, err)
 		}
 		log.Log.V(2).Infof("preference %v created", preference.GetName())
 		return nil
@@ -151,7 +151,7 @@ func (r *Reconciler) createOrUpdatePreference(preference *instancetypev1beta1.Vi
 
 	preference.ResourceVersion = foundObj.ResourceVersion
 	if _, err := r.clientset.VirtualMachineClusterPreference().Update(context.Background(), preference, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("unable to update preference %+v: %v", preference, err)
+		return fmt.Errorf("unable to update preference %s: %v", preference.Name, err)
 	}
 	log.Log.V(2).Infof("preference %v updated", preference.GetName())
 

--- a/pkg/virt-operator/resource/apply/instancetypes.go
+++ b/pkg/virt-operator/resource/apply/instancetypes.go
@@ -49,6 +49,7 @@ func (r *Reconciler) createOrUpdateInstancetype(instancetype *instancetypev1beta
 
 	if errors.IsNotFound(err) {
 		if _, err := r.clientset.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{}); err != nil {
+			log.Log.V(2).Infof("failed to create instancetype %s: %+v", instancetype.Name, instancetype)
 			return fmt.Errorf("unable to create instancetype %s: %v", instancetype.Name, err)
 		}
 		log.Log.V(2).Infof("instancetype %v created", instancetype.GetName())
@@ -64,6 +65,7 @@ func (r *Reconciler) createOrUpdateInstancetype(instancetype *instancetypev1beta
 
 	instancetype.ResourceVersion = foundObj.ResourceVersion
 	if _, err := r.clientset.VirtualMachineClusterInstancetype().Update(context.Background(), instancetype, metav1.UpdateOptions{}); err != nil {
+		log.Log.V(2).Infof("failed to update instancetype %s: %+v", instancetype.Name, instancetype)
 		return fmt.Errorf("unable to update instancetype %s: %v", instancetype.Name, err)
 	}
 	log.Log.V(2).Infof("instancetype %v updated", instancetype.GetName())
@@ -136,6 +138,7 @@ func (r *Reconciler) createOrUpdatePreference(preference *instancetypev1beta1.Vi
 
 	if errors.IsNotFound(err) {
 		if _, err := r.clientset.VirtualMachineClusterPreference().Create(context.Background(), preference, metav1.CreateOptions{}); err != nil {
+			log.Log.V(2).Infof("failed to create preference %s: %+v", preference.Name, preference)
 			return fmt.Errorf("unable to create preference %s: %v", preference.Name, err)
 		}
 		log.Log.V(2).Infof("preference %v created", preference.GetName())
@@ -151,6 +154,7 @@ func (r *Reconciler) createOrUpdatePreference(preference *instancetypev1beta1.Vi
 
 	preference.ResourceVersion = foundObj.ResourceVersion
 	if _, err := r.clientset.VirtualMachineClusterPreference().Update(context.Background(), preference, metav1.UpdateOptions{}); err != nil {
+		log.Log.V(2).Infof("failed to update preference %s: %+v", preference.Name, preference)
 		return fmt.Errorf("unable to update preference %s: %v", preference.Name, err)
 	}
 	log.Log.V(2).Infof("preference %v updated", preference.GetName())

--- a/pkg/virt-operator/resource/apply/prometheus.go
+++ b/pkg/virt-operator/resource/apply/prometheus.go
@@ -43,6 +43,7 @@ func (r *Reconciler) createOrUpdateServiceMonitor(serviceMonitor *promv1.Service
 		_, err := prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.Namespace).Create(context.Background(), serviceMonitor, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ServiceMonitor.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create serviceMonitor %s: %+v", serviceMonitor.Name, serviceMonitor)
 			return fmt.Errorf("unable to create serviceMonitor %s: %v", serviceMonitor.Name, err)
 		}
 
@@ -71,6 +72,7 @@ func (r *Reconciler) createOrUpdateServiceMonitor(serviceMonitor *promv1.Service
 
 	_, err = prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.Namespace).Patch(context.Background(), serviceMonitor.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch serviceMonitor %s: %+v", serviceMonitor.Name, serviceMonitor)
 		return fmt.Errorf("unable to patch serviceMonitor %s: %v", serviceMonitor.Name, err)
 	}
 
@@ -118,6 +120,7 @@ func (r *Reconciler) createOrUpdatePrometheusRule(prometheusRule *promv1.Prometh
 		_, err := prometheusClient.MonitoringV1().PrometheusRules(prometheusRule.Namespace).Create(context.Background(), prometheusRule, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.PrometheusRule.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create PrometheusRule %s: %+v", prometheusRule.Name, prometheusRule)
 			return fmt.Errorf("unable to create PrometheusRule %s: %v", prometheusRule.Name, err)
 		}
 
@@ -142,6 +145,7 @@ func (r *Reconciler) createOrUpdatePrometheusRule(prometheusRule *promv1.Prometh
 
 	_, err = prometheusClient.MonitoringV1().PrometheusRules(prometheusRule.Namespace).Patch(context.Background(), prometheusRule.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch PrometheusRule %s: %+v", prometheusRule.Name, prometheusRule)
 		return fmt.Errorf("unable to patch PrometheusRule %s: %v", prometheusRule.Name, err)
 	}
 

--- a/pkg/virt-operator/resource/apply/prometheus.go
+++ b/pkg/virt-operator/resource/apply/prometheus.go
@@ -43,7 +43,7 @@ func (r *Reconciler) createOrUpdateServiceMonitor(serviceMonitor *promv1.Service
 		_, err := prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.Namespace).Create(context.Background(), serviceMonitor, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.ServiceMonitor.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create serviceMonitor %+v: %v", serviceMonitor, err)
+			return fmt.Errorf("unable to create serviceMonitor %s: %v", serviceMonitor.Name, err)
 		}
 
 		log.Log.V(2).Infof("serviceMonitor %v created", serviceMonitor.GetName())
@@ -71,7 +71,7 @@ func (r *Reconciler) createOrUpdateServiceMonitor(serviceMonitor *promv1.Service
 
 	_, err = prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.Namespace).Patch(context.Background(), serviceMonitor.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch serviceMonitor %+v: %v", serviceMonitor, err)
+		return fmt.Errorf("unable to patch serviceMonitor %s: %v", serviceMonitor.Name, err)
 	}
 
 	log.Log.V(2).Infof("serviceMonitor %v updated", serviceMonitor.GetName())
@@ -118,7 +118,7 @@ func (r *Reconciler) createOrUpdatePrometheusRule(prometheusRule *promv1.Prometh
 		_, err := prometheusClient.MonitoringV1().PrometheusRules(prometheusRule.Namespace).Create(context.Background(), prometheusRule, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.PrometheusRule.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create PrometheusRule %+v: %v", prometheusRule, err)
+			return fmt.Errorf("unable to create PrometheusRule %s: %v", prometheusRule.Name, err)
 		}
 
 		log.Log.V(2).Infof("PrometheusRule %v created", prometheusRule.GetName())
@@ -142,7 +142,7 @@ func (r *Reconciler) createOrUpdatePrometheusRule(prometheusRule *promv1.Prometh
 
 	_, err = prometheusClient.MonitoringV1().PrometheusRules(prometheusRule.Namespace).Patch(context.Background(), prometheusRule.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch PrometheusRule %+v: %v", prometheusRule, err)
+		return fmt.Errorf("unable to patch PrometheusRule %s: %v", prometheusRule.Name, err)
 	}
 
 	log.Log.V(2).Infof("PrometheusRule %v updated", prometheusRule.GetName())

--- a/pkg/virt-operator/resource/apply/rbac.go
+++ b/pkg/virt-operator/resource/apply/rbac.go
@@ -56,6 +56,7 @@ func rbacCreateOrUpdate(r *Reconciler, required runtime.Object, imageTag, imageR
 		// Create non existent
 		err = getRbacCreateFunction(r, required)()
 		if err != nil {
+			log.Log.V(2).Infof("failed to create %v %s: %+v", roleTypeName, requiredMeta.GetName(), required)
 			return fmt.Errorf("unable to create %v %s: %v", roleTypeName, requiredMeta.GetName(), err)
 		}
 		log.Log.V(2).Infof("%v %v created", roleTypeName, requiredMeta.GetName())
@@ -79,6 +80,7 @@ func rbacCreateOrUpdate(r *Reconciler, required runtime.Object, imageTag, imageR
 	// Update existing, we don't need to patch for rbac rules.
 	err = getRbacUpdateFunction(r, existingCopy)()
 	if err != nil {
+		log.Log.V(2).Infof("failed to update %v %s: %+v", roleTypeName, requiredMeta.GetName(), existingCopy)
 		return fmt.Errorf("unable to update %v %s: %v", roleTypeName, requiredMeta.GetName(), err)
 	}
 	log.Log.V(2).Infof("%v %v updated", roleTypeName, requiredMeta.GetName())

--- a/pkg/virt-operator/resource/apply/rbac.go
+++ b/pkg/virt-operator/resource/apply/rbac.go
@@ -56,7 +56,7 @@ func rbacCreateOrUpdate(r *Reconciler, required runtime.Object, imageTag, imageR
 		// Create non existent
 		err = getRbacCreateFunction(r, required)()
 		if err != nil {
-			return fmt.Errorf("unable to create %v %+v: %v", roleTypeName, required, err)
+			return fmt.Errorf("unable to create %v %s: %v", roleTypeName, requiredMeta.GetName(), err)
 		}
 		log.Log.V(2).Infof("%v %v created", roleTypeName, requiredMeta.GetName())
 		return nil
@@ -79,7 +79,7 @@ func rbacCreateOrUpdate(r *Reconciler, required runtime.Object, imageTag, imageR
 	// Update existing, we don't need to patch for rbac rules.
 	err = getRbacUpdateFunction(r, existingCopy)()
 	if err != nil {
-		return fmt.Errorf("unable to update %v %+v: %v", roleTypeName, required, err)
+		return fmt.Errorf("unable to update %v %s: %v", roleTypeName, requiredMeta.GetName(), err)
 	}
 	log.Log.V(2).Infof("%v %v updated", roleTypeName, requiredMeta.GetName())
 

--- a/pkg/virt-operator/resource/apply/routes.go
+++ b/pkg/virt-operator/resource/apply/routes.go
@@ -54,6 +54,7 @@ func (r *Reconciler) syncRoute(route *routev1.Route, caBundle []byte) error {
 		_, err := r.clientset.RouteClient().Routes(route.Namespace).Create(context.Background(), route, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Route.LowerExpectations(r.kvKey, 1, 0)
+			log.Log.V(2).Infof("failed to create route %s: %+v", route.Name, route)
 			return fmt.Errorf("unable to create route %s: %v", route.Name, err)
 		}
 
@@ -80,6 +81,7 @@ func (r *Reconciler) syncRoute(route *routev1.Route, caBundle []byte) error {
 
 	_, err = r.clientset.RouteClient().Routes(route.Namespace).Patch(context.Background(), route.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Log.V(2).Infof("failed to patch route %s: %+v", route.Name, route)
 		return fmt.Errorf("unable to patch route %s: %v", route.Name, err)
 	}
 	log.Log.V(4).Infof("route %v updated", route.GetName())

--- a/pkg/virt-operator/resource/apply/routes.go
+++ b/pkg/virt-operator/resource/apply/routes.go
@@ -54,7 +54,7 @@ func (r *Reconciler) syncRoute(route *routev1.Route, caBundle []byte) error {
 		_, err := r.clientset.RouteClient().Routes(route.Namespace).Create(context.Background(), route, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.Route.LowerExpectations(r.kvKey, 1, 0)
-			return fmt.Errorf("unable to create route %+v: %v", route, err)
+			return fmt.Errorf("unable to create route %s: %v", route.Name, err)
 		}
 
 		return nil
@@ -80,7 +80,7 @@ func (r *Reconciler) syncRoute(route *routev1.Route, caBundle []byte) error {
 
 	_, err = r.clientset.RouteClient().Routes(route.Namespace).Patch(context.Background(), route.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		return fmt.Errorf("unable to patch route %+v: %v", route, err)
+		return fmt.Errorf("unable to patch route %s: %v", route.Name, err)
 	}
 	log.Log.V(4).Infof("route %v updated", route.GetName())
 

--- a/pkg/virt-operator/resource/apply/ssc.go
+++ b/pkg/virt-operator/resource/apply/ssc.go
@@ -37,7 +37,7 @@ func (r *Reconciler) createOrUpdateSCC() error {
 			_, err := sec.SecurityContextConstraints().Create(context.Background(), scc, metav1.CreateOptions{})
 			if err != nil {
 				r.expectations.SCC.LowerExpectations(r.kvKey, 1, 0)
-				return fmt.Errorf("unable to create SCC %+v: %v", scc, err)
+				return fmt.Errorf("unable to create SCC %s: %v", scc.Name, err)
 			}
 
 			log.Log.V(2).Infof("SCC %v created", scc.Name)
@@ -71,7 +71,7 @@ func (r *Reconciler) removeKvServiceAccountsFromDefaultSCC(targetNamespace strin
 
 	SCC, ok := SCCObj.(*secv1.SecurityContextConstraints)
 	if !ok {
-		return fmt.Errorf("couldn't cast object to SecurityContextConstraints: %+v", SCCObj)
+		return fmt.Errorf("couldn't cast object to SecurityContextConstraints: %T", SCCObj)
 	}
 
 	modified := false

--- a/pkg/virt-operator/resource/apply/ssc.go
+++ b/pkg/virt-operator/resource/apply/ssc.go
@@ -37,6 +37,7 @@ func (r *Reconciler) createOrUpdateSCC() error {
 			_, err := sec.SecurityContextConstraints().Create(context.Background(), scc, metav1.CreateOptions{})
 			if err != nil {
 				r.expectations.SCC.LowerExpectations(r.kvKey, 1, 0)
+				log.Log.V(2).Infof("failed to create SCC %s: %+v", scc.Name, scc)
 				return fmt.Errorf("unable to create SCC %s: %v", scc.Name, err)
 			}
 
@@ -71,6 +72,7 @@ func (r *Reconciler) removeKvServiceAccountsFromDefaultSCC(targetNamespace strin
 
 	SCC, ok := SCCObj.(*secv1.SecurityContextConstraints)
 	if !ok {
+		log.Log.V(2).Infof("failed to cast object to SecurityContextConstraints: %+v", SCCObj)
 		return fmt.Errorf("couldn't cast object to SecurityContextConstraints: %T", SCCObj)
 	}
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Error messages returned from resource create/update/patch operations in
the virt-operator `apply` package use `fmt.Errorf` with `%+v`, dumping the
entire Go struct representation of the resource into the error string.
These errors propagate up to `UpdateConditionsFailedError()` in
`pkg/virt-operator/util/client.go`, which writes them into four separate
status conditions (`Synchronized`, `Available`, `Progressing`, `Degraded`)
on the KubeVirt CR.

For large resources like the `virtualmachineinstances.kubevirt.io` CRD —
which contains an extensive OpenAPI v3 schema — the `%+v` dump produces
hundreds of kilobytes of text. Multiplied across four conditions, this
pushes the KubeVirt CR beyond the 3MB etcd object size limit, causing
status updates to fail with `Request entity too large: limit is 3145728`
and the operator to enter an infinite retry loop that blocks all rollouts.

#### After this PR:

All `%+v` format verbs in `return fmt.Errorf(...)` calls across the
`apply` package are replaced with `%s` using only the resource `.Name`.
Error messages are now concise (e.g. `unable to create crd
virtualmachineinstances.kubevirt.io: ...`) and will not bloat the
KubeVirt CR status.

### References

- Fixes #17572

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Only `return fmt.Errorf(...)` calls were changed since these propagate into the KubeVirt CR status. `log.Log.Errorf(...)` calls with `%+v` in `delete.go` and `reconcile.go` were left untouched as they only affect log output, not CR size.
- One cast-failure error in `ssc.go` was changed from `%+v` to `%T` (type name) since the object name is not meaningful in that context.

The following alternatives were considered:
- Truncating the error message in `UpdateConditionsFailedError()` — this would be a single-point fix but would mask useful error context from other resource types that have reasonable error messages.
- Adding a size limit to status condition messages — more defensive but adds complexity and could still lose useful information.

### Special notes for your reviewer

The change is mechanical: `%+v` → `%s` with `.Name` (or `.GetName()` for interface types) across 10 files, 48 occurrences. No logic changes.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Bug fix: virt-operator error messages no longer dump entire resource structs via %+v, preventing the KubeVirt CR from exceeding the etcd 3MB object size limit when resource creation fails
```