### PR TITLE
virt-operator: add fallback API Get when CRD is not found in informer cache

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -318,6 +318,9 @@ func (k *KubeVirtTestData) BeforeTest() {
 		return true, nil, nil
 	})
 	k.extClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "customresourcedefinitions" {
+			return true, nil, errors.NewNotFound(schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}, action.(testing.GetAction).GetName())
+		}
 		Expect(action).To(BeNil())
 		return true, nil, nil
 	})

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2715,6 +2715,81 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kv.ObjectMeta.Finalizers).To(ConsistOf(util.KubeVirtFinalizer))
 		})
 
+		It("should update CRDs via fallback API Get when not found in informer cache", func() {
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			err := kvTestData.controller.stores.NamespaceCache.Add(&k8sv1.Namespace{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Namespace",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: NAMESPACE,
+					Labels: map[string]string{
+						"openshift.io/cluster-monitoring": "true",
+					},
+				},
+			})
+			Expect(err).To(Not(HaveOccurred()))
+
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Generation: int64(1),
+					Finalizers: []string{util.KubeVirtFinalizer},
+				},
+				Status: v1.KubeVirtStatus{
+					Phase:              v1.KubeVirtPhaseDeployed,
+					ObservedGeneration: pointer.P(int64(1)),
+				},
+			}
+			enableTemplateFeatureGate(kv)
+			enableContainerPathVolumesFeatureGate(kv)
+			kubecontroller.SetLatestApiVersionAnnotation(kv)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
+			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeHandlerReady()
+
+			// Save the CRDs before removing them from cache
+			cachedCrds := kvTestData.controller.stores.OperatorCrdCache.List()
+			Expect(cachedCrds).ToNot(BeEmpty())
+
+			// Remove all CRDs from the informer cache to simulate a label
+			// mismatch (e.g. managed-by: kustomize instead of virt-operator)
+			for _, obj := range cachedCrds {
+				kvTestData.controller.stores.OperatorCrdCache.Delete(obj)
+			}
+			Expect(kvTestData.controller.stores.OperatorCrdCache.List()).To(BeEmpty())
+
+			// Register a get reactor that returns CRDs from the API server,
+			// simulating CRDs that exist on the cluster but are not in cache
+			kvTestData.extClient.Fake.PrependReactor("get", "customresourcedefinitions", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				getAction := action.(testing.GetAction)
+				for _, cached := range cachedCrds {
+					crd := cached.(*extv1.CustomResourceDefinition)
+					if crd.Name == getAction.GetName() {
+						return true, crd, nil
+					}
+				}
+				return true, nil, errors.NewNotFound(schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}, getAction.GetName())
+			})
+
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectCreations()
+			kvTestData.shouldExpectPatchesAndUpdates(kv)
+
+			kvTestData.controller.Execute()
+
+			kv = kvTestData.getLatestKubeVirt(kv)
+			// Verify the operator reached deployed state (not stuck in error loop)
+			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
+		})
+
 		It("should pause rollback until api server is rolled over.", func() {
 			defer GinkgoRecover()
 

--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -8,6 +8,7 @@ import (
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -82,6 +83,19 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1.CustomResourceDefinition) erro
 	crd = crd.DeepCopy()
 	injectOperatorMetadata(r.kv, &crd.ObjectMeta, version, imageRegistry, id, true)
 	obj, exists, _ := r.stores.OperatorCrdCache.Get(crd)
+	// since these objects was in the past unmanaged, reconcile and pick it up if it exists
+	if !exists {
+		var err error
+		cachedCrd, err = client.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crd.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			exists = false
+		} else if err != nil {
+			return err
+		} else {
+			exists = true
+		}
+	}
+
 	if !exists {
 		// Create non existent
 		r.expectations.OperatorCrd.RaiseExpectations(r.kvKey, 1, 0)
@@ -97,7 +111,9 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1.CustomResourceDefinition) erro
 		return nil
 	}
 
-	cachedCrd = obj.(*extv1.CustomResourceDefinition)
+	if cachedCrd == nil {
+		cachedCrd = obj.(*extv1.CustomResourceDefinition)
+	}
 	modified := resourcemerge.BoolPtr(false)
 	expectedGeneration := GetExpectedGeneration(crd, r.kv.Status.Generations)
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When the informer cache does not contain a CRD (e.g. due to a label/annotation
mismatch after an upgrade, or the cache not being fully synced),
`createOrUpdateCrd()` goes straight to `Create()` which fails with
`"already exists"` if the CRD is actually present on the cluster. This triggers
the error-to-status flow and blocks all component rollouts.

Other resource types already handle this gracefully with a fallback direct API
Get when the cache misses:

- `createOrUpdateAPIService` (`apiservices.go:39-47`)
- `createOrUpdateValidatingWebhookConfiguration` (`admissionregistration.go:179-187`)
- `createOrUpdateMutatingWebhookConfiguration` (`admissionregistration.go:321-329`)

These all have the comment `"since these objects was in the past unmanaged,
reconcile and pick it up if it exists"` and do a direct Get before falling through to Create. CRDs were missing this pattern.

#### After this PR:

`createOrUpdateCrd()` now falls back to a direct API Get when the informer
cache misses, matching the established pattern from the other resource types.
If the CRD exists on the cluster, it proceeds to the update/patch path instead
of failing with "already exists".

### References

- Fixes #17575
- Partially addresses #17572

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The fix follows the exact same pattern already used by APIServices and webhook
  configurations, keeping the codebase consistent.

The following alternatives were considered:
- Handling the `IsAlreadyExists` error from Create and retrying as an update —
  this would work but is less clean and inconsistent with how the other resource
  types handle it.

### Special notes for your reviewer

Compare the new code in `crds.go` with the existing pattern in `apiservices.go:37-50`
and `admissionregistration.go:176-190` — the structure is identical.

This PR is companion to #17573 which fixes the verbose `%+v` error messages that
cause the KubeVirt CR to exceed the etcd size limit. This PR fixes the root cause
(CRD cache miss leading to unnecessary Create failure), while #17573 fixes the
secondary issue (error messages bloating the status).

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Bug fix: virt-operator now falls back to a direct API Get when a CRD is not found in the informer cache, preventing unnecessary "already exists" errors that could block rollouts during upgrades
```