### PR TITLE
Add TargetReadinessPolicy enum options to VirtualMachineRestoreSpec

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -26923,6 +26923,7 @@ var CRDsValidation map[string]string = map[string]string{
           type: object
           x-kubernetes-map-type: atomic
         targetReadinessPolicy:
+          default: WaitGracePeriod
           description: |-
             TargetReadinessPolicy defines how to handle the restore in case
             the target is not ready

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -26926,6 +26926,11 @@ var CRDsValidation map[string]string = map[string]string{
           description: |-
             TargetReadinessPolicy defines how to handle the restore in case
             the target is not ready
+          enum:
+          - StopTarget
+          - WaitGracePeriod
+          - FailImmediate
+          - WaitEventually
           type: string
         virtualMachineSnapshotName:
           type: string

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -387,6 +387,7 @@ type VirtualMachineRestoreSpec struct {
 	VirtualMachineSnapshotName string `json:"virtualMachineSnapshotName"`
 
 	// +optional
+	// +kubebuilder:validation:Enum=StopTarget;WaitGracePeriod;FailImmediate;WaitEventually
 	TargetReadinessPolicy *TargetReadinessPolicy `json:"targetReadinessPolicy,omitempty"`
 
 	// +optional

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -387,6 +387,7 @@ type VirtualMachineRestoreSpec struct {
 	VirtualMachineSnapshotName string `json:"virtualMachineSnapshotName"`
 
 	// +optional
+	// +kubebuilder:default=WaitGracePeriod
 	// +kubebuilder:validation:Enum=StopTarget;WaitGracePeriod;FailImmediate;WaitEventually
 	TargetReadinessPolicy *TargetReadinessPolicy `json:"targetReadinessPolicy,omitempty"`
 

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
@@ -150,7 +150,7 @@ func (VirtualMachineRestoreSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                       "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestore resource",
 		"target":                 "initially only VirtualMachine type supported",
-		"targetReadinessPolicy":  "+optional\n+kubebuilder:validation:Enum=StopTarget;WaitGracePeriod;FailImmediate;WaitEventually",
+		"targetReadinessPolicy":  "+optional\n+kubebuilder:default=WaitGracePeriod\n+kubebuilder:validation:Enum=StopTarget;WaitGracePeriod;FailImmediate;WaitEventually",
 		"volumeRestorePolicy":    "+optional",
 		"volumeOwnershipPolicy":  "+optional",
 		"volumeRestoreOverrides": "VolumeRestoreOverrides gives the option to change properties of each restored volume\nFor example, specifying the name of the restored volume, or adding labels/annotations to it\n+optional\n+listType=atomic",

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
@@ -150,7 +150,7 @@ func (VirtualMachineRestoreSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                       "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestore resource",
 		"target":                 "initially only VirtualMachine type supported",
-		"targetReadinessPolicy":  "+optional",
+		"targetReadinessPolicy":  "+optional\n+kubebuilder:validation:Enum=StopTarget;WaitGracePeriod;FailImmediate;WaitEventually",
 		"volumeRestorePolicy":    "+optional",
 		"volumeOwnershipPolicy":  "+optional",
 		"volumeRestoreOverrides": "VolumeRestoreOverrides gives the option to change properties of each restored volume\nFor example, specifying the name of the restored volume, or adding labels/annotations to it\n+optional\n+listType=atomic",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
When creating a restore with a non-existent target readiness policy, the resource appears stuck in an "Initializing VirtualMachineRestore" status.

#### After this PR:
Invalid policy values are now rejected at creation time with clear error messages.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Assisted by Claude Code.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Added enum validation for the targetReadinessPolicy field for restore resources.
```

