### PR TITLE
Fix migration completion race: remove stale domain send from TargetMigrationMonitor

### DIFF
--- a/pkg/virt-launcher/notify-client/BUILD.bazel
+++ b/pkg/virt-launcher/notify-client/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/reference:go_default_library",

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -273,10 +273,6 @@ func (e eventNotifier) SendEvent(event watch.Event) error {
 	return e.client.SendDomainEvent(event)
 }
 
-func (e eventNotifier) UpdateEvents(event watch.Event) {
-	e.client.updateEvents(event, e.domain, e.events)
-}
-
 func isGuestPanicEvent(event *libvirt.DomainEventLifecycle) bool {
 	return event != nil && event.Event == libvirt.DOMAIN_EVENT_CRASHED
 }
@@ -408,7 +404,7 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 			eventType = watch.Added
 		}
 	case libvirtEvent.Event != nil:
-		if shouldAdd := processLifecycleEvent(client, domain, libvirtEvent.Event, metadataCache, events, c, vmi); shouldAdd {
+		if shouldAdd := processLifecycleEvent(domain, libvirtEvent.Event, metadataCache, events, c, vmi); shouldAdd {
 			eventType = watch.Added
 		}
 	}
@@ -723,7 +719,7 @@ func processJobCompletedEvent(domain *api.Domain, d cli.VirDomain, jobCompletedE
 	}
 }
 
-func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, events chan watch.Event, c cli.Connection, vmi *v1.VirtualMachineInstance) bool {
+func processLifecycleEvent(domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, events chan watch.Event, c cli.Connection, vmi *v1.VirtualMachineInstance) bool {
 	if lifecycleEvent.Event == libvirt.DOMAIN_EVENT_DEFINED &&
 		libvirt.DomainEventDefinedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_DEFINED_ADDED {
 		return true
@@ -739,12 +735,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 		// Usually this is performed by the source launcher/handler. However, in case of upgrade, this is not
 		// guaranteed as the cluster will have an updated virt-handler together with outdated launchers, this
 		// makes sure that migrations actually finish in those cases.
-		notifier := eventNotifier{
-			client: client,
-			domain: domain,
-			events: events,
-		}
-		monitor := virtwrap.NewTargetMigrationMonitor(c, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := virtwrap.NewTargetMigrationMonitor(c, log.Log.Object(vmi), domain, metadataCache)
 		monitor.StartMonitor()
 	}
 	return false

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -13,6 +13,7 @@ import (
 
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"libvirt.org/go/libvirt"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -702,16 +703,24 @@ func (n *Notifier) Close() {
 }
 
 func processJobCompletedEvent(domain *api.Domain, d cli.VirDomain, jobCompletedEvent *libvirt.DomainEventJobCompleted, metadataCache *metadata.Cache) bool {
-	if jobCompletedEvent.Info.Operation != libvirt.DOMAIN_JOB_OPERATION_BACKUP {
-		log.Log.V(3).Infof("Recieved a job completion event for operation %v", jobCompletedEvent.Info.Operation)
+	switch jobCompletedEvent.Info.Operation {
+	case libvirt.DOMAIN_JOB_OPERATION_MIGRATION_OUT:
+		var uid types.UID
+		if migration, exists := metadataCache.Migration.Load(); exists {
+			uid = migration.UID
+		}
+		virtwrap.LogMigrationInfo(log.Log, uid, &jobCompletedEvent.Info)
+		return false
+	case libvirt.DOMAIN_JOB_OPERATION_BACKUP:
+		storage.HandleBackupJobCompletedEvent(d, jobCompletedEvent, metadataCache)
+		if value, exists := metadataCache.Backup.Load(); exists {
+			domain.Spec.Metadata.KubeVirt.Backup = &value
+		}
+		return true
+	default:
+		log.Log.V(3).Infof("Received a job completion event for operation %v", jobCompletedEvent.Info.Operation)
 		return false
 	}
-
-	storage.HandleBackupJobCompletedEvent(d, jobCompletedEvent, metadataCache)
-	if value, exists := metadataCache.Backup.Load(); exists {
-		domain.Spec.Metadata.KubeVirt.Backup = &value
-	}
-	return true
 }
 
 func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, events chan watch.Event, c cli.Connection, vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -263,16 +263,6 @@ func (e *eventCaller) updateStatus(status *api.DomainStatus) {
 	e.domainStatusChangeReason = status.Reason
 }
 
-type eventNotifier struct {
-	client *Notifier
-	domain *api.Domain
-	events chan watch.Event
-}
-
-func (e eventNotifier) SendEvent(event watch.Event) error {
-	return e.client.SendDomainEvent(event)
-}
-
 func isGuestPanicEvent(event *libvirt.DomainEventLifecycle) bool {
 	return event != nil && event.Event == libvirt.DOMAIN_EVENT_CRASHED
 }

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -508,6 +508,8 @@ func (n *Notifier) StartDomainNotifier(
 						fsFreezeStatus,
 						metadataCache,
 					)
+				} else {
+					log.Log.Warning("Dropping metadata cache notification")
 				}
 			}
 		}

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -744,7 +744,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 			domain: domain,
 			events: events,
 		}
-		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := virtwrap.NewTargetMigrationMonitor(c, events, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 	}
 	return false

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -744,7 +744,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 			domain: domain,
 			events: events,
 		}
-		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, domain, metadataCache, notifier)
+		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 	}
 	return false

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -744,7 +744,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 			domain: domain,
 			events: events,
 		}
-		monitor := virtwrap.NewTargetMigrationMonitor(c, events, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := virtwrap.NewTargetMigrationMonitor(c, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 	}
 	return false

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -131,6 +131,7 @@ go_test(
         "//pkg/virt-launcher/virtwrap/testing:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -141,7 +141,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -87,7 +87,6 @@ type migrationMonitor struct {
 
 	progressTimeout          int64
 	acceptableCompletionTime int64
-	migrationFailedWithError error
 }
 
 type inflightMigrationAborted struct {
@@ -589,44 +588,37 @@ func (m *migrationMonitor) startMonitor() {
 	logInterval := 0
 
 	for {
+		var ok bool
 		err = nil
 		select {
-		case err = <-m.migrationErr:
+		case err, ok = <-m.migrationErr:
+			if !ok {
+				return
+			}
 		case <-time.After(monitorSleepPeriodMS * time.Millisecond):
 		}
 
-		if err != nil && m.migrationFailedWithError == nil {
-			logger.Reason(err).Error("Received a live migration error. Will check the latest migration status.")
-			m.migrationFailedWithError = err
-		} else if m.migrationFailedWithError != nil {
-			logger.Info("Didn't manage to get a job status. Post the received error and finalize.")
-			logger.Reason(m.migrationFailedWithError).Error(liveMigrationFailed)
+		if err != nil {
+			logger.Reason(err).Error(liveMigrationFailed)
 			var abortStatus v1.MigrationAbortStatus
-			if strings.Contains(m.migrationFailedWithError.Error(), "canceled by client") {
+			if strings.Contains(err.Error(), "canceled by client") {
 				abortStatus = v1.MigrationAbortSucceeded
 			}
-			// Improve the error message when the volume migration fails because the destination size is smaller then the source volume
-			if len(vmi.Status.MigratedVolumes) > 0 && strings.Contains(standardizeSpaces(m.migrationFailedWithError.Error()),
+			// Improve the error message when the volume migration fails because the destination size is smaller than the source volume
+			if len(vmi.Status.MigratedVolumes) > 0 && strings.Contains(standardizeSpaces(err.Error()),
 				"has to be smaller or equal to the actual size of the containing file") {
 				m.l.setMigrationResult(true, fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v",
-					m.migrationFailedWithError), abortStatus)
+					err), abortStatus)
 				return
 			}
-			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", m.migrationFailedWithError), abortStatus)
+			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", err), abortStatus)
 			return
 		}
 
-		var jobStats *libvirt.DomainJobInfo
-		jobStats, err = dom.GetJobStats(0)
+		jobStats, err := dom.GetJobStats(0)
 		if err != nil {
-			logger.Reason(err).Info("failed to get domain job info, checking for completed job")
-			jobStats, err = dom.GetJobStats(libvirt.DOMAIN_JOB_STATS_COMPLETED | libvirt.DOMAIN_JOB_STATS_KEEP_COMPLETED)
-			if err != nil {
-				// This could only happen when the domain is gone (successful migration) but there is lock contention in stats retrieval.
-				// In case of a sudden domain crash the migrationErr handling above takes care of it.
-				logger.Reason(err).Warning("failed to get completed job stats, will retry")
-				continue
-			}
+			logger.Reason(err).Info("failed to get domain job info, will retry")
+			continue
 		}
 
 		if jobStats.DataRemainingSet {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -651,10 +651,6 @@ func (m *migrationMonitor) startMonitor() {
 			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
-		case libvirt.DOMAIN_JOB_CANCELLED:
-			logger.Info("Migration was canceled")
-			m.l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)
-			return
 		}
 	}
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -32,6 +32,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -305,11 +306,8 @@ func (l *LibvirtDomainManager) startMigration(vmi *v1.VirtualMachineInstance, op
 
 func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachineInstance, migrationMode v1.MigrationMode) (bool, error) {
 	migrationMetadata, exists := l.metadataCache.Migration.Load()
-	migrationUID := vmi.Status.MigrationState.MigrationUID
-	if vmi.Status.MigrationState.SourceState != nil {
-		migrationUID = vmi.Status.MigrationState.SourceState.MigrationUID
-	}
-	if exists && migrationMetadata.UID == migrationUID {
+	uid := MigrationUID(vmi)
+	if exists && migrationMetadata.UID == uid {
 		if migrationMetadata.EndTimestamp == nil {
 			// don't stop on currently executing migrations
 			return true, nil
@@ -323,7 +321,7 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 
 	now := metav1.Now()
 	m := api.MigrationMetadata{
-		UID:            migrationUID,
+		UID:            uid,
 		StartTimestamp: &now,
 		Mode:           migrationMode,
 	}
@@ -635,10 +633,7 @@ func (m *migrationMonitor) startMonitor() {
 			m.remainingData = jobStats.DataRemaining
 		}
 
-		migrationUID := vmi.Status.MigrationState.MigrationUID
-		if vmi.Status.MigrationState.SourceState != nil {
-			migrationUID = vmi.Status.MigrationState.SourceState.MigrationUID
-		}
+		uid := MigrationUID(vmi)
 		switch jobStats.Type {
 		case libvirt.DOMAIN_JOB_UNBOUNDED:
 			aborted := m.processInflightMigration(dom, jobStats)
@@ -649,10 +644,10 @@ func (m *migrationMonitor) startMonitor() {
 			}
 			logInterval++
 			if logInterval%monitorLogInterval == 0 {
-				logMigrationInfo(logger, string(migrationUID), jobStats)
+				logMigrationInfo(logger, uid, jobStats)
 			}
 		case libvirt.DOMAIN_JOB_COMPLETED:
-			logMigrationInfo(logger, string(migrationUID), jobStats)
+			logMigrationInfo(logger, uid, jobStats)
 			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
@@ -664,8 +659,18 @@ func (m *migrationMonitor) startMonitor() {
 	}
 }
 
+func MigrationUID(vmi *v1.VirtualMachineInstance) types.UID {
+	if s := vmi.Status.MigrationState; s != nil {
+		if s.SourceState != nil {
+			return s.SourceState.MigrationUID
+		}
+		return s.MigrationUID
+	}
+	return ""
+}
+
 // logMigrationInfo logs the same migration info as `virsh -r domjobinfo`
-func logMigrationInfo(logger *log.FilteredLogger, uid string, info *libvirt.DomainJobInfo) {
+func logMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.DomainJobInfo) {
 	bToMiB := func(bytes uint64) uint64 {
 		return bytes / 1024 / 1024
 	}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -457,47 +457,6 @@ func (m *migrationMonitor) isMigrationProgressing() bool {
 	return true
 }
 
-func (m *migrationMonitor) determineNonRunningMigrationStatus(dom cli.VirDomain) *libvirt.DomainJobInfo {
-	logger := log.Log.Object(m.vmi)
-	// check if an ongoing migration has been completed before we could capture the outcome
-	if m.lastProgressUpdate > m.start {
-		logger.Info("Migration job has probably completed before we could capture the status. Getting latest status.")
-		// at this point the migration is over, but we don't know the result.
-		// check if we were trying to cancel this job. In this case, finalize the migration.
-		migration, _ := m.l.metadataCache.Migration.Load()
-		if migration.AbortStatus == string(v1.MigrationAbortInProgress) {
-			logger.Info("Migration job was canceled")
-			return &libvirt.DomainJobInfo{
-				Type:             libvirt.DOMAIN_JOB_CANCELLED,
-				DataRemaining:    m.remainingData,
-				DataRemainingSet: true,
-			}
-		}
-
-		// If the domain is active, it means that the migration has failed.
-		domainState, _, err := dom.GetState()
-		if err != nil {
-			logger.Reason(err).Error("failed to get domain state")
-			if libvirtError, ok := err.(libvirt.Error); ok &&
-				(libvirtError.Code == libvirt.ERR_NO_DOMAIN ||
-					libvirtError.Code == libvirt.ERR_OPERATION_INVALID) {
-				logger.Info("domain is not running on this node")
-				return nil
-			}
-		}
-		if domainState == libvirt.DOMAIN_RUNNING {
-			logger.Info("Migration job failed")
-			return &libvirt.DomainJobInfo{
-				Type:             libvirt.DOMAIN_JOB_FAILED,
-				DataRemaining:    m.remainingData,
-				DataRemainingSet: true,
-			}
-		}
-	}
-	logger.Info("Migration job didn't start yet")
-	return nil
-}
-
 func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *libvirt.DomainJobInfo) *inflightMigrationAborted {
 	logger := log.Log.Object(m.vmi)
 
@@ -610,7 +569,6 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 }
 
 func (m *migrationMonitor) startMonitor() {
-	var completedJobInfo *libvirt.DomainJobInfo
 	vmi := m.vmi
 
 	m.start = time.Now().UTC().UnixNano()
@@ -660,13 +618,10 @@ func (m *migrationMonitor) startMonitor() {
 			return
 		}
 
-		jobStats := completedJobInfo
-		if jobStats == nil {
-			jobStats, err = dom.GetJobStats(0)
-			if err != nil {
-				logger.Reason(err).Warning("failed to get domain job info, will retry")
-				continue
-			}
+		jobStats, err := dom.GetJobStats(0)
+		if err != nil {
+			logger.Reason(err).Warning("failed to get domain job info, will retry")
+			continue
 		}
 
 		if jobStats.DataRemainingSet {
@@ -690,7 +645,7 @@ func (m *migrationMonitor) startMonitor() {
 				logMigrationInfo(logger, string(migrationUID), jobStats)
 			}
 		case libvirt.DOMAIN_JOB_NONE:
-			completedJobInfo = m.determineNonRunningMigrationStatus(dom)
+			logger.Info("Migration job is not active")
 		case libvirt.DOMAIN_JOB_CANCELLED:
 			logger.Info("Migration was canceled")
 			m.l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -371,6 +371,11 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason stri
 		return nil
 	}
 
+	// Improve the error message when the volume migration fails because the destination size is smaller than the source volume
+	if failed && strings.Contains(standardizeSpaces(reason), "has to be smaller or equal to the actual size of the containing file") {
+		reason = fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v", reason)
+	}
+
 	l.metadataCache.Migration.WithSafeBlock(func(migrationMetadata *api.MigrationMetadata, _ bool) {
 		if failed {
 			migrationMetadata.Failed = true
@@ -603,13 +608,6 @@ func (m *migrationMonitor) startMonitor() {
 			var abortStatus v1.MigrationAbortStatus
 			if strings.Contains(err.Error(), "canceled by client") {
 				abortStatus = v1.MigrationAbortSucceeded
-			}
-			// Improve the error message when the volume migration fails because the destination size is smaller than the source volume
-			if len(vmi.Status.MigratedVolumes) > 0 && strings.Contains(standardizeSpaces(err.Error()),
-				"has to be smaller or equal to the actual size of the containing file") {
-				m.l.setMigrationResult(true, fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v",
-					err), abortStatus)
-				return
 			}
 			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", err), abortStatus)
 			return

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -679,13 +679,19 @@ func logMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.D
 		return bytes * 8 / 1000000
 	}
 
+	// For completed jobs, Downtime is the final downtime, DowntimeNet contains the actual network overhead during the cutover
+	downtimeInfo := fmt.Sprintf("ExpectedDowntime:%dms", info.Downtime)
+	if info.DowntimeNetSet && info.DowntimeNet > 0 {
+		downtimeInfo = fmt.Sprintf("Downtime:%dms DowntimeNet:%dms", info.Downtime, info.DowntimeNet)
+	}
+
 	logger.V(2).Info(fmt.Sprintf(`Migration info for %s: TimeElapsed:%dms DataProcessed:%dMiB DataRemaining:%dMiB DataTotal:%dMiB `+
 		`MemoryProcessed:%dMiB MemoryRemaining:%dMiB MemoryTotal:%dMiB MemoryBandwidth:%dMbps DirtyRate:%dMbps `+
-		`Iteration:%d PostcopyRequests:%d ConstantPages:%d NormalPages:%d NormalData:%dMiB ExpectedDowntime:%dms `+
+		`Iteration:%d PostcopyRequests:%d ConstantPages:%d NormalPages:%d NormalData:%dMiB %s `+
 		`DiskMbps:%d`,
 		uid, info.TimeElapsed, bToMiB(info.DataProcessed), bToMiB(info.DataRemaining), bToMiB(info.DataTotal),
 		bToMiB(info.MemProcessed), bToMiB(info.MemRemaining), bToMiB(info.MemTotal), bpsToMbps(info.MemBps), bpsToMbps(info.MemDirtyRate*info.MemPageSize),
-		info.MemIteration, info.MemPostcopyReqs, info.MemConstant, info.MemNormal, bToMiB(info.MemNormalBytes), info.Downtime,
+		info.MemIteration, info.MemPostcopyReqs, info.MemConstant, info.MemNormal, bToMiB(info.MemNormalBytes), downtimeInfo,
 		bpsToMbps(info.DiskBps),
 	))
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -636,11 +636,8 @@ func (m *migrationMonitor) startMonitor() {
 			}
 			logInterval++
 			if logInterval%monitorLogInterval == 0 {
-				logMigrationInfo(logger, uid, jobStats)
+				LogMigrationInfo(logger, uid, jobStats)
 			}
-		case libvirt.DOMAIN_JOB_COMPLETED:
-			logMigrationInfo(logger, uid, jobStats)
-			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
 		}
@@ -657,8 +654,8 @@ func MigrationUID(vmi *v1.VirtualMachineInstance) types.UID {
 	return ""
 }
 
-// logMigrationInfo logs the same migration info as `virsh -r domjobinfo`
-func logMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.DomainJobInfo) {
+// LogMigrationInfo logs the same migration info as `virsh -r domjobinfo`
+func LogMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.DomainJobInfo) {
 	bToMiB := func(bytes uint64) uint64 {
 		return bytes / 1024 / 1024
 	}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -618,10 +618,17 @@ func (m *migrationMonitor) startMonitor() {
 			return
 		}
 
-		jobStats, err := dom.GetJobStats(0)
+		var jobStats *libvirt.DomainJobInfo
+		jobStats, err = dom.GetJobStats(0)
 		if err != nil {
-			logger.Reason(err).Warning("failed to get domain job info, will retry")
-			continue
+			logger.Reason(err).Info("failed to get domain job info, checking for completed job")
+			jobStats, err = dom.GetJobStats(libvirt.DOMAIN_JOB_STATS_COMPLETED | libvirt.DOMAIN_JOB_STATS_KEEP_COMPLETED)
+			if err != nil {
+				// This could only happen when the domain is gone (successful migration) but there is lock contention in stats retrieval.
+				// In case of a sudden domain crash the migrationErr handling above takes care of it.
+				logger.Reason(err).Warning("failed to get completed job stats, will retry")
+				continue
+			}
 		}
 
 		if jobStats.DataRemainingSet {
@@ -644,6 +651,9 @@ func (m *migrationMonitor) startMonitor() {
 			if logInterval%monitorLogInterval == 0 {
 				logMigrationInfo(logger, string(migrationUID), jobStats)
 			}
+		case libvirt.DOMAIN_JOB_COMPLETED:
+			logMigrationInfo(logger, string(migrationUID), jobStats)
+			return
 		case libvirt.DOMAIN_JOB_NONE:
 			logger.Info("Migration job is not active")
 		case libvirt.DOMAIN_JOB_CANCELLED:

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -329,9 +329,12 @@ func getVMIHotplugCount(vmi *v1.VirtualMachineInstance) int {
 
 // The TargetMigrationMonitor is expected to be created and started at the very end of a migration,
 // after the target domain has been resumed.
-// It will poll the current libvirt job on the domain to ensure the migration is really over.
-// This is because a migration isn't truly over even when the target has been resumed.
-// Once no migration job is observed on the domain, the monitor will trigger the notifier.
+// TargetMigrationMonitor polls the current libvirt job on the domain to
+// ensure the migration is really over (a migration isn't truly over even
+// when the target has been resumed). Once no migration job is observed, the
+// monitor sets EndTimestamp in the metadata cache; the cache's notification
+// mechanism then causes the main event loop to send a fresh domain update
+// to virt-handler with the timestamp included.
 // See https://issues.redhat.com/browse/RHEL-117250
 type TargetMigrationMonitor struct {
 	c             cli.Connection
@@ -391,6 +394,13 @@ func (m *TargetMigrationMonitor) StartMonitor() {
 		} else {
 			m.logger.Info("Incoming migration job completed, setting EndTimestamp")
 		}
+		// Only update the metadata cache. WithSafeBlock's notify() will
+		// signal the main event loop (via metadataCache.Listen()), which
+		// builds a fresh domain from live libvirt state + current metadata
+		// and sends it to virt-handler. Sending m.domain directly here
+		// would race: m.domain is a stale snapshot captured at monitor
+		// creation and lacks EndTimestamp, so it can overwrite the correct
+		// domain in virt-handler's store if it arrives last.
 		setEndTimestamp(m.metadataCache)
 	}()
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -338,7 +338,6 @@ type TargetMigrationMonitor struct {
 	c             cli.Connection
 	events        chan watch.Event
 	logger        *log.FilteredLogger
-	vmi           *v1.VirtualMachineInstance
 	domain        *api.Domain
 	metadataCache *metadata.Cache
 	notifier      MigrationEventNotifier
@@ -352,7 +351,6 @@ type MigrationEventNotifier interface {
 func NewTargetMigrationMonitor(
 	c cli.Connection,
 	events chan watch.Event,
-	vmi *v1.VirtualMachineInstance,
 	logger *log.FilteredLogger,
 	domain *api.Domain,
 	metadataCache *metadata.Cache,
@@ -362,7 +360,6 @@ func NewTargetMigrationMonitor(
 		c:             c,
 		events:        events,
 		logger:        logger,
-		vmi:           vmi,
 		domain:        domain,
 		metadataCache: metadataCache,
 		notifier:      notifier}
@@ -373,7 +370,7 @@ var retryDelays = []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Sec
 func (m *TargetMigrationMonitor) StartMonitor() {
 	go func() {
 		var err error
-		domName := api.VMINamespaceKeyFunc(m.vmi)
+		domName := m.domain.Spec.Name
 		for attempt := 0; attempt <= len(retryDelays); attempt++ {
 			err = virtwait.PollImmediately(100*time.Millisecond, 3*time.Second, func(context context.Context) (bool, error) {
 				dom, err := m.c.LookupDomainByName(domName)

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -339,12 +338,6 @@ type TargetMigrationMonitor struct {
 	logger        *log.FilteredLogger
 	domain        *api.Domain
 	metadataCache *metadata.Cache
-	notifier      MigrationEventNotifier
-}
-
-type MigrationEventNotifier interface {
-	SendEvent(event watch.Event) error
-	UpdateEvents(event watch.Event)
 }
 
 func NewTargetMigrationMonitor(
@@ -352,14 +345,13 @@ func NewTargetMigrationMonitor(
 	logger *log.FilteredLogger,
 	domain *api.Domain,
 	metadataCache *metadata.Cache,
-	notifier MigrationEventNotifier,
 ) *TargetMigrationMonitor {
 	return &TargetMigrationMonitor{
 		c:             c,
 		logger:        logger,
 		domain:        domain,
 		metadataCache: metadataCache,
-		notifier:      notifier}
+	}
 }
 
 var retryDelays = []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second}
@@ -400,9 +392,6 @@ func (m *TargetMigrationMonitor) StartMonitor() {
 			m.logger.Info("Incoming migration job completed, setting EndTimestamp")
 		}
 		setEndTimestamp(m.metadataCache)
-		event := watch.Event{Type: watch.Modified, Object: m.domain}
-		m.notifier.SendEvent(event)
-		m.notifier.UpdateEvents(event)
 	}()
 }
 

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -337,6 +337,7 @@ func getVMIHotplugCount(vmi *v1.VirtualMachineInstance) int {
 type TargetMigrationMonitor struct {
 	c             cli.Connection
 	events        chan watch.Event
+	logger        *log.FilteredLogger
 	vmi           *v1.VirtualMachineInstance
 	domain        *api.Domain
 	metadataCache *metadata.Cache
@@ -359,6 +360,7 @@ func NewTargetMigrationMonitor(
 	return &TargetMigrationMonitor{
 		c:             c,
 		events:        events,
+		logger:        log.Log.Object(vmi),
 		vmi:           vmi,
 		domain:        domain,
 		metadataCache: metadataCache,
@@ -380,7 +382,7 @@ func (m *TargetMigrationMonitor) StartMonitor() {
 				defer dom.Free()
 				jobInfo, err := dom.GetJobInfo()
 				if err != nil {
-					log.Log.Object(m.vmi).V(4).Reason(err).Info("Failed to get domain job info")
+					m.logger.V(4).Reason(err).Info("Failed to get domain job info")
 					// This can happen if the current job doesn't support `GetJobInfo()`, let's try again
 					return false, nil
 				}
@@ -388,19 +390,19 @@ func (m *TargetMigrationMonitor) StartMonitor() {
 					// No migration job is currently running
 					return true, nil
 				}
-				log.Log.Object(m.vmi).V(4).Infof("Incoming migration job active (type %d)", jobInfo.Type)
+				m.logger.V(4).Infof("Incoming migration job active (type %d)", jobInfo.Type)
 				return false, nil
 			})
 			if err == nil || attempt == len(retryDelays) {
 				break
 			}
-			log.Log.Object(m.vmi).Info("A migration job is still active, retrying after delay")
+			m.logger.Info("A migration job is still active, retrying after delay")
 			time.Sleep(retryDelays[attempt])
 		}
 		if err != nil {
-			log.Log.Object(m.vmi).Info("Error polling libvirt, setting EndTimestamp anyway to unblock migration")
+			m.logger.Info("Error polling libvirt, setting EndTimestamp anyway to unblock migration")
 		} else {
-			log.Log.Object(m.vmi).Info("Incoming migration job completed, setting EndTimestamp")
+			m.logger.Info("Incoming migration job completed, setting EndTimestamp")
 		}
 		setEndTimestamp(m.metadataCache)
 		event := watch.Event{Type: watch.Modified, Object: m.domain}

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -353,6 +353,7 @@ func NewTargetMigrationMonitor(
 	c cli.Connection,
 	events chan watch.Event,
 	vmi *v1.VirtualMachineInstance,
+	logger *log.FilteredLogger,
 	domain *api.Domain,
 	metadataCache *metadata.Cache,
 	notifier MigrationEventNotifier,
@@ -360,7 +361,7 @@ func NewTargetMigrationMonitor(
 	return &TargetMigrationMonitor{
 		c:             c,
 		events:        events,
-		logger:        log.Log.Object(vmi),
+		logger:        logger,
 		vmi:           vmi,
 		domain:        domain,
 		metadataCache: metadataCache,

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -336,7 +336,6 @@ func getVMIHotplugCount(vmi *v1.VirtualMachineInstance) int {
 // See https://issues.redhat.com/browse/RHEL-117250
 type TargetMigrationMonitor struct {
 	c             cli.Connection
-	events        chan watch.Event
 	logger        *log.FilteredLogger
 	domain        *api.Domain
 	metadataCache *metadata.Cache
@@ -350,7 +349,6 @@ type MigrationEventNotifier interface {
 
 func NewTargetMigrationMonitor(
 	c cli.Connection,
-	events chan watch.Event,
 	logger *log.FilteredLogger,
 	domain *api.Domain,
 	metadataCache *metadata.Cache,
@@ -358,7 +356,6 @@ func NewTargetMigrationMonitor(
 ) *TargetMigrationMonitor {
 	return &TargetMigrationMonitor{
 		c:             c,
-		events:        events,
 		logger:        logger,
 		domain:        domain,
 		metadataCache: metadataCache,

--- a/pkg/virt-launcher/virtwrap/live-migration-target_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"k8s.io/apimachinery/pkg/watch"
 	api2 "kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/log"
 	"libvirt.org/go/libvirt"
@@ -37,16 +36,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/testing"
 )
-
-type eventNotifier struct {
-}
-
-func (e eventNotifier) SendEvent(_ watch.Event) error {
-	return nil
-}
-
-func (e eventNotifier) UpdateEvents(_ watch.Event) {
-}
 
 var _ = Describe("client", func() {
 	var shareDir string
@@ -77,8 +66,7 @@ var _ = Describe("client", func() {
 		vmi := api2.NewMinimalVMI("fake-vmi")
 		domain := api.NewMinimalDomain("test")
 		metadataCache := metadata.NewCache()
-		notifier := &eventNotifier{}
-		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, log.Log.Object(vmi), domain, metadataCache)
 		monitor.StartMonitor()
 
 		By("Ensuring that nothing gets added to the metadata cache as long as the migration is running")

--- a/pkg/virt-launcher/virtwrap/live-migration-target_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target_test.go
@@ -79,7 +79,7 @@ var _ = Describe("client", func() {
 		domain := api.NewMinimalDomain("test")
 		metadataCache := metadata.NewCache()
 		notifier := &eventNotifier{}
-		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 
 		By("Ensuring that nothing gets added to the metadata cache as long as the migration is running")

--- a/pkg/virt-launcher/virtwrap/live-migration-target_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target_test.go
@@ -74,12 +74,11 @@ var _ = Describe("client", func() {
 			}, domainJobError
 		}).AnyTimes()
 		mockLibvirt.DomainEXPECT().Free().Return(nil).AnyTimes()
-		eventChan := make(chan watch.Event, 100)
 		vmi := api2.NewMinimalVMI("fake-vmi")
 		domain := api.NewMinimalDomain("test")
 		metadataCache := metadata.NewCache()
 		notifier := &eventNotifier{}
-		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, log.Log.Object(vmi), domain, metadataCache, notifier)
+		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 
 		By("Ensuring that nothing gets added to the metadata cache as long as the migration is running")

--- a/pkg/virt-launcher/virtwrap/live-migration-target_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/watch"
 	api2 "kubevirt.io/client-go/api"
+	"kubevirt.io/client-go/log"
 	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
@@ -78,7 +79,7 @@ var _ = Describe("client", func() {
 		domain := api.NewMinimalDomain("test")
 		metadataCache := metadata.NewCache()
 		notifier := &eventNotifier{}
-		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, vmi, domain, metadataCache, notifier)
+		monitor := NewTargetMigrationMonitor(mockLibvirt.VirtConnection, eventChan, vmi, log.Log.Object(vmi), domain, metadataCache, notifier)
 		monitor.StartMonitor()
 
 		By("Ensuring that nothing gets added to the metadata cache as long as the migration is running")

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1825,15 +1825,13 @@ var _ = Describe("Manager", func() {
 		})
 		It("migration should switch to PostCopy", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a completed event otherwise this
+				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
-					}
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{}
 				}
 
 				migrationData -= 125
@@ -1876,15 +1874,13 @@ var _ = Describe("Manager", func() {
 
 		It("migration should switch to PostCopy eventually", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a completed event otherwise this
+				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
-					}
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{}
 				}
 
 				migrationData -= 125
@@ -1940,15 +1936,13 @@ var _ = Describe("Manager", func() {
 		})
 		It("migration should switch to Paused if AllowWorkloadDisruption is allowed and PostCopy is not", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a completed event otherwise this
+				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_COMPLETED,
-					}
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{}
 				}
 
 				migrationData -= 125
@@ -2133,14 +2127,11 @@ var _ = Describe("Manager", func() {
 			}
 
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			gomock.InOrder(
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
-					func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
-						migrationErrorChan <- fmt.Errorf("operation aborted: canceled by client")
-						return fake_jobinfo_running, nil
-					},
-				),
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil),
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
+				func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
+					migrationErrorChan <- fmt.Errorf("operation aborted: canceled by client")
+					return fake_jobinfo_running, nil
+				},
 			)
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
@@ -2149,6 +2140,51 @@ var _ = Describe("Manager", func() {
 				migration, _ := metadataCache.Migration.Load()
 				return migration.AbortStatus
 			}, 5*time.Second, 2).Should(Equal(string(v1.MigrationAbortSucceeded)))
+		})
+
+		It("monitor should exit when migration error channel is closed", func() {
+			migrationErrorChan := make(chan error)
+
+			options := &cmdclient.MigrationOptions{
+				Bandwidth:               resource.MustParse("64Mi"),
+				ProgressTimeout:         3,
+				CompletionTimeoutPerGiB: 150,
+			}
+			vmi := newVMI(testNamespace, testVmName)
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID: "111222333",
+			}
+
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.UID = vmi.Status.MigrationState.MigrationUID
+			metadataCache.Migration.Store(migrationMetadata)
+
+			manager := &LibvirtDomainManager{
+				virConn:       mockLibvirt.VirtConnection,
+				virtShareDir:  testVirtShareDir,
+				metadataCache: metadataCache,
+				cpuSetGetter:  fakeCpuSetGetter,
+			}
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
+				func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
+					close(migrationErrorChan)
+					return &libvirt.DomainJobInfo{
+						Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+						DataRemainingSet: true,
+						DataRemaining:    uint64(32479827777),
+					}, nil
+				},
+			)
+
+			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			done := make(chan struct{})
+			go func() {
+				monitor.startMonitor()
+				close(done)
+			}()
+			Eventually(done, 5*time.Second).Should(BeClosed())
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2099,15 +2099,8 @@ var _ = Describe("Manager", func() {
 			manager, _ := newLibvirtDomainManagerDefault()
 			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
 		})
-		It("migration cancellation should be finilized even if we missed status update", func() {
-			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
-			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_NONE,
-					DataRemaining: uint64(0),
-				}
-			}()
+		It("migration cancellation should be finalized even if we missed status update", func() {
+			migrationErrorChan := make(chan error, 1)
 			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
 					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
@@ -2139,11 +2132,9 @@ var _ = Describe("Manager", func() {
 			}
 
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
-			gomock.InOrder(
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil),
-				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo, nil),
-			)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil)
+
+			migrationErrorChan <- fmt.Errorf("operation canceled by client")
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1828,11 +1828,11 @@ var _ = Describe("Manager", func() {
 			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a different event otherwise this
+				// stop decreasing data and send a completed event otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_CANCELLED,
+						Type: libvirt.DOMAIN_JOB_COMPLETED,
 					}
 				}
 
@@ -1879,11 +1879,11 @@ var _ = Describe("Manager", func() {
 			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a different event otherwise this
+				// stop decreasing data and send a completed event otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_CANCELLED,
+						Type: libvirt.DOMAIN_JOB_COMPLETED,
 					}
 				}
 
@@ -1943,11 +1943,11 @@ var _ = Describe("Manager", func() {
 			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
-				// stop decreasing data and send a different event otherwise this
+				// stop decreasing data and send a completed event otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
 					return &libvirt.DomainJobInfo{
-						Type: libvirt.DOMAIN_JOB_CANCELLED,
+						Type: libvirt.DOMAIN_JOB_COMPLETED,
 					}
 				}
 
@@ -2101,6 +2101,7 @@ var _ = Describe("Manager", func() {
 		})
 		It("migration cancellation should be finalized even if we missed status update", func() {
 			migrationErrorChan := make(chan error, 1)
+			defer close(migrationErrorChan)
 			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
 					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
@@ -2132,9 +2133,15 @@ var _ = Describe("Manager", func() {
 			}
 
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil)
-
-			migrationErrorChan <- fmt.Errorf("operation canceled by client")
+			gomock.InOrder(
+				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
+					func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
+						migrationErrorChan <- fmt.Errorf("operation aborted: canceled by client")
+						return fake_jobinfo_running, nil
+					},
+				),
+				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).Return(fake_jobinfo_running, nil),
+			)
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


### What this PR does
#### Before this PR:
The TargetMigrationMonitor goroutine sent m.domain to virt-handler after setting EndTimestamp in the metadata cache. However, m.domain was a stale snapshot captured at monitor creation (before setEndTimestamp), so it lacked EndTimestamp. This stale domain could arrive at virt-handler after a correct domain (sent by the main event loop with fresh metadata), overwriting it in the informer store. virt-handler then never saw EndTimestamp, never called ackMigrationCompletion, and the migration hung until the 300s domain resync — well past test timeouts.

#### After this PR:
The monitor only updates the metadata cache. setEndTimestamp's WithSafeBlock triggers notify(), which wakes the main event loop's metadataCache.Listen() case. That path builds a fresh domain from live libvirt state and current metadata, so the domain sent to virt-handler always includes EndTimestamp. No stale domain is ever sent.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- should resolve https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17539/pull-kubevirt-e2e-k8s-1.35-sig-compute/2047263703828533248
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The metadataCache notification mechanism already ensures virt-handler receives a domain with EndTimestamp. The explicit SendEvent from the monitor was redundant and introduced a race where Go's sync.Mutex and goroutine scheduling non-determinism could cause the stale send to arrive last, silently overwriting the correct domain in virt-handler's last-write-wins store.

The following alternatives were considered:

Reloading metadata into m.domain before sending — fixes the immediate staleness but doesn't address potential Spec staleness from other fields, and remains redundant with the cache notification.
Adding a dedicated "EndTimestamp-only" notification — unnecessary complexity given the existing mechanism works correctly.

### Special notes for your reviewer
The race was diagnosed from a CI failure where the target virt-handler repeatedly processed the VMI with Domain status: Running, reason: Unknown but never saw EndTimestamp in the domain store, despite the target virt-launcher having logged Incoming migration job completed, setting EndTimestamp.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```NONE

```
