### PR TITLE
Fix ControllerRevision name and label overflow for long instancetype names

### DIFF
--- a/pkg/apimachinery/BUILD.bazel
+++ b/pkg/apimachinery/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,4 +6,20 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/apimachinery",
     visibility = ["//visibility:public"],
     deps = ["//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "apimachinery_suite_test.go",
+        "labels_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
+    ],
 )

--- a/pkg/apimachinery/apimachinery_suite_test.go
+++ b/pkg/apimachinery/apimachinery_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package apimachinery_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestApimachinery(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/apimachinery/labels.go
+++ b/pkg/apimachinery/labels.go
@@ -21,28 +21,35 @@ package apimachinery
 
 import (
 	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
+	"hash"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-// CalculateVirtualMachineInstanceID calculates a stable and unique identifier for a VMI based on its name attribute.
-// For VMI names longer than 63 characters, the name is a truncated and hashed to ensure uniqueness.
-func CalculateVirtualMachineInstanceID(vmiName string) string {
-	if len(vmiName) <= validation.DNS1035LabelMaxLength {
-		return vmiName
+const truncateHashLength = 8
+
+func truncateWithHasher(value string, maxLength int, hasher hash.Hash) string {
+	if len(value) <= maxLength {
+		return value
 	}
+	hasher.Write([]byte(value))
+	h := fmt.Sprintf("%x", hasher.Sum(nil))
+	return fmt.Sprintf("%s-%s", value[:maxLength-truncateHashLength-1], h[:truncateHashLength])
+}
 
-	const (
-		hashLength             = 8
-		vmiNamePrefixMaxLength = validation.DNS1035LabelMaxLength - hashLength - 1
-	)
+func TruncateWithHash(value string, maxLength int) string {
+	return truncateWithHasher(value, maxLength, sha256.New())
+}
 
-	truncatedVMIName := vmiName[:vmiNamePrefixMaxLength]
+func TruncateLabelValue(value string) string {
+	return TruncateWithHash(value, validation.LabelValueMaxLength)
+}
 
-	hasher := sha1.New()
-	hasher.Write([]byte(vmiName))
-	vmiNameHash := fmt.Sprintf("%x", hasher.Sum(nil))
-
-	return fmt.Sprintf("%s-%s", truncatedVMIName, vmiNameHash[:hashLength])
+// CalculateVirtualMachineInstanceID calculates a stable and unique identifier for a VMI based on its name attribute.
+// For VMI names longer than 63 characters, the name is truncated and hashed to ensure uniqueness.
+// This uses SHA1 for backward compatibility with existing pod labels (shipped in v1.7.0).
+func CalculateVirtualMachineInstanceID(vmiName string) string {
+	return truncateWithHasher(vmiName, validation.DNS1035LabelMaxLength, sha1.New())
 }

--- a/pkg/apimachinery/labels_test.go
+++ b/pkg/apimachinery/labels_test.go
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package apimachinery_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery"
+)
+
+var _ = Describe("TruncateWithHash", func() {
+	It("should return value unchanged when within limit", func() {
+		Expect(apimachinery.TruncateWithHash("short-name", 253)).To(Equal("short-name"))
+	})
+
+	It("should return value unchanged when exactly at limit", func() {
+		value := rand.String(253)
+		Expect(apimachinery.TruncateWithHash(value, 253)).To(Equal(value))
+	})
+
+	It("should truncate and hash when exceeding limit", func() {
+		value := rand.String(300)
+		result := apimachinery.TruncateWithHash(value, 253)
+		Expect(result).To(HaveLen(253))
+	})
+
+	It("should be deterministic", func() {
+		value := rand.String(300)
+		Expect(apimachinery.TruncateWithHash(value, 253)).To(Equal(apimachinery.TruncateWithHash(value, 253)))
+	})
+
+	It("should produce different results for different inputs", func() {
+		value1 := rand.String(300)
+		value2 := rand.String(300)
+		Expect(apimachinery.TruncateWithHash(value1, 253)).ToNot(Equal(apimachinery.TruncateWithHash(value2, 253)))
+	})
+})
+
+var _ = Describe("TruncateLabelValue", func() {
+	It("should return value unchanged when within 63 chars", func() {
+		Expect(apimachinery.TruncateLabelValue("short")).To(Equal("short"))
+	})
+
+	It("should truncate when exceeding 63 chars", func() {
+		value := rand.String(100)
+		Expect(apimachinery.TruncateLabelValue(value)).To(HaveLen(validation.LabelValueMaxLength))
+	})
+})

--- a/pkg/instancetype/find/BUILD.bazel
+++ b/pkg/instancetype/find/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/instancetype/find",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery:go_default_library",
         "//pkg/instancetype/compatibility:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/pkg/instancetype/find/revision.go
+++ b/pkg/instancetype/find/revision.go
@@ -26,6 +26,8 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery"
 )
 
 type revisionFinder struct {
@@ -56,7 +58,8 @@ func (f *revisionFinder) Find(vm *virtv1.VirtualMachine) (*appsv1.ControllerRevi
 			return nil, err
 		}
 		// Only return the found CR if it is for the referenced instance type
-		if label, ok := cr.Labels[instancetypeapi.ControllerRevisionObjectNameLabel]; ok && label == vm.Spec.Instancetype.Name {
+		label, ok := cr.Labels[instancetypeapi.ControllerRevisionObjectNameLabel]
+		if ok && label == apimachinery.TruncateLabelValue(vm.Spec.Instancetype.Name) {
 			return cr, nil
 		}
 	}

--- a/pkg/instancetype/preference/find/BUILD.bazel
+++ b/pkg/instancetype/preference/find/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/instancetype/preference/find",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery:go_default_library",
         "//pkg/instancetype/compatibility:go_default_library",
         "//pkg/instancetype/find:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/instancetype/preference/find/revision.go
+++ b/pkg/instancetype/preference/find/revision.go
@@ -27,6 +27,7 @@ import (
 	instancetypeapi "kubevirt.io/api/instancetype"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery"
 	"kubevirt.io/kubevirt/pkg/instancetype/find"
 )
 
@@ -62,7 +63,8 @@ func (f *revisionFinder) FindPreference(vm *virtv1.VirtualMachine) (*appsv1.Cont
 			return nil, err
 		}
 		// Only return the found CR if it is for the referenced instance type
-		if label, ok := cr.Labels[instancetypeapi.ControllerRevisionObjectNameLabel]; ok && label == vm.Spec.Preference.Name {
+		label, ok := cr.Labels[instancetypeapi.ControllerRevisionObjectNameLabel]
+		if ok && label == apimachinery.TruncateLabelValue(vm.Spec.Preference.Name) {
 			return cr, nil
 		}
 	}

--- a/pkg/instancetype/revision/BUILD.bazel
+++ b/pkg/instancetype/revision/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/instancetype/revision",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery:go_default_library",
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/instancetype/apply:go_default_library",
         "//pkg/instancetype/compatibility:go_default_library",
@@ -30,6 +31,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
@@ -44,6 +46,7 @@ go_test(
     race = "on",
     deps = [
         ":go_default_library",
+        "//pkg/apimachinery:go_default_library",
         "//pkg/instancetype/conflict:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
@@ -61,6 +64,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/instancetype/revision/store.go
+++ b/pkg/instancetype/revision/store.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -38,6 +39,7 @@ import (
 
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery"
 	"kubevirt.io/kubevirt/pkg/instancetype/apply"
 	"kubevirt.io/kubevirt/pkg/instancetype/find"
 	preferenceFind "kubevirt.io/kubevirt/pkg/instancetype/preference/find"
@@ -241,7 +243,8 @@ func (h *revisionHandler) createPreferenceRevision(vm *virtv1.VirtualMachine) (*
 }
 
 func GenerateName(vmName, resourceName, resourceVersion string, resourceUID types.UID, resourceGeneration int64) string {
-	return fmt.Sprintf("%s-%s-%s-%s-%d", vmName, resourceName, resourceVersion, resourceUID, resourceGeneration)
+	fullName := fmt.Sprintf("%s-%s-%s-%s-%d", vmName, resourceName, resourceVersion, resourceUID, resourceGeneration)
+	return apimachinery.TruncateWithHash(fullName, validation.DNS1123SubdomainMaxLength)
 }
 
 func CreateControllerRevision(vm *virtv1.VirtualMachine, object runtime.Object) (*appsv1.ControllerRevision, error) {
@@ -276,7 +279,7 @@ func CreateControllerRevision(vm *virtv1.VirtualMachine, object runtime.Object) 
 			Labels: map[string]string{
 				api.ControllerRevisionObjectGenerationLabel: fmt.Sprintf("%d", metaObj.GetGeneration()),
 				api.ControllerRevisionObjectKindLabel:       obj.GetObjectKind().GroupVersionKind().Kind,
-				api.ControllerRevisionObjectNameLabel:       metaObj.GetName(),
+				api.ControllerRevisionObjectNameLabel:       apimachinery.TruncateLabelValue(metaObj.GetName()),
 				api.ControllerRevisionObjectUIDLabel:        string(metaObj.GetUID()),
 				api.ControllerRevisionObjectVersionLabel:    obj.GetObjectKind().GroupVersionKind().Version,
 			},

--- a/pkg/instancetype/revision/store_test.go
+++ b/pkg/instancetype/revision/store_test.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
@@ -40,8 +42,10 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	fakeclientset "kubevirt.io/client-go/kubevirt/fake"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery"
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 	"kubevirt.io/kubevirt/pkg/instancetype/revision"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
@@ -675,6 +679,65 @@ var _ = Describe("Instancetype and Preferences revision handler", func() {
 
 				Expect(storeHandler.Store(vm)).To(MatchError(ContainSubstring("found existing ControllerRevision with unexpected data")))
 			})
+		})
+	})
+
+	Context("GenerateName", func() {
+		It("should return unchanged name when within DNS subdomain limit", func() {
+			name := revision.GenerateName("vm", "instancetype", "v1beta1", "uid-1234", 1)
+			Expect(name).To(Equal("vm-instancetype-v1beta1-uid-1234-1"))
+		})
+
+		It("should truncate and hash when name exceeds DNS subdomain limit", func() {
+			longResourceName := rand.String(253)
+			name := revision.GenerateName("vm", longResourceName, "v1beta1", resourceUID, resourceGeneration)
+			Expect(name).To(HaveLen(validation.DNS1123SubdomainMaxLength))
+		})
+
+		It("should be deterministic", func() {
+			longResourceName := rand.String(253)
+			name1 := revision.GenerateName("vm", longResourceName, "v1beta1", resourceUID, resourceGeneration)
+			name2 := revision.GenerateName("vm", longResourceName, "v1beta1", resourceUID, resourceGeneration)
+			Expect(name1).To(Equal(name2))
+		})
+
+		It("should produce different names for different inputs", func() {
+			longResourceName1 := rand.String(253)
+			longResourceName2 := rand.String(253)
+			name1 := revision.GenerateName("vm", longResourceName1, "v1beta1", resourceUID, resourceGeneration)
+			name2 := revision.GenerateName("vm", longResourceName2, "v1beta1", resourceUID, resourceGeneration)
+			Expect(name1).ToNot(Equal(name2))
+		})
+	})
+
+	Context("CreateControllerRevision with long names", func() {
+		It("should truncate label value for long cluster instancetype names", func() {
+			longName := rand.String(100)
+			clusterInstancetype := &instancetypev1beta1.VirtualMachineClusterInstancetype{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiinstancetype.ClusterSingularResourceName,
+					APIVersion: instancetypev1beta1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       longName,
+					UID:        resourceUID,
+					Generation: resourceGeneration,
+				},
+				Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
+					CPU: instancetypev1beta1.CPUInstancetype{
+						Guest: uint32(2),
+					},
+				},
+			}
+			vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault)))
+
+			cr, err := revision.CreateControllerRevision(vm, clusterInstancetype)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(cr.Name)).To(BeNumerically("<=", validation.DNS1123SubdomainMaxLength))
+			labelValue := cr.Labels[apiinstancetype.ControllerRevisionObjectNameLabel]
+			Expect(len(labelValue)).To(BeNumerically("<=", validation.LabelValueMaxLength))
+			Expect(labelValue).To(Equal(apimachinery.TruncateLabelValue(longName)))
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`GenerateName()` in `pkg/instancetype/revision/store.go` builds ControllerRevision names by concatenating `{vmName}-{resourceName}-{resourceVersion}-{resourceUID}-{resourceGeneration}` with no length check. This can produce names exceeding the 253-character DNS subdomain limit when using cluster-scoped instancetype or preference resources with long names (up to 253 chars each), causing `ControllerRevisions.Create()` to fail and leaving the VM stuck.

Additionally, `ControllerRevisionObjectNameLabel` stores the resource name directly as a label value, which has a 63-character limit — also failing for long cluster-scoped resource names.

#### After this PR:

Both the ControllerRevision name and label value are truncated with an 8-character SHA256 hash suffix when they exceed their respective limits. Values within limits are returned unchanged, preserving backward compatibility with existing deployments.

### Why we need it and why it was done in this way
The following tradeoffs were made:
- The `TruncateWithHash` and `TruncateLabelValue` helpers are added to the existing `pkg/apimachinery` package alongside the similar `CalculateVirtualMachineInstanceID` function, consolidating truncation logic in one place.
- The truncation approach (prefix + hash suffix) follows the existing pattern already used by `CalculateVirtualMachineInstanceID`.

The following alternatives were considered:
- A separate `pkg/instancetype/naming` package — rejected per reviewer feedback to avoid another package that duplicates existing functionality.
- Moving the name label to an annotation for long values — rejected in favor of a simpler truncate+hash approach that keeps the same code path for all name lengths.
- Refactoring `CalculateVirtualMachineInstanceID` to use `TruncateWithHash` — not done because it uses SHA1 and changing the hash algorithm would break existing service selectors.

### Special notes for your reviewer

The generated name is treated as an opaque identifier throughout the codebase — no code parses or reconstructs it from components. The `ControllerRevisionObjectNameLabel` is only read after fetching the CR by name (not used in label selectors), so the truncated comparison is safe.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit tests added for `GenerateName`, `TruncateWithHash`, `TruncateLabelValue`, and `CreateControllerRevision` with long names
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Fix ControllerRevision name and label value overflow when using cluster-scoped instancetype or preference resources with long names, which could cause VM creation to fail.
```