### PR TITLE
clean up of source-side live migration monitor and abort handling

### DIFF
--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -13,8 +13,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-const CancelMigrationFailedVmiNotMigratingErr = "failed to cancel migration - vmi is not migrating"
-
 const (
 	QueuePriorityRunning           int = 1000
 	QueuePrioritySystemCritical    int = 100

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1321,7 +1321,7 @@ func (c *Controller) updateTargetMemoryOverheadFromPod(vmi *virtv1.VirtualMachin
 func (c *Controller) markMigrationAbortInVmiStatus(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
 
 	if vmi.Status.MigrationState == nil {
-		return fmt.Errorf("migration state is nil when trying to mark migratio abortion in vmi status")
+		return fmt.Errorf("migration state is nil when trying to mark migration abortion in vmi status")
 	}
 
 	vmiCopy := vmi.DeepCopy()

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -200,14 +200,11 @@ func (c *MigrationSourceController) setMigrationProgressStatus(vmi *v1.VirtualMa
 	vmi.Status.MigrationState.Failed = migrationMetadata.Failed
 
 	if migrationMetadata.Failed {
+		vmi.Status.MigrationState.Completed = true
 		vmi.Status.MigrationState.EndTimestamp = migrationMetadata.EndTimestamp
+		vmi.Status.MigrationState.AbortStatus = v1.MigrationAbortStatus(migrationMetadata.AbortStatus)
 		vmi.Status.MigrationState.FailureReason = migrationMetadata.FailureReason
 		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("VirtualMachineInstance migration uid %s failed. reason:%s", string(migrationMetadata.UID), migrationMetadata.FailureReason))
-	}
-
-	vmi.Status.MigrationState.AbortStatus = v1.MigrationAbortStatus(migrationMetadata.AbortStatus)
-	if migrationMetadata.AbortStatus == string(v1.MigrationAbortSucceeded) {
-		vmi.Status.MigrationState.EndTimestamp = migrationMetadata.EndTimestamp
 	}
 
 	vmi.Status.MigrationState.Mode = migrationMetadata.Mode

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -488,7 +488,7 @@ func (c *MigrationSourceController) migrateVMI(vmi *v1.VirtualMachineInstance, d
 	}
 
 	if vmi.Status.MigrationState.AbortRequested {
-		err = c.handleMigrationAbort(vmi, client)
+		err = c.handleMigrationAbort(vmi, domain, client)
 		return err
 	}
 
@@ -616,8 +616,17 @@ func (c *MigrationSourceController) updateDomainFunc(_, new interface{}) {
 	}
 }
 
-func (c *MigrationSourceController) handleMigrationAbort(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
-	if vmi.Status.MigrationState.AbortStatus == v1.MigrationAbortInProgress || vmi.Status.MigrationState.AbortStatus == v1.MigrationAbortSucceeded {
+func (c *MigrationSourceController) handleMigrationAbort(vmi *v1.VirtualMachineInstance, domain *api.Domain, client cmdclient.LauncherClient) error {
+	// Check both the VMI status and the domain metadata to avoid redundant cancel RPCs.
+	// The domain metadata reflects the launcher's abort status before the API server round-trip.
+	abortHandled := func(status v1.MigrationAbortStatus) bool {
+		return status == v1.MigrationAbortInProgress || status == v1.MigrationAbortSucceeded
+	}
+	if abortHandled(vmi.Status.MigrationState.AbortStatus) {
+		return nil
+	}
+	if domain != nil && domain.Spec.Metadata.KubeVirt.Migration != nil &&
+		abortHandled(v1.MigrationAbortStatus(domain.Spec.Metadata.KubeVirt.Migration.AbortStatus)) {
 		return nil
 	}
 

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -43,7 +43,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/hypervisor"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/vmisync"
 	"kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/util/migrations"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
@@ -623,10 +622,6 @@ func (c *MigrationSourceController) handleMigrationAbort(vmi *v1.VirtualMachineI
 	}
 
 	if err := client.CancelVirtualMachineMigration(vmi); err != nil {
-		if err.Error() == migrations.CancelMigrationFailedVmiNotMigratingErr {
-			// If migration did not even start there is no need to cancel it
-			c.logger.Object(vmi).Infof("skipping migration cancellation since vmi is not migrating")
-		}
 		return err
 	}
 

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -384,42 +384,72 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 	})
 
 	Context("handleMigrationAbort", func() {
-		DescribeTable("should abort the migration with an abort request", func(vmi *v1.VirtualMachineInstance) {
+		DescribeTable("should abort the migration with an abort request", func(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 			client.EXPECT().CancelVirtualMachineMigration(vmi)
-			Expect(controller.handleMigrationAbort(vmi, client)).To(Succeed())
+			Expect(controller.handleMigrationAbort(vmi, domain, client)).To(Succeed())
 			testutils.ExpectEvent(recorder, VMIAbortingMigration)
 		},
-			Entry("when the request failed", libvmi.New(libvmi.WithUID(vmiTestUUID),
+			Entry("when the previous abort attempt failed", libvmi.New(libvmi.WithUID(vmiTestUUID),
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
 						AbortRequested: true,
 						AbortStatus:    v1.MigrationAbortFailed,
 					})))),
+				nil,
 			),
-			Entry("when the request the abort status isn't set", libvmi.New(libvmi.WithUID(vmiTestUUID),
+			Entry("when the abort status isn't set", libvmi.New(libvmi.WithUID(vmiTestUUID),
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
 						AbortRequested: true,
 					})))),
+				nil,
+			),
+			Entry("when abort status is empty in both VMI and domain metadata", libvmi.New(libvmi.WithUID(vmiTestUUID),
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+						AbortRequested: true,
+					})))),
+				&api.Domain{Spec: api.DomainSpec{Metadata: api.Metadata{KubeVirt: api.KubeVirtMetadata{
+					Migration: &api.MigrationMetadata{AbortStatus: ""},
+				}}}},
 			),
 		)
-		DescribeTable("should do nothing", func(vmi *v1.VirtualMachineInstance) {
-
-			Expect(controller.handleMigrationAbort(vmi, client)).To(Succeed())
+		DescribeTable("should do nothing", func(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+			Expect(controller.handleMigrationAbort(vmi, domain, client)).To(Succeed())
 		},
-			Entry("when the request succeeded", libvmi.New(libvmi.WithUID(vmiTestUUID),
+			Entry("when VMI abort status is InProgress", libvmi.New(libvmi.WithUID(vmiTestUUID),
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
 						AbortRequested: true,
 						AbortStatus:    v1.MigrationAbortInProgress,
 					})))),
+				nil,
 			),
-			Entry("when the request is in progress", libvmi.New(libvmi.WithUID(vmiTestUUID),
+			Entry("when VMI abort status is Succeeded", libvmi.New(libvmi.WithUID(vmiTestUUID),
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
 						AbortRequested: true,
 						AbortStatus:    v1.MigrationAbortSucceeded,
 					})))),
+				nil,
+			),
+			Entry("when domain metadata has AbortInProgress", libvmi.New(libvmi.WithUID(vmiTestUUID),
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+						AbortRequested: true,
+					})))),
+				&api.Domain{Spec: api.DomainSpec{Metadata: api.Metadata{KubeVirt: api.KubeVirtMetadata{
+					Migration: &api.MigrationMetadata{AbortStatus: string(v1.MigrationAbortInProgress)},
+				}}}},
+			),
+			Entry("when domain metadata has AbortSucceeded", libvmi.New(libvmi.WithUID(vmiTestUUID),
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+						AbortRequested: true,
+					})))),
+				&api.Domain{Spec: api.DomainSpec{Metadata: api.Metadata{KubeVirt: api.KubeVirtMetadata{
+					Migration: &api.MigrationMetadata{AbortStatus: string(v1.MigrationAbortSucceeded)},
+				}}}},
 			),
 		)
 
@@ -431,7 +461,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 						AbortRequested: true,
 					}))))
 			client.EXPECT().CancelVirtualMachineMigration(vmi).Return(fmt.Errorf(errMsg))
-			Expect(controller.handleMigrationAbort(vmi, client)).To(MatchError(errMsg))
+			Expect(controller.handleMigrationAbort(vmi, nil, client)).To(MatchError(errMsg))
 		})
 
 		It("should abort vmi migration vmi when migration object indicates deletion", func() {

--- a/pkg/virt-launcher/notify-client/BUILD.bazel
+++ b/pkg/virt-launcher/notify-client/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/reference:go_default_library",

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -13,7 +13,6 @@ import (
 
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"libvirt.org/go/libvirt"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -717,11 +716,11 @@ func (n *Notifier) Close() {
 func processJobCompletedEvent(domain *api.Domain, d cli.VirDomain, jobCompletedEvent *libvirt.DomainEventJobCompleted, metadataCache *metadata.Cache) bool {
 	switch jobCompletedEvent.Info.Operation {
 	case libvirt.DOMAIN_JOB_OPERATION_MIGRATION_OUT:
-		var uid types.UID
 		if migration, exists := metadataCache.Migration.Load(); exists {
-			uid = migration.UID
+			virtwrap.LogMigrationInfo(log.Log, migration.UID, &jobCompletedEvent.Info)
+		} else {
+			log.Log.Warning("Received migration completed event, but no migration is being tracked")
 		}
-		virtwrap.LogMigrationInfo(log.Log, uid, &jobCompletedEvent.Info)
 		return false
 	case libvirt.DOMAIN_JOB_OPERATION_BACKUP:
 		storage.HandleBackupJobCompletedEvent(d, jobCompletedEvent, metadataCache)

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -43,7 +43,6 @@ go_library(
         "//pkg/unsafepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
-        "//pkg/util/migrations:go_default_library",
         "//pkg/util/net/ip:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -128,7 +128,6 @@ go_test(
         "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
         "//pkg/virt-launcher/virtwrap/disksource:go_default_library",
         "//pkg/virt-launcher/virtwrap/efi:go_default_library",
-        "//pkg/virt-launcher/virtwrap/errors:go_default_library",
         "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/testing:go_default_library",

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -379,9 +379,13 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason stri
 		return nil
 	}
 
-	// Improve the error message when the volume migration fails because the destination size is smaller than the source volume
-	if failed && strings.Contains(standardizeSpaces(reason), "has to be smaller or equal to the actual size of the containing file") {
-		reason = fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v", reason)
+	if failed {
+		switch {
+		case strings.Contains(reason, "canceled by client"):
+			reason = "Live migration has been aborted"
+		case strings.Contains(standardizeSpaces(reason), "has to be smaller or equal to the actual size of the containing file"):
+			reason = fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v", reason)
+		}
 	}
 
 	l.metadataCache.Migration.WithSafeBlock(func(migrationMetadata *api.MigrationMetadata, _ bool) {
@@ -683,7 +687,7 @@ func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstanc
 				l.setMigrationAbortStatus(v1.MigrationAbortFailed)
 				return
 			}
-			l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)
+			l.setMigrationAbortStatus(v1.MigrationAbortSucceeded)
 			log.Log.Object(vmi).Info("Live migration abort succeeded")
 		} else {
 			log.Log.Object(vmi).Infof("migration job is not active (type=%d), nothing to abort", jobInfo.Type)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -480,6 +480,9 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 	elapsed := now - m.start
 
 	m.l.domainInfoStats = statsconv.Convert_libvirt_DomainJobInfo_To_stats_DomainJobInfo(stats)
+	if stats.DataRemainingSet {
+		m.remainingData = stats.DataRemaining
+	}
 	if (m.progressWatermark == 0) || (m.remainingData < m.progressWatermark) {
 		m.lastProgressUpdate = now
 	}
@@ -616,10 +619,6 @@ func (m *migrationMonitor) startMonitor() {
 		if err != nil {
 			logger.Reason(err).Info("failed to get domain job info, will retry")
 			continue
-		}
-
-		if jobStats.DataRemainingSet {
-			m.remainingData = jobStats.DataRemaining
 		}
 
 		uid := MigrationUID(vmi)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -41,7 +41,6 @@ import (
 	osdisk "kubevirt.io/kubevirt/pkg/os/disk"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
-	"kubevirt.io/kubevirt/pkg/util/migrations"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -336,17 +335,24 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 }
 
 func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) error {
-	migration, _ := l.metadataCache.Migration.Load()
-	if migration.EndTimestamp != nil || migration.Failed || migration.StartTimestamp == nil {
-		return fmt.Errorf(migrations.CancelMigrationFailedVmiNotMigratingErr)
-	}
+	l.metadataCache.Migration.WithSafeBlock(func(migration *api.MigrationMetadata, _ bool) {
+		if migration.EndTimestamp != nil || migration.Failed || migration.StartTimestamp == nil {
+			log.Log.Object(vmi).Infof("cancel migration ignored: vmi is not migrating")
+			return
+		}
 
-	if migration.AbortStatus == string(v1.MigrationAbortInProgress) {
-		return nil
-	}
+		switch v1.MigrationAbortStatus(migration.AbortStatus) {
+		case v1.MigrationAbortInProgress:
+			log.Log.Object(vmi).Infof("cancel migration ignored: abort is already in progress")
+			return
+		case v1.MigrationAbortSucceeded:
+			log.Log.Object(vmi).Infof("cancel migration ignored: abort already succeeded")
+			return
+		}
 
-	l.setMigrationAbortStatus(v1.MigrationAbortInProgress)
-	l.asyncMigrationAbort(vmi)
+		migration.AbortStatus = string(v1.MigrationAbortInProgress)
+		l.asyncMigrationAbort(vmi)
+	})
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -464,14 +464,16 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 	now := time.Now().UTC().UnixNano()
 	elapsed := now - m.start
 
-	m.l.domainInfoStats = statsconv.Convert_libvirt_DomainJobInfo_To_stats_DomainJobInfo(stats)
-	if stats.DataRemainingSet {
-		m.remainingData = stats.DataRemaining
+	if stats != nil && stats.Type == libvirt.DOMAIN_JOB_UNBOUNDED {
+		m.l.domainInfoStats = statsconv.Convert_libvirt_DomainJobInfo_To_stats_DomainJobInfo(stats)
+		if stats.DataRemainingSet {
+			m.remainingData = stats.DataRemaining
+		}
+		if (m.progressWatermark == 0) || (m.remainingData < m.progressWatermark) {
+			m.lastProgressUpdate = now
+		}
+		m.progressWatermark = m.remainingData
 	}
-	if (m.progressWatermark == 0) || (m.remainingData < m.progressWatermark) {
-		m.lastProgressUpdate = now
-	}
-	m.progressWatermark = m.remainingData
 
 	switch {
 	case m.isMigrationPostCopy():
@@ -588,20 +590,17 @@ func (m *migrationMonitor) startMonitor(ready chan<- error) {
 
 		jobStats, err := dom.GetJobStats(0)
 		if err != nil {
-			logger.Reason(err).Info("failed to get domain job info, will retry")
-			continue
+			logger.Reason(err).Info("failed to get domain job info")
+			jobStats = nil
 		}
 
-		uid := MigrationUID(vmi)
-		switch jobStats.Type {
-		case libvirt.DOMAIN_JOB_UNBOUNDED:
-			m.processInflightMigration(dom, jobStats)
+		m.processInflightMigration(dom, jobStats)
+
+		if jobStats != nil && jobStats.Type == libvirt.DOMAIN_JOB_UNBOUNDED {
 			logInterval++
 			if logInterval%monitorLogInterval == 0 {
-				LogMigrationInfo(logger, uid, jobStats)
+				LogMigrationInfo(logger, MigrationUID(vmi), jobStats)
 			}
-		case libvirt.DOMAIN_JOB_NONE:
-			logger.Info("Migration job is not active")
 		}
 	}
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -21,7 +21,6 @@ package virtwrap
 
 import (
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -343,13 +342,11 @@ func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) e
 		return fmt.Errorf(migrations.CancelMigrationFailedVmiNotMigratingErr)
 	}
 
-	if err := l.setMigrationAbortStatus(v1.MigrationAbortInProgress); err != nil {
-		if errors.Is(err, domainerrors.MigrationAbortInProgressError) {
-			return nil
-		}
-		return err
+	if migration.AbortStatus == string(v1.MigrationAbortInProgress) {
+		return nil
 	}
 
+	l.setMigrationAbortStatus(v1.MigrationAbortInProgress)
 	l.asyncMigrationAbort(vmi)
 	return nil
 }
@@ -415,8 +412,11 @@ func (l *LibvirtDomainManager) setMigrationResult(failed bool, reason string, ab
 	return l.setMigrationResultHelper(failed, reason, abortStatus)
 }
 
-func (l *LibvirtDomainManager) setMigrationAbortStatus(abortStatus v1.MigrationAbortStatus) error {
-	return l.setMigrationResultHelper(false, "", abortStatus)
+func (l *LibvirtDomainManager) setMigrationAbortStatus(abortStatus v1.MigrationAbortStatus) {
+	l.metadataCache.Migration.WithSafeBlock(func(migrationMetadata *api.MigrationMetadata, _ bool) {
+		migrationMetadata.AbortStatus = string(abortStatus)
+	})
+	log.Log.V(2).Infof("set migration abort status in metadata: %s", l.metadataCache.Migration.String())
 }
 
 func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationDone <-chan struct{}) *migrationMonitor {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -78,7 +78,7 @@ type migrationMonitor struct {
 	vmi     *v1.VirtualMachineInstance
 	options *cmdclient.MigrationOptions
 
-	migrationErr chan error
+	migrationDone <-chan struct{}
 
 	start              int64
 	lastProgressUpdate int64
@@ -415,12 +415,12 @@ func (l *LibvirtDomainManager) setMigrationAbortStatus(abortStatus v1.MigrationA
 	return l.setMigrationResultHelper(false, "", abortStatus)
 }
 
-func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationErr chan error) *migrationMonitor {
+func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationDone <-chan struct{}) *migrationMonitor {
 	monitor := &migrationMonitor{
 		l:                        l,
 		vmi:                      vmi,
 		options:                  options,
-		migrationErr:             migrationErr,
+		migrationDone:            migrationDone,
 		progressWatermark:        0,
 		remainingData:            0,
 		progressTimeout:          options.ProgressTimeout,
@@ -590,29 +590,15 @@ func (m *migrationMonitor) startMonitor(ready chan<- error) {
 		return
 	}
 	defer dom.Free()
-	close(ready)
+	close(ready) // signal we're ready to monitor migration
 
 	logInterval := 0
 
 	for {
-		var ok bool
-		err = nil
 		select {
-		case err, ok = <-m.migrationErr:
-			if !ok {
-				return
-			}
-		case <-time.After(monitorSleepPeriodMS * time.Millisecond):
-		}
-
-		if err != nil {
-			logger.Reason(err).Error(liveMigrationFailed)
-			var abortStatus v1.MigrationAbortStatus
-			if strings.Contains(err.Error(), "canceled by client") {
-				abortStatus = v1.MigrationAbortSucceeded
-			}
-			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", err), abortStatus)
+		case <-m.migrationDone:
 			return
+		case <-time.After(monitorSleepPeriodMS * time.Millisecond):
 		}
 
 		jobStats, err := dom.GetJobStats(0)
@@ -1069,15 +1055,15 @@ func (l *LibvirtDomainManager) migrate(vmi *v1.VirtualMachineInstance, options *
 		return
 	}
 
-	migrationErrorChan := make(chan error, 1)
-	defer close(migrationErrorChan)
+	migrationDone := make(chan struct{})
+	defer close(migrationDone)
 
 	log.Log.Object(vmi).Infof("Initiating live migration.")
 	if options.UnsafeMigration {
 		log.Log.Object(vmi).Info("UNSAFE_MIGRATION flag is set, libvirt's migration checks will be disabled!")
 	}
 
-	monitor := newMigrationMonitor(vmi, l, options, migrationErrorChan)
+	monitor := newMigrationMonitor(vmi, l, options, migrationDone)
 	monitorReady := make(chan error, 1)
 	go monitor.startMonitor(monitorReady)
 

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -51,7 +51,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/sriov"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/disksource"
-	domainerrors "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/statsconv"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
@@ -351,29 +350,16 @@ func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) e
 	return nil
 }
 
-func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason string, abortStatus v1.MigrationAbortStatus) error {
+func (l *LibvirtDomainManager) setMigrationResult(failed bool, reason string) {
 	migrationMetadata, exists := l.metadataCache.Migration.Load()
 	if !exists {
-		// nothing to report if migration metadata is empty
-		return nil
-	}
-
-	metaAbortStatus := migrationMetadata.AbortStatus
-	if abortStatus != "" {
-		if metaAbortStatus == string(abortStatus) && metaAbortStatus == string(v1.MigrationAbortInProgress) {
-			return domainerrors.MigrationAbortInProgressError
-		}
-	}
-
-	if metaAbortStatus == string(v1.MigrationAbortInProgress) &&
-		abortStatus != v1.MigrationAbortFailed &&
-		abortStatus != v1.MigrationAbortSucceeded {
-		return domainerrors.MigrationAbortInProgressError
+		log.Log.Errorf("setMigrationResult called but migration metadata is empty")
+		return
 	}
 
 	if migrationMetadata.EndTimestamp != nil {
-		// the migration result has already been reported and should not be overwritten
-		return nil
+		log.Log.Errorf("setMigrationResult called but migration result has already been reported at %v", migrationMetadata.EndTimestamp)
+		return
 	}
 
 	if failed {
@@ -391,13 +377,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason stri
 			migrationMetadata.FailureReason = reason
 		}
 
-		migrationMetadata.AbortStatus = string(abortStatus)
-
-		if abortStatus == "" || abortStatus == v1.MigrationAbortSucceeded {
-			// only mark the migration as complete if there was no abortion or
-			// the abortion succeeded
-			migrationMetadata.EndTimestamp = pointer.P(metav1.Now())
-		}
+		migrationMetadata.EndTimestamp = pointer.P(metav1.Now())
 	})
 
 	logger := log.Log.V(2)
@@ -405,11 +385,6 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, reason stri
 		logger = logger.V(4)
 	}
 	logger.Infof("set migration result in metadata: %s", l.metadataCache.Migration.String())
-	return nil
-}
-
-func (l *LibvirtDomainManager) setMigrationResult(failed bool, reason string, abortStatus v1.MigrationAbortStatus) error {
-	return l.setMigrationResultHelper(failed, reason, abortStatus)
 }
 
 func (l *LibvirtDomainManager) setMigrationAbortStatus(abortStatus v1.MigrationAbortStatus) {
@@ -1055,7 +1030,7 @@ func shouldImmediatelyFailMigration(vmi *v1.VirtualMachineInstance) bool {
 func (l *LibvirtDomainManager) migrate(vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions) {
 	if shouldImmediatelyFailMigration(vmi) {
 		log.Log.Object(vmi).Error("Live migration failed. Failure is forced by functional tests suite.")
-		l.setMigrationResult(true, "Failed migration to satisfy functional test condition", "")
+		l.setMigrationResult(true, "Failed migration to satisfy functional test condition")
 		return
 	}
 
@@ -1073,19 +1048,19 @@ func (l *LibvirtDomainManager) migrate(vmi *v1.VirtualMachineInstance, options *
 
 	if err := <-monitorReady; err != nil {
 		log.Log.Object(vmi).Reason(err).Error("migration monitor failed to start")
-		l.setMigrationResult(true, err.Error(), "")
+		l.setMigrationResult(true, err.Error())
 		return
 	}
 
 	err := l.migrateHelper(vmi, options)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error(liveMigrationFailed)
-		l.setMigrationResult(true, err.Error(), "")
+		l.setMigrationResult(true, err.Error())
 		return
 	}
 
 	log.Log.Object(vmi).Infof("Live migration succeeded.")
-	l.setMigrationResult(false, "", "")
+	l.setMigrationResult(false, "")
 }
 
 func (l *LibvirtDomainManager) updateVMIMigrationMode(mode v1.MigrationMode) {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -1044,9 +1044,6 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 		return err
 	}
 
-	log.Log.Object(vmi).Info("migration completed successfully")
-	l.setMigrationResult(false, "", "")
-
 	return nil
 }
 
@@ -1091,6 +1088,7 @@ func (l *LibvirtDomainManager) migrate(vmi *v1.VirtualMachineInstance, options *
 	}
 
 	log.Log.Object(vmi).Infof("Live migration succeeded.")
+	l.setMigrationResult(false, "", "")
 }
 
 func (l *LibvirtDomainManager) updateVMIMigrationMode(mode v1.MigrationMode) {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -470,6 +470,12 @@ func (m *migrationMonitor) isMigrationProgressing() bool {
 func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *libvirt.DomainJobInfo) {
 	logger := log.Log.Object(m.vmi)
 
+	// only send abort if one is not in progress already or if a previous attempt failed
+	shouldAbort := func() bool {
+		migration, _ := m.l.metadataCache.Migration.Load()
+		return migration.AbortStatus == "" || migration.AbortStatus == string(v1.MigrationAbortFailed)
+	}
+
 	now := time.Now().UTC().UnixNano()
 	elapsed := now - m.start
 
@@ -545,7 +551,7 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 		// It usually indicates a problem with the network or qemu's connection handling.
 		// In this case, we abort the migration directly without trying to pause/post-copy,
 		// since the problem is highly unlikely to be caused by a high dirty rate.
-		if migration, _ := m.l.metadataCache.Migration.Load(); migration.AbortStatus == "" {
+		if shouldAbort() {
 			progressDelay := now - m.lastProgressUpdate
 			logger.Warningf("Aborting migration: stuck for %d seconds", progressDelay/int64(time.Second))
 			m.l.cancelMigration(m.vmi)
@@ -556,7 +562,7 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 		// if the total migration time exceeds an acceptable
 		// limit, then the migration will get aborted, but
 		// only if post copy migration hasn't been enabled
-		if migration, _ := m.l.metadataCache.Migration.Load(); migration.AbortStatus == "" {
+		if shouldAbort() {
 			logger.Warningf("Aborting migration: not completed after %d seconds", m.acceptableCompletionTime)
 			m.l.cancelMigration(m.vmi)
 		}
@@ -669,17 +675,18 @@ func LogMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.D
 
 func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstance) {
 	go func(l *LibvirtDomainManager, vmi *v1.VirtualMachineInstance) {
-
 		domName := api.VMINamespaceKeyFunc(vmi)
 		dom, err := l.virConn.LookupDomainByName(domName)
 		if err != nil {
 			log.Log.Object(vmi).Reason(err).Warning("failed to cancel migration, domain not found ")
+			l.setMigrationAbortStatus(v1.MigrationAbortFailed)
 			return
 		}
 		defer dom.Free()
 		jobInfo, err := dom.GetJobInfo()
 		if err != nil {
 			log.Log.Object(vmi).Reason(err).Error("failed to get domain job info")
+			l.setMigrationAbortStatus(v1.MigrationAbortFailed)
 			return
 		}
 		if jobInfo.Type == libvirt.DOMAIN_JOB_UNBOUNDED {
@@ -691,6 +698,9 @@ func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstanc
 			}
 			l.setMigrationResult(true, "Live migration aborted ", v1.MigrationAbortSucceeded)
 			log.Log.Object(vmi).Info("Live migration abort succeeded")
+		} else {
+			log.Log.Object(vmi).Infof("migration job is not active (type=%d), nothing to abort", jobInfo.Type)
+			l.setMigrationAbortStatus(v1.MigrationAbortFailed)
 		}
 	}(l, vmi)
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -1040,9 +1040,8 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 	err = dom.MigrateToURI3(dstURI, params, migrateFlags)
 	l.abortWg.Wait() // wait for in-flight cancellation
 	if err != nil {
-		l.setMigrationResult(true, err.Error(), "")
-		log.Log.Object(vmi).Errorf("migration failed with error: %v", err)
-		return fmt.Errorf("error encountered during MigrateToURI3 libvirt api call: %v", err)
+		log.Log.Object(vmi).Errorf("error encountered during MigrateToURI3 libvirt api call: %v", err)
+		return err
 	}
 
 	log.Log.Object(vmi).Info("migration completed successfully")
@@ -1081,16 +1080,13 @@ func (l *LibvirtDomainManager) migrate(vmi *v1.VirtualMachineInstance, options *
 		log.Log.Object(vmi).Info("UNSAFE_MIGRATION flag is set, libvirt's migration checks will be disabled!")
 	}
 
-	// From here on out, any error encountered must be sent to the
-	// migrationError channel which is processed by the liveMigrationMonitor
-	// go routine.
 	monitor := newMigrationMonitor(vmi, l, options, migrationErrorChan)
 	go monitor.startMonitor()
 
 	err := l.migrateHelper(vmi, options)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error(liveMigrationFailed)
-		migrationErrorChan <- err
+		l.setMigrationResult(true, err.Error(), "")
 		return
 	}
 

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -89,11 +89,6 @@ type migrationMonitor struct {
 	acceptableCompletionTime int64
 }
 
-type inflightMigrationAborted struct {
-	message     string
-	abortStatus v1.MigrationAbortStatus
-}
-
 func generateMigrationFlags(isBlockMigration, migratePaused bool, options *cmdclient.MigrationOptions) libvirt.DomainMigrateFlags {
 	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
@@ -472,10 +467,9 @@ func (m *migrationMonitor) isMigrationProgressing() bool {
 	return true
 }
 
-func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *libvirt.DomainJobInfo) *inflightMigrationAborted {
+func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *libvirt.DomainJobInfo) {
 	logger := log.Log.Object(m.vmi)
 
-	// Migration is running
 	now := time.Now().UTC().UnixNano()
 	elapsed := now - m.start
 
@@ -503,7 +497,7 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 			err := dom.MigrateStartPostCopy(0)
 			if err != nil {
 				logger.Reason(err).Error("failed to start post migration")
-				return nil
+				return
 			}
 			m.l.updateVMIMigrationMode(v1.MigrationPostCopy)
 		} else if vmitrait.HasVFIO(m.vmi) {
@@ -511,18 +505,17 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 			// TODO: once the VGPULiveMigration featuregate graduates
 			//  (and even possibly other VFIO live migration featuregates)
 			//  we should consider merging this with the "else" case below.
-			// Setting a very high max downtime causes QEMU to
-			//  trigger its internal switchover, which pauses vCPUs and
-			//  transitions VFIO devices to _STOP_COPY. This is more
-			//  correct than dom.Suspend() which only pauses vCPUs but
-			//  leaves VFIO devices in _RUNNING with perpetual dirty
-			//  page reporting.
+			// Setting a very high max downtime causes QEMU to trigger its
+			// internal switchover, which pauses vCPUs and transitions VFIO
+			// devices to _STOP_COPY. This is more correct than dom.Suspend()
+			// which only pauses vCPUs but leaves VFIO devices in _RUNNING
+			// with perpetual dirty page reporting.
 			maxDowntimeSec := m.acceptableCompletionTime * 2
 			// qemu doesn't allow max downtime larger than 2000s
 			err := dom.MigrateSetMaxDowntime(min(uint64(maxDowntimeSec)*1000, 2_000_000), 0)
 			if err != nil {
 				logger.Reason(err).Error("Setting max downtime failed.")
-				return nil
+				return
 			}
 			logger.Infof("Set max downtime to %ds for %s", maxDowntimeSec, m.vmi.GetObjectMeta().GetName())
 
@@ -536,7 +529,7 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 			err := dom.Suspend()
 			if err != nil {
 				logger.Reason(err).Error("Signalling suspension failed.")
-				return nil
+				return
 			}
 			logger.Infof("Signaled pause for %s", m.vmi.GetObjectMeta().GetName())
 
@@ -552,35 +545,22 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 		// It usually indicates a problem with the network or qemu's connection handling.
 		// In this case, we abort the migration directly without trying to pause/post-copy,
 		// since the problem is highly unlikely to be caused by a high dirty rate.
-		err := dom.AbortJob()
-		if err != nil {
-			logger.Reason(err).Error("failed to abort migration")
-			return nil
+		if migration, _ := m.l.metadataCache.Migration.Load(); migration.AbortStatus == "" {
+			progressDelay := now - m.lastProgressUpdate
+			logger.Warningf("Aborting migration: stuck for %d seconds", progressDelay/int64(time.Second))
+			m.l.cancelMigration(m.vmi)
 		}
 
-		progressDelay := now - m.lastProgressUpdate
-		aborted := &inflightMigrationAborted{}
-		aborted.message = fmt.Sprintf("Live migration stuck for %d seconds and has been aborted", progressDelay/int64(time.Second))
-		aborted.abortStatus = v1.MigrationAbortSucceeded
-		return aborted
 	case m.shouldTriggerTimeout(elapsed):
 		// check the overall migration time
 		// if the total migration time exceeds an acceptable
 		// limit, then the migration will get aborted, but
 		// only if post copy migration hasn't been enabled
-		err := dom.AbortJob()
-		if err != nil {
-			logger.Reason(err).Error("failed to abort migration")
-			return nil
+		if migration, _ := m.l.metadataCache.Migration.Load(); migration.AbortStatus == "" {
+			logger.Warningf("Aborting migration: not completed after %d seconds", m.acceptableCompletionTime)
+			m.l.cancelMigration(m.vmi)
 		}
-
-		aborted := &inflightMigrationAborted{}
-		aborted.message = fmt.Sprintf("Live migration is not completed after %d seconds and has been aborted", m.acceptableCompletionTime)
-		aborted.abortStatus = v1.MigrationAbortSucceeded
-		return aborted
 	}
-
-	return nil
 }
 
 func (m *migrationMonitor) startMonitor() {
@@ -639,12 +619,7 @@ func (m *migrationMonitor) startMonitor() {
 		uid := MigrationUID(vmi)
 		switch jobStats.Type {
 		case libvirt.DOMAIN_JOB_UNBOUNDED:
-			aborted := m.processInflightMigration(dom, jobStats)
-			if aborted != nil {
-				logger.Errorf("Live migration abort detected with reason: %s", aborted.message)
-				m.l.setMigrationResult(true, aborted.message, aborted.abortStatus)
-				return
-			}
+			m.processInflightMigration(dom, jobStats)
 			logInterval++
 			if logInterval%monitorLogInterval == 0 {
 				LogMigrationInfo(logger, uid, jobStats)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -643,37 +643,48 @@ func LogMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.D
 }
 
 func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstance) {
+	// Libvirt calls (GetJobInfo, AbortJob) can hang indefinitely if the QEMU
+	// monitor is unresponsive. Wrap with a timeout.
 	l.abortWg.Add(1)
-	go func(l *LibvirtDomainManager, vmi *v1.VirtualMachineInstance) {
-		defer l.abortWg.Done()
-		domName := api.VMINamespaceKeyFunc(vmi)
-		dom, err := l.virConn.LookupDomainByName(domName)
-		if err != nil {
-			log.Log.Object(vmi).Reason(err).Warning("failed to cancel migration, domain not found ")
-			l.setMigrationAbortStatus(v1.MigrationAbortFailed)
-			return
-		}
-		defer dom.Free()
-		jobInfo, err := dom.GetJobInfo()
-		if err != nil {
-			log.Log.Object(vmi).Reason(err).Error("failed to get domain job info")
-			l.setMigrationAbortStatus(v1.MigrationAbortFailed)
-			return
-		}
-		if jobInfo.Type == libvirt.DOMAIN_JOB_UNBOUNDED {
-			err := dom.AbortJob()
+	go func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			domName := api.VMINamespaceKeyFunc(vmi)
+			dom, err := l.virConn.LookupDomainByName(domName)
 			if err != nil {
-				log.Log.Object(vmi).Reason(err).Error("failed to cancel migration")
+				log.Log.Object(vmi).Reason(err).Warning("failed to cancel migration, domain not found")
 				l.setMigrationAbortStatus(v1.MigrationAbortFailed)
 				return
 			}
-			l.setMigrationAbortStatus(v1.MigrationAbortSucceeded)
-			log.Log.Object(vmi).Info("Live migration abort succeeded")
-		} else {
-			log.Log.Object(vmi).Infof("migration job is not active (type=%d), nothing to abort", jobInfo.Type)
+			defer dom.Free()
+			jobInfo, err := dom.GetJobInfo()
+			if err != nil {
+				log.Log.Object(vmi).Reason(err).Error("failed to get domain job info")
+				l.setMigrationAbortStatus(v1.MigrationAbortFailed)
+				return
+			}
+			if jobInfo.Type == libvirt.DOMAIN_JOB_UNBOUNDED {
+				if err := dom.AbortJob(); err != nil {
+					log.Log.Object(vmi).Reason(err).Error("failed to cancel migration")
+					l.setMigrationAbortStatus(v1.MigrationAbortFailed)
+					return
+				}
+				l.setMigrationAbortStatus(v1.MigrationAbortSucceeded)
+				log.Log.Object(vmi).Info("Live migration abort succeeded")
+			} else {
+				log.Log.Object(vmi).Infof("migration job is not active (type=%d), nothing to abort", jobInfo.Type)
+				l.setMigrationAbortStatus(v1.MigrationAbortFailed)
+			}
+		}()
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			log.Log.Object(vmi).Error("migration abort timed out waiting for libvirt")
 			l.setMigrationAbortStatus(v1.MigrationAbortFailed)
 		}
-	}(l, vmi)
+		l.abortWg.Done()
+	}()
 }
 
 func generateDomainName(vmi *v1.VirtualMachineInstance) string {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -572,7 +572,7 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain, stats *li
 	}
 }
 
-func (m *migrationMonitor) startMonitor() {
+func (m *migrationMonitor) startMonitor(ready chan<- error) {
 	vmi := m.vmi
 
 	m.start = time.Now().UTC().UnixNano()
@@ -586,11 +586,11 @@ func (m *migrationMonitor) startMonitor() {
 	domName := api.VMINamespaceKeyFunc(vmi)
 	dom, err := m.l.virConn.LookupDomainByName(domName)
 	if err != nil {
-		logger.Reason(err).Error(liveMigrationFailed)
-		m.l.setMigrationResult(true, fmt.Sprintf("%v", err), "")
+		ready <- fmt.Errorf("migration monitor failed to look up domain: %v", err)
 		return
 	}
 	defer dom.Free()
+	close(ready)
 
 	logInterval := 0
 
@@ -1078,7 +1078,14 @@ func (l *LibvirtDomainManager) migrate(vmi *v1.VirtualMachineInstance, options *
 	}
 
 	monitor := newMigrationMonitor(vmi, l, options, migrationErrorChan)
-	go monitor.startMonitor()
+	monitorReady := make(chan error, 1)
+	go monitor.startMonitor(monitorReady)
+
+	if err := <-monitorReady; err != nil {
+		log.Log.Object(vmi).Reason(err).Error("migration monitor failed to start")
+		l.setMigrationResult(true, err.Error(), "")
+		return
+	}
 
 	err := l.migrateHelper(vmi, options)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -673,7 +673,9 @@ func LogMigrationInfo(logger *log.FilteredLogger, uid types.UID, info *libvirt.D
 }
 
 func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstance) {
+	l.abortWg.Add(1)
 	go func(l *LibvirtDomainManager, vmi *v1.VirtualMachineInstance) {
+		defer l.abortWg.Done()
 		domName := api.VMINamespaceKeyFunc(vmi)
 		dom, err := l.virConn.LookupDomainByName(domName)
 		if err != nil {
@@ -1036,6 +1038,7 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 	}
 
 	err = dom.MigrateToURI3(dstURI, params, migrateFlags)
+	l.abortWg.Wait() // wait for in-flight cancellation
 	if err != nil {
 		l.setMigrationResult(true, err.Error(), "")
 		log.Log.Object(vmi).Errorf("migration failed with error: %v", err)

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -47,7 +47,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/testing"
 )
 
@@ -93,7 +92,7 @@ var _ = Describe("Live migration source", func() {
 		})
 
 		It("should only be set once", func() {
-			libvirtDomainManager.setMigrationResult(false, "", "")
+			libvirtDomainManager.setMigrationResult(false, "")
 			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(exists).To(BeTrue(), "migrationMetadata not found")
 			Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
@@ -101,63 +100,106 @@ var _ = Describe("Live migration source", func() {
 
 			endTimestamp := migrationMetadata.EndTimestamp.DeepCopy()
 
-			libvirtDomainManager.setMigrationResult(true, "", "")
+			libvirtDomainManager.setMigrationResult(true, "")
 			Expect(exists).To(BeTrue())
 			Expect(migrationMetadata.EndTimestamp).To(Equal(endTimestamp), "migrationMetadata changed")
 			Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
 		})
 
-		DescribeTable("EndTimestamp", func(isFailed bool, abortStatus v1.MigrationAbortStatus, shouldEndTimestampBeSet bool) {
-			libvirtDomainManager.setMigrationResult(isFailed, "", abortStatus)
+		DescribeTable("EndTimestamp", func(isFailed bool, abortStatus v1.MigrationAbortStatus) {
+			if abortStatus != "" {
+				libvirtDomainManager.setMigrationAbortStatus(abortStatus)
+			}
+			libvirtDomainManager.setMigrationResult(isFailed, "")
 			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(exists).To(BeTrue(), "migrationMetadata not found")
 			Expect(migrationMetadata.Failed).To(Equal(isFailed), "migration result is wrong")
-
-			if shouldEndTimestampBeSet {
-				Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
-			} else {
-				Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
-			}
+			Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
 		},
-			Entry("should be set when the migration is successful", false, v1.MigrationAbortStatus(""), true),
-			Entry("should be set when the migration has failed", true, v1.MigrationAbortStatus(""), true),
-			Entry("should be set when the migration has been aborted", false, v1.MigrationAbortSucceeded, true),
-			Entry("should not be set when an abortion request does not succeed", false, v1.MigrationAbortFailed, false),
-			Entry("should not be set when an abortion request is still in progress", false, v1.MigrationAbortInProgress, false),
+			Entry("should be set when the migration is successful", false, v1.MigrationAbortStatus("")),
+			Entry("should be set when the migration has failed", true, v1.MigrationAbortStatus("")),
+			Entry("should be set when the migration has been aborted", false, v1.MigrationAbortSucceeded),
+			Entry("should be set when an abortion request did not succeed", false, v1.MigrationAbortFailed),
+			Entry("should be set when an abortion request is still in progress", false, v1.MigrationAbortInProgress),
 		)
 
-		DescribeTable("when an abortion is in progress", func(isFailed bool, abortStatus v1.MigrationAbortStatus, shouldEndTimestampBeSet bool, expectedError error) {
-			// make it in progress first
-			libvirtDomainManager.setMigrationResult(false, "", v1.MigrationAbortInProgress)
+		DescribeTable("when an abortion is in progress", func(isFailed bool) {
+			libvirtDomainManager.setMigrationAbortStatus(v1.MigrationAbortInProgress)
 
-			err := libvirtDomainManager.setMigrationResult(isFailed, "", abortStatus)
-			if expectedError != nil {
-				Expect(err).To(Equal(expectedError))
-			} else {
-				Expect(err).ToNot(HaveOccurred())
-			}
+			libvirtDomainManager.setMigrationResult(isFailed, "")
 
 			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(exists).To(BeTrue(), "migrationMetadata not found")
-
-			if shouldEndTimestampBeSet {
-				Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
-			} else {
-				Expect(migrationMetadata.EndTimestamp).To(BeNil(), "migration EndTimestamp is set")
-			}
-
-			if expectedError != nil {
-				Expect(migrationMetadata.Failed).To(BeFalse(), "migration has failed")
-			} else {
-				Expect(migrationMetadata.Failed).To(BeTrue(), "migration has not failed")
-			}
+			Expect(migrationMetadata.EndTimestamp).ToNot(BeNil(), "migration EndTimestamp not set")
+			Expect(migrationMetadata.Failed).To(Equal(isFailed), "migration result is wrong")
+			Expect(migrationMetadata.AbortStatus).To(Equal(string(v1.MigrationAbortInProgress)), "abort status should be unchanged")
 		},
-			Entry("setting 'Aborting' should return an error", false, v1.MigrationAbortInProgress, false, errors.MigrationAbortInProgressError),
-			Entry("setting 'Succeeded' should return an error", true, v1.MigrationAbortSucceeded, true, nil),
-			Entry("setting 'Failed' should return an error", true, v1.MigrationAbortFailed, false, nil),
-			Entry("marking the migration as failed without an abortion result should return an error", true, v1.MigrationAbortStatus(""), false, errors.MigrationAbortInProgressError),
-			Entry("marking the migration as completed without an abortion result should return an error", false, v1.MigrationAbortStatus(""), false, errors.MigrationAbortInProgressError),
+			Entry("marking the migration as failed should finalize", true),
+			Entry("marking the migration as completed should finalize", false),
 		)
+	})
+
+	Context("Migration abort status", func() {
+		BeforeEach(func() {
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigrationState: &v1.VirtualMachineInstanceMigrationState{
+						MigrationUID: types.UID(fmt.Sprintf("%v", GinkgoRandomSeed())),
+					},
+				},
+			}
+
+			mockConn := &cli.MockConnection{}
+			testVirtShareDir := fmt.Sprintf("fake-virt-share-%d", GinkgoRandomSeed())
+			testEphemeralDiskDir := fmt.Sprintf("fake-ephemeral-disk-%d", GinkgoRandomSeed())
+			ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
+			metadataCache := metadata.NewCache()
+
+			manager, _ := NewLibvirtDomainManager(
+				mockConn,
+				testVirtShareDir,
+				testEphemeralDiskDir,
+				nil, // agent store
+				virtconfig.DefaultARCHOVMFPath,
+				ephemeralDiskCreatorMock,
+				metadataCache,
+				nil, //stop chn
+				virtconfig.DefaultDiskVerificationMemoryLimitBytes,
+				fakeCpuSetGetter,
+				false, // image volume enabled
+				false, // libvirt hooks server and client enabled
+				nil,
+				v1.KvmHypervisorName,
+				nil,
+				"", false,
+			)
+			libvirtDomainManager = manager.(*LibvirtDomainManager)
+			libvirtDomainManager.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)
+		})
+
+		DescribeTable("should set abort status", func(abortStatus v1.MigrationAbortStatus) {
+			libvirtDomainManager.setMigrationAbortStatus(abortStatus)
+			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue(), "migrationMetadata not found")
+			Expect(migrationMetadata.AbortStatus).To(Equal(string(abortStatus)))
+			Expect(migrationMetadata.EndTimestamp).To(BeNil(), "EndTimestamp should not be set by abort status")
+		},
+			Entry("to InProgress", v1.MigrationAbortInProgress),
+			Entry("to Succeeded", v1.MigrationAbortSucceeded),
+			Entry("to Failed", v1.MigrationAbortFailed),
+		)
+
+		It("should overwrite previous abort status", func() {
+			libvirtDomainManager.setMigrationAbortStatus(v1.MigrationAbortInProgress)
+			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue())
+			Expect(migrationMetadata.AbortStatus).To(Equal(string(v1.MigrationAbortInProgress)))
+
+			libvirtDomainManager.setMigrationAbortStatus(v1.MigrationAbortFailed)
+			migrationMetadata, exists = libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue())
+			Expect(migrationMetadata.AbortStatus).To(Equal(string(v1.MigrationAbortFailed)))
+		})
 	})
 
 	Context("classifyVolumesForMigration", func() {

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -41,7 +41,7 @@ import (
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
-	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
@@ -140,8 +140,10 @@ var _ = Describe("Live migration source", func() {
 	})
 
 	Context("Migration abort status", func() {
+		var vmi *v1.VirtualMachineInstance
+
 		BeforeEach(func() {
-			vmi := &v1.VirtualMachineInstance{
+			vmi = &v1.VirtualMachineInstance{
 				Status: v1.VirtualMachineInstanceStatus{
 					MigrationState: &v1.VirtualMachineInstanceMigrationState{
 						MigrationUID: types.UID(fmt.Sprintf("%v", GinkgoRandomSeed())),
@@ -199,6 +201,46 @@ var _ = Describe("Live migration source", func() {
 			migrationMetadata, exists = libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(exists).To(BeTrue())
 			Expect(migrationMetadata.AbortStatus).To(Equal(string(v1.MigrationAbortFailed)))
+		})
+		It("cancelMigration should no-op when migration has no StartTimestamp", func() {
+			libvirtDomainManager.metadataCache.Migration.WithSafeBlock(func(m *api.MigrationMetadata, _ bool) {
+				m.StartTimestamp = nil
+			})
+			original, _ := libvirtDomainManager.metadataCache.Migration.Load()
+
+			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+
+			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(after.AbortStatus).To(Equal(original.AbortStatus))
+		})
+
+		It("cancelMigration should no-op when migration already has EndTimestamp", func() {
+			libvirtDomainManager.metadataCache.Migration.WithSafeBlock(func(m *api.MigrationMetadata, _ bool) {
+				m.EndTimestamp = pointer.P(metav1.Now())
+			})
+
+			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+
+			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(after.AbortStatus).To(Equal(""))
+		})
+
+		It("cancelMigration should no-op when abort is already in progress", func() {
+			libvirtDomainManager.setMigrationAbortStatus(v1.MigrationAbortInProgress)
+
+			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+
+			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(after.AbortStatus).To(Equal(string(v1.MigrationAbortInProgress)))
+		})
+
+		It("cancelMigration should no-op when abort already succeeded", func() {
+			libvirtDomainManager.setMigrationAbortStatus(v1.MigrationAbortSucceeded)
+
+			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+
+			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(after.AbortStatus).To(Equal(string(v1.MigrationAbortSucceeded)))
 		})
 	})
 
@@ -667,8 +709,8 @@ var _ = Describe("Live migration source", func() {
 			shouldConfigure, _ := shouldConfigureParallelMigration(options)
 			Expect(shouldConfigure).To(BeTrue())
 		},
-			Entry("with non-nil migration threads and post-copy not allowed", &cmdclient.MigrationOptions{ParallelMigrationThreads: virtpointer.P(uint(3)), AllowPostCopy: false}),
-			Entry("with non-nil migration threads and post-copy allowed", &cmdclient.MigrationOptions{ParallelMigrationThreads: virtpointer.P(uint(3)), AllowPostCopy: true}),
+			Entry("with non-nil migration threads and post-copy not allowed", &cmdclient.MigrationOptions{ParallelMigrationThreads: pointer.P(uint(3)), AllowPostCopy: false}),
+			Entry("with non-nil migration threads and post-copy allowed", &cmdclient.MigrationOptions{ParallelMigrationThreads: pointer.P(uint(3)), AllowPostCopy: true}),
 		)
 	})
 
@@ -738,7 +780,7 @@ var _ = Describe("Live migration source", func() {
 
 				shouldConfigureParallel, parallelMigrationThreads := shouldConfigureParallelMigration(options)
 				if shouldConfigureParallel {
-					options.ParallelMigrationThreads = virtpointer.P(uint(parallelMigrationThreads))
+					options.ParallelMigrationThreads = pointer.P(uint(parallelMigrationThreads))
 				}
 
 				flags := generateMigrationFlags(isBlockMigration, isVmiPaused, options)
@@ -909,11 +951,11 @@ var _ = Describe("migratableDomXML", func() {
 				VolumeName: volName,
 				SourcePVCInfo: &v1.PersistentVolumeClaimInfo{
 					ClaimName:  sourcePvcName,
-					VolumeMode: virtpointer.P(k8sv1.PersistentVolumeFilesystem),
+					VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem),
 				},
 				DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{
 					ClaimName:  destPvcName,
-					VolumeMode: virtpointer.P(k8sv1.PersistentVolumeFilesystem),
+					VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem),
 				},
 			},
 		}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -249,6 +249,8 @@ type LibvirtDomainManager struct {
 
 	hypervisorDeviceAvailable bool
 	hypervisorName            string
+
+	abortWg sync.WaitGroup
 }
 
 type pausedVMIs struct {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1769,7 +1769,7 @@ var _ = Describe("Manager", func() {
 	})
 	Context("test migration monitor", func() {
 		It("migration should be canceled if it's not progressing", func() {
-			migrationErrorChan := make(chan error)
+			migrationDone := make(chan struct{})
 			fake_jobinfo := &libvirt.DomainJobInfo{
 				Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
 				DataRemaining:    32479827394,
@@ -1807,16 +1807,16 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
 					time.Sleep(time.Second)
-					close(migrationErrorChan)
+					close(migrationDone)
 				}()
 				return nil
 			})
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration abort should be retried after transient failure", func() {
-			migrationErrorChan := make(chan error)
+			migrationDone := make(chan struct{})
 			fake_jobinfo := &libvirt.DomainJobInfo{
 				Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
 				DataRemaining:    32479827394,
@@ -1874,17 +1874,17 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
 					time.Sleep(time.Second)
-					close(migrationErrorChan)
+					close(migrationDone)
 				}()
 				return nil
 			})
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
 			Eventually(abortStatus, 2*time.Second, 100*time.Millisecond).Should(Equal(string(v1.MigrationAbortSucceeded)))
 		})
 		It("migration should be canceled if timeout has been reached", func() {
-			migrationErrorChan := make(chan error)
+			migrationDone := make(chan struct{})
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				migrationData -= 125
@@ -1925,22 +1925,22 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
 					time.Sleep(time.Second)
-					close(migrationErrorChan)
+					close(migrationDone)
 				}()
 				return nil
 			})
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration should switch to PostCopy", func() {
-			migrationErrorChan := make(chan error)
+			migrationDone := make(chan struct{})
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					close(migrationErrorChan)
+					close(migrationDone)
 					return &libvirt.DomainJobInfo{}
 				}
 
@@ -1978,18 +1978,18 @@ var _ = Describe("Manager", func() {
 			})
 			mockLibvirt.DomainEXPECT().MigrateStartPostCopy(gomock.Eq(uint32(0))).Times(1).Return(nil)
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
 		})
 
 		It("migration should switch to PostCopy eventually", func() {
-			migrationErrorChan := make(chan error)
+			migrationDone := make(chan struct{})
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					close(migrationErrorChan)
+					close(migrationDone)
 					return &libvirt.DomainJobInfo{}
 				}
 
@@ -2041,17 +2041,17 @@ var _ = Describe("Manager", func() {
 				return nil
 			})
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration should switch to Paused if AllowWorkloadDisruption is allowed and PostCopy is not", func() {
-			migrationErrorChan := make(chan error)
+			migrationDone := make(chan struct{})
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				// stop decreasing data and close the channel otherwise this
 				// job will run indefinitely until timeout
 				if migrationData <= 32479826519 {
-					close(migrationErrorChan)
+					close(migrationDone)
 					return &libvirt.DomainJobInfo{}
 				}
 
@@ -2092,11 +2092,11 @@ var _ = Describe("Manager", func() {
 			})
 			mockLibvirt.DomainEXPECT().Suspend().Times(1).Return(nil)
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration should be canceled if Paused workload didn't migrate until timeout was reached", func() {
-			migrationErrorChan := make(chan error)
+			migrationDone := make(chan struct{})
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				migrationData -= 125
@@ -2144,12 +2144,12 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
 					time.Sleep(time.Second)
-					close(migrationErrorChan)
+					close(migrationDone)
 				}()
 				return nil
 			})
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
 		})
 		// This is incomplete as it is not verifying that we abort. Previously it wasn't even testing anything at all
@@ -2214,57 +2214,8 @@ var _ = Describe("Manager", func() {
 			manager, _ := newLibvirtDomainManagerDefault()
 			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
 		})
-		It("migration cancellation should be finalized even if we missed status update", func() {
-			migrationErrorChan := make(chan error, 1)
-			defer close(migrationErrorChan)
-			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
-				return &libvirt.DomainJobInfo{
-					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining:    uint64(32479827777),
-					DataRemainingSet: true,
-				}
-			}()
-
-			options := &cmdclient.MigrationOptions{
-				Bandwidth:               resource.MustParse("64Mi"),
-				ProgressTimeout:         3,
-				CompletionTimeoutPerGiB: 150,
-			}
-			vmi := newVMI(testNamespace, testVmName)
-			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				MigrationUID: "111222333",
-			}
-
-			migrationMetadata, _ := metadataCache.Migration.Load()
-			migrationMetadata.UID = vmi.Status.MigrationState.MigrationUID
-			migrationMetadata.AbortStatus = string(v1.MigrationAbortInProgress)
-			metadataCache.Migration.Store(migrationMetadata)
-
-			manager := &LibvirtDomainManager{
-				virConn:       mockLibvirt.VirtConnection,
-				virtShareDir:  testVirtShareDir,
-				metadataCache: metadataCache,
-				cpuSetGetter:  fakeCpuSetGetter,
-			}
-
-			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
-			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
-				func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
-					migrationErrorChan <- fmt.Errorf("operation aborted: canceled by client")
-					return fake_jobinfo_running, nil
-				},
-			)
-
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor(make(chan error, 1))
-			Eventually(func() string {
-				migration, _ := metadataCache.Migration.Load()
-				return migration.AbortStatus
-			}, 5*time.Second, 2).Should(Equal(string(v1.MigrationAbortSucceeded)))
-		})
-
-		It("monitor should exit when migration error channel is closed", func() {
-			migrationErrorChan := make(chan error)
+		It("monitor should exit when migration done channel is closed", func() {
+			migrationDone := make(chan struct{})
 
 			options := &cmdclient.MigrationOptions{
 				Bandwidth:               resource.MustParse("64Mi"),
@@ -2290,7 +2241,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).DoAndReturn(
 				func(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error) {
-					close(migrationErrorChan)
+					close(migrationDone)
 					return &libvirt.DomainJobInfo{
 						Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
 						DataRemainingSet: true,
@@ -2299,7 +2250,7 @@ var _ = Describe("Manager", func() {
 				},
 			)
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			done := make(chan struct{})
 			go func() {
 				monitor.startMonitor(make(chan error, 1))
@@ -2307,8 +2258,8 @@ var _ = Describe("Manager", func() {
 			}()
 			Eventually(done, 5*time.Second).Should(BeClosed())
 		})
-		It("monitor should signal error on ready channel if domain lookup fails", func() {
-			migrationErrorChan := make(chan error)
+		It("monitor should signal error on ready channel if it fails to start", func() {
+			migrationDone := make(chan struct{})
 
 			options := &cmdclient.MigrationOptions{
 				Bandwidth:               resource.MustParse("64Mi"),
@@ -2326,7 +2277,7 @@ var _ = Describe("Manager", func() {
 
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).Return(nil, fmt.Errorf("domain not found"))
 
-			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			ready := make(chan error, 1)
 			monitor.startMonitor(ready)
 			Expect(ready).To(Receive(MatchError(ContainSubstring("domain not found"))))

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1815,6 +1815,74 @@ var _ = Describe("Manager", func() {
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()
 		})
+		It("migration abort should be retried after transient failure", func() {
+			migrationErrorChan := make(chan error)
+			fake_jobinfo := &libvirt.DomainJobInfo{
+				Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+				DataRemaining:    32479827394,
+				DataRemainingSet: true,
+			}
+
+			options := &cmdclient.MigrationOptions{
+				Bandwidth:               resource.MustParse("64Mi"),
+				ProgressTimeout:         2,
+				CompletionTimeoutPerGiB: 300,
+			}
+
+			vmi := newVMI(testNamespace, testVmName)
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID: "111222333",
+			}
+
+			now := metav1.Now()
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.StartTimestamp = &now
+			metadataCache.Migration.Store(migrationMetadata)
+
+			manager := &LibvirtDomainManager{
+				virConn:       mockLibvirt.VirtConnection,
+				virtShareDir:  testVirtShareDir,
+				metadataCache: metadataCache,
+				cpuSetGetter:  fakeCpuSetGetter,
+			}
+
+			abortStatus := func() string {
+				m, _ := metadataCache.Migration.Load()
+				return m.AbortStatus
+			}
+
+			Expect(abortStatus()).To(Equal(""))
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(fake_jobinfo, nil)
+
+			// First attempt: cancelMigration sets AbortInProgress, GetJobInfo fails → AbortFailed
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobInfo().DoAndReturn(func() (*libvirt.DomainJobInfo, error) {
+				Expect(abortStatus()).To(Equal(string(v1.MigrationAbortInProgress)))
+				return nil, fmt.Errorf("transient error")
+			})
+
+			// Reaching this point proves the monitor saw AbortFailed and retried.
+			// cancelMigration has already overwritten it back to AbortInProgress.
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobInfo().DoAndReturn(func() (*libvirt.DomainJobInfo, error) {
+				Expect(abortStatus()).To(Equal(string(v1.MigrationAbortInProgress)))
+				return &libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil
+			})
+			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
+				go func() {
+					time.Sleep(time.Second)
+					close(migrationErrorChan)
+				}()
+				return nil
+			})
+
+			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			monitor.startMonitor()
+			Eventually(abortStatus, 2*time.Second, 100*time.Millisecond).Should(Equal(string(v1.MigrationAbortSucceeded)))
+		})
 		It("migration should be canceled if timeout has been reached", func() {
 			migrationErrorChan := make(chan error)
 			var migrationData = 32479827394

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2284,6 +2284,261 @@ var _ = Describe("Manager", func() {
 		})
 	})
 
+	Context("migrate() concurrency", func() {
+		const minimalDomainXML = `<domain type="kvm"><name>testnamespace_testvmi</name><uuid>12345</uuid><devices></devices></domain>`
+
+		var manager *LibvirtDomainManager
+		var vmi *v1.VirtualMachineInstance
+
+		migrationOptions := func() *cmdclient.MigrationOptions {
+			return &cmdclient.MigrationOptions{
+				Bandwidth:               resource.MustParse("64Mi"),
+				ProgressTimeout:         150,
+				CompletionTimeoutPerGiB: 150,
+			}
+		}
+
+		setupMigrateHelperMocks := func() {
+			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).AnyTimes().Return(minimalDomainXML, nil)
+			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).AnyTimes().Return(minimalDomainXML, nil)
+		}
+
+		BeforeEach(func() {
+			vmi = newVMI(testNamespace, testVmName)
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID: "111222333",
+			}
+			manager = &LibvirtDomainManager{
+				virConn:       mockLibvirt.VirtConnection,
+				virtShareDir:  testVirtShareDir,
+				metadataCache: metadataCache,
+				cpuSetGetter:  fakeCpuSetGetter,
+			}
+			manager.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)
+		})
+
+		It("should set success result when MigrateToURI3 succeeds", func() {
+			// Monitor: lookup domain for monitor loop
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(&libvirt.DomainJobInfo{
+				Type: libvirt.DOMAIN_JOB_NONE,
+			}, nil)
+
+			// migrateHelper: lookup domain
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			setupMigrateHelperMocks()
+			mockLibvirt.DomainEXPECT().MigrateToURI3(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				manager.migrate(vmi, migrationOptions())
+			}()
+			Eventually(done, 10*time.Second).Should(BeClosed())
+
+			migration, _ := metadataCache.Migration.Load()
+			Expect(migration.Failed).To(BeFalse())
+			Expect(migration.EndTimestamp).ToNot(BeNil())
+		})
+
+		It("should set failure result when MigrateToURI3 fails without abort", func() {
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(&libvirt.DomainJobInfo{
+				Type: libvirt.DOMAIN_JOB_NONE,
+			}, nil)
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			setupMigrateHelperMocks()
+			mockLibvirt.DomainEXPECT().MigrateToURI3(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("connection reset"))
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				manager.migrate(vmi, migrationOptions())
+			}()
+			Eventually(done, 10*time.Second).Should(BeClosed())
+
+			migration, _ := metadataCache.Migration.Load()
+			Expect(migration.Failed).To(BeTrue())
+			Expect(migration.FailureReason).To(ContainSubstring("connection reset"))
+			Expect(migration.EndTimestamp).ToNot(BeNil())
+			Expect(migration.AbortStatus).To(Equal(""))
+		})
+
+		It("should resolve abort before setting migration result when abort succeeds during MigrateToURI3", func() {
+			migrateBlocking := make(chan struct{})
+			abortOrdered := make(chan struct{})
+
+			// Monitor: lookup + job stats for the loop
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(&libvirt.DomainJobInfo{
+				Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+				DataRemaining:    32479827394,
+				DataRemainingSet: true,
+			}, nil)
+
+			// migrateHelper: lookup domain
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			setupMigrateHelperMocks()
+
+			// MigrateToURI3 blocks until abort releases it
+			mockLibvirt.DomainEXPECT().MigrateToURI3(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ string, _ *libvirt.DomainMigrateParameters, _ libvirt.DomainMigrateFlags) error {
+					<-migrateBlocking
+					return fmt.Errorf("operation aborted: canceled by client")
+				})
+
+			// asyncMigrationAbort: lookup domain
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
+			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
+				close(abortOrdered)
+				// Simulate libvirt abort delay: MigrateToURI3 returns after AbortJob
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					close(migrateBlocking)
+				}()
+				return nil
+			})
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				manager.migrate(vmi, migrationOptions())
+			}()
+
+			// Wait for MigrateToURI3 to be blocking, then trigger abort
+			time.Sleep(500 * time.Millisecond)
+			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+
+			Eventually(abortOrdered, 5*time.Second).Should(BeClosed())
+			Eventually(done, 10*time.Second).Should(BeClosed())
+
+			migration, _ := metadataCache.Migration.Load()
+			Expect(migration.AbortStatus).To(Equal(string(v1.MigrationAbortSucceeded)))
+			Expect(migration.Failed).To(BeTrue())
+			Expect(migration.EndTimestamp).ToNot(BeNil())
+		})
+
+		It("should resolve abort before setting migration result when abort fails during MigrateToURI3", func() {
+			migrateBlocking := make(chan struct{})
+
+			// Monitor
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(&libvirt.DomainJobInfo{
+				Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+				DataRemaining:    32479827394,
+				DataRemainingSet: true,
+			}, nil)
+
+			// migrateHelper
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			setupMigrateHelperMocks()
+
+			mockLibvirt.DomainEXPECT().MigrateToURI3(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ string, _ *libvirt.DomainMigrateParameters, _ libvirt.DomainMigrateFlags) error {
+					<-migrateBlocking
+					return fmt.Errorf("connection reset")
+				})
+
+			// asyncMigrationAbort: domain lookup fails
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				// Release MigrateToURI3 after abort fails
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					close(migrateBlocking)
+				}()
+				return nil, fmt.Errorf("domain not found")
+			})
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				manager.migrate(vmi, migrationOptions())
+			}()
+
+			time.Sleep(500 * time.Millisecond)
+			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+			Eventually(done, 10*time.Second).Should(BeClosed())
+
+			migration, _ := metadataCache.Migration.Load()
+			Expect(migration.AbortStatus).To(Equal(string(v1.MigrationAbortFailed)))
+			Expect(migration.Failed).To(BeTrue())
+			Expect(migration.EndTimestamp).ToNot(BeNil())
+		})
+
+		It("should handle late abort after MigrateToURI3 already returned", func() {
+			// Monitor
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(&libvirt.DomainJobInfo{
+				Type: libvirt.DOMAIN_JOB_NONE,
+			}, nil)
+
+			// migrateHelper
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(func(_ string) (cli.VirDomain, error) {
+				mockLibvirt.DomainEXPECT().Free()
+				return mockLibvirt.VirtDomain, nil
+			})
+			setupMigrateHelperMocks()
+			mockLibvirt.DomainEXPECT().MigrateToURI3(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("connection reset"))
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				manager.migrate(vmi, migrationOptions())
+			}()
+			Eventually(done, 10*time.Second).Should(BeClosed())
+
+			// Migration already finished — EndTimestamp is set
+			migration, _ := metadataCache.Migration.Load()
+			Expect(migration.Failed).To(BeTrue())
+			Expect(migration.EndTimestamp).ToNot(BeNil())
+			endTimestamp := migration.EndTimestamp.DeepCopy()
+
+			// Late abort: cancelMigration is a no-op because EndTimestamp is already set
+			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+
+			// EndTimestamp should not be overwritten
+			migration, _ = metadataCache.Migration.Load()
+			Expect(migration.EndTimestamp).To(Equal(endTimestamp))
+		})
+	})
+
 	Context("on successful VirtualMachineInstance migrate", func() {
 		funcPreviousValue := ip.GetLoopbackAddress
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1770,7 +1770,6 @@ var _ = Describe("Manager", func() {
 	Context("test migration monitor", func() {
 		It("migration should be canceled if it's not progressing", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			fake_jobinfo := &libvirt.DomainJobInfo{
 				Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
 				DataRemaining:    32479827394,
@@ -1788,6 +1787,11 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
+			now := metav1.Now()
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.StartTimestamp = &now
+			metadataCache.Migration.Store(migrationMetadata)
+
 			manager := &LibvirtDomainManager{
 				virConn:       mockLibvirt.VirtConnection,
 				virtShareDir:  testVirtShareDir,
@@ -1798,14 +1802,21 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(fake_jobinfo, nil)
-			mockLibvirt.DomainEXPECT().AbortJob()
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
+			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
+				go func() {
+					time.Sleep(time.Second)
+					close(migrationErrorChan)
+				}()
+				return nil
+			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()
 		})
 		It("migration should be canceled if timeout has been reached", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				migrationData -= 125
@@ -1826,6 +1837,11 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
+			now := metav1.Now()
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.StartTimestamp = &now
+			metadataCache.Migration.Store(migrationMetadata)
+
 			manager := &LibvirtDomainManager{
 				virConn:       mockLibvirt.VirtConnection,
 				virtShareDir:  testVirtShareDir,
@@ -1836,7 +1852,15 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(fake_jobinfo, nil)
-			mockLibvirt.DomainEXPECT().AbortJob()
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
+			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
+				go func() {
+					time.Sleep(time.Second)
+					close(migrationErrorChan)
+				}()
+				return nil
+			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()
@@ -2005,7 +2029,6 @@ var _ = Describe("Manager", func() {
 		})
 		It("migration should be canceled if Paused workload didn't migrate until timeout was reached", func() {
 			migrationErrorChan := make(chan error)
-			defer close(migrationErrorChan)
 			var migrationData = 32479827394
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				migrationData -= 125
@@ -2027,6 +2050,10 @@ var _ = Describe("Manager", func() {
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				MigrationUID: "111222333",
 			}
+			now := metav1.Now()
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.StartTimestamp = &now
+			metadataCache.Migration.Store(migrationMetadata)
 
 			manager := &LibvirtDomainManager{
 				paused: pausedVMIs{
@@ -2044,7 +2071,15 @@ var _ = Describe("Manager", func() {
 				return fake_jobinfo(), nil
 			})
 			mockLibvirt.DomainEXPECT().Suspend().Times(1).Return(nil)
-			mockLibvirt.DomainEXPECT().AbortJob()
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
+			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
+				go func() {
+					time.Sleep(time.Second)
+					close(migrationErrorChan)
+				}()
+				return nil
+			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			monitor.startMonitor()

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1813,7 +1813,7 @@ var _ = Describe("Manager", func() {
 			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration abort should be retried after transient failure", func() {
 			migrationErrorChan := make(chan error)
@@ -1880,7 +1880,7 @@ var _ = Describe("Manager", func() {
 			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 			Eventually(abortStatus, 2*time.Second, 100*time.Millisecond).Should(Equal(string(v1.MigrationAbortSucceeded)))
 		})
 		It("migration should be canceled if timeout has been reached", func() {
@@ -1931,7 +1931,7 @@ var _ = Describe("Manager", func() {
 			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration should switch to PostCopy", func() {
 			migrationErrorChan := make(chan error)
@@ -1979,7 +1979,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().MigrateStartPostCopy(gomock.Eq(uint32(0))).Times(1).Return(nil)
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 		})
 
 		It("migration should switch to PostCopy eventually", func() {
@@ -2042,7 +2042,7 @@ var _ = Describe("Manager", func() {
 			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration should switch to Paused if AllowWorkloadDisruption is allowed and PostCopy is not", func() {
 			migrationErrorChan := make(chan error)
@@ -2093,7 +2093,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().Suspend().Times(1).Return(nil)
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 		})
 		It("migration should be canceled if Paused workload didn't migrate until timeout was reached", func() {
 			migrationErrorChan := make(chan error)
@@ -2150,7 +2150,7 @@ var _ = Describe("Manager", func() {
 			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 		})
 		// This is incomplete as it is not verifying that we abort. Previously it wasn't even testing anything at all
 		It("migration should be canceled when requested", func() {
@@ -2256,7 +2256,7 @@ var _ = Describe("Manager", func() {
 			)
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
-			monitor.startMonitor()
+			monitor.startMonitor(make(chan error, 1))
 			Eventually(func() string {
 				migration, _ := metadataCache.Migration.Load()
 				return migration.AbortStatus
@@ -2302,10 +2302,34 @@ var _ = Describe("Manager", func() {
 			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
 			done := make(chan struct{})
 			go func() {
-				monitor.startMonitor()
+				monitor.startMonitor(make(chan error, 1))
 				close(done)
 			}()
 			Eventually(done, 5*time.Second).Should(BeClosed())
+		})
+		It("monitor should signal error on ready channel if domain lookup fails", func() {
+			migrationErrorChan := make(chan error)
+
+			options := &cmdclient.MigrationOptions{
+				Bandwidth:               resource.MustParse("64Mi"),
+				ProgressTimeout:         3,
+				CompletionTimeoutPerGiB: 150,
+			}
+			vmi := newVMI(testNamespace, testVmName)
+
+			manager := &LibvirtDomainManager{
+				virConn:       mockLibvirt.VirtConnection,
+				virtShareDir:  testVirtShareDir,
+				metadataCache: metadataCache,
+				cpuSetGetter:  fakeCpuSetGetter,
+			}
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).Return(nil, fmt.Errorf("domain not found"))
+
+			monitor := newMigrationMonitor(vmi, manager, options, migrationErrorChan)
+			ready := make(chan error, 1)
+			monitor.startMonitor(ready)
+			Expect(ready).To(Receive(MatchError(ContainSubstring("domain not found"))))
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1883,6 +1883,53 @@ var _ = Describe("Manager", func() {
 			monitor.startMonitor(make(chan error, 1))
 			Eventually(abortStatus, 2*time.Second, 100*time.Millisecond).Should(Equal(string(v1.MigrationAbortSucceeded)))
 		})
+		DescribeTable("migration should be canceled when GetJobStats does not report progress", func(stubGetJobStats func()) {
+			migrationDone := make(chan struct{})
+
+			options := &cmdclient.MigrationOptions{
+				Bandwidth:               resource.MustParse("64Mi"),
+				ProgressTimeout:         3,
+				CompletionTimeoutPerGiB: 150,
+			}
+
+			vmi := newVMI(testNamespace, testVmName)
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID: "111222333",
+			}
+
+			now := metav1.Now()
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.StartTimestamp = &now
+			metadataCache.Migration.Store(migrationMetadata)
+
+			manager := &LibvirtDomainManager{
+				virConn:       mockLibvirt.VirtConnection,
+				virtShareDir:  testVirtShareDir,
+				metadataCache: metadataCache,
+				cpuSetGetter:  fakeCpuSetGetter,
+			}
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			stubGetJobStats()
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
+			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
+				close(migrationDone)
+				return nil
+			})
+
+			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
+			monitor.startMonitor(make(chan error, 1))
+		},
+			Entry("because GetJobStats keeps failing", func() {
+				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(nil, fmt.Errorf("persistent stats error"))
+			}),
+			Entry("because GetJobStats always returns JOB_NONE", func() {
+				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(
+					&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_NONE}, nil)
+			}),
+		)
 		It("migration should be canceled if timeout has been reached", func() {
 			migrationDone := make(chan struct{})
 			var migrationData = 32479827394

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -438,7 +438,7 @@ func ConfirmVMIPostMigrationFailed(vmi *v1.VirtualMachineInstance, migrationUID 
 	Expect(vmi.Status.MigrationState.EndTimestamp).ToNot(BeNil())
 	Expect(vmi.Status.MigrationState.SourceNode).To(Equal(vmi.Status.NodeName))
 	Expect(vmi.Status.MigrationState.TargetNode).ToNot(Equal(vmi.Status.MigrationState.SourceNode))
-	Expect(vmi.Status.MigrationState.Completed).To(BeFalse())
+	Expect(vmi.Status.MigrationState.Completed).To(BeTrue())
 	Expect(vmi.Status.MigrationState.Failed).To(BeTrue())
 	Expect(vmi.Status.MigrationState.TargetNodeAddress).ToNot(Equal(""))
 	Expect(string(vmi.Status.MigrationState.MigrationUID)).To(Equal(migrationUID))
@@ -463,8 +463,7 @@ func ConfirmVMIPostMigrationAborted(vmi *v1.VirtualMachineInstance, migrationUID
 
 	}, timeout, 1*time.Second).Should(
 		gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"Completed":   BeFalse(),
-			"AbortStatus": Equal(v1.MigrationAbortSucceeded),
+			"Completed": BeTrue(),
 		}),
 	)
 
@@ -482,6 +481,7 @@ func ConfirmVMIPostMigrationAborted(vmi *v1.VirtualMachineInstance, migrationUID
 	ExpectWithOffset(1, string(vmi.Status.MigrationState.MigrationUID)).To(Equal(migrationUID))
 	ExpectWithOffset(1, vmi.Status.MigrationState.Failed).To(BeTrue())
 	ExpectWithOffset(1, vmi.Status.MigrationState.AbortRequested).To(BeTrue())
+	ExpectWithOffset(1, vmi.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
 
 	By("Verifying the VMI's is in the running state")
 	ExpectWithOffset(1, vmi).To(matcher.BeInPhase(v1.Running))


### PR DESCRIPTION
### What this PR does

Cleanup and hardening of the source-side live migration monitor, abort flow, and cross-component error handling. Built on top of #17301 and #17561.

#### Migration monitor simplification
- Remove `determineNonRunningMigrationStatus` and `completedJobInfo` caching — all code paths already covered by `MigrateToURI3` error return and `migrationErrorChan`
- Remove `migrationFailedWithError` two-phase error handling — errors processed immediately
- Remove redundant `DOMAIN_JOB_CANCELLED` handling — always followed by `MigrateToURI3` error
- Retrieve completed migration stats via libvirt job completion event instead of polling
- Fix monitor busy loop after successful migration (fallback `GetJobStats` with `COMPLETED` flag)
- Log actual Downtime/DowntimeNet for completed jobs
- Move volume size error rewrite into `setMigrationResultHelper` where it runs on first call

#### Migration abort decoupling
- Delegate all abort calls from monitor to `cancelMigration()` — single guarded path with `AbortStatus` tracking
- Separate `setMigrationAbortStatus` from `setMigrationResult` — abort only sets abort, result only sets result
- `asyncMigrationAbort` no longer calls `setMigrationResult` directly
- Add `sync.WaitGroup` so `migrateHelper` waits for in-flight abort before `migrate()` sets final result
- `migrate()` is now the sole owner of `setMigrationResult` on all paths

#### Monitor reliability
- Gate migration start on monitor readiness — if monitor can't initialize, migration doesn't proceed
- Replace `migrationErrorChan` (bidirectional `chan error`) with `migrationDone` (`chan struct{}`) — pure exit signal
- Enforce migration timeouts regardless of job type — `processInflightMigration` runs every iteration even when `GetJobStats` fails or returns `JOB_NONE`

#### Reduce noisy abort logs
- `cancelMigration` returns nil and logs when migration is not active or abort already in progress/succeeded — eliminates error propagation through gRPC for expected conditions
- virt-handler `handleMigrationAbort` checks both VMI status and domain metadata before issuing cancel RPC — eliminates redundant calls
- Remove unused `CancelMigrationFailedVmiNotMigratingErr` constant

### Why we need it and why it was done in this way

The migration monitor accumulated overlapping error handling, redundant status-setting paths, and mixed abort/result responsibilities that made the code hard to reason about and caused observable issues:
- Stale domain sends racing with fresh metadata notifications
- Redundant abort RPC calls from virt-handler due to stale status and broken error string matching
- Timeouts not firing when `GetJobStats` fails or returns `JOB_NONE`

### Special notes for your reviewer

The commits are ordered to be individually reviewable. The abort decoupling series builds incrementally — each step preserves correctness while removing one mixed responsibility.

### Checklist

- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: Write code that humans can understand and Keep it simple
- [X] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [X] Testing: New code requires new unit tests
- [X] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```
NONE
```