### PR TITLE
make sysprep support appendIndexToSecretRefs/appendIndexToConfigRefs

### DIFF
--- a/pkg/virt-controller/watch/pool/pool.go
+++ b/pkg/virt-controller/watch/pool/pool.go
@@ -823,6 +823,13 @@ func indexVMSpec(poolSpec *poolv1.VirtualMachinePoolSpec, idx int) *virtv1.Virtu
 			if volume.VolumeSource.CloudInitConfigDrive.NetworkDataSecretRef != nil {
 				volume.CloudInitConfigDrive.NetworkDataSecretRef.Name += suffix
 			}
+		} else if volume.VolumeSource.Sysprep != nil {
+			if volume.VolumeSource.Sysprep.Secret != nil && appendIndexToSecretRefs {
+				volume.Sysprep.Secret.Name += suffix
+			}
+			if volume.VolumeSource.Sysprep.ConfigMap != nil && appendIndexToConfigMapRefs {
+				volume.Sysprep.ConfigMap.Name += suffix
+			}
 		}
 	}
 


### PR DESCRIPTION
### What this PR does

This PR harmonizes the secret references for sysprep. It now respects `appendIndexTo*Refs` the same way that is commonly used across other refs.

#### Before this PR:

references to config maps and secrets did not add `-<IDX>` suffixes when `appendIndexToSecretRefs: true` or `appendIndexToConfigMapRefs: true` where present

#### After this PR:

Now these references are correctly numbered and therefor are consistent with other refs in 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

