### PR TITLE
launcher, converter: Extract RebootPolicy configuration logic

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "os.go",
         "panic_devices.go",
         "qemu_cmd.go",
+        "reboot_policy.go",
         "rng.go",
         "sound.go",
         "sysinfo.go",

--- a/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "memory_test.go",
         "os_test.go",
         "panic_devices_test.go",
+        "reboot_policy_test.go",
         "rng_test.go",
         "sound_test.go",
         "sysinfo_test.go",

--- a/pkg/virt-launcher/virtwrap/converter/compute/reboot_policy.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/reboot_policy.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package compute
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+type RebootPolicyDomainConfigurator struct{}
+
+func (r RebootPolicyDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+	// In case the RebootPolicy is not set, we rely on libvirt default behavior
+	// that is to reboot the guest silently.
+	if vmi.Spec.Domain.RebootPolicy != nil {
+		switch *vmi.Spec.Domain.RebootPolicy {
+		case v1.RebootPolicyTerminate:
+			domain.Spec.OnReboot = api.DomainOnRebootDestroy
+		case v1.RebootPolicyReboot:
+			domain.Spec.OnReboot = api.DomainOnRebootRestart
+		}
+	}
+
+	return nil
+}

--- a/pkg/virt-launcher/virtwrap/converter/compute/reboot_policy.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/reboot_policy.go
@@ -30,13 +30,15 @@ type RebootPolicyDomainConfigurator struct{}
 func (r RebootPolicyDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	// In case the RebootPolicy is not set, we rely on libvirt default behavior
 	// that is to reboot the guest silently.
-	if vmi.Spec.Domain.RebootPolicy != nil {
-		switch *vmi.Spec.Domain.RebootPolicy {
-		case v1.RebootPolicyTerminate:
-			domain.Spec.OnReboot = api.DomainOnRebootDestroy
-		case v1.RebootPolicyReboot:
-			domain.Spec.OnReboot = api.DomainOnRebootRestart
-		}
+	if vmi.Spec.Domain.RebootPolicy == nil {
+		return nil
+	}
+
+	switch *vmi.Spec.Domain.RebootPolicy {
+	case v1.RebootPolicyTerminate:
+		domain.Spec.OnReboot = api.DomainOnRebootDestroy
+	case v1.RebootPolicyReboot:
+		domain.Spec.OnReboot = api.DomainOnRebootRestart
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/converter/compute/reboot_policy_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/reboot_policy_test.go
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package compute_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
+)
+
+var _ = Describe("RebootPolicy Domain Configurator", func() {
+	It("Should not set OnReboot when RebootPolicy is unspecified in VMI", func() {
+		vmi := libvmi.New()
+		var domain api.Domain
+
+		Expect(compute.RebootPolicyDomainConfigurator{}.Configure(vmi, &domain)).To(Succeed())
+		Expect(domain).To(Equal(api.Domain{}))
+	})
+
+	DescribeTable("Should set OnReboot when RebootPolicy is specified in VMI",
+		func(policy v1.RebootPolicy, expectedOnReboot string) {
+			vmi := libvmi.New(withRebootPolicy(policy))
+			var domain api.Domain
+
+			Expect(compute.RebootPolicyDomainConfigurator{}.Configure(vmi, &domain)).To(Succeed())
+			expectedDomain := api.Domain{
+				Spec: api.DomainSpec{
+					OnReboot: expectedOnReboot,
+				},
+			}
+			Expect(domain).To(Equal(expectedDomain))
+		},
+		Entry("Terminate policy maps to destroy",
+			v1.RebootPolicyTerminate, api.DomainOnRebootDestroy,
+		),
+		Entry("Reboot policy maps to restart",
+			v1.RebootPolicyReboot, api.DomainOnRebootRestart,
+		),
+	)
+})
+
+func withRebootPolicy(policy v1.RebootPolicy) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.RebootPolicy = &policy
+	}
+}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1076,6 +1076,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		compute.NewCPUDomainConfigurator(c.Architecture.SupportCPUHotplug(), c.Architecture.RequiresMPXCPUValidation()),
 		compute.NewIOThreadsDomainConfigurator(uint(ioThreadCount)),
 		compute.MemoryConfigurator{},
+		compute.RebootPolicyDomainConfigurator{},
 	}
 
 	switch c.HypervisorName {
@@ -1246,17 +1247,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			}
 		} else {
 			log.Log.Infof("Skipping PCIe root complex placement: architecture %s does not support PCIe placement", c.Architecture.GetArchitecture())
-		}
-	}
-
-	// In case the RebootPolicy is not set, we rely on libvirt default behavior
-	// that is to reboot the guest silently.
-	if vmi.Spec.Domain.RebootPolicy != nil {
-		switch *vmi.Spec.Domain.RebootPolicy {
-		case v1.RebootPolicyTerminate:
-			domain.Spec.OnReboot = api.DomainOnRebootDestroy
-		case v1.RebootPolicyReboot:
-			domain.Spec.OnReboot = api.DomainOnRebootRestart
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The reboot policy configuration logic lives inline in `Convert_v1_VirtualMachineInstance_To_api_Domain`, mixed in with 
unrelated domain conversion concerns.
#### After this PR:
The reboot policy logic is encapsulated in a dedicated `RebootPolicyDomainConfigurator` in the `compute` package, following the established `Configurator` interface pattern.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
-->
- Partially addresses https://github.com/kubevirt/kubevirt/issues/16117

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

