### PR TITLE
Disable PCI hotplug on occupied pcie-root-port controllers

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -71,6 +71,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/efi:go_default_library",
         "//pkg/virt-launcher/virtwrap/errors:go_default_library",
         "//pkg/virt-launcher/virtwrap/network:go_default_library",
+        "//pkg/virt-launcher/virtwrap/pci:go_default_library",
         "//pkg/virt-launcher/virtwrap/plugins:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -107,6 +107,7 @@ const (
 	AddressCCW     = "ccw"
 
 	ControllerTypePCI              = "pci"
+	ControllerModelPCIRoot         = "pci-root"
 	ControllerModelPCIeRoot        = "pcie-root"
 	ControllerModelPCIeRootPort    = "pcie-root-port"
 	ControllerModelPCIeExpanderBus = "pcie-expander-bus"
@@ -804,6 +805,7 @@ type PCIHole64 struct {
 
 // BEGIN ControllerTarget
 type ControllerTarget struct {
+	Hotplug  string  `xml:"hotplug,attr,omitempty"`
 	BusNr    *uint32 `xml:"busNr,attr,omitempty"`
 	NUMANode *uint32 `xml:"node,omitempty"`
 }

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/dra"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/pci"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/storage"
 
 	"libvirt.org/go/libvirt"
@@ -1751,11 +1752,14 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 	// providing genuine hotplug capacity.
 	if extraControllers > 0 {
 		appendPCIeRootPortControllers(domainSpec, extraControllers)
-		dom.Free()
-		dom, err = l.setDomainSpecWithHooks(vmi, domainSpec)
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	pci.DisableHotplugOnOccupiedRootPorts(domainSpec)
+
+	dom.Free()
+	dom, err = l.setDomainSpecWithHooks(vmi, domainSpec)
+	if err != nil {
+		return nil, err
 	}
 
 	return dom, nil

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1746,6 +1746,17 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 		return nil, err
 	}
 
+	// When placeholderCount == 0, WithNetworkIfacesResources skips the
+	// read-back, so domainSpec lacks libvirt-assigned Target.BusNr values
+	// needed by DisableHotplugOnOccupiedRootPorts.
+	if placeholderCount == 0 {
+		readBack, readErr := util.GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_INACTIVE)
+		if readErr != nil {
+			return nil, readErr
+		}
+		readBack.Devices.DeepCopyInto(&domainSpec.Devices)
+	}
+
 	// Extra controllers must be added AFTER WithNetworkIfacesResources so
 	// that libvirt has already assigned devices to root ports. Controllers
 	// appended here get indices above the occupied ports and remain empty,
@@ -1756,7 +1767,9 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 
 	pci.DisableHotplugOnOccupiedRootPorts(domainSpec)
 
-	dom.Free()
+	if freeErr := dom.Free(); freeErr != nil {
+		err = errors.Join(err, freeErr)
+	}
 	dom, err = l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return nil, err

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -461,6 +461,11 @@ var _ = Describe("Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 			extraControllers, err := calculateExtraControllerCount(vmi, domainSpec, placeholderCount)
 			Expect(err).ToNot(HaveOccurred())
+			if placeholderCount == 0 {
+				domainXML, err := xml.MarshalIndent(domainSpec, "", "\t")
+				Expect(err).ToNot(HaveOccurred())
+				mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(domainXML), nil)
+			}
 			if extraControllers > 0 {
 				appendPCIeRootPortControllers(domainSpec, extraControllers)
 				// The xmlns:qemu attribute is lost during the XML marshal/unmarshal
@@ -504,6 +509,9 @@ var _ = Describe("Manager", func() {
 				mockLibvirt.ConnectionEXPECT().DomainDefineXML(string(domainXMLWithExtra)).DoAndReturn(mockDomainWithFreeExpectation)
 			}
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(domainXML), nil)
+			if placeholderCount == 0 {
+				mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(domainXML), nil)
+			}
 		}
 
 		It("should define and start a new VirtualMachineInstance", func() {
@@ -773,6 +781,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
+			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(xmlDomain), nil)
 
 			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{
@@ -1013,6 +1022,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
+			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(xmlDomain), nil)
 			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hotplug.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/pci",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "hotplug_test.go",
+        "pci_suite_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
@@ -17,9 +17,11 @@ go_test(
         "hotplug_test.go",
         "pci_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/pci/hotplug.go
+++ b/pkg/virt-launcher/virtwrap/pci/hotplug.go
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package pci
+
+import (
+	"strconv"
+	"strings"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+func busNrFromTarget(target *api.ControllerTarget) (int, bool) {
+	if target == nil || target.BusNr == nil {
+		return 0, false
+	}
+	return int(*target.BusNr), true
+}
+
+// DisableHotplugOnOccupiedRootPorts sets hotplug="off" on pcie-root-port
+// controllers that have a non-interface device behind them, preventing guests
+// from ejecting critical devices (disks, balloon, RNG, etc.) at runtime.
+// Interface (NIC) ports are left hotpluggable to preserve NIC hot-unplug.
+//
+// Must be called after the libvirt read-back so that Target.BusNr is populated.
+//
+// Note: when the PlacePCIDevicesOnRootComplex annotation is set, devices sit
+// directly on the root bus with slot-based addressing (no pcie-root-ports),
+// so they remain ejectable regardless of this function.
+func DisableHotplugOnOccupiedRootPorts(spec *api.DomainSpec) {
+	occupiedBuses := collectOccupiedPCIBuses(spec)
+
+	for i, controller := range spec.Devices.Controllers {
+		if controller.Model != api.ControllerModelPCIeRootPort {
+			continue
+		}
+		bus, ok := busNrFromTarget(controller.Target)
+		if !ok {
+			continue
+		}
+		if _, occupied := occupiedBuses[bus]; occupied {
+			if spec.Devices.Controllers[i].Target == nil {
+				spec.Devices.Controllers[i].Target = &api.ControllerTarget{}
+			}
+			spec.Devices.Controllers[i].Target.Hotplug = "off"
+		}
+	}
+}
+
+func collectOccupiedPCIBuses(spec *api.DomainSpec) map[int]struct{} {
+	addrs := collectNonInterfacePCIAddresses(spec)
+
+	buses := make(map[int]struct{}, len(addrs))
+	for _, addr := range addrs {
+		if addr == nil || addr.Bus == "" {
+			continue
+		}
+		if bus, err := strconv.ParseInt(strings.TrimPrefix(addr.Bus, "0x"), 16, 32); err == nil {
+			buses[int(bus)] = struct{}{}
+		}
+	}
+	return buses
+}
+
+// collectNonInterfacePCIAddresses returns PCI addresses of all devices except
+// network interfaces, which are excluded to keep their root ports hotpluggable.
+func collectNonInterfacePCIAddresses(spec *api.DomainSpec) []*api.Address {
+	var addrs []*api.Address
+	for i, disk := range spec.Devices.Disks {
+		if disk.Target.Bus != v1.DiskBusVirtio {
+			continue
+		}
+		addrs = append(addrs, spec.Devices.Disks[i].Address)
+	}
+	for _, controller := range spec.Devices.Controllers {
+		if controller.Model == api.ControllerModelPCIRoot ||
+			controller.Model == api.ControllerModelPCIeRoot ||
+			controller.Model == api.ControllerModelPCIeRootPort ||
+			controller.Model == api.ControllerModelPCIeExpanderBus {
+			continue
+		}
+		addrs = append(addrs, controller.Address)
+	}
+	for i, input := range spec.Devices.Inputs {
+		if input.Bus != v1.VirtIO {
+			continue
+		}
+		addrs = append(addrs, spec.Devices.Inputs[i].Address)
+	}
+	for i := range spec.Devices.Watchdogs {
+		addrs = append(addrs, spec.Devices.Watchdogs[i].Address)
+	}
+	for _, hostDev := range spec.Devices.HostDevices {
+		if hostDev.Type != api.HostDevicePCI {
+			continue
+		}
+		addrs = append(addrs, hostDev.Address)
+	}
+	if spec.Devices.Ballooning != nil {
+		addrs = append(addrs, spec.Devices.Ballooning.Address)
+	}
+	if spec.Devices.Rng != nil {
+		addrs = append(addrs, spec.Devices.Rng.Address)
+	}
+	if spec.Devices.Memory != nil {
+		addrs = append(addrs, spec.Devices.Memory.Address)
+	}
+	return addrs
+}

--- a/pkg/virt-launcher/virtwrap/pci/hotplug.go
+++ b/pkg/virt-launcher/virtwrap/pci/hotplug.go
@@ -57,9 +57,6 @@ func DisableHotplugOnOccupiedRootPorts(spec *api.DomainSpec) {
 			continue
 		}
 		if _, occupied := occupiedBuses[bus]; occupied {
-			if spec.Devices.Controllers[i].Target == nil {
-				spec.Devices.Controllers[i].Target = &api.ControllerTarget{}
-			}
 			spec.Devices.Controllers[i].Target.Hotplug = "off"
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/pci/hotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/pci/hotplug_test.go
@@ -1,0 +1,239 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package pci_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/pci"
+)
+
+var _ = Describe("DisableHotplugOnOccupiedRootPorts", func() {
+	pciAddr := func(bus string) *api.Address {
+		return &api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: bus, Slot: "0x00", Function: "0x0"}
+	}
+
+	uint32Ptr := func(v uint32) *uint32 { return &v }
+
+	newRootPortController := func(index string, busNr uint32) api.Controller {
+		return api.Controller{
+			Type:   api.ControllerTypePCI,
+			Index:  index,
+			Model:  api.ControllerModelPCIeRootPort,
+			Target: &api.ControllerTarget{BusNr: uint32Ptr(busNr)},
+		}
+	}
+
+	expectHotplugOff := func(controller api.Controller, desc string) {
+		ExpectWithOffset(1, controller.Target).NotTo(BeNil(), desc)
+		ExpectWithOffset(1, controller.Target.Hotplug).To(Equal("off"), desc)
+	}
+
+	expectHotplugUnchanged := func(controller api.Controller, desc string) {
+		if controller.Target == nil {
+			return
+		}
+		ExpectWithOffset(1, controller.Target.Hotplug).To(BeEmpty(), desc)
+	}
+
+	It("should disable hotplug on occupied ports and leave empty ones unchanged", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1),
+					newRootPortController("2", 2),
+					newRootPortController("3", 3),
+				},
+				Interfaces: []api.Interface{{Address: pciAddr("0x01")}},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x02")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "port with NIC stays hotpluggable")
+		expectHotplugOff(spec.Devices.Controllers[2], "port with balloon")
+		expectHotplugUnchanged(spec.Devices.Controllers[3], "empty port")
+	})
+
+	It("should detect all non-interface PCI device types", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1), newRootPortController("2", 2), newRootPortController("3", 3), newRootPortController("4", 4),
+					newRootPortController("5", 5), newRootPortController("6", 6), newRootPortController("7", 7), newRootPortController("8", 8),
+					newRootPortController("9", 9),
+				},
+				Interfaces:  []api.Interface{{Address: pciAddr("0x01")}},
+				Disks:       []api.Disk{{Target: api.DiskTarget{Bus: v1.DiskBusVirtio}, Address: pciAddr("0x02")}},
+				Inputs:      []api.Input{{Bus: v1.VirtIO, Address: pciAddr("0x03")}},
+				Watchdogs:   []api.Watchdog{{Address: pciAddr("0x04")}},
+				HostDevices: []api.HostDevice{{Type: api.HostDevicePCI, Address: pciAddr("0x05")}},
+				Ballooning:  &api.MemBalloon{Address: pciAddr("0x06")},
+				Rng:         &api.Rng{Address: pciAddr("0x07")},
+				Memory:      &api.MemoryDevice{Address: pciAddr("0x08")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "NIC port stays hotpluggable")
+		expectHotplugOff(spec.Devices.Controllers[2], "virtio disk on bus 2")
+		expectHotplugOff(spec.Devices.Controllers[3], "virtio input on bus 3")
+		expectHotplugOff(spec.Devices.Controllers[4], "watchdog on bus 4")
+		expectHotplugOff(spec.Devices.Controllers[5], "PCI host device on bus 5")
+		expectHotplugOff(spec.Devices.Controllers[6], "memory balloon on bus 6")
+		expectHotplugOff(spec.Devices.Controllers[7], "RNG on bus 7")
+		expectHotplugOff(spec.Devices.Controllers[8], "memory device on bus 8")
+		expectHotplugUnchanged(spec.Devices.Controllers[9], "empty port")
+	})
+
+	It("should not modify non-pcie-root-port controllers", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					{Type: "usb", Index: "0", Model: "none"},
+					{Type: "scsi", Index: "0", Model: "virtio-scsi", Address: pciAddr("0x05")},
+				},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		for _, ctrl := range spec.Devices.Controllers {
+			Expect(ctrl.Target).To(BeNil())
+		}
+	})
+
+	It("should skip root ports with nil Target (no BusNr available)", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "1", Model: api.ControllerModelPCIeRootPort},
+				},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x01")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[0], "nil Target means no BusNr, port skipped")
+	})
+
+	It("should preserve existing Target fields when setting hotplug off", func() {
+		busNr := uint32(1)
+		numaNode := uint32(0)
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{
+						Type:  api.ControllerTypePCI,
+						Index: "1",
+						Model: api.ControllerModelPCIeRootPort,
+						Target: &api.ControllerTarget{
+							BusNr:    &busNr,
+							NUMANode: &numaNode,
+						},
+					},
+				},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x01")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		target := spec.Devices.Controllers[0].Target
+		Expect(target).NotTo(BeNil())
+		Expect(target.Hotplug).To(Equal("off"))
+		Expect(target.BusNr).To(Equal(&busNr))
+		Expect(target.NUMANode).To(Equal(&numaNode))
+	})
+
+	It("should mark a root port as occupied when a child controller sits on its bus", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1),
+					newRootPortController("5", 5),
+					{Type: "scsi", Index: "0", Model: "virtio-scsi", Address: pciAddr("0x05")},
+				},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x01")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugOff(spec.Devices.Controllers[1], "balloon on bus 1")
+		expectHotplugOff(spec.Devices.Controllers[2], "SCSI controller on bus 5")
+	})
+
+	It("should not mark interface ports as occupied to preserve NIC hot-unplug", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1),
+					newRootPortController("2", 2),
+					newRootPortController("3", 3),
+				},
+				Interfaces: []api.Interface{
+					{Address: pciAddr("0x01")},
+					{Address: pciAddr("0x02")},
+					{Address: pciAddr("0x03")},
+				},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "NIC on bus 1")
+		expectHotplugUnchanged(spec.Devices.Controllers[2], "NIC on bus 2")
+		expectHotplugUnchanged(spec.Devices.Controllers[3], "NIC on bus 3")
+	})
+
+	It("should ignore non-PCI device addresses (SATA disks, USB inputs)", func() {
+		driveAddr := &api.Address{Type: "drive", Bus: "0", Controller: "0", Target: "0", Unit: "0"}
+		usbAddr := &api.Address{Type: "usb", Bus: "0"}
+
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					newRootPortController("0", 0),
+					newRootPortController("1", 1),
+				},
+				Disks:  []api.Disk{{Target: api.DiskTarget{Bus: "sata"}, Address: driveAddr}},
+				Inputs: []api.Input{{Type: "tablet", Bus: "usb", Address: usbAddr}},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[0], "SATA disk drive address must not match")
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "USB input address must not match")
+	})
+})

--- a/pkg/virt-launcher/virtwrap/pci/pci_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/pci/pci_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package pci_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestPCI(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}


### PR DESCRIPTION
### What this PR does

Prevents guest operating systems from ejecting critical PCI devices (virtio disks, memory balloon, RNG, watchdog, SCSI/USB/virtio-serial controllers) by setting `hotplug="off"` on `pcie-root-port` controllers that have a non-NIC device behind them.

NIC ports are intentionally left hotpluggable to preserve the existing NIC hot-unplug functionality.

#### Before this PR:
- All `pcie-root-port` controllers default to `hotplug="on"`.
- The guest OS can eject any PCI device — on Windows via the "Safely Remove Hardware" tray icon, on Linux via `echo 1 > /sys/bus/pci/.../power/control`.
- A user or automated guest agent can accidentally remove a virtio disk (risking data corruption), the memory balloon (breaking memory management), or the RNG device.

#### After this PR:

- After libvirt assigns PCI addresses (via the throwaway domain define in `WithNetworkIfacesResources`), a new `pci.DisableHotplugOnOccupiedRootPorts` pass walks the domain spec, identifies which PCI bus numbers host
non-NIC devices, and sets `hotplug="off"` on the corresponding `pcie-root-port` controllers before the final domain definition.

Placeholder ports reserved for future NIC hotplug remain with `hotplug="on"` so dynamic attachment continues to work.

**Why `allocateHotplugPorts` in manager.go?**

This is the only point where we have the full picture: libvirt has auto-created `pcie-root-port` controllers and assigned PCI addresses to all devices, but the domain hasn't been finalized yet. 
The refactored flow is:
WithNetworkIfacesResources → DisableHotplugOnOccupiedRootPorts → setDomainSpecWithHooks (enrich topology) (apply hotplug policy) (final define)

### Special notes for your reviewer

- The `Hotplug` field on `ControllerTarget` maps to libvirt's `<target hotplug="off"/>` attribute, supported since libvirt 6.3.0 on `pcie-root-port` controllers.
- `collectDevicePCIAddresses` intentionally filters by device bus/type to avoid misinterpreting SATA drive addresses (`type="drive"`) or USB addresses (`type="usb"`) as PCI bus numbers.
- The `pci-root` controller model (i440fx machines) is excluded from processing, matching the pattern in `converter.iteratePCIAddresses`.

### References

- Fixes: https://issues.redhat.com/browse/CNV-77514
- libvirt `<target hotplug>` docs: https://libvirt.org/formatdomain.html#controllers

### Release note
```release-note
Bug fix: Prevent guest OS from ejecting critical PCI devices (disks, memory balloon, RNG, watchdog) via hotplug mechanisms like the Windows "Safely Remove Hardware" tray menu. PCI root ports hosting non-NIC devices are now marked as non-hotpluggable, while NIC ports and empty ports reserved for future hotplug remain available.
```