### PR TITLE
[release-1.5] net, networkpolicy: Fix network policy for IPv4/IPv6

### DIFF
--- a/tests/libnet/cloudinit/BUILD.bazel
+++ b/tests/libnet/cloudinit/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnet/cloudinit",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
+        "//tests/libnet/cluster:go_default_library",
         "//tests/libnet/dns:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/tests/libnet/cloudinit/cloudinit.go
+++ b/tests/libnet/cloudinit/cloudinit.go
@@ -22,6 +22,8 @@ package cloudinit
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
 	"kubevirt.io/kubevirt/tests/libnet/dns"
 
 	"sigs.k8s.io/yaml"
@@ -81,16 +83,28 @@ func WithAddresses(addresses ...string) NetworkDataInterfaceOption {
 
 func WithDHCP4Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		enabled := true
-		networkDataInterface.DHCP4 = &enabled
+		networkDataInterface.DHCP4 = pointer.P(true)
 		return nil
 	}
 }
 
 func WithDHCP6Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		enabled := true
-		networkDataInterface.DHCP6 = &enabled
+		networkDataInterface.DHCP6 = pointer.P(true)
+		return nil
+	}
+}
+
+func WithDHCP4Disabled() NetworkDataInterfaceOption {
+	return func(networkDataInterface *CloudInitInterface) error {
+		networkDataInterface.DHCP4 = pointer.P(false)
+		return nil
+	}
+}
+
+func WithDHCP6Disabled() NetworkDataInterfaceOption {
+	return func(networkDataInterface *CloudInitInterface) error {
+		networkDataInterface.DHCP6 = pointer.P(false)
 		return nil
 	}
 }
@@ -176,18 +190,44 @@ const (
 	DefaultIPv6Gateway = "fd10:0:2::1"
 )
 
-// CreateDefaultCloudInitNetworkData generates a default configuration
-// for the Cloud-Init Network Data, in version 2 format.
-// The default configuration sets dynamic IPv4 (DHCP) and static IPv6 addresses,
-// inclusing DNS settings of the cluster nameserver IP and search domains.
+// CreateDefaultCloudInitNetworkData returns cloud-init v2 network-config for eth0 from cluster IP family probes.
 func CreateDefaultCloudInitNetworkData() string {
-	data, err := NewNetworkData(
-		WithEthernet("eth0",
+	supportsIPv4, errV4 := cluster.SupportsIpv4()
+	if errV4 != nil {
+		panic(errV4)
+	}
+	supportsIPv6, errV6 := cluster.SupportsIpv6()
+	if errV6 != nil {
+		panic(errV6)
+	}
+
+	var ifaceOpts []NetworkDataInterfaceOption
+	switch {
+	case supportsIPv4 && supportsIPv6: // DHCPv4 + static IPv6 + gateway6
+		ifaceOpts = []NetworkDataInterfaceOption{
 			WithDHCP4Enabled(),
 			WithAddresses(DefaultIPv6CIDR),
 			WithGateway6(DefaultIPv6Gateway),
 			WithNameserverFromCluster(),
-		))
+		}
+	case supportsIPv4: // DHCPv4 only
+		ifaceOpts = []NetworkDataInterfaceOption{
+			WithDHCP4Enabled(),
+			WithDHCP6Disabled(),
+			WithNameserverFromCluster(),
+		}
+	case supportsIPv6: // static IPv6 + gateway6
+		ifaceOpts = []NetworkDataInterfaceOption{
+			WithDHCP4Disabled(),
+			WithAddresses(DefaultIPv6CIDR),
+			WithGateway6(DefaultIPv6Gateway),
+			WithNameserverFromCluster(),
+		}
+	default: // probes ok but neither family — should not happen
+		panic(fmt.Errorf("cluster IPv4/IPv6 probes succeeded but neither family is supported"))
+	}
+
+	data, err := NewNetworkData(WithEthernet("eth0", ifaceOpts...))
 	if err != nil {
 		panic(err)
 	}

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -23,6 +23,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	libvmi "kubevirt.io/kubevirt/pkg/libvmi"
+
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -392,9 +394,13 @@ func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
 }
 
 func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {
-	clientVMI := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
-	var err error
-	clientVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
+	clientVMI := libvmifact.NewAlpineWithTestTooling(
+		libvmi.WithCloudInitNoCloud(
+			libvmifact.WithDummyCloudForFastBoot(),
+		),
+		libnet.WithMasqueradeNetworking(),
+	)
+	clientVMI, err := virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -405,6 +411,9 @@ func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.V
 
 func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, serverVMILabels map[string]string) (*v1.VirtualMachineInstance, error) {
 	serverVMI := libvmifact.NewAlpineWithTestTooling(
+		libvmi.WithCloudInitNoCloud(
+			libvmifact.WithDummyCloudForFastBoot(),
+		),
 		libnet.WithMasqueradeNetworking(
 			v1.Port{
 				Name:     "http80",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Backport of https://github.com/kubevirt/kubevirt/pull/17067 to release-1.5 by manual cherry pick of commit https://github.com/kubevirt/kubevirt/commit/2ac1c2985b2c95780864a2447e546f7a47477e3e.

Note: https://github.com/kubevirt/kubevirt/commit/71acedd88b9ff55ebca62486d411092de65a8e21 is not being backported because it adds a decorator for s390 which is not required in older versions.

The reason for backporting is to fix NetworkPolicy test failures occurring in single IP family setups running older releases.

Since this PR only changes test infrastructure, the risk of regression in production code is low.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

