### PR TITLE
Add HTTP server timeouts to all components

### DIFF
--- a/cmd/synchronization-controller/BUILD.bazel
+++ b/cmd/synchronization-controller/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/healthz:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/synchronization-controller:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/ratelimiter:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/cmd/synchronization-controller/synchronization-controller.go
+++ b/cmd/synchronization-controller/synchronization-controller.go
@@ -289,7 +289,9 @@ func (app *synchronizationControllerApp) runWithLeaderElection(synchronizationCo
 		TLSConfig: tlsConfig,
 		// Disable HTTP/2
 		// See CVE-2023-44487
-		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	go func() {

--- a/cmd/synchronization-controller/synchronization-controller.go
+++ b/cmd/synchronization-controller/synchronization-controller.go
@@ -56,6 +56,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/synchronization-controller"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/ratelimiter"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	virthandler "kubevirt.io/kubevirt/pkg/virt-handler"
@@ -290,8 +291,8 @@ func (app *synchronizationControllerApp) runWithLeaderElection(synchronizationCo
 		// Disable HTTP/2
 		// See CVE-2023-44487
 		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: util.DefaultReadHeaderTimeout,
+		IdleTimeout:       util.DefaultIdleTimeout,
 	}
 
 	go func() {

--- a/cmd/virt-exportproxy/BUILD.bazel
+++ b/cmd/virt-exportproxy/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/service:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/cmd/virt-exportproxy/virt-exportproxy.go
+++ b/cmd/virt-exportproxy/virt-exportproxy.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"regexp"
+	"time"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
@@ -98,7 +99,9 @@ func (app *exportProxyApp) Run() {
 		TLSConfig: appTLSConfig,
 		// Disable HTTP/2
 		// See CVE-2023-44487
-		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	if err := server.ListenAndServeTLS("", ""); err != nil {

--- a/cmd/virt-exportproxy/virt-exportproxy.go
+++ b/cmd/virt-exportproxy/virt-exportproxy.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"regexp"
-	"time"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
@@ -44,6 +43,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/service"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -100,8 +100,8 @@ func (app *exportProxyApp) Run() {
 		// Disable HTTP/2
 		// See CVE-2023-44487
 		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: util.DefaultReadHeaderTimeout,
+		IdleTimeout:       util.DefaultIdleTimeout,
 	}
 
 	if err := server.ListenAndServeTLS("", ""); err != nil {

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -616,7 +616,9 @@ func (app *virtHandlerApp) runPrometheusServer(errCh chan error) {
 		TLSConfig: app.promTLSConfig,
 		// Disable HTTP/2
 		// See CVE-2023-44487
-		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 	errCh <- server.ListenAndServeTLS("", "")
 }
@@ -648,8 +650,9 @@ func (app *virtHandlerApp) runServer(errCh chan error, consoleHandler *rest.Cons
 		Addr:    fmt.Sprintf("%s:%d", app.ServiceListen.BindAddress, app.consoleServerPort),
 		Handler: restful.DefaultContainer,
 		// we use migration TLS also for console connections (initiated by virt-api)
-		TLSConfig:   app.serverTLSConfig,
-		IdleTimeout: 60 * time.Second,
+		TLSConfig:         app.serverTLSConfig,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 	errCh <- server.ListenAndServeTLS("", "")
 }

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -617,8 +617,8 @@ func (app *virtHandlerApp) runPrometheusServer(errCh chan error) {
 		// Disable HTTP/2
 		// See CVE-2023-44487
 		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: util.DefaultReadHeaderTimeout,
+		IdleTimeout:       util.DefaultIdleTimeout,
 	}
 	errCh <- server.ListenAndServeTLS("", "")
 }
@@ -651,8 +651,8 @@ func (app *virtHandlerApp) runServer(errCh chan error, consoleHandler *rest.Cons
 		Handler: restful.DefaultContainer,
 		// we use migration TLS also for console connections (initiated by virt-api)
 		TLSConfig:         app.serverTLSConfig,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: util.DefaultReadHeaderTimeout,
+		IdleTimeout:       util.DefaultIdleTimeout,
 	}
 	errCh <- server.ListenAndServeTLS("", "")
 }

--- a/pkg/storage/export/virt-exportserver/BUILD.bazel
+++ b/pkg/storage/export/virt-exportserver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/storage/cbt/nbd/v1:go_default_library",
         "//pkg/storage/export/export:go_default_library",
         "//pkg/storage/utils:go_default_library",
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/api/backup/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -284,9 +284,11 @@ func (s *exportServer) buildServer() *http.Server {
 	}
 
 	return &http.Server{
-		Addr:      s.ListenAddr,
-		Handler:   rootHandler,
-		TLSConfig: tlsConfig,
+		Addr:              s.ListenAddr,
+		Handler:           rootHandler,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 }
 

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -64,6 +64,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
 	storageutils "kubevirt.io/kubevirt/pkg/storage/utils"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -287,8 +288,8 @@ func (s *exportServer) buildServer() *http.Server {
 		Addr:              s.ListenAddr,
 		Handler:           rootHandler,
 		TLSConfig:         tlsConfig,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: util.DefaultReadHeaderTimeout,
+		IdleTimeout:       util.DefaultIdleTimeout,
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +38,12 @@ const (
 	ENV_VAR_LIBVIRT_DEBUG_LOGS          = "LIBVIRT_DEBUG_LOGS"
 	ENV_VAR_VIRTIOFSD_DEBUG_LOGS        = "VIRTIOFSD_DEBUG_LOGS"
 	ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY = "VIRT_LAUNCHER_LOG_VERBOSITY"
+
+	// HTTP server timeout defaults for all KubeVirt components.
+	// ReadHeaderTimeout limits the time to read request headers (mitigates slowloris).
+	// IdleTimeout limits how long idle keep-alive connections remain open.
+	DefaultReadHeaderTimeout = 10 * time.Second
+	DefaultIdleTimeout       = 60 * time.Second
 )
 
 func IsNonRootVMI(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1113,7 +1113,9 @@ func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory) 
 		TLSConfig: app.tlsConfig,
 		// Disable HTTP/2
 		// See CVE-2023-44487
-		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	// start TLS server

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1114,8 +1114,8 @@ func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory) 
 		// Disable HTTP/2
 		// See CVE-2023-44487
 		TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: util.DefaultReadHeaderTimeout,
+		IdleTimeout:       util.DefaultIdleTimeout,
 	}
 
 	// start TLS server

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -556,7 +556,9 @@ func (vca *VirtControllerApp) Run() {
 			TLSConfig: promTLSConfig,
 			// Disable HTTP/2
 			// See CVE-2023-44487
-			TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+			TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       60 * time.Second,
 		}
 		if err := server.ListenAndServeTLS("", ""); err != nil {
 			golog.Fatal(err)

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -557,8 +557,8 @@ func (vca *VirtControllerApp) Run() {
 			// Disable HTTP/2
 			// See CVE-2023-44487
 			TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
-			ReadHeaderTimeout: 10 * time.Second,
-			IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: util.DefaultReadHeaderTimeout,
+		IdleTimeout:       util.DefaultIdleTimeout,
 		}
 		if err := server.ListenAndServeTLS("", ""); err != nil {
 			golog.Fatal(err)

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/monitoring/profiler:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/service:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/util/webhooks/validating-webhooks:go_default_library",

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
@@ -370,7 +371,9 @@ func (app *VirtOperatorApp) Run() {
 			TLSConfig: promTLSConfig,
 			// Disable HTTP/2
 			// See CVE-2023-44487
-			TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+			TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       60 * time.Second,
 		}
 		if err := server.ListenAndServeTLS("", ""); err != nil {
 			golog.Fatal(err)
@@ -417,8 +420,10 @@ func (app *VirtOperatorApp) Run() {
 	tlsConfig := kvtls.SetupTLSWithCertManager(caManager, app.operatorCertManager, tls.VerifyClientCertIfGiven, app.clusterConfig)
 
 	webhookServer := &http.Server{
-		Addr:      fmt.Sprintf("%s:%d", app.BindAddress, 8444),
-		TLSConfig: tlsConfig,
+		Addr:              fmt.Sprintf("%s:%d", app.BindAddress, 8444),
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	var mux http.ServeMux

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -27,8 +27,8 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"time"
 
+	kvutil "kubevirt.io/kubevirt/pkg/util"
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
 	"github.com/emicklei/go-restful/v3"
@@ -372,8 +372,8 @@ func (app *VirtOperatorApp) Run() {
 			// Disable HTTP/2
 			// See CVE-2023-44487
 			TLSNextProto:      map[string]func(*http.Server, *tls.Conn, http.Handler){},
-			ReadHeaderTimeout: 10 * time.Second,
-			IdleTimeout:       60 * time.Second,
+			ReadHeaderTimeout: kvutil.DefaultReadHeaderTimeout,
+			IdleTimeout:       kvutil.DefaultIdleTimeout,
 		}
 		if err := server.ListenAndServeTLS("", ""); err != nil {
 			golog.Fatal(err)
@@ -422,8 +422,8 @@ func (app *VirtOperatorApp) Run() {
 	webhookServer := &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", app.BindAddress, 8444),
 		TLSConfig:         tlsConfig,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: kvutil.DefaultReadHeaderTimeout,
+		IdleTimeout:       kvutil.DefaultIdleTimeout,
 	}
 
 	var mux http.ServeMux


### PR DESCRIPTION
Set ReadHeaderTimeout and IdleTimeout on all HTTP servers across
virt-api, virt-handler, virt-exportproxy, virt-exportserver,
virt-operator, and synchronization-controller to prevent idle
connections from consuming resources indefinitely.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
All KubeVirt HTTP servers were created without ReadHeaderTimeout or IdleTimeout, allowing slow or idle clients to hold connections open indefinitely.

#### After this PR:
Every HTTP server across all components has ReadHeaderTimeout: 10s and IdleTimeout: 60s, defined as shared constants in pkg/util for easy future adjustment.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add HTTP server timeouts
```

