### PR TITLE
[release-1.4] virt-launcher: suppress GuestAgentPing probe for migration and healthy paused states

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15467,7 +15467,7 @@
       "format": "int32"
      },
      "guestAgentPing": {
-      "description": "GuestAgentPing contacts the qemu-guest-agent for availability checks.",
+      "description": "GuestAgentPing contacts the qemu-guest-agent for availability checks. Probe failures are automatically suppressed when the guest agent is unreachable for a non-fault reason: during live migration (guest paused on one pod while memory is transferred) and whenever the VM is paused for an intentional or transient reason such as a user pause, snapshot, save, or dump. Failures are not suppressed when the VM is paused due to a fault (IO error, crash, or postcopy failure).",
       "$ref": "#/definitions/v1.GuestAgentPing"
      },
      "httpGet": {

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -19,10 +19,47 @@ To easily define this on VM spec, specify `guestAgentPing: {}` in VM's readiness
 > Note: You can only define one of the type of probe.
 
 
-**Important:** If the qemu-guest-agent is not installed **and** enabled inside the VM, the probe will fail. 
-Many images don't enabled the agent by default so make sure you either run one that does or enable it. 
+**Important:** If the qemu-guest-agent is not installed **and** enabled inside the VM, the probe will fail.
+Many images don't enable the agent by default so make sure you either run one that does or enable it.
 
 Make sure to provide enough delay and failureThreshold for the VM and the agent to be online.
+
+### Automatic probe suppression
+
+The `guestAgentPing` probe is automatically suppressed whenever the guest agent is unreachable for a reason that does not indicate a real guest fault. Suppression returns a synthetic success so that Kubernetes does not restart the pod or consider the VM unhealthy.
+
+#### During live migration
+
+During live migration the probe is suppressed on any virt-launcher pod where a ping to the guest agent fails with an unreachable-guest error:
+
+- **Pre-copy phase** — the guest is paused on the *target* pod while it receives incoming memory pages; it is still running on the source pod.
+- **Post-copy phase** — the guest is paused on the *source* pod, with execution handed off to the target; it is running on the target pod.
+
+Because the probe is implemented as a Kubernetes exec probe running inside each pod's compute container, kubelet executes it on both pods simultaneously. KubeVirt detects the migration-in-progress condition on each pod and returns a synthetic success so that Kubernetes does not restart the pod before it is terminated at the end of the migration.
+
+#### While the VM is paused
+
+When a VM is paused for an intentional or transient reason, the guest agent is unreachable by design. KubeVirt suppresses `guestAgentPing` probe failures in these cases so that a user-initiated pause (or an internal platform pause such as snapshotting or save/restore) does not cause Kubernetes to kill the pod.
+
+Suppression applies when the domain is paused for any of the following reasons:
+
+| Libvirt pause reason | Typical cause |
+|---|---|
+| `User` | `virtctl pause` / API pause request |
+| `Migration` | Pre-copy migration (source domain paused for handoff) |
+| `Save` | VM state save |
+| `Dump` | Memory dump / core dump |
+| `FromSnapshot` | Domain restored from a snapshot, not yet resumed |
+| `ShuttingDown` | Graceful shutdown in progress |
+| `Snapshot` | Live snapshot in progress |
+| `StartingUp` | Domain paused during initial startup |
+| `Postcopy` | Post-copy migration |
+
+Probe failures are **not** suppressed when the domain is paused due to a fault — `IOError`, `Crashed`, or `PostcopyFailed` — because these indicate a genuine guest problem that the probe should surface.
+
+#### Other probe types
+
+Other probe types (`exec`, `httpGet`, `tcpSocket`) are **not** suppressed in any of the above situations. Their failure semantics are consistent with those of regular Kubernetes pods, and the existing `initialDelaySeconds` / `failureThreshold` knobs are the right way to tune their tolerance.
 
 ### Example
 

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -262,6 +262,19 @@ func WithStartStrategy(startStrategy v1.StartStrategy) Option {
 	}
 }
 
+func WithGuestAgentPingLivenessProbe(initialDelaySeconds, periodSeconds, failureThreshold int32) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.LivenessProbe = &v1.Probe{
+			Handler: v1.Handler{
+				GuestAgentPing: &v1.GuestAgentPing{},
+			},
+			InitialDelaySeconds: initialDelaySeconds,
+			PeriodSeconds:       periodSeconds,
+			FailureThreshold:    failureThreshold,
+		}
+	}
+}
+
 func WithoutSerialConsole() Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		enabled := false

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -689,8 +689,8 @@ func (app *SubresourceAPIApp) PauseVMIRequestHandler(request *restful.Request, r
 		if vmi.Status.Phase != v1.Running {
 			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf(vmNotRunning))
 		}
-		if vmi.Spec.LivenessProbe != nil {
-			return errors.NewForbidden(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("Pausing VMIs with LivenessProbe is currently not supported"))
+		if vmi.Spec.LivenessProbe != nil && vmi.Spec.LivenessProbe.GuestAgentPing == nil {
+			return errors.NewForbidden(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("Pausing VMIs with a non-GuestAgentPing LivenessProbe is not supported"))
 		}
 		condManager := controller.NewVirtualMachineInstanceConditionManager()
 		if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -2277,23 +2277,67 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			Entry("with dry-run option", &v1.PauseOptions{DryRun: getDryRunOption()}),
 		)
 
-		DescribeTable("Should fail pausing", func(running bool, paused bool, pauseOptions *v1.PauseOptions) {
+		withLivenessProbe := func(vmi *v1.VirtualMachineInstance) {
+			vmi.Spec.LivenessProbe = &v1.Probe{
+				Handler:             v1.Handler{},
+				InitialDelaySeconds: 120,
+				TimeoutSeconds:      120,
+				PeriodSeconds:       120,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			}
+		}
+		withGuestAgentPingLivenessProbe := func(vmi *v1.VirtualMachineInstance) {
+			vmi.Spec.LivenessProbe = &v1.Probe{
+				Handler:             v1.Handler{GuestAgentPing: &v1.GuestAgentPing{}},
+				InitialDelaySeconds: 120,
+				TimeoutSeconds:      120,
+				PeriodSeconds:       120,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			}
+		}
+		nilAdditionalOps := func(vmi *v1.VirtualMachineInstance) {
+			return
+		}
 
-			expectVMI(running, paused)
+		DescribeTable("Should fail pausing", func(running bool, paused bool, additionalOpts func(vmi *v1.VirtualMachineInstance), pauseOptions *v1.PauseOptions, expectedCode int) {
+			expectVMI(running, paused, additionalOpts)
 
 			bytesRepresentation, _ := json.Marshal(pauseOptions)
 			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
 
 			app.PauseVMIRequestHandler(request, response)
 
-			ExpectStatusErrorWithCode(recorder, http.StatusConflict)
+			ExpectStatusErrorWithCode(recorder, expectedCode)
 		},
-			Entry("a not running VMI", NotRunning, UnPaused, &v1.PauseOptions{}),
-			Entry("a not running VMI with dry-run option", NotRunning, UnPaused, &v1.PauseOptions{DryRun: getDryRunOption()}),
+			Entry("a not running VMI", NotRunning, UnPaused, nilAdditionalOps, &v1.PauseOptions{}, http.StatusConflict),
+			Entry("a not running VMI with dry-run option", NotRunning, UnPaused, nilAdditionalOps, &v1.PauseOptions{DryRun: getDryRunOption()}, http.StatusConflict),
 
-			Entry("a running but paused VMI", Running, Paused, &v1.PauseOptions{}),
-			Entry("a running but paused VMI with dry-run option", Running, Paused, &v1.PauseOptions{DryRun: getDryRunOption()}),
+			Entry("a running but paused VMI", Running, Paused, nilAdditionalOps, &v1.PauseOptions{}, http.StatusConflict),
+			Entry("a running but paused VMI with dry-run option", Running, Paused, nilAdditionalOps, &v1.PauseOptions{DryRun: getDryRunOption()}, http.StatusConflict),
+
+			Entry("a running VMI with LivenessProbe", Running, UnPaused, withLivenessProbe, &v1.PauseOptions{}, http.StatusForbidden),
+			Entry("a running VMI with LivenessProbe with dry-run option", Running, UnPaused, withLivenessProbe, &v1.PauseOptions{DryRun: getDryRunOption()}, http.StatusForbidden),
 		)
+
+		It("Should allow pausing a running VMI with a GuestAgentPing LivenessProbe", func() {
+			backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", "/v1/namespaces/default/virtualmachineinstances/testvmi/pause"),
+					ghttp.RespondWith(http.StatusOK, ""),
+				),
+			)
+			expectVMI(Running, UnPaused, withGuestAgentPingLivenessProbe)
+
+			bytesRepresentation, _ := json.Marshal(&v1.PauseOptions{})
+			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
+
+			app.PauseVMIRequestHandler(request, response)
+
+			Expect(response.StatusCode()).To(Equal(http.StatusOK))
+			Expect(backend.ReceivedRequests()).To(HaveLen(1))
+		})
 
 		DescribeTable("Should fail unpausing", func(running bool, paused bool, unpauseOptions *v1.UnpauseOptions) {
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -36,6 +36,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -609,7 +610,81 @@ func (l *LibvirtDomainManager) Exec(domainName, command string, args []string, t
 func (l *LibvirtDomainManager) GuestPing(domainName string) error {
 	pingCmd := `{"execute":"guest-ping"}`
 	_, err := l.virConn.QemuAgentCommand(pingCmd, domainName)
+	if err == nil {
+		return nil
+	}
+	if isGuestAgentUnavailableError(err) && (l.isLiveMigrationInProgress() || l.isPausedButHealthy(domainName)) {
+		log.Log.V(4).Infof("GuestPing for %s failed with %v but VM is in a healthy transient state; suppressing probe error", domainName, err)
+		return nil
+	}
 	return err
+}
+
+// isGuestAgentUnavailableError returns true when the error from QemuAgentCommand
+// indicates that the guest agent is unreachable rather than a libvirt or
+// connection issue unrelated to the guest state.
+func isGuestAgentUnavailableError(err error) bool {
+	var libvirtErr libvirt.Error
+	if !errors.As(err, &libvirtErr) {
+		return false
+	}
+	switch libvirtErr.Code {
+	case libvirt.ERR_AGENT_UNRESPONSIVE, libvirt.ERR_NO_DOMAIN:
+		// ERR_AGENT_UNRESPONSIVE: guest agent not responding (pre-copy target,
+		// post-copy source, or paused VM).
+		// ERR_NO_DOMAIN: domain not yet present on the target before pages start
+		// flowing (prepareMigrationTarget has run but migration has not begun).
+		return true
+	}
+	return false
+}
+
+// isLiveMigrationInProgress returns true when migration metadata indicates a
+// live migration has been started but not yet completed on this pod.
+func (l *LibvirtDomainManager) isLiveMigrationInProgress() bool {
+	m, exists := l.metadataCache.Migration.Load()
+	return exists && m.StartTimestamp != nil && m.EndTimestamp == nil
+}
+
+// isPausedButHealthy returns true when the domain is paused for an intentional
+// or transient reason: user pause (virtctl pause), snapshot, live snapshot,
+// save/restore, memory dump, postcopy migration, or domain startup. In these
+// states the QEMU guest agent is unreachable by design and probe failure does
+// not signal a guest fault.
+//
+// Fault pauses (IOError, Crashed, PostcopyFailed) return false so they remain
+// exposed to Kubernetes as liveness probe failures.
+func (l *LibvirtDomainManager) isPausedButHealthy(domainName string) bool {
+	domain, err := l.virConn.LookupDomainByName(domainName)
+	if err != nil {
+		if domainerrors.IsNotFound(err) {
+			// Domain not found at this stage is likely the target pod for a migration where the domain has still to be created
+			return true
+		}
+		return false
+	}
+	defer domain.Free()
+
+	state, reason, err := domain.GetState()
+	if err != nil {
+		// An error on GetState here likely means the domain terminated under our feet.
+		// Probably the last probe before declaring pod dead, but to let it die peacefully
+		return true
+	}
+
+	healthyPausedReasons := []api.StateChangeReason{
+		api.ReasonPausedUser,
+		api.ReasonPausedMigration,
+		api.ReasonPausedSave,
+		api.ReasonPausedDump,
+		api.ReasonPausedFromSnapshot,
+		api.ReasonPausedShuttingDown,
+		api.ReasonPausedSnapshot,
+		api.ReasonPausedStartingUp,
+		api.ReasonPausedPostcopy,
+	}
+
+	return state == libvirt.DOMAIN_PAUSED && slices.Contains(healthyPausedReasons, util.ConvReason(state, reason))
 }
 
 func getVMIEphemeralDisksTotalSize(ephemeralDiskDir string) *resource.Quantity {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2408,6 +2408,191 @@ var _ = Describe("Manager", func() {
 		Expect(err).To(MatchError(ContainSubstring("failed to find the status of volume test1")))
 	})
 
+	Context("on GuestPing", func() {
+		const pingCmd = `{"execute":"guest-ping"}`
+
+		It("should succeed when guest-ping returns successfully", func() {
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+			mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+			Expect(manager.GuestPing(testDomainName)).To(Succeed())
+		})
+
+		It("should return error when guest-ping fails and no migration is in progress", func() {
+			pingErr := fmt.Errorf("guest agent not responding")
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+			mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", pingErr)
+			Expect(manager.GuestPing(testDomainName)).To(MatchError(pingErr))
+		})
+
+		// GuestAgentPing is implemented as a Kubernetes exec probe running virt-probe
+		// inside the compute container. Kubelet therefore executes the probe on both
+		// the source and the target pods simultaneously throughout the migration.
+		//
+		// Pre-copy phase: source VM is still running (probe succeeds); target VM is
+		// paused receiving memory pages (probe fails → must be suppressed).
+		//
+		// Post-copy phase: target VM is now running (probe succeeds); source VM has
+		// been handed off and is in a ghost/paused state (probe fails → must be
+		// suppressed).
+		//
+		// Suppression is gated on the error being a guest-agent-unavailable libvirt
+		// error (ERR_AGENT_UNRESPONSIVE or ERR_NO_DOMAIN) so that unrelated libvirt
+		// or connection errors are still surfaced even during migration.
+
+		Context("in pre-copy migration phase", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				metadataCache.Migration.Store(api.MigrationMetadata{
+					UID:            "test-migration-uid",
+					StartTimestamp: &now,
+					Mode:           v1.MigrationPreCopy,
+				})
+			})
+
+			It("should not suppress a passing probe on the source pod (VM is running and reachable)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE on the target pod (VM paused, receiving memory pages)", func() {
+				agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_NO_DOMAIN on the target pod (domain not yet present)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should still surface unrelated libvirt errors during migration", func() {
+				connErr := libvirt.Error{Code: libvirt.ERR_INTERNAL_ERROR}
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", connErr)
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(connErr))
+			})
+		})
+
+		Context("in post-copy migration phase", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				metadataCache.Migration.Store(api.MigrationMetadata{
+					UID:            "test-migration-uid",
+					StartTimestamp: &now,
+					Mode:           v1.MigrationPostCopy,
+				})
+			})
+
+			It("should not suppress a passing probe on the target pod (VM is running and reachable)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE on the source pod (VM handed off, no longer accessible)", func() {
+				agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+		})
+
+		It("should not suppress agent errors once the migration has completed", func() {
+			now := metav1.Now()
+			later := metav1.NewTime(now.Add(time.Second))
+			metadataCache.Migration.Store(api.MigrationMetadata{
+				UID:            "test-migration-uid",
+				StartTimestamp: &now,
+				EndTimestamp:   &later,
+			})
+			agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+			mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, int(libvirt.DOMAIN_RUNNING_UNKNOWN), nil)
+			Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+		})
+
+		// When no migration is in progress the probe suppression falls back to
+		// isPausedButHealthy: guest agent unavailability is expected whenever the
+		// domain is paused for an intentional/transient reason (user request,
+		// snapshot, save, …). It must NOT be suppressed when the domain is paused
+		// due to a fault (IO error, crash, postcopy failure).
+		Context("when the VM is paused but in a healthy state (no migration in progress)", func() {
+			var agentErr libvirt.Error
+
+			BeforeEach(func() {
+				agentErr = libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+			})
+
+			DescribeTable("should suppress ERR_AGENT_UNRESPONSIVE for healthy pause reasons",
+				func(pauseReason libvirt.DomainPausedReason) {
+					manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+					mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+					mockConn.EXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+					mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(pauseReason), nil)
+					Expect(manager.GuestPing(testDomainName)).To(Succeed())
+				},
+				Entry("paused by user", libvirt.DOMAIN_PAUSED_USER),
+				Entry("paused for migration (pre-copy source)", libvirt.DOMAIN_PAUSED_MIGRATION),
+				Entry("paused for save", libvirt.DOMAIN_PAUSED_SAVE),
+				Entry("paused for dump", libvirt.DOMAIN_PAUSED_DUMP),
+				Entry("paused from snapshot", libvirt.DOMAIN_PAUSED_FROM_SNAPSHOT),
+				Entry("paused while shutting down", libvirt.DOMAIN_PAUSED_SHUTTING_DOWN),
+				Entry("paused for snapshot", libvirt.DOMAIN_PAUSED_SNAPSHOT),
+				Entry("paused while starting up", libvirt.DOMAIN_PAUSED_STARTING_UP),
+				Entry("paused for postcopy migration", libvirt.DOMAIN_PAUSED_POSTCOPY),
+			)
+
+			DescribeTable("should not suppress ERR_AGENT_UNRESPONSIVE for unhealthy pause reasons",
+				func(pauseReason libvirt.DomainPausedReason) {
+					manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+					mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+					mockConn.EXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+					mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(pauseReason), nil)
+					Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+				},
+				Entry("paused due to IO error", libvirt.DOMAIN_PAUSED_IOERROR),
+				Entry("paused due to crash", libvirt.DOMAIN_PAUSED_CRASHED),
+				Entry("postcopy migration failed", libvirt.DOMAIN_PAUSED_POSTCOPY_FAILED),
+				Entry("unknown pause reason", libvirt.DOMAIN_PAUSED_UNKNOWN),
+			)
+
+			It("should not suppress ERR_AGENT_UNRESPONSIVE when the domain is running (not paused)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockConn.EXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+				mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 0, nil)
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE when domain is not found (target pod before domain creation)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(nil, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should not suppress ERR_AGENT_UNRESPONSIVE when LookupDomainByName fails with an unrelated error", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(nil, libvirt.Error{Code: libvirt.ERR_INTERNAL_ERROR})
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE when GetState fails (domain terminated during probe)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockConn.EXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+				mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_NOSTATE, 0, fmt.Errorf("domain gone"))
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+		})
+	})
+
 	// TODO: test error reporting on non successful VirtualMachineInstance syncs and kill attempts
 })
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7033,8 +7033,14 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -7231,8 +7237,14 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -12242,8 +12254,14 @@ var CRDsValidation map[string]string = map[string]string{
               format: int32
               type: integer
             guestAgentPing:
-              description: GuestAgentPing contacts the qemu-guest-agent for availability
-                checks.
+              description: |-
+                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                Probe failures are automatically suppressed when the guest agent is
+                unreachable for a non-fault reason: during live migration (guest paused
+                on one pod while memory is transferred) and whenever the VM is paused
+                for an intentional or transient reason such as a user pause, snapshot,
+                save, or dump. Failures are not suppressed when the VM is paused due to
+                a fault (IO error, crash, or postcopy failure).
               type: object
             httpGet:
               description: HTTPGet specifies the http request to perform.
@@ -12439,8 +12457,14 @@ var CRDsValidation map[string]string = map[string]string{
               format: int32
               type: integer
             guestAgentPing:
-              description: GuestAgentPing contacts the qemu-guest-agent for availability
-                checks.
+              description: |-
+                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                Probe failures are automatically suppressed when the guest agent is
+                unreachable for a non-fault reason: during live migration (guest paused
+                on one pod while memory is transferred) and whenever the VM is paused
+                for an intentional or transient reason such as a user pause, snapshot,
+                save, or dump. Failures are not suppressed when the VM is paused due to
+                a fault (IO error, crash, or postcopy failure).
               type: object
             httpGet:
               description: HTTPGet specifies the http request to perform.
@@ -17840,8 +17864,14 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -18038,8 +18068,14 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -22365,8 +22401,14 @@ var CRDsValidation map[string]string = map[string]string{
                               format: int32
                               type: integer
                             guestAgentPing:
-                              description: GuestAgentPing contacts the qemu-guest-agent
-                                for availability checks.
+                              description: |-
+                                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                Probe failures are automatically suppressed when the guest agent is
+                                unreachable for a non-fault reason: during live migration (guest paused
+                                on one pod while memory is transferred) and whenever the VM is paused
+                                for an intentional or transient reason such as a user pause, snapshot,
+                                save, or dump. Failures are not suppressed when the VM is paused due to
+                                a fault (IO error, crash, or postcopy failure).
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
@@ -22563,8 +22605,14 @@ var CRDsValidation map[string]string = map[string]string{
                               format: int32
                               type: integer
                             guestAgentPing:
-                              description: GuestAgentPing contacts the qemu-guest-agent
-                                for availability checks.
+                              description: |-
+                                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                Probe failures are automatically suppressed when the guest agent is
+                                unreachable for a non-fault reason: during live migration (guest paused
+                                on one pod while memory is transferred) and whenever the VM is paused
+                                for an intentional or transient reason such as a user pause, snapshot,
+                                save, or dump. Failures are not suppressed when the VM is paused due to
+                                a fault (IO error, crash, or postcopy failure).
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
@@ -27576,8 +27624,14 @@ var CRDsValidation map[string]string = map[string]string{
                                   format: int32
                                   type: integer
                                 guestAgentPing:
-                                  description: GuestAgentPing contacts the qemu-guest-agent
-                                    for availability checks.
+                                  description: |-
+                                    GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                    Probe failures are automatically suppressed when the guest agent is
+                                    unreachable for a non-fault reason: during live migration (guest paused
+                                    on one pod while memory is transferred) and whenever the VM is paused
+                                    for an intentional or transient reason such as a user pause, snapshot,
+                                    save, or dump. Failures are not suppressed when the VM is paused due to
+                                    a fault (IO error, crash, or postcopy failure).
                                   type: object
                                 httpGet:
                                   description: HTTPGet specifies the http request
@@ -27776,8 +27830,14 @@ var CRDsValidation map[string]string = map[string]string{
                                   format: int32
                                   type: integer
                                 guestAgentPing:
-                                  description: GuestAgentPing contacts the qemu-guest-agent
-                                    for availability checks.
+                                  description: |-
+                                    GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                    Probe failures are automatically suppressed when the guest agent is
+                                    unreachable for a non-fault reason: during live migration (guest paused
+                                    on one pod while memory is transferred) and whenever the VM is paused
+                                    for an intentional or transient reason such as a user pause, snapshot,
+                                    save, or dump. Failures are not suppressed when the VM is paused due to
+                                    a fault (IO error, crash, or postcopy failure).
                                   type: object
                                 httpGet:
                                   description: HTTPGet specifies the http request

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1830,6 +1830,12 @@ type Handler struct {
 	// +optional
 	Exec *k8sv1.ExecAction `json:"exec,omitempty" protobuf:"bytes,1,opt,name=exec"`
 	// GuestAgentPing contacts the qemu-guest-agent for availability checks.
+	// Probe failures are automatically suppressed when the guest agent is
+	// unreachable for a non-fault reason: during live migration (guest paused
+	// on one pod while memory is transferred) and whenever the VM is paused
+	// for an intentional or transient reason such as a user pause, snapshot,
+	// save, or dump. Failures are not suppressed when the VM is paused due to
+	// a fault (IO error, crash, or postcopy failure).
 	// +optional
 	GuestAgentPing *GuestAgentPing `json:"guestAgentPing,omitempty"`
 	// HTTPGet specifies the http request to perform.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -457,7 +457,7 @@ func (Handler) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":               "Handler defines a specific action that should be taken",
 		"exec":           "One and only one of the following should be specified.\nExec specifies the action to take, it will be executed on the guest through the qemu-guest-agent.\nIf the guest agent is not available, this probe will fail.\n+optional",
-		"guestAgentPing": "GuestAgentPing contacts the qemu-guest-agent for availability checks.\n+optional",
+		"guestAgentPing": "GuestAgentPing contacts the qemu-guest-agent for availability checks.\nProbe failures are automatically suppressed when the guest agent is\nunreachable for a non-fault reason: during live migration (guest paused\non one pod while memory is transferred) and whenever the VM is paused\nfor an intentional or transient reason such as a user pause, snapshot,\nsave, or dump. Failures are not suppressed when the VM is paused due to\na fault (IO error, crash, or postcopy failure).\n+optional",
 		"httpGet":        "HTTPGet specifies the http request to perform.\n+optional",
 		"tcpSocket":      "TCPSocket specifies an action involving a TCP port.\nTCP hooks not yet supported\n+optional",
 	}

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19827,7 +19827,7 @@ func schema_kubevirtio_api_core_v1_Handler(ref common.ReferenceCallback) common.
 					},
 					"guestAgentPing": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks.",
+							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. Probe failures are automatically suppressed when the guest agent is unreachable for a non-fault reason: during live migration (guest paused on one pod while memory is transferred) and whenever the VM is paused for an intentional or transient reason such as a user pause, snapshot, save, or dump. Failures are not suppressed when the VM is paused due to a fault (IO error, crash, or postcopy failure).",
 							Ref:         ref("kubevirt.io/api/core/v1.GuestAgentPing"),
 						},
 					},
@@ -22705,7 +22705,7 @@ func schema_kubevirtio_api_core_v1_Probe(ref common.ReferenceCallback) common.Op
 					},
 					"guestAgentPing": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks.",
+							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. Probe failures are automatically suppressed when the guest agent is unreachable for a non-fault reason: during live migration (guest paused on one pod while memory is transferred) and whenever the VM is paused for an intentional or transient reason such as a user pause, snapshot, save, or dump. Failures are not suppressed when the VM is paused due to a fault (IO error, crash, or postcopy failure).",
 							Ref:         ref("kubevirt.io/api/core/v1.GuestAgentPing"),
 						},
 					},

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -3404,6 +3404,35 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			}, 60*time.Second, 1*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstanceMigrationRejectedByResourceQuota))
 		})
 	})
+	Describe("with a guest-agent-ping liveness probe", func() {
+		// Regression test for probe suppression on the migration target pod.
+		// Before the fix, the QEMU guest agent was unreachable on the target
+		// pod while it was receiving the incoming migration, causing the
+		// Kubernetes liveness probe to fail. Because virt-launcher pods use
+		// restartPolicy: Never, the failed probe kills the compute container
+		// and the pod enters Failed phase, aborting the migration.
+		It("should complete migration without the liveness probe killing the target pod", func() {
+			By("Creating a Fedora VMI with a GuestAgentPing liveness probe")
+			vmi := libvmifact.NewFedora(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithResourceMemory(fedoraVMSize),
+				libvmi.WithGuestAgentPingLivenessProbe(120, 5, 2),
+			)
+
+			By("Starting the VirtualMachineInstance")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Waiting for the guest agent to connect")
+			Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("Starting a migration")
+			migration := libmigration.New(vmi.Name, vmi.Namespace)
+			migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+			By("Confirming the VMI migrated successfully and is still running")
+			libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+		})
+	})
 })
 
 func createResourceQuota(resourceQuota *k8sv1.ResourceQuota) *k8sv1.ResourceQuota {

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -191,6 +191,49 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 					Entry("[Serial] Kubevirt CR", Serial, applyWithKubevirtCR),
 				)
 
+				FContext("with a guest-agent-ping liveness probe", func() {
+					// Regression test for probe suppression on the migration source pod
+					// during post-copy. Once post-copy starts the source VM is handed off
+					// to the target and enters a ghost/paused state, making it unreachable
+					// via the QEMU guest agent. Because virt-launcher pods use
+					// restartPolicy: Never, the failed probe kills the compute container
+					// and the pod enters Failed phase, aborting the migration.
+					It("should complete post-copy migration without the liveness probe killing the source pod", func() {
+						By("Creating a Fedora VMI with a GuestAgentPing liveness probe")
+						vmi := libvmifact.NewFedora(
+							libnet.WithMasqueradeNetworking(),
+							libvmi.WithResourceMemory("512Mi"),
+							libvmi.WithRng(),
+							libvmi.WithNamespace(testsuite.NamespacePrivileged),
+							libvmi.WithGuestAgentPingLivenessProbe(120, 5, 2),
+						)
+
+						By("Applying the post-copy migration policy")
+						AlignPolicyAndVmi(vmi, migrationPolicy)
+						migrationPolicy = CreateMigrationPolicy(virtClient, migrationPolicy)
+
+						By("Starting the VirtualMachineInstance")
+						vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
+
+						By("Waiting for the guest agent to connect")
+						Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+						By("Logging into the VMI")
+						Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+						By("Running a stress test to dirty pages and trigger post-copy")
+						runStressTest(vmi, "350M", stressDefaultSleepDuration)
+
+						By("Starting the migration")
+						migration := libmigration.New(vmi.Name, vmi.Namespace)
+						migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+						By("Confirming the VMI migrated successfully via post-copy and is still running")
+						vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+						libmigration.ConfirmMigrationMode(virtClient, vmi, v1.MigrationPostCopy)
+					})
+				})
+
 				Context("[Serial] and fail", Serial, func() {
 					var createdPods []string
 					BeforeEach(func() {

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -243,6 +243,48 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 			})
 		})
 
+		Context("Liveness probe with guest agent ping and user-paused VMI", func() {
+			It("should not kill the VMI while it is paused by the user", func() {
+				// Low FailureThreshold so that without the fix the probe would
+				// kill the VMI within a few probe cycles.
+				livenessProbe := &v1.Probe{
+					Handler:             v1.Handler{GuestAgentPing: &v1.GuestAgentPing{}},
+					InitialDelaySeconds: 120,
+					PeriodSeconds:       5,
+					FailureThreshold:    2,
+				}
+				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withLivelinessProbe(livenessProbe))
+				vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+
+				By("Waiting for agent to connect")
+				Eventually(matcher.ThisVMI(vmi)).
+					WithTimeout(12 * time.Minute).
+					WithPolling(2 * time.Second).
+					Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Pausing the VMI")
+				Expect(kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})).To(Succeed())
+				Eventually(matcher.ThisVMI(vmi)).
+					WithTimeout(30 * time.Second).
+					WithPolling(2 * time.Second).
+					Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
+
+				By("Verifying the VMI stays alive while paused (probe errors must be suppressed)")
+				// Wait long enough for several probe cycles to elapse.
+				Consistently(matcher.ThisVMI(vmi)).
+					WithTimeout(30 * time.Second).
+					WithPolling(2 * time.Second).
+					Should(Not(matcher.BeInPhase(v1.Failed)))
+
+				By("Unpausing the VMI")
+				Expect(kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})).To(Succeed())
+				Eventually(matcher.ThisVMI(vmi)).
+					WithTimeout(30 * time.Second).
+					WithPolling(2 * time.Second).
+					Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+			})
+		})
+
 		DescribeTable("should fail the VMI", func(livenessProbe *v1.Probe, vmiFactory func(opts ...libvmi.Option) *v1.VirtualMachineInstance) {
 			By("Specifying a VMI with a livenessProbe probe")
 			vmi = vmiFactory(withLivelinessProbe(livenessProbe))


### PR DESCRIPTION
### What this PR does
This is manual cherrypick of https://github.com/kubevirt/kubevirt/pull/17235
Original credits belongs to @tiraboschi 

During live migration the QEMU guest agent is temporarily unreachable on two different pods depending on the migration phase:

* Pre-copy: the target pod has the guest paused while receiving memory pages — the agent is unreachable there.
* Post-copy: the source VM is handed off to the target and enters a ghost/paused state — the agent is unreachable on the source pod.

Additionally, whenever a VM is paused for an intentional reason (user pause, snapshot, save, dump, etc.) the guest agent is also unreachable, and a GuestAgentPing liveness probe would kill the pod.

Because GuestAgentPing is implemented as a Kubernetes exec probe running inside each pod's compute container, kubelet executes it on both pods simultaneously throughout the migration. Without suppression the failing probe causes Kubernetes to restart the affected pod and abort the migration.

Fix GuestPing in LibvirtDomainManager to suppress probe errors in two scenarios:

1. During migration: if migration metadata has StartTimestamp set and no EndTimestamp, any probe failure is suppressed with a synthetic success. The suppression window closes as soon as EndTimestamp is set.

2. For healthy paused states: when no migration is in progress, GuestPing inspects the libvirt domain pause reason and suppresses failures for an allowlist of intentional/transient pause reasons (user pause, snapshot, save, dump, postcopy, domain startup). Fault pauses (IOError, Crashed, PostcopyFailed) are excluded so genuine guest problems are surfaced.

Other probe types (exec, httpGet, tcpSocket) are intentionally left unchanged; their semantics during migration are consistent with regular Kubernetes pods and are tuneable via initialDelaySeconds/failureThreshold.
#### Before this PR:

#### After this PR:

### References

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fix: GuestAgentPing liveness/readiness probes no longer cause Kubernetes to restart the virt-launcher pod when the guest agent is temporarily unreachable for a non-fault reason; suppression covers live migration (both pre-copy target and post-copy source) and any intentional or transient VM pause such  as user pause, snapshot, save, or dump.
```

