### PR TITLE
virt-config: Discontinue DisableMDEVConfiguration feature gate

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16541,7 +16541,7 @@
     "type": "object",
     "properties": {
      "enabled": {
-      "description": "Enable the creation and removal of mediated devices by virt-handler Replaces the deprecated DisableMDEVConfiguration feature gate Defaults to true",
+      "description": "Enable the creation and removal of mediated devices by virt-handler Defaults to true",
       "type": "boolean"
      },
      "mediatedDeviceTypes": {

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -713,7 +713,6 @@ spec:
                       enabled:
                         description: |-
                           Enable the creation and removal of mediated devices by virt-handler
-                          Replaces the deprecated DisableMDEVConfiguration feature gate
                           Defaults to true
                         type: boolean
                       mediatedDeviceTypes:
@@ -4186,7 +4185,6 @@ spec:
                       enabled:
                         description: |-
                           Enable the creation and removal of mediated devices by virt-handler
-                          Replaces the deprecated DisableMDEVConfiguration feature gate
                           Defaults to true
                         type: boolean
                       mediatedDeviceTypes:

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -33,7 +33,6 @@ go_test(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
-        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -19,7 +19,6 @@ import (
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
@@ -777,27 +776,10 @@ var _ = Describe("test configuration", func() {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kubevirtConfig)
 		Expect(clusterConfig.MediatedDevicesHandlingDisabled()).To(Equal(expectedHandling))
 	},
-		Entry("should return true when Enabled is false and FG missing",
+		Entry("should return true when Enabled is false",
 			&v1.KubeVirtConfiguration{
 				MediatedDevicesConfiguration: &v1.MediatedDevicesConfiguration{
 					Enabled: pointer.P(false),
-				},
-			},
-			true,
-		),
-		Entry("should return true when MediatedDevicesConfiguration is nil and FG is present",
-			&v1.KubeVirtConfiguration{
-				DeveloperConfiguration: &v1.DeveloperConfiguration{
-					FeatureGates: []string{featuregate.DisableMediatedDevicesHandling},
-				},
-			},
-			true,
-		),
-		Entry("should return true when Enabled is nil and FG is present",
-			&v1.KubeVirtConfiguration{
-				MediatedDevicesConfiguration: &v1.MediatedDevicesConfiguration{},
-				DeveloperConfiguration: &v1.DeveloperConfiguration{
-					FeatureGates: []string{featuregate.DisableMediatedDevicesHandling},
 				},
 			},
 			true,
@@ -810,27 +792,13 @@ var _ = Describe("test configuration", func() {
 			},
 			false,
 		),
-		Entry("should return false when Enabled is explicitly true even when FG is present",
+		Entry("should return false when Enabled is nil",
 			&v1.KubeVirtConfiguration{
-				MediatedDevicesConfiguration: &v1.MediatedDevicesConfiguration{
-					Enabled: pointer.P(true),
-				},
-				DeveloperConfiguration: &v1.DeveloperConfiguration{
-					FeatureGates: []string{featuregate.DisableMediatedDevicesHandling},
-				},
+				MediatedDevicesConfiguration: &v1.MediatedDevicesConfiguration{},
 			},
 			false,
 		),
-		Entry("should return false when MediatedDevicesConfiguration is nil and FG missing",
-			&v1.KubeVirtConfiguration{
-				MediatedDevicesConfiguration: nil,
-				DeveloperConfiguration: &v1.DeveloperConfiguration{
-					FeatureGates: []string{},
-				},
-			},
-			false,
-		),
-		Entry("should return false when MediatedDevicesConfiguration and DeveloperConfiguration are nil",
+		Entry("should return false when MediatedDevicesConfiguration is nil",
 			&v1.KubeVirtConfiguration{},
 			false,
 		),

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -124,6 +124,7 @@ const (
 	// Owner: sig-compute
 	// Alpha: v1.0.0
 	// Deprecated: v1.8.0
+	// Discontinued: v1.9.0
 	//
 	// DisableMediatedDevicesHandling disables the handling of mediated
 	// devices, its creation and deletion
@@ -178,7 +179,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: InstancetypeReferencePolicy, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: MultiArchitecture, State: Deprecated, Message: "MultiArchitecture has been deprecated since v1.8.0"})
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSConfigVolumesGate, State: GA})
-	RegisterFeatureGate(FeatureGate{Name: DisableMediatedDevicesHandling, State: Deprecated, Message: "DisableMDEVConfiguration has been deprecated since v1.8.0"})
+	RegisterFeatureGate(FeatureGate{Name: DisableMediatedDevicesHandling, State: Discontinued, Message: "DisableMDEVConfiguration has been discontinued since v1.9.0. Please use the mediatedDevicesConfiguration.enabled field instead."})
 	RegisterFeatureGate(FeatureGate{Name: ExpandDisksGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: PanicDevicesGate, State: GA})
 }

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -30,8 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	v1 "kubevirt.io/api/core/v1"
-
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 const (
@@ -502,7 +500,7 @@ func (c *ClusterConfig) MediatedDevicesHandlingDisabled() bool {
 	if mdevConfig != nil && mdevConfig.Enabled != nil {
 		return !*mdevConfig.Enabled
 	}
-	return c.isFeatureGateEnabled(featuregate.DisableMediatedDevicesHandling)
+	return false
 }
 
 func (c *ClusterConfig) GetHypervisor() *v1.HypervisorConfiguration {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1316,7 +1316,6 @@ var CRDsValidation map[string]string = map[string]string{
                 enabled:
                   description: |-
                     Enable the creation and removal of mediated devices by virt-handler
-                    Replaces the deprecated DisableMDEVConfiguration feature gate
                     Defaults to true
                   type: boolean
                 mediatedDeviceTypes:

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -400,7 +400,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			Entry("with Passt", featuregate.PasstGate, featuregate.PasstDiscontinueMessage),
 			Entry("with MacvtapGate", featuregate.MacvtapGate, featuregate.MacvtapDiscontinueMessage),
 			Entry("with ExperimentalVirtiofsSupport", featuregate.VirtIOFSGate, featuregate.VirtioFsFeatureGateDiscontinueMessage),
-			Entry("with DisableMediatedDevicesHandling", featuregate.DisableMediatedDevicesHandling, "DisableMDEVConfiguration has been deprecated since v1.8.0"),
+			Entry("with DisableMediatedDevicesHandling", featuregate.DisableMediatedDevicesHandling, "DisableMDEVConfiguration has been discontinued since v1.9.0. Please use the mediatedDevicesConfiguration.enabled field instead."),
 		)
 
 		DescribeTable("should raise warning when archConfig is set for ppc64le", func(shouldWarn bool, archConfig *v1.ArchConfiguration) {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -3510,7 +3510,6 @@ type MediatedDevicesConfiguration struct {
 	// +listType=atomic
 	NodeMediatedDeviceTypes []NodeMediatedDeviceTypesConfig `json:"nodeMediatedDeviceTypes,omitempty"`
 	// Enable the creation and removal of mediated devices by virt-handler
-	// Replaces the deprecated DisableMDEVConfiguration feature gate
 	// Defaults to true
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -1097,7 +1097,7 @@ func (MediatedDevicesConfiguration) SwaggerDoc() map[string]string {
 		"mediatedDevicesTypes":    "Deprecated. Use mediatedDeviceTypes instead.\n+optional\n+listType=atomic",
 		"mediatedDeviceTypes":     "+optional\n+listType=atomic",
 		"nodeMediatedDeviceTypes": "+optional\n+listType=atomic",
-		"enabled":                 "Enable the creation and removal of mediated devices by virt-handler\nReplaces the deprecated DisableMDEVConfiguration feature gate\nDefaults to true\n+optional",
+		"enabled":                 "Enable the creation and removal of mediated devices by virt-handler\nDefaults to true\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23662,7 +23662,7 @@ func schema_kubevirtio_api_core_v1_MediatedDevicesConfiguration(ref common.Refer
 					},
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enable the creation and removal of mediated devices by virt-handler Replaces the deprecated DisableMDEVConfiguration feature gate Defaults to true",
+							Description: "Enable the creation and removal of mediated devices by virt-handler Defaults to true",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -22,7 +22,6 @@ import (
 
 	virtwait "kubevirt.io/kubevirt/pkg/apimachinery/wait"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -197,16 +196,17 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 			Eventually(checkAllMDEVCreated(desiredMdevTypeName, expectedInstancesNum), 3*time.Minute, 15*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
 		})
 
-		It("Should make sure that no mdev is removed if the feature is gated", func() {
+		It("Should make sure that no mdev is removed if the feature is disabled via the configuration", func() {
 
-			By("Adding feature gate to disable mdevs handling")
+			By("Disabling mdevs handling via the configuration")
 
-			config.DeveloperConfiguration.FeatureGates = append(config.DeveloperConfiguration.FeatureGates, featuregate.DisableMediatedDevicesHandling)
+			enabled := false
+			config.MediatedDevicesConfiguration.Enabled = &enabled
 			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 
 			By("Removing the mediated devices configuration and expecting no devices being removed")
 			config.PermittedHostDevices = &v1.PermittedHostDevices{}
-			config.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{}
+			config.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{Enabled: &enabled}
 			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 			Eventually(checkAllMDEVCreated(desiredMdevTypeName, expectedInstancesNum), 3*time.Minute, 15*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
 		})


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The `DisableMDEVConfiguration` feature gate was deprecated in v1.8.0 but still functional as a fallback in `MediatedDevicesHandlingDisabled()`.

#### After this PR:

The feature gate is moved to `Discontinued` state and kept registered as a no-op with a warning, per the [deprecation policy](https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md). `MediatedDevicesHandlingDisabled()` now only checks the `mediatedDevicesConfiguration.enabled` API field that replaced it. Users who still have the feature gate configured will receive a warning directing them to use the replacement field.

### References

- Follow-up to #16220 which deprecated the feature gate in v1.8.0

### Why we need it and why it was done in this way
Per the [deprecation policy](https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md) and the feature gate state machine (`Deprecated` = "going to be discontinued in the following release"), the gate is eligible for discontinuation in v1.9.0. The policy also states that "the feature gate should remain as a no-op with a warning popping up", so the registration is kept in `Discontinued` state.

The `mediatedDevicesConfiguration.enabled` field was introduced as the replacement in #16220 and already takes precedence over the feature gate. This PR removes the fallback path and updates the gate state.

### Special notes for your reviewer

The integration test in `tests/mdev_configuration_allocation_test.go` was updated to use `MediatedDevicesConfiguration.Enabled = false` instead of the removed feature gate fallback.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
The DisableMDEVConfiguration feature gate has been discontinued. Users should use the `mediatedDevicesConfiguration.enabled` field instead to control mediated device handling.
```