### PR TITLE
docs: Document feature gate lifecycle and Discontinued state

### DIFF
--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -23,6 +23,18 @@ Over time the new features would stabilize and graduate their API versions (i.e.
 that happens, and therefore the risk of jeopardizing the user decreases significantly, the feature should be enabled
 by default and the feature gate should be deprecated (see section below).
 
+#### Lifecycle
+
+A feature gate progresses through the following states:
+
+| State | Default | Description |
+|-------|---------|-------------|
+| **Alpha** | Disabled | Feature is under experimentation. Can be enabled explicitly through the feature gate. |
+| **Beta** | Disabled | Feature is under evaluation. Can be enabled explicitly through the feature gate. |
+| **GA** | Enabled | Feature has reached General Availability. The feature gate is a no-op and can be safely removed from the KubeVirt CR. A warning is presented if the feature gate is still listed. |
+| **Deprecated** | Disabled | Feature gate is going to be discontinued in the following release. A warning is presented if the feature gate is still listed. |
+| **Discontinued** | Disabled | Feature gate has been removed and has no effect. A warning is presented if the feature gate is still listed, directing users to any replacement. |
+
 #### Deprecation
 A feature gate should be deprecated for one of the following reasons:
 * When a feature stabilizes and there is no need to guard it by a feature gate.
@@ -37,7 +49,11 @@ In order to deprecate a feature gate the following conditions must be met:
   best fit to trigger the warning is probably our validating webhooks.
 * A mail should be sent to kubevirt-dev mailing list (kubevirt-dev@googlegroups.com) to inform about the deprecation.
 
-After the above deprecation process, the feature gate should remain as a no-op with a warning popping up.
+#### Discontinuation
+In the release following the deprecation, the feature gate should be moved to the **Discontinued** state:
+* Any remaining functional code that checked the feature gate should be removed.
+* The feature gate registration should remain so that users who still have it configured receive a warning directing
+  them to any replacement.
 
 ## Discussion
 An ongoing discussion takes part in the following issue: https://github.com/kubevirt/kubevirt/issues/7745


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The deprecation policy documented the `Deprecated` state and the process for deprecating feature gates, but did not describe the full feature gate lifecycle or the `Discontinued` state that follows deprecation.

#### After this PR:

Adds a lifecycle table covering all feature gate states (Alpha, Beta, GA, Deprecated, Discontinued) and a Discontinuation section describing what should happen in the release after deprecation.

### References

- Related to #17620

### Why we need it and why it was done in this way
The code in `pkg/virt-config/featuregate/feature-gates.go` defines five feature gate states, but the documentation only covered deprecation. This made it unclear what the expected next step was after deprecating a feature gate. The new documentation aligns with the existing code.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```