### PR TITLE
[VEP-10] test: disable minikube target in test.sh

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -61,6 +61,12 @@ if [[ ! $TARGET =~ .*kind.* ]]; then
   export KUBEVIRT_PSA="true"
 fi
 
+# Temporarily disabled: minikube provider is in development and not ready for use
+if [[ $TARGET =~ .*minikube.* ]]; then
+  echo "ERROR: Minikube target is currently not enabled"
+  exit 1
+fi
+
 case "$TARGET" in
   *windows*)
     echo "picking the default provider for windows tests"


### PR DESCRIPTION
Minikube will probably be needed in some related dra tests for the
s390x architecture. Since the provider is in development and
highly experimental, for now test.sh exits with error when minikube
target is detected as it's currently not enabled for testing.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

