### PR TITLE
chore: add build-system files to sig-buildsystem OWNERS filter

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,7 @@ filters:
       - approvers
     emeritus_approvers:
       - emeritus_approvers
-  "BUILD\\.bazel|.*\\.bzl|WORKSPACE":
+  "BUILD\\.bazel|.*\\.bzl|WORKSPACE|Makefile|\\.bazelrc|ci\\.bazelrc|\\.bazelversion|nogo_config\\.json":
     reviewers:
       - sig-buildsystem-reviewers
     approvers:


### PR DESCRIPTION
## Summary
- Extends the sig-buildsystem OWNERS filter to include `Makefile`, `.bazelrc`, `ci.bazelrc`, `.bazelversion`, and `nogo_config.json` in addition to the existing `BUILD.bazel`, `*.bzl`, and `WORKSPACE` patterns

## Test plan
- [ ] Verify OWNERS file syntax is valid
- [ ] Confirm sig-buildsystem label is applied to PRs touching these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)