### PR TITLE
[release-1.5] tests/infra/prometheous: remove test_id:4146

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -524,31 +524,6 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 		Entry("[test_id:6241] by IPv6", k8sv1.IPv6Protocol),
 	)
 
-	DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
-		ip := libnet.GetIP(handlerMetricIPs, family)
-
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
-
-		fetcher := metricsutil.NewMetricsFetcher("")
-		fetcher.AddNameFilter("kubevirt_vmi_")
-		fetcher.AddLabelFilter("phase", "Running")
-
-		metrics, err := fetcher.LoadMetrics(metricsPayload)
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Checking the collected metrics")
-		for _, results := range metrics {
-			for _, metricResult := range results {
-				Expect(metricResult.Value).To(Equal(float64(len(preparedVMIs))))
-			}
-		}
-	},
-		Entry("[test_id:4146] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6242] by IPv6", k8sv1.IPv6Protocol),
-	)
-
 	DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
 		libnet.SkipWhenClusterNotSupportIPFamily(family)
 


### PR DESCRIPTION
### What this PR does
This PR removed test_id:4146 since it's covered by unit-tests, and current implementation is wrong`Expect(metricResult.Value).To(Equal(float64(len(preparedVMIs))))` makes no sense

since `len(preparedVMIs))` is evaluated to 2, and metricResult.Value is the 1 since it's a gauge vector.

but that doesn't work either since `kubevirt_vmi_info` is located in virt-controller, this test queries virt-handler, therefore result is empty and test pass as no-op

manual cherry-pick 

### Release note
```release-note
none
```

