### PR TITLE
virt-launcher: fail fast on missing startup DRA metadata

### DIFF
--- a/pkg/dra/utils.go
+++ b/pkg/dra/utils.go
@@ -21,6 +21,7 @@ package dra
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,8 @@ import (
 	// TODO: Replace with k8s.io types when KEP-5304 is implemented in kubernetes
 	"kubevirt.io/kubevirt/pkg/dra/metadata"
 )
+
+var ErrMissingClaimRequestMetadata = errors.New("missing claim request metadata")
 
 // IsGPUDRA returns true if the GPU is a DRA GPU
 func IsGPUDRA(gpu v1.GPU) bool {
@@ -104,7 +107,7 @@ func resolveDevice(basePath string, resourceClaims []k8sv1.PodResourceClaim, cla
 			return &req.Devices[0], nil
 		}
 	}
-	return nil, fmt.Errorf("request %q not found in metadata for claim %q (available requests: %v)", requestName, md.Name, metadataRequestNames(md))
+	return nil, fmt.Errorf("request %q not found in metadata for claim %q (available requests: %v): %w", requestName, md.Name, metadataRequestNames(md), ErrMissingClaimRequestMetadata)
 }
 
 // resolveClaimMetadata reads the metadata file for a claim ref + request pair.
@@ -134,7 +137,7 @@ func readMetadataFromDir(basePath, claimName, requestName string) (*metadata.Dev
 		return nil, fmt.Errorf("failed to glob metadata for claim %q request %q: %w", claimName, requestName, err)
 	}
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("failed to read metadata for claim %q request %q: no files matching %s", claimName, requestName, pattern)
+		return nil, fmt.Errorf("failed to read metadata for claim %q request %q: no files matching %s: %w", claimName, requestName, pattern, ErrMissingClaimRequestMetadata)
 	}
 	if len(matches) > 1 {
 		return nil, fmt.Errorf("found %d metadata files for claim %q request %q but KubeVirt only supports exactly one driver per request", len(matches), claimName, requestName)

--- a/pkg/dra/utils_test.go
+++ b/pkg/dra/utils_test.go
@@ -21,6 +21,7 @@ package dra
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -136,7 +137,8 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "missing-claim", "req1")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to read metadata"))
+			Expect(err.Error()).To(ContainSubstring("failed to read metadata for claim"))
+			Expect(errors.Is(err, ErrMissingClaimRequestMetadata)).To(BeTrue())
 		})
 	})
 
@@ -190,6 +192,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "missing-req")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to read metadata for claim"))
+			Expect(errors.Is(err, ErrMissingClaimRequestMetadata)).To(BeTrue())
 		})
 
 		It("should return error when pciBusID attribute not present", func() {

--- a/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cmd-server",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/dra:go_default_library",
         "//pkg/handler-launcher-com/cmd/info:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/util/net/grpc:go_default_library",
@@ -34,6 +35,7 @@ go_test(
     embed = [":go_default_library"],
     race = "on",
     deps = [
+        "//pkg/dra:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -34,6 +34,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	drautil "kubevirt.io/kubevirt/pkg/dra"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	grpcutil "kubevirt.io/kubevirt/pkg/util/net/grpc"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
@@ -201,6 +202,10 @@ func (l *Launcher) SyncVirtualMachine(_ context.Context, request *cmdv1.VMIReque
 	}
 
 	if _, err := l.domainManager.SyncVMI(vmi, l.allowEmulation, request.Options); err != nil {
+		if shouldSignalEarlyExitOnSyncError(vmi, err) {
+			os.Setenv(receivedEarlyExitSignalEnvVar, "")
+			log.Log.Object(vmi).Reason(err).Error("startup sync error is fatal, signaling early exit")
+		}
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to sync vmi")
 		response.Success = false
 		response.Message = getErrorMessage(err)
@@ -209,6 +214,19 @@ func (l *Launcher) SyncVirtualMachine(_ context.Context, request *cmdv1.VMIReque
 
 	log.Log.Object(vmi).Info("Synced vmi")
 	return response, nil
+}
+
+func shouldSignalEarlyExitOnSyncError(vmi *v1.VirtualMachineInstance, err error) bool {
+	if !errors.Is(err, drautil.ErrMissingClaimRequestMetadata) {
+		return false
+	}
+
+	switch vmi.Status.Phase {
+	case v1.VmPhaseUnset, v1.Pending, v1.Scheduling, v1.Scheduled:
+		return true
+	default:
+		return false
+	}
 }
 
 func (l *Launcher) PauseVirtualMachine(_ context.Context, request *cmdv1.VMIRequest) (*cmdv1.Response, error) {

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -22,6 +22,7 @@ package cmdserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -35,6 +36,7 @@ import (
 	backupv1 "kubevirt.io/api/backup/v1alpha1"
 	v1 "kubevirt.io/api/core/v1"
 
+	drautil "kubevirt.io/kubevirt/pkg/dra"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap"
@@ -89,6 +91,20 @@ var _ = Describe("Virt remote commands", func() {
 			domainManager.EXPECT().SyncVMI(vmi, allowEmulation, &cmdv1.VirtualMachineOptions{}).Return(&domain.Spec, nil)
 
 			Expect(client.SyncVirtualMachine(vmi, &cmdv1.VirtualMachineOptions{})).To(Succeed())
+		})
+
+		It("should signal early exit when startup sync misses claim request metadata", func() {
+			vmi := v1.NewVMIReferenceFromName("testvmi")
+			vmi.Status.Phase = v1.Scheduled
+			_ = os.Unsetenv(receivedEarlyExitSignalEnvVar)
+			defer os.Unsetenv(receivedEarlyExitSignalEnvVar)
+
+			domainManager.EXPECT().SyncVMI(vmi, allowEmulation, &cmdv1.VirtualMachineOptions{}).
+				Return(nil, fmt.Errorf("sync failed: %w", drautil.ErrMissingClaimRequestMetadata))
+
+			Expect(client.SyncVirtualMachine(vmi, &cmdv1.VirtualMachineOptions{})).NotTo(Succeed())
+			_, found := os.LookupEnv(receivedEarlyExitSignalEnvVar)
+			Expect(found).To(BeTrue())
 		})
 
 		It("should kill a vmi", func() {


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Treat missing DRA claim/request metadata as a fatal startup sync error in virt-launcher. When SyncVMI hits this condition before the VMI reaches running phase, signal early exit so launcher stops retrying forever.

Also expose a typed DRA metadata-missing error and add cmd-server tests that verify startup exits are signaled only for startup phases.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

