### PR TITLE
Increase VMI deletion timeout to 120s in vmi_kernel_boot_test.go

### DIFF
--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -161,7 +161,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", decorators.SigCom
 			Eventually(func() error {
 				_, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, v1.GetOptions{})
 				return err
-			}, 60*time.Second, 3*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "VMI Should be successfully deleted")
+			}, 120*time.Second, 3*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "VMI Should be successfully deleted")
 
 			By("Ensuring virt-launcher is deleted")
 			Eventually(func() error {


### PR DESCRIPTION
VMIs based on the MSHV hypervisor take longer to be deleted. 60 seconds timeout is not enough at times, which causes flakiness in the test. 120 seconds has been seen to be sufficient.

### What this PR does
#### Before this PR:

The test case `[sig-compute]VMI with external kernel boot with external alpine-based kernel only (without initrd) ensure successful boot and deletion when VMI has a disk defined` in `tests/vmi_kernel_boot_test.go` expects the VMI to be deleted within 60 seconds, otherwise the test fails. On MSHV hypervisor, VM takes much longer than KVM, causing the timeout to be violated. This results in flakiness in the test.

#### After this PR:

The timeout is increased to 120 seconds, which is high enough for both KVM and MSHV. The test consistently passes.


### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

