### PR TITLE
Ensure synchronizationAddresses point to running pods in EnsureKubevirtReady

### DIFF
--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -29,6 +29,11 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
+const (
+	// logVerbosityLevel defines the verbosity level for detailed network status logging
+	logVerbosityLevel = 4
+)
+
 // NetworkStatusesByPodIfaceName creates a map of NetworkStatus objects by pod interface name.
 func NetworkStatusesByPodIfaceName(networkStatuses []networkv1.NetworkStatus) map[string]networkv1.NetworkStatus {
 	statusesByPodIfaceName := map[string]networkv1.NetworkStatus{}
@@ -60,4 +65,40 @@ func LookupPodPrimaryIfaceName(networkStatuses []networkv1.NetworkStatus) string
 	}
 
 	return ""
+}
+
+// GetMigrationNetworkIPs extracts IP addresses from a pod for migration communication.
+// It first checks for migration network IPs in pod network status annotations,
+// falling back to standard pod network IPs if the migration network is not configured.
+// This matches the logic used by virt-operator when updating synchronizationAddresses.
+func GetMigrationNetworkIPs(pod *k8scorev1.Pod, migrationInterface string) []string {
+	// Check for migration network IPs in pod annotations
+	networkStatuses := NetworkStatusesFromPod(pod)
+	for _, networkStatus := range networkStatuses {
+		if networkStatus.Interface == migrationInterface {
+			if len(networkStatus.IPs) > 0 {
+				log.Log.Object(pod).V(logVerbosityLevel).Infof("found migration network IP addresses %v", networkStatus.IPs)
+				return networkStatus.IPs
+			}
+			break
+		}
+	}
+
+	log.Log.Object(pod).V(logVerbosityLevel).Infof("didn't find migration network IP in annotations, using pod IPs")
+
+	// Fall back to pod network IPs if migration network is not configured
+	if len(pod.Status.PodIPs) > 0 {
+		ips := make([]string, len(pod.Status.PodIPs))
+		for i, podIP := range pod.Status.PodIPs {
+			ips[i] = podIP.IP
+		}
+		return ips
+	}
+
+	// Last resort: use single pod IP
+	if pod.Status.PodIP != "" {
+		return []string{pod.Status.PodIP}
+	}
+
+	return nil
 }

--- a/pkg/network/multus/status_test.go
+++ b/pkg/network/multus/status_test.go
@@ -130,6 +130,132 @@ var _ = Describe("Network Status", func() {
 			),
 		)
 	})
+
+	Context("GetMigrationNetworkIPs", func() {
+		const (
+			migrationInterface = "migration0"
+			podIP              = "10.244.0.50"
+			podIPv6            = "fd10:244::32"
+			migrationIP        = "172.21.42.5"
+			migrationIPv6      = "2001:db8::1"
+		)
+
+		DescribeTable("should extract IPs correctly", func(pod *k8scorev1.Pod, expectedIPs []string) {
+			Expect(multus.GetMigrationNetworkIPs(pod, migrationInterface)).To(Equal(expectedIPs))
+		},
+			Entry("when migration network has IPv4 address",
+				&k8scorev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							networkv1.NetworkStatusAnnot: `[` +
+								`{"name":"k8s-pod-network","interface":"eth0","ips":["` + podIP + `"],"default":true},` +
+								`{"name":"migration-net","interface":"` + migrationInterface + `","ips":["` + migrationIP + `"]}` +
+								`]`,
+						},
+					},
+					Status: k8scorev1.PodStatus{
+						PodIP: podIP,
+						PodIPs: []k8scorev1.PodIP{
+							{IP: podIP},
+						},
+					},
+				},
+				[]string{migrationIP},
+			),
+			Entry("when migration network has both IPv4 and IPv6 addresses",
+				&k8scorev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							networkv1.NetworkStatusAnnot: `[` +
+								`{"name":"k8s-pod-network","interface":"eth0","ips":["` + podIP + `","` + podIPv6 + `"],"default":true},` +
+								`{"name":"migration-net","interface":"` + migrationInterface + `","ips":["` + migrationIP + `","` + migrationIPv6 + `"]}` +
+								`]`,
+						},
+					},
+					Status: k8scorev1.PodStatus{
+						PodIP: podIP,
+						PodIPs: []k8scorev1.PodIP{
+							{IP: podIP},
+							{IP: podIPv6},
+						},
+					},
+				},
+				[]string{migrationIP, migrationIPv6},
+			),
+			Entry("when migration network is not configured, should return pod IPs",
+				&k8scorev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							networkv1.NetworkStatusAnnot: `[` +
+								`{"name":"k8s-pod-network","interface":"eth0","ips":["` + podIP + `","` + podIPv6 + `"],"default":true}` +
+								`]`,
+						},
+					},
+					Status: k8scorev1.PodStatus{
+						PodIP: podIP,
+						PodIPs: []k8scorev1.PodIP{
+							{IP: podIP},
+							{IP: podIPv6},
+						},
+					},
+				},
+				[]string{podIP, podIPv6},
+			),
+			Entry("when migration network exists but has no IPs, should return pod IPs",
+				&k8scorev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							networkv1.NetworkStatusAnnot: `[` +
+								`{"name":"k8s-pod-network","interface":"eth0","ips":["` + podIP + `"],"default":true},` +
+								`{"name":"migration-net","interface":"` + migrationInterface + `","ips":[]}` +
+								`]`,
+						},
+					},
+					Status: k8scorev1.PodStatus{
+						PodIP: podIP,
+						PodIPs: []k8scorev1.PodIP{
+							{IP: podIP},
+						},
+					},
+				},
+				[]string{podIP},
+			),
+			Entry("when no network status annotations, should return pod IPs",
+				&k8scorev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Status: k8scorev1.PodStatus{
+						PodIP: podIP,
+						PodIPs: []k8scorev1.PodIP{
+							{IP: podIP},
+						},
+					},
+				},
+				[]string{podIP},
+			),
+			Entry("when only single pod IP is available (no PodIPs slice)",
+				&k8scorev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Status: k8scorev1.PodStatus{
+						PodIP: podIP,
+					},
+				},
+				[]string{podIP},
+			),
+			Entry("when pod has no IPs at all, should return nil",
+				&k8scorev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Status: k8scorev1.PodStatus{},
+				},
+				nil,
+			),
+		)
+	})
 })
 
 func newStubPod(annotations map[string]string) *k8scorev1.Pod {

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -837,14 +837,7 @@ func (r *Reconciler) updateSynchronizationAddress() (err error) {
 	}
 
 	// Check for the migration network address in the pod annotations.
-	ips := r.getIpsFromAnnotations(pod)
-	if len(ips) == 0 && pod.Status.PodIPs != nil {
-		// Did not find annotations, use the pod ip address instead
-		ips = make([]string, len(pod.Status.PodIPs))
-		for i, podIP := range pod.Status.PodIPs {
-			ips[i] = podIP.IP
-		}
-	}
+	ips := multus.GetMigrationNetworkIPs(pod, v1.MigrationInterfaceName)
 	if len(ips) == 0 {
 		return nil
 	}
@@ -861,20 +854,5 @@ func (r *Reconciler) updateSynchronizationAddress() (err error) {
 		addresses[i] = net.JoinHostPort(ip, strconv.Itoa(int(port)))
 	}
 	r.kv.Status.SynchronizationAddresses = addresses
-	return nil
-}
-
-func (r *Reconciler) getIpsFromAnnotations(pod *corev1.Pod) []string {
-	networkStatuses := multus.NetworkStatusesFromPod(pod)
-	for _, networkStatus := range networkStatuses {
-		if networkStatus.Interface == v1.MigrationInterfaceName {
-			if len(networkStatus.IPs) == 0 {
-				break
-			}
-			log.Log.Object(pod).V(4).Infof("found migration network ip addresses %v", networkStatus.IPs)
-			return networkStatus.IPs
-		}
-	}
-	log.Log.Object(pod).V(4).Infof("didn't find migration network ip in annotations %v", pod.Annotations)
 	return nil
 }

--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/network/multus:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/cbt:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -22,6 +22,7 @@ package testsuite
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -44,6 +45,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/network/multus"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -189,6 +191,53 @@ func EnsureDefaultKubevirtReadyWithTimeout(timeout time.Duration) {
 	EnsureKubevirtReadyWithTimeout(kv, timeout)
 }
 
+func ensureSynchronizationAddressesPointToRunningPods(virtClient kubecli.KubevirtClient, kv *v1.KubeVirt) error {
+	if len(kv.Status.SynchronizationAddresses) == 0 {
+		return nil
+	}
+
+	pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "kubevirt.io=virt-synchronization-controller",
+	})
+	if err != nil {
+		return err
+	}
+
+	runningPodIPs := make(map[string]bool)
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != k8sv1.PodRunning || pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		// Extract IPs the same way virt-operator does: check migration network first,
+		// fall back to pod network IPs if migration network is not configured
+		ips := multus.GetMigrationNetworkIPs(&pod, v1.MigrationInterfaceName)
+		for _, ip := range ips {
+			runningPodIPs[ip] = true
+		}
+	}
+
+	// If no running pods, this is likely a transient state (e.g., during feature gate disable).
+	// Return error to allow Eventually to retry until CR is updated.
+	if len(runningPodIPs) == 0 {
+		return fmt.Errorf("no running pod IPs found")
+	}
+
+	for _, addr := range kv.Status.SynchronizationAddresses {
+		ip, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			// Address might not have a port, treat whole string as IP
+			ip = addr
+		}
+		if runningPodIPs[ip] {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("synchronizationAddresses %v do not match any running pod IPs %v",
+		kv.Status.SynchronizationAddresses, runningPodIPs)
+}
+
 func EnsureKubevirtReadyWithTimeout(kv *v1.KubeVirt, timeout time.Duration) {
 	virtClient := kubevirt.Client()
 
@@ -210,6 +259,15 @@ func EnsureKubevirtReadyWithTimeout(kv *v1.KubeVirt, timeout time.Duration) {
 				return kv.ObjectMeta.Generation == *kv.Status.ObservedGeneration
 			}),
 		), "One of the Kubevirt control-plane components is not ready.")
+
+	// Ensure synchronization addresses point to running pods, not terminating ones
+	Eventually(func() error {
+		foundKV, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		return ensureSynchronizationAddressesPointToRunningPods(virtClient, foundKV)
+	}, timeout, 1*time.Second).Should(Succeed(), "synchronizationAddresses should point to running pods")
 }
 
 func shouldAllowEmulation(virtClient kubecli.KubevirtClient) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
During rolling deployments (e.g., after feature gate changes), the KubeVirt CR can temporarily contain stale synchronizationAddresses from terminating pods. This causes flaky cross-namespace migration tests when they capture these stale addresses in their BeforeEach blocks.

This fix enhances EnsureKubevirtReadyWithTimeout() to validate that all synchronizationAddresses in the KubeVirt CR match actual running (non-terminating) synchronization controller pod IPs before declaring KubeVirt ready.

The validation gracefully handles transient states during feature gate toggling by returning nil when no pods are found, allowing the Eventually retry loop to wait for the CR to be updated.

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

