### PR TITLE
dra/admitter: reject duplicate claim/request across device types

### DIFF
--- a/pkg/dra/admitter/dra_admitter.go
+++ b/pkg/dra/admitter/dra_admitter.go
@@ -77,11 +77,21 @@ func validateCreationDRA(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSp
 		rcNames.Insert(rc.Name)
 	}
 
-	gpuCauses, gpuClaimNames := validateDRAGPUs(field, spec.Domain.Devices.GPUs, checker)
+	gpuCauses, gpuClaimNames, gpuClaimRequestPairs := validateDRAGPUs(field, spec.Domain.Devices.GPUs, checker)
 	causes = append(causes, gpuCauses...)
 
-	hdCauses, hdClaimNames := validateDRAHostDevices(field, spec.Domain.Devices.HostDevices, checker)
+	hdCauses, hdClaimNames, hdClaimRequestPairs := validateDRAHostDevices(field, spec.Domain.Devices.HostDevices, checker)
 	causes = append(causes, hdCauses...)
+
+	for key, hdIdx := range hdClaimRequestPairs {
+		if gpuIdx, found := gpuClaimRequestPairs[key]; found {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueDuplicate,
+				Message: fmt.Sprintf("duplicate claimName/requestName pair %q between GPUs[%d] and HostDevices[%d]", key, gpuIdx, hdIdx),
+				Field:   field.Child("domain", "devices", "hostDevices").Index(hdIdx).String(),
+			})
+		}
+	}
 
 	allClaimNames := gpuClaimNames.Union(hdClaimNames)
 
@@ -132,7 +142,7 @@ type indexedDevice struct {
 	device draCapableDevice
 }
 
-func validateDRAGPUs(field *k8sfield.Path, gpus []v1.GPU, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string]) {
+func validateDRAGPUs(field *k8sfield.Path, gpus []v1.GPU, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
 	devices := make([]draCapableDevice, len(gpus))
 	for i, g := range gpus {
 		devices[i] = gpuAdapter(g)
@@ -145,7 +155,7 @@ func validateDRAGPUs(field *k8sfield.Path, gpus []v1.GPU, checker DRAConfigCheck
 	})
 }
 
-func validateDRAHostDevices(field *k8sfield.Path, hostDevices []v1.HostDevice, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string]) {
+func validateDRAHostDevices(field *k8sfield.Path, hostDevices []v1.HostDevice, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
 	devices := make([]draCapableDevice, len(hostDevices))
 	for i, hd := range hostDevices {
 		devices[i] = hostDeviceAdapter(hd)
@@ -158,7 +168,7 @@ func validateDRAHostDevices(field *k8sfield.Path, hostDevices []v1.HostDevice, c
 	})
 }
 
-func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg deviceValidationConfig) ([]metav1.StatusCause, sets.Set[string]) {
+func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg deviceValidationConfig) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
 	var (
 		causes     []metav1.StatusCause
 		draDevs    []indexedDevice
@@ -180,7 +190,7 @@ func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg de
 			Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains both DRA and non-DRA %ss; each %s must be either DRA or non-DRA", cfg.fieldPath, cfg.typeName, cfg.typeName),
 			Field:   devField.String(),
 		})
-		return causes, sets.New[string]()
+		return causes, sets.New[string](), map[string]int{}
 	}
 
 	for _, nd := range nonDRADevs {
@@ -205,7 +215,7 @@ func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg de
 			Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains DRA enabled %ss but feature gate is not enabled", cfg.fieldPath, cfg.typeName),
 			Field:   devField.String(),
 		})
-		return causes, sets.New[string]()
+		return causes, sets.New[string](), map[string]int{}
 	}
 
 	var validDRA []indexedDevice
@@ -234,9 +244,13 @@ func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg de
 	}
 
 	claimRequestPairs := sets.New[string]()
+	validPairFirstIndexByKey := map[string]int{}
 	for _, id := range validDRA {
 		cr := id.device.getClaimRequest()
 		key := *cr.ClaimName + "/" + *cr.RequestName
+		if _, exists := validPairFirstIndexByKey[key]; !exists {
+			validPairFirstIndexByKey[key] = id.idx
+		}
 		if claimRequestPairs.Has(key) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueDuplicate,
@@ -252,7 +266,7 @@ func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg de
 		claimNames.Insert(*id.device.getClaimRequest().ClaimName)
 	}
 
-	return causes, claimNames
+	return causes, claimNames, validPairFirstIndexByKey
 }
 
 func ValidateCreation(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, clusterCfg *virtconfig.ClusterConfig) []metav1.StatusCause {

--- a/pkg/dra/admitter/dra_admitter_test.go
+++ b/pkg/dra/admitter/dra_admitter_test.go
@@ -1060,6 +1060,38 @@ var _ = Describe("DRA Admitter", func() {
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(BeEmpty())
 		})
+
+		It("should reject when GPU and HostDevice share the same claimName/requestName pair", func() {
+			spec := &v1.VirtualMachineInstanceSpec{
+				ResourceClaims: []k8sv1.PodResourceClaim{
+					{Name: "shared-claim"},
+				},
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{
+						GPUs: []v1.GPU{{
+							Name: "gpu1",
+							ClaimRequest: &v1.ClaimRequest{
+								ClaimName:   ptr.To("shared-claim"),
+								RequestName: ptr.To("shared-req"),
+							},
+						}},
+						HostDevices: []v1.HostDevice{{
+							Name: "hd1",
+							ClaimRequest: &v1.ClaimRequest{
+								ClaimName:   ptr.To("shared-claim"),
+								RequestName: ptr.To("shared-req"),
+							},
+						}},
+					},
+				},
+			}
+			causes := validateCreationDRA(field, spec, checker)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueDuplicate))
+			Expect(causes[0].Message).To(ContainSubstring("duplicate claimName/requestName pair"))
+			Expect(causes[0].Message).To(ContainSubstring("between GPUs[0] and HostDevices[0]"))
+			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[0]"))
+		})
 	})
 
 	Context("Validator methods", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Note:
extracts the 2nd commit of https://github.com/kubevirt/kubevirt/pull/17490
in case it ease review.

---

DRA duplicate validation previously ran independently for GPUs and HostDevices, which allowed one GPU and one HostDevice to reuse the same claimName/requestName pair.
Track validated pairs and reject cross-list duplicates to keep each request bound to a single VMI device mapping.

Add a regression test for shared claim/request usage across GPU and HostDevice specs.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

