### PR TITLE
feat: Add annotation-based GuestAgentPing probe pausing (VEP 207)

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -40,6 +40,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -250,7 +251,8 @@ type LibvirtDomainManager struct {
 	hypervisorDeviceAvailable bool
 	hypervisorName            string
 
-	abortWg sync.WaitGroup
+	guestAgentProbePaused atomic.Bool
+	abortWg               sync.WaitGroup
 
 	// iommuFD holds the IOMMUFD file descriptor received from the device plugin
 	// via SCM_RIGHTS. A value of -1 means no IOMMUFD FD is available.
@@ -689,13 +691,17 @@ func (l *LibvirtDomainManager) Exec(domainName, command string, args []string, t
 }
 
 func (l *LibvirtDomainManager) GuestPing(domainName string) error {
+	if l.guestAgentProbePaused.Load() {
+		log.Log.V(4).Infof("GuestPing for %s skipped: guest agent probe is paused via annotation", domainName)
+		return nil
+	}
 	pingCmd := `{"execute":"guest-ping"}`
 	_, err := l.virConn.QemuAgentCommand(pingCmd, domainName)
 	if err == nil {
 		return nil
 	}
 	if isGuestAgentUnavailableError(err) && (l.isLiveMigrationInProgress() || l.isPausedButHealthy(domainName)) {
-		log.Log.V(4).Infof("GuestPing for %s failed with %v but the VM is healthy although paused on this pod; suppressing probe error", domainName, err)
+		log.Log.V(4).Infof("GuestPing for %s failed with %v but the VM is healthy; suppressing probe error", domainName, err)
 		return nil
 	}
 	return err
@@ -1450,6 +1456,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 
 	l.refreshDeviceAliasMap(dom)
 	l.syncGracePeriod(vmi)
+	l.syncGuestAgentProbePaused(vmi)
 
 	// TODO: check if VirtualMachineInstance Spec and Domain Spec are equal or if we have to sync
 	return oldSpec, nil
@@ -2847,6 +2854,14 @@ func (l *LibvirtDomainManager) syncGracePeriod(vmi *v1.VirtualMachineInstance) {
 			log.Log.Object(vmi).Infof("Set new termination grace period: %d", gracePeriod)
 		}
 	})
+}
+
+func (l *LibvirtDomainManager) syncGuestAgentProbePaused(vmi *v1.VirtualMachineInstance) {
+	paused, _ := strconv.ParseBool(vmi.Annotations[v1.PauseGuestAgentProbesAnnotation])
+	wasPaused := l.guestAgentProbePaused.Swap(paused)
+	if paused != wasPaused {
+		log.Log.Object(vmi).Infof("Guest agent probe pause state changed: paused=%t", paused)
+	}
 }
 
 func getDiskTargetPathFromImageVolumeView(volumeIndex int, volumePath string) (*safepath.Path, error) {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -3439,6 +3439,53 @@ var _ = Describe("Manager", func() {
 				Expect(manager.GuestPing(testDomainName)).To(Succeed())
 			})
 		})
+
+		Context("when guest agent probes are paused by annotation", func() {
+			It("should skip probe entirely when paused", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				manager.(*LibvirtDomainManager).guestAgentProbePaused.Store(true)
+				// QemuAgentCommand must not be called when the probe is paused.
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should resume normal probe behavior when unpaused", func() {
+				agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+				manager, _ := newLibvirtDomainManagerDefault()
+				manager.(*LibvirtDomainManager).guestAgentProbePaused.Store(true)
+				// Paused: no QemuAgentCommand call expected.
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+
+				manager.(*LibvirtDomainManager).guestAgentProbePaused.Store(false)
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+				mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+			})
+		})
+	})
+
+	Context("syncGuestAgentProbePaused", func() {
+		DescribeTable("should parse annotation value correctly",
+			func(annotations map[string]string, expected bool) {
+				manager, _ := newLibvirtDomainManagerDefault()
+				ldm := manager.(*LibvirtDomainManager)
+				ldm.guestAgentProbePaused.Store(!expected)
+				vmi := &v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: annotations,
+					},
+				}
+				ldm.syncGuestAgentProbePaused(vmi)
+				Expect(ldm.guestAgentProbePaused.Load()).To(Equal(expected))
+			},
+			Entry("annotation 'true'", map[string]string{v1.PauseGuestAgentProbesAnnotation: "true"}, true),
+			Entry("annotation '1'", map[string]string{v1.PauseGuestAgentProbesAnnotation: "1"}, true),
+			Entry("annotation 'TRUE'", map[string]string{v1.PauseGuestAgentProbesAnnotation: "TRUE"}, true),
+			Entry("annotation 'false'", map[string]string{v1.PauseGuestAgentProbesAnnotation: "false"}, false),
+			Entry("annotation '0'", map[string]string{v1.PauseGuestAgentProbesAnnotation: "0"}, false),
+			Entry("annotation non-bool value", map[string]string{v1.PauseGuestAgentProbesAnnotation: "foo"}, false),
+			Entry("nil annotations map", nil, false),
+		)
 	})
 
 	// TODO: test error reporting on non successful VirtualMachineInstance syncs and kill attempts

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1450,6 +1450,12 @@ const (
 	// This annotation is set by virt-handler based on the cluster configuration.
 	QGSSocketPathAnnotation = "kubevirt.io/qgs-socket-path"
 
+	// PauseGuestAgentProbesAnnotation, when set to a truthy value (strconv.ParseBool)
+	// on a VMI, causes virt-launcher to short-circuit GuestAgentPing probes and
+	// return immediate success without contacting the QEMU guest agent.
+	// Remove the annotation (or set to a falsy value) to resume normal probe behavior.
+	PauseGuestAgentProbesAnnotation string = "kubevirt.io/pause-guest-agent-probes"
+
 	// AllowAccessClusterServicesNPLabel is a pod label to be set by virt-components to indicate that they require
 	// access to cluster services otherwise blocked by the strict network policy (NP).
 	// This label will be applied to the following virt pods:

--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/compute",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -32,9 +32,11 @@ import (
 	k8scorev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/tests/console"
@@ -285,6 +287,67 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, decorators.WgS39
 				WithTimeout(30 * time.Second).
 				WithPolling(2 * time.Second).
 				Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+		})
+	})
+
+	Context("Liveness probe with guest agent ping and annotation-paused probes", func() {
+		It("should not kill the VMI when probes are paused by annotation", func() {
+			livenessProbe := &v1.Probe{
+				Handler:             v1.Handler{GuestAgentPing: &v1.GuestAgentPing{}},
+				InitialDelaySeconds: 30,
+				PeriodSeconds:       5,
+				FailureThreshold:    3,
+			}
+			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withLivenessProbe(livenessProbe))
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, vmiStartTimeout)
+
+			By("Waiting for agent to connect")
+			Eventually(matcher.ThisVMI(vmi)).
+				WithTimeout(guestAgentConnectTimeout).
+				WithPolling(2 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+			By("Adding the pause-guest-agent-probes annotation")
+			patchBytes, err := patch.New(
+				patch.WithAdd(
+					fmt.Sprintf("/metadata/annotations/%s",
+						patch.EscapeJSONPointer(v1.PauseGuestAgentProbesAnnotation)),
+					"true",
+				),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).
+				Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Stopping guest agent to simulate maintenance")
+			Expect(stopGuestAgent(vmi)).To(Succeed())
+
+			By("Verifying the VMI stays alive while annotation is set (probes paused)")
+			Consistently(matcher.ThisVMI(vmi)).
+				WithTimeout(45 * time.Second).
+				WithPolling(2 * time.Second).
+				Should(Not(matcher.BeInPhase(v1.Failed)))
+
+			By("Removing the pause annotation to resume probes")
+			removePatchBytes, err := patch.New(
+				patch.WithRemove(
+					fmt.Sprintf("/metadata/annotations/%s",
+						patch.EscapeJSONPointer(v1.PauseGuestAgentProbesAnnotation)),
+				),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).
+				Patch(context.Background(), vmi.Name, types.JSONPatchType, removePatchBytes, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying the VMI eventually succeeds after annotation is removed (agent still stopped, pod terminates cleanly)")
+			Eventually(matcher.ThisVMI(vmi)).
+				WithTimeout(2 * time.Minute).
+				WithPolling(1 * time.Second).
+				Should(matcher.HaveSucceeded())
 		})
 	})
 }))


### PR DESCRIPTION
### What this PR does
#### Before this PR:
When a guest agent becomes temporarily unavailable during maintenance operations (e.g., guest OS updates, Windows updates), the GuestAgentPing liveness probe fails and causes the Pod to restart. There is no way to temporarily suppress probe checks without removing the probe from the VMI spec entirely, which requires recreating the  VMI. 
#### After this PR:
Users can pause GuestAgentPing probes by setting the annotation kubevirt.io/pause-guest-agent-probes: "true" on a VMI. While the annotation is set, virt-launcher short-circuits GuestPing calls and returns immediate success without contacting the QEMU guest agent, preventing unnecessary Pod restarts during maintenance windows. Removing the annotation resumes normal probe behavior.       

### References
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/207


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
feat: Add annotation-based GuestAgentPing probe pausing
```

