### PR TITLE
[release-1.7] virt-launcher: temporarily skip GuestAgentPing probe on guests paused for a good reason

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16286,7 +16286,7 @@
       "format": "int32"
      },
      "guestAgentPing": {
-      "description": "GuestAgentPing contacts the qemu-guest-agent for availability checks.",
+      "description": "GuestAgentPing contacts the qemu-guest-agent for availability checks. During live migration the probe is suppressed on any pod where the guest is not actually running: the target pod in pre-copy phase (VM paused, receiving memory pages) and the source pod in post-copy phase (VM paused, execution handed off to target). Once migration completes those pods are terminated.",
       "$ref": "#/definitions/v1.GuestAgentPing"
      },
      "httpGet": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16286,7 +16286,7 @@
       "format": "int32"
      },
      "guestAgentPing": {
-      "description": "GuestAgentPing contacts the qemu-guest-agent for availability checks. During live migration the probe is suppressed on any pod where the guest is not actually running: the target pod in pre-copy phase (VM paused, receiving memory pages) and the source pod in post-copy phase (VM paused, execution handed off to target). Once migration completes those pods are terminated.",
+      "description": "GuestAgentPing contacts the qemu-guest-agent for availability checks. Probe failures are automatically suppressed when the guest agent is unreachable for a non-fault reason: during live migration (guest paused on one pod while memory is transferred) and whenever the VM is paused for an intentional or transient reason such as a user pause, snapshot, save, or dump. Failures are not suppressed when the VM is paused due to a fault (IO error, crash, or postcopy failure).",
       "$ref": "#/definitions/v1.GuestAgentPing"
      },
      "httpGet": {

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -19,10 +19,21 @@ To easily define this on VM spec, specify `guestAgentPing: {}` in VM's readiness
 > Note: You can only define one of the type of probe.
 
 
-**Important:** If the qemu-guest-agent is not installed **and** enabled inside the VM, the probe will fail. 
-Many images don't enabled the agent by default so make sure you either run one that does or enable it. 
+**Important:** If the qemu-guest-agent is not installed **and** enabled inside the VM, the probe will fail.
+Many images don't enable the agent by default so make sure you either run one that does or enable it.
 
 Make sure to provide enough delay and failureThreshold for the VM and the agent to be online.
+
+### Behaviour during live migration
+
+During live migration the `guestAgentPing` probe is automatically suppressed on any virt-launcher pod where a ping to the guest agent fails with an unreachable-guest error:
+
+- **Pre-copy phase** — the guest is paused on the *target* pod while it receives incoming memory pages; it is still running on the source pod.
+- **Post-copy phase** — the guest is paused on the *source* pod, with execution handed off to the target; it is running on the target pod.
+
+Because the probe is implemented as a Kubernetes exec probe running inside each pod's compute container, kubelet executes it on both pods simultaneously. KubeVirt detects the migration-in-progress condition on each pod and returns a synthetic success so that Kubernetes does not restart the pod before it is terminated at the end of the migration.
+
+Other probe types (`exec`, `httpGet`, `tcpSocket`) are **not** suppressed during migration. Their failure semantics during migration are consistent with those of regular Kubernetes pods, and the existing `initialDelaySeconds` / `failureThreshold` knobs are the right way to tune their tolerance.
 
 ### Example
 

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -24,16 +24,42 @@ Many images don't enable the agent by default so make sure you either run one th
 
 Make sure to provide enough delay and failureThreshold for the VM and the agent to be online.
 
-### Behaviour during live migration
+### Automatic probe suppression
 
-During live migration the `guestAgentPing` probe is automatically suppressed on any virt-launcher pod where a ping to the guest agent fails with an unreachable-guest error:
+The `guestAgentPing` probe is automatically suppressed whenever the guest agent is unreachable for a reason that does not indicate a real guest fault. Suppression returns a synthetic success so that Kubernetes does not restart the pod or consider the VM unhealthy.
+
+#### During live migration
+
+During live migration the probe is suppressed on any virt-launcher pod where a ping to the guest agent fails with an unreachable-guest error:
 
 - **Pre-copy phase** — the guest is paused on the *target* pod while it receives incoming memory pages; it is still running on the source pod.
 - **Post-copy phase** — the guest is paused on the *source* pod, with execution handed off to the target; it is running on the target pod.
 
 Because the probe is implemented as a Kubernetes exec probe running inside each pod's compute container, kubelet executes it on both pods simultaneously. KubeVirt detects the migration-in-progress condition on each pod and returns a synthetic success so that Kubernetes does not restart the pod before it is terminated at the end of the migration.
 
-Other probe types (`exec`, `httpGet`, `tcpSocket`) are **not** suppressed during migration. Their failure semantics during migration are consistent with those of regular Kubernetes pods, and the existing `initialDelaySeconds` / `failureThreshold` knobs are the right way to tune their tolerance.
+#### While the VM is paused
+
+When a VM is paused for an intentional or transient reason, the guest agent is unreachable by design. KubeVirt suppresses `guestAgentPing` probe failures in these cases so that a user-initiated pause (or an internal platform pause such as snapshotting or save/restore) does not cause Kubernetes to kill the pod.
+
+Suppression applies when the domain is paused for any of the following reasons:
+
+| Libvirt pause reason | Typical cause |
+|---|---|
+| `User` | `virtctl pause` / API pause request |
+| `Migration` | Pre-copy migration (source domain paused for handoff) |
+| `Save` | VM state save |
+| `Dump` | Memory dump / core dump |
+| `FromSnapshot` | Domain restored from a snapshot, not yet resumed |
+| `ShuttingDown` | Graceful shutdown in progress |
+| `Snapshot` | Live snapshot in progress |
+| `StartingUp` | Domain paused during initial startup |
+| `Postcopy` | Post-copy migration |
+
+Probe failures are **not** suppressed when the domain is paused due to a fault — `IOError`, `Crashed`, or `PostcopyFailed` — because these indicate a genuine guest problem that the probe should surface.
+
+#### Other probe types
+
+Other probe types (`exec`, `httpGet`, `tcpSocket`) are **not** suppressed in any of the above situations. Their failure semantics are consistent with those of regular Kubernetes pods, and the existing `initialDelaySeconds` / `failureThreshold` knobs are the right way to tune their tolerance.
 
 ### Example
 

--- a/pkg/libvmi/lifecycle.go
+++ b/pkg/libvmi/lifecycle.go
@@ -36,3 +36,16 @@ func WithStartStrategy(startStrategy v1.StartStrategy) Option {
 		vmi.Spec.StartStrategy = &startStrategy
 	}
 }
+
+func WithGuestAgentPingLivenessProbe(initialDelaySeconds, periodSeconds, failureThreshold int32) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.LivenessProbe = &v1.Probe{
+			Handler: v1.Handler{
+				GuestAgentPing: &v1.GuestAgentPing{},
+			},
+			InitialDelaySeconds: initialDelaySeconds,
+			PeriodSeconds:       periodSeconds,
+			FailureThreshold:    failureThreshold,
+		}
+	}
+}

--- a/pkg/virt-api/rest/lifecycle.go
+++ b/pkg/virt-api/rest/lifecycle.go
@@ -282,8 +282,8 @@ func (app *SubresourceAPIApp) PauseVMIRequestHandler(request *restful.Request, r
 		if vmi.Status.Phase != v1.Running {
 			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf(vmNotRunning))
 		}
-		if vmi.Spec.LivenessProbe != nil {
-			return errors.NewForbidden(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("Pausing VMIs with LivenessProbe is currently not supported"))
+		if vmi.Spec.LivenessProbe != nil && vmi.Spec.LivenessProbe.GuestAgentPing == nil {
+			return errors.NewForbidden(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("Pausing VMIs with a non-GuestAgentPing LivenessProbe is not supported"))
 		}
 		condManager := controller.NewVirtualMachineInstanceConditionManager()
 		if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1288,6 +1288,16 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				FailureThreshold:    1,
 			}
 		}
+		withGuestAgentPingLivenessProbe := func(vmi *v1.VirtualMachineInstance) {
+			vmi.Spec.LivenessProbe = &v1.Probe{
+				Handler:             v1.Handler{GuestAgentPing: &v1.GuestAgentPing{}},
+				InitialDelaySeconds: 120,
+				TimeoutSeconds:      120,
+				PeriodSeconds:       120,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			}
+		}
 		nilAdditionalOps := func(vmi *v1.VirtualMachineInstance) {
 			return
 		}
@@ -1309,9 +1319,27 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			Entry("a running but paused VMI", Running, Paused, nilAdditionalOps, &v1.PauseOptions{}, http.StatusConflict, "VMI is already paused"),
 			Entry("a running but paused VMI with dry-run option", Running, Paused, nilAdditionalOps, &v1.PauseOptions{DryRun: withDryRun()}, http.StatusConflict, "VMI is already paused"),
 
-			Entry("a running VMI with LivenessProbe", Running, UnPaused, withLivenessProbe, &v1.PauseOptions{}, http.StatusForbidden, "Pausing VMIs with LivenessProbe is currently not supported"),
-			Entry("a running VMI with LivenessProbe with dry-run option", Running, UnPaused, withLivenessProbe, &v1.PauseOptions{DryRun: withDryRun()}, http.StatusForbidden, "Pausing VMIs with LivenessProbe is currently not supported"),
+			Entry("a running VMI with LivenessProbe", Running, UnPaused, withLivenessProbe, &v1.PauseOptions{}, http.StatusForbidden, "Pausing VMIs with a non-GuestAgentPing LivenessProbe is not supported"),
+			Entry("a running VMI with LivenessProbe with dry-run option", Running, UnPaused, withLivenessProbe, &v1.PauseOptions{DryRun: withDryRun()}, http.StatusForbidden, "Pausing VMIs with a non-GuestAgentPing LivenessProbe is not supported"),
 		)
+
+		It("Should allow pausing a running VMI with a GuestAgentPing LivenessProbe", func() {
+			backend.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", "/v1/namespaces/default/virtualmachineinstances/testvmi/pause"),
+					ghttp.RespondWith(http.StatusOK, ""),
+				),
+			)
+			expectVMI(Running, UnPaused, withGuestAgentPingLivenessProbe)
+
+			bytesRepresentation, _ := json.Marshal(&v1.PauseOptions{})
+			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
+
+			app.PauseVMIRequestHandler(request, response)
+
+			Expect(response.StatusCode()).To(Equal(http.StatusOK))
+			Expect(backend.ReceivedRequests()).To(HaveLen(1))
+		})
 
 		DescribeTable("Should fail unpausing due to VMI state", func(running bool, paused bool, unpauseOptions *v1.UnpauseOptions, expectedError string) {
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -638,7 +638,40 @@ func (l *LibvirtDomainManager) Exec(domainName, command string, args []string, t
 func (l *LibvirtDomainManager) GuestPing(domainName string) error {
 	pingCmd := `{"execute":"guest-ping"}`
 	_, err := l.virConn.QemuAgentCommand(pingCmd, domainName)
+	if err == nil {
+		return nil
+	}
+	if isGuestAgentUnavailableError(err) && l.isLiveMigrationInProgress() {
+		log.Log.V(4).Infof("GuestPing for %s failed with %v but a live migration is in progress; suppressing probe error", domainName, err)
+		return nil
+	}
 	return err
+}
+
+// isGuestAgentUnavailableError returns true when the error from QemuAgentCommand
+// indicates that the guest agent is unreachable rather than a libvirt or
+// connection issue unrelated to the guest state.
+func isGuestAgentUnavailableError(err error) bool {
+	var libvirtErr libvirt.Error
+	if !errors.As(err, &libvirtErr) {
+		return false
+	}
+	switch libvirtErr.Code {
+	case libvirt.ERR_AGENT_UNRESPONSIVE, libvirt.ERR_NO_DOMAIN:
+		// ERR_AGENT_UNRESPONSIVE: guest agent not responding (pre-copy target,
+		// post-copy source).
+		// ERR_NO_DOMAIN: domain not yet present on the target before pages start
+		// flowing (prepareMigrationTarget has run but migration has not begun).
+		return true
+	}
+	return false
+}
+
+// isLiveMigrationInProgress returns true when migration metadata indicates a
+// live migration has been started but not yet completed on this pod.
+func (l *LibvirtDomainManager) isLiveMigrationInProgress() bool {
+	m, exists := l.metadataCache.Migration.Load()
+	return exists && m.StartTimestamp != nil && m.EndTimestamp == nil
 }
 
 func getVMIEphemeralDisksTotalSize(ephemeralDiskDir string) *resource.Quantity {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -37,6 +37,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -641,8 +642,8 @@ func (l *LibvirtDomainManager) GuestPing(domainName string) error {
 	if err == nil {
 		return nil
 	}
-	if isGuestAgentUnavailableError(err) && l.isLiveMigrationInProgress() {
-		log.Log.V(4).Infof("GuestPing for %s failed with %v but a live migration is in progress; suppressing probe error", domainName, err)
+	if isGuestAgentUnavailableError(err) && (l.isLiveMigrationInProgress() || l.isPausedButHealthy(domainName)) {
+		log.Log.V(4).Infof("GuestPing for %s failed with %v but the VM is healthy although paused on this pod; suppressing probe error", domainName, err)
 		return nil
 	}
 	return err
@@ -672,6 +673,41 @@ func isGuestAgentUnavailableError(err error) bool {
 func (l *LibvirtDomainManager) isLiveMigrationInProgress() bool {
 	m, exists := l.metadataCache.Migration.Load()
 	return exists && m.StartTimestamp != nil && m.EndTimestamp == nil
+}
+
+// isPausedButHealthy returns true when domain state indicates
+// that the VM is paused although in an healthy condition.
+func (l *LibvirtDomainManager) isPausedButHealthy(domainName string) bool {
+	domain, err := l.virConn.LookupDomainByName(domainName)
+	if err != nil {
+		if domainerrors.IsNotFound(err) {
+			// Domain not found at this stage is likely the target pod for a migration where the domain has still to be created
+			return true
+		}
+		return false
+	}
+	defer domain.Free()
+
+	state, reason, err := domain.GetState()
+	if err != nil {
+		// An error on GetState here likely means the domain terminated under our feet.
+		// Probably the last probe before declaring pod dead, but to let it die peacefully
+		return true
+	}
+
+	healthyPausedReasons := []api.StateChangeReason{
+		api.ReasonPausedUser,
+		api.ReasonPausedMigration,
+		api.ReasonPausedSave,
+		api.ReasonPausedDump,
+		api.ReasonPausedFromSnapshot,
+		api.ReasonPausedShuttingDown,
+		api.ReasonPausedSnapshot,
+		api.ReasonPausedStartingUp,
+		api.ReasonPausedPostcopy,
+	}
+
+	return state == libvirt.DOMAIN_PAUSED && slices.Contains(healthyPausedReasons, util.ConvReason(state, reason))
 }
 
 func getVMIEphemeralDisksTotalSize(ephemeralDiskDir string) *resource.Quantity {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2735,6 +2735,113 @@ var _ = Describe("Manager", func() {
 		Expect(err).To(MatchError(ContainSubstring("failed to find the status of volume test1")))
 	})
 
+	Context("on GuestPing", func() {
+		const pingCmd = `{"execute":"guest-ping"}`
+
+		It("should succeed when guest-ping returns successfully", func() {
+			manager, _ := newLibvirtDomainManagerDefault()
+			mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+			Expect(manager.GuestPing(testDomainName)).To(Succeed())
+		})
+
+		It("should return error when guest-ping fails and no migration is in progress", func() {
+			pingErr := fmt.Errorf("guest agent not responding")
+			manager, _ := newLibvirtDomainManagerDefault()
+			mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", pingErr)
+			Expect(manager.GuestPing(testDomainName)).To(MatchError(pingErr))
+		})
+
+		// GuestAgentPing is implemented as a Kubernetes exec probe running virt-probe
+		// inside the compute container. Kubelet therefore executes the probe on both
+		// the source and the target pods simultaneously throughout the migration.
+		//
+		// Pre-copy phase: source VM is still running (probe succeeds); target VM is
+		// paused receiving memory pages (probe fails → must be suppressed).
+		//
+		// Post-copy phase: target VM is now running (probe succeeds); source VM has
+		// been handed off and is in a ghost/paused state (probe fails → must be
+		// suppressed).
+		//
+		// Suppression is gated on the error being a guest-agent-unavailable libvirt
+		// error (ERR_AGENT_UNRESPONSIVE or ERR_NO_DOMAIN) so that unrelated libvirt
+		// or connection errors are still surfaced even during migration.
+
+		Context("in pre-copy migration phase", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				metadataCache.Migration.Store(api.MigrationMetadata{
+					UID:            "test-migration-uid",
+					StartTimestamp: &now,
+					Mode:           v1.MigrationPreCopy,
+				})
+			})
+
+			It("should not suppress a passing probe on the source pod (VM is running and reachable)", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE on the target pod (VM paused, receiving memory pages)", func() {
+				agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_NO_DOMAIN on the target pod (domain not yet present)", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should still surface unrelated libvirt errors during migration", func() {
+				connErr := libvirt.Error{Code: libvirt.ERR_INTERNAL_ERROR}
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", connErr)
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(connErr))
+			})
+		})
+
+		Context("in post-copy migration phase", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				metadataCache.Migration.Store(api.MigrationMetadata{
+					UID:            "test-migration-uid",
+					StartTimestamp: &now,
+					Mode:           v1.MigrationPostCopy,
+				})
+			})
+
+			It("should not suppress a passing probe on the target pod (VM is running and reachable)", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE on the source pod (VM handed off, no longer accessible)", func() {
+				agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+		})
+
+		It("should not suppress agent errors once the migration has completed", func() {
+			now := metav1.Now()
+			later := metav1.NewTime(now.Add(time.Second))
+			metadataCache.Migration.Store(api.MigrationMetadata{
+				UID:            "test-migration-uid",
+				StartTimestamp: &now,
+				EndTimestamp:   &later,
+			})
+			agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+			manager, _ := newLibvirtDomainManagerDefault()
+			mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+			Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+		})
+	})
+
 	// TODO: test error reporting on non successful VirtualMachineInstance syncs and kill attempts
 })
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2838,7 +2838,85 @@ var _ = Describe("Manager", func() {
 			agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
 			manager, _ := newLibvirtDomainManagerDefault()
 			mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, int(libvirt.DOMAIN_RUNNING_UNKNOWN), nil)
 			Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+		})
+
+		// When no migration is in progress the probe suppression falls back to
+		// isPausedButHealthy: guest agent unavailability is expected whenever the
+		// domain is paused for an intentional/transient reason (user request,
+		// snapshot, save, …). It must NOT be suppressed when the domain is paused
+		// due to a fault (IO error, crash, postcopy failure).
+		Context("when the VM is paused but in a healthy state (no migration in progress)", func() {
+			var agentErr libvirt.Error
+
+			BeforeEach(func() {
+				agentErr = libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+			})
+
+			DescribeTable("should suppress ERR_AGENT_UNRESPONSIVE for healthy pause reasons",
+				func(pauseReason libvirt.DomainPausedReason) {
+					manager, _ := newLibvirtDomainManagerDefault()
+					mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+					mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+					mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(pauseReason), nil)
+					Expect(manager.GuestPing(testDomainName)).To(Succeed())
+				},
+				Entry("paused by user", libvirt.DOMAIN_PAUSED_USER),
+				Entry("paused for migration (pre-copy source)", libvirt.DOMAIN_PAUSED_MIGRATION),
+				Entry("paused for save", libvirt.DOMAIN_PAUSED_SAVE),
+				Entry("paused for dump", libvirt.DOMAIN_PAUSED_DUMP),
+				Entry("paused from snapshot", libvirt.DOMAIN_PAUSED_FROM_SNAPSHOT),
+				Entry("paused while shutting down", libvirt.DOMAIN_PAUSED_SHUTTING_DOWN),
+				Entry("paused for snapshot", libvirt.DOMAIN_PAUSED_SNAPSHOT),
+				Entry("paused while starting up", libvirt.DOMAIN_PAUSED_STARTING_UP),
+				Entry("paused for postcopy migration", libvirt.DOMAIN_PAUSED_POSTCOPY),
+			)
+
+			DescribeTable("should not suppress ERR_AGENT_UNRESPONSIVE for unhealthy pause reasons",
+				func(pauseReason libvirt.DomainPausedReason) {
+					manager, _ := newLibvirtDomainManagerDefault()
+					mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+					mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+					mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(pauseReason), nil)
+					Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+				},
+				Entry("paused due to IO error", libvirt.DOMAIN_PAUSED_IOERROR),
+				Entry("paused due to crash", libvirt.DOMAIN_PAUSED_CRASHED),
+				Entry("postcopy migration failed", libvirt.DOMAIN_PAUSED_POSTCOPY_FAILED),
+				Entry("unknown pause reason", libvirt.DOMAIN_PAUSED_UNKNOWN),
+			)
+
+			It("should not suppress ERR_AGENT_UNRESPONSIVE when the domain is running (not paused)", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+				mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 0, nil)
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE when domain is not found (target pod before domain creation)", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).Return(nil, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should not suppress ERR_AGENT_UNRESPONSIVE when LookupDomainByName fails with an unrelated error", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).Return(nil, libvirt.Error{Code: libvirt.ERR_INTERNAL_ERROR})
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE when GetState fails (domain terminated during probe)", func() {
+				manager, _ := newLibvirtDomainManagerDefault()
+				mockLibvirt.ConnectionEXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+				mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_NOSTATE, 0, fmt.Errorf("domain gone"))
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
 		})
 	})
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7207,11 +7207,12 @@ var CRDsValidation map[string]string = map[string]string{
                     guestAgentPing:
                       description: |-
                         GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                        During live migration the probe is suppressed on any pod where the guest
-                        is not actually running: the target pod in pre-copy phase (VM paused,
-                        receiving memory pages) and the source pod in post-copy phase (VM paused,
-                        execution handed off to target). Once migration completes those pods are
-                        terminated.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -7410,11 +7411,12 @@ var CRDsValidation map[string]string = map[string]string{
                     guestAgentPing:
                       description: |-
                         GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                        During live migration the probe is suppressed on any pod where the guest
-                        is not actually running: the target pod in pre-copy phase (VM paused,
-                        receiving memory pages) and the source pod in post-copy phase (VM paused,
-                        execution handed off to target). Once migration completes those pods are
-                        terminated.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -12693,11 +12695,12 @@ var CRDsValidation map[string]string = map[string]string{
             guestAgentPing:
               description: |-
                 GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                During live migration the probe is suppressed on any pod where the guest
-                is not actually running: the target pod in pre-copy phase (VM paused,
-                receiving memory pages) and the source pod in post-copy phase (VM paused,
-                execution handed off to target). Once migration completes those pods are
-                terminated.
+                Probe failures are automatically suppressed when the guest agent is
+                unreachable for a non-fault reason: during live migration (guest paused
+                on one pod while memory is transferred) and whenever the VM is paused
+                for an intentional or transient reason such as a user pause, snapshot,
+                save, or dump. Failures are not suppressed when the VM is paused due to
+                a fault (IO error, crash, or postcopy failure).
               type: object
             httpGet:
               description: HTTPGet specifies the http request to perform.
@@ -12895,11 +12898,12 @@ var CRDsValidation map[string]string = map[string]string{
             guestAgentPing:
               description: |-
                 GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                During live migration the probe is suppressed on any pod where the guest
-                is not actually running: the target pod in pre-copy phase (VM paused,
-                receiving memory pages) and the source pod in post-copy phase (VM paused,
-                execution handed off to target). Once migration completes those pods are
-                terminated.
+                Probe failures are automatically suppressed when the guest agent is
+                unreachable for a non-fault reason: during live migration (guest paused
+                on one pod while memory is transferred) and whenever the VM is paused
+                for an intentional or transient reason such as a user pause, snapshot,
+                save, or dump. Failures are not suppressed when the VM is paused due to
+                a fault (IO error, crash, or postcopy failure).
               type: object
             httpGet:
               description: HTTPGet specifies the http request to perform.
@@ -18923,11 +18927,12 @@ var CRDsValidation map[string]string = map[string]string{
                     guestAgentPing:
                       description: |-
                         GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                        During live migration the probe is suppressed on any pod where the guest
-                        is not actually running: the target pod in pre-copy phase (VM paused,
-                        receiving memory pages) and the source pod in post-copy phase (VM paused,
-                        execution handed off to target). Once migration completes those pods are
-                        terminated.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -19126,11 +19131,12 @@ var CRDsValidation map[string]string = map[string]string{
                     guestAgentPing:
                       description: |-
                         GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                        During live migration the probe is suppressed on any pod where the guest
-                        is not actually running: the target pod in pre-copy phase (VM paused,
-                        receiving memory pages) and the source pod in post-copy phase (VM paused,
-                        execution handed off to target). Once migration completes those pods are
-                        terminated.
+                        Probe failures are automatically suppressed when the guest agent is
+                        unreachable for a non-fault reason: during live migration (guest paused
+                        on one pod while memory is transferred) and whenever the VM is paused
+                        for an intentional or transient reason such as a user pause, snapshot,
+                        save, or dump. Failures are not suppressed when the VM is paused due to
+                        a fault (IO error, crash, or postcopy failure).
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -23913,11 +23919,12 @@ var CRDsValidation map[string]string = map[string]string{
                             guestAgentPing:
                               description: |-
                                 GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                                During live migration the probe is suppressed on any pod where the guest
-                                is not actually running: the target pod in pre-copy phase (VM paused,
-                                receiving memory pages) and the source pod in post-copy phase (VM paused,
-                                execution handed off to target). Once migration completes those pods are
-                                terminated.
+                                Probe failures are automatically suppressed when the guest agent is
+                                unreachable for a non-fault reason: during live migration (guest paused
+                                on one pod while memory is transferred) and whenever the VM is paused
+                                for an intentional or transient reason such as a user pause, snapshot,
+                                save, or dump. Failures are not suppressed when the VM is paused due to
+                                a fault (IO error, crash, or postcopy failure).
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
@@ -24116,11 +24123,12 @@ var CRDsValidation map[string]string = map[string]string{
                             guestAgentPing:
                               description: |-
                                 GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                                During live migration the probe is suppressed on any pod where the guest
-                                is not actually running: the target pod in pre-copy phase (VM paused,
-                                receiving memory pages) and the source pod in post-copy phase (VM paused,
-                                execution handed off to target). Once migration completes those pods are
-                                terminated.
+                                Probe failures are automatically suppressed when the guest agent is
+                                unreachable for a non-fault reason: during live migration (guest paused
+                                on one pod while memory is transferred) and whenever the VM is paused
+                                for an intentional or transient reason such as a user pause, snapshot,
+                                save, or dump. Failures are not suppressed when the VM is paused due to
+                                a fault (IO error, crash, or postcopy failure).
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
@@ -29332,11 +29340,12 @@ var CRDsValidation map[string]string = map[string]string{
                                 guestAgentPing:
                                   description: |-
                                     GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                                    During live migration the probe is suppressed on any pod where the guest
-                                    is not actually running: the target pod in pre-copy phase (VM paused,
-                                    receiving memory pages) and the source pod in post-copy phase (VM paused,
-                                    execution handed off to target). Once migration completes those pods are
-                                    terminated.
+                                    Probe failures are automatically suppressed when the guest agent is
+                                    unreachable for a non-fault reason: during live migration (guest paused
+                                    on one pod while memory is transferred) and whenever the VM is paused
+                                    for an intentional or transient reason such as a user pause, snapshot,
+                                    save, or dump. Failures are not suppressed when the VM is paused due to
+                                    a fault (IO error, crash, or postcopy failure).
                                   type: object
                                 httpGet:
                                   description: HTTPGet specifies the http request
@@ -29537,11 +29546,12 @@ var CRDsValidation map[string]string = map[string]string{
                                 guestAgentPing:
                                   description: |-
                                     GuestAgentPing contacts the qemu-guest-agent for availability checks.
-                                    During live migration the probe is suppressed on any pod where the guest
-                                    is not actually running: the target pod in pre-copy phase (VM paused,
-                                    receiving memory pages) and the source pod in post-copy phase (VM paused,
-                                    execution handed off to target). Once migration completes those pods are
-                                    terminated.
+                                    Probe failures are automatically suppressed when the guest agent is
+                                    unreachable for a non-fault reason: during live migration (guest paused
+                                    on one pod while memory is transferred) and whenever the VM is paused
+                                    for an intentional or transient reason such as a user pause, snapshot,
+                                    save, or dump. Failures are not suppressed when the VM is paused due to
+                                    a fault (IO error, crash, or postcopy failure).
                                   type: object
                                 httpGet:
                                   description: HTTPGet specifies the http request

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7205,8 +7205,13 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        During live migration the probe is suppressed on any pod where the guest
+                        is not actually running: the target pod in pre-copy phase (VM paused,
+                        receiving memory pages) and the source pod in post-copy phase (VM paused,
+                        execution handed off to target). Once migration completes those pods are
+                        terminated.
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -7403,8 +7408,13 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        During live migration the probe is suppressed on any pod where the guest
+                        is not actually running: the target pod in pre-copy phase (VM paused,
+                        receiving memory pages) and the source pod in post-copy phase (VM paused,
+                        execution handed off to target). Once migration completes those pods are
+                        terminated.
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -12681,8 +12691,13 @@ var CRDsValidation map[string]string = map[string]string{
               format: int32
               type: integer
             guestAgentPing:
-              description: GuestAgentPing contacts the qemu-guest-agent for availability
-                checks.
+              description: |-
+                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                During live migration the probe is suppressed on any pod where the guest
+                is not actually running: the target pod in pre-copy phase (VM paused,
+                receiving memory pages) and the source pod in post-copy phase (VM paused,
+                execution handed off to target). Once migration completes those pods are
+                terminated.
               type: object
             httpGet:
               description: HTTPGet specifies the http request to perform.
@@ -12878,8 +12893,13 @@ var CRDsValidation map[string]string = map[string]string{
               format: int32
               type: integer
             guestAgentPing:
-              description: GuestAgentPing contacts the qemu-guest-agent for availability
-                checks.
+              description: |-
+                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                During live migration the probe is suppressed on any pod where the guest
+                is not actually running: the target pod in pre-copy phase (VM paused,
+                receiving memory pages) and the source pod in post-copy phase (VM paused,
+                execution handed off to target). Once migration completes those pods are
+                terminated.
               type: object
             httpGet:
               description: HTTPGet specifies the http request to perform.
@@ -18901,8 +18921,13 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        During live migration the probe is suppressed on any pod where the guest
+                        is not actually running: the target pod in pre-copy phase (VM paused,
+                        receiving memory pages) and the source pod in post-copy phase (VM paused,
+                        execution handed off to target). Once migration completes those pods are
+                        terminated.
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -19099,8 +19124,13 @@ var CRDsValidation map[string]string = map[string]string{
                       format: int32
                       type: integer
                     guestAgentPing:
-                      description: GuestAgentPing contacts the qemu-guest-agent for
-                        availability checks.
+                      description: |-
+                        GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                        During live migration the probe is suppressed on any pod where the guest
+                        is not actually running: the target pod in pre-copy phase (VM paused,
+                        receiving memory pages) and the source pod in post-copy phase (VM paused,
+                        execution handed off to target). Once migration completes those pods are
+                        terminated.
                       type: object
                     httpGet:
                       description: HTTPGet specifies the http request to perform.
@@ -23881,8 +23911,13 @@ var CRDsValidation map[string]string = map[string]string{
                               format: int32
                               type: integer
                             guestAgentPing:
-                              description: GuestAgentPing contacts the qemu-guest-agent
-                                for availability checks.
+                              description: |-
+                                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                During live migration the probe is suppressed on any pod where the guest
+                                is not actually running: the target pod in pre-copy phase (VM paused,
+                                receiving memory pages) and the source pod in post-copy phase (VM paused,
+                                execution handed off to target). Once migration completes those pods are
+                                terminated.
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
@@ -24079,8 +24114,13 @@ var CRDsValidation map[string]string = map[string]string{
                               format: int32
                               type: integer
                             guestAgentPing:
-                              description: GuestAgentPing contacts the qemu-guest-agent
-                                for availability checks.
+                              description: |-
+                                GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                During live migration the probe is suppressed on any pod where the guest
+                                is not actually running: the target pod in pre-copy phase (VM paused,
+                                receiving memory pages) and the source pod in post-copy phase (VM paused,
+                                execution handed off to target). Once migration completes those pods are
+                                terminated.
                               type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
@@ -29290,8 +29330,13 @@ var CRDsValidation map[string]string = map[string]string{
                                   format: int32
                                   type: integer
                                 guestAgentPing:
-                                  description: GuestAgentPing contacts the qemu-guest-agent
-                                    for availability checks.
+                                  description: |-
+                                    GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                    During live migration the probe is suppressed on any pod where the guest
+                                    is not actually running: the target pod in pre-copy phase (VM paused,
+                                    receiving memory pages) and the source pod in post-copy phase (VM paused,
+                                    execution handed off to target). Once migration completes those pods are
+                                    terminated.
                                   type: object
                                 httpGet:
                                   description: HTTPGet specifies the http request
@@ -29490,8 +29535,13 @@ var CRDsValidation map[string]string = map[string]string{
                                   format: int32
                                   type: integer
                                 guestAgentPing:
-                                  description: GuestAgentPing contacts the qemu-guest-agent
-                                    for availability checks.
+                                  description: |-
+                                    GuestAgentPing contacts the qemu-guest-agent for availability checks.
+                                    During live migration the probe is suppressed on any pod where the guest
+                                    is not actually running: the target pod in pre-copy phase (VM paused,
+                                    receiving memory pages) and the source pod in post-copy phase (VM paused,
+                                    execution handed off to target). Once migration completes those pods are
+                                    terminated.
                                   type: object
                                 httpGet:
                                   description: HTTPGet specifies the http request

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2313,6 +2313,11 @@ type Handler struct {
 	// +optional
 	Exec *k8sv1.ExecAction `json:"exec,omitempty" protobuf:"bytes,1,opt,name=exec"`
 	// GuestAgentPing contacts the qemu-guest-agent for availability checks.
+	// During live migration the probe is suppressed on any pod where the guest
+	// is not actually running: the target pod in pre-copy phase (VM paused,
+	// receiving memory pages) and the source pod in post-copy phase (VM paused,
+	// execution handed off to target). Once migration completes those pods are
+	// terminated.
 	// +optional
 	GuestAgentPing *GuestAgentPing `json:"guestAgentPing,omitempty"`
 	// HTTPGet specifies the http request to perform.

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2313,11 +2313,12 @@ type Handler struct {
 	// +optional
 	Exec *k8sv1.ExecAction `json:"exec,omitempty" protobuf:"bytes,1,opt,name=exec"`
 	// GuestAgentPing contacts the qemu-guest-agent for availability checks.
-	// During live migration the probe is suppressed on any pod where the guest
-	// is not actually running: the target pod in pre-copy phase (VM paused,
-	// receiving memory pages) and the source pod in post-copy phase (VM paused,
-	// execution handed off to target). Once migration completes those pods are
-	// terminated.
+	// Probe failures are automatically suppressed when the guest agent is
+	// unreachable for a non-fault reason: during live migration (guest paused
+	// on one pod while memory is transferred) and whenever the VM is paused
+	// for an intentional or transient reason such as a user pause, snapshot,
+	// save, or dump. Failures are not suppressed when the VM is paused due to
+	// a fault (IO error, crash, or postcopy failure).
 	// +optional
 	GuestAgentPing *GuestAgentPing `json:"guestAgentPing,omitempty"`
 	// HTTPGet specifies the http request to perform.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -574,7 +574,7 @@ func (Handler) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":               "Handler defines a specific action that should be taken",
 		"exec":           "One and only one of the following should be specified.\nExec specifies the action to take, it will be executed on the guest through the qemu-guest-agent.\nIf the guest agent is not available, this probe will fail.\n+optional",
-		"guestAgentPing": "GuestAgentPing contacts the qemu-guest-agent for availability checks.\n+optional",
+		"guestAgentPing": "GuestAgentPing contacts the qemu-guest-agent for availability checks.\nDuring live migration the probe is suppressed on any pod where the guest\nis not actually running: the target pod in pre-copy phase (VM paused,\nreceiving memory pages) and the source pod in post-copy phase (VM paused,\nexecution handed off to target). Once migration completes those pods are\nterminated.\n+optional",
 		"httpGet":        "HTTPGet specifies the http request to perform.\n+optional",
 		"tcpSocket":      "TCPSocket specifies an action involving a TCP port.\nTCP hooks not yet supported\n+optional",
 	}

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -574,7 +574,7 @@ func (Handler) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":               "Handler defines a specific action that should be taken",
 		"exec":           "One and only one of the following should be specified.\nExec specifies the action to take, it will be executed on the guest through the qemu-guest-agent.\nIf the guest agent is not available, this probe will fail.\n+optional",
-		"guestAgentPing": "GuestAgentPing contacts the qemu-guest-agent for availability checks.\nDuring live migration the probe is suppressed on any pod where the guest\nis not actually running: the target pod in pre-copy phase (VM paused,\nreceiving memory pages) and the source pod in post-copy phase (VM paused,\nexecution handed off to target). Once migration completes those pods are\nterminated.\n+optional",
+		"guestAgentPing": "GuestAgentPing contacts the qemu-guest-agent for availability checks.\nProbe failures are automatically suppressed when the guest agent is\nunreachable for a non-fault reason: during live migration (guest paused\non one pod while memory is transferred) and whenever the VM is paused\nfor an intentional or transient reason such as a user pause, snapshot,\nsave, or dump. Failures are not suppressed when the VM is paused due to\na fault (IO error, crash, or postcopy failure).\n+optional",
 		"httpGet":        "HTTPGet specifies the http request to perform.\n+optional",
 		"tcpSocket":      "TCPSocket specifies an action involving a TCP port.\nTCP hooks not yet supported\n+optional",
 	}

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20745,7 +20745,7 @@ func schema_kubevirtio_api_core_v1_Handler(ref common.ReferenceCallback) common.
 					},
 					"guestAgentPing": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks.",
+							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. During live migration the probe is suppressed on any pod where the guest is not actually running: the target pod in pre-copy phase (VM paused, receiving memory pages) and the source pod in post-copy phase (VM paused, execution handed off to target). Once migration completes those pods are terminated.",
 							Ref:         ref("kubevirt.io/api/core/v1.GuestAgentPing"),
 						},
 					},
@@ -23879,7 +23879,7 @@ func schema_kubevirtio_api_core_v1_Probe(ref common.ReferenceCallback) common.Op
 					},
 					"guestAgentPing": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks.",
+							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. During live migration the probe is suppressed on any pod where the guest is not actually running: the target pod in pre-copy phase (VM paused, receiving memory pages) and the source pod in post-copy phase (VM paused, execution handed off to target). Once migration completes those pods are terminated.",
 							Ref:         ref("kubevirt.io/api/core/v1.GuestAgentPing"),
 						},
 					},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20745,7 +20745,7 @@ func schema_kubevirtio_api_core_v1_Handler(ref common.ReferenceCallback) common.
 					},
 					"guestAgentPing": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. During live migration the probe is suppressed on any pod where the guest is not actually running: the target pod in pre-copy phase (VM paused, receiving memory pages) and the source pod in post-copy phase (VM paused, execution handed off to target). Once migration completes those pods are terminated.",
+							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. Probe failures are automatically suppressed when the guest agent is unreachable for a non-fault reason: during live migration (guest paused on one pod while memory is transferred) and whenever the VM is paused for an intentional or transient reason such as a user pause, snapshot, save, or dump. Failures are not suppressed when the VM is paused due to a fault (IO error, crash, or postcopy failure).",
 							Ref:         ref("kubevirt.io/api/core/v1.GuestAgentPing"),
 						},
 					},
@@ -23879,7 +23879,7 @@ func schema_kubevirtio_api_core_v1_Probe(ref common.ReferenceCallback) common.Op
 					},
 					"guestAgentPing": {
 						SchemaProps: spec.SchemaProps{
-							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. During live migration the probe is suppressed on any pod where the guest is not actually running: the target pod in pre-copy phase (VM paused, receiving memory pages) and the source pod in post-copy phase (VM paused, execution handed off to target). Once migration completes those pods are terminated.",
+							Description: "GuestAgentPing contacts the qemu-guest-agent for availability checks. Probe failures are automatically suppressed when the guest agent is unreachable for a non-fault reason: during live migration (guest paused on one pod while memory is transferred) and whenever the VM is paused for an intentional or transient reason such as a user pause, snapshot, save, or dump. Failures are not suppressed when the VM is paused due to a fault (IO error, crash, or postcopy failure).",
 							Ref:         ref("kubevirt.io/api/core/v1.GuestAgentPing"),
 						},
 					},

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -209,6 +209,48 @@ var _ = Describe(SIG("GuestAgent", decorators.GuestAgentProbes, func() {
 				Should(Or(matcher.BeInPhase(v1.Failed), matcher.HaveSucceeded()))
 		})
 	})
+
+	Context("Liveness probe with guest agent ping and user-paused VMI", func() {
+		It("should not kill the VMI while it is paused by the user", func() {
+			// Low FailureThreshold so that without the fix the probe would
+			// kill the VMI within a few probe cycles.
+			livenessProbe := &v1.Probe{
+				Handler:             v1.Handler{GuestAgentPing: &v1.GuestAgentPing{}},
+				InitialDelaySeconds: 120,
+				PeriodSeconds:       5,
+				FailureThreshold:    2,
+			}
+			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), withLivenessProbe(livenessProbe))
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+
+			By("Waiting for agent to connect")
+			Eventually(matcher.ThisVMI(vmi)).
+				WithTimeout(12 * time.Minute).
+				WithPolling(2 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("Pausing the VMI")
+			Expect(kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})).To(Succeed())
+			Eventually(matcher.ThisVMI(vmi)).
+				WithTimeout(30 * time.Second).
+				WithPolling(2 * time.Second).
+				Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
+
+			By("Verifying the VMI stays alive while paused (probe errors must be suppressed)")
+			// Wait long enough for several probe cycles to elapse.
+			Consistently(matcher.ThisVMI(vmi)).
+				WithTimeout(30 * time.Second).
+				WithPolling(2 * time.Second).
+				Should(Not(matcher.BeInPhase(v1.Failed)))
+
+			By("Unpausing the VMI")
+			Expect(kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})).To(Succeed())
+			Eventually(matcher.ThisVMI(vmi)).
+				WithTimeout(30 * time.Second).
+				WithPolling(2 * time.Second).
+				Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+		})
+	})
 }))
 
 func createExecProbe(period, initialSeconds, timeoutSeconds int32, command ...string) *v1.Probe {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2909,6 +2909,36 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
 		})
 	})
+
+	Describe("with a guest-agent-ping liveness probe", func() {
+		// Regression test for probe suppression on the migration target pod.
+		// Before the fix, the QEMU guest agent was unreachable on the target
+		// pod while it was receiving the incoming migration, causing the
+		// Kubernetes liveness probe to fail. Because virt-launcher pods use
+		// restartPolicy: Never, the failed probe kills the compute container
+		// and the pod enters Failed phase, aborting the migration.
+		It("should complete migration without the liveness probe killing the target pod", func() {
+			By("Creating a Fedora VMI with a GuestAgentPing liveness probe")
+			vmi := libvmifact.NewFedora(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithMemoryRequest(fedoraVMSize),
+				libvmi.WithGuestAgentPingLivenessProbe(120, 5, 2),
+			)
+
+			By("Starting the VirtualMachineInstance")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+
+			By("Waiting for the guest agent to connect")
+			Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("Starting a migration")
+			migration := libmigration.New(vmi.Name, vmi.Namespace)
+			migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+			By("Confirming the VMI migrated successfully and is still running")
+			libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+		})
+	})
 }))
 
 func createResourceQuota(resourceQuota *k8sv1.ResourceQuota) *k8sv1.ResourceQuota {

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -164,6 +164,49 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 			Entry("the Kubevirt CR", Serial, applyWithKubevirtCR),
 		)
 
+		Context("with a guest-agent-ping liveness probe", func() {
+			// Regression test for probe suppression on the migration source pod
+			// during post-copy. Once post-copy starts the source VM is handed off
+			// to the target and enters a ghost/paused state, making it unreachable
+			// via the QEMU guest agent. Because virt-launcher pods use
+			// restartPolicy: Never, the failed probe kills the compute container
+			// and the pod enters Failed phase, aborting the migration.
+			It("should complete post-copy migration without the liveness probe killing the source pod", func() {
+				By("Creating a Fedora VMI with a GuestAgentPing liveness probe")
+				vmi := libvmifact.NewFedora(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithMemoryRequest("512Mi"),
+					libvmi.WithRng(),
+					libvmi.WithNamespace(testsuite.NamespacePrivileged),
+					libvmi.WithGuestAgentPingLivenessProbe(120, 5, 2),
+				)
+
+				By("Applying the post-copy migration policy")
+				AlignPolicyAndVmi(vmi, migrationPolicy)
+				migrationPolicy = CreateMigrationPolicy(virtClient, migrationPolicy)
+
+				By("Starting the VirtualMachineInstance")
+				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+
+				By("Waiting for the guest agent to connect")
+				Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Logging into the VMI")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Running a stress test to dirty pages and trigger post-copy")
+				runStressTest(vmi, "350M")
+
+				By("Starting the migration")
+				migration := libmigration.New(vmi.Name, vmi.Namespace)
+				migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+				By("Confirming the VMI migrated successfully via post-copy and is still running")
+				vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+				libmigration.ConfirmMigrationMode(virtClient, vmi, v1.MigrationPostCopy)
+			})
+		})
+
 		Context("and fail", Serial, func() {
 			var killerPod string
 


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/17235
Original credit goes to @tiraboschi 

### What this PR does
#### Before this PR:
During live migration the QEMU guest agent is temporarily unreachable on two different pods depending on the migration phase:

Pre-copy: the target pod has the guest paused while receiving memory pages — a GuestAgentPing probe there produces false negatives, causing Kubernetes to restart the target pod and abort the migration.
Post-copy: the source VM is handed off to the target and enters a ghost/paused state — the same probe on the source pod produces false negatives, again risking a pod restart.
Because GuestAgentPing is implemented as a Kubernetes exec probe running inside each pod's compute container, kubelet executes it on both pods simultaneously throughout the migration. Both failure modes could abort an in-progress migration.

More generally, whenever a VM is paused by the user or by the platform for an intentional reason (snapshot, save, dump, …) the guest agent is also unreachable, and a GuestAgentPing liveness probe would kill the pod.

#### After this PR:
This PR is split into two commits that can be cherry-picked independently to release branches.

Commit 1 - migration (MVP): LibvirtDomainManager.GuestPing suppresses probe errors for the duration of an in-progress migration on any pod where they occur. The check is intentionally simple: if migration metadata has StartTimestamp set and no EndTimestamp, a migration is in progress and any probe failure is returned as a synthetic success. No attempt is made to distinguish source from target, the suppression path is only reached when the probe has already failed, which only happens when the guest is genuinely unreachable. The suppression window closes as soon as EndTimestamp is set, after which the real guest-agent ping resumes normally.

Commit 2 - healthy paused states: When no migration is in progress, GuestPing falls back to a new isPausedButHealthy helper that inspects the libvirt domain pause reason via the API. Suppression is applied for an explicit allowlist of intentional/transient pause reasons (user pause, snapshot, save, dump, postcopy, …). Fault pauses (IOError, Crashed, PostcopyFailed) are intentionally excluded so genuine guest problems are still surfaced. An allowlist is preferred over a denylist so that unknown future libvirt pause reasons default to not being suppressed.

Other probe types (exec, httpGet, tcpSocket) are intentionally left unchanged — their semantics during migration are consistent with regular Kubernetes pods and are tuneable via initialDelaySeconds/failureThreshold.

Documentation updated in docs/probes.md and in the GuestAgentPing API comment. Unit tests cover all migration-phase/pod-role combinations and every healthy and unhealthy pause reason. E2e regression tests cover both the migration case and the user-pause case.

### Fixes: https://redhat.atlassian.net/browse/CNV-86287

### Release note
```release-note
Fix: GuestAgentPing liveness/readiness probes no longer cause Kubernetes to restart the virt-launcher pod when the guest agent is temporarily unreachable for a non-fault reason; suppression covers live migration (both pre-copy target and post-copy source) and any intentional or transient VM pause such  as user pause, snapshot, save, or dump.
```

