### PR TITLE
Fix copyResourceClaims to deduplicate by {Name, Request}

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -405,18 +405,24 @@ func requestResourceClaims(resources *k8sv1.ResourceRequirements, claim *k8sv1.R
 	resources.Claims = append(resources.Claims, *claim)
 }
 
+type claimKey struct {
+	name    string
+	request string
+}
+
 func copyResourceClaims(resources *k8sv1.ResourceRequirements, claims *[]k8sv1.ResourceClaim) {
-	existing := make(map[string]struct{})
+	existing := make(map[claimKey]struct{})
 	for _, c := range *claims {
-		existing[c.Name] = struct{}{}
+		existing[claimKey{c.Name, c.Request}] = struct{}{}
 	}
 
 	for _, value := range resources.Claims {
-		if _, found := existing[value.Name]; found {
-			continue // skip duplicates by Name
+		key := claimKey{value.Name, value.Request}
+		if _, found := existing[key]; found {
+			continue
 		}
 		*claims = append(*claims, value)
-		existing[value.Name] = struct{}{}
+		existing[key] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig compute

**What this PR does / why we need it:**

`copyResourceClaims` deduplicates resource claim references using only the claim `Name`. When a single ResourceClaim has multiple requests (e.g., `gpu`, `nic`, `cpu` all in one claim), each GPU/hostDevice entry adds a reference with the same claim Name but a different Request value. The first reference is kept and subsequent references with the same Name are dropped, causing the kubelet to only inject CDI devices for the first request.

This fixes the deduplication key from `Name` to `{Name, Request}` so all unique request references are preserved.

**Which issue(s) this PR fixes:**

Fixes https://github.com/kubevirt/kubevirt/issues/17672

**Special notes for your reviewer:**

Observed when using a single ResourceClaim with GPU + NIC + NVMe requests for a KubeVirt VM with DRA passthrough. Only the GPU got CDI devices; the NIC and NVMe were silently dropped.

**Release note:**

```release-note
Fix DRA resource claim deduplication to preserve multiple request references from the same claim.
```