### PR TITLE
Add IPC_LOCK and SYS_RAWIO capabilities for DRA VFIO passthrough

### DIFF
--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -291,5 +291,23 @@ func requiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
 		capabilities = append(capabilities, CAP_SYS_NICE)
 	}
 
+	if hasDRADevices(vmi) {
+		capabilities = append(capabilities, CAP_IPC_LOCK, CAP_SYS_RAWIO)
+	}
+
 	return capabilities
+}
+
+func hasDRADevices(vmi *v1.VirtualMachineInstance) bool {
+	for _, gpu := range vmi.Spec.Domain.Devices.GPUs {
+		if gpu.ClaimRequest != nil {
+			return true
+		}
+	}
+	for _, hd := range vmi.Spec.Domain.Devices.HostDevices {
+		if hd.ClaimRequest != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -98,6 +98,8 @@ const qemuTimeoutJitterRange = 120
 const (
 	CAP_NET_BIND_SERVICE = "NET_BIND_SERVICE"
 	CAP_SYS_NICE         = "SYS_NICE"
+	CAP_IPC_LOCK         = "IPC_LOCK"
+	CAP_SYS_RAWIO        = "SYS_RAWIO"
 )
 
 // LibvirtStartupDelay is added to custom liveness and readiness probes initial delay value.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig compute

**What this PR does / why we need it:**

When GPUs or host devices are provisioned via DRA (`ClaimRequest` is set), the virt-launcher pod is created without `IPC_LOCK` and `SYS_RAWIO` capabilities. VFIO passthrough requires `IPC_LOCK` for DMA memory pinning (`mlock`/`mlockall`) and `SYS_RAWIO` for PCI config space access. Without them, libvirt fails with:

```
cannot limit locked memory of process: Operation not permitted
```

Device-plugin devices get these capabilities through the `permittedHostDevices` configuration path. DRA-provisioned devices bypass that path and need the capabilities added directly in `requiredCapabilities`.

**Which issue(s) this PR fixes:**

Fixes https://github.com/kubevirt/kubevirt/issues/17674

**Release note:**

```release-note
Add IPC_LOCK and SYS_RAWIO capabilities for virt-launcher pods with DRA GPU or host device passthrough.
```