### PR TITLE
virt-api: nil-check CPU topology in admitHotplugCPU

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -192,6 +192,9 @@ func admitHotplug(
 }
 
 func admitHotplugCPU(oldCPUTopology, newCPUTopology *v1.CPU) *admissionv1.AdmissionResponse {
+	if oldCPUTopology == nil || newCPUTopology == nil {
+		return nil
+	}
 
 	if oldCPUTopology.MaxSockets != newCPUTopology.MaxSockets {
 		return webhookutils.ToAdmissionResponse([]metav1.StatusCause{


### PR DESCRIPTION
Closes #16959. spec.domain.cpu is optional; nil pointer panics the admission webhook on VMI update.