### PR TITLE
e2e, net: Remove non-authoritative IPv6 validations in bridge binding tests

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -33,6 +33,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -64,22 +65,8 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 
 		Context("VMI connected to the pod network using bridge binding", func() {
 			When("Guest Agent exists", func() {
-				var (
-					vmi   *v1.VirtualMachineInstance
-					vmiIP = func() string {
-						var err error
-						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-						ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving VMI to get IP")
-						return vmi.Status.Interfaces[0].IP
-					}
+				var vmi *v1.VirtualMachineInstance
 
-					vmiIPs = func() []string {
-						var err error
-						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-						ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving VMI to get IPs")
-						return vmi.Status.Interfaces[0].IPs
-					}
-				)
 				BeforeEach(func() {
 					libnet.SkipWhenClusterNotSupportIpv4()
 					var err error
@@ -94,16 +81,16 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				})
 
-				It("should report PodIP/s on interface status", func() {
+				It("should report PodIP on interface status, with GuestAgent infoSource", func() {
 					vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Expect(err).NotTo(HaveOccurred())
 
-					Eventually(vmiIP, 2*time.Minute, 5*time.Second).Should(Equal(vmiPod.Status.PodIP), "should contain VMI Status IP as Pod status ip")
-					var podIPs []string
-					for _, ip := range vmiPod.Status.PodIPs {
-						podIPs = append(podIPs, ip.IP)
-					}
-					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(Equal(podIPs), "should contain VMI Status IP as Pod status IPs")
+					Eventually(func(g Gomega) {
+						updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(vmispec.ContainsInfoSource(updatedVMI.Status.Interfaces[0].InfoSource, vmispec.InfoSourceGuestAgent)).To(BeTrue(), "interface infoSource should include guest agent")
+						g.Expect(updatedVMI.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP))
+					}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 				})
 			})
 		})

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -157,7 +158,12 @@ var _ = Describe(SIG("Infosource", func() {
 
 			networkInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceMac)
 			Expect(networkInterface).NotTo(BeNil(), "interface not found")
-			Expect(networkInterface.IP).NotTo(BeEmpty())
+
+			supportsIpv4, err := cluster.SupportsIpv4()
+			Expect(err).NotTo(HaveOccurred())
+			if supportsIpv4 {
+				Expect(networkInterface.IP).NotTo(BeEmpty(), "IP address not present in IPv4 cluster for MAC %s", networkInterface.MAC)
+			}
 
 			guestInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceNewMac)
 			Expect(guestInterface).NotTo(BeNil(), "interface not found")

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -82,8 +82,14 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		})
 		Context("with a test outbound VMI", func() {
 			BeforeEach(func() {
-				inboundVMI = libvmifact.NewCirros()
-				outboundVMI = libvmifact.NewCirros()
+				inboundVMI = libvmifact.NewCirros(
+					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				outboundVMI = libvmifact.NewCirros(
+					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
 				inboundVMIWithCustomMacAddress = vmiWithCustomMacAddress("de:ad:00:00:be:af")
 				inboundVMIWithMultiQueueSingleCPU = vmiWithMultiQueue()
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -106,7 +106,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				vmiPod, err := libpod.GetPodByVirtualMachineInstance(outboundVMI, outboundVMI.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(libnet.ValidateVMIandPodIPMatch(outboundVMI, vmiPod)).To(Succeed(), "Should have matching IP/s between pod and vmi")
+				Expect(outboundVMI.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP), "Should have matching IP between pod and vmi")
 
 				var mtu int
 				for _, ifaceName := range []string{"k6t-eth0", "tap0"} {


### PR DESCRIPTION
### What this PR does

Bridge binding tests currently validate that both IPv4 and IPv6 addresses
match between pod and VMI. However, for bridge binding:
- KubeVirt does not support DHCPv6, so pod IPv6 addresses never propagate
to the guest
- Only the primary IP field is authoritative; secondary pod IPs in the IPs
array are unreachable

This PR updates bridge binding tests to validate only authoritative IP
information:

1. **Remove IPs array validation** - Stops comparing the full IPs slice
between pod and VMI status, since secondary IPv6 addresses are not
authoritative
2. **Validate only the primary IP** - Keeps validation of the main IP field
 (Status.Interfaces[0].IP), which contains the authoritative address
3. **Add guest agent infoSource check** - Ensures interface status includes
 guest agent data before validating IPs
4. **Allow empty IP for IPv6-only** - In IPv6-only clusters, the Domain
status entry (original MAC) can have empty IP since the IPv6 LLA is only
generated after MAC change

This prepares for a follow-up PR that will remove unreachable pod IPv6
addresses from VMI status for bridge binding (CNV-80582).

### References
- https://redhat.atlassian.net/browse/CNV-80582


### Release note
```release-note
NONE
```