### PR TITLE
Force root mode and add CAP_SYS_RESOURCE for VFIO passthrough

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -79,7 +79,7 @@ func ApplyNewVMIMutations(newVMI *v1.VirtualMachineInstance, clusterConfig *virt
 		}
 	}
 
-	if !clusterConfig.RootEnabled() {
+	if !clusterConfig.RootEnabled() && !util.IsVFIOVMI(newVMI) {
 		markAsNonroot(newVMI)
 	}
 

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -291,5 +291,9 @@ func requiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
 		capabilities = append(capabilities, CAP_SYS_NICE)
 	}
 
+	if util.IsVFIOVMI(vmi) {
+		capabilities = append(capabilities, CAP_SYS_RESOURCE)
+	}
+
 	return capabilities
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -98,6 +98,7 @@ const qemuTimeoutJitterRange = 120
 const (
 	CAP_NET_BIND_SERVICE = "NET_BIND_SERVICE"
 	CAP_SYS_NICE         = "SYS_NICE"
+	CAP_SYS_RESOURCE     = "SYS_RESOURCE"
 )
 
 // LibvirtStartupDelay is added to custom liveness and readiness probes initial delay value.


### PR DESCRIPTION
## Summary

- Force root mode for VFIO VMIs by skipping `markAsNonroot()` in the mutating webhook when `IsVFIOVMI()` is true
- Add `CAP_SYS_RESOURCE` capability for VFIO VMIs so libvirt can call `prlimit()` on the QEMU child process
- Non-VFIO VMs remain non-root with minimal capabilities

## Root Cause

VFIO passthrough fails in non-root mode (the default when `Root` feature gate is not enabled) because libvirt calls `prlimit(QEMU_pid, RLIMIT_MEMLOCK, 2^53-1)` via `virProcessSetMaxMemLock()` on the QEMU child process during domain creation. The Linux kernel requires `CAP_SYS_RESOURCE` for `prlimit()` on another process, regardless of whether the value is being raised or lowered.

virt-handler's external `prlimit64` on virtqemud works correctly — `IsVFIOVMI` returns true for both DRA and device-plugin devices, `FindVirtqemudProcess` finds the process, and `SetProcessMemoryLockRLimit` succeeds. But libvirt's internal `prlimit()` call fails with `EPERM` because the non-root container lacks `CAP_SYS_RESOURCE`.

See #17675 for the full investigation and virt-handler log traces.

**What this PR does / why we need it:**

/kind bug
/sig compute

**Which issue(s) this PR fixes:**

Fixes https://github.com/kubevirt/kubevirt/issues/17694
Related: https://github.com/kubevirt/kubevirt/issues/12433
Related: https://github.com/kubevirt/kubevirt/issues/10379

## Test plan

- [x] Deploy KubeVirt from `main` without `Root` feature gate
- [x] Create a VM with DRA VFIO GPU (NVIDIA A40 via `gpu.nvidia.com` DRA driver)
- [x] Verify VM fails with `cannot limit locked memory of process` without this fix
- [x] Apply fix and verify VM starts successfully with `RunAsUser=0`, caps `["NET_BIND_SERVICE", "SYS_NICE", "SYS_RESOURCE"]`
- [x] Verify non-VFIO VMs still run as non-root with minimal capabilities
- [ ] Verify device-plugin VFIO passthrough also works without `Root` feature gate

```release-note
Force root mode and add CAP_SYS_RESOURCE for virt-launcher pods with VFIO passthrough devices, fixing memlock prlimit failure in default non-root mode.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)