### PR TITLE
fix (vmexport): don't populate vm manifest if source is pvc

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1132,9 +1132,6 @@ func (ctrl *VMExportController) createExporterPodManifest(vmExport *exportv1.Vir
 		Name:  "DEADLINE",
 		Value: getDeadlineValue(deadline, vmExport).Format(time.RFC3339),
 	}, corev1.EnvVar{
-		Name:  "EXPORT_VM_DEF_URI",
-		Value: manifestsPath,
-	}, corev1.EnvVar{
 		Name:  "EXPORT_SECRET_DEF_URI",
 		Value: secretManifestPath,
 	})

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -92,9 +92,6 @@ var (
 	qemuGid            int64 = 107
 	expectedPodEnvVars       = []k8sv1.EnvVar{
 		{
-			Name:  "EXPORT_VM_DEF_URI",
-			Value: manifestsPath,
-		}, {
 			Name:  "CERT_FILE",
 			Value: "/cert/tls.crt",
 		}, {
@@ -1012,6 +1009,26 @@ var _ = Describe("Export controller", func() {
 			gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TLS_CIPHER_SUITES")}),
 		))
 	})
+
+	DescribeTable("Should set export pod env vars", func(vmExport *exportv1.VirtualMachineExport, source exportSource, expectManifest bool) {
+		pod, err := controller.createExporterPodManifest(vmExport, nil, source)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod.Spec.Containers[0].Env).To(ContainElements(expectedPodEnvVars))
+		if expectManifest {
+			Expect(pod.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{
+				Name:  "EXPORT_VM_DEF_URI",
+				Value: manifestsPath,
+			}))
+		} else {
+			Expect(pod.Spec.Containers[0].Env).ToNot(ContainElement(
+				HaveField("Name", "EXPORT_VM_DEF_URI"),
+			))
+		}
+	},
+		Entry("for VM source", createVMVMExport(), NewVMSource(&sourceVolumes{}), true),
+		Entry("for VM Snapshot source", createSnapshotVMExport(), NewVMSnapshotSource(&sourceVolumes{}, "test-vm"), true),
+		Entry("for PVC source", createPVCVMExport(), NewPVCSource(&sourceVolumes{}), false),
+	)
 
 	DescribeTable("Volumemount names should be trimmed depending on the PVC name", func(pvcName string) {
 		testVMExport := createPVCVMExportWithName(pvcName)

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -69,6 +69,10 @@ func (s *VMSource) ServicePorts() []corev1.ServicePort {
 }
 
 func (s *VMSource) ConfigurePod(pod *corev1.Pod) {
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+		Name:  "EXPORT_VM_DEF_URI",
+		Value: manifestsPath,
+	})
 	s.sourceVolumes.configurePodVolumes(pod)
 }
 

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -79,6 +79,10 @@ func (s *VMSnapshotSource) ServicePorts() []corev1.ServicePort {
 }
 
 func (s *VMSnapshotSource) ConfigurePod(pod *corev1.Pod) {
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+		Name:  "EXPORT_VM_DEF_URI",
+		Value: manifestsPath,
+	})
 	s.sourceVolumes.configurePodVolumes(pod)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Regardless of the source, VM manifest links are added to VMExport objects. This PR changes that so these manifests are not added when the source type is of PVC

Fixes: https://redhat.atlassian.net/browse/CNV-25557

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  

- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
only populate vmexport with a vm manifest if source is not pvc
```

