### PR TITLE
[release-1.8] Add recording rules with new naming

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -16,7 +16,7 @@
 | kubevirt_virt_operator_leading_status | Metric | Gauge | Indication for an operating virt-operator. |
 | kubevirt_virt_operator_ready_status | Metric | Gauge | Indication for a virt-operator that is ready to take the lead. |
 | kubevirt_vm_create_date_timestamp_seconds | Metric | Gauge | Virtual Machine creation timestamp. |
-| kubevirt_vm_created_by_pod_total | Metric | Counter | The total number of VMs created by namespace and virt-api pod, since install. |
+| kubevirt_vm_created_by_pod_total | Metric | Counter | [Deprecated] The total number of VMs created by namespace and virt-api pod, since install. |
 | kubevirt_vm_disk_allocated_size_bytes | Metric | Gauge | Allocated disk size of a Virtual Machine in bytes, based on its PersistentVolumeClaim. Includes persistentvolumeclaim (PVC name), volume_mode (disk presentation mode: Filesystem or Block), and device (disk name). |
 | kubevirt_vm_error_status_last_transition_timestamp_seconds | Metric | Counter | Virtual Machine last transition timestamp to error status. |
 | kubevirt_vm_info | Metric | Gauge | Information about Virtual Machines. |
@@ -103,33 +103,53 @@
 | kubevirt_workqueue_retries_total | Metric | Counter | Total number of retries handled by workqueue |
 | kubevirt_workqueue_unfinished_work_seconds | Metric | Gauge | How many seconds of work have been in progress without being observed by work_duration. Large values indicate stuck threads. The number of stuck threads can be deduced by observing the rate at which this value increases. |
 | kubevirt_workqueue_work_duration_seconds | Metric | Histogram | How long in seconds processing an item from workqueue takes. |
+| cluster:kubevirt_api_request_deprecated_total:sum | Recording rule | Counter | The total number of requests to deprecated KubeVirt APIs, by API verb (e.g., LIST, WATCH). |
+| cluster:kubevirt_nodes_allocatable:count | Recording rule | Gauge | The number of allocatable nodes in the cluster. |
+| cluster:kubevirt_nodes_with_kvm:count | Recording rule | Gauge | The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. |
 | cluster:kubevirt_non_schedulable_nodes:sum | Recording rule | Gauge | The number of non-schedulable nodes in the cluster. |
+| cluster:kubevirt_virt_api_up:sum | Recording rule | Gauge | The number of virt-api pods that are up. |
 | cluster:kubevirt_virt_controller_pods_running:count | Recording rule | Gauge | The number of virt-controller pods that are running. |
+| cluster:kubevirt_virt_controller_ready:sum | Recording rule | Gauge | The number of virt-controller pods that are ready. |
+| cluster:kubevirt_virt_controller_up:sum | Recording rule | Gauge | The number of virt-controller pods that are up. |
+| cluster:kubevirt_virt_handler_up:sum | Recording rule | Gauge | The number of virt-handler pods that are up. |
+| cluster:kubevirt_virt_operator_leading:sum | Recording rule | Gauge | The number of virt-operator pods that are leading. |
 | cluster:kubevirt_virt_operator_pods_running:count | Recording rule | Gauge | The number of virt-operator pods that are running. |
-| kubevirt_allocatable_nodes | Recording rule | Gauge | The number of allocatable nodes in the cluster. |
-| kubevirt_api_request_deprecated_total | Recording rule | Counter | The total number of requests to deprecated KubeVirt APIs. |
-| kubevirt_memory_delta_from_requested_bytes | Recording rule | Gauge | The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher). |
-| kubevirt_nodes_with_kvm | Recording rule | Gauge | The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. |
-| kubevirt_number_of_vms | Recording rule | Gauge | The number of VMs in the cluster by namespace. |
-| kubevirt_virt_api_up | Recording rule | Gauge | The number of virt-api pods that are up. |
-| kubevirt_virt_controller_ready | Recording rule | Gauge | The number of virt-controller pods that are ready. |
-| kubevirt_virt_controller_up | Recording rule | Gauge | The number of virt-controller pods that are up. |
-| kubevirt_virt_handler_up | Recording rule | Gauge | The number of virt-handler pods that are up. |
-| kubevirt_virt_operator_leading | Recording rule | Gauge | The number of virt-operator pods that are leading. |
-| kubevirt_virt_operator_ready | Recording rule | Gauge | The number of virt-operator pods that are ready. |
-| kubevirt_virt_operator_up | Recording rule | Gauge | The number of virt-operator pods that are up. |
-| kubevirt_vm_container_memory_request_margin_based_on_rss_bytes | Recording rule | Gauge | Difference between requested memory and rss for VM containers (request margin). Can be negative when usage exceeds request. |
-| kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes | Recording rule | Gauge | Difference between requested memory and working set for VM containers (request margin). Can be negative when usage exceeds request. |
-| kubevirt_vm_created_total | Recording rule | Counter | The total number of VMs created by namespace, since install. |
-| kubevirt_vmi_guest_vcpu_queue | Recording rule | Gauge | Guest queue length. |
-| kubevirt_vmi_memory_used_bytes | Recording rule | Gauge | Amount of `used` memory as seen by the domain. |
+| cluster:kubevirt_virt_operator_ready:sum | Recording rule | Gauge | The number of virt-operator pods that are ready. |
+| cluster:kubevirt_virt_operator_up:sum | Recording rule | Gauge | The number of virt-operator pods that are up. |
+| container:kubevirt_memory_delta_from_requested_bytes:max | Recording rule | Gauge | The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher). |
+| kubevirt_allocatable_nodes | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_nodes_allocatable:count. |
+| kubevirt_api_request_deprecated_total | Recording rule | Counter | [Deprecated] Replaced by cluster:kubevirt_api_request_deprecated_total:sum. |
+| kubevirt_memory_delta_from_requested_bytes | Recording rule | Gauge | [Deprecated] Replaced by container:kubevirt_memory_delta_from_requested_bytes:max. |
+| kubevirt_nodes_with_kvm | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_nodes_with_kvm:count. |
+| kubevirt_number_of_vms | Recording rule | Gauge | [Deprecated] Replaced by namespace:kubevirt_vm:sum. |
+| kubevirt_virt_api_up | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_virt_api_up:sum. |
+| kubevirt_virt_controller_ready | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_virt_controller_ready:sum. |
+| kubevirt_virt_controller_up | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_virt_controller_up:sum. |
+| kubevirt_virt_handler_up | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_virt_handler_up:sum. |
+| kubevirt_virt_operator_leading | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_virt_operator_leading:sum. |
+| kubevirt_virt_operator_ready | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_virt_operator_ready:sum. |
+| kubevirt_virt_operator_up | Recording rule | Gauge | [Deprecated] Replaced by cluster:kubevirt_virt_operator_up:sum. |
+| kubevirt_vm_container_memory_request_margin_based_on_rss_bytes | Recording rule | Gauge | [Deprecated] Replaced by pod_container:kubevirt_vm_memory_request_margin_based_on_rss_bytes:sum. |
+| kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes | Recording rule | Gauge | [Deprecated] Replaced by pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum. |
+| kubevirt_vm_created_total | Recording rule | Counter | [Deprecated] The total number of VMs created by namespace, since install. |
+| kubevirt_vmi_guest_vcpu_queue | Recording rule | Gauge | [Deprecated] Replaced by vmi:kubevirt_vmi_guest_queue_length:sum. |
+| kubevirt_vmi_memory_used_bytes | Recording rule | Gauge | [Deprecated] Replaced by vmi:kubevirt_vmi_memory_used_bytes:sum. |
 | kubevirt_vmi_migration_data_total_bytes | Recording rule | Counter | [Deprecated] Replaced by kubevirt_vmi_migration_data_bytes_total. |
-| kubevirt_vmi_phase_count | Recording rule | Gauge | Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`]. |
-| kubevirt_vmsnapshot_disks_restored_from_source | Recording rule | Gauge | Returns the total number of virtual machine disks restored from the source virtual machine. |
-| kubevirt_vmsnapshot_disks_restored_from_source_bytes | Recording rule | Gauge | Returns the amount of space in bytes restored from the source virtual machine. |
-| kubevirt_vmsnapshot_persistentvolumeclaim_labels | Recording rule | Gauge | Returns the labels of the persistent volume claims that are used for restoring virtual machines. |
+| kubevirt_vmi_phase_count | Recording rule | Gauge | [Deprecated] Replaced by node:kubevirt_vmi_phase:sum. |
+| kubevirt_vmsnapshot_disks_restored_from_source | Recording rule | Gauge | [Deprecated] Replaced by vm:kubevirt_vmsnapshot_disks_restored:sum. |
+| kubevirt_vmsnapshot_disks_restored_from_source_bytes | Recording rule | Gauge | [Deprecated] Replaced by vm:kubevirt_vmsnapshot_restored_bytes:sum. |
+| kubevirt_vmsnapshot_persistentvolumeclaim_labels | Recording rule | Gauge | [Deprecated] Replaced by pvc:kubevirt_vmsnapshot_labels:info. |
+| namespace:kubevirt_vm:sum | Recording rule | Gauge | The number of VMs in the cluster by namespace. |
+| node:kubevirt_vmi_phase:sum | Recording rule | Gauge | Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`]. |
+| pod_container:kubevirt_vm_memory_request_margin_based_on_rss_bytes:sum | Recording rule | Gauge | Difference between requested memory and rss for VM containers (request margin). Can be negative when usage exceeds request. |
+| pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum | Recording rule | Gauge | Difference between requested memory and working set for VM containers (request margin). Can be negative when usage exceeds request. |
+| pvc:kubevirt_vmsnapshot_labels:info | Recording rule | Gauge | Returns the labels of the persistent volume claims that are used for restoring virtual machines. |
+| vm:kubevirt_vmsnapshot_disks_restored:sum | Recording rule | Gauge | Returns the total number of virtual machine disks restored from the source virtual machine. |
+| vm:kubevirt_vmsnapshot_restored_bytes:sum | Recording rule | Gauge | Returns the amount of space in bytes restored from the source virtual machine. |
+| vmi:kubevirt_vmi_guest_queue_length:sum | Recording rule | Gauge | Guest queue length. |
 | vmi:kubevirt_vmi_memory_available_bytes:sum | Recording rule | Gauge | Sum of available memory bytes per VMI (aggregated by name, namespace). |
 | vmi:kubevirt_vmi_memory_headroom_ratio:sum | Recording rule | Gauge | Usable memory to available memory ratio per VMI (aggregated by name, namespace). |
+| vmi:kubevirt_vmi_memory_used_bytes:sum | Recording rule | Gauge | Amount of `used` memory as seen by the domain. |
 | vmi:kubevirt_vmi_pgmajfaults:rate30m | Recording rule | Gauge | Rate of major page faults over 30 minutes per VMI (aggregated by name, namespace). |
 | vmi:kubevirt_vmi_pgmajfaults:rate5m | Recording rule | Gauge | Rate of major page faults over 5 minutes per VMI (aggregated by name, namespace). |
 | vmi:kubevirt_vmi_swap_traffic_bytes:rate30m | Recording rule | Gauge | Total swap I/O traffic rate over 30 minutes per VMI (swap in + swap out, aggregated by name, namespace). |

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -550,15 +550,15 @@ tests:
         # time:  0          1          2          3
         values: "1073176576 1073176576 1073176576 1273176576"
     promql_expr_test:
-      - expr: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes'
+      - expr: 'pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum'
         eval_time: 1m
         exp_samples:
-          - labels: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
+          - labels: 'pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
             value: 303706112
-      - expr: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes'
+      - expr: 'pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum'
         eval_time: 3m
         exp_samples:
-          - labels: 'kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
+          - labels: 'pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum{pod="virt-launcher-example-1", namespace="namespace-example-1",container="compute"}'
             value: 103706112
   # VM eviction strategy is set but vm is not migratable
   - interval: 1m
@@ -612,15 +612,15 @@ tests:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-foo-1", namespace="ns-a", container="compute", resource="memory"}'
         values: '1000 1000'
     promql_expr_test:
-      - expr: 'kubevirt_memory_delta_from_requested_bytes{reason="memory_working_set_delta_from_request"}'
+      - expr: 'container:kubevirt_memory_delta_from_requested_bytes:max{reason="memory_working_set_delta_from_request"}'
         eval_time: 1m
         exp_samples:
-          - labels: 'kubevirt_memory_delta_from_requested_bytes{container="compute",namespace="ns-a",pod="virt-launcher-foo-1",reason="memory_working_set_delta_from_request"}'
+          - labels: 'container:kubevirt_memory_delta_from_requested_bytes:max{container="compute",namespace="ns-a",pod="virt-launcher-foo-1",reason="memory_working_set_delta_from_request"}'
             value: 500
-      - expr: 'kubevirt_memory_delta_from_requested_bytes{reason="memory_rss_delta_from_request"}'
+      - expr: 'container:kubevirt_memory_delta_from_requested_bytes:max{reason="memory_rss_delta_from_request"}'
         eval_time: 1m
         exp_samples:
-          - labels: 'kubevirt_memory_delta_from_requested_bytes{container="compute",namespace="ns-a",pod="virt-launcher-foo-1",reason="memory_rss_delta_from_request"}'
+          - labels: 'container:kubevirt_memory_delta_from_requested_bytes:max{container="compute",namespace="ns-a",pod="virt-launcher-foo-1",reason="memory_rss_delta_from_request"}'
             value: 200
 
   # Test recording rule
@@ -641,19 +641,19 @@ tests:
         # time:  0          1          2          3
         values: "2448936960 2448936960 2448936960 2658936964"
     promql_expr_test:
-      - expr: 'kubevirt_vmi_memory_used_bytes'
+      - expr: 'vmi:kubevirt_vmi_memory_used_bytes:sum'
         eval_time: 1m
         exp_samples:
-          - labels: 'kubevirt_vmi_memory_used_bytes{container="virt-handler", name="vm-example-1", namespace="default", node="node-1"}'
+          - labels: 'vmi:kubevirt_vmi_memory_used_bytes:sum{container="virt-handler", name="vm-example-1", namespace="default", node="node-1"}'
             value: 303706112
-          - labels: 'kubevirt_vmi_memory_used_bytes{container="virt-handler", name="vm-example-2", namespace="default", node="node-1"}'
+          - labels: 'vmi:kubevirt_vmi_memory_used_bytes:sum{container="virt-handler", name="vm-example-2", namespace="default", node="node-1"}'
             value: 444329984
-      - expr: 'kubevirt_vmi_memory_used_bytes'
+      - expr: 'vmi:kubevirt_vmi_memory_used_bytes:sum'
         eval_time: 3m
         exp_samples:
-          - labels: 'kubevirt_vmi_memory_used_bytes{container="virt-handler", name="vm-example-1", namespace="default", node="node-1"}'
+          - labels: 'vmi:kubevirt_vmi_memory_used_bytes:sum{container="virt-handler", name="vm-example-1", namespace="default", node="node-1"}'
             value: 103706112
-          - labels: 'kubevirt_vmi_memory_used_bytes{container="virt-handler", name="vm-example-2", namespace="default", node="node-1"}'
+          - labels: 'vmi:kubevirt_vmi_memory_used_bytes:sum{container="virt-handler", name="vm-example-2", namespace="default", node="node-1"}'
             value: 234329980
 
   # Mass Failed virt-launcher pods should trigger critical alert after 10m

--- a/pkg/monitoring/metrics/virt-api/vm_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/vm_metrics.go
@@ -32,7 +32,7 @@ var (
 	vmsCreatedCounter = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_vm_created_by_pod_total",
-			Help: "The total number of VMs created by namespace and virt-api pod, since install.",
+			Help: "[Deprecated] The total number of VMs created by namespace and virt-api pod, since install.",
 		},
 		[]string{"namespace"},
 	)

--- a/pkg/monitoring/rules/alerts/system.go
+++ b/pkg/monitoring/rules/alerts/system.go
@@ -29,7 +29,7 @@ func systemAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "LowKVMNodesCount",
-			Expr:  intstr.FromString("(kubevirt_allocatable_nodes > 1) and (kubevirt_nodes_with_kvm < 2)"),
+			Expr:  intstr.FromString("(cluster:kubevirt_nodes_allocatable:count > 1) and (cluster:kubevirt_nodes_with_kvm:count < 2)"),
 			For:   ptr.To(promv1.Duration("5m")),
 			Annotations: map[string]string{
 				descriptionAnnotationKey: "Low number of nodes with KVM resource available.",
@@ -43,7 +43,7 @@ func systemAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "KubeVirtNoAvailableNodesToRunVMs",
 			Expr: intstr.FromString(
-				"((sum(kube_node_status_allocatable{resource='devices_kubevirt_io_kvm'}) or on() vector(0)) == 0 " +
+				"((cluster:kubevirt_nodes_with_kvm:count or on() vector(0)) == 0 " +
 					" and (sum(kubevirt_configuration_emulation_enabled) or on() vector(0)) == 0) " +
 					" or (sum(kube_node_labels{label_kubevirt_io_schedulable='true'} * on(node) group_left() (1 - kube_node_spec_unschedulable)) " +
 					" or on() vector(0)) == 0"),

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -30,7 +30,7 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtAPIDown",
-			Expr:  intstr.FromString("kubevirt_virt_api_up == 0"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_api_up:sum == 0"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "All virt-api servers are down.",
@@ -43,7 +43,7 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "LowVirtAPICount",
 			Expr: intstr.FromString(fmt.Sprintf(
-				"kubevirt_virt_api_up / on() kube_deployment_spec_replicas{deployment='virt-api', namespace='%s'} < 0.75", namespace,
+				"cluster:kubevirt_virt_api_up:sum / on() kube_deployment_spec_replicas{deployment='virt-api', namespace='%s'} < 0.75", namespace,
 			)),
 			For: ptr.To(promv1.Duration("60m")),
 			Annotations: map[string]string{
@@ -69,10 +69,11 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "KubeVirtDeprecatedAPIRequested",
 			Expr: intstr.FromString(
-				"sum by (resource,group,version) ((round(increase(kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH|DELETE\"}[10m])) > 0 and " +
-					" kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH|DELETE\"} offset 10m) or " +
-					" (kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH|DELETE\"} != 0 " +
-					" unless kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH|DELETE\"} offset 10m))",
+				"sum by (resource,group,version) (" +
+					"(round(increase(cluster:kubevirt_api_request_deprecated_total:sum{verb!~\"LIST|WATCH|DELETE\"}[10m])) > 0 and " +
+					" cluster:kubevirt_api_request_deprecated_total:sum{verb!~\"LIST|WATCH|DELETE\"} offset 10m) or " +
+					" (cluster:kubevirt_api_request_deprecated_total:sum{verb!~\"LIST|WATCH|DELETE\"} != 0 " +
+					" unless cluster:kubevirt_api_request_deprecated_total:sum{verb!~\"LIST|WATCH|DELETE\"} offset 10m))",
 			),
 			Annotations: map[string]string{
 				descriptionAnnotationKey: "Detected requests to the deprecated {{ $labels.resource }}.{{ $labels.group }}/{{ $labels.version }} API.",

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -30,7 +30,7 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "LowReadyVirtControllersCount",
-			Expr:  intstr.FromString("kubevirt_virt_controller_ready < cluster:kubevirt_virt_controller_pods_running:count"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_ready:sum < cluster:kubevirt_virt_controller_pods_running:count"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Some virt controllers are running but not ready.",
@@ -42,7 +42,7 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtController",
-			Expr:  intstr.FromString("kubevirt_virt_controller_ready == 0"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_ready:sum == 0"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-controller was detected for the last 10 min.",
@@ -67,7 +67,7 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "LowVirtControllersCount",
 			Expr: intstr.FromString(fmt.Sprintf(
-				"kubevirt_virt_controller_up / on() kube_deployment_spec_replicas{deployment='virt-controller', namespace='%s'} < 0.75",
+				"cluster:kubevirt_virt_controller_up:sum / on() kube_deployment_spec_replicas{deployment='virt-controller', namespace='%s'} < 0.75",
 				namespace,
 			)),
 			For: ptr.To(promv1.Duration("10m")),

--- a/pkg/monitoring/rules/alerts/virt-operator.go
+++ b/pkg/monitoring/rules/alerts/virt-operator.go
@@ -30,7 +30,7 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtOperatorDown",
-			Expr:  intstr.FromString("kubevirt_virt_operator_up == 0"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_up:sum == 0"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "All virt-operator servers are down.",
@@ -42,9 +42,13 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowVirtOperatorCount",
-			Expr: intstr.FromString(fmt.Sprintf(
-				"kubevirt_virt_operator_up / on() kube_deployment_spec_replicas{deployment='virt-operator', namespace='%s'} < 0.75", namespace,
-			)),
+			Expr: intstr.FromString(
+				fmt.Sprintf(
+					"cluster:kubevirt_virt_operator_up:sum / on() "+
+						"kube_deployment_spec_replicas{deployment='virt-operator', namespace='%s'} < 0.75",
+					namespace,
+				),
+			),
 			For: ptr.To(promv1.Duration("60m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Less than 75% of desired virt-operator pods are running.",
@@ -68,7 +72,7 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowReadyVirtOperatorsCount",
-			Expr:  intstr.FromString("kubevirt_virt_operator_ready < cluster:kubevirt_virt_operator_pods_running:count"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_ready:sum < cluster:kubevirt_virt_operator_pods_running:count"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Some virt-operators are running but not ready.",
@@ -80,7 +84,7 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtOperator",
-			Expr:  intstr.FromString("kubevirt_virt_operator_ready == 0"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_ready:sum == 0"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-operator was detected for the last 10 min.",
@@ -92,7 +96,7 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoLeadingVirtOperator",
-			Expr:  intstr.FromString("kubevirt_virt_operator_leading == 0"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_leading:sum == 0"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No leading virt-operator was detected for the last 10 min.",

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -107,7 +107,7 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "GuestVCPUQueueHighWarning",
-		Expr:  intstr.FromString("kubevirt_vmi_guest_vcpu_queue > 10"),
+		Expr:  intstr.FromString("vmi:kubevirt_vmi_guest_queue_length:sum > 10"),
 		Annotations: map[string]string{
 			descriptionAnnotationKey: "VirtualMachineInstance {{ $labels.name }} CPU queue length > 10",
 			summaryAnnotationKey:     "Guest vCPU Queue within collection cycle > 10",
@@ -119,7 +119,7 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "GuestVCPUQueueHighCritical",
-		Expr:  intstr.FromString("kubevirt_vmi_guest_vcpu_queue > 20"),
+		Expr:  intstr.FromString("vmi:kubevirt_vmi_guest_queue_length:sum > 20"),
 		Annotations: map[string]string{
 			descriptionAnnotationKey: "VirtualMachineInstance {{ $labels.name }} CPU queue length > 20",
 			summaryAnnotationKey:     "Guest vCPU Queue within collection cycle > 20",

--- a/pkg/monitoring/rules/recordingrules/BUILD.bazel
+++ b/pkg/monitoring/rules/recordingrules/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "api.go",
+        "deprecated_recordingrules.go",
         "nodes.go",
         "operator.go",
         "recordingrules.go",

--- a/pkg/monitoring/rules/recordingrules/api.go
+++ b/pkg/monitoring/rules/recordingrules/api.go
@@ -27,8 +27,8 @@ import (
 var apiRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_api_request_deprecated_total",
-			Help: "The total number of requests to deprecated KubeVirt APIs.",
+			Name: "cluster:kubevirt_api_request_deprecated_total:sum",
+			Help: "The total number of requests to deprecated KubeVirt APIs, by API verb (e.g., LIST, WATCH).",
 		},
 		MetricType: operatormetrics.CounterType,
 		Expr: intstr.FromString(

--- a/pkg/monitoring/rules/recordingrules/deprecated_recordingrules.go
+++ b/pkg/monitoring/rules/recordingrules/deprecated_recordingrules.go
@@ -1,0 +1,212 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package recordingrules
+
+import (
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatorrules"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// All deprecated recording rules centralized here, aliasing the new names
+var deprecatedRecordingRules = []operatorrules.RecordingRule{
+	// Nodes
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_allocatable_nodes",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_nodes_allocatable:count.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_nodes_allocatable:count"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_nodes_with_kvm",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_nodes_with_kvm:count.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_nodes_with_kvm:count"),
+	},
+	// API
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_api_request_deprecated_total",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_api_request_deprecated_total:sum.",
+		},
+		MetricType: operatormetrics.CounterType,
+		Expr:       intstr.FromString("cluster:kubevirt_api_request_deprecated_total:sum"),
+	},
+	// VM
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_number_of_vms",
+			Help: "[Deprecated] Replaced by namespace:kubevirt_vm:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("namespace:kubevirt_vm:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vm_container_memory_request_margin_based_on_rss_bytes",
+			Help: "[Deprecated] Replaced by pod_container:kubevirt_vm_memory_request_margin_based_on_rss_bytes:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("pod_container:kubevirt_vm_memory_request_margin_based_on_rss_bytes:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes",
+			Help: "[Deprecated] Replaced by pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vm_created_total",
+			Help: "[Deprecated] The total number of VMs created by namespace, since install.",
+		},
+		MetricType: operatormetrics.CounterType,
+		Expr:       intstr.FromString("sum by (namespace) (kubevirt_vm_created_by_pod_total)"),
+	},
+	// VMI
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_guest_vcpu_queue",
+			Help: "[Deprecated] Replaced by vmi:kubevirt_vmi_guest_queue_length:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("vmi:kubevirt_vmi_guest_queue_length:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_memory_used_bytes",
+			Help: "[Deprecated] Replaced by vmi:kubevirt_vmi_memory_used_bytes:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("vmi:kubevirt_vmi_memory_used_bytes:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_phase_count",
+			Help: "[Deprecated] Replaced by node:kubevirt_vmi_phase:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("node:kubevirt_vmi_phase:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_migration_data_total_bytes",
+			Help: "[Deprecated] Replaced by kubevirt_vmi_migration_data_bytes_total.",
+		},
+		MetricType: operatormetrics.CounterType,
+		Expr:       intstr.FromString("kubevirt_vmi_migration_data_bytes_total"),
+	},
+	// Virt components
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_api_up",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_virt_api_up:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_virt_api_up:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_controller_up",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_virt_controller_up:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_virt_controller_up:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_controller_ready",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_virt_controller_ready:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_virt_controller_ready:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_operator_up",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_virt_operator_up:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_virt_operator_up:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_operator_ready",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_virt_operator_ready:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_virt_operator_ready:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_operator_leading",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_virt_operator_leading:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_virt_operator_leading:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_handler_up",
+			Help: "[Deprecated] Replaced by cluster:kubevirt_virt_handler_up:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("cluster:kubevirt_virt_handler_up:sum"),
+	},
+	// VM Snapshot
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmsnapshot_persistentvolumeclaim_labels",
+			Help: "[Deprecated] Replaced by pvc:kubevirt_vmsnapshot_labels:info.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("pvc:kubevirt_vmsnapshot_labels:info"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmsnapshot_disks_restored_from_source",
+			Help: "[Deprecated] Replaced by vm:kubevirt_vmsnapshot_disks_restored:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("vm:kubevirt_vmsnapshot_disks_restored:sum"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmsnapshot_disks_restored_from_source_bytes",
+			Help: "[Deprecated] Replaced by vm:kubevirt_vmsnapshot_restored_bytes:sum.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("vm:kubevirt_vmsnapshot_restored_bytes:sum"),
+	},
+	// Operator
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_memory_delta_from_requested_bytes",
+			Help: "[Deprecated] Replaced by container:kubevirt_memory_delta_from_requested_bytes:max.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("container:kubevirt_memory_delta_from_requested_bytes:max"),
+	},
+}

--- a/pkg/monitoring/rules/recordingrules/nodes.go
+++ b/pkg/monitoring/rules/recordingrules/nodes.go
@@ -35,7 +35,7 @@ var nodesRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_allocatable_nodes",
+			Name: "cluster:kubevirt_nodes_allocatable:count",
 			Help: "The number of allocatable nodes in the cluster.",
 		},
 		MetricType: operatormetrics.GaugeType,
@@ -43,7 +43,7 @@ var nodesRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_nodes_with_kvm",
+			Name: "cluster:kubevirt_nodes_with_kvm:count",
 			Help: "The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available.",
 		},
 		MetricType: operatormetrics.GaugeType,

--- a/pkg/monitoring/rules/recordingrules/operator.go
+++ b/pkg/monitoring/rules/recordingrules/operator.go
@@ -27,7 +27,7 @@ import (
 var operatorRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_memory_delta_from_requested_bytes",
+			Name: "container:kubevirt_memory_delta_from_requested_bytes:max",
 			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, " +
 				"virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher).",
 			ConstLabels: map[string]string{
@@ -46,7 +46,7 @@ var operatorRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_memory_delta_from_requested_bytes",
+			Name: "container:kubevirt_memory_delta_from_requested_bytes:max",
 			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, " +
 				"virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher).",
 			ConstLabels: map[string]string{

--- a/pkg/monitoring/rules/recordingrules/recordingrules.go
+++ b/pkg/monitoring/rules/recordingrules/recordingrules.go
@@ -29,5 +29,6 @@ func Register(registry *operatorrules.Registry, namespace string) error {
 		vmRecordingRules,
 		vmiRecordingRules,
 		vmsnapshotRecordingRules,
+		deprecatedRecordingRules,
 	)
 }

--- a/pkg/monitoring/rules/recordingrules/virt.go
+++ b/pkg/monitoring/rules/recordingrules/virt.go
@@ -30,7 +30,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 	return []operatorrules.RecordingRule{
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "kubevirt_virt_api_up",
+				Name: "cluster:kubevirt_virt_api_up:sum",
 				Help: "The number of virt-api pods that are up.",
 			},
 			MetricType: operatormetrics.GaugeType,
@@ -50,7 +50,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 		},
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "kubevirt_virt_controller_up",
+				Name: "cluster:kubevirt_virt_controller_up:sum",
 				Help: "The number of virt-controller pods that are up.",
 			},
 			MetricType: operatormetrics.GaugeType,
@@ -60,7 +60,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 		},
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "kubevirt_virt_controller_ready",
+				Name: "cluster:kubevirt_virt_controller_ready:sum",
 				Help: "The number of virt-controller pods that are ready.",
 			},
 			MetricType: operatormetrics.GaugeType,
@@ -71,7 +71,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 		},
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "kubevirt_virt_operator_up",
+				Name: "cluster:kubevirt_virt_operator_up:sum",
 				Help: "The number of virt-operator pods that are up.",
 			},
 			MetricType: operatormetrics.GaugeType,
@@ -91,7 +91,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 		},
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "kubevirt_virt_operator_ready",
+				Name: "cluster:kubevirt_virt_operator_ready:sum",
 				Help: "The number of virt-operator pods that are ready.",
 			},
 			MetricType: operatormetrics.GaugeType,
@@ -102,7 +102,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 		},
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "kubevirt_virt_operator_leading",
+				Name: "cluster:kubevirt_virt_operator_leading:sum",
 				Help: "The number of virt-operator pods that are leading.",
 			},
 			MetricType: operatormetrics.GaugeType,
@@ -112,7 +112,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 		},
 		{
 			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "kubevirt_virt_handler_up",
+				Name: "cluster:kubevirt_virt_handler_up:sum",
 				Help: "The number of virt-handler pods that are up.",
 			},
 			MetricType: operatormetrics.GaugeType,

--- a/pkg/monitoring/rules/recordingrules/vm.go
+++ b/pkg/monitoring/rules/recordingrules/vm.go
@@ -27,7 +27,7 @@ import (
 var vmRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_container_memory_request_margin_based_on_working_set_bytes",
+			Name: "pod_container:kubevirt_vm_memory_request_margin_based_on_working_set_bytes:sum",
 			Help: "Difference between requested memory and working set for VM containers (request margin). " +
 				"Can be negative when usage exceeds request.",
 		},
@@ -40,7 +40,7 @@ var vmRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_container_memory_request_margin_based_on_rss_bytes",
+			Name: "pod_container:kubevirt_vm_memory_request_margin_based_on_rss_bytes:sum",
 			Help: "Difference between requested memory and rss for VM containers (request margin). " +
 				"Can be negative when usage exceeds request.",
 		},
@@ -53,25 +53,11 @@ var vmRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_number_of_vms",
+			Name: "namespace:kubevirt_vm:sum",
 			Help: "The number of VMs in the cluster by namespace.",
 		},
 		MetricType: operatormetrics.GaugeType,
 		Expr: intstr.FromString(
-			"sum by (namespace) " +
-				"(count by (name,namespace) " +
-				"(kubevirt_vm_error_status_last_transition_timestamp_seconds + " +
-				"kubevirt_vm_migrating_status_last_transition_timestamp_seconds + " +
-				"kubevirt_vm_non_running_status_last_transition_timestamp_seconds + " +
-				"kubevirt_vm_running_status_last_transition_timestamp_seconds + " +
-				"kubevirt_vm_starting_status_last_transition_timestamp_seconds))"),
-	},
-	{
-		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_created_total",
-			Help: "The total number of VMs created by namespace, since install.",
-		},
-		MetricType: operatormetrics.CounterType,
-		Expr:       intstr.FromString("sum by (namespace) (kubevirt_vm_created_by_pod_total)"),
+			"sum by (namespace) (count by (name, namespace) (kubevirt_vm_info))"),
 	},
 }

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -27,7 +27,7 @@ import (
 var vmiRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_phase_count",
+			Name: "node:kubevirt_vmi_phase:sum",
 			Help: "Sum of VMIs per phase and node. `phase` can be one of the following: " +
 				"[`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`].",
 		},
@@ -41,7 +41,7 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_memory_used_bytes",
+			Name: "vmi:kubevirt_vmi_memory_used_bytes:sum",
 			Help: "Amount of `used` memory as seen by the domain.",
 		},
 		MetricType: operatormetrics.GaugeType,
@@ -57,11 +57,11 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_guest_vcpu_queue",
+			Name: "vmi:kubevirt_vmi_guest_queue_length:sum",
 			Help: "Guest queue length.",
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString("clamp_min(kubevirt_vmi_guest_load_1m - vmi:kubevirt_vmi_vcpu:count, 0)"),
+		Expr:       intstr.FromString("sum by (name, namespace) (clamp_min(kubevirt_vmi_guest_load_1m - vmi:kubevirt_vmi_vcpu:count, 0))"),
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
@@ -118,13 +118,5 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 			"sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes[30m])) + " +
 				" sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes[30m]))",
 		),
-	},
-	{
-		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_migration_data_total_bytes",
-			Help: "[Deprecated] Replaced by kubevirt_vmi_migration_data_bytes_total.",
-		},
-		MetricType: operatormetrics.CounterType,
-		Expr:       intstr.FromString("kubevirt_vmi_migration_data_bytes_total"),
 	},
 }

--- a/pkg/monitoring/rules/recordingrules/vmsnapshot.go
+++ b/pkg/monitoring/rules/recordingrules/vmsnapshot.go
@@ -27,7 +27,7 @@ import (
 var vmsnapshotRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vmsnapshot_persistentvolumeclaim_labels",
+			Name: "pvc:kubevirt_vmsnapshot_labels:info",
 			Help: "Returns the labels of the persistent volume claims that are used for restoring virtual machines.",
 		},
 		MetricType: operatormetrics.GaugeType,
@@ -41,20 +41,20 @@ var vmsnapshotRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vmsnapshot_disks_restored_from_source",
+			Name: "vm:kubevirt_vmsnapshot_disks_restored:sum",
 			Help: "Returns the total number of virtual machine disks restored from the source virtual machine.",
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString("sum by(vm_name, vm_namespace) (kubevirt_vmsnapshot_persistentvolumeclaim_labels)"),
+		Expr:       intstr.FromString("sum by(vm_name, vm_namespace) (pvc:kubevirt_vmsnapshot_labels:info)"),
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "kubevirt_vmsnapshot_disks_restored_from_source_bytes",
+			Name: "vm:kubevirt_vmsnapshot_restored_bytes:sum",
 			Help: "Returns the amount of space in bytes restored from the source virtual machine.",
 		},
 		MetricType: operatormetrics.GaugeType,
 		Expr: intstr.FromString(
 			"sum by(vm_name, vm_namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes * " +
-				"on(persistentvolumeclaim, namespace) group_left(vm_name, vm_namespace) kubevirt_vmsnapshot_persistentvolumeclaim_labels)"),
+				"on(persistentvolumeclaim, namespace) group_left(vm_name, vm_namespace) pvc:kubevirt_vmsnapshot_labels:info)"),
 	},
 }

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -119,7 +119,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 	Context("Up metrics", func() {
 		It("VirtOperatorDown should be triggered when virt-operator is down", func() {
 			By("Waiting for the operator to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_operator_up", 0)
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_up:sum", 0)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtOperator.downAlert)
@@ -127,7 +127,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 
 		It("NoReadyVirtOperator should be triggered when virt-operator is down", func() {
 			By("Waiting for the operator to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_operator_ready", 0)
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_ready:sum", 0)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtOperator.noReadyAlert)
@@ -138,7 +138,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			scales.UpdateScale(virtController.deploymentName, int32(0))
 
 			By("Waiting for the controller to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_controller_up", 0)
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_controller_up:sum", 0)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtController.downAlert)
@@ -149,7 +149,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			scales.UpdateScale(virtController.deploymentName, int32(0))
 
 			By("Waiting for the controller to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_controller_ready", 0)
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_controller_ready:sum", 0)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtController.noReadyAlert)
@@ -160,7 +160,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			scales.UpdateScale(virtApi.deploymentName, int32(0))
 
 			By("Waiting for the api to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_api_up", 0)
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_api_up:sum", 0)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtApi.downAlert)
@@ -348,14 +348,14 @@ func restoreOperator(virtClient kubecli.KubevirtClient, scales *libmonitoring.Sc
 		scales.UpdateScale(virtOperator.deploymentName, int32(replica))
 
 		By("Waiting for the operator to be up")
-		libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_operator_up", float64(replica))
+		libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_up:sum", float64(replica))
 
 		By("Waiting for the operator to be ready")
-		libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_operator_ready", float64(replica))
+		libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_ready:sum", float64(replica))
 	}
 
 	By("Waiting for an operator to be leading")
-	libmonitoring.WaitForMetricValue(virtClient, "kubevirt_virt_operator_leading", 1.0)
+	libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_leading:sum", 1.0)
 }
 
 func increaseRateLimit(virtClient kubecli.KubevirtClient) {

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -289,7 +289,7 @@ func setupSharedVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
 	vm := createRunningVM(virtClient, vmi, v1.RunStrategyAlways, true)
 
 	By("Waiting for the VM to be reported")
-	libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_number_of_vms", 1, map[string]string{"namespace": vm.Namespace}, 1)
+	libmonitoring.WaitForMetricValueWithLabels(virtClient, "namespace:kubevirt_vm:sum", 1, map[string]string{"namespace": vm.Namespace}, 1)
 
 	By("Waiting for the VMI to be reported")
 	labels := map[string]string{

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -177,8 +177,8 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 		}
 
 		It("[test_id:8639]Number of disks restored and total restored bytes metric values should be correct", func() {
-			totalMetric := fmt.Sprintf("kubevirt_vmsnapshot_disks_restored_from_source{vm_name='simple-vm',vm_namespace='%s'}", testsuite.NamespaceTestDefault)
-			bytesMetric := fmt.Sprintf("kubevirt_vmsnapshot_disks_restored_from_source_bytes{vm_name='simple-vm',vm_namespace='%s'}", testsuite.NamespaceTestDefault)
+			totalMetric := fmt.Sprintf("vm:kubevirt_vmsnapshot_disks_restored:sum{vm_name='simple-vm',vm_namespace='%s'}", testsuite.NamespaceTestDefault)
+			bytesMetric := fmt.Sprintf("vm:kubevirt_vmsnapshot_restored_bytes:sum{vm_name='simple-vm',vm_namespace='%s'}", testsuite.NamespaceTestDefault)
 			numPVCs := 2.0
 
 			for i := 1.0; i < numPVCs+1; i++ {
@@ -317,7 +317,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 	})
 
 	Context("Cluster VM metrics", func() {
-		It("kubevirt_number_of_vms should reflect the number of VMs", func() {
+		It("namespace:kubevirt_vm:sum should reflect the number of VMs", func() {
 			for i := 0; i < 5; i++ {
 				vmi := libvmifact.NewGuestless()
 				vm := libvmi.NewVirtualMachine(vmi)
@@ -325,7 +325,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_number_of_vms", 5, map[string]string{"namespace": testsuite.GetTestNamespace(nil)}, 1)
+			libmonitoring.WaitForMetricValueWithLabels(virtClient, "namespace:kubevirt_vm:sum", 5, map[string]string{"namespace": testsuite.GetTestNamespace(nil)}, 1)
 		})
 	})
 

--- a/tools/perfscale-audit/metric-client/metric-client.go
+++ b/tools/perfscale-audit/metric-client/metric-client.go
@@ -49,7 +49,7 @@ const (
 //
 //	at all times.
 const (
-	vmiPhaseCount                 = `sum by (phase) (kubevirt_vmi_phase_count{})`
+	vmiPhaseSum                   = `sum by (phase) (node:kubevirt_vmi_phase:sum{})`
 	avgVirtAPICPUUsage            = `avg(rate(container_cpu_usage_seconds_total{namespace="kubevirt",pod=~"virt-api.*", container!="",container!="POD"}[%ds]))`
 	avgVirtAPIMemUsageInMB        = `avg(avg_over_time(container_memory_rss{pod=~"virt-api.*", container!="POD", container!=""}[%ds]))/1024/1024`
 	avgMinVirtAPIMemUsageInMB     = `avg(min_over_time(container_memory_rss{pod=~"virt-api.*", container!="POD", container!=""}[%ds]))/1024/1024`
@@ -60,12 +60,12 @@ const (
 	maxVirtControllerMemUsageInMB = `max(max_over_time(container_memory_rss{pod=~"virt-controller.*", container!="POD", container!=""}[%ds]))/1024/1024`
 	avgVirtControllerCPUUsage     = `max(rate(container_cpu_usage_seconds_total{namespace="kubevirt",pod=~"virt-controller.*", container!="",container!="POD"}[%ds]))`
 	// avg_over_time gives the average memory utilization of the virt-handler pod per node over time, the outside max, min, avg gives the pods with highest, lowest and average avg_over_time values respectively
-	avgVirtHandlerMemUsageInMB = `avg(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
-	maxVirtHandlerMemUsageInMB = `max(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
-	minVirtHandlerMemUsageInMB = `min(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
-	avgVirtHandlerCPUUsage     = `avg((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))`
-	maxVirtHandlerCPUUsage     = `max((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))`
-	minVirtHandlerCPUUsage     = `min((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))`
+	avgVirtHandlerMemUsageInMB = `avg(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (node:kubevirt_vmi_phase:sum{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
+	maxVirtHandlerMemUsageInMB = `max(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (node:kubevirt_vmi_phase:sum{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
+	minVirtHandlerMemUsageInMB = `min(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (node:kubevirt_vmi_phase:sum{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
+	avgVirtHandlerCPUUsage     = `avg((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (node:kubevirt_vmi_phase:sum{node != "", node != "<no value>"})))`
+	maxVirtHandlerCPUUsage     = `max((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (node:kubevirt_vmi_phase:sum{node != "", node != "<no value>"})))`
+	minVirtHandlerCPUUsage     = `min((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (node:kubevirt_vmi_phase:sum{node != "", node != "<no value>"})))`
 	// Monitors how quickly the items are added to the workqueue
 	virtControllerWorkqueueAddRate = `sum(rate(kubevirt_workqueue_adds_total{container="virt-controller"}[%ds]))`
 	// Track to identify any backlogs or delays in the workqueue
@@ -305,7 +305,7 @@ func (m *MetricClient) getTimePercentilesFromQuery(r *audit_api.Result, rangeVec
 }
 
 func (m *MetricClient) getPhaseBreakdown(r *audit_api.Result) error {
-	query := vmiPhaseCount
+	query := vmiPhaseSum
 
 	val, err := m.query(query)
 	if err != nil {


### PR DESCRIPTION
cherry-pick for https://github.com/kubevirt/kubevirt/pull/17065

### What this PR does
add recording rules with new naming that follow the names linter and best practices, and deprecate old names.

#### Before this PR:
linter failed on wrong recording rules names (so we ignored the names from the linter) .

#### After this PR:
linter pass on new recording rules names (old names still ignored from the linter) .
 
jira-ticket: https://issues.redhat.com/browse/CNV-71475

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
multiple recording rules are deprecated in favor of new names, in order to comply with the recording rules naming conventions. kubevirt_vm_created_total recording rule and kubevirt_vm_created_by_pod_total metric are deprecated completely
```