### PR TITLE
migration controller: cleanup old virt-launcher pods along with migration objects

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -2249,8 +2249,7 @@ func (c vmimCollection) Swap(i, j int) {
 }
 
 func (c *Controller) garbageCollectFinalizedMigrations(vmi *virtv1.VirtualMachineInstance) error {
-
-	var finalizedMigrations []string
+	var finalizedMigrations []*virtv1.VirtualMachineInstanceMigration
 
 	migrations, err := c.listMigrationsMatchingVMI(vmi.Namespace, vmi.Name)
 	if err != nil {
@@ -2261,7 +2260,7 @@ func (c *Controller) garbageCollectFinalizedMigrations(vmi *virtv1.VirtualMachin
 	sort.Sort(vmimCollection(migrations))
 	for _, migration := range migrations {
 		if migration.IsFinal() && migration.DeletionTimestamp == nil {
-			finalizedMigrations = append(finalizedMigrations, migration.Name)
+			finalizedMigrations = append(finalizedMigrations, migration)
 		}
 	}
 
@@ -2273,13 +2272,39 @@ func (c *Controller) garbageCollectFinalizedMigrations(vmi *virtv1.VirtualMachin
 	}
 
 	for i := range garbageCollectionCount {
-		err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), finalizedMigrations[i], v1.DeleteOptions{})
+		mig := finalizedMigrations[i]
+		oldPodName := ""
+		if mig.Status.MigrationState != nil {
+			// If the migration is a failed one, also garbage-collect its defunct target pod
+			// If the migration is a successful one, also garbage-collect its defunct source pod
+			// If the migration neither failed nor succeeded, be safe and do nothing
+			if mig.Status.MigrationState.Failed {
+				oldPodName = mig.Status.MigrationState.TargetPod
+			} else if mig.Status.MigrationState.Completed {
+				oldPodName = mig.Status.MigrationState.SourcePod
+			}
+		}
+
+		if oldPodName != "" {
+			err = c.clientset.CoreV1().Pods(vmi.Namespace).Delete(context.Background(), oldPodName, metav1.DeleteOptions{})
+			if err != nil && k8serrors.IsNotFound(err) {
+				// This is safe to ignore. It's possible in some
+				// scenarios that the pod we're trying to garbage
+				// collect has already disappeared. Let's log it
+				// and suppress the error in this situation.
+				log.Log.Reason(err).Infof("error encountered when garbage collecting pod object %s/%s", vmi.Namespace, oldPodName)
+			} else if err != nil {
+				return err
+			}
+		}
+
+		err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), mig.Name, v1.DeleteOptions{})
 		if err != nil && k8serrors.IsNotFound(err) {
 			// This is safe to ignore. It's possible in some
 			// scenarios that the migration we're trying to garbage
-			// collect has already disappeared. Let's log it as debug
+			// collect has already disappeared. Let's log it
 			// and suppress the error in this situation.
-			log.Log.Reason(err).Infof("error encountered when garbage collecting migration object %s/%s", vmi.Namespace, finalizedMigrations[i])
+			log.Log.Reason(err).Infof("error encountered when garbage collecting migration object %s/%s", vmi.Namespace, mig.Name)
 		} else if err != nil {
 			return err
 		}

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -1372,6 +1372,18 @@ var _ = Describe("Migration watcher", func() {
 	})
 
 	Context("Migration garbage collection", func() {
+		createPod := func(name, ns string) {
+			pod := k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec:   k8sv1.PodSpec{},
+				Status: k8sv1.PodStatus{},
+			}
+			_, err := kubeClient.CoreV1().Pods(ns).Create(context.Background(), &pod, metav1.CreateOptions{})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		}
 		DescribeTable("should garbage old finalized migration objects", func(phase v1.VirtualMachineInstanceMigrationPhase) {
 			vmi := newVirtualMachine("testvmi", v1.Running)
 
@@ -1456,25 +1468,55 @@ var _ = Describe("Migration watcher", func() {
 			Entry("in running phase", v1.MigrationRunning),
 		)
 		It("should garbage collect oldest finalized migrations when exceeding buffer", func() {
-			// Setup: Create a VMI and 8 finalized migrations (buffer=5, expect 3 oldest deleted)
 			vmi := newVirtualMachine("testvmi", v1.Running)
 			addVirtualMachineInstance(vmi)
 
 			baseTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 
+			// Only the 3 oldest migrations (finalized-mig-0/1/2) exceed the garbage collection buffer (5) and are
+			// expected to be deleted below, along with their pods. Each of those 3 migrations gets its own
+			// source/target pods and a distinct MigrationState so that we can assert that pod cleanup depends on
+			// how the migration ended:
+			//  - finalized-mig-0 succeeded, so only its source pod (the old virt-launcher) is stale and gets
+			//    deleted, the target pod remains as the VMI's current virt-launcher.
+			//  - finalized-mig-1 failed, so only its target pod (the failed virt-launcher) is stale and gets
+			//    deleted, the source pod remains as the VMI's current virt-launcher.
+			//  - finalized-mig-2 never completed nor failed (its MigrationState is inconclusive), so neither pod
+			//    is touched to be safe.
+			// This doesn't perfectly reflect a real cluster, where the source/target pods of consecutive
+			// migrations would actually be shared (e.g. the target of migration N is the source of migration
+			// N+1), but it lets us verify each cleanup path independently.
+			By("Creating 8 finalized migrations, only the 3 oldest of which have associated pods")
 			for i := range 8 {
 				migName := fmt.Sprintf("finalized-mig-%d", i)
 				mig := newMigration(migName, vmi.Name, v1.MigrationSucceeded)
 				mig.CreationTimestamp = metav1.Time{Time: baseTime.Add(time.Duration(i) * time.Minute)}
+				if i < 3 {
+					createPod(fmt.Sprintf("source-mig-%d", i), vmi.Namespace)
+					createPod(fmt.Sprintf("target-mig-%d", i), vmi.Namespace)
+					mig.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+						SourcePod: fmt.Sprintf("source-mig-%d", i),
+						TargetPod: fmt.Sprintf("target-mig-%d", i),
+					}
+					switch i {
+					case 0:
+						mig.Status.MigrationState.Completed = true
+						mig.Status.MigrationState.Failed = false
+					case 1:
+						mig.Status.MigrationState.Failed = true
+					default:
+						// migration 2 is left with neither Completed nor Failed set
+					}
+				}
 				Expect(controller.migrationIndexer.Add(mig)).To(Succeed())
 				_, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(vmi.Namespace).Create(context.Background(), mig, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			// Call the function
+			By("Running garbage collection")
 			Expect(controller.garbageCollectFinalizedMigrations(vmi)).To(Succeed())
 
-			// Verify remaining migrations (newest 5)
+			By("Expecting only the newest 5 migrations to remain")
 			migrationList, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(vmi.Namespace).List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(migrationList.Items).To(WithTransform(func(migrations []v1.VirtualMachineInstanceMigration) []string {
@@ -1484,15 +1526,26 @@ var _ = Describe("Migration watcher", func() {
 				}
 				return migrationNames // No sort needed
 			}, ConsistOf("finalized-mig-3", "finalized-mig-4", "finalized-mig-5", "finalized-mig-6", "finalized-mig-7")))
+
+			By("Expecting the target pod of the succeeded migration, the source pod of the failed migration, and both pods of the inconclusive migration to remain")
+			podList, err := kubeClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(podList.Items).To(WithTransform(func(pods []k8sv1.Pod) []string {
+				var podNames []string
+				for _, pod := range pods {
+					podNames = append(podNames, pod.Name)
+				}
+				return podNames // No sort needed
+			}, ConsistOf("target-mig-0", "source-mig-1", "source-mig-2", "target-mig-2")))
 		})
 
 		It("should handle errors during garbage collection deletions", func() {
-			// Setup: Similar to above, but only 6 finalized (expect 1 deletion, but fail it)
 			vmi := newVirtualMachine("testvmi", v1.Running)
 			addVirtualMachineInstance(vmi)
 
 			baseTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 
+			By("Creating 6 finalized migrations, 1 above the garbage collection buffer")
 			for i := range 6 {
 				migName := fmt.Sprintf("finalized-mig-%d", i)
 				mig := newMigration(migName, vmi.Name, v1.MigrationSucceeded)
@@ -1502,12 +1555,12 @@ var _ = Describe("Migration watcher", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			// Mock deletion to fail
+			By("Making the migration deletion fail")
 			virtClientset.PrependReactor("delete", "virtualmachineinstancemigrations", func(action testing.Action) (handled bool, ret k8sruntime.Object, err error) {
 				return true, nil, fmt.Errorf("simulated deletion error")
 			})
 
-			// Call the function: Expect error propagation
+			By("Expecting the error to propagate")
 			err := controller.garbageCollectFinalizedMigrations(vmi)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("simulated deletion error"))


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Old migration objects get cleaned up but not their associated virt-launcher pods

#### After this PR:
Pods also get cleaned up

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher pods get cleaned up along with migration objects
```
