### PR TITLE
Skip cpumanager node selector for VMIs with DRA resource claims

### DIFF
--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -16,6 +16,7 @@ type NodeSelectorRenderer struct {
 	cpuModelLabel          string
 	machineTypeLabel       string
 	hasDedicatedCPU        bool
+	hasDRAResourceClaims   bool
 	hyperv                 bool
 	podNodeSelectors       map[string]string
 	tscFrequency           *int64
@@ -52,7 +53,7 @@ func NewNodeSelectorRenderer(
 }
 
 func (nsr *NodeSelectorRenderer) Render() map[string]string {
-	if nsr.hasDedicatedCPU {
+	if nsr.hasDedicatedCPU && !nsr.hasDRAResourceClaims {
 		nsr.enableSelectorLabel(v1.CPUManager)
 	}
 	if nsr.hyperv {
@@ -140,6 +141,12 @@ func WithTDXSelector() NodeSelectorRendererOption {
 func WithDedicatedCPU() NodeSelectorRendererOption {
 	return func(renderer *NodeSelectorRenderer) {
 		renderer.hasDedicatedCPU = true
+	}
+}
+
+func WithDRAResourceClaims() NodeSelectorRendererOption {
+	return func(renderer *NodeSelectorRenderer) {
+		renderer.hasDRAResourceClaims = true
 	}
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -712,6 +712,9 @@ func (t *TemplateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 	if vmi.IsCPUDedicated() {
 		opts = append(opts, WithDedicatedCPU())
 	}
+	if len(vmi.Spec.ResourceClaims) > 0 {
+		opts = append(opts, WithDRAResourceClaims())
+	}
 	if t.clusterConfig.HypervStrictCheckEnabled() {
 		opts = append(opts, WithHyperv(vmi.Spec.Domain.Features))
 	}


### PR DESCRIPTION
## Summary

Skip the `kubevirt.io/cpumanager=true` node selector requirement when the VMI has DRA resource claims with `dedicatedCpuPlacement: true`.

## Problem

When using DRA-based CPU pinning (via [dra-driver-cpu](https://github.com/kubernetes-sigs/dra-driver-cpu)) with `cpuManagerPolicy: none` (the default), VMs with `dedicatedCpuPlacement: true` are permanently unschedulable:

1. virt-handler reads `cpu_manager_state`, finds `policyName: none`, labels the node `kubevirt.io/cpumanager=false`
2. virt-controller adds node selector `kubevirt.io/cpumanager: "true"` because `dedicatedCpuPlacement: true`
3. No node matches -- pod stays Pending forever

With DRA CPU pinning, the dra-driver-cpu handles CPU allocation and pinning via NRI, independent of the kubelet CPU manager. The cpumanager label is not relevant.

## Fix

When `dedicatedCpuPlacement` is true AND the VMI has DRA resource claims (`len(vmi.Spec.ResourceClaims) > 0`), skip adding the cpumanager node selector. Non-DRA VMs with `dedicatedCpuPlacement` continue to require the label as before.

## Design note: cpuManagerPolicy interaction

Kubelet CPU manager and DRA CPU pinning are mutually exclusive, selected by `cpuManagerPolicy`:

- `cpuManagerPolicy: static` -- kubelet CPU manager handles pinning. DRA CPU driver is not deployed. The cpumanager label gate works as before.
- `cpuManagerPolicy: none` (default) -- DRA CPU driver handles pinning via NRI. Kubelet CPU manager is inactive. The cpumanager label is irrelevant and this PR skips it.

The two systems do not run simultaneously. The deployment decides which path to use based on `cpuManagerPolicy` and whether the DRA CPU driver is deployed.

The condition `len(vmi.Spec.ResourceClaims) > 0` triggers for any DRA claim (GPU, NIC, CPU), not just CPU claims. This is intentional for this POC: if a VM uses DRA claims with `dedicatedCpuPlacement`, it is expected to be on a node with `cpuManagerPolicy: none` and DRA CPU pinning. VEP-152 will provide the proper upstream solution with a `CPUsWithDRA` feature gate.

**What this PR does / why we need it:**

/kind bug
/sig compute

**Which issue(s) this PR fixes:**

Related: https://github.com/kubevirt/kubevirt/issues/17694

## Test plan

- [ ] Deploy KubeVirt with `cpuManagerPolicy: none` and dra-driver-cpu
- [ ] Create a VM with `dedicatedCpuPlacement: true` and a DRA CPU resource claim
- [ ] Verify VM schedules and runs (without fix: permanently Pending)
- [ ] Verify non-DRA VM with `dedicatedCpuPlacement: true` still requires cpumanager label

```release-note
Skip kubevirt.io/cpumanager node selector for VMs with DRA resource claims, allowing DRA-based CPU pinning with cpuManagerPolicy: none.
```