### PR TITLE
Fix reserved overhead memlock not required

### DIFF
--- a/pkg/hypervisor/kvm/hypervisorbackend_test.go
+++ b/pkg/hypervisor/kvm/hypervisorbackend_test.go
@@ -308,7 +308,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 	})
 
 	When("reservedOverhead value is provided", func() {
-		DescribeTable("should be considered as a resource overhead", func(overhead *resource.Quantity) {
+		DescribeTable("should include addedOverhead in the overhead", func(overhead *resource.Quantity) {
 			cpuArch := "amd64"
 			vmi.Spec.Domain.Memory = &v1.Memory{}
 			vmi.Spec.Domain.Memory.ReservedOverhead = &v1.ReservedOverhead{
@@ -327,6 +327,50 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			Entry("with some value", resource.NewScaledQuantity(100, resource.Giga)),
 			Entry("with zero value", &resource.Quantity{}),
 		)
+	})
+
+	When("reservedOverhead with addedOverhead is set", func() {
+		It("should include addedOverhead regardless of memLock setting", func() {
+			cpuArch := "amd64"
+			addedOverhead := resource.MustParse("1Gi")
+			vmi.Spec.Domain.Memory = &v1.Memory{}
+			vmi.Spec.Domain.Memory.ReservedOverhead = &v1.ReservedOverhead{
+				AddedOverhead: &addedOverhead,
+				MemLock:       pointer.P(v1.MemLockRequirement(v1.MemLockNotRequired)),
+			}
+
+			overhead := kvm.NewKvmHypervisorBackend().GetMemoryOverhead(vmi, cpuArch, nil)
+
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(addedOverhead)
+
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+
+		It("should include addedOverhead with memLock Required", func() {
+			cpuArch := "amd64"
+			addedOverhead := resource.MustParse("1Gi")
+			vmi.Spec.Domain.Memory = &v1.Memory{}
+			vmi.Spec.Domain.Memory.ReservedOverhead = &v1.ReservedOverhead{
+				AddedOverhead: &addedOverhead,
+				MemLock:       pointer.P(v1.MemLockRequirement(v1.MemLockRequired)),
+			}
+
+			overhead := kvm.NewKvmHypervisorBackend().GetMemoryOverhead(vmi, cpuArch, nil)
+
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(addedOverhead)
+
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
 	})
 
 	Context("Template with guest-to-request memory headroom", func() {

--- a/pkg/hypervisor/kvm/runtime.go
+++ b/pkg/hypervisor/kvm/runtime.go
@@ -94,6 +94,13 @@ func (k *KvmVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config 
 
 	memlockSize := k.CalculateMemlockSize(vmi, config)
 
+	// addedOverhead is included in GetMemoryOverhead for pod memory sizing,
+	// but should be excluded from the memlock rlimit when memLock is "NotRequired".
+	// See https://github.com/kubevirt/enhancements/issues/144
+	if util.RequiresMemoryOverheadReservation(vmi) && !util.RequiresLockingMemory(vmi) {
+		memlockSize.Sub(*vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead)
+	}
+
 	if err := common.SetProcessMemoryLockRLimit(targetProcessID, memlockSize.Value()); err != nil {
 		return fmt.Errorf("failed to set process %d memlock rlimit to %d: %v", targetProcessID, memlockSize.Value(), err)
 	}

--- a/pkg/hypervisor/mshv/runtime.go
+++ b/pkg/hypervisor/mshv/runtime.go
@@ -97,6 +97,14 @@ func (m *MshvVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config
 		// and we are sure that all VMIs include the MemoryOverhead status field
 		memlockSize = m.GetMemoryOverhead(vmi, runtime.GOARCH, config.AdditionalGuestMemoryOverheadRatio)
 	}
+
+	// addedOverhead is included in GetMemoryOverhead for pod memory sizing,
+	// but should be excluded from the memlock rlimit when memLock is "NotRequired".
+	// See https://github.com/kubevirt/enhancements/issues/144
+	if util.RequiresMemoryOverheadReservation(vmi) && !util.RequiresLockingMemory(vmi) {
+		memlockSize.Sub(*vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead)
+	}
+
 	// Add memory assigned to the VM
 	vmiBaseMemory := getVMIBaseMemory(vmi)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
When a VM with VFIO devices (e.g., SR-IOV) has `spec.domain.memory.reservedOverhead.addedOverhead` set with `memLock: "NotRequired"`, the `addedOverhead` is incorrectly included in the memlock rlimit calculation. This causes `virtqemud` to have a higher memory lock limit than intended (X + addedOverhead instead of just X).

#### After this PR:
When `memLock: "NotRequired"` is set, `addedOverhead` is subtracted from the memlock size in `AdjustResources()`. The pod memory request still includes `addedOverhead` (for scheduling headroom), but the memlock rlimit correctly excludes it, respecting the user's intent.

### References
- Fixes #17619

### Why we need it and why it was done in this way

`GetMemoryOverhead()` unconditionally adds `addedOverhead` to the total overhead when `RequiresMemoryOverheadReservation()` is true. This overhead value is used both for pod memory requests (where `addedOverhead` should always be included) and for the memlock rlimit (where it should only be included if `memLock: "Required"`).

The following tradeoffs were made:
Rather than modifying `GetMemoryOverhead()` (which would change its interface and affect pod sizing), the fix subtracts `addedOverhead` from the memlock size in the caller (`AdjustResources()`) when `memLock` is not `Required`. This keeps the pod memory request correct while fixing only the memlock path.

The following alternatives were considered:
- **Modifying `GetMemoryOverhead()` to accept a flag or split into two functions**: Rejected because `GetMemoryOverhead()` is widely used and changing its interface would have a larger blast radius.
- **Adding an admission policy to disallow `memLock: "NotRequired"` with VFIO**: Rejected because this is a valid use case — users may want extra pod headroom without locking that memory.


### Special notes for your reviewer
The same fix is applied to both `pkg/hypervisor/kvm/runtime.go` and `pkg/hypervisor/mshv/runtime.go` for parity. Two unit tests are added in `hypervisorbackend_test.go` to verify that `addedOverhead` is excluded from the memlock calculation when `memLock: "NotRequired"` and included when `memLock: "Required"`.

### Checklist
- [x] Code changes are covered by unit tests
- [x] Commit message has DCO sign-off
<!-- optional -->



This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

