### PR TITLE
[release-1.6] Gate PCI topology on machine type, not just architecture

### DIFF
--- a/pkg/defaults/BUILD.bazel
+++ b/pkg/defaults/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         ":go_default_library",
         "//pkg/libdv:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -425,15 +425,20 @@ func setDefaultArchitectureFromDataSource(clusterConfig *virtconfig.ClusterConfi
 	}
 }
 
-// SupportsPCIeHotplug reports whether the architecture uses PCIe bus
-// topology and requires pcie-root-port controllers for hotplug capacity.
-// Architectures like s390x (CCW) and ppc64le (SPAPR) use flat bus
-// topologies and do not support pcie-root-port controllers.
-func SupportsPCIeHotplug(arch string) bool {
-	switch arch {
+// SupportsPCIeHotplug reports whether the VMI spec uses PCIe bus topology
+// and requires pcie-root-port controllers for hotplug capacity.
+// Returns false for architectures that use flat bus topologies (s390x, ppc64le)
+// and for non-PCIe machine types (i440fx).
+func SupportsPCIeHotplug(spec *v1.VirtualMachineInstanceSpec) bool {
+	switch spec.Architecture {
 	case "amd64", "arm64", "":
-		return true
 	default:
 		return false
 	}
+	if spec.Domain.Machine != nil &&
+		!strings.Contains(spec.Domain.Machine.Type, "q35") &&
+		!strings.HasPrefix(spec.Domain.Machine.Type, "virt") {
+		return false
+	}
+	return true
 }

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -18,6 +18,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/defaults"
 	"kubevirt.io/kubevirt/pkg/libdv"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
@@ -191,5 +192,29 @@ var _ = Describe("Defaults", func() {
 				}, runtime.GOARCH),
 			)
 		})
+	})
+
+	Context("SupportsPCIeHotplug", func() {
+		DescribeTable("should report PCIe hotplug support based on architecture and machine type",
+			func(arch string, machineType *string, expected bool) {
+				spec := &v1.VirtualMachineInstanceSpec{
+					Architecture: arch,
+				}
+				if machineType != nil {
+					spec.Domain.Machine = &v1.Machine{Type: *machineType}
+				}
+				Expect(defaults.SupportsPCIeHotplug(spec)).To(Equal(expected))
+			},
+			Entry("amd64 with q35", "amd64", pointer.P("pc-q35-3.0"), true),
+			Entry("amd64 with no machine type", "amd64", nil, true),
+			Entry("amd64 with i440fx", "amd64", pointer.P("pc-i440fx-2.12"), false),
+			Entry("arm64 with virt", "arm64", pointer.P("virt"), true),
+			Entry("arm64 with versioned virt", "arm64", pointer.P("virt-6.2"), true),
+			Entry("arm64 with no machine type", "arm64", nil, true),
+			Entry("empty arch with q35", "", pointer.P("pc-q35-3.0"), true),
+			Entry("empty arch with no machine type", "", nil, true),
+			Entry("s390x", "s390x", nil, false),
+			Entry("ppc64le", "ppc64le", nil, false),
+		)
 	})
 })

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -99,7 +99,7 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	defaults.SetVirtualMachineDefaults(vm, mutator.ClusterConfig, preferenceSpec, mutator.virtClient)
 
 	if ar.Request.Operation == admissionv1.Create {
-		if defaults.SupportsPCIeHotplug(vm.Spec.Template.Spec.Architecture) {
+		if defaults.SupportsPCIeHotplug(&vm.Spec.Template.Spec) {
 			setDefaultPciTopologyVersion(&vm.Spec.Template.ObjectMeta)
 		}
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -201,6 +201,18 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		Entry("ppc64le skipped", "ppc64le", false),
 	)
 
+	It("should skip PCI topology version for i440fx machine type", func() {
+		vm.Spec.Template.Spec.Domain.Machine = &v1.Machine{Type: "pc-i440fx-2.12"}
+		vmSpec, _ := getVMSpecMetaFromResponseCreateWithArch("amd64")
+		Expect(vmSpec.Template.ObjectMeta.Annotations).NotTo(HaveKey(v1.PciTopologyVersionAnnotation))
+	})
+
+	It("should set PCI topology version for PCIe-capable machine type on amd64", func() {
+		vm.Spec.Template.Spec.Domain.Machine = &v1.Machine{Type: "q35"}
+		vmSpec, _ := getVMSpecMetaFromResponseCreateWithArch("amd64")
+		Expect(vmSpec.Template.ObjectMeta.Annotations).To(HaveKey(v1.PciTopologyVersionAnnotation))
+	})
+
 	It("should not override existing PCI topology version annotation on VM template", func() {
 		vm.Spec.Template.ObjectMeta.Annotations = map[string]string{
 			v1.PciTopologyVersionAnnotation: v1.PciTopologyVersionV2,

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -85,7 +85,7 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 			return webhookutils.ToAdmissionResponseError(err)
 		}
 
-		if defaults.SupportsPCIeHotplug(newVMI.Spec.Architecture) {
+		if defaults.SupportsPCIeHotplug(&newVMI.Spec) {
 			setDefaultPciTopologyVersion(&newVMI.ObjectMeta)
 		}
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -638,6 +638,12 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Entry("ppc64le skipped", "ppc64le", false),
 	)
 
+	It("should skip PCI topology version for i440fx machine type", func() {
+		vmi.Spec.Domain.Machine = &v1.Machine{Type: "pc-i440fx-2.12"}
+		vmiMeta, _, _ := getMetaSpecStatusFromAdmitWithArch("amd64")
+		Expect(vmiMeta.Annotations).NotTo(HaveKey(v1.PciTopologyVersionAnnotation))
+	})
+
 	It("should not override existing PCI topology version annotation", func() {
 		vmi.Annotations = map[string]string{
 			v1.PciTopologyVersionAnnotation: v1.PciTopologyVersionV2,

--- a/pkg/virt-handler/pci_topology.go
+++ b/pkg/virt-handler/pci_topology.go
@@ -46,7 +46,7 @@ func (c *VirtualMachineController) detectPCITopologyAndAnnotate(vmi *v1.VirtualM
 		return nil
 	}
 
-	if !defaults.SupportsPCIeHotplug(vmi.Spec.Architecture) {
+	if !defaults.SupportsPCIeHotplug(&vmi.Spec) {
 		return nil
 	}
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1413,8 +1413,8 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 ) (cli.VirDomain, error) {
 	logger := log.Log.Object(vmi)
 
-	if !defaults.SupportsPCIeHotplug(vmi.Spec.Architecture) {
-		logger.Infof("Skipping hotplug port allocation: architecture %s does not use PCIe topology", vmi.Spec.Architecture)
+	if !defaults.SupportsPCIeHotplug(&vmi.Spec) {
+		logger.Infof("Skipping hotplug port allocation: architecture or machine type does not support PCIe topology")
 		return l.setDomainSpecWithHooks(vmi, domainSpec)
 	}
 


### PR DESCRIPTION
SupportsPCIeHotplug now checks the machine type in addition to architecture. Non-PCIe machine types like i440fx do not support pcie-root-port controllers and must be excluded from PCI topology annotation and hotplug port allocation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

SupportsPCIeHotplug only checked architecture, so i440fx VMs on amd64 were incorrectly getting PCI topology annotations and hotplug port allocation

#### Before this PR:

Any amd64 or arm64 VM gets the kubevirt.io/pci-topology-version annotation and pcie-root-port controller allocation, regardless of machine type. i440fx VMs don't support pcie-root-port controllers, so this could cause domain definition failures

#### After this PR:

SupportsPCIeHotplug checks both architecture and machine type. Only q35 and arm64 virt machine types get PCI topology annotations and hotplug port allocation. i440fx VMs are skipped


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Gate PCI topology on machine type, not just architecture
```

