### PR TITLE
linter: Ban ginkgo Skip() in new test code via forbidigo

### DIFF
--- a/hack/linter/.golangci.yml
+++ b/hack/linter/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - dupl
     - errcheck
     - exhaustive
+    - forbidigo
     - funlen
     - gochecknoinits
     - goconst
@@ -32,6 +33,16 @@ linters:
   settings:
     dupl:
       threshold: 100
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: ^Skip$
+          pkg: ^github\.com/onsi/ginkgo/v2$
+          msg: >-
+            Use labels/decorators instead of runtime Skip().
+            Runtime skips silently suppress tests, making it easy to
+            unknowingly stop running tests you care about.
+            Labeling shifts the choice of what to run to the test executor.
     funlen:
       lines: 100
       statements: 50

--- a/pkg/network/driver/nmstate/integration_test.go
+++ b/pkg/network/driver/nmstate/integration_test.go
@@ -43,7 +43,7 @@ func init() {
 var _ = Describe("NMState", integrationLabel, func() {
 	BeforeEach(func() {
 		if !runIntegrationTests {
-			Skip("integration tests are not set to run")
+			Skip("integration tests are not set to run") //nolint:forbidigo
 		}
 	})
 

--- a/pkg/virt-api/rest/streamer_test.go
+++ b/pkg/virt-api/rest/streamer_test.go
@@ -465,7 +465,7 @@ var _ = Describe("Streamer", func() {
 		// This test is mutually exclusive with the `-race` flag, as there is no other way to check
 		// if a write-only channel is closed than to write to it and catch the panic.
 		if raceDetectorEnabled {
-			Skip("Data Race Detector is enabled")
+			Skip("Data Race Detector is enabled") //nolint:forbidigo
 		}
 
 		var results chan<- streamFuncResult

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -59,7 +59,7 @@ var _ = Describe("PCI Device", func() {
 		By("making sure the environment has a PCI device at " + fakeAddress)
 		_, err := os.Stat("/sys/bus/pci/devices/" + fakeAddress)
 		if errors.Is(err, os.ErrNotExist) {
-			Skip("No PCI device found at " + fakeAddress + ", can't run PCI tests")
+			Skip("No PCI device found at " + fakeAddress + ", can't run PCI tests") //nolint:forbidigo
 		}
 
 		By("mocking PCI functions to simulate a vfio-pci device at " + fakeAddress)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1492,7 +1492,7 @@ var _ = Describe("Manager", func() {
 
 		It("should return a VirtualMachineInstance launch measurement", func() {
 			if runtime.GOARCH == "s390x" {
-				Skip("Test is specific to amd64 architecture")
+				Skip("Test is specific to amd64 architecture") //nolint:forbidigo
 			}
 
 			domainLaunchSecurityParameters := &libvirt.DomainLaunchSecurityParameters{

--- a/tests/libnet/skips.go
+++ b/tests/libnet/skips.go
@@ -12,7 +12,7 @@ func SkipWhenClusterNotSupportIpv4() {
 	clusterSupportsIpv4, err := cluster.SupportsIpv4()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv4")
 	if !clusterSupportsIpv4 {
-		Skip("This test requires an ipv4 network config.")
+		Skip("This test requires an ipv4 network config.") //nolint:forbidigo
 	}
 }
 
@@ -20,7 +20,7 @@ func SkipWhenClusterNotSupportIpv6() {
 	clusterSupportsIpv6, err := cluster.SupportsIpv6()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv6")
 	if !clusterSupportsIpv6 {
-		Skip("This test requires an ipv6 network config.")
+		Skip("This test requires an ipv6 network config.") //nolint:forbidigo
 	}
 }
 

--- a/tests/libstorage/storageclass.go
+++ b/tests/libstorage/storageclass.go
@@ -345,7 +345,7 @@ func CheckNoProvisionerStorageClassPVs(storageClassName string, numExpectedPVs i
 	Expect(err).ToNot(HaveOccurred())
 
 	if countLocalStoragePVAvailableForUse(pvList, storageClassName) < numExpectedPVs {
-		Skip("Not enough available filesystem local storage PVs available, expected: %d", numExpectedPVs)
+		Skip("Not enough available filesystem local storage PVs available, expected: %d", numExpectedPVs) //nolint:forbidigo
 	}
 }
 

--- a/tests/migration/host_model.go
+++ b/tests/migration/host_model.go
@@ -52,7 +52,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 		It("[test_id:6981]should migrate only to nodes supporting right cpu model", func() {
 			sourceNode, targetNode, err := libmigration.GetValidSourceNodeAndTargetNodeForHostModelMigration(kubevirt.Client())
 			if err != nil {
-				Skip(err.Error())
+				Skip(err.Error()) //nolint:forbidigo
 			}
 
 			By("Creating a VMI with default CPU mode to land in source node")
@@ -166,7 +166,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			BeforeEach(func() {
 				nodes = libnode.GetAllSchedulableNodes(kubevirt.Client()).Items
 				if len(nodes) == 1 || len(nodes) > 10 {
-					Skip("This test can't run with single node and it's too slow to run with more than 10 nodes")
+					Skip("This test can't run with single node and it's too slow to run with more than 10 nodes") //nolint:forbidigo
 				}
 
 				By("Creating a VMI with default CPU mode")
@@ -235,7 +235,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			var err error
 			sourceNode, targetNode, err = libmigration.GetValidSourceNodeAndTargetNodeForHostModelMigration(kubevirt.Client())
 			if err != nil {
-				Skip(err.Error())
+				Skip(err.Error()) //nolint:forbidigo
 			}
 			targetNode = libinfra.ExpectStoppingNodeLabellerToSucceed(targetNode.Name, kubevirt.Client())
 		})

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -847,7 +847,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
 				sc, foundSC := libstorage.GetRWOFileSystemStorageClass()
 				if !foundSC {
-					Skip("Skip test when Filesystem storage is not present")
+					Skip("Skip test when Filesystem storage is not present") //nolint:forbidigo
 				}
 
 				dataVolume := libdv.NewDataVolume(
@@ -1376,7 +1376,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					cfg := getCurrentKvConfig(virtClient)
 					tlsEnabled := cfg.MigrationConfiguration.DisableTLS == nil || *cfg.MigrationConfiguration.DisableTLS == false
 					if !tlsEnabled {
-						Skip("test requires secure migrations to be enabled")
+						Skip("test requires secure migrations to be enabled") //nolint:forbidigo
 					}
 				})
 
@@ -1788,7 +1788,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			It("[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi", func() {
 				sc, exists := libstorage.GetRWOBlockStorageClass()
 				if !exists {
-					Skip("Skip test when Block storage is not present")
+					Skip("Skip test when Block storage is not present") //nolint:forbidigo
 				}
 
 				// Start the VirtualMachineInstance with the PVC attached
@@ -1824,7 +1824,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteMany)
 				if !foundSC {
-					Skip("Skip test when Block storage is not present")
+					Skip("Skip test when Block storage is not present") //nolint:forbidigo
 				}
 
 				dv := libdv.NewDataVolume(
@@ -2292,7 +2292,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			}
 
 			if count < 2 {
-				Skip(fmt.Sprintf("Not enough nodes with hugepages %s capacity. Need 2, found %d.", hugepageType, count))
+				Skip(fmt.Sprintf("Not enough nodes with hugepages %s capacity. Need 2, found %d.", hugepageType, count)) //nolint:forbidigo
 			}
 
 			hugepagesVmi := libvmifact.NewAlpine(

--- a/tests/network/dual_stack_cluster.go
+++ b/tests/network/dual_stack_cluster.go
@@ -13,7 +13,7 @@ var _ = Describe(SIG("Dual stack cluster network configuration", func() {
 	Context("when dual stack cluster configuration is enabled", func() {
 		Specify("the cluster must be dual stack", func() {
 			if flags.SkipDualStackTests {
-				Skip("user requested the dual stack check on the live cluster to be skipped")
+				Skip("user requested the dual stack check on the live cluster to be skipped") //nolint:forbidigo
 			}
 
 			isClusterDualStack, err := cluster.DualStack()

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -70,7 +70,7 @@ var _ = Describe(SIG("Port-forward", func() {
 			libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 			if ipFamily == k8sv1.IPv6Protocol {
-				Skip(skipIPv6Message)
+				Skip(skipIPv6Message) //nolint:forbidigo
 			}
 
 			vmi := createAlpineVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1421,7 +1421,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 		BeforeEach(func() {
 			if !prometheusRuleEnabled() {
-				Skip("Test applies on when PrometheusRule is defined")
+				Skip("Test applies on when PrometheusRule is defined") //nolint:forbidigo
 			}
 		})
 
@@ -1440,7 +1440,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 
 		BeforeEach(func() {
 			if !serviceMonitorEnabled() {
-				Skip("Test requires ServiceMonitor to be valid")
+				Skip("Test requires ServiceMonitor to be valid") //nolint:forbidigo
 			}
 		})
 

--- a/tests/performance/density-kwok.go
+++ b/tests/performance/density-kwok.go
@@ -57,7 +57,7 @@ var _ = Describe(KWOK("Control Plane Performance Density Testing using kwok", fu
 
 	BeforeEach(func() {
 		if !flags.DeployFakeKWOKNodesFlag {
-			Skip("Skipping test as KWOK flag is not enabled")
+			Skip("Skipping test as KWOK flag is not enabled") //nolint:forbidigo
 		}
 
 		virtClient = kubevirt.Client()

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -65,12 +65,12 @@ func SIG(text string, args ...interface{}) (extendedText string, newArgs []inter
 
 func skipIfNoPerformanceTests() {
 	if !RunPerfTests {
-		Skip("Performance tests are not enabled.")
+		Skip("Performance tests are not enabled.") //nolint:forbidigo
 	}
 }
 
 func skipIfNoRealtimePerformanceTests() {
 	if !RunPerfRealtime {
-		Skip("Realtime performance tests are not enabled")
+		Skip("Realtime performance tests are not enabled") //nolint:forbidigo
 	}
 }

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -533,7 +533,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 					realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
 				}
 				if realRegistryPort == "" {
-					Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
+					Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry") //nolint:forbidigo
 				}
 
 				fakeRegistryName := "fakeregistry"

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -840,7 +840,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				exists := false
 				sc, exists = libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Fail no filesystem storage class available")
+					Skip("Fail no filesystem storage class available") //nolint:forbidigo
 				}
 
 				vmi := libvmifact.NewCirros()
@@ -866,7 +866,7 @@ var _ = Describe(SIG("Hotplug", func() {
 
 			It("should count only vmis with hotplug ephemeral volumes, ignoring persistent volumes and unplugs", Serial, func() {
 				if !isPrometheusDeployed() {
-					Skip("Prometheus not deployed")
+					Skip("Prometheus not deployed") //nolint:forbidigo
 				}
 				kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
 				kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
@@ -912,7 +912,7 @@ var _ = Describe(SIG("Hotplug", func() {
 
 			It("should ignore delcarative hotplugs", Serial, func() {
 				if !isPrometheusDeployed() {
-					Skip("Prometheus not deployed")
+					Skip("Prometheus not deployed") //nolint:forbidigo
 				}
 				kvconfig.EnableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
 				kvconfig.DisableFeatureGate(featuregate.HotplugVolumesGate)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1261,7 +1261,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 			It("[test_id:9705]Should show included and excluded volumes in the snapshot", func() {
 				noSnapshotSC := libstorage.GetNoVolumeSnapshotStorageClass("local")
 				if noSnapshotSC == "" {
-					Skip("Skipping test, no storage class without snapshot support")
+					Skip("Skipping test, no storage class without snapshot support") //nolint:forbidigo
 				}
 				By("Creating DV with snapshot supported storage class")
 				includedDataVolume := libdv.NewDataVolume(

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -509,7 +509,7 @@ var _ = Describe(SIG("Storage", func() {
 
 			BeforeEach(func() {
 				if !checks.HasFeature(featuregate.HostDiskGate) {
-					Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
+					Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests") //nolint:forbidigo
 				}
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Enable the forbidigo linter in golangci-lint to prevent new runtime
Skip() calls in Ginkgo tests. Existing call sites are grandfathered
with //nolint:forbidigo inline comments.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

