### PR TITLE
[release-1.2] Use defined deployment number of replicas as base to fire low count alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -922,3 +922,133 @@ tests:
       - eval_time: 3m
         alertname: KubeVirtDeprecatedAPIRequested
         exp_alerts: []
+
+
+  # LowVirtAPICount - should fire when less than 75% of desired virt-api pods are running
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="ci", pod="virt-api-1"}'
+        values: '1+0x61'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-api", namespace="ci"}'
+        values: '4+0x61'
+
+    alert_rule_test:
+      # should not fire before 60m
+      - eval_time: 59m
+        alertname: LowVirtAPICount
+        exp_alerts: []
+      # should fire at 60m (1 out of 4 pods running = 25% < 75%)
+      - eval_time: 60m
+        alertname: LowVirtAPICount
+        exp_alerts:
+          - exp_annotations:
+              summary: "Less than 75% of desired virt-api pods are running."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowVirtAPICount"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # LowVirtAPICount - should not fire when 75% or more of desired virt-api pods are running
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="ci", pod="virt-api-1"}'
+        values: '1+0x61'
+      - series: 'up{namespace="ci", pod="virt-api-2"}'
+        values: '1+0x61'
+      - series: 'up{namespace="ci", pod="virt-api-3"}'
+        values: '1+0x61'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-api", namespace="ci"}'
+        values: '4+0x61'
+
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: LowVirtAPICount
+        exp_alerts: []
+
+  # LowVirtControllersCount - should fire when less than 75% of desired virt-controller pods are up
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="ci", pod="virt-controller-1"}'
+        values: '1+0x11'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-controller", namespace="ci"}'
+        values: '4+0x11'
+
+    alert_rule_test:
+      # should not fire before 10m
+      - eval_time: 9m
+        alertname: LowVirtControllersCount
+        exp_alerts: []
+      # should fire at 10m (1 out of 4 pods up = 25% < 75%)
+      - eval_time: 10m
+        alertname: LowVirtControllersCount
+        exp_alerts:
+          - exp_annotations:
+              summary: "Less than 75% of desired virt-controller pods are ready."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowVirtControllersCount"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # LowVirtControllersCount - should not fire when 75% or more of desired virt-controller pods are up
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="ci", pod="virt-controller-1"}'
+        values: '1+0x11'
+      - series: 'up{namespace="ci", pod="virt-controller-2"}'
+        values: '1+0x11'
+      - series: 'up{namespace="ci", pod="virt-controller-3"}'
+        values: '1+0x11'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-controller", namespace="ci"}'
+        values: '4+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LowVirtControllersCount
+        exp_alerts: []
+
+  # LowVirtOperatorCount - should fire when less than 75% of desired virt-operator pods are running
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="ci", pod="virt-operator-1"}'
+        values: '1+0x61'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-operator", namespace="ci"}'
+        values: '4+0x61'
+
+    alert_rule_test:
+      # should not fire before 60m
+      - eval_time: 59m
+        alertname: LowVirtOperatorCount
+        exp_alerts: []
+      # should fire at 60m (1 out of 4 pods running = 25% < 75%)
+      - eval_time: 60m
+        alertname: LowVirtOperatorCount
+        exp_alerts:
+          - exp_annotations:
+              summary: "Less than 75% of desired virt-operator pods are running."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowVirtOperatorCount"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # LowVirtOperatorCount - should not fire when 75% or more of desired virt-operator pods are running
+  - interval: 1m
+    input_series:
+      - series: 'up{namespace="ci", pod="virt-operator-1"}'
+        values: '1+0x61'
+      - series: 'up{namespace="ci", pod="virt-operator-2"}'
+        values: '1+0x61'
+      - series: 'up{namespace="ci", pod="virt-operator-3"}'
+        values: '1+0x61'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-operator", namespace="ci"}'
+        values: '4+0x61'
+
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: LowVirtOperatorCount
+        exp_alerts: []

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -17,6 +17,8 @@ limitations under the License.
 package alerts
 
 import (
+	"fmt"
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -38,10 +40,12 @@ func virtApiAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowVirtAPICount",
-			Expr:  intstr.FromString("(kubevirt_allocatable_nodes > 1) and (kubevirt_virt_api_up < 2)"),
-			For:   ptr.To(promv1.Duration("60m")),
+			Expr: intstr.FromString(fmt.Sprintf(
+				"kubevirt_virt_api_up / on() kube_deployment_spec_replicas{deployment='virt-api', namespace='%s'} < 0.75", namespace,
+			)),
+			For: ptr.To(promv1.Duration("60m")),
 			Annotations: map[string]string{
-				"summary": "More than one virt-api should be running if more than one worker nodes exist.",
+				"summary": "Less than 75% of desired virt-api pods are running.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package alerts
 
 import (
+	"fmt"
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -62,10 +64,13 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowVirtControllersCount",
-			Expr:  intstr.FromString("(kubevirt_allocatable_nodes > 1) and (kubevirt_virt_controller_ready < 2)"),
-			For:   ptr.To(promv1.Duration("10m")),
+			Expr: intstr.FromString(fmt.Sprintf(
+				"kubevirt_virt_controller_up / on() kube_deployment_spec_replicas{deployment='virt-controller', namespace='%s'} < 0.75",
+				namespace,
+			)),
+			For: ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				"summary": "More than one virt-controller should be ready if more than one worker node.",
+				"summary": "Less than 75% of desired virt-controller pods are ready.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",

--- a/pkg/monitoring/rules/alerts/virt-operator.go
+++ b/pkg/monitoring/rules/alerts/virt-operator.go
@@ -17,6 +17,8 @@ limitations under the License.
 package alerts
 
 import (
+	"fmt"
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -38,10 +40,12 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowVirtOperatorCount",
-			Expr:  intstr.FromString("(kubevirt_allocatable_nodes > 1) and (kubevirt_virt_operator_up < 2)"),
-			For:   ptr.To(promv1.Duration("60m")),
+			Expr: intstr.FromString(fmt.Sprintf(
+				"kubevirt_virt_operator_up / on() kube_deployment_spec_replicas{deployment='virt-operator', namespace='%s'} < 0.75", namespace,
+			)),
+			For: ptr.To(promv1.Duration("60m")),
 			Annotations: map[string]string{
-				"summary": "More than one virt-operator should be running if more than one worker nodes exist.",
+				"summary": "Less than 75% of desired virt-operator pods are running.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -52,7 +52,6 @@ type alerts struct {
 	downAlert            string
 	noReadyAlert         string
 	restErrorsBurtsAlert string
-	lowCountAlert        string
 }
 
 var (
@@ -60,14 +59,12 @@ var (
 		deploymentName:       "virt-api",
 		downAlert:            "VirtAPIDown",
 		restErrorsBurtsAlert: "VirtApiRESTErrorsBurst",
-		lowCountAlert:        "LowVirtAPICount",
 	}
 	virtController = alerts{
 		deploymentName:       "virt-controller",
 		downAlert:            "VirtControllerDown",
 		noReadyAlert:         "NoReadyVirtController",
 		restErrorsBurtsAlert: "VirtControllerRESTErrorsBurst",
-		lowCountAlert:        "LowVirtControllersCount",
 	}
 	virtHandler = alerts{
 		deploymentName:       "virt-handler",
@@ -78,7 +75,6 @@ var (
 		downAlert:            "VirtOperatorDown",
 		noReadyAlert:         "NoReadyVirtOperator",
 		restErrorsBurtsAlert: "VirtOperatorRESTErrorsBurst",
-		lowCountAlert:        "LowVirtOperatorCount",
 	}
 )
 
@@ -133,29 +129,15 @@ var _ = Describe("[Serial][sig-monitoring]Component Monitoring", Serial, decorat
 			verifyAlertExist(virtClient, virtOperator.noReadyAlert)
 		})
 
-		It("LowVirtOperatorCount should be triggered when virt-operator count is low", decorators.RequiresTwoSchedulableNodes, func() {
-			verifyAlertExist(virtClient, virtOperator.lowCountAlert)
-		})
-
 		It("VirtControllerDown and NoReadyVirtController should be triggered when virt-controller is down", func() {
 			scales.UpdateScale(virtController.deploymentName, int32(0))
 			verifyAlertExist(virtClient, virtController.downAlert)
 			verifyAlertExist(virtClient, virtController.noReadyAlert)
 		})
 
-		It("LowVirtControllersCount should be triggered when virt-controller count is low", decorators.RequiresTwoSchedulableNodes, func() {
-			scales.UpdateScale(virtController.deploymentName, int32(0))
-			verifyAlertExist(virtClient, virtController.lowCountAlert)
-		})
-
 		It("VirtApiDown should be triggered when virt-api is down", func() {
 			scales.UpdateScale(virtApi.deploymentName, int32(0))
 			verifyAlertExist(virtClient, virtApi.downAlert)
-		})
-
-		It("LowVirtAPICount should be triggered when virt-api count is low", decorators.RequiresTwoSchedulableNodes, func() {
-			scales.UpdateScale(virtApi.deploymentName, int32(0))
-			verifyAlertExist(virtClient, virtApi.lowCountAlert)
 		})
 	})
 

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -117,9 +117,9 @@ var _ = Describe("[Serial][sig-monitoring]Component Monitoring", Serial, decorat
 
 			time.Sleep(10 * time.Second)
 			alerts := []string{
-				virtOperator.downAlert, virtOperator.noReadyAlert, virtOperator.lowCountAlert,
-				virtController.downAlert, virtController.noReadyAlert, virtController.lowCountAlert,
-				virtApi.downAlert, virtApi.noReadyAlert, virtApi.lowCountAlert,
+				virtOperator.downAlert, virtOperator.noReadyAlert,
+				virtController.downAlert, virtController.noReadyAlert,
+				virtApi.downAlert, virtApi.noReadyAlert,
 			}
 			waitUntilAlertDoesNotExist(virtClient, alerts...)
 		})


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/16806

jira-ticket: https://redhat.atlassian.net/browse/CNV-62894

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use defined deployment number of replicas as base to fire low count alerts
```

