### PR TITLE
tests: Remove address assertions from memballoon e2e tests

### DIFF
--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1:go_default_library",

--- a/tests/compute/vmidefaults.go
+++ b/tests/compute/vmidefaults.go
@@ -32,7 +32,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -102,35 +101,21 @@ var _ = Describe(SIG("VMIDefaults", func() {
 			domain, err := libdomain.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
-			expected := api.MemBalloon{
-				Model: "virtio-non-transitional",
-				Stats: &api.Stats{
-					Period: 10,
-				},
-				Address: &api.Address{
-					Type:     api.AddressPCI,
-					Domain:   "0x0000",
-					Bus:      "0x07",
-					Slot:     "0x00",
-					Function: "0x0",
-				},
-			}
-			if testsuite.Arch == testsuite.ArchS390x {
-				expected.Model = "virtio"
-				expected.Address = &api.Address{
-					Type:  api.AddressCCW,
-					CSSID: "0xfe",
-					SSID:  "0x0",
-					DevNo: "0x0006",
-				}
-			}
-			if kvConfiguration.VirtualMachineOptions != nil && kvConfiguration.VirtualMachineOptions.DisableFreePageReporting != nil {
-				expected.FreePageReporting = "off"
-			} else {
-				expected.FreePageReporting = "on"
-			}
 			Expect(domain.Devices.Ballooning).ToNot(BeNil(), "There should be default memballoon device")
-			Expect(*domain.Devices.Ballooning).To(Equal(expected), "Default to virtio model and 10 seconds pooling")
+
+			expectedModel := "virtio-non-transitional"
+			if testsuite.Arch == testsuite.ArchS390x {
+				expectedModel = "virtio"
+			}
+			Expect(domain.Devices.Ballooning.Model).To(Equal(expectedModel))
+			Expect(domain.Devices.Ballooning.Stats).ToNot(BeNil(), "Stats should be set")
+			Expect(domain.Devices.Ballooning.Stats.Period).To(Equal(uint(10)), "Default stats period should be 10")
+
+			if kvConfiguration.VirtualMachineOptions != nil && kvConfiguration.VirtualMachineOptions.DisableFreePageReporting != nil {
+				Expect(domain.Devices.Ballooning.FreePageReporting).To(Equal("off"))
+			} else {
+				Expect(domain.Devices.Ballooning.FreePageReporting).To(Equal("on"))
+			}
 		})
 
 		DescribeTable("Should override period in domain if present in virt-config ", Serial, func(period uint32) {
@@ -138,34 +123,6 @@ var _ = Describe(SIG("VMIDefaults", func() {
 			kvConfigurationCopy := kvConfiguration.DeepCopy()
 			kvConfigurationCopy.MemBalloonStatsPeriod = &period
 			config.UpdateKubeVirtConfigValueAndWait(*kvConfigurationCopy)
-
-			expected := api.MemBalloon{
-				Model: "virtio-non-transitional",
-				Address: &api.Address{
-					Type:     api.AddressPCI,
-					Domain:   "0x0000",
-					Bus:      "0x07",
-					Slot:     "0x00",
-					Function: "0x0",
-				},
-			}
-			if testsuite.Arch == testsuite.ArchS390x {
-				expected.Model = "virtio"
-				expected.Address = &api.Address{
-					Type:  api.AddressCCW,
-					CSSID: "0xfe",
-					SSID:  "0x0",
-					DevNo: "0x0006",
-				}
-			}
-			if period > 0 {
-				expected.Stats = &api.Stats{Period: uint(period)}
-			}
-			if kvConfiguration.VirtualMachineOptions != nil && kvConfiguration.VirtualMachineOptions.DisableFreePageReporting != nil {
-				expected.FreePageReporting = "off"
-			} else {
-				expected.FreePageReporting = "on"
-			}
 
 			By("Creating a virtual machine")
 			vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
@@ -176,34 +133,32 @@ var _ = Describe(SIG("VMIDefaults", func() {
 
 			By("Getting domain of vmi")
 			domain, err := libdomain.GetRunningVMIDomainSpec(vmi)
-
 			Expect(err).ToNot(HaveOccurred())
+
 			Expect(domain.Devices.Ballooning).ToNot(BeNil(), "There should be memballoon device")
-			Expect(*domain.Devices.Ballooning).To(Equal(expected))
+
+			expectedModel := "virtio-non-transitional"
+			if testsuite.Arch == testsuite.ArchS390x {
+				expectedModel = "virtio"
+			}
+			Expect(domain.Devices.Ballooning.Model).To(Equal(expectedModel))
+
+			if period > 0 {
+				Expect(domain.Devices.Ballooning.Stats).ToNot(BeNil(), "Stats should be set when period > 0")
+				Expect(domain.Devices.Ballooning.Stats.Period).To(Equal(uint(period)))
+			} else {
+				Expect(domain.Devices.Ballooning.Stats).To(BeNil(), "Stats should not be set when period is 0")
+			}
+
+			if kvConfiguration.VirtualMachineOptions != nil && kvConfiguration.VirtualMachineOptions.DisableFreePageReporting != nil {
+				Expect(domain.Devices.Ballooning.FreePageReporting).To(Equal("off"))
+			} else {
+				Expect(domain.Devices.Ballooning.FreePageReporting).To(Equal("on"))
+			}
 		},
 			Entry("[test_id:4557]with period 12", uint32(12)),
 			Entry("[test_id:4558]with period 0", uint32(0)),
 		)
-
-		It("[test_id:4559]Should not be present in domain ", func() {
-			By("Creating a virtual machine with autoAttachmemballoon set to false")
-			vmi.Spec.Domain.Devices.AutoattachMemBalloon = pointer.P(false)
-			vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Waiting for successful start")
-			libwait.WaitForSuccessfulVMIStart(vmi)
-
-			By("Getting domain of vmi")
-			domain, err := libdomain.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			expected := api.MemBalloon{
-				Model: "none",
-			}
-			Expect(domain.Devices.Ballooning).ToNot(BeNil(), "There should be memballoon device")
-			Expect(*domain.Devices.Ballooning).To(Equal(expected))
-		})
 
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Removes the PCI/CCW address assertions from memballoon e2e tests (test_id:4556, 4557, 4558) and removes test_id:4559 entirely. The address is assigned by libvirt at domain definition time, not by KubeVirt, so asserting on it is unnecessary. test_id:4559 (autoattach=false) is fully covered by unit tests in balloon_test.go and converter_test.go.

The remaining e2e tests (4556, 4557, 4558) now assert on Model, Stats, and FreePageReporting individually, preserving coverage for the default stats period config-to-domain flow which cannot be verified by unit tests alone.

#### Before this PR:
test_id:4556, 4557, 4558 use full struct comparison including PCI/CCW address fields that are assigned by libvirt and not under KubeVirt's control. test_id:4559 duplicates autoattach=false logic already covered by unit tests.

#### After this PR:
test_id:4556, 4557, 4558 assert only on KubeVirt-controlled fields (Model, Stats, FreePageReporting). test_id:4559 is removed.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```

