### PR TITLE
fix (tests): flaky cleanup in hotplug LUN tests

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -2105,20 +2105,31 @@ var _ = Describe(SIG("Hotplug", func() {
 			pvc                       *k8sv1.PersistentVolumeClaim
 			pv                        *k8sv1.PersistentVolume
 			vm                        *v1.VirtualMachine
+			vmi                       *v1.VirtualMachineInstance
 		)
 
 		BeforeEach(func() {
+			vmi = nil
 			nodeName = libnode.GetNodeNameWithHandler()
 			address, device = CreateSCSIDisk(nodeName, []string{})
 			By(fmt.Sprintf("Create PVC with SCSI disk %s", device))
 			pv, pvc, err = CreatePVandPVCwithSCSIDisk(nodeName, device, testsuite.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")
 			Expect(err).ToNot(HaveOccurred(), "failed to create PV and PVC for SCSI disk")
+			DeferCleanup(func() {
+				Expect(virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
+				RemoveSCSIDisk(nodeName, address)
+			})
 		})
 
 		AfterEach(func() {
-			// Delete the scsi disk
-			RemoveSCSIDisk(nodeName, address)
-			Expect(virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred(), "failed to delete PersistentVolume %s", pv.Name)
+			if vmi != nil {
+				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, metav1.DeleteOptions{})
+				Expect(err).To(Or(
+					Not(HaveOccurred()),
+					MatchError(errors.IsNotFound, "errors.IsNotFound"),
+				))
+				Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, time.Second*180)).To(Succeed())
+			}
 			err := deleteVirtualMachine(vm)
 			Expect(err).ToNot(HaveOccurred(), "failed to delete VirtualMachine")
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In some test environments, hotplug LUN tests are seen failing during test cleanup when trying to remove the `scsi_debug` module because the block device is still seen in use. ```"failed executing command=[/usr/bin/virt-chroot --mount /proc/1/ns/mnt exec -- /usr/sbin/modprobe -r scsi_debug], error=command terminated with exit code 1, stdout=, stderr=modprobe: FATAL: Module scsi_debug is in use.\n",```

The test completes after it verifies the volume has been unplugged and the device is no longer accessible on the guest, it then proceeds to the cleanup step to remove the scsi module. However during this time, it is possible that the attachment pod is still in the process of being cleaned up and still has the block device bind mounted.

To avoid this potential conflict, this PR wraps this module removal logic in an Eventually retry to allow the pod enough time to be cleaned up to ensure the block device is no longer in use.

Fixes: https://redhat.atlassian.net/browse/CNV-86979


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

