### PR TITLE
Add unit testing for block volume hotplug allow list

### DIFF
--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -39,13 +39,14 @@ go_test(
     race = "on",
     deps = [
         "//pkg/safepath:go_default_library",
-        "//pkg/virt-handler/isolation:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/opencontainers/cgroups:go_default_library",
         "//vendor/github.com/opencontainers/cgroups/devices/config:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
     ],
 )

--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -146,7 +146,12 @@ func NewManagerFromVM(vmi *v1.VirtualMachineInstance, host string, hypervisorDev
 		return nil, err
 	}
 
-	vmiDeviceRules, err := generateDeviceRulesForVMI(vmi, isolationRes, host, hypervisorDevice, allowEmulation)
+	mountRoot, err := isolationRes.MountRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	vmiDeviceRules, err := generateDeviceRulesForVMI(vmi, mountRoot, host, hypervisorDevice, allowEmulation)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -20,21 +20,24 @@
 package cgroup
 
 import (
+	"io/fs"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	cgroups "github.com/opencontainers/cgroups"
 	devices "github.com/opencontainers/cgroups/devices/config"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/sys/unix"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/safepath"
-	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
 
 var _ = Describe("cgroup manager", func() {
@@ -346,53 +349,285 @@ var _ = Describe("parseDevicesList", func() {
 
 var _ = Describe("generateDeviceRulesForVMI", func() {
 	var (
-		ctrl    *gomock.Controller
-		tempDir string
+		origStatDevice func(*safepath.Path, string) (os.FileInfo, error)
+		origReadDevDir func(*safepath.Path, string) ([]os.DirEntry, error)
 	)
 
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		tempDir = GinkgoT().TempDir()
-		Expect(os.MkdirAll(filepath.Join(tempDir, "dev"), 0755)).To(Succeed())
-	})
-
-	newMockIsolationWithMountRoot := func() isolation.IsolationResult {
-		mountRoot, err := safepath.NewPathNoFollow(tempDir)
-		Expect(err).ToNot(HaveOccurred())
-
-		mockIso := isolation.NewMockIsolationResult(ctrl)
-		mockIso.EXPECT().MountRoot().Return(mountRoot, nil)
-		return mockIso
+	noDevices := func(_ *safepath.Path, _ string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	noDirs := func(_ *safepath.Path, _ string) ([]os.DirEntry, error) {
+		return nil, os.ErrNotExist
 	}
 
+	BeforeEach(func() {
+		origStatDevice = statDevice
+		origReadDevDir = readDeviceDir
+	})
+
+	AfterEach(func() {
+		statDevice = origStatDevice
+		readDeviceDir = origReadDevDir
+	})
+
 	It("should skip hypervisor device rule when emulation is allowed and device is missing", func() {
-		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "", "kvm", true)
+		statDevice = noDevices
+		readDeviceDir = noDirs
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rules).To(BeEmpty())
 	})
 
 	It("should fail when hypervisor device is missing and emulation is not allowed", func() {
-		_, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "", "kvm", false)
+		statDevice = noDevices
+		readDeviceDir = noDirs
+
+		_, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", false)
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should create a rule for the hypervisor device", func() {
+		statDevice = func(_ *safepath.Path, relPath string) (os.FileInfo, error) {
+			if relPath == "/dev/kvm" {
+				return charDeviceInfo(10, 232), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		readDeviceDir = noDirs
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(devices.CharDevice), "Major": Equal(int64(10)), "Minor": Equal(int64(232)),
+			})),
+		))
+	})
+
+	It("should discover VFIO device nodes", func() {
+		statDevice = func(_ *safepath.Path, relPath string) (os.FileInfo, error) {
+			switch relPath {
+			case "/dev/vfio/vfio":
+				return charDeviceInfo(10, 196), nil
+			case "/dev/vfio/42":
+				return charDeviceInfo(243, 0), nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		}
+		readDeviceDir = func(_ *safepath.Path, relPath string) ([]os.DirEntry, error) {
+			if relPath == "/dev/vfio" {
+				return []os.DirEntry{
+					&fakeDirEntry{name: "vfio"},
+					&fakeDirEntry{name: "42"},
+				}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(devices.CharDevice), "Major": Equal(int64(10)), "Minor": Equal(int64(196)),
+			})),
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(devices.CharDevice), "Major": Equal(int64(243)), "Minor": Equal(int64(0)),
+			})),
+		))
+	})
+
+	It("should discover USB device nodes in nested directories", func() {
+		statDevice = func(_ *safepath.Path, relPath string) (os.FileInfo, error) {
+			switch relPath {
+			case "/dev/bus/usb/001/001":
+				return charDeviceInfo(189, 0), nil
+			case "/dev/bus/usb/001/002":
+				return charDeviceInfo(189, 1), nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		}
+		readDeviceDir = func(_ *safepath.Path, relPath string) ([]os.DirEntry, error) {
+			switch relPath {
+			case "/dev/bus/usb":
+				return []os.DirEntry{&fakeDirEntry{name: "001", isDir: true}}, nil
+			case "/dev/bus/usb/001":
+				return []os.DirEntry{
+					&fakeDirEntry{name: "001"},
+					&fakeDirEntry{name: "002"},
+				}, nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		}
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(devices.CharDevice), "Major": Equal(int64(189)), "Minor": Equal(int64(0)),
+			})),
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(devices.CharDevice), "Major": Equal(int64(189)), "Minor": Equal(int64(1)),
+			})),
+		))
+	})
+
+	It("should discover devices from both VFIO and USB", func() {
+		statDevice = func(_ *safepath.Path, relPath string) (os.FileInfo, error) {
+			switch relPath {
+			case "/dev/vfio/vfio":
+				return charDeviceInfo(10, 196), nil
+			case "/dev/vfio/0":
+				return charDeviceInfo(243, 0), nil
+			case "/dev/bus/usb/001/001":
+				return charDeviceInfo(189, 0), nil
+			case "/dev/bus/usb/002/001":
+				return charDeviceInfo(189, 128), nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		}
+		readDeviceDir = func(_ *safepath.Path, relPath string) ([]os.DirEntry, error) {
+			switch relPath {
+			case "/dev/vfio":
+				return []os.DirEntry{
+					&fakeDirEntry{name: "vfio"},
+					&fakeDirEntry{name: "0"},
+				}, nil
+			case "/dev/bus/usb":
+				return []os.DirEntry{
+					&fakeDirEntry{name: "001", isDir: true},
+					&fakeDirEntry{name: "002", isDir: true},
+				}, nil
+			case "/dev/bus/usb/001":
+				return []os.DirEntry{&fakeDirEntry{name: "001"}}, nil
+			case "/dev/bus/usb/002":
+				return []os.DirEntry{&fakeDirEntry{name: "001"}}, nil
+			default:
+				return nil, os.ErrNotExist
+			}
+		}
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(HaveLen(4))
+	})
+
+	It("should create a rule for urandom when RNG is enabled", func() {
+		statDevice = func(_ *safepath.Path, relPath string) (os.FileInfo, error) {
+			if relPath == "/dev/urandom" {
+				return charDeviceInfo(1, 9), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		readDeviceDir = noDirs
+
+		vmi := &v1.VirtualMachineInstance{}
+		vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
+
+		rules, err := generateDeviceRulesForVMI(vmi, nil, "", "kvm", true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(devices.CharDevice), "Major": Equal(int64(1)), "Minor": Equal(int64(9)),
+			})),
+		))
+	})
+
+	It("should create a rule for vhost-vsock when AutoattachVSOCK is enabled", func() {
+		statDevice = func(_ *safepath.Path, relPath string) (os.FileInfo, error) {
+			if relPath == "/dev/vhost-vsock" {
+				return charDeviceInfo(10, 241), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		readDeviceDir = noDirs
+
+		autoAttach := true
+		vmi := &v1.VirtualMachineInstance{}
+		vmi.Spec.Domain.Devices.AutoattachVSOCK = &autoAttach
+
+		rules, err := generateDeviceRulesForVMI(vmi, nil, "", "kvm", true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(devices.CharDevice), "Major": Equal(int64(10)), "Minor": Equal(int64(241)),
+			})),
+		))
+	})
+
 	It("should not fail when /dev/vfio does not exist", func() {
-		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "", "kvm", true)
+		statDevice = noDevices
+		readDeviceDir = noDirs
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rules).To(BeEmpty())
 	})
 
 	It("should not fail when /dev/vfio exists but is empty", func() {
-		Expect(os.MkdirAll(filepath.Join(tempDir, "dev", "vfio"), 0755)).To(Succeed())
-		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "", "kvm", true)
+		statDevice = noDevices
+		readDeviceDir = func(_ *safepath.Path, relPath string) ([]os.DirEntry, error) {
+			if relPath == "/dev/vfio" {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rules).To(BeEmpty())
 	})
 
 	It("should not fail when /dev/bus/usb exists but is empty", func() {
-		Expect(os.MkdirAll(filepath.Join(tempDir, "dev", "bus", "usb"), 0755)).To(Succeed())
-		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "", "kvm", true)
+		statDevice = noDevices
+		readDeviceDir = func(_ *safepath.Path, relPath string) ([]os.DirEntry, error) {
+			if relPath == "/dev/bus/usb" {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, nil, "", "kvm", true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rules).To(BeEmpty())
 	})
 })
+
+func charDeviceInfo(major, minor uint32) os.FileInfo {
+	return &fakeFileInfo{
+		mode: os.ModeDevice | os.ModeCharDevice,
+		rdev: unix.Mkdev(major, minor),
+	}
+}
+
+type fakeFileInfo struct {
+	name string
+	mode os.FileMode
+	rdev uint64
+}
+
+func (f *fakeFileInfo) Name() string       { return f.name }
+func (f *fakeFileInfo) Size() int64        { return 0 }
+func (f *fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f *fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f *fakeFileInfo) IsDir() bool        { return f.mode.IsDir() }
+func (f *fakeFileInfo) Sys() interface{}   { return &syscall.Stat_t{Rdev: f.rdev} }
+
+type fakeDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (e *fakeDirEntry) Name() string { return e.name }
+func (e *fakeDirEntry) IsDir() bool  { return e.isDir }
+func (e *fakeDirEntry) Type() fs.FileMode {
+	if e.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (e *fakeDirEntry) Info() (fs.FileInfo, error) { return nil, nil }

--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -44,7 +44,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/safepath"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
-	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
 
 type CgroupVersion string
@@ -62,6 +61,25 @@ const (
 
 var (
 	defaultDeviceRules []*devices.Rule
+	statDevice         = func(mountRoot *safepath.Path, relPath string) (os.FileInfo, error) {
+		path, err := safepath.JoinNoFollow(mountRoot, relPath)
+		if err != nil {
+			return nil, err
+		}
+		return safepath.StatAtNoFollow(path)
+	}
+	readDeviceDir = func(mountRoot *safepath.Path, relPath string) ([]os.DirEntry, error) {
+		dirPath, err := safepath.JoinNoFollow(mountRoot, relPath)
+		if err != nil {
+			return nil, err
+		}
+		var entries []os.DirEntry
+		err = dirPath.ExecuteNoFollow(func(path string) (err error) {
+			entries, err = os.ReadDir(path)
+			return err
+		})
+		return entries, err
+	}
 )
 
 type execVirtChrootFunc func(r *cgroups.Resources, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error
@@ -140,11 +158,7 @@ func getDeviceRwmPermissions() devices.Permissions {
 // This builds up the known persistent block devices allow list for a VMI (as in, hotplugged volumes are handled separately)
 // This will be maintained and extended as new devices likely have to end up on this list as well
 // For example - https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
-func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, isolationRes isolation.IsolationResult, host, hypervisorDevice string, allowEmulation bool) ([]*devices.Rule, error) {
-	mountRoot, err := isolationRes.MountRoot()
-	if err != nil {
-		return nil, err
-	}
+func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, mountRoot *safepath.Path, host, hypervisorDevice string, allowEmulation bool) ([]*devices.Rule, error) {
 	migSrcBlockVols := getSourceBlockToFsMigratedVolumes(vmi, host)
 	var vmiDeviceRules []*devices.Rule
 	for _, volume := range vmi.Spec.Volumes {
@@ -163,64 +177,54 @@ func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, isolationRes isol
 		default:
 			continue
 		}
-		path, err := safepath.JoinNoFollow(mountRoot, filepath.Join("dev", volume.Name))
+		rule, err := newAllowedDeviceRule(mountRoot, filepath.Join("/dev", volume.Name), getDeviceRwmPermissions())
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to resolve path for volume %s: %v", volume.Name, err)
 		}
-		if deviceRule, err := newAllowedDeviceRule(path, getDeviceRwmPermissions()); err != nil {
-			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
-		} else if deviceRule != nil {
-			log.Log.V(loggingVerbosity).Infof("device rule for volume %s: %v", volume.Name, deviceRule)
-			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
+		if rule != nil {
+			log.Log.V(loggingVerbosity).Infof("device rule for volume %s: %v", volume.Name, rule)
+			vmiDeviceRules = append(vmiDeviceRules, rule)
 		}
 	}
 	if vmi.Spec.Domain.Devices.Rng != nil {
-		path, err := safepath.JoinNoFollow(mountRoot, "/dev/urandom")
+		rule, err := newAllowedDeviceRule(mountRoot, "/dev/urandom", getDeviceRwmPermissions())
 		if err != nil {
 			return nil, err
 		}
-		if deviceRule, err := newAllowedDeviceRule(path, getDeviceRwmPermissions()); err != nil {
-			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
-		} else if deviceRule != nil {
-			log.Log.V(loggingVerbosity).Infof("device rule for volume rng: %v", deviceRule)
-			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
+		if rule != nil {
+			log.Log.V(loggingVerbosity).Infof("device rule for volume rng: %v", rule)
+			vmiDeviceRules = append(vmiDeviceRules, rule)
 		}
 	}
 	if util.IsAutoAttachVSOCK(vmi) {
-		path, err := safepath.JoinNoFollow(mountRoot, "/dev/vhost-vsock")
+		rule, err := newAllowedDeviceRule(mountRoot, "/dev/vhost-vsock", getDeviceRwmPermissions())
 		if err != nil {
 			return nil, err
 		}
-		if deviceRule, err := newAllowedDeviceRule(path, getDeviceRwmPermissions()); err != nil {
-			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
-		} else if deviceRule != nil {
-			log.Log.V(loggingVerbosity).Infof("device rule for volume vsock: %v", deviceRule)
-			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
+		if rule != nil {
+			log.Log.V(loggingVerbosity).Infof("device rule for volume vsock: %v", rule)
+			vmiDeviceRules = append(vmiDeviceRules, rule)
 		}
 	}
 
-	path, err := safepath.JoinNoFollow(mountRoot, fmt.Sprintf("/dev/%s", hypervisorDevice))
+	rule, err := newAllowedDeviceRule(mountRoot, fmt.Sprintf("/dev/%s", hypervisorDevice), getDevicePermissionsFromCgroups())
 	if err != nil {
 		if !allowEmulation {
 			return nil, err
 		}
-	} else {
-		if deviceRule, err := newAllowedDeviceRule(path, getDevicePermissionsFromCgroups()); err != nil {
-			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
-		} else if deviceRule != nil {
-			log.Log.V(loggingVerbosity).Infof("device rule for device %s: %v", hypervisorDevice, deviceRule)
-			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
-		}
+	} else if rule != nil {
+		log.Log.V(loggingVerbosity).Infof("device rule for device %s: %v", hypervisorDevice, rule)
+		vmiDeviceRules = append(vmiDeviceRules, rule)
 	}
 
 	// Device-plugin-provisioned devices (VFIO, USB) must be in the cgroup
 	// rule cache so they survive eBPF program rebuilds during hotplug.
 	for _, devDir := range []string{
-		filepath.Join("dev", "vfio"),
-		filepath.Join("dev", "bus", "usb"),
+		filepath.Join("/dev", "vfio"),
+		filepath.Join("/dev", "bus", "usb"),
 	} {
 		rules, err := discoverDeviceRulesInDir(mountRoot, devDir)
 		if err != nil {
@@ -239,7 +243,7 @@ func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, isolationRes isol
 // they are not lost when the eBPF device filter is rebuilt by subsequent
 // Set() calls (e.g. during hotplug volume mounting).
 func discoverDeviceRulesInDir(mountRoot *safepath.Path, relPath string) ([]*devices.Rule, error) {
-	dirPath, err := safepath.JoinNoFollow(mountRoot, relPath)
+	entries, err := readDeviceDir(mountRoot, relPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
@@ -247,43 +251,31 @@ func discoverDeviceRulesInDir(mountRoot *safepath.Path, relPath string) ([]*devi
 		return nil, err
 	}
 
-	var entries []os.DirEntry
-	err = dirPath.ExecuteNoFollow(func(path string) (err error) {
-		entries, err = os.ReadDir(path)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	var rules []*devices.Rule
 	for _, entry := range entries {
+		entryPath := filepath.Join(relPath, entry.Name())
 		if entry.IsDir() {
-			subRules, err := discoverDeviceRulesInDir(mountRoot, filepath.Join(relPath, entry.Name()))
+			subRules, err := discoverDeviceRulesInDir(mountRoot, entryPath)
 			if err != nil {
 				return nil, err
 			}
 			rules = append(rules, subRules...)
 			continue
 		}
-		devPath, err := safepath.JoinNoFollow(dirPath, entry.Name())
+		rule, err := newAllowedDeviceRule(mountRoot, entryPath, getDeviceRwmPermissions())
 		if err != nil {
-			return nil, err
-		}
-		rule, err := newAllowedDeviceRule(devPath, getDeviceRwmPermissions())
-		if err != nil {
-			return nil, fmt.Errorf("failed to create device rule for %s/%s: %v", relPath, entry.Name(), err)
+			return nil, fmt.Errorf("failed to create device rule for %s: %v", entryPath, err)
 		}
 		if rule != nil {
-			log.Log.V(loggingVerbosity).Infof("device rule for %s/%s: %v", relPath, entry.Name(), rule)
+			log.Log.V(loggingVerbosity).Infof("device rule for %s: %v", entryPath, rule)
 			rules = append(rules, rule)
 		}
 	}
 	return rules, nil
 }
 
-func newAllowedDeviceRule(devicePath *safepath.Path, devicePermissions devices.Permissions) (*devices.Rule, error) {
-	fileInfo, err := safepath.StatAtNoFollow(devicePath)
+func newAllowedDeviceRule(mountRoot *safepath.Path, relPath string, devicePermissions devices.Permissions) (*devices.Rule, error) {
+	fileInfo, err := statDevice(mountRoot, relPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Make necessary adaptations so unit tests are real,
avoiding any direct os calls, which allows us to add
unit tests covering VFIO, USB, hypervisor device, RNG, and VSOCK
rule discovery.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

