### PR TITLE
[release-1.6] Fix VM with PCI hostdev failing to restart after hotplug block volume

### DIFF
--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -39,6 +39,9 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/safepath:go_default_library",
+        "//pkg/virt-handler/isolation:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -1,12 +1,20 @@
 package cgroup
 
 import (
+	"os"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	runc_cgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	runc_configs "github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"go.uber.org/mock/gomock"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/safepath"
+	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
 
 var _ = Describe("cgroup manager", func() {
@@ -175,4 +183,46 @@ var _ = Describe("cgroup manager", func() {
 			},
 		),
 	)
+})
+
+var _ = Describe("generateDeviceRulesForVMI", func() {
+	var (
+		ctrl    *gomock.Controller
+		tempDir string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		tempDir = GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(tempDir, "dev"), 0755)).To(Succeed())
+	})
+
+	newMockIsolationWithMountRoot := func() isolation.IsolationResult {
+		mountRoot, err := safepath.NewPathNoFollow(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		mockIso := isolation.NewMockIsolationResult(ctrl)
+		mockIso.EXPECT().MountRoot().Return(mountRoot, nil)
+		return mockIso
+	}
+
+	It("should not fail when /dev/vfio does not exist", func() {
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(BeEmpty())
+	})
+
+	It("should not fail when /dev/vfio exists but is empty", func() {
+		Expect(os.MkdirAll(filepath.Join(tempDir, "dev", "vfio"), 0755)).To(Succeed())
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(BeEmpty())
+	})
+
+	It("should not fail when /dev/bus/usb exists but is empty", func() {
+		Expect(os.MkdirAll(filepath.Join(tempDir, "dev", "bus", "usb"), 0755)).To(Succeed())
+		rules, err := generateDeviceRulesForVMI(&v1.VirtualMachineInstance{}, newMockIsolationWithMountRoot(), "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rules).To(BeEmpty())
+	})
 })

--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -172,7 +172,70 @@ func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, isolationRes isol
 		}
 	}
 
+	// Device-plugin-provisioned devices (VFIO, USB) must be in the cgroup
+	// rule cache so they survive eBPF program rebuilds during hotplug.
+	for _, devDir := range []string{
+		filepath.Join("dev", "vfio"),
+		filepath.Join("dev", "bus", "usb"),
+	} {
+		rules, err := discoverDeviceRulesInDir(mountRoot, devDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover device rules in %s: %v", devDir, err)
+		}
+		vmiDeviceRules = append(vmiDeviceRules, rules...)
+	}
+
 	return vmiDeviceRules, nil
+}
+
+// discoverDeviceRulesInDir recursively scans a directory under the
+// container's filesystem and creates allow rules for all device nodes
+// found. These devices are provisioned by device plugins or the container
+// runtime and must be preserved in the v2 cgroup manager's rule cache so
+// they are not lost when the eBPF device filter is rebuilt by subsequent
+// Set() calls (e.g. during hotplug volume mounting).
+func discoverDeviceRulesInDir(mountRoot *safepath.Path, relPath string) ([]*devices.Rule, error) {
+	dirPath, err := safepath.JoinNoFollow(mountRoot, relPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var entries []os.DirEntry
+	err = dirPath.ExecuteNoFollow(func(path string) (err error) {
+		entries, err = os.ReadDir(path)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var rules []*devices.Rule
+	for _, entry := range entries {
+		if entry.IsDir() {
+			subRules, err := discoverDeviceRulesInDir(mountRoot, filepath.Join(relPath, entry.Name()))
+			if err != nil {
+				return nil, err
+			}
+			rules = append(rules, subRules...)
+			continue
+		}
+		devPath, err := safepath.JoinNoFollow(dirPath, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		rule, err := newAllowedDeviceRule(devPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create device rule for %s/%s: %v", relPath, entry.Name(), err)
+		}
+		if rule != nil {
+			log.Log.V(loggingVerbosity).Infof("device rule for %s/%s: %v", relPath, entry.Name(), rule)
+			rules = append(rules, rule)
+		}
+	}
+	return rules, nil
 }
 
 func newAllowedDeviceRule(devicePath *safepath.Path) (*devices.Rule, error) {

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -2265,6 +2265,83 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifyVolumeNolongerAccessible(vmi, targets[0])
 		})
 	})
+
+	// Regression test for https://github.com/kubevirt/kubevirt/issues/17124
+	Context("with PCI hostdev", Serial, func() {
+		const deviceName = "example.org/soundcard"
+
+		BeforeEach(func() {
+			kvconfig.EnableFeatureGate(featuregate.HostDevicesGate)
+
+			kv := libkubevirt.GetCurrentKv(virtClient)
+			config := kv.Spec.Configuration
+			config.PermittedHostDevices = &v1.PermittedHostDevices{
+				PciHostDevices: []v1.PciHostDevice{
+					{
+						PCIVendorSelector: "8086:2668",
+						ResourceName:      deviceName,
+					},
+				},
+			}
+			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
+		})
+
+		AfterEach(func() {
+			kv := libkubevirt.GetCurrentKv(virtClient)
+			config := kv.Spec.Configuration
+			config.PermittedHostDevices = &v1.PermittedHostDevices{}
+			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
+			kvconfig.DisableFeatureGate(featuregate.HostDevicesGate)
+		})
+
+		It("should restart a VM after hotplugging a block volume", decorators.RequiresBlockStorage, func() {
+			sc, exists := libstorage.GetRWOBlockStorageClass()
+			if !exists {
+				Fail("Fail test when block storage class is not available")
+			}
+
+			vmiSpec := libvmifact.NewAlpineWithTestTooling()
+			vmiSpec.Spec.Domain.Devices.HostDevices = []v1.HostDevice{
+				{Name: "sound0", DeviceName: deviceName},
+			}
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(
+				context.Background(),
+				libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways)),
+				metav1.CreateOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			libwait.WaitForSuccessfulVMIStart(vmi, libwait.WithTimeout(240))
+
+			dvBuilder := libdv.NewDataVolume(
+				libdv.WithBlankImageSource(),
+				libdv.WithStorage(
+					libdv.StorageWithStorageClass(sc),
+					libdv.StorageWithVolumeSize(cd.BlankVolumeSize),
+					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeBlock),
+				),
+			)
+			dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(
+				context.Background(), dvBuilder, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			libstorage.EventuallyDV(dv, 240, Or(matcher.HaveSucceeded(), matcher.WaitForFirstConsumer()))
+
+			By("Hotplugging a block volume to the running VM")
+			addVolumeVMWithSource(vm.Name, vm.Namespace, getAddVolumeOptions("hotplug-vol", v1.DiskBusSCSI, &v1.HotplugVolumeSource{
+				DataVolume: &v1.DataVolumeSource{Name: dv.Name},
+			}, false, false, ""))
+			verifyVolumeStatus(vmi, v1.VolumeReady, "", "hotplug-vol")
+
+			By("Restarting the VM")
+			vm = libvmops.StopVirtualMachine(vm)
+			err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 300*time.Second, time.Second).Should(matcher.BeReady())
+		})
+	})
 }))
 
 func verifyVolumeAndDiskVMAdded(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, volumeNames ...string) {


### PR DESCRIPTION
manual backport of https://github.com/kubevirt/kubevirt/pull/17527

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix VM with PCI hostdev failing to restart after hotplug block volume
```

