### PR TITLE
[main] virt-controller: set RestartRequired when reservedOverhead.addedOverhead changes

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -126,6 +126,7 @@ const (
 	volumesUpdateErrorReason           = "VolumesUpdateError"
 	tolerationsChangeErrorReason       = "TolerationsChangeError"
 	annotationsLabelsChangeErrorReason = "AnnotationsLabelsChangeError"
+	reservedOverheadErrorReason        = "ReservedOverheadError"
 )
 
 const defaultMaxCrashLoopBackoffDelaySeconds = 300
@@ -3303,6 +3304,15 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 		}
 	}
 
+	// addedOverhead is never live-updatable (K8s pod resources are immutable); call
+	// unconditionally regardless of rollout strategy.
+	if err := c.handleReservedOverheadRequest(vmCopy, vmi); err != nil {
+		return vm, vmi, common.NewSyncError(
+			fmt.Errorf("error encountered while handling reservedOverhead request: %v", err),
+			reservedOverheadErrorReason,
+		), nil
+	}
+
 	if !equality.Semantic.DeepEqual(vm.Spec, vmCopy.Spec) || !equality.Semantic.DeepEqual(vm.ObjectMeta, vmCopy.ObjectMeta) {
 		updatedVm, err := c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy, metav1.UpdateOptions{})
 		if err != nil {
@@ -3489,6 +3499,31 @@ func (c *Controller) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi *
 
 	log.Log.Object(vmi).Infof("%s", logMsg)
 
+	return nil
+}
+
+func (c *Controller) handleReservedOverheadRequest(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
+	if vmi == nil || vmi.DeletionTimestamp != nil {
+		return nil
+	}
+
+	var vmOverhead *resource.Quantity
+	if vm.Spec.Template.Spec.Domain.Memory != nil &&
+		vm.Spec.Template.Spec.Domain.Memory.ReservedOverhead != nil {
+		vmOverhead = vm.Spec.Template.Spec.Domain.Memory.ReservedOverhead.AddedOverhead
+	}
+
+	var vmiOverhead *resource.Quantity
+	if vmi.Spec.Domain.Memory != nil &&
+		vmi.Spec.Domain.Memory.ReservedOverhead != nil {
+		vmiOverhead = vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead
+	}
+
+	if equality.Semantic.DeepEqual(vmOverhead, vmiOverhead) {
+		return nil
+	}
+
+	setRestartRequired(vm, "reservedOverhead.addedOverhead updated in template spec, restart required for new pod memory allocation to take effect")
 	return nil
 }
 

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -5832,6 +5832,134 @@ var _ = Describe("VirtualMachine", func() {
 				})
 			})
 
+			Context("ReservedOverhead", func() {
+				It("should not set RestartRequired when vmi is nil", func() {
+					vm, _ := watchtesting.DefaultVirtualMachine(true)
+					Expect(controller.handleReservedOverheadRequest(vm, nil)).To(Succeed())
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+				})
+
+				It("should not set RestartRequired when vmi is being deleted", func() {
+					vm, _ := watchtesting.DefaultVirtualMachine(true)
+					overhead := resource.MustParse("1Gi")
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
+						ReservedOverhead: &v1.ReservedOverhead{
+							AddedOverhead: &overhead,
+						},
+					}
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					now := metav1.Now()
+					vmi.DeletionTimestamp = &now
+
+					Expect(controller.handleReservedOverheadRequest(vm, vmi)).To(Succeed())
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+				})
+
+				It("should not set RestartRequired when addedOverhead is unchanged", func() {
+					vm, _ := watchtesting.DefaultVirtualMachine(true)
+					vmOverhead := resource.MustParse("500Mi")
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
+						ReservedOverhead: &v1.ReservedOverhead{
+							AddedOverhead: &vmOverhead,
+						},
+					}
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					vmiOverhead := resource.MustParse("500Mi")
+					vmi.Spec.Domain.Memory = &v1.Memory{
+						ReservedOverhead: &v1.ReservedOverhead{
+							AddedOverhead: &vmiOverhead,
+						},
+					}
+
+					Expect(controller.handleReservedOverheadRequest(vm, vmi)).To(Succeed())
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+				})
+
+				It("should not set RestartRequired when neither VM nor VMI has addedOverhead", func() {
+					vm, _ := watchtesting.DefaultVirtualMachine(true)
+					vmi := api.NewMinimalVMI(vm.Name)
+
+					Expect(controller.handleReservedOverheadRequest(vm, vmi)).To(Succeed())
+					Expect(vm).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+				})
+
+				It("should set RestartRequired when addedOverhead is added to running VM", func() {
+					vm, _ := watchtesting.DefaultVirtualMachine(true)
+					overhead := resource.MustParse("1Gi")
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
+						ReservedOverhead: &v1.ReservedOverhead{
+							AddedOverhead: &overhead,
+						},
+					}
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					// VMI has no addedOverhead (was started before the field was set)
+
+					Expect(controller.handleReservedOverheadRequest(vm, vmi)).To(Succeed())
+					vmCondManager := virtcontroller.NewVirtualMachineConditionManager()
+					cond := vmCondManager.GetCondition(vm, v1.VirtualMachineRestartRequired)
+					Expect(cond).To(Not(BeNil()))
+					Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Type":    Equal(v1.VirtualMachineRestartRequired),
+						"Message": ContainSubstring("reservedOverhead.addedOverhead"),
+						"Status":  Equal(k8sv1.ConditionTrue),
+					}))
+				})
+
+				It("should set RestartRequired when addedOverhead is changed on running VM", func() {
+					vm, _ := watchtesting.DefaultVirtualMachine(true)
+					newOverhead := resource.MustParse("1Gi")
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
+						ReservedOverhead: &v1.ReservedOverhead{
+							AddedOverhead: &newOverhead,
+						},
+					}
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					oldOverhead := resource.MustParse("500Mi")
+					vmi.Spec.Domain.Memory = &v1.Memory{
+						ReservedOverhead: &v1.ReservedOverhead{
+							AddedOverhead: &oldOverhead,
+						},
+					}
+
+					Expect(controller.handleReservedOverheadRequest(vm, vmi)).To(Succeed())
+					vmCondManager := virtcontroller.NewVirtualMachineConditionManager()
+					cond := vmCondManager.GetCondition(vm, v1.VirtualMachineRestartRequired)
+					Expect(cond).To(Not(BeNil()))
+					Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Type":    Equal(v1.VirtualMachineRestartRequired),
+						"Message": ContainSubstring("reservedOverhead.addedOverhead"),
+						"Status":  Equal(k8sv1.ConditionTrue),
+					}))
+				})
+
+				It("should set RestartRequired when addedOverhead is removed from running VM", func() {
+					vm, _ := watchtesting.DefaultVirtualMachine(true)
+					// VM spec has no addedOverhead (user removed it)
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					oldOverhead := resource.MustParse("500Mi")
+					vmi.Spec.Domain.Memory = &v1.Memory{
+						ReservedOverhead: &v1.ReservedOverhead{
+							AddedOverhead: &oldOverhead,
+						},
+					}
+
+					Expect(controller.handleReservedOverheadRequest(vm, vmi)).To(Succeed())
+					vmCondManager := virtcontroller.NewVirtualMachineConditionManager()
+					cond := vmCondManager.GetCondition(vm, v1.VirtualMachineRestartRequired)
+					Expect(cond).To(Not(BeNil()))
+					Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Type":    Equal(v1.VirtualMachineRestartRequired),
+						"Message": ContainSubstring("reservedOverhead.addedOverhead"),
+						"Status":  Equal(k8sv1.ConditionTrue),
+					}))
+				})
+			})
+
 			Context("Tolerations", func() {
 				DescribeTable("should be live-updated", func(existingTolerations, updatedTolerations []k8sv1.Toleration) {
 					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{


### PR DESCRIPTION
## Context

This is **PR 1 of 2** for #17622.

- **PR 1 (this):** detect `addedOverhead` changes on a running VM and set `RestartRequired`
- **PR 2 (follow-up):** `memLock` runtime update via `AdjustResources` in virt-handler

## What changed

Add `handleReservedOverheadRequest` in `pkg/virt-controller/watch/vm/vm.go`. It compares `reservedOverhead.addedOverhead` between the VM template spec and the live VMI spec — if they differ, it sets `VirtualMachineRestartRequired`.

The handler runs unconditionally outside the LiveUpdate block because pod memory requests are immutable in Kubernetes; a restart is always required regardless of rollout strategy.

## Tests

7 unit tests: nil VMI, terminating VMI, unchanged/absent overhead → no condition; overhead added/changed/removed → `RestartRequired` with message assertion.

Fixes #17622

```release-note
Set `VirtualMachineRestartRequired` condition when `reservedOverhead.addedOverhead` is updated on a running VM.
```