### PR TITLE
VMs with hotplugged volumes respect node affinity of those volumes by merging affinities

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -634,6 +634,14 @@ spec:
           - delete
           - patch
         - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - snapshot.kubevirt.io
           resources:
           - virtualmachinesnapshots

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -666,6 +666,14 @@ rules:
   - delete
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - snapshot.kubevirt.io
   resources:
   - virtualmachinesnapshots

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -667,6 +667,14 @@ rules:
   - delete
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - snapshot.kubevirt.io
   resources:
   - virtualmachinesnapshots

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -206,6 +206,9 @@ type KubeInformerFactory interface {
 	// Watches for PersistentVolumeClaim objects
 	PersistentVolumeClaim() cache.SharedIndexInformer
 
+	// Watches for PersistentVolume objects
+	PersistentVolume() cache.SharedIndexInformer
+
 	// Watches for ControllerRevision objects
 	ControllerRevision() cache.SharedIndexInformer
 
@@ -1169,6 +1172,14 @@ func (f *kubeInformerFactory) PersistentVolumeClaim() cache.SharedIndexInformer 
 		restClient := f.k8sClient.CoreV1().RESTClient()
 		lw := cache.NewListWatchFromClient(restClient, "persistentvolumeclaims", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &k8sv1.PersistentVolumeClaim{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	})
+}
+
+func (f *kubeInformerFactory) PersistentVolume() cache.SharedIndexInformer {
+	return f.getInformer("persistentVolumeInformer", func() cache.SharedIndexInformer {
+		restClient := f.k8sClient.CoreV1().RESTClient()
+		lw := cache.NewListWatchFromClient(restClient, "persistentvolumes", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &k8sv1.PersistentVolume{}, f.defaultResync, cache.Indexers{})
 	})
 }
 

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -200,6 +200,9 @@ type KubeInformerFactory interface {
 	// Watches for PersistentVolumeClaim objects
 	PersistentVolumeClaim() cache.SharedIndexInformer
 
+	// Watches for PersistentVolume objects
+	PersistentVolume() cache.SharedIndexInformer
+
 	// Watches for ControllerRevision objects
 	ControllerRevision() cache.SharedIndexInformer
 
@@ -1138,6 +1141,14 @@ func (f *kubeInformerFactory) PersistentVolumeClaim() cache.SharedIndexInformer 
 		restClient := f.k8sClient.CoreV1().RESTClient()
 		lw := cache.NewListWatchFromClient(restClient, "persistentvolumeclaims", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &k8sv1.PersistentVolumeClaim{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	})
+}
+
+func (f *kubeInformerFactory) PersistentVolume() cache.SharedIndexInformer {
+	return f.getInformer("persistentVolumeInformer", func() cache.SharedIndexInformer {
+		restClient := f.k8sClient.CoreV1().RESTClient()
+		lw := cache.NewListWatchFromClient(restClient, "persistentvolumes", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &k8sv1.PersistentVolume{}, f.defaultResync, cache.Indexers{})
 	})
 }
 

--- a/pkg/storage/export/export/backup-source_test.go
+++ b/pkg/storage/export/export/backup-source_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Backup source", func() {
 		vmBackupInformer            cache.SharedIndexInformer
 		vmBackupTrackerInformer     cache.SharedIndexInformer
 		controllerRevisionInformer  cache.SharedIndexInformer
+		pvInformer                  cache.SharedIndexInformer
 		rqInformer                  cache.SharedIndexInformer
 		nsInformer                  cache.SharedIndexInformer
 		k8sClient                   *k8sfake.Clientset
@@ -125,6 +126,7 @@ var _ = Describe("Backup source", func() {
 		controllerRevisionInformer, _ = testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		vmBackupInformer, _ = testutils.NewFakeInformerFor(&backupv1.VirtualMachineBackup{})
 		vmBackupTrackerInformer, _ = testutils.NewFakeInformerFor(&backupv1.VirtualMachineBackupTracker{})
+		pvInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		rqInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		nsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
@@ -152,7 +154,7 @@ var _ = Describe("Backup source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               fakeCertManager,
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -113,6 +113,7 @@ var _ = Describe("Export controller", func() {
 		controller                  *VMExportController
 		recorder                    *record.FakeRecorder
 		pvcInformer                 cache.SharedIndexInformer
+		pvInformer                  cache.SharedIndexInformer
 		podInformer                 cache.SharedIndexInformer
 		cmInformer                  cache.SharedIndexInformer
 		vmExportInformer            cache.SharedIndexInformer
@@ -150,6 +151,7 @@ var _ = Describe("Export controller", func() {
 	syncCaches := func(stop chan struct{}) {
 		go vmExportInformer.Run(stop)
 		go pvcInformer.Run(stop)
+		go pvInformer.Run(stop)
 		go podInformer.Run(stop)
 		go dvInformer.Run(stop)
 		go cmInformer.Run(stop)
@@ -173,6 +175,7 @@ var _ = Describe("Export controller", func() {
 			stop,
 			vmExportInformer.HasSynced,
 			pvcInformer.HasSynced,
+			pvInformer.HasSynced,
 			podInformer.HasSynced,
 			dvInformer.HasSynced,
 			cmInformer.HasSynced,
@@ -200,6 +203,7 @@ var _ = Describe("Export controller", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
@@ -252,7 +256,7 @@ var _ = Describe("Export controller", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               fakeCertManager,
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -111,6 +111,7 @@ var _ = Describe("Export controller", func() {
 		controller                  *VMExportController
 		recorder                    *record.FakeRecorder
 		pvcInformer                 cache.SharedIndexInformer
+		pvInformer                  cache.SharedIndexInformer
 		podInformer                 cache.SharedIndexInformer
 		cmInformer                  cache.SharedIndexInformer
 		vmExportInformer            cache.SharedIndexInformer
@@ -147,6 +148,7 @@ var _ = Describe("Export controller", func() {
 	syncCaches := func(stop chan struct{}) {
 		go vmExportInformer.Run(stop)
 		go pvcInformer.Run(stop)
+		go pvInformer.Run(stop)
 		go podInformer.Run(stop)
 		go dvInformer.Run(stop)
 		go cmInformer.Run(stop)
@@ -170,6 +172,7 @@ var _ = Describe("Export controller", func() {
 			stop,
 			vmExportInformer.HasSynced,
 			pvcInformer.HasSynced,
+			pvInformer.HasSynced,
 			podInformer.HasSynced,
 			dvInformer.HasSynced,
 			cmInformer.HasSynced,
@@ -197,6 +200,7 @@ var _ = Describe("Export controller", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
@@ -248,7 +252,7 @@ var _ = Describe("Export controller", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               fakeCertManager,
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/pvc-source_test.go
+++ b/pkg/storage/export/export/pvc-source_test.go
@@ -67,6 +67,7 @@ var _ = Describe("PVC source", func() {
 		controller                  *VMExportController
 		recorder                    *record.FakeRecorder
 		pvcInformer                 cache.SharedIndexInformer
+		pvInformer                  cache.SharedIndexInformer
 		podInformer                 cache.SharedIndexInformer
 		cmInformer                  cache.SharedIndexInformer
 		vmExportInformer            cache.SharedIndexInformer
@@ -101,6 +102,7 @@ var _ = Describe("PVC source", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
@@ -152,7 +154,7 @@ var _ = Describe("PVC source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               fakeCertManager,
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -68,6 +68,7 @@ var _ = Describe("PVC source", func() {
 		controller                  *VMExportController
 		recorder                    *record.FakeRecorder
 		pvcInformer                 cache.SharedIndexInformer
+		pvInformer                  cache.SharedIndexInformer
 		podInformer                 cache.SharedIndexInformer
 		cmInformer                  cache.SharedIndexInformer
 		vmExportInformer            cache.SharedIndexInformer
@@ -102,6 +103,7 @@ var _ = Describe("PVC source", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
@@ -153,7 +155,7 @@ var _ = Describe("PVC source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               fakeCertManager,
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -68,6 +68,7 @@ var _ = Describe("VMSnapshot source", func() {
 		controller                  *VMExportController
 		recorder                    *record.FakeRecorder
 		pvcInformer                 cache.SharedIndexInformer
+		pvInformer                  cache.SharedIndexInformer
 		podInformer                 cache.SharedIndexInformer
 		cmInformer                  cache.SharedIndexInformer
 		vmExportInformer            cache.SharedIndexInformer
@@ -104,6 +105,7 @@ var _ = Describe("VMSnapshot source", func() {
 		Expect(err).ToNot(HaveOccurred())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
@@ -154,7 +156,7 @@ var _ = Describe("VMSnapshot source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               fakeCertManager,
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/vmtemplate-source_test.go
+++ b/pkg/storage/export/export/vmtemplate-source_test.go
@@ -73,6 +73,7 @@ var _ = Describe("VMTemplate source", func() {
 		controller         *VMExportController
 		recorder           *record.FakeRecorder
 		pvcInformer        cache.SharedIndexInformer
+		pvInformer         cache.SharedIndexInformer
 		vmExportInformer   cache.SharedIndexInformer
 		dvInformer         cache.SharedIndexInformer
 		vmTemplateInformer cache.SharedIndexInformer
@@ -85,6 +86,7 @@ var _ = Describe("VMTemplate source", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		cmInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		serviceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Service{})
@@ -137,7 +139,7 @@ var _ = Describe("VMTemplate source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               fakeCertManager,
 			RouteCache:                  routeInformer.GetStore(),
 			IngressCache:                ingressInformer.GetStore(),

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "container_disk_test.go",
+        "nodeaffinity_merge_test.go",
         "nodeselectorrenderer_test.go",
         "rendercontainer_test.go",
         "renderresources_test.go",

--- a/pkg/virt-controller/services/container_disk_test.go
+++ b/pkg/virt-controller/services/container_disk_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Container disk", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil),
+				cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil),
 				kubecli.NewMockKubevirtClient(ctrl),
 				config,
 				107,

--- a/pkg/virt-controller/services/nodeaffinity_merge_test.go
+++ b/pkg/virt-controller/services/nodeaffinity_merge_test.go
@@ -1,0 +1,421 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package services
+
+import (
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+)
+
+// req is a tiny constructor to keep the table entries readable.
+func req(key string, op k8sv1.NodeSelectorOperator, vals ...string) k8sv1.NodeSelectorRequirement {
+	return k8sv1.NodeSelectorRequirement{Key: key, Operator: op, Values: vals}
+}
+
+func term(matchExpressions []k8sv1.NodeSelectorRequirement, matchFields []k8sv1.NodeSelectorRequirement) k8sv1.NodeSelectorTerm {
+	return k8sv1.NodeSelectorTerm{MatchExpressions: matchExpressions, MatchFields: matchFields}
+}
+
+var _ = Describe("Node affinity merge algorithm", func() {
+
+	Describe("simplifyNodeSelectorRequirements", func() {
+		DescribeTable("canonicalises and detects unsatisfiability",
+			func(input []k8sv1.NodeSelectorRequirement, expected []k8sv1.NodeSelectorRequirement, expectedSat bool, expectErr bool) {
+				out, sat, err := simplifyNodeSelectorRequirements(input)
+				if expectErr {
+					Expect(err).To(HaveOccurred())
+					return
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sat).To(Equal(expectedSat))
+				if !expectedSat {
+					return
+				}
+				Expect(out).To(Equal(expected))
+			},
+			Entry("empty input is satisfiable and produces no requirements",
+				[]k8sv1.NodeSelectorRequirement{},
+				[]k8sv1.NodeSelectorRequirement{},
+				true, false,
+			),
+			Entry("two In requirements on the same key intersect",
+				[]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpIn, "a", "b", "c"),
+					req("zone", k8sv1.NodeSelectorOpIn, "b", "c", "d"),
+				},
+				[]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "b", "c")},
+				true, false,
+			),
+			Entry("disjoint In requirements are unsatisfiable",
+				[]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpIn, "a"),
+					req("zone", k8sv1.NodeSelectorOpIn, "b"),
+				},
+				nil, false, false,
+			),
+			Entry("NotIn requirements union and prune In",
+				[]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpIn, "a", "b", "c"),
+					req("zone", k8sv1.NodeSelectorOpNotIn, "b"),
+					req("zone", k8sv1.NodeSelectorOpNotIn, "c"),
+				},
+				[]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")},
+				true, false,
+			),
+			Entry("In fully consumed by NotIn is unsatisfiable",
+				[]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpIn, "a"),
+					req("zone", k8sv1.NodeSelectorOpNotIn, "a"),
+				},
+				nil, false, false,
+			),
+			Entry("Gt and Lt with no integer between them are unsatisfiable",
+				[]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpGt, "5"),
+					req("rank", k8sv1.NodeSelectorOpLt, "6"),
+				},
+				nil, false, false,
+			),
+			Entry("Gt and Lt with at least one integer between them are kept",
+				[]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpGt, "5"),
+					req("rank", k8sv1.NodeSelectorOpLt, "7"),
+				},
+				[]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpGt, "5"),
+					req("rank", k8sv1.NodeSelectorOpLt, "7"),
+				},
+				true, false,
+			),
+			Entry("In with Gt drops non-conforming integers and non-integers",
+				[]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpIn, "1", "5", "10", "foo"),
+					req("rank", k8sv1.NodeSelectorOpGt, "4"),
+				},
+				[]k8sv1.NodeSelectorRequirement{req("rank", k8sv1.NodeSelectorOpIn, "10", "5")},
+				true, false,
+			),
+			Entry("Exists with In is collapsed to In only",
+				[]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpExists),
+					req("zone", k8sv1.NodeSelectorOpIn, "a"),
+				},
+				[]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")},
+				true, false,
+			),
+			Entry("Exists with DoesNotExist is unsatisfiable",
+				[]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpExists),
+					req("zone", k8sv1.NodeSelectorOpDoesNotExist),
+				},
+				nil, false, false,
+			),
+			Entry("Gt with no value returns an error",
+				[]k8sv1.NodeSelectorRequirement{
+					{Key: "rank", Operator: k8sv1.NodeSelectorOpGt},
+				},
+				nil, false, true,
+			),
+		)
+	})
+
+	Describe("mergeNestedNodeSelectorTerms", func() {
+		It("returns a single empty term for an empty input (matches all nodes)", func() {
+			out, err := mergeNestedNodeSelectorTerms(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(k8sv1.NodeSelectorTerm{}))
+		})
+
+		It("preserves a single PV's OR'd terms", func() {
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "us-east-1a")}, nil),
+					term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "us-east-1b")}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(
+				term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "us-east-1a")}, []k8sv1.NodeSelectorRequirement{}),
+				term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "us-east-1b")}, []k8sv1.NodeSelectorRequirement{}),
+			))
+		})
+
+		It("intersects two PVs sharing a single key", func() {
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a", "b")}, nil)},
+				{term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "b", "c")}, nil)},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(
+				term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "b")}, []k8sv1.NodeSelectorRequirement{}),
+			))
+		})
+
+		It("returns an error when no cross-product is satisfiable", func() {
+			_, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")}, nil)},
+				{term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "b")}, nil)},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("drops unsatisfiable cross-products and keeps the satisfiable ones", func() {
+			// PV1 requires zone in {a,b}; PV2 allows zone=a OR zone=c.
+			// Cross-products: (a∩{a,b})=a is satisfiable, (c∩{a,b}) is unsatisfiable.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a", "b")}, nil)},
+				{
+					term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")}, nil),
+					term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "c")}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(
+				term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")}, []k8sv1.NodeSelectorRequirement{}),
+			))
+		})
+
+		It("merges MatchFields and MatchExpressions on the same term", func() {
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{term(
+					[]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")},
+					nil,
+				)},
+				{term(
+					nil,
+					[]k8sv1.NodeSelectorRequirement{req("metadata.name", k8sv1.NodeSelectorOpIn, "n1", "n2")},
+				)},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(term(
+				[]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")},
+				[]k8sv1.NodeSelectorRequirement{req("metadata.name", k8sv1.NodeSelectorOpIn, "n1", "n2")},
+			)))
+		})
+
+		It("prunes a disjunct fully subsumed by another", func() {
+			// {zone In [a]} is a subset of {zone In [a, b]} so the more-specific
+			// term is redundant in a disjunction and gets dropped.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a", "b")}, nil),
+					term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a")}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(
+				term([]k8sv1.NodeSelectorRequirement{req("zone", k8sv1.NodeSelectorOpIn, "a", "b")}, []k8sv1.NodeSelectorRequirement{}),
+			))
+		})
+
+		It("prunes a tight Gt+Lt disjunct subsumed by an In superset", func() {
+			// (Gt:4, Lt:8) admits {5,6,7} which is a strict subset of In:[3,5,6,7,9],
+			// so the Gt+Lt term is redundant. Detection requires impliesIn to recognise
+			// the bounded range as an enumerable In set.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpIn, "3", "5", "6", "7", "9"),
+					}, nil),
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpGt, "4"),
+						req("rank", k8sv1.NodeSelectorOpLt, "8"),
+					}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(
+				term([]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpIn, "3", "5", "6", "7", "9"),
+				}, []k8sv1.NodeSelectorRequirement{}),
+			))
+		})
+
+		It("respects NotIn when checking Gt+Lt subsumption against an In superset", func() {
+			// (Gt:4, Lt:8) ∧ NotIn:[6] admits {5,7}, which is a subset of In:[5,7,9].
+			// NotIn must be subtracted from the range count for the implication to
+			// be detected; otherwise we'd mistakenly require 6 to be in the In set.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpIn, "5", "7", "9"),
+					}, nil),
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpGt, "4"),
+						req("rank", k8sv1.NodeSelectorOpLt, "8"),
+						req("rank", k8sv1.NodeSelectorOpNotIn, "6"),
+					}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(
+				term([]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpIn, "5", "7", "9"),
+				}, []k8sv1.NodeSelectorRequirement{}),
+			))
+		})
+
+		It("does not prune Gt+Lt and In disjuncts when neither subsumes the other", func() {
+			// (Gt:0, Lt:10) admits {1..9}; In:[3,5,7,100] admits {3,5,7,100}.
+			// Neither set is a subset of the other (1 ∉ In, 100 ∉ range), so both
+			// disjuncts must survive — the Gt+Lt → In implication must NOT fire.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpIn, "3", "5", "7", "100"),
+					}, nil),
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpGt, "0"),
+						req("rank", k8sv1.NodeSelectorOpLt, "10"),
+					}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(HaveLen(2))
+		})
+
+		It("prunes a stricter Lt disjunct subsumed by a looser Lt", func() {
+			// Lt:5 admits {..,3,4}; Lt:10 admits {..,9}. The smaller bound is
+			// stricter, so Lt:5 ⊆ Lt:10 and the stricter disjunct is redundant.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{req("rank", k8sv1.NodeSelectorOpLt, "10")}, nil),
+					term([]k8sv1.NodeSelectorRequirement{req("rank", k8sv1.NodeSelectorOpLt, "5")}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(term(
+				[]k8sv1.NodeSelectorRequirement{req("rank", k8sv1.NodeSelectorOpLt, "10")},
+				[]k8sv1.NodeSelectorRequirement{},
+			)))
+		})
+
+		It("prunes a stricter Gt disjunct subsumed by a looser Gt", func() {
+			// Gt:10 admits {11,..}; Gt:5 admits {6,..}. The larger Gt bound is
+			// stricter, so Gt:10 ⊆ Gt:5 and the stricter disjunct is redundant.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{req("rank", k8sv1.NodeSelectorOpGt, "5")}, nil),
+					term([]k8sv1.NodeSelectorRequirement{req("rank", k8sv1.NodeSelectorOpGt, "10")}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(term(
+				[]k8sv1.NodeSelectorRequirement{req("rank", k8sv1.NodeSelectorOpGt, "5")},
+				[]k8sv1.NodeSelectorRequirement{},
+			)))
+		})
+
+		It("prunes a Gt+Lt range strictly contained in another Gt+Lt range", func() {
+			// (Gt:5, Lt:10) admits {6,7,8,9}; (Gt:0, Lt:15) admits {1..14}.
+			// The inner range is a subset, so the inner disjunct is redundant.
+			// Detection requires impliesGt and impliesLt to both fire on direct
+			// bound comparison.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpGt, "0"),
+						req("rank", k8sv1.NodeSelectorOpLt, "15"),
+					}, nil),
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpGt, "5"),
+						req("rank", k8sv1.NodeSelectorOpLt, "10"),
+					}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(term(
+				[]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpGt, "0"),
+					req("rank", k8sv1.NodeSelectorOpLt, "15"),
+				},
+				[]k8sv1.NodeSelectorRequirement{},
+			)))
+		})
+
+		It("does not prune Gt+Lt ranges that overlap without containment", func() {
+			// (Gt:0, Lt:10) admits {1..9}; (Gt:5, Lt:15) admits {6..14}. They
+			// overlap on {6,7,8,9} but neither is a subset, so both must survive.
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpGt, "0"),
+						req("rank", k8sv1.NodeSelectorOpLt, "10"),
+					}, nil),
+					term([]k8sv1.NodeSelectorRequirement{
+						req("rank", k8sv1.NodeSelectorOpGt, "5"),
+						req("rank", k8sv1.NodeSelectorOpLt, "15"),
+					}, nil),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(HaveLen(2))
+		})
+
+		It("fails fast when the cross-product would exceed maxNodeSelectorCrossProduct", func() {
+			// One volume with > maxNodeSelectorCrossProduct disjuncts forces the
+			// guard at the first merge (1 × N > limit).
+			oversized := make([]k8sv1.NodeSelectorTerm, maxNodeSelectorCrossProduct+1)
+			for i := range oversized {
+				oversized[i] = term([]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpIn, "z"+strconv.Itoa(i)),
+				}, nil)
+			}
+			_, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{oversized})
+			Expect(err).To(MatchError(ContainSubstring("cross-product")))
+		})
+
+		It("fails fast when the simplified disjunction exceeds maxNodeSelectorFinalTerms", func() {
+			// Each disjunct is on a distinct key, so none can subsume any other
+			// in the prune step. Cross-product stays at len = N (under the
+			// cross-product limit), but the final term count exceeds the cap.
+			disjuncts := make([]k8sv1.NodeSelectorTerm, maxNodeSelectorFinalTerms+1)
+			for i := range disjuncts {
+				disjuncts[i] = term([]k8sv1.NodeSelectorRequirement{
+					req("k"+strconv.Itoa(i), k8sv1.NodeSelectorOpExists),
+				}, nil)
+			}
+			_, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{disjuncts})
+			Expect(err).To(MatchError(ContainSubstring("limit")))
+		})
+
+		It("preserves NotIn / Gt / Lt operators end-to-end", func() {
+			out, err := mergeNestedNodeSelectorTerms([][]k8sv1.NodeSelectorTerm{
+				{term([]k8sv1.NodeSelectorRequirement{
+					req("zone", k8sv1.NodeSelectorOpNotIn, "blocked"),
+					req("rank", k8sv1.NodeSelectorOpGt, "5"),
+					req("rank", k8sv1.NodeSelectorOpLt, "100"),
+				}, nil)},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ConsistOf(term(
+				[]k8sv1.NodeSelectorRequirement{
+					req("rank", k8sv1.NodeSelectorOpGt, "5"),
+					req("rank", k8sv1.NodeSelectorOpLt, "100"),
+					req("zone", k8sv1.NodeSelectorOpNotIn, "blocked"),
+				},
+				[]k8sv1.NodeSelectorRequirement{},
+			)))
+		})
+	})
+})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -122,6 +122,17 @@ const (
 	FailedToRenderLaunchManifestErrFormat = "failed to render launch manifest: %v"
 )
 
+// Safety guards for the disjunctive cross-product merge below.
+const (
+	// maxNodeSelectorCrossProduct caps the size of an intermediate cross-product
+	// before pruning. Checked in mergeNodeSelectorTerms before allocation.
+	maxNodeSelectorCrossProduct = 1000
+	// maxNodeSelectorFinalTerms caps the simplified disjunction attached to the
+	// pod. Etcd's ~1.5MB object limit is the upstream constraint; this leaves
+	// plenty of room for the rest of the pod spec.
+	maxNodeSelectorFinalTerms = 100
+)
+
 type netMemoryCalculator interface {
 	Calculate(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) resource.Quantity
 }
@@ -144,6 +155,7 @@ type TemplateService struct {
 	hotplugDiskDir             string
 	imagePullSecret            string
 	persistentVolumeClaimStore cache.Store
+	persistentVolumeStore      cache.Store
 	virtClient                 kubecli.KubevirtClient
 	clusterConfig              *virtconfig.ClusterConfig
 	launcherSubGid             int64
@@ -192,9 +204,75 @@ func setPersistentReservationAntiAffinity(vmi *v1.VirtualMachineInstance, pod *k
 	return nil
 }
 
-func setNodeAffinityForPod(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
+func (t *TemplateService) getHotpluggedPVsForVMI(vmi *v1.VirtualMachineInstance) ([]*k8sv1.PersistentVolume, error) {
+	var pvs []*k8sv1.PersistentVolume
+	if !vmi.Spec.Domain.Devices.DisableHotplug {
+		for _, volume := range vmi.Spec.Volumes {
+			// Assume (for now it's always true) that PVC name matches DV name
+			pvcName := ""
+			if volume.DataVolume != nil && volume.DataVolume.Hotpluggable {
+				pvcName = volume.DataVolume.Name
+			} else if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable {
+				pvcName = volume.PersistentVolumeClaim.ClaimName
+			}
+
+			if pvcName == "" {
+				continue
+			}
+
+			obj, exists, err := t.persistentVolumeClaimStore.GetByKey(vmi.Namespace + "/" + pvcName)
+			if err != nil {
+				return nil, err
+			}
+			if !exists {
+				// We can't tell if the PVC doesn't exist or if it's just not in the cache yet so if we don't find it here, we just skip it
+				// as there's nothing to take topology constraints from and creating the PVC after the VMI is not something we want to break
+				continue
+			}
+			pvc, ok := obj.(*k8sv1.PersistentVolumeClaim)
+			if !ok {
+				return nil, fmt.Errorf("couldn't cast object to PersistentVolumeClaim: %+v", obj)
+			}
+			// Skip unbound PVCs (WaitForFirstConsumer) as there no topology constraints to enforce yet
+			if pvc.Status.Phase != k8sv1.ClaimBound || pvc.Spec.VolumeName == "" {
+				continue
+			}
+
+			pvName := pvc.Spec.VolumeName
+			obj, exists, err = t.persistentVolumeStore.GetByKey(pvName)
+			if err != nil {
+				return nil, err
+			}
+			if !exists {
+				// On the other hand, if the PVC exists and is Bound but we can't find the PV, it's definitely a cache timing issue so we should
+				// just return an error and retry instead of skipping the PV
+				return nil, fmt.Errorf("PersistentVolume %s not found in cache", pvName)
+			}
+			pv, ok := obj.(*k8sv1.PersistentVolume)
+			if !ok {
+				return nil, fmt.Errorf("couldn't cast object to PersistentVolume: %+v", obj)
+			}
+			pvs = append(pvs, pv)
+		}
+	}
+	return pvs, nil
+}
+
+func (t *TemplateService) setNodeAffinityForPod(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) error {
 	setNodeAffinityForHostModelCpuModel(vmi, pod)
 	setNodeAffinityForbiddenFeaturePolicy(vmi, pod)
+
+	hotpluggedVolumes, err := t.getHotpluggedPVsForVMI(vmi)
+	if err != nil {
+		return err
+	}
+
+	if len(hotpluggedVolumes) > 0 {
+		if err := t.setNodeAffinityForHotpluggedVolumeTopology(hotpluggedVolumes, pod); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func setPreferredArchitectureAffinity(architecture string, pod *k8sv1.Pod) {
@@ -227,7 +305,7 @@ func setPreferredArchitectureAffinity(architecture string, pod *k8sv1.Pod) {
 
 func setNodeAffinityForHostModelCpuModel(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel {
-		pod.Spec.Affinity = modifyNodeAffintyToRejectLabel(pod.Spec.Affinity, v1.NodeHostModelIsObsoleteLabel)
+		pod.Spec.Affinity = modifyNodeAffinityToRejectLabel(pod.Spec.Affinity, v1.NodeHostModelIsObsoleteLabel)
 	}
 }
 
@@ -238,12 +316,700 @@ func setNodeAffinityForbiddenFeaturePolicy(vmi *v1.VirtualMachineInstance, pod *
 
 	for _, feature := range vmi.Spec.Domain.CPU.Features {
 		if feature.Policy == "forbid" {
-			pod.Spec.Affinity = modifyNodeAffintyToRejectLabel(pod.Spec.Affinity, v1.CPUFeatureLabel+feature.Name)
+			pod.Spec.Affinity = modifyNodeAffinityToRejectLabel(pod.Spec.Affinity, v1.CPUFeatureLabel+feature.Name)
 		}
 	}
 }
 
-func modifyNodeAffintyToRejectLabel(origAffinity *k8sv1.Affinity, labelToReject string) *k8sv1.Affinity {
+func (t *TemplateService) setNodeAffinityForHotpluggedVolumeTopology(hotpluggedVolumes []*k8sv1.PersistentVolume, pod *k8sv1.Pod) error {
+	var requiredNodeSelectorTerms [][]k8sv1.NodeSelectorTerm
+	for _, vol := range hotpluggedVolumes {
+		if vol.Spec.NodeAffinity != nil && vol.Spec.NodeAffinity.Required != nil && len(vol.Spec.NodeAffinity.Required.NodeSelectorTerms) > 0 {
+			requiredNodeSelectorTerms = append(requiredNodeSelectorTerms, vol.Spec.NodeAffinity.Required.NodeSelectorTerms)
+		}
+	}
+
+	if len(requiredNodeSelectorTerms) == 0 {
+		return nil
+	}
+
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &k8sv1.Affinity{}
+	}
+	podAffinity := pod.Spec.Affinity
+
+	if podAffinity.NodeAffinity == nil {
+		podAffinity.NodeAffinity = &k8sv1.NodeAffinity{}
+	}
+	nodeAffinity := podAffinity.NodeAffinity
+
+	if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &k8sv1.NodeSelector{}
+	}
+	required := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+
+	if len(required.NodeSelectorTerms) != 0 {
+		requiredNodeSelectorTerms = append(requiredNodeSelectorTerms, required.NodeSelectorTerms)
+	}
+
+	mergedNodeSelectorTerms, err := mergeNestedNodeSelectorTerms(slices.Clone(requiredNodeSelectorTerms))
+	if err != nil {
+		return err
+	}
+	required.NodeSelectorTerms = mergedNodeSelectorTerms
+	return nil
+}
+
+// Clones term and sorts In/NotIn for easy pruning of duplicate terms
+func normalizeNodeSelectorTerms(term []k8sv1.NodeSelectorTerm) []k8sv1.NodeSelectorTerm {
+	res := make([]k8sv1.NodeSelectorTerm, 0, len(term))
+	for _, selector := range term {
+		matchExpression := make([]k8sv1.NodeSelectorRequirement, 0, len(selector.MatchExpressions))
+		for _, expr := range selector.MatchExpressions {
+			if expr.Operator == k8sv1.NodeSelectorOpIn || expr.Operator == k8sv1.NodeSelectorOpNotIn {
+				expr.Values = slices.Sorted(slices.Values(expr.Values))
+			}
+			matchExpression = append(matchExpression, expr)
+		}
+		matchFields := make([]k8sv1.NodeSelectorRequirement, 0, len(selector.MatchFields))
+		for _, expr := range selector.MatchFields {
+			if expr.Operator == k8sv1.NodeSelectorOpIn || expr.Operator == k8sv1.NodeSelectorOpNotIn {
+				expr.Values = slices.Sorted(slices.Values(expr.Values))
+			}
+			matchFields = append(matchFields, expr)
+		}
+		res = append(res, k8sv1.NodeSelectorTerm{
+			MatchExpressions: matchExpression,
+			MatchFields:      matchFields,
+		})
+	}
+	return res
+}
+
+func nodeSelectorRequirementByKeyAndOperator(reqs []k8sv1.NodeSelectorRequirement) map[string]map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement {
+	res := make(map[string]map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement)
+	for _, req := range reqs {
+		if _, exists := res[req.Key]; !exists {
+			res[req.Key] = make(map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement)
+		}
+		if _, exists := res[req.Key][req.Operator]; !exists {
+			res[req.Key][req.Operator] = make([]k8sv1.NodeSelectorRequirement, 0)
+		}
+		res[req.Key][req.Operator] = append(res[req.Key][req.Operator], req)
+	}
+	return res
+}
+
+// Assume terms are normalized already and simplify. At worst returns unique keys * 4 terms
+func simplifyNodeSelectorRequirements(reqs []k8sv1.NodeSelectorRequirement) ([]k8sv1.NodeSelectorRequirement, bool, error) {
+	stringsToSet := func(vals []string) map[string]struct{} {
+		res := make(map[string]struct{})
+		for _, val := range vals {
+			res[val] = struct{}{}
+		}
+		return res
+	}
+
+	newTerms := make([]k8sv1.NodeSelectorRequirement, 0)
+	byKeyAndOp := nodeSelectorRequirementByKeyAndOperator(reqs)
+	keys := slices.Sorted(maps.Keys(byKeyAndOp))
+	for _, key := range keys {
+		ops := byKeyAndOp[key]
+		// inValues are the intersection of all matches
+		var inValues map[string]struct{} = nil
+		inReqs, mustBeIn := ops[k8sv1.NodeSelectorOpIn]
+		for idx, req := range inReqs {
+			valsSet := stringsToSet(req.Values)
+			if idx == 0 {
+				inValues = valsSet
+				continue
+			}
+			for val := range inValues {
+				if _, exists := valsSet[val]; !exists {
+					delete(inValues, val)
+				}
+			}
+			if len(inValues) == 0 {
+				break
+			}
+		}
+
+		// notInValues are the union of all matches
+		var notInValues map[string]struct{} = make(map[string]struct{})
+		notInReqs, mustNotBeIn := ops[k8sv1.NodeSelectorOpNotIn]
+		for _, req := range notInReqs {
+			for _, val := range req.Values {
+				notInValues[val] = struct{}{}
+				delete(inValues, val)
+			}
+		}
+
+		// greater than the greatest term
+		var greaterThanValue int64 = 0
+		gtReqs, mustBeGreaterThan := ops[k8sv1.NodeSelectorOpGt]
+		for idx, req := range gtReqs {
+			if len(req.Values) == 0 {
+				return nil, false, fmt.Errorf("Gt requirement on key %q has no value", key)
+			}
+			val, err := strconv.ParseInt(req.Values[0], 10, 64)
+			if err != nil {
+				return nil, false, err
+			}
+			if idx == 0 {
+				greaterThanValue = val
+				continue
+			}
+			if val > greaterThanValue {
+				greaterThanValue = val
+			}
+		}
+		// If In and Gt are on the the same key, we can further simplify In
+		// This would likely be a bug in the user affinity
+		if mustBeGreaterThan && mustBeIn {
+			for val := range inValues {
+				valAsInt, err := strconv.ParseInt(val, 10, 64)
+				// K8S will drop non-integer constraints when Gt is applied
+				if err != nil || valAsInt <= greaterThanValue {
+					delete(inValues, val)
+				}
+			}
+		}
+
+		// less than the least term
+		var lessThanValue int64 = 0
+		ltReqs, mustBeLessThan := ops[k8sv1.NodeSelectorOpLt]
+		for idx, req := range ltReqs {
+			if len(req.Values) == 0 {
+				return nil, false, fmt.Errorf("Lt requirement on key %q has no value", key)
+			}
+			val, err := strconv.ParseInt(req.Values[0], 10, 64)
+			if err != nil {
+				return nil, false, err
+			}
+			if idx == 0 {
+				lessThanValue = val
+				continue
+			}
+			if val < lessThanValue {
+				lessThanValue = val
+			}
+		}
+		// If In and Lt are on the the same key, we can further simplify In
+		// This would likely be a bug in the user affinity
+		if mustBeLessThan && mustBeIn {
+			for val := range inValues {
+				valAsInt, err := strconv.ParseInt(val, 10, 64)
+				// K8S will drop non-integer constraints when Lt is applied
+				if err != nil || valAsInt >= lessThanValue {
+					delete(inValues, val)
+				}
+			}
+		}
+
+		// After all possible pruning of inValues, assert there is anything left
+		if mustBeIn && len(inValues) == 0 {
+			return nil, false, nil
+		}
+
+		// Assert that Lt and Gt constraints are satisfiable together
+		if mustBeLessThan && mustBeGreaterThan && lessThanValue <= greaterThanValue+1 {
+			return nil, false, nil
+		}
+
+		// At this point since In values are canonical (they encode NotIn/Gt/Lt) and are satisfiable
+		// we can just drop NotIn/Gt/Lt
+		if mustBeIn {
+			mustNotBeIn = false
+			mustBeGreaterThan = false
+			mustBeLessThan = false
+		}
+
+		// In/Gt/Lt imply Exists so we don't need an explicit selector
+		_, hasExists := ops[k8sv1.NodeSelectorOpExists]
+		mustExist := hasExists && !mustBeGreaterThan && !mustBeLessThan && !mustBeIn
+
+		// Nothing implies DoesNotExist
+		_, mustNotExist := ops[k8sv1.NodeSelectorOpDoesNotExist]
+
+		// All the other selectors other than mustNotBeIn need to be false for this to be satisfiable
+		if mustNotExist && (mustExist || mustBeLessThan || mustBeGreaterThan || mustBeIn) {
+			return nil, false, nil
+		}
+
+		// Always canonize in order of In/NotIn/Gt/Lt/Exists/DoesNotExist and sort values
+		if mustBeIn {
+			vals := slices.Sorted(maps.Keys(inValues))
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpIn,
+				Values:   vals,
+			})
+		}
+
+		if mustNotBeIn {
+			vals := slices.Sorted(maps.Keys(notInValues))
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpNotIn,
+				Values:   vals,
+			})
+		}
+
+		if mustBeGreaterThan {
+			val := strconv.FormatInt(greaterThanValue, 10)
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpGt,
+				Values:   []string{val},
+			})
+		}
+
+		if mustBeLessThan {
+			val := strconv.FormatInt(lessThanValue, 10)
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpLt,
+				Values:   []string{val},
+			})
+		}
+
+		if mustExist {
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpExists,
+			})
+		}
+
+		if mustNotExist {
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpDoesNotExist,
+			})
+		}
+	}
+
+	return newTerms, true, nil
+}
+
+func nodeSelectorRequirementsCanBeMadeRedundant(reqs1 []k8sv1.NodeSelectorRequirement, reqs2 []k8sv1.NodeSelectorRequirement) (bool, error) {
+	reqs1ByKeyOp := nodeSelectorRequirementByKeyAndOperator(reqs1)
+	reqs2ByKeyOp := nodeSelectorRequirementByKeyAndOperator(reqs2)
+	// If reqs1 is stricter (has more keys) then reqs2, it cannot made it redundant
+	if len(reqs1ByKeyOp) > len(reqs2ByKeyOp) {
+		return false, nil
+	}
+	// All keys in reqs1 must be in reqs2
+	for key := range reqs1ByKeyOp {
+		if _, exists := reqs2ByKeyOp[key]; !exists {
+			return false, nil
+		}
+	}
+	// Validate that we have reqs in canonical form
+	for key := range reqs1ByKeyOp {
+		for op, term := range reqs1ByKeyOp[key] {
+			if len(term) > 1 {
+				return false, fmt.Errorf("Received denormalized node selector terms for %v", op)
+			}
+		}
+	}
+	for key := range reqs2ByKeyOp {
+		for op, term := range reqs2ByKeyOp[key] {
+			if len(term) > 1 {
+				return false, fmt.Errorf("Received denormalized node selector terms for %v", op)
+			}
+		}
+	}
+
+	type normRec struct {
+		hasExists       bool
+		hasDoesNotExist bool
+		hasIn           bool
+		hasNotIn        bool
+		hasGt           bool
+		hasLt           bool
+		greaterThanVal  int64
+		lessThanVal     int64
+		inValuesSet     map[string]struct{}
+		notInValuesSet  map[string]struct{}
+	}
+
+	toNormRec := func(m map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement) (normRec, error) {
+		_, hasExists := m[k8sv1.NodeSelectorOpExists]
+		_, hasDoesNotExist := m[k8sv1.NodeSelectorOpDoesNotExist]
+
+		inTermSlice, hasIn := m[k8sv1.NodeSelectorOpIn]
+		var InValuesSet map[string]struct{}
+		if hasIn {
+			InValuesSet = make(map[string]struct{})
+			for _, val := range inTermSlice[0].Values {
+				InValuesSet[val] = struct{}{}
+			}
+		}
+
+		notInTermSlice, hasNotIn := m[k8sv1.NodeSelectorOpNotIn]
+		var notInValuesSet map[string]struct{}
+		if hasNotIn {
+			notInValuesSet = make(map[string]struct{})
+			for _, val := range notInTermSlice[0].Values {
+				notInValuesSet[val] = struct{}{}
+			}
+		}
+
+		gtTermSlice, hasGt := m[k8sv1.NodeSelectorOpGt]
+		var gtValue int64
+		if hasGt {
+			valStr := gtTermSlice[0].Values[0]
+			val, err := strconv.ParseInt(valStr, 10, 64)
+			if err != nil {
+				return normRec{}, err
+			}
+			gtValue = val
+		}
+
+		ltTermSlice, hasLt := m[k8sv1.NodeSelectorOpLt]
+		var ltValue int64
+		if hasLt {
+			valStr := ltTermSlice[0].Values[0]
+			val, err := strconv.ParseInt(valStr, 10, 64)
+			if err != nil {
+				return normRec{}, err
+			}
+			ltValue = val
+		}
+		return normRec{
+			hasExists:       hasExists,
+			hasDoesNotExist: hasDoesNotExist,
+			hasIn:           hasIn,
+			hasNotIn:        hasNotIn,
+			hasGt:           hasGt,
+			hasLt:           hasLt,
+			inValuesSet:     InValuesSet,
+			notInValuesSet:  notInValuesSet,
+			greaterThanVal:  gtValue,
+			lessThanVal:     ltValue,
+		}, nil
+	}
+
+	// Note: This set of function require that b.has<Operator> is true otherwise the result will be incorrect
+	impliesExists := func(a normRec, _ normRec) bool {
+		// Returns true if a implies b for the Exists operator
+		return a.hasExists || a.hasIn || a.hasGt || a.hasLt
+	}
+
+	impliesDoesNotExist := func(a normRec, _ normRec) bool {
+		// Returns true if a implies b for the DoesNotExist operator
+		return a.hasDoesNotExist
+	}
+
+	impliesIn := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the In operator
+		if a.hasIn {
+			for val := range a.inValuesSet {
+				if _, exists := b.inValuesSet[val]; !exists {
+					return false
+				}
+			}
+			return true
+		}
+
+		// A Gt+Lt-bounded range can imply In if every integer the range admits
+		// (minus NotIn'd values) appears in b.inValuesSet. We verify this by
+		// counting rather than enumerating, so a wide (Gt, Lt) is cheap.
+		if a.hasGt && a.hasLt {
+			rangeCount := a.lessThanVal - a.greaterThanVal - 1
+			if rangeCount <= 0 {
+				return false // simplify should have caught this; bail out conservatively
+			}
+			for sv := range a.notInValuesSet {
+				n, err := strconv.ParseInt(sv, 10, 64)
+				if err == nil && n > a.greaterThanVal && n < a.lessThanVal {
+					rangeCount -= 1
+				}
+			}
+			var matched int64
+			for sv := range b.inValuesSet {
+				n, err := strconv.ParseInt(sv, 10, 64)
+				if err != nil || n <= a.greaterThanVal || n >= a.lessThanVal {
+					continue
+				}
+				if _, denied := a.notInValuesSet[sv]; denied {
+					continue
+				}
+				matched++
+			}
+			return matched >= rangeCount
+		}
+
+		return false
+	}
+
+	impliesNotIn := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the NotIn operator
+		if a.hasDoesNotExist {
+			return true
+		}
+
+		for val := range b.notInValuesSet {
+			if a.hasIn {
+				if _, exists := a.inValuesSet[val]; exists {
+					return false
+				}
+				continue
+			}
+
+			if a.hasNotIn {
+				if _, exists := a.notInValuesSet[val]; exists {
+					continue
+				}
+			}
+
+			if a.hasLt || a.hasGt {
+				valInt64, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					continue
+				}
+				if a.hasGt && valInt64 <= a.greaterThanVal {
+					continue
+				}
+				if a.hasLt && valInt64 >= a.lessThanVal {
+					continue
+				}
+			}
+
+			return false
+		}
+
+		return true
+	}
+
+	impliesGt := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the Gt operator
+		if a.hasDoesNotExist || !(a.hasExists || a.hasIn || a.hasGt || a.hasLt) {
+			return false
+		}
+
+		if a.hasIn {
+			for val := range a.inValuesSet {
+				valInt64, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return false
+				}
+				if valInt64 <= b.greaterThanVal {
+					return false
+				}
+			}
+			return true
+		}
+
+		if a.hasGt && a.greaterThanVal >= b.greaterThanVal {
+			return true
+		}
+
+		return false
+	}
+
+	impliesLt := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the Lt operator
+		if a.hasDoesNotExist || !(a.hasExists || a.hasIn || a.hasGt || a.hasLt) {
+			return false
+		}
+
+		if a.hasIn {
+			for val := range a.inValuesSet {
+				valInt64, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return false
+				}
+				if valInt64 >= b.lessThanVal {
+					return false
+				}
+			}
+			return true
+		}
+
+		if a.hasLt && a.lessThanVal <= b.lessThanVal {
+			return true
+		}
+
+		return false
+	}
+
+	// For each (key, operator) in reqs1, if reqs2 at (key, operator) logically implies reqs1 at (key, operator)
+	// that means that for every node that would satisfy reqs2, reqs1 is also satisfied meaning reqs2 is redundant
+	// We only have to care about the operators of reqs1 since if all the operators in reqs1 are implied than
+	// any extra bounds on reqs2 could only make the set of nodes that satisfy reqs2 smaller than reqs1
+	for key := range reqs1ByKeyOp {
+		normRec1, err := toNormRec(reqs1ByKeyOp[key])
+		if err != nil {
+			return false, err
+		}
+		normRec2, err := toNormRec(reqs2ByKeyOp[key])
+		if err != nil {
+			return false, err
+		}
+		if normRec1.hasExists {
+			if !impliesExists(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasDoesNotExist {
+			if !impliesDoesNotExist(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasIn {
+			if !impliesIn(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasNotIn {
+			if !impliesNotIn(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasGt {
+			if !impliesGt(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasLt {
+			if !impliesLt(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func pruneRedundantNodeSelectorTerms(terms []k8sv1.NodeSelectorTerm) ([]k8sv1.NodeSelectorTerm, error) {
+	// This logic cannot be better than n^2 but in all but the most pathological cases, this should be rather fast
+	type nodeSelectorTermsWithKeyset struct {
+		selector              k8sv1.NodeSelectorTerm
+		keySetMatchExpression map[string]struct{}
+		keySetMatchFields     map[string]struct{}
+	}
+
+	// For a set to be made redundant by another set with OR, it must have equal or less keys
+	// Sorting first by keyset cardinality is a small optimization by comparing each set
+	// first to sets that are more likely to able to make later constraints redundant
+	termsWithKeyset := make([]nodeSelectorTermsWithKeyset, 0, len(terms))
+	for _, term := range terms {
+		keySetMatchExpression := make(map[string]struct{})
+		keySetMatchFields := make(map[string]struct{})
+		for _, req := range term.MatchExpressions {
+			keySetMatchExpression[req.Key] = struct{}{}
+		}
+		for _, req := range term.MatchFields {
+			keySetMatchFields[req.Key] = struct{}{}
+		}
+		termsWithKeyset = append(termsWithKeyset, nodeSelectorTermsWithKeyset{
+			selector:              term,
+			keySetMatchExpression: keySetMatchExpression,
+			keySetMatchFields:     keySetMatchFields,
+		})
+	}
+	slices.SortStableFunc(termsWithKeyset, func(a nodeSelectorTermsWithKeyset, b nodeSelectorTermsWithKeyset) int {
+		return (len(a.keySetMatchExpression) + len(a.keySetMatchFields)) - (len(b.keySetMatchExpression) + len(b.keySetMatchFields))
+	})
+
+	newNodeTerms := make([]k8sv1.NodeSelectorTerm, 0)
+	for _, candidateWithKeyset := range termsWithKeyset {
+		candidateMatchExpressions := candidateWithKeyset.selector.MatchExpressions
+		candidateMatchFields := candidateWithKeyset.selector.MatchFields
+
+		canBeMadeRedundant := false
+		for _, kept := range newNodeTerms {
+			matchExpressionCanBeMadeRedundantByKept, err := nodeSelectorRequirementsCanBeMadeRedundant(kept.MatchExpressions, candidateMatchExpressions)
+			if err != nil {
+				return nil, err
+			}
+			matchFieldsCanBeMadeRedundantByKept, err := nodeSelectorRequirementsCanBeMadeRedundant(kept.MatchFields, candidateMatchFields)
+			if err != nil {
+				return nil, err
+			}
+			if matchExpressionCanBeMadeRedundantByKept && matchFieldsCanBeMadeRedundantByKept {
+				canBeMadeRedundant = true
+				break
+			}
+		}
+		if canBeMadeRedundant {
+			continue
+		}
+		// When cardinality of terms are the <= either matchExpressions/matchFields, this candidate can actually made redundant a node term from newNodeTerms
+		filteredNewNodeTerms := make([]k8sv1.NodeSelectorTerm, 0, len(newNodeTerms))
+		for _, kept := range newNodeTerms {
+			matchExpressionCanMadeRedundantKept, err := nodeSelectorRequirementsCanBeMadeRedundant(candidateMatchExpressions, kept.MatchExpressions)
+			if err != nil {
+				return nil, err
+			}
+			matchFieldsCanMadeRedundantKept, err := nodeSelectorRequirementsCanBeMadeRedundant(candidateMatchFields, kept.MatchFields)
+			if err != nil {
+				return nil, err
+			}
+			if !matchExpressionCanMadeRedundantKept || !matchFieldsCanMadeRedundantKept {
+				filteredNewNodeTerms = append(filteredNewNodeTerms, kept)
+			}
+		}
+		newNodeTerms = append(filteredNewNodeTerms, candidateWithKeyset.selector)
+	}
+
+	return newNodeTerms, nil
+}
+
+func mergeNodeSelectorTerms(terms1 []k8sv1.NodeSelectorTerm, terms2 []k8sv1.NodeSelectorTerm) ([]k8sv1.NodeSelectorTerm, error) {
+	if len(terms1)*len(terms2) > maxNodeSelectorCrossProduct {
+		return nil, fmt.Errorf("node selector cross-product would exceed %d terms (%d × %d); affinity inputs are likely pathological or incompatible", maxNodeSelectorCrossProduct, len(terms1), len(terms2))
+	}
+	newTerms := make([]k8sv1.NodeSelectorTerm, 0, max(len(terms1), len(terms2)))
+	for _, term1 := range terms1 {
+		for _, term2 := range terms2 {
+			matchExpressions, satisfiable, err := simplifyNodeSelectorRequirements(append(append([]k8sv1.NodeSelectorRequirement{}, term1.MatchExpressions...), term2.MatchExpressions...))
+			if err != nil {
+				return nil, err
+			}
+			if !satisfiable {
+				continue
+			}
+
+			matchFields, satisfiable, err := simplifyNodeSelectorRequirements(append(append([]k8sv1.NodeSelectorRequirement{}, term1.MatchFields...), term2.MatchFields...))
+			if err != nil {
+				return nil, err
+			}
+			if !satisfiable {
+				continue
+			}
+
+			newTerms = append(newTerms, k8sv1.NodeSelectorTerm{
+				MatchExpressions: matchExpressions,
+				MatchFields:      matchFields,
+			})
+		}
+	}
+	// Since nodeSelectorTerms are OR'd, only one term actually has to be satisfiable
+	// If nothing in the cross product is satisfiable we should error
+	if len(newTerms) == 0 {
+		return nil, fmt.Errorf("all merged terms are unsatisfiable for cross product")
+	}
+	return pruneRedundantNodeSelectorTerms(newTerms)
+}
+
+func mergeNestedNodeSelectorTerms(nestedTerms [][]k8sv1.NodeSelectorTerm) ([]k8sv1.NodeSelectorTerm, error) {
+	res := []k8sv1.NodeSelectorTerm{{}}
+	for _, term := range nestedTerms {
+		var err error
+		res, err = mergeNodeSelectorTerms(res, normalizeNodeSelectorTerms(term))
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(res) > maxNodeSelectorFinalTerms {
+		return nil, fmt.Errorf("merged node selector produced %d terms (limit %d); disjuncts do not subsume each other", len(res), maxNodeSelectorFinalTerms)
+	}
+	return res, nil
+}
+
+func modifyNodeAffinityToRejectLabel(origAffinity *k8sv1.Affinity, labelToReject string) *k8sv1.Affinity {
 	affinity := origAffinity.DeepCopy()
 	requirement := k8sv1.NodeSelectorRequirement{
 		Key:      labelToReject,
@@ -760,7 +1526,9 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		pod.Spec.Affinity = vmi.Spec.Affinity.DeepCopy()
 	}
 
-	setNodeAffinityForPod(vmi, &pod)
+	if err := t.setNodeAffinityForPod(vmi, &pod); err != nil {
+		return nil, err
+	}
 	if err := setPersistentReservationAntiAffinity(vmi, &pod, t.persistentVolumeClaimStore); err != nil {
 		return nil, err
 	}
@@ -1414,6 +2182,7 @@ func NewTemplateService(launcherImage string,
 	hotplugDiskDir string,
 	imagePullSecret string,
 	persistentVolumeClaimCache cache.Store,
+	persistentVolumeCache cache.Store,
 	virtClient kubecli.KubevirtClient,
 	clusterConfig *virtconfig.ClusterConfig,
 	launcherSubGid int64,
@@ -1434,6 +2203,7 @@ func NewTemplateService(launcherImage string,
 		hotplugDiskDir:              hotplugDiskDir,
 		imagePullSecret:             imagePullSecret,
 		persistentVolumeClaimStore:  persistentVolumeClaimCache,
+		persistentVolumeStore:       persistentVolumeCache,
 		virtClient:                  virtClient,
 		clusterConfig:               clusterConfig,
 		launcherSubGid:              launcherSubGid,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -120,6 +120,17 @@ const (
 	FailedToRenderLaunchManifestErrFormat = "failed to render launch manifest: %v"
 )
 
+// Safety guards for the disjunctive cross-product merge below.
+const (
+	// maxNodeSelectorCrossProduct caps the size of an intermediate cross-product
+	// before pruning. Checked in mergeNodeSelectorTerms before allocation.
+	maxNodeSelectorCrossProduct = 1000
+	// maxNodeSelectorFinalTerms caps the simplified disjunction attached to the
+	// pod. Etcd's ~1.5MB object limit is the upstream constraint; this leaves
+	// plenty of room for the rest of the pod spec.
+	maxNodeSelectorFinalTerms = 100
+)
+
 type netMemoryCalculator interface {
 	Calculate(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) resource.Quantity
 }
@@ -142,6 +153,7 @@ type TemplateService struct {
 	hotplugDiskDir             string
 	imagePullSecret            string
 	persistentVolumeClaimStore cache.Store
+	persistentVolumeStore      cache.Store
 	virtClient                 kubecli.KubevirtClient
 	clusterConfig              *virtconfig.ClusterConfig
 	launcherSubGid             int64
@@ -190,14 +202,80 @@ func setPersistentReservationAntiAffinity(vmi *v1.VirtualMachineInstance, pod *k
 	return nil
 }
 
-func setNodeAffinityForPod(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
+func (t *TemplateService) getHotpluggedPVsForVMI(vmi *v1.VirtualMachineInstance) ([]*k8sv1.PersistentVolume, error) {
+	var pvs []*k8sv1.PersistentVolume
+	if !vmi.Spec.Domain.Devices.DisableHotplug {
+		for _, volume := range vmi.Spec.Volumes {
+			// Assume (for now it's always true) that PVC name matches DV name
+			pvcName := ""
+			if volume.DataVolume != nil && volume.DataVolume.Hotpluggable {
+				pvcName = volume.DataVolume.Name
+			} else if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable {
+				pvcName = volume.PersistentVolumeClaim.ClaimName
+			}
+
+			if pvcName == "" {
+				continue
+			}
+
+			obj, exists, err := t.persistentVolumeClaimStore.GetByKey(vmi.Namespace + "/" + pvcName)
+			if err != nil {
+				return nil, err
+			}
+			if !exists {
+				// We can't tell if the PVC doesn't exist or if it's just not in the cache yet so if we don't find it here, we just skip it
+				// as there's nothing to take topology constraints from and creating the PVC after the VMI is not something we want to break
+				continue
+			}
+			pvc, ok := obj.(*k8sv1.PersistentVolumeClaim)
+			if !ok {
+				return nil, fmt.Errorf("couldn't cast object to PersistentVolumeClaim: %+v", obj)
+			}
+			// Skip unbound PVCs (WaitForFirstConsumer) as there no topology constraints to enforce yet
+			if pvc.Status.Phase != k8sv1.ClaimBound || pvc.Spec.VolumeName == "" {
+				continue
+			}
+
+			pvName := pvc.Spec.VolumeName
+			obj, exists, err = t.persistentVolumeStore.GetByKey(pvName)
+			if err != nil {
+				return nil, err
+			}
+			if !exists {
+				// On the other hand, if the PVC exists and is Bound but we can't find the PV, it's definitely a cache timing issue so we should
+				// just return an error and retry instead of skipping the PV
+				return nil, fmt.Errorf("PersistentVolume %s not found in cache", pvName)
+			}
+			pv, ok := obj.(*k8sv1.PersistentVolume)
+			if !ok {
+				return nil, fmt.Errorf("couldn't cast object to PersistentVolume: %+v", obj)
+			}
+			pvs = append(pvs, pv)
+		}
+	}
+	return pvs, nil
+}
+
+func (t *TemplateService) setNodeAffinityForPod(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) error {
 	setNodeAffinityForHostModelCpuModel(vmi, pod)
 	setNodeAffinityForbiddenFeaturePolicy(vmi, pod)
+
+	hotpluggedVolumes, err := t.getHotpluggedPVsForVMI(vmi)
+	if err != nil {
+		return err
+	}
+
+	if len(hotpluggedVolumes) > 0 {
+		if err := t.setNodeAffinityForHotpluggedVolumeTopology(hotpluggedVolumes, pod); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func setNodeAffinityForHostModelCpuModel(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel {
-		pod.Spec.Affinity = modifyNodeAffintyToRejectLabel(pod.Spec.Affinity, v1.NodeHostModelIsObsoleteLabel)
+		pod.Spec.Affinity = modifyNodeAffinityToRejectLabel(pod.Spec.Affinity, v1.NodeHostModelIsObsoleteLabel)
 	}
 }
 
@@ -208,12 +286,700 @@ func setNodeAffinityForbiddenFeaturePolicy(vmi *v1.VirtualMachineInstance, pod *
 
 	for _, feature := range vmi.Spec.Domain.CPU.Features {
 		if feature.Policy == "forbid" {
-			pod.Spec.Affinity = modifyNodeAffintyToRejectLabel(pod.Spec.Affinity, v1.CPUFeatureLabel+feature.Name)
+			pod.Spec.Affinity = modifyNodeAffinityToRejectLabel(pod.Spec.Affinity, v1.CPUFeatureLabel+feature.Name)
 		}
 	}
 }
 
-func modifyNodeAffintyToRejectLabel(origAffinity *k8sv1.Affinity, labelToReject string) *k8sv1.Affinity {
+func (t *TemplateService) setNodeAffinityForHotpluggedVolumeTopology(hotpluggedVolumes []*k8sv1.PersistentVolume, pod *k8sv1.Pod) error {
+	var requiredNodeSelectorTerms [][]k8sv1.NodeSelectorTerm
+	for _, vol := range hotpluggedVolumes {
+		if vol.Spec.NodeAffinity != nil && vol.Spec.NodeAffinity.Required != nil && len(vol.Spec.NodeAffinity.Required.NodeSelectorTerms) > 0 {
+			requiredNodeSelectorTerms = append(requiredNodeSelectorTerms, vol.Spec.NodeAffinity.Required.NodeSelectorTerms)
+		}
+	}
+
+	if len(requiredNodeSelectorTerms) == 0 {
+		return nil
+	}
+
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &k8sv1.Affinity{}
+	}
+	podAffinity := pod.Spec.Affinity
+
+	if podAffinity.NodeAffinity == nil {
+		podAffinity.NodeAffinity = &k8sv1.NodeAffinity{}
+	}
+	nodeAffinity := podAffinity.NodeAffinity
+
+	if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &k8sv1.NodeSelector{}
+	}
+	required := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+
+	if len(required.NodeSelectorTerms) != 0 {
+		requiredNodeSelectorTerms = append(requiredNodeSelectorTerms, required.NodeSelectorTerms)
+	}
+
+	mergedNodeSelectorTerms, err := mergeNestedNodeSelectorTerms(slices.Clone(requiredNodeSelectorTerms))
+	if err != nil {
+		return err
+	}
+	required.NodeSelectorTerms = mergedNodeSelectorTerms
+	return nil
+}
+
+// Clones term and sorts In/NotIn for easy pruning of duplicate terms
+func normalizeNodeSelectorTerms(term []k8sv1.NodeSelectorTerm) []k8sv1.NodeSelectorTerm {
+	res := make([]k8sv1.NodeSelectorTerm, 0, len(term))
+	for _, selector := range term {
+		matchExpression := make([]k8sv1.NodeSelectorRequirement, 0, len(selector.MatchExpressions))
+		for _, expr := range selector.MatchExpressions {
+			if expr.Operator == k8sv1.NodeSelectorOpIn || expr.Operator == k8sv1.NodeSelectorOpNotIn {
+				expr.Values = slices.Sorted(slices.Values(expr.Values))
+			}
+			matchExpression = append(matchExpression, expr)
+		}
+		matchFields := make([]k8sv1.NodeSelectorRequirement, 0, len(selector.MatchFields))
+		for _, expr := range selector.MatchFields {
+			if expr.Operator == k8sv1.NodeSelectorOpIn || expr.Operator == k8sv1.NodeSelectorOpNotIn {
+				expr.Values = slices.Sorted(slices.Values(expr.Values))
+			}
+			matchFields = append(matchFields, expr)
+		}
+		res = append(res, k8sv1.NodeSelectorTerm{
+			MatchExpressions: matchExpression,
+			MatchFields:      matchFields,
+		})
+	}
+	return res
+}
+
+func nodeSelectorRequirementByKeyAndOperator(reqs []k8sv1.NodeSelectorRequirement) map[string]map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement {
+	res := make(map[string]map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement)
+	for _, req := range reqs {
+		if _, exists := res[req.Key]; !exists {
+			res[req.Key] = make(map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement)
+		}
+		if _, exists := res[req.Key][req.Operator]; !exists {
+			res[req.Key][req.Operator] = make([]k8sv1.NodeSelectorRequirement, 0)
+		}
+		res[req.Key][req.Operator] = append(res[req.Key][req.Operator], req)
+	}
+	return res
+}
+
+// Assume terms are normalized already and simplify. At worst returns unique keys * 4 terms
+func simplifyNodeSelectorRequirements(reqs []k8sv1.NodeSelectorRequirement) ([]k8sv1.NodeSelectorRequirement, bool, error) {
+	stringsToSet := func(vals []string) map[string]struct{} {
+		res := make(map[string]struct{})
+		for _, val := range vals {
+			res[val] = struct{}{}
+		}
+		return res
+	}
+
+	newTerms := make([]k8sv1.NodeSelectorRequirement, 0)
+	byKeyAndOp := nodeSelectorRequirementByKeyAndOperator(reqs)
+	keys := slices.Sorted(maps.Keys(byKeyAndOp))
+	for _, key := range keys {
+		ops := byKeyAndOp[key]
+		// inValues are the intersection of all matches
+		var inValues map[string]struct{} = nil
+		inReqs, mustBeIn := ops[k8sv1.NodeSelectorOpIn]
+		for idx, req := range inReqs {
+			valsSet := stringsToSet(req.Values)
+			if idx == 0 {
+				inValues = valsSet
+				continue
+			}
+			for val := range inValues {
+				if _, exists := valsSet[val]; !exists {
+					delete(inValues, val)
+				}
+			}
+			if len(inValues) == 0 {
+				break
+			}
+		}
+
+		// notInValues are the union of all matches
+		var notInValues map[string]struct{} = make(map[string]struct{})
+		notInReqs, mustNotBeIn := ops[k8sv1.NodeSelectorOpNotIn]
+		for _, req := range notInReqs {
+			for _, val := range req.Values {
+				notInValues[val] = struct{}{}
+				delete(inValues, val)
+			}
+		}
+
+		// greater than the greatest term
+		var greaterThanValue int64 = 0
+		gtReqs, mustBeGreaterThan := ops[k8sv1.NodeSelectorOpGt]
+		for idx, req := range gtReqs {
+			if len(req.Values) == 0 {
+				return nil, false, fmt.Errorf("Gt requirement on key %q has no value", key)
+			}
+			val, err := strconv.ParseInt(req.Values[0], 10, 64)
+			if err != nil {
+				return nil, false, err
+			}
+			if idx == 0 {
+				greaterThanValue = val
+				continue
+			}
+			if val > greaterThanValue {
+				greaterThanValue = val
+			}
+		}
+		// If In and Gt are on the the same key, we can further simplify In
+		// This would likely be a bug in the user affinity
+		if mustBeGreaterThan && mustBeIn {
+			for val := range inValues {
+				valAsInt, err := strconv.ParseInt(val, 10, 64)
+				// K8S will drop non-integer constraints when Gt is applied
+				if err != nil || valAsInt <= greaterThanValue {
+					delete(inValues, val)
+				}
+			}
+		}
+
+		// less than the least term
+		var lessThanValue int64 = 0
+		ltReqs, mustBeLessThan := ops[k8sv1.NodeSelectorOpLt]
+		for idx, req := range ltReqs {
+			if len(req.Values) == 0 {
+				return nil, false, fmt.Errorf("Lt requirement on key %q has no value", key)
+			}
+			val, err := strconv.ParseInt(req.Values[0], 10, 64)
+			if err != nil {
+				return nil, false, err
+			}
+			if idx == 0 {
+				lessThanValue = val
+				continue
+			}
+			if val < lessThanValue {
+				lessThanValue = val
+			}
+		}
+		// If In and Lt are on the the same key, we can further simplify In
+		// This would likely be a bug in the user affinity
+		if mustBeLessThan && mustBeIn {
+			for val := range inValues {
+				valAsInt, err := strconv.ParseInt(val, 10, 64)
+				// K8S will drop non-integer constraints when Lt is applied
+				if err != nil || valAsInt >= lessThanValue {
+					delete(inValues, val)
+				}
+			}
+		}
+
+		// After all possible pruning of inValues, assert there is anything left
+		if mustBeIn && len(inValues) == 0 {
+			return nil, false, nil
+		}
+
+		// Assert that Lt and Gt constraints are satisfiable together
+		if mustBeLessThan && mustBeGreaterThan && lessThanValue <= greaterThanValue+1 {
+			return nil, false, nil
+		}
+
+		// At this point since In values are canonical (they encode NotIn/Gt/Lt) and are satisfiable
+		// we can just drop NotIn/Gt/Lt
+		if mustBeIn {
+			mustNotBeIn = false
+			mustBeGreaterThan = false
+			mustBeLessThan = false
+		}
+
+		// In/Gt/Lt imply Exists so we don't need an explicit selector
+		_, hasExists := ops[k8sv1.NodeSelectorOpExists]
+		mustExist := hasExists && !mustBeGreaterThan && !mustBeLessThan && !mustBeIn
+
+		// Nothing implies DoesNotExist
+		_, mustNotExist := ops[k8sv1.NodeSelectorOpDoesNotExist]
+
+		// All the other selectors other than mustNotBeIn need to be false for this to be satisfiable
+		if mustNotExist && (mustExist || mustBeLessThan || mustBeGreaterThan || mustBeIn) {
+			return nil, false, nil
+		}
+
+		// Always canonize in order of In/NotIn/Gt/Lt/Exists/DoesNotExist and sort values
+		if mustBeIn {
+			vals := slices.Sorted(maps.Keys(inValues))
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpIn,
+				Values:   vals,
+			})
+		}
+
+		if mustNotBeIn {
+			vals := slices.Sorted(maps.Keys(notInValues))
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpNotIn,
+				Values:   vals,
+			})
+		}
+
+		if mustBeGreaterThan {
+			val := strconv.FormatInt(greaterThanValue, 10)
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpGt,
+				Values:   []string{val},
+			})
+		}
+
+		if mustBeLessThan {
+			val := strconv.FormatInt(lessThanValue, 10)
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpLt,
+				Values:   []string{val},
+			})
+		}
+
+		if mustExist {
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpExists,
+			})
+		}
+
+		if mustNotExist {
+			newTerms = append(newTerms, k8sv1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: k8sv1.NodeSelectorOpDoesNotExist,
+			})
+		}
+	}
+
+	return newTerms, true, nil
+}
+
+func nodeSelectorRequirementsCanBeMadeRedundant(reqs1 []k8sv1.NodeSelectorRequirement, reqs2 []k8sv1.NodeSelectorRequirement) (bool, error) {
+	reqs1ByKeyOp := nodeSelectorRequirementByKeyAndOperator(reqs1)
+	reqs2ByKeyOp := nodeSelectorRequirementByKeyAndOperator(reqs2)
+	// If reqs1 is stricter (has more keys) then reqs2, it cannot made it redundant
+	if len(reqs1ByKeyOp) > len(reqs2ByKeyOp) {
+		return false, nil
+	}
+	// All keys in reqs1 must be in reqs2
+	for key := range reqs1ByKeyOp {
+		if _, exists := reqs2ByKeyOp[key]; !exists {
+			return false, nil
+		}
+	}
+	// Validate that we have reqs in canonical form
+	for key := range reqs1ByKeyOp {
+		for op, term := range reqs1ByKeyOp[key] {
+			if len(term) > 1 {
+				return false, fmt.Errorf("Received denormalized node selector terms for %v", op)
+			}
+		}
+	}
+	for key := range reqs2ByKeyOp {
+		for op, term := range reqs2ByKeyOp[key] {
+			if len(term) > 1 {
+				return false, fmt.Errorf("Received denormalized node selector terms for %v", op)
+			}
+		}
+	}
+
+	type normRec struct {
+		hasExists       bool
+		hasDoesNotExist bool
+		hasIn           bool
+		hasNotIn        bool
+		hasGt           bool
+		hasLt           bool
+		greaterThanVal  int64
+		lessThanVal     int64
+		inValuesSet     map[string]struct{}
+		notInValuesSet  map[string]struct{}
+	}
+
+	toNormRec := func(m map[k8sv1.NodeSelectorOperator][]k8sv1.NodeSelectorRequirement) (normRec, error) {
+		_, hasExists := m[k8sv1.NodeSelectorOpExists]
+		_, hasDoesNotExist := m[k8sv1.NodeSelectorOpDoesNotExist]
+
+		inTermSlice, hasIn := m[k8sv1.NodeSelectorOpIn]
+		var InValuesSet map[string]struct{}
+		if hasIn {
+			InValuesSet = make(map[string]struct{})
+			for _, val := range inTermSlice[0].Values {
+				InValuesSet[val] = struct{}{}
+			}
+		}
+
+		notInTermSlice, hasNotIn := m[k8sv1.NodeSelectorOpNotIn]
+		var notInValuesSet map[string]struct{}
+		if hasNotIn {
+			notInValuesSet = make(map[string]struct{})
+			for _, val := range notInTermSlice[0].Values {
+				notInValuesSet[val] = struct{}{}
+			}
+		}
+
+		gtTermSlice, hasGt := m[k8sv1.NodeSelectorOpGt]
+		var gtValue int64
+		if hasGt {
+			valStr := gtTermSlice[0].Values[0]
+			val, err := strconv.ParseInt(valStr, 10, 64)
+			if err != nil {
+				return normRec{}, err
+			}
+			gtValue = val
+		}
+
+		ltTermSlice, hasLt := m[k8sv1.NodeSelectorOpLt]
+		var ltValue int64
+		if hasLt {
+			valStr := ltTermSlice[0].Values[0]
+			val, err := strconv.ParseInt(valStr, 10, 64)
+			if err != nil {
+				return normRec{}, err
+			}
+			ltValue = val
+		}
+		return normRec{
+			hasExists:       hasExists,
+			hasDoesNotExist: hasDoesNotExist,
+			hasIn:           hasIn,
+			hasNotIn:        hasNotIn,
+			hasGt:           hasGt,
+			hasLt:           hasLt,
+			inValuesSet:     InValuesSet,
+			notInValuesSet:  notInValuesSet,
+			greaterThanVal:  gtValue,
+			lessThanVal:     ltValue,
+		}, nil
+	}
+
+	// Note: This set of function require that b.has<Operator> is true otherwise the result will be incorrect
+	impliesExists := func(a normRec, _ normRec) bool {
+		// Returns true if a implies b for the Exists operator
+		return a.hasExists || a.hasIn || a.hasGt || a.hasLt
+	}
+
+	impliesDoesNotExist := func(a normRec, _ normRec) bool {
+		// Returns true if a implies b for the DoesNotExist operator
+		return a.hasDoesNotExist
+	}
+
+	impliesIn := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the In operator
+		if a.hasIn {
+			for val := range a.inValuesSet {
+				if _, exists := b.inValuesSet[val]; !exists {
+					return false
+				}
+			}
+			return true
+		}
+
+		// A Gt+Lt-bounded range can imply In if every integer the range admits
+		// (minus NotIn'd values) appears in b.inValuesSet. We verify this by
+		// counting rather than enumerating, so a wide (Gt, Lt) is cheap.
+		if a.hasGt && a.hasLt {
+			rangeCount := a.lessThanVal - a.greaterThanVal - 1
+			if rangeCount <= 0 {
+				return false // simplify should have caught this; bail out conservatively
+			}
+			for sv := range a.notInValuesSet {
+				n, err := strconv.ParseInt(sv, 10, 64)
+				if err == nil && n > a.greaterThanVal && n < a.lessThanVal {
+					rangeCount -= 1
+				}
+			}
+			var matched int64
+			for sv := range b.inValuesSet {
+				n, err := strconv.ParseInt(sv, 10, 64)
+				if err != nil || n <= a.greaterThanVal || n >= a.lessThanVal {
+					continue
+				}
+				if _, denied := a.notInValuesSet[sv]; denied {
+					continue
+				}
+				matched++
+			}
+			return matched >= rangeCount
+		}
+
+		return false
+	}
+
+	impliesNotIn := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the NotIn operator
+		if a.hasDoesNotExist {
+			return true
+		}
+
+		for val := range b.notInValuesSet {
+			if a.hasIn {
+				if _, exists := a.inValuesSet[val]; exists {
+					return false
+				}
+				continue
+			}
+
+			if a.hasNotIn {
+				if _, exists := a.notInValuesSet[val]; exists {
+					continue
+				}
+			}
+
+			if a.hasLt || a.hasGt {
+				valInt64, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					continue
+				}
+				if a.hasGt && valInt64 <= a.greaterThanVal {
+					continue
+				}
+				if a.hasLt && valInt64 >= a.lessThanVal {
+					continue
+				}
+			}
+
+			return false
+		}
+
+		return true
+	}
+
+	impliesGt := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the Gt operator
+		if a.hasDoesNotExist || !(a.hasExists || a.hasIn || a.hasGt || a.hasLt) {
+			return false
+		}
+
+		if a.hasIn {
+			for val := range a.inValuesSet {
+				valInt64, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return false
+				}
+				if valInt64 <= b.greaterThanVal {
+					return false
+				}
+			}
+			return true
+		}
+
+		if a.hasGt && a.greaterThanVal >= b.greaterThanVal {
+			return true
+		}
+
+		return false
+	}
+
+	impliesLt := func(a normRec, b normRec) bool {
+		// Returns true if a implies b for the Lt operator
+		if a.hasDoesNotExist || !(a.hasExists || a.hasIn || a.hasGt || a.hasLt) {
+			return false
+		}
+
+		if a.hasIn {
+			for val := range a.inValuesSet {
+				valInt64, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return false
+				}
+				if valInt64 >= b.lessThanVal {
+					return false
+				}
+			}
+			return true
+		}
+
+		if a.hasLt && a.lessThanVal <= b.lessThanVal {
+			return true
+		}
+
+		return false
+	}
+
+	// For each (key, operator) in reqs1, if reqs2 at (key, operator) logically implies reqs1 at (key, operator)
+	// that means that for every node that would satisfy reqs2, reqs1 is also satisfied meaning reqs2 is redundant
+	// We only have to care about the operators of reqs1 since if all the operators in reqs1 are implied than
+	// any extra bounds on reqs2 could only make the set of nodes that satisfy reqs2 smaller than reqs1
+	for key := range reqs1ByKeyOp {
+		normRec1, err := toNormRec(reqs1ByKeyOp[key])
+		if err != nil {
+			return false, err
+		}
+		normRec2, err := toNormRec(reqs2ByKeyOp[key])
+		if err != nil {
+			return false, err
+		}
+		if normRec1.hasExists {
+			if !impliesExists(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasDoesNotExist {
+			if !impliesDoesNotExist(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasIn {
+			if !impliesIn(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasNotIn {
+			if !impliesNotIn(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasGt {
+			if !impliesGt(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+		if normRec1.hasLt {
+			if !impliesLt(normRec2, normRec1) {
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func pruneRedundantNodeSelectorTerms(terms []k8sv1.NodeSelectorTerm) ([]k8sv1.NodeSelectorTerm, error) {
+	// This logic cannot be better than n^2 but in all but the most pathological cases, this should be rather fast
+	type nodeSelectorTermsWithKeyset struct {
+		selector              k8sv1.NodeSelectorTerm
+		keySetMatchExpression map[string]struct{}
+		keySetMatchFields     map[string]struct{}
+	}
+
+	// For a set to be made redundant by another set with OR, it must have equal or less keys
+	// Sorting first by keyset cardinality is a small optimization by comparing each set
+	// first to sets that are more likely to able to make later constraints redundant
+	termsWithKeyset := make([]nodeSelectorTermsWithKeyset, 0, len(terms))
+	for _, term := range terms {
+		keySetMatchExpression := make(map[string]struct{})
+		keySetMatchFields := make(map[string]struct{})
+		for _, req := range term.MatchExpressions {
+			keySetMatchExpression[req.Key] = struct{}{}
+		}
+		for _, req := range term.MatchFields {
+			keySetMatchFields[req.Key] = struct{}{}
+		}
+		termsWithKeyset = append(termsWithKeyset, nodeSelectorTermsWithKeyset{
+			selector:              term,
+			keySetMatchExpression: keySetMatchExpression,
+			keySetMatchFields:     keySetMatchFields,
+		})
+	}
+	slices.SortStableFunc(termsWithKeyset, func(a nodeSelectorTermsWithKeyset, b nodeSelectorTermsWithKeyset) int {
+		return (len(a.keySetMatchExpression) + len(a.keySetMatchFields)) - (len(b.keySetMatchExpression) + len(b.keySetMatchFields))
+	})
+
+	newNodeTerms := make([]k8sv1.NodeSelectorTerm, 0)
+	for _, candidateWithKeyset := range termsWithKeyset {
+		candidateMatchExpressions := candidateWithKeyset.selector.MatchExpressions
+		candidateMatchFields := candidateWithKeyset.selector.MatchFields
+
+		canBeMadeRedundant := false
+		for _, kept := range newNodeTerms {
+			matchExpressionCanBeMadeRedundantByKept, err := nodeSelectorRequirementsCanBeMadeRedundant(kept.MatchExpressions, candidateMatchExpressions)
+			if err != nil {
+				return nil, err
+			}
+			matchFieldsCanBeMadeRedundantByKept, err := nodeSelectorRequirementsCanBeMadeRedundant(kept.MatchFields, candidateMatchFields)
+			if err != nil {
+				return nil, err
+			}
+			if matchExpressionCanBeMadeRedundantByKept && matchFieldsCanBeMadeRedundantByKept {
+				canBeMadeRedundant = true
+				break
+			}
+		}
+		if canBeMadeRedundant {
+			continue
+		}
+		// When cardinality of terms are the <= either matchExpressions/matchFields, this candidate can actually made redundant a node term from newNodeTerms
+		filteredNewNodeTerms := make([]k8sv1.NodeSelectorTerm, 0, len(newNodeTerms))
+		for _, kept := range newNodeTerms {
+			matchExpressionCanMadeRedundantKept, err := nodeSelectorRequirementsCanBeMadeRedundant(candidateMatchExpressions, kept.MatchExpressions)
+			if err != nil {
+				return nil, err
+			}
+			matchFieldsCanMadeRedundantKept, err := nodeSelectorRequirementsCanBeMadeRedundant(candidateMatchFields, kept.MatchFields)
+			if err != nil {
+				return nil, err
+			}
+			if !matchExpressionCanMadeRedundantKept || !matchFieldsCanMadeRedundantKept {
+				filteredNewNodeTerms = append(filteredNewNodeTerms, kept)
+			}
+		}
+		newNodeTerms = append(filteredNewNodeTerms, candidateWithKeyset.selector)
+	}
+
+	return newNodeTerms, nil
+}
+
+func mergeNodeSelectorTerms(terms1 []k8sv1.NodeSelectorTerm, terms2 []k8sv1.NodeSelectorTerm) ([]k8sv1.NodeSelectorTerm, error) {
+	if len(terms1)*len(terms2) > maxNodeSelectorCrossProduct {
+		return nil, fmt.Errorf("node selector cross-product would exceed %d terms (%d × %d); affinity inputs are likely pathological or incompatible", maxNodeSelectorCrossProduct, len(terms1), len(terms2))
+	}
+	newTerms := make([]k8sv1.NodeSelectorTerm, 0, max(len(terms1), len(terms2)))
+	for _, term1 := range terms1 {
+		for _, term2 := range terms2 {
+			matchExpressions, satisfiable, err := simplifyNodeSelectorRequirements(append(append([]k8sv1.NodeSelectorRequirement{}, term1.MatchExpressions...), term2.MatchExpressions...))
+			if err != nil {
+				return nil, err
+			}
+			if !satisfiable {
+				continue
+			}
+
+			matchFields, satisfiable, err := simplifyNodeSelectorRequirements(append(append([]k8sv1.NodeSelectorRequirement{}, term1.MatchFields...), term2.MatchFields...))
+			if err != nil {
+				return nil, err
+			}
+			if !satisfiable {
+				continue
+			}
+
+			newTerms = append(newTerms, k8sv1.NodeSelectorTerm{
+				MatchExpressions: matchExpressions,
+				MatchFields:      matchFields,
+			})
+		}
+	}
+	// Since nodeSelectorTerms are OR'd, only one term actually has to be satisfiable
+	// If nothing in the cross product is satisfiable we should error
+	if len(newTerms) == 0 {
+		return nil, fmt.Errorf("all merged terms are unsatisfiable for cross product")
+	}
+	return pruneRedundantNodeSelectorTerms(newTerms)
+}
+
+func mergeNestedNodeSelectorTerms(nestedTerms [][]k8sv1.NodeSelectorTerm) ([]k8sv1.NodeSelectorTerm, error) {
+	res := []k8sv1.NodeSelectorTerm{{}}
+	for _, term := range nestedTerms {
+		var err error
+		res, err = mergeNodeSelectorTerms(res, normalizeNodeSelectorTerms(term))
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(res) > maxNodeSelectorFinalTerms {
+		return nil, fmt.Errorf("merged node selector produced %d terms (limit %d); disjuncts do not subsume each other", len(res), maxNodeSelectorFinalTerms)
+	}
+	return res, nil
+}
+
+func modifyNodeAffinityToRejectLabel(origAffinity *k8sv1.Affinity, labelToReject string) *k8sv1.Affinity {
 	affinity := origAffinity.DeepCopy()
 	requirement := k8sv1.NodeSelectorRequirement{
 		Key:      labelToReject,
@@ -727,7 +1493,9 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		pod.Spec.Affinity = vmi.Spec.Affinity.DeepCopy()
 	}
 
-	setNodeAffinityForPod(vmi, &pod)
+	if err := t.setNodeAffinityForPod(vmi, &pod); err != nil {
+		return nil, err
+	}
 	if err := setPersistentReservationAntiAffinity(vmi, &pod, t.persistentVolumeClaimStore); err != nil {
 		return nil, err
 	}
@@ -1343,6 +2111,7 @@ func NewTemplateService(launcherImage string,
 	hotplugDiskDir string,
 	imagePullSecret string,
 	persistentVolumeClaimCache cache.Store,
+	persistentVolumeCache cache.Store,
 	virtClient kubecli.KubevirtClient,
 	clusterConfig *virtconfig.ClusterConfig,
 	launcherSubGid int64,
@@ -1363,6 +2132,7 @@ func NewTemplateService(launcherImage string,
 		hotplugDiskDir:              hotplugDiskDir,
 		imagePullSecret:             imagePullSecret,
 		persistentVolumeClaimStore:  persistentVolumeClaimCache,
+		persistentVolumeStore:       persistentVolumeCache,
 		virtClient:                  virtClient,
 		clusterConfig:               clusterConfig,
 		launcherSubGid:              launcherSubGid,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Template", func() {
 	var defaultArch = "amd64"
 
 	pvcCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+	pvCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
 	var svc *TemplateService
 
 	var ctrl *gomock.Controller
@@ -137,6 +138,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -2189,6 +2191,904 @@ var _ = Describe("Template", func() {
 				Entry("empty string should be treated as host-model", ""),
 				Entry("nil should be treated as host-model", nil),
 			)
+			Context("when hotplugged volumes are present", func() {
+				AfterEach(func() {
+					for _, ns := range pvcCache.List() {
+						err := pvcCache.Delete(ns)
+						Expect(err).ToNot(HaveOccurred())
+					}
+					for _, ns := range pvCache.List() {
+						err := pvCache.Delete(ns)
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
+
+				It("should add not add node affinities to pod if PVC WFFC", func() {
+					config, kvStore, svc = configFactory(defaultArch)
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimPending,
+						},
+					}
+					err := pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest since PVC is not bound")
+				})
+
+				It("should add node affinities to pod if PVC Bound with affinities", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					// PVC 1 will have an affinity for one node
+					pvc1Name := "pvc-affinities"
+					pv1Name := "pv-affinities"
+					node1Name := "test-node-0"
+					pvc1 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc1Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv1Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc1)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv1 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv1Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{node1Name},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv1)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+					// PVC 2 will have an affinity for one node
+					pvc2Name := "pvc-affinities-2"
+					pv2Name := "pv-affinities-2"
+					allNodeNames := []string{"test-node-0", "test-node-1", "test-node-2"}
+					pvc2 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc2Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv2Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc2)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv2 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv2Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   allNodeNames,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv2)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumesSingleNodeAffinity := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc1Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					volumesMultiNodeAffinity := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc2Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmiSingleNodeAffinity := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesSingleNodeAffinity, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+					vmiMultiNodeAffinity := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesMultiNodeAffinity, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmiSingleNodeAffinity)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{node1Name},
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+
+					pod, err = svc.RenderLaunchManifest(&vmiMultiNodeAffinity)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms = pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   allNodeNames,
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+				})
+
+				It("should pass kubernetes.io/hostname terms through unchanged", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					pvcName := "pvc-hostname"
+					pvName := "pv-hostname"
+					nodeName := "test-node-0"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "kubernetes.io/hostname",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{nodeName},
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+				})
+
+				It("should keep existing node affinities on VMI", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvName := "pv-affinities"
+					nodeName := "test-node-0"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					originalMatchFields := []k8sv1.NodeSelectorRequirement{
+						{
+							Key:      "metadata.name",
+							Operator: k8sv1.NodeSelectorOpIn,
+							Values:   []string{"test-node-0", "test-node-1", "test-node-2"},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{
+							Volumes: volumes,
+							Domain: v1.DomainSpec{
+								Devices: v1.Devices{
+									DisableHotplug: false,
+									Disks:          disks,
+								},
+								CPU: &v1.CPU{
+									Model: "Conroe",
+								},
+							},
+							Affinity: &k8sv1.Affinity{
+								NodeAffinity: &k8sv1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+										NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+											{
+												MatchFields: originalMatchFields,
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{nodeName},
+							},
+						},
+						MatchFields: originalMatchFields,
+					}))
+				})
+
+				It("should not add node affinities to pod if PVC Bound with no affinities", func() {
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvName := "pv-affinities"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err := pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest since hotplugged PVC has no node affinities")
+				})
+
+				It("should not set affinity if PVCs are not hotplugged", func() {
+					config, kvStore, svc = configFactory(defaultArch)
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvName := "pv-affinities"
+					nodeName := "test-node-0"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err := pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumesWithHotplug := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					volumesNoHotplug := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+
+					vmiHotplugEnableNoVolumes := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesNoHotplug, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					vmiHotplugDisableWithVolumes := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi2", Namespace: namespace, UID: "12345",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesWithHotplug, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: true,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmiHotplugEnableNoVolumes)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest no hotplugged volumes")
+
+					pod, err = svc.RenderLaunchManifest(&vmiHotplugDisableWithVolumes)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest since hotplug is disabled")
+				})
+
+				It("should set affinity to intersection of multiple PVs or error if scheduling is impossible", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+					namespace := "testns"
+					// PVC 1 will be schedulable on test-node-0 and test-node-1
+					pvc1Name := "pvc-affinities-1"
+					pv1Name := "pv-affinities-1"
+					pvc1 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc1Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv1Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc1)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv1 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv1Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{"test-node-0", "test-node-1"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv1)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					// PVC 2 will be schedulable on test-node-1 and test-node-2
+					pvc2Name := "pvc-affinities-2"
+					pv2Name := "pv-affinities-2"
+					pvc2 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc2Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv2Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc2)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv2 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv2Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{"test-node-1", "test-node-2"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv2)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					// PVC 3 will be schedulable only on test-node-3
+					pvc3Name := "pvc-affinities-3"
+					pv3Name := "pv-affinities-3"
+					pvc3 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc3Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv3Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc3)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv3 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv3Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{"test-node-2"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv3)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volume1Name := "pvc-volume"
+					volume2Name := "pvc-volume-2"
+					volume3Name := "pvc-volume-3"
+					volumesWithIntersection := []v1.Volume{
+						{
+							Name: volume1Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc1Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+						{
+							Name: volume2Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc2Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disksWithIntersection := []v1.Disk{
+						{
+							Name: volume1Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+						{
+							Name: volume2Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					volumesWithNoIntersection := []v1.Volume{
+						{
+							Name: volume1Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc1Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+						{
+							Name: volume3Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc3Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disksWithNoIntersection := []v1.Disk{
+						{
+							Name: volume1Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+						{
+							Name: volume3Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+
+					schedulableVMI := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesWithIntersection, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								Disks: disksWithIntersection,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					unschedulableVMI := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesWithNoIntersection, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								Disks: disksWithNoIntersection,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&schedulableVMI)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{"test-node-1"},
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+
+					pod, err = svc.RenderLaunchManifest(&unschedulableVMI)
+					Expect(err).To(HaveOccurred(), "Expected error since no node can satisfy both PVs")
+				})
+			})
 		})
 		Context("with cpu and memory constraints", func() {
 			DescribeTable("should add cpu and memory constraints to a template", func(arch string, requestMemory string, limitMemory string) {
@@ -3226,6 +4126,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6091,6 +6992,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6161,6 +7063,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6190,6 +7093,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6250,6 +7154,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6291,6 +7196,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6329,6 +7235,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6363,6 +7270,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Template", func() {
 	var defaultArch = "amd64"
 
 	pvcCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+	pvCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
 	var svc *TemplateService
 
 	var ctrl *gomock.Controller
@@ -137,6 +138,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -2135,6 +2137,904 @@ var _ = Describe("Template", func() {
 				Entry("empty string should be treated as host-model", ""),
 				Entry("nil should be treated as host-model", nil),
 			)
+			Context("when hotplugged volumes are present", func() {
+				AfterEach(func() {
+					for _, ns := range pvcCache.List() {
+						err := pvcCache.Delete(ns)
+						Expect(err).ToNot(HaveOccurred())
+					}
+					for _, ns := range pvCache.List() {
+						err := pvCache.Delete(ns)
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
+
+				It("should add not add node affinities to pod if PVC WFFC", func() {
+					config, kvStore, svc = configFactory(defaultArch)
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimPending,
+						},
+					}
+					err := pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest since PVC is not bound")
+				})
+
+				It("should add node affinities to pod if PVC Bound with affinities", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					// PVC 1 will have an affinity for one node
+					pvc1Name := "pvc-affinities"
+					pv1Name := "pv-affinities"
+					node1Name := "test-node-0"
+					pvc1 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc1Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv1Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc1)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv1 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv1Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{node1Name},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv1)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+					// PVC 2 will have an affinity for one node
+					pvc2Name := "pvc-affinities-2"
+					pv2Name := "pv-affinities-2"
+					allNodeNames := []string{"test-node-0", "test-node-1", "test-node-2"}
+					pvc2 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc2Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv2Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc2)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv2 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv2Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   allNodeNames,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv2)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumesSingleNodeAffinity := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc1Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					volumesMultiNodeAffinity := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc2Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmiSingleNodeAffinity := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesSingleNodeAffinity, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+					vmiMultiNodeAffinity := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesMultiNodeAffinity, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmiSingleNodeAffinity)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{node1Name},
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+
+					pod, err = svc.RenderLaunchManifest(&vmiMultiNodeAffinity)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms = pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   allNodeNames,
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+				})
+
+				It("should pass kubernetes.io/hostname terms through unchanged", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					pvcName := "pvc-hostname"
+					pvName := "pv-hostname"
+					nodeName := "test-node-0"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "kubernetes.io/hostname",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{nodeName},
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+				})
+
+				It("should keep existing node affinities on VMI", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvName := "pv-affinities"
+					nodeName := "test-node-0"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					originalMatchFields := []k8sv1.NodeSelectorRequirement{
+						{
+							Key:      "metadata.name",
+							Operator: k8sv1.NodeSelectorOpIn,
+							Values:   []string{"test-node-0", "test-node-1", "test-node-2"},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{
+							Volumes: volumes,
+							Domain: v1.DomainSpec{
+								Devices: v1.Devices{
+									DisableHotplug: false,
+									Disks:          disks,
+								},
+								CPU: &v1.CPU{
+									Model: "Conroe",
+								},
+							},
+							Affinity: &k8sv1.Affinity{
+								NodeAffinity: &k8sv1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+										NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+											{
+												MatchFields: originalMatchFields,
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{nodeName},
+							},
+						},
+						MatchFields: originalMatchFields,
+					}))
+				})
+
+				It("should not add node affinities to pod if PVC Bound with no affinities", func() {
+					config, kvStore, svc = configFactory(defaultArch)
+
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvName := "pv-affinities"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err := pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumes := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest since hotplugged PVC has no node affinities")
+				})
+
+				It("should not set affinity if PVCs are not hotplugged", func() {
+					config, kvStore, svc = configFactory(defaultArch)
+					namespace := "testns"
+					pvcName := "pvc-affinities"
+					pvName := "pv-affinities"
+					nodeName := "test-node-0"
+					pvc := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pvName,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err := pvcCache.Add(&pvc)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volumeName := "pvc-volume"
+					volumesWithHotplug := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					volumesNoHotplug := []v1.Volume{
+						{
+							Name: volumeName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+								},
+							},
+						},
+					}
+					disks := []v1.Disk{
+						{
+							Name: volumeName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+
+					vmiHotplugEnableNoVolumes := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesNoHotplug, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: false,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					vmiHotplugDisableWithVolumes := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi2", Namespace: namespace, UID: "12345",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesWithHotplug, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: true,
+								Disks:          disks,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmiHotplugEnableNoVolumes)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest no hotplugged volumes")
+
+					pod, err = svc.RenderLaunchManifest(&vmiHotplugDisableWithVolumes)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).To(BeNil(), "Expected no affinity in manifest since hotplug is disabled")
+				})
+
+				It("should set affinity to intersection of multiple PVs or error if scheduling is impossible", func() {
+					var err error
+					config, kvStore, svc = configFactory(defaultArch)
+					namespace := "testns"
+					// PVC 1 will be schedulable on test-node-0 and test-node-1
+					pvc1Name := "pvc-affinities-1"
+					pv1Name := "pv-affinities-1"
+					pvc1 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc1Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv1Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc1)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv1 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv1Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{"test-node-0", "test-node-1"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv1)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					// PVC 2 will be schedulable on test-node-1 and test-node-2
+					pvc2Name := "pvc-affinities-2"
+					pv2Name := "pv-affinities-2"
+					pvc2 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc2Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv2Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc2)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv2 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv2Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{"test-node-1", "test-node-2"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv2)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					// PVC 3 will be schedulable only on test-node-3
+					pvc3Name := "pvc-affinities-3"
+					pv3Name := "pv-affinities-3"
+					pvc3 := k8sv1.PersistentVolumeClaim{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvc3Name},
+						Spec: k8sv1.PersistentVolumeClaimSpec{
+							VolumeName: pv3Name,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimBound,
+						},
+					}
+					err = pvcCache.Add(&pvc3)
+					Expect(err).ToNot(HaveOccurred(), "Added PVC to cache successfully")
+
+					pv3 := k8sv1.PersistentVolume{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: pv3Name},
+						Spec: k8sv1.PersistentVolumeSpec{
+							NodeAffinity: &k8sv1.VolumeNodeAffinity{
+								Required: &k8sv1.NodeSelector{
+									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+										{
+											MatchExpressions: []k8sv1.NodeSelectorRequirement{
+												{
+													Key:      "my.csi.driver/node",
+													Operator: k8sv1.NodeSelectorOpIn,
+													Values:   []string{"test-node-2"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+					err = pvCache.Add(&pv3)
+					Expect(err).ToNot(HaveOccurred(), "Added PV to cache successfully")
+
+					volume1Name := "pvc-volume"
+					volume2Name := "pvc-volume-2"
+					volume3Name := "pvc-volume-3"
+					volumesWithIntersection := []v1.Volume{
+						{
+							Name: volume1Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc1Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+						{
+							Name: volume2Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc2Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disksWithIntersection := []v1.Disk{
+						{
+							Name: volume1Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+						{
+							Name: volume2Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+					volumesWithNoIntersection := []v1.Volume{
+						{
+							Name: volume1Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc1Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+						{
+							Name: volume3Name,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: pvc3Name},
+									Hotpluggable:                      true,
+								},
+							},
+						},
+					}
+					disksWithNoIntersection := []v1.Disk{
+						{
+							Name: volume1Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+						{
+							Name: volume3Name,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: "virtio",
+								},
+							},
+						},
+					}
+
+					schedulableVMI := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesWithIntersection, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								Disks: disksWithIntersection,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					unschedulableVMI := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testvmi", Namespace: namespace, UID: "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{Volumes: volumesWithNoIntersection, Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								Disks: disksWithNoIntersection,
+							},
+							CPU: &v1.CPU{
+								Model: "Conroe",
+							},
+						}},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&schedulableVMI)
+					Expect(err).ToNot(HaveOccurred(), "Render manifest successfully")
+					Expect(pod.Spec.Affinity).ToNot(BeNil(), "Expected affinity in manifest since hotplugged PVC is bound")
+					nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					Expect(nodeSelectorTerms).To(ConsistOf(k8sv1.NodeSelectorTerm{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{
+								Key:      "my.csi.driver/node",
+								Operator: k8sv1.NodeSelectorOpIn,
+								Values:   []string{"test-node-1"},
+							},
+						},
+						MatchFields: []k8sv1.NodeSelectorRequirement{},
+					}))
+
+					pod, err = svc.RenderLaunchManifest(&unschedulableVMI)
+					Expect(err).To(HaveOccurred(), "Expected error since no node can satisfy both PVs")
+				})
+			})
 		})
 		Context("with cpu and memory constraints", func() {
 			DescribeTable("should add cpu and memory constraints to a template", func(arch string, requestMemory string, limitMemory string) {
@@ -3172,6 +4072,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -5988,6 +6889,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6058,6 +6960,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6087,6 +6990,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6147,6 +7051,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6188,6 +7093,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6226,6 +7132,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,
@@ -6260,6 +7167,7 @@ var _ = Describe("Template", func() {
 				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
+				pvCache,
 				virtClient,
 				config,
 				qemuGid,

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -171,6 +171,8 @@ type VirtControllerApp struct {
 	persistentVolumeClaimCache    cache.Store
 	persistentVolumeClaimInformer cache.SharedIndexInformer
 
+	persistentVolumeInformer cache.SharedIndexInformer
+
 	rsController *replicaset.Controller
 	rsInformer   cache.SharedIndexInformer
 
@@ -386,6 +388,8 @@ func Execute() {
 
 	app.persistentVolumeClaimInformer = app.informerFactory.PersistentVolumeClaim()
 	app.persistentVolumeClaimCache = app.persistentVolumeClaimInformer.GetStore()
+
+	app.persistentVolumeInformer = app.informerFactory.PersistentVolume()
 
 	app.pdbInformer = app.informerFactory.K8SInformerFactory().Policy().V1().PodDisruptionBudgets().Informer()
 
@@ -671,6 +675,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.hotplugDiskDir,
 		vca.imagePullSecret,
 		vca.persistentVolumeClaimCache,
+		vca.persistentVolumeInformer.GetStore(),
 		virtClient,
 		vca.clusterConfig,
 		vca.launcherSubGid,

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -172,6 +172,8 @@ type VirtControllerApp struct {
 	persistentVolumeClaimCache    cache.Store
 	persistentVolumeClaimInformer cache.SharedIndexInformer
 
+	persistentVolumeInformer cache.SharedIndexInformer
+
 	rsController *replicaset.Controller
 	rsInformer   cache.SharedIndexInformer
 
@@ -396,6 +398,8 @@ func Execute() {
 
 	app.persistentVolumeClaimInformer = app.informerFactory.PersistentVolumeClaim()
 	app.persistentVolumeClaimCache = app.persistentVolumeClaimInformer.GetStore()
+
+	app.persistentVolumeInformer = app.informerFactory.PersistentVolume()
 
 	app.pdbInformer = app.informerFactory.K8SInformerFactory().Policy().V1().PodDisruptionBudgets().Informer()
 
@@ -705,6 +709,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.hotplugDiskDir,
 		vca.imagePullSecret,
 		vca.persistentVolumeClaimCache,
+		vca.persistentVolumeInformer.GetStore(),
 		virtClient,
 		vca.clusterConfig,
 		vca.launcherSubGid,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Application", func() {
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		resourceQuotaInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		namespaceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		crInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
@@ -140,7 +141,7 @@ var _ = Describe("Application", func() {
 		app.evacuationController, _ = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
 		app.disruptionBudgetController, _ = disruptionbudget.NewDisruptionBudgetController(vmiInformer, pdbInformer, podInformer, migrationInformer, recorder, virtClient)
 		app.nodeController, _ = node.NewController(virtClient, nodeInformer, vmiInformer, recorder)
-		app.vmiController, _ = vmi.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+		app.vmiController, _ = vmi.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
 			vmInformer,
 			podInformer,
@@ -184,7 +185,7 @@ var _ = Describe("Application", func() {
 			[]string{},
 			[]string{},
 		)
-		app.migrationController, _ = migration.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+		app.migrationController, _ = migration.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
 			podInformer,
 			migrationInformer,
@@ -231,7 +232,7 @@ var _ = Describe("Application", func() {
 		_ = app.restoreController.Init()
 		app.exportController = &export.VMExportController{
 			Client:                      virtClient,
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			VMExportInformer:            vmExportInformer,
 			PVCInformer:                 pvcInformer,
 			PodInformer:                 podInformer,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Application", func() {
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		resourceQuotaInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		namespaceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		crInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
@@ -140,7 +141,7 @@ var _ = Describe("Application", func() {
 		app.evacuationController, _ = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
 		app.disruptionBudgetController, _ = disruptionbudget.NewDisruptionBudgetController(vmiInformer, pdbInformer, podInformer, migrationInformer, recorder, virtClient)
 		app.nodeController, _ = node.NewController(virtClient, nodeInformer, vmiInformer, recorder)
-		app.vmiController, _ = vmi.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+		app.vmiController, _ = vmi.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
 			vmInformer,
 			podInformer,
@@ -185,7 +186,7 @@ var _ = Describe("Application", func() {
 			[]string{},
 			[]string{},
 		)
-		app.migrationController, _ = migration.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+		app.migrationController, _ = migration.NewController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
 			podInformer,
 			migrationInformer,
@@ -232,7 +233,7 @@ var _ = Describe("Application", func() {
 		_ = app.restoreController.Init()
 		app.exportController = &export.VMExportController{
 			Client:                      virtClient,
-			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+			ManifestRenderer:            services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			VMExportInformer:            vmExportInformer,
 			PVCInformer:                 pvcInformer,
 			PodInformer:                 podInformer,

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -232,12 +232,13 @@ var _ = Describe("Migration watcher", func() {
 		nodeInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Node{})
 
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		storageProfileInformer, _ := testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 		kubevirtInformer, _ := testutils.NewFakeInformerFor(&v1.KubeVirt{})
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 		controller, _ = NewController(
-			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
 			podInformer,
 			migrationInformer,

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -249,12 +249,13 @@ var _ = Describe("Migration watcher", func() {
 		nodeInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Node{})
 
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		storageProfileInformer, _ := testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 		kubevirtInformer, _ := testutils.NewFakeInformerFor(&v1.KubeVirt{})
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 		controller, _ = NewController(
-			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
 			podInformer,
 			migrationInformer,

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -215,6 +215,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolume{})
 		migrationInformer, _ := testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstanceMigration{}, kvcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 		storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		storageClassStore = storageClassInformer.GetStore()
@@ -231,7 +232,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		}
 
 		controller, _ = NewController(
-			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", pvcInformer.GetStore(), pvInformer.GetStore(), virtClient, config, qemuGid, "g", rqInformer.GetStore(), nsInformer.GetStore()),
 			vmiInformer,
 			vmInformer,
 			podInformer,

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -312,6 +312,17 @@ func baseControllerClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"persistentvolumes",
+				},
+				Verbs: []string{
+					"get", "list", "watch",
+				},
+			},
+			{
+				APIGroups: []string{
 					"snapshot.kubevirt.io",
 				},
 				Resources: []string{


### PR DESCRIPTION
### What this PR does
#### Before this PR:
VMs with hotplugged volumes don't respect node affinity of those volumes

#### After this PR:
VMs with hotplugged volumes do respect node affinity of those volumes

### References
- Fixes #16945

### Why we need it and why it was done in this way
Without this change, it's possible to hotplug a new volume into a VM and have that VM fail to be scheduled on next stop/start. The scheduler doesn't inherently know about hotplugged volumes since they are actually attached to the hotplug helper pods which are themselves started after the VM is already scheduled (and when it's too late to take into account volume affinities).

#### The following tradeoffs were made:

The merge/simplify/subsume logic is complicated. Also in the pathological case the explosion of terms is still O((ave # node selector terms)^(# of affinities being merged)). Practically, the pathological case will never be met by any real world PV affinities and this code guards against unbounded nodeSelectorTerm explosions in cardinality.

#### The following alternatives were considered:

A must simpler implementation that has Kubevirt implement some of the scheduler logic is here: https://github.com/kubevirt/kubevirt/pull/16994

#### Links to places where the discussion took place:

Issue #16945

### Special notes for your reviewer

This is mutually exclusive with https://github.com/kubevirt/kubevirt/pull/16994.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```