### PR TITLE
Prevent libvirt reconnect from disrupting unrelated VMIs

### DIFF
--- a/pkg/virt-handler/notify-server/BUILD.bazel
+++ b/pkg/virt-handler/notify-server/BUILD.bazel
@@ -35,8 +35,10 @@ go_test(
     race = "on",
     deps = [
         ":go_default_library",
+        "//pkg/handler-launcher-com/notify/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -88,7 +88,6 @@ func (n *Notify) HandleDomainEvent(_ context.Context, request *notifyv1.DomainEv
 		n.EventChan <- watch.Event{Type: watch.Deleted, Object: domain}
 	case string(watch.Error):
 		log.Log.Object(domain).Errorf("Domain error event with message: %s", status.Message)
-		n.EventChan <- watch.Event{Type: watch.Error, Object: status}
 	}
 	return response, nil
 }

--- a/pkg/virt-handler/notify-server/server_test.go
+++ b/pkg/virt-handler/notify-server/server_test.go
@@ -20,6 +20,8 @@
 package eventsserver_test
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"time"
@@ -27,10 +29,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
+	notifyv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/v1"
 	eventsserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
 )
 
@@ -92,5 +96,36 @@ var _ = Describe("RunServer", func() {
 
 		close(stopChan)
 		Eventually(errChan).WithTimeout(15 * time.Second).Should(Receive(BeNil()))
+	})
+})
+
+var _ = Describe("HandleDomainEvent", func() {
+	var (
+		eventChan chan watch.Event
+		notify    *eventsserver.Notify
+	)
+
+	BeforeEach(func() {
+		eventChan = make(chan watch.Event, 1)
+		notify = &eventsserver.Notify{
+			EventChan: eventChan,
+		}
+	})
+
+	It("should not translate domain error events to informer watch.Error event", func() {
+		statusJSON, err := json.Marshal(&metav1.Status{
+			Status:  metav1.StatusFailure,
+			Message: "domain error",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		response, err := notify.HandleDomainEvent(context.Background(), &notifyv1.DomainEventRequest{
+			EventType:  string(watch.Error),
+			StatusJSON: statusJSON,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(response.Success).To(BeTrue())
+
+		Consistently(eventChan).WithTimeout(100 * time.Millisecond).ShouldNot(Receive())
 	})
 })


### PR DESCRIPTION
## Summary

Remove the `watch.Error` event forwarding from `HandleDomainEvent` in `pkg/virt-handler/notify-server/server.go`:

```go
n.EventChan <- watch.Event{Type: watch.Error, Object: status}
```

## Problem

When a virt-launcher's libvirt connection drops and reconnects (which can happen during VMI lifecycle operations such as domain destruction), it sends a watch.Error ("Libvirt reconnect") event to virt-handler via the gRPC notify pipe.

The reflector treats any `watch.Error` as a watch-level failure and calls `GracefulStop` on the gRPC server.
GracefulStop severs ALL notify pipe connections on the node — not just the one that errored. Any VMI in transient mode (not RUNNING) on the same node loses its connection to virt-handler, so virt-handler never receives the domain state update and acts on stale cache instead.

For example on the failed tests, virt-handler acted on stale cache (`Shutoff`), wrongly concluded the VMI had failed to start, and ran cleanup, unmounting the container disk. Depending on timing, this either killed the sidecar container (leaving the VMI Running but never Ready) or left the container disk permanently unavailable (preventing the VMI from starting at all).

This is a systematic problem: domain destruction is routine, so any node where one VMI is dying while another is starting up can hit it.

### Affected tests

Confirmed as root cause of flaky failures across two separate runs on different clusters and dates:

- `[test_id:1528] should survive guest shutdown, multiple times`
- `should remain to able resolve the VM IP` (migration with headless service)

In both cases, a VMI from an unrelated parallel test destroyed an inflight VMI on the same node via this cascade.

### Example

```
# testvmi-5mdhn (namespace default1) is starting up on this node.
# It's the VMI owned by the failing test [test_id:1528].
# Its notify pipe to virt-handler connects successfully:
05:26:16.492 launcher-clients.go:255 — "Accepted new notify pipe connection for vmi" [testvmi-5mdhn, default1]

# Meanwhile, testvmi-jvpww (namespace default4) is an unrelated VMI
# from a different parallel test, also on this node.
# Its virt-launcher's libvirt connection drops and reconnects,
# sending a watch.Error event that hits HandleDomainEvent in server.go:
05:26:16.649 server.go:90 — "Domain error event with message: Libvirt reconnect, domain kubevirt-test-default4_testvmi-jvpww-..."

# The watch.Error is forwarded to the reflector via EventChan.
# The reflector treats it as a watch-level failure and calls GracefulStop
# on the gRPC server. Since there is ONE gRPC server per node, this
# severs ALL notify pipe connections — including testvmi-5mdhn's:
05:26:16.649 launcher-clients.go:272 — "gracefully closed notify pipe connection for vmi" [testvmi-5mdhn, default1]
05:26:16.649 server.go:201 — "notify server GracefulStop complete"
05:26:16.649 reflector.go:492 — watch of *api.Domain ended with: Libvirt reconnect, domain ...testvmi-jvpww-...

# The reflector restarts, but before testvmi-5mdhn's domain state is
# re-synced, virt-handler reconciles it using stale cached state (Shutoff).
# It wrongly concludes the VMI failed to start and runs cleanup:
05:26:17.237 vm.go:1362 — "VMI is in phase: Scheduled | Domain status: Shutoff, reason: Unknown" [testvmi-5mdhn, default1]
05:26:17.237 vm.go:1686 — "Signaled deletion for testvmi-5mdhn-..." [default1]
05:26:17.239 mount.go:348 — "unmounting container disk at path .../disk_0.img" [testvmi-5mdhn, default1]
05:26:17.326 mount.go:382 — "containerdisk disk0 not yet ready" [testvmi-5mdhn, default1]
```

## Fix

Remove the watch.Error forwarding from HandleDomainEvent. The error is still logged for observability. Domain state reconciliation after a libvirt reconnect is already handled by virt-launcher's monitoring loop (1s interval, watch.Modified events) and re-registered libvirt lifecycle callbacks.

A unit test is added that reproduces the cascade: it sends a watch.Error via gRPC, simulates the reflector shutting down the server on receipt, and verifies the server stays alive and can still process subsequent watch.Modified events from other VMIs.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where a libvirt reconnect event from one VMI could disrupt unrelated VMIs on the same node by triggering a node-wide gRPC server shutdown.
```

Jira : https://redhat.atlassian.net/browse/CNV-87667

