### PR TITLE
fix: use net.JoinHostPort for IPv6-safe sync address formatting

### DIFF
--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -842,7 +842,7 @@ func (s *SynchronizationController) getVMIFromMigration(migration *virtv1.Virtua
 
 func (s *SynchronizationController) getLocalSynchronizationAddress() (string, error) {
 	if s.ip != "" {
-		return fmt.Sprintf("%s:%d", s.ip, s.bindPort), nil
+		return net.JoinHostPort(s.ip, strconv.Itoa(s.bindPort)), nil
 	}
 	// TODO figure out how to get my URL with or without submariner (url changes based on export)
 	return s.listener.Addr().String(), nil

--- a/pkg/synchronization-controller/synchronization-controller_test.go
+++ b/pkg/synchronization-controller/synchronization-controller_test.go
@@ -124,6 +124,25 @@ var _ = Describe("VMI status synchronization controller", func() {
 		})
 	})
 
+	Context("getLocalSynchronizationAddress", func() {
+		DescribeTable("should produce an address parseable by net.SplitHostPort", func(ip string, port int, expectedHost, expectedPort string) {
+			ctrl := &SynchronizationController{ip: ip, bindPort: port}
+
+			addr, err := ctrl.getLocalSynchronizationAddress()
+			Expect(err).ToNot(HaveOccurred())
+
+			host, p, err := net.SplitHostPort(addr)
+			Expect(err).ToNot(HaveOccurred(), "address %q must be parseable by net.SplitHostPort", addr)
+			Expect(host).To(Equal(expectedHost))
+			Expect(p).To(Equal(expectedPort))
+		},
+			Entry("IPv4 address", "10.0.0.1", 9185, "10.0.0.1", "9185"),
+			Entry("IPv6 address", "fd02:0:0:1::cb", 9185, "fd02:0:0:1::cb", "9185"),
+			Entry("IPv6 loopback", "::1", 9185, "::1", "9185"),
+			Entry("IPv6 full address", "2001:db8::1", 4321, "2001:db8::1", "4321"),
+		)
+	})
+
 	Context("grpc SyncSourceMigrationStatus", func() {
 		var (
 			vmi       *virtv1.VirtualMachineInstance

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strconv"
 	"time"
 
@@ -857,7 +858,7 @@ func (r *Reconciler) updateSynchronizationAddress() (err error) {
 	}
 	addresses := make([]string, len(ips))
 	for i, ip := range ips {
-		addresses[i] = fmt.Sprintf("%s:%d", ip, port)
+		addresses[i] = net.JoinHostPort(ip, strconv.Itoa(int(port)))
 	}
 	r.kv.Status.SynchronizationAddresses = addresses
 	return nil

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -1021,6 +1021,19 @@ var _ = Describe("Apply", func() {
 					},
 				},
 			}, "1234", "2.2.2.2:1234"),
+			Entry("if pod found with IPv6 address, address should be bracket-wrapped", &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      synchronizationControllerPodName,
+					Namespace: kubevirtNamespace,
+				},
+				Status: corev1.PodStatus{
+					PodIPs: []corev1.PodIP{
+						{
+							IP: "fd02:0:0:1::cb",
+						},
+					},
+				},
+			}, "", "[fd02:0:0:1::cb]:9185"),
 		)
 	})
 })


### PR DESCRIPTION
### What this PR does
Use `net.JoinHostPort` instead of `fmt.Sprintf("%s:%d")` when formatting synchronization addresses, so IPv6 addresses are properly bracket-wrapped.

#### Before this PR:
- On IPv6 clusters, `getLocalSynchronizationAddress()` produces `fd02:0:0:1::cb:9185` which gRPC interprets as IPv6 address `fd02::1:0:0:cb:9185` on default port 443.
- All cross-namespace migrations fail with `WaitingForSync` timeout because the sync gRPC connection never establishes.

#### After this PR:
- The address is formatted as `[fd02:0:0:1::cb]:9185` using `net.JoinHostPort`, matching the pattern already used by `createTcpListener` in the same file.

### References
- Related IPv6 bracket fix precedent: https://github.com/kubevirt/kubevirt/pull/9851

### Release note
```release-note
fix: cross-namespace live migration now works on IPv6 clusters
```