### PR TITLE
[release-1.6] tests: use localhost when curling handler metrics

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -184,11 +184,10 @@ var _ = Describe("[sig-monitoring][rfe_id:3187][crit:medium][vendor:cnv-qe@redha
 
 var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", func() {
 	var (
-		virtClient          kubecli.KubevirtClient
-		preparedVMIs        []*v1.VirtualMachineInstance
-		pod                 *k8sv1.Pod
-		handlerMetricIPs    []string
-		controllerMetricIPs []string
+		virtClient       kubecli.KubevirtClient
+		preparedVMIs     []*v1.VirtualMachineInstance
+		pod              *k8sv1.Pod
+		handlerMetricIPs []string
 	)
 
 	prepareVMIForTests := func(preferredNodeName string) string {
@@ -232,22 +231,8 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 	}
 
 	BeforeEach(func() {
+		var err error
 		virtClient = kubevirt.Client()
-
-		preparedVMIs = []*v1.VirtualMachineInstance{}
-		pod = nil
-		handlerMetricIPs = []string{}
-		controllerMetricIPs = []string{}
-
-		By("Finding the virt-controller prometheus endpoint")
-		virtControllerLeaderPodName := libinfra.GetLeader()
-		leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(
-			context.Background(), virtControllerLeaderPodName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred(), "Should find the virt-controller pod")
-
-		for _, ip := range leaderPod.Status.PodIPs {
-			controllerMetricIPs = append(controllerMetricIPs, ip.IP)
-		}
 
 		// The initial test for the metrics subsystem used only a single VM for the sake of simplicity.
 		// However, testing a single entity is a corner case (do we test handling sequences? potential clashes
@@ -265,6 +250,12 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		for _, ip := range pod.Status.PodIPs {
 			handlerMetricIPs = append(handlerMetricIPs, ip.IP)
 		}
+	})
+
+	AfterEach(func() {
+		preparedVMIs = []*v1.VirtualMachineInstance{}
+		pod = nil
+		handlerMetricIPs = []string{}
 	})
 
 	It("[test_id:4136] should find one leading virt-controller and two ready", func() {
@@ -375,26 +366,17 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		Entry("[test_id:6226] by using IPv6", k8sv1.IPv6Protocol),
 	)
 
-	DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
-		ip := libnet.GetIP(handlerMetricIPs, family)
-
+	It("[test_id:4141]should include the metrics for a running VM", func() {
 		By("Scraping the Prometheus endpoint")
 		Eventually(func() string {
-			out := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+			out := libmonitoring.GetKubevirtVMMetrics(pod)
 			lines := libinfra.TakeMetricsWithPrefix(out, "kubevirt")
 			return strings.Join(lines, "\n")
 		}, 30*time.Second, 2*time.Second).Should(ContainSubstring("kubevirt"))
-	},
-		Entry("[test_id:4141] by using IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6227] by using IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 
 	It("should expose kubevirt_node_deprecated_machine_types metric", func() {
-		ip := libnet.GetIP(handlerMetricIPs, k8sv1.IPv4Protocol)
-
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
 		fetcher.AddNameFilter("kubevirt_node_deprecated_machine_types")
@@ -410,11 +392,8 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 		}
 	})
 
-	DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricName, operator string) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
-		ip := libnet.GetIP(handlerMetricIPs, family)
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+	DescribeTable("should include the storage metrics for a running VM", func(metricName, operator string) {
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		By("Checking the collected metrics")
 		for _, vmi := range preparedVMIs {
@@ -434,41 +413,24 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 	},
-		Entry("[test_id:4142] storage flush requests metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-		Entry("[test_id:6228] storage flush requests metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-		Entry("[test_id:4142] time spent on cache flushing metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_times_seconds_total", ">="),
-		Entry("[test_id:6229] time spent on cache flushing metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_times_seconds_total", ">="),
-		Entry("[test_id:4142] I/O read operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-		Entry("[test_id:6230] I/O read operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-		Entry("[test_id:4142] I/O write operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-		Entry("[test_id:6231] I/O write operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-		Entry("[test_id:4142] storage read operation time metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_times_seconds_total", ">="),
-		Entry("[test_id:6232] storage read operation time metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_times_seconds_total", ">="),
-		Entry("[test_id:4142] storage read traffic in bytes metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-		Entry("[test_id:6233] storage read traffic in bytes metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-		Entry("[test_id:4142] storage write operation time metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_times_seconds_total", ">="),
-		Entry("[test_id:6234] storage write operation time metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_times_seconds_total", ">="),
-		Entry("[test_id:4142] storage write traffic in bytes metric by using IPv4",
-			k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
-		Entry("[test_id:6235] storage write traffic in bytes metric by using IPv6",
-			k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+		Entry("[test_id:4142] storage flush requests metric",
+			"kubevirt_vmi_storage_flush_requests_total", ">="),
+		Entry("[test_id:4142] time spent on cache flushing metric",
+			"kubevirt_vmi_storage_flush_times_seconds_total", ">="),
+		Entry("[test_id:4142] I/O read operations metric", "kubevirt_vmi_storage_iops_read_total", ">="),
+		Entry("[test_id:4142] I/O write operations metric", "kubevirt_vmi_storage_iops_write_total", ">="),
+		Entry("[test_id:4142] storage read operation time metric",
+			"kubevirt_vmi_storage_read_times_seconds_total", ">="),
+		Entry("[test_id:4142] storage read traffic in bytes metric",
+			"kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+		Entry("[test_id:4142] storage write operation time metric",
+			"kubevirt_vmi_storage_write_times_seconds_total", ">="),
+		Entry("[test_id:4142] storage write traffic in bytes metric",
+			"kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
 	)
 
-	DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
-		ip := libnet.GetIP(handlerMetricIPs, family)
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+	DescribeTable("should include metrics for a running VM", func(metricSubstring, operator string) {
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
 		fetcher.AddNameFilter(metricSubstring)
@@ -483,23 +445,15 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 	},
-		Entry("[test_id:4143] network metrics by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_network_", ">="),
-		Entry("[test_id:6236] network metrics by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_network_", ">="),
-		Entry("[test_id:4144] memory metrics by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_memory", ">="),
-		Entry("[test_id:6237] memory metrics by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_memory", ">="),
-		Entry("[test_id:4553] vcpu wait by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-		Entry("[test_id:6238] vcpu wait by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-		Entry("[test_id:4554] vcpu seconds by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_seconds_total", ">="),
-		Entry("[test_id:6239] vcpu seconds by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_seconds_total", ">="),
-		Entry("[test_id:4556] vmi unused memory by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
-		Entry("[test_id:6240] vmi unused memory by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
+		Entry("[test_id:4143] network metrics", "kubevirt_vmi_network_", ">="),
+		Entry("[test_id:4144] memory metrics", "kubevirt_vmi_memory", ">="),
+		Entry("[test_id:4553] vcpu wait", "kubevirt_vmi_vcpu_wait", "=="),
+		Entry("[test_id:4554] vcpu seconds", "kubevirt_vmi_vcpu_seconds_total", ">="),
+		Entry("[test_id:4556] vmi unused memory", "kubevirt_vmi_memory_unused_bytes", ">="),
 	)
 
-	DescribeTable("[QUARANTINE]should include VMI infos for a running VM", decorators.Quarantine, func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
-		ip := libnet.GetIP(handlerMetricIPs, family)
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+	It("[QUARANTINE][test_id:4145]should include VMI infos for a running VM", decorators.Quarantine, func() {
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
 		fetcher.AddNameFilter("kubevirt_vmi_")
@@ -536,39 +490,50 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 				))
 			}
 		}
-	},
-		Entry("[test_id:4145] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6241] by IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 
-	DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
+	Context("VMI eviction blocker status", func() {
+		var controllerMetricIPs []string
 
-		ip := libnet.GetIP(controllerMetricIPs, family)
+		BeforeEach(func() {
+			virtControllerLeaderPodName := libinfra.GetLeader()
+			leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), virtControllerLeaderPodName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred(), "Should find the virt-controller pod")
+			for _, ip := range leaderPod.Status.PodIPs {
+				controllerMetricIPs = append(controllerMetricIPs, ip.IP)
+			}
+		})
 
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+		AfterEach(func() {
+			controllerMetricIPs = nil
+		})
 
-		fetcher := metricsutil.NewMetricsFetcher("")
-		fetcher.AddNameFilter("kubevirt_vmi_non_evictable")
+		DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
-		metrics, err := fetcher.LoadMetrics(metricsPayload)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected")
+			ip := libnet.GetIP(controllerMetricIPs, family)
 
-		results := metrics["kubevirt_vmi_non_evictable"]
-		Expect(results).ToNot(BeEmpty())
-		Expect(results[0].Value).To(BeNumerically(">=", float64(0.0)))
-	},
-		Entry("[test_id:4148] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6243] by IPv6", k8sv1.IPv6Protocol),
-	)
+			metricsPayload := libmonitoring.GetKubevirtVMMetricsByIP(pod, ip) //nolint:staticcheck
 
-	DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
+			fetcher := metricsutil.NewMetricsFetcher("")
+			fetcher.AddNameFilter("kubevirt_vmi_non_evictable")
 
-		ip := libnet.GetIP(handlerMetricIPs, family)
+			metrics, err := fetcher.LoadMetrics(metricsPayload)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected")
 
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+			results := metrics["kubevirt_vmi_non_evictable"]
+			Expect(results).ToNot(BeEmpty())
+			Expect(results[0].Value).To(BeNumerically(">=", float64(0.0)))
+		},
+			Entry("[test_id:4148] by IPv4", k8sv1.IPv4Protocol),
+			Entry("[test_id:6243] by IPv6", k8sv1.IPv6Protocol),
+		)
+	})
+
+	It("[test_id:4147]should include kubernetes labels to VMI metrics", func() {
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
 		fetcher.AddNameFilter("kubevirt_vmi_vcpu_seconds_total")
@@ -590,18 +555,11 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 		Expect(containK8sLabel).To(BeTrue())
-	},
-		Entry("[test_id:4147] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6244] by IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 
 	// explicit test swap metrics as test_id:4144 doesn't catch if they are missing
-	DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
-		libnet.SkipWhenClusterNotSupportIPFamily(family)
-
-		ip := libnet.GetIP(handlerMetricIPs, family)
-
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+	It("[test_id:4555]should include swap metrics", func() {
+		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
 		fetcher := metricsutil.NewMetricsFetcher("")
 		fetcher.AddNameFilter("kubevirt_vmi_memory_swap_")
@@ -625,10 +583,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 
 		Expect(in).To(BeTrue())
 		Expect(out).To(BeTrue())
-	},
-		Entry("[test_id:4555] by IPv4", k8sv1.IPv4Protocol),
-		Entry("[test_id:6245] by IPv6", k8sv1.IPv6Protocol),
-	)
+	})
 }))
 
 func countReadyAndLeaderPods(pod *k8sv1.Pod, component string) (foundMetrics map[string]int, err error) {

--- a/tests/libmigration/BUILD.bazel
+++ b/tests/libmigration/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmonitoring:go_default_library",
-        "//tests/libnet:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -29,7 +29,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmonitoring"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 )
@@ -514,7 +513,6 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 	var err error
 	virtClient := kubevirt.Client()
 	var pod *k8sv1.Pod
-	var metricsIPs []string
 	var migrationMetrics = []string{
 		"kubevirt_vmi_migration_data_total_bytes",
 		"kubevirt_vmi_migration_data_remaining_bytes",
@@ -522,18 +520,10 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 		"kubevirt_vmi_migration_dirty_memory_rate_bytes",
 		"kubevirt_vmi_migration_disk_transfer_rate_bytes",
 	}
-	const family = k8sv1.IPv4Protocol
 
 	By("Finding the prometheus endpoint")
 	pod, err = libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)
 	Expect(err).ToNot(HaveOccurred(), "Should find the virt-handler pod")
-	Expect(pod.Status.PodIPs).ToNot(BeEmpty(), "pod IPs must not be empty")
-	for _, ip := range pod.Status.PodIPs {
-		metricsIPs = append(metricsIPs, ip.IP)
-	}
-
-	By("Waiting until the Migration Completes")
-	ip := libnet.GetIP(metricsIPs, family)
 
 	_ = RunMigration(virtClient, migration)
 
@@ -552,7 +542,7 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 	}
 
 	Eventually(func() error {
-		out := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+		out := libmonitoring.GetKubevirtVMMetrics(pod)
 		for _, metricName := range migrationMetrics {
 			lines := libinfra.TakeMetricsWithPrefix(out, metricName)
 			metrics, err := libinfra.ParseMetricsToMap(lines)

--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -412,18 +412,24 @@ func getPrometheusAlerts(virtClient kubecli.KubevirtClient) promv1.PrometheusRul
 	return newRules
 }
 
-func GetKubevirtVMMetrics(pod *k8sv1.Pod, ip string) string {
+// Works whenever pod has curl
+func GetKubevirtVMMetrics(pod *k8sv1.Pod) string {
+	return GetKubevirtVMMetricsByIP(pod, "localhost")
+}
+
+// Deprecated: Use GetKubevirtVMMetrics or grab metrics indirectly through prometheus
+func GetKubevirtVMMetricsByIP(pod *k8sv1.Pod, ip string) string {
 	metricsURL := PrepareMetricsURL(ip, 8443)
-	stdout, _, err := execute.ExecuteCommandOnPodWithResults(
+	stdout, stderr, err := execute.ExecuteCommandOnPodWithResults(
 		pod,
-		"virt-handler",
+		pod.Spec.Containers[0].Name,
 		[]string{
 			"curl",
 			"-L",
 			"-k",
 			metricsURL,
 		})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "out: %s stderr: %s", stdout, stderr)
 	return stdout
 }
 

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -69,7 +69,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmonitoring"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libstorage"
@@ -456,15 +455,12 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			for _, ip := range pod.Status.PodIPs {
 				metricsIPs = append(metricsIPs, ip.IP)
 			}
-			By("Waiting until the Migration Completes")
-			ip := libnet.GetIP(metricsIPs, k8sv1.IPv4Protocol)
-
 			By("Update volumes")
 			updateVMWithDV(vm, volName, destDV.Name)
 
 			threshold := resource.MustParse("500Mi")
 			Eventually(func() []string {
-				out := libmonitoring.GetKubevirtVMMetrics(pod, ip)
+				out := libmonitoring.GetKubevirtVMMetrics(pod)
 				return libinfra.TakeMetricsWithPrefix(out, "kubevirt_vmi_migration_data_processed_bytes")
 			}, 4*time.Minute, 10*time.Second).Should(
 				WithTransform(func(lines []string) []float64 {


### PR DESCRIPTION
### What this PR does

This PR is a manual backport of #16476 to release-1.6.

The automated cherry-pick failed due to a conflict in tests/infrastructure/prometheus.go: the `"should include VMI phase metrics for all running VMs"` test exists on main but not on release-1.6, so the surrounding context didn't match. The resolution was to apply the same changes (removing IPv6 table entries, switching to localhost-based GetKubevirtVMMetrics, and scoping controllerMetricIPs to the eviction blocker context) to the release-1.6 version of the file, which simply lacks that one test.

### Release note
```release-note
none
```

