### PR TITLE
memballoon, tests: Improve coverage and reduce duplication

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
@@ -63,6 +63,30 @@ var _ = Describe("Balloon Domain Configurator", func() {
 		Entry("Both SEV and PV enabled", useSEV, usePV, &api.MemBalloonDriver{IOMMU: "on"}),
 	)
 
+	DescribeTable("free page reporting", func(enabled bool, expected string) {
+		vmi := libvmi.New()
+		var domain api.Domain
+
+		configurator := compute.NewBalloonDomainConfigurator(
+			compute.BalloonWithUseLaunchSecuritySEV(false),
+			compute.BalloonWithUseLaunchSecurityPV(false),
+			compute.BalloonWithFreePageReporting(enabled),
+			compute.BalloonWithMemBalloonStatsPeriod(0),
+			compute.BalloonWithVirtioModel("virtio-non-transitional"),
+		)
+
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		expectedDomain := newDomainWithBallooning(api.MemBalloon{
+			Model:             "virtio-non-transitional",
+			FreePageReporting: expected,
+		})
+		Expect(domain).To(Equal(expectedDomain))
+	},
+		Entry("enabled", true, "on"),
+		Entry("disabled", false, "off"),
+	)
+
 	DescribeTable("memballoon stats period", func(period uint, expectedStats *api.Stats) {
 		vmi := libvmi.New()
 		var domain api.Domain

--- a/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
@@ -63,55 +63,30 @@ var _ = Describe("Balloon Domain Configurator", func() {
 		Entry("Both SEV and PV enabled", useSEV, usePV, &api.MemBalloonDriver{IOMMU: "on"}),
 	)
 
-	Context("with memballoon stats period", func() {
-		It("should set Stats when period is non-zero", func() {
-			vmi := libvmi.New()
-			var domain api.Domain
+	DescribeTable("memballoon stats period", func(period uint, expectedStats *api.Stats) {
+		vmi := libvmi.New()
+		var domain api.Domain
 
-			configurator := compute.NewBalloonDomainConfigurator(
-				compute.BalloonWithVirtioModel("virtio-non-transitional"),
-				compute.BalloonWithUseLaunchSecuritySEV(false),
-				compute.BalloonWithUseLaunchSecurityPV(false),
-				compute.BalloonWithFreePageReporting(true),
-				compute.BalloonWithMemBalloonStatsPeriod(5),
-			)
+		configurator := compute.NewBalloonDomainConfigurator(
+			compute.BalloonWithUseLaunchSecuritySEV(false),
+			compute.BalloonWithUseLaunchSecurityPV(false),
+			compute.BalloonWithFreePageReporting(false),
+			compute.BalloonWithMemBalloonStatsPeriod(period),
+			compute.BalloonWithVirtioModel("virtio-non-transitional"),
+		)
 
-			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedDomain := newDomainWithBallooning(
-				api.MemBalloon{
-					Model:             "virtio-non-transitional",
-					FreePageReporting: "on",
-					Stats:             &api.Stats{Period: 5},
-				},
-			)
-			Expect(domain).To(Equal(expectedDomain))
+		expectedDomain := newDomainWithBallooning(api.MemBalloon{
+			Model:             "virtio-non-transitional",
+			FreePageReporting: "off",
+			Stats:             expectedStats,
 		})
-
-		It("should not set Stats when period is zero", func() {
-			vmi := libvmi.New()
-			var domain api.Domain
-
-			configurator := compute.NewBalloonDomainConfigurator(
-				compute.BalloonWithVirtioModel("virtio-non-transitional"),
-				compute.BalloonWithUseLaunchSecuritySEV(false),
-				compute.BalloonWithUseLaunchSecurityPV(false),
-				compute.BalloonWithFreePageReporting(true),
-				compute.BalloonWithMemBalloonStatsPeriod(0),
-			)
-
-			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
-
-			expectedDomain := newDomainWithBallooning(
-				api.MemBalloon{
-					Model:             "virtio-non-transitional",
-					FreePageReporting: "on",
-					Stats:             nil,
-				},
-			)
-			Expect(domain).To(Equal(expectedDomain))
-		})
-	})
+		Expect(domain).To(Equal(expectedDomain))
+	},
+		Entry("zero period", uint(0), nil),
+		Entry("non-zero period", uint(5), &api.Stats{Period: 5}),
+	)
 
 	Context("with AutoattachMemBalloon false", func() {
 		DescribeTable("should configure memballoon with model none", func(model string) {

--- a/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
@@ -23,69 +23,45 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	v1 "kubevirt.io/api/core/v1"
-
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
 var _ = Describe("Balloon Domain Configurator", func() {
-	Context("amd64 with SEV", func() {
-		It("Should set IOMMU attribute of the MemBalloonDriver", func() {
-			vmi := libvmi.New(withLaunchSecurity(v1.LaunchSecurity{SEV: &v1.SEV{}}))
-			var domain api.Domain
+	const (
+		useSEV = true
+		usePV  = true
+	)
 
-			configurator := compute.NewBalloonDomainConfigurator(
-				compute.BalloonWithUseLaunchSecuritySEV(true),
-				compute.BalloonWithUseLaunchSecurityPV(false),
-				compute.BalloonWithFreePageReporting(false),
-				compute.BalloonWithMemBalloonStatsPeriod(0),
-				compute.BalloonWithVirtioModel("virtio-non-transitional"),
-			)
+	DescribeTable("IOMMU driver configuration", func(useSEV, usePV bool, expectedDriver *api.MemBalloonDriver) {
+		vmi := libvmi.New()
+		var domain api.Domain
 
-			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+		configurator := compute.NewBalloonDomainConfigurator(
+			compute.BalloonWithUseLaunchSecuritySEV(useSEV),
+			compute.BalloonWithUseLaunchSecurityPV(usePV),
+			compute.BalloonWithFreePageReporting(false),
+			compute.BalloonWithMemBalloonStatsPeriod(0),
+			compute.BalloonWithVirtioModel("virtio-non-transitional"),
+		)
 
-			expectedDomain := newDomainWithBallooning(
-				api.MemBalloon{
-					Model:             "virtio-non-transitional",
-					Stats:             nil,
-					Address:           nil,
-					Driver:            &api.MemBalloonDriver{IOMMU: "on"},
-					FreePageReporting: "off",
-				},
-			)
-			Expect(domain).To(Equal(expectedDomain))
-		})
-	})
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-	Context("s390x with LaunchSecurity", func() {
-		It("Should set IOMMU attribute of the MemBalloonDriver", func() {
-			vmi := libvmi.New()
-			var domain api.Domain
-
-			configurator := compute.NewBalloonDomainConfigurator(
-				compute.BalloonWithUseLaunchSecuritySEV(false),
-				compute.BalloonWithUseLaunchSecurityPV(true),
-				compute.BalloonWithFreePageReporting(false),
-				compute.BalloonWithMemBalloonStatsPeriod(0),
-				compute.BalloonWithVirtioModel("virtio"),
-			)
-
-			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
-
-			expectedDomain := newDomainWithBallooning(
-				api.MemBalloon{
-					Model:             "virtio",
-					Stats:             nil,
-					Address:           nil,
-					Driver:            &api.MemBalloonDriver{IOMMU: "on"},
-					FreePageReporting: "off",
-				},
-			)
-			Expect(domain).To(Equal(expectedDomain))
-		})
-	})
+		expectedDomain := newDomainWithBallooning(
+			api.MemBalloon{
+				Model:             "virtio-non-transitional",
+				Driver:            expectedDriver,
+				FreePageReporting: "off",
+			},
+		)
+		Expect(domain).To(Equal(expectedDomain))
+	},
+		Entry("neither SEV nor PV", !useSEV, !usePV, nil),
+		Entry("SEV enabled", useSEV, !usePV, &api.MemBalloonDriver{IOMMU: "on"}),
+		Entry("PV enabled", !useSEV, usePV, &api.MemBalloonDriver{IOMMU: "on"}),
+		Entry("Both SEV and PV enabled", useSEV, usePV, &api.MemBalloonDriver{IOMMU: "on"}),
+	)
 
 	Context("with memballoon stats period", func() {
 		It("should set Stats when period is non-zero", func() {

--- a/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
@@ -112,28 +112,26 @@ var _ = Describe("Balloon Domain Configurator", func() {
 		Entry("non-zero period", uint(5), &api.Stats{Period: 5}),
 	)
 
-	Context("with AutoattachMemBalloon false", func() {
-		DescribeTable("should configure memballoon with model none", func(model string) {
-			vmi := libvmi.New(libvmi.WithAutoattachMemBalloon(false))
-			var domain api.Domain
+	It("should configure memballoon with model none when AutoattachMemBalloon is false", func() {
+		vmi := libvmi.New(libvmi.WithAutoattachMemBalloon(false))
+		var domain api.Domain
 
-			configurator := compute.NewBalloonDomainConfigurator(
-				compute.BalloonWithVirtioModel(model),
-			)
-
-			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
-
-			expectedDomain := newDomainWithBallooning(
-				api.MemBalloon{
-					Model: "none",
-				},
-			)
-			Expect(domain).To(Equal(expectedDomain))
-		},
-			Entry("for amd64", "virtio-non-transitional"),
-			Entry("for arm64", "virtio-non-transitional"),
-			Entry("for s390x", "virtio"),
+		configurator := compute.NewBalloonDomainConfigurator(
+			compute.BalloonWithUseLaunchSecuritySEV(false),
+			compute.BalloonWithUseLaunchSecurityPV(false),
+			compute.BalloonWithFreePageReporting(true),
+			compute.BalloonWithMemBalloonStatsPeriod(10),
+			compute.BalloonWithVirtioModel("virtio-non-transitional"),
 		)
+
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		expectedDomain := newDomainWithBallooning(
+			api.MemBalloon{
+				Model: "none",
+			},
+		)
+		Expect(domain).To(Equal(expectedDomain))
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
@@ -46,19 +46,15 @@ var _ = Describe("Balloon Domain Configurator", func() {
 
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedDomain := api.Domain{
-				Spec: api.DomainSpec{
-					Devices: api.Devices{
-						Ballooning: &api.MemBalloon{
-							Model:             "virtio-non-transitional",
-							Stats:             nil,
-							Address:           nil,
-							Driver:            &api.MemBalloonDriver{IOMMU: "on"},
-							FreePageReporting: "off",
-						},
-					},
+			expectedDomain := newDomainWithBallooning(
+				api.MemBalloon{
+					Model:             "virtio-non-transitional",
+					Stats:             nil,
+					Address:           nil,
+					Driver:            &api.MemBalloonDriver{IOMMU: "on"},
+					FreePageReporting: "off",
 				},
-			}
+			)
 			Expect(domain).To(Equal(expectedDomain))
 		})
 	})
@@ -78,19 +74,15 @@ var _ = Describe("Balloon Domain Configurator", func() {
 
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedDomain := api.Domain{
-				Spec: api.DomainSpec{
-					Devices: api.Devices{
-						Ballooning: &api.MemBalloon{
-							Model:             "virtio",
-							Stats:             nil,
-							Address:           nil,
-							Driver:            &api.MemBalloonDriver{IOMMU: "on"},
-							FreePageReporting: "off",
-						},
-					},
+			expectedDomain := newDomainWithBallooning(
+				api.MemBalloon{
+					Model:             "virtio",
+					Stats:             nil,
+					Address:           nil,
+					Driver:            &api.MemBalloonDriver{IOMMU: "on"},
+					FreePageReporting: "off",
 				},
-			}
+			)
 			Expect(domain).To(Equal(expectedDomain))
 		})
 	})
@@ -110,17 +102,13 @@ var _ = Describe("Balloon Domain Configurator", func() {
 
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedDomain := api.Domain{
-				Spec: api.DomainSpec{
-					Devices: api.Devices{
-						Ballooning: &api.MemBalloon{
-							Model:             "virtio-non-transitional",
-							FreePageReporting: "on",
-							Stats:             &api.Stats{Period: 5},
-						},
-					},
+			expectedDomain := newDomainWithBallooning(
+				api.MemBalloon{
+					Model:             "virtio-non-transitional",
+					FreePageReporting: "on",
+					Stats:             &api.Stats{Period: 5},
 				},
-			}
+			)
 			Expect(domain).To(Equal(expectedDomain))
 		})
 
@@ -138,17 +126,13 @@ var _ = Describe("Balloon Domain Configurator", func() {
 
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedDomain := api.Domain{
-				Spec: api.DomainSpec{
-					Devices: api.Devices{
-						Ballooning: &api.MemBalloon{
-							Model:             "virtio-non-transitional",
-							FreePageReporting: "on",
-							Stats:             nil,
-						},
-					},
+			expectedDomain := newDomainWithBallooning(
+				api.MemBalloon{
+					Model:             "virtio-non-transitional",
+					FreePageReporting: "on",
+					Stats:             nil,
 				},
-			}
+			)
 			Expect(domain).To(Equal(expectedDomain))
 		})
 	})
@@ -164,15 +148,11 @@ var _ = Describe("Balloon Domain Configurator", func() {
 
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedDomain := api.Domain{
-				Spec: api.DomainSpec{
-					Devices: api.Devices{
-						Ballooning: &api.MemBalloon{
-							Model: "none",
-						},
-					},
+			expectedDomain := newDomainWithBallooning(
+				api.MemBalloon{
+					Model: "none",
 				},
-			}
+			)
 			Expect(domain).To(Equal(expectedDomain))
 		},
 			Entry("for amd64", "virtio-non-transitional"),
@@ -181,3 +161,13 @@ var _ = Describe("Balloon Domain Configurator", func() {
 		)
 	})
 })
+
+func newDomainWithBallooning(ballooning api.MemBalloon) api.Domain {
+	return api.Domain{
+		Spec: api.DomainSpec{
+			Devices: api.Devices{
+				Ballooning: &ballooning,
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The BalloonDomainConfigurator tests had architecture-named contexts that implied awareness the configurator doesn't have, duplicate entries with identical inputs, and no isolated coverage for free page reporting or the IOMMU-off path. Restructure each concern (IOMMU, free page reporting, stats period, AutoattachMemBalloon) into a focused test that varies only the relevant input, passes all five configurator options explicitly, and achieves 100% coverage on `balloon.go`.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This is a follow-up to https://github.com/kubevirt/kubevirt/pull/16362

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

