### PR TITLE
add `--with-kubevirt-control-plane-label` flag to csv-generator and manifest-templator

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -55,6 +55,7 @@ done
 bundle_out_dir=${MANIFESTS_OUT_DIR}/release/olm/bundle
 
 # then process variables
+templator_extra_flags="${TEMPLATOR_EXTRA_FLAGS:-}"
 args=$(cd ${KUBEVIRT_DIR}/manifests && find . -type f -name "*.yaml.in.tmp")
 for arg in $args; do
 
@@ -93,6 +94,7 @@ for arg in $args; do
         --runbook-url-template=${runbook_url_template} \
         --verbosity=${verbosity} \
         --hypervisor=${hypervisor} \
+        ${templator_extra_flags} \
         >${outfile}
 done
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -205,6 +205,7 @@ ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=operator-rbac
 # values after the file is generated.
 _fake_replaces_csv_version="1111.1111.1111"
 _fake_csv_version="2222.2222.2222"
+csv_generator_extra_flags="${CSV_GENERATOR_EXTRA_FLAGS:-}"
 ${KUBEVIRT_DIR}/tools/csv-generator/csv-generator \
     --operatorImageVersion="{{.DockerTag}}" \
     --csvCreatedAtTimestamp={{.CreatedAt}} \
@@ -216,6 +217,7 @@ ${KUBEVIRT_DIR}/tools/csv-generator/csv-generator \
     --pullPolicy={{.ImagePullPolicy}} \
     --replacesCsvVersion="$_fake_replaces_csv_version" \
     --verbosity={{.Verbosity}} \
+    ${csv_generator_extra_flags} \
     >${KUBEVIRT_DIR}/manifests/generated/operator-csv.yaml.in
 
 sed -i "s/$_fake_csv_version/{{.CsvVersion}}/g" ${KUBEVIRT_DIR}/manifests/generated/operator-csv.yaml.in

--- a/tools/csv-generator/BUILD.bazel
+++ b/tools/csv-generator/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/resource/generate/csv:go_default_library",
         "//pkg/virt-operator/util:go_default_library",
+        "//tools/placement:go_default_library",
         "//tools/util:go_default_library",
+        "//vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
     ],
 )
 

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -20,12 +20,18 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"os"
+	"slices"
+
+	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/csv"
 	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
+	"kubevirt.io/kubevirt/tools/placement"
 	"kubevirt.io/kubevirt/tools/util"
 )
 
@@ -62,6 +68,7 @@ func main() {
 	prHelperImage := flag.String("pr-helper-image", "", "custom image for pr-helper. "+customImageExample)
 	sidecarShimImage := flag.String("sidecar-shim-image", "", "custom image for sidecar-shim. "+customImageExample)
 	dumpNetworkPolicies := flag.Bool("dump-network-policies", false, "dump Network Policies along with CSV manifests to stdout")
+	withKubeVirtControlPlaneLabel := flag.Bool("with-kubevirt-control-plane-label", false, "add node-role.kubevirt.io/control-plane as an additional node selector term for the operator deployment")
 
 	flag.Parse()
 
@@ -99,6 +106,12 @@ func main() {
 		panic(err)
 	}
 
+	if *withKubeVirtControlPlaneLabel {
+		if err := injectKubeVirtControlPlaneLabelIntoCSV(operatorCsv); err != nil {
+			panic(err)
+		}
+	}
+
 	util.MarshallObject(operatorCsv, os.Stdout)
 
 	if *dumpCRDs {
@@ -123,4 +136,38 @@ func main() {
 			util.MarshallObject(v, os.Stdout)
 		}
 	}
+}
+
+// These types mirror the unexported csvDeployments and csvStrategySpec in
+// pkg/virt-operator/resource/generate/csv/csv.go. Keep them in sync.
+type strategyDeployment struct {
+	Name string                `json:"name"`
+	Spec appsv1.DeploymentSpec `json:"spec,omitempty"`
+}
+
+type strategySpec struct {
+	ClusterPermissions json.RawMessage      `json:"clusterPermissions"`
+	Permissions        json.RawMessage      `json:"permissions"`
+	Deployments        []strategyDeployment `json:"deployments"`
+}
+
+func injectKubeVirtControlPlaneLabelIntoCSV(operatorCsv *csvv1.ClusterServiceVersion) error {
+	var strategy strategySpec
+	if err := json.Unmarshal(operatorCsv.Spec.InstallStrategy.StrategySpecRaw, &strategy); err != nil {
+		return err
+	}
+
+	idx := slices.IndexFunc(strategy.Deployments, func(dep strategyDeployment) bool {
+		return dep.Name == "virt-operator"
+	})
+	if idx > -1 {
+		placement.InjectKubeVirtControlPlanePlacement(&strategy.Deployments[idx].Spec.Template.Spec)
+	}
+
+	raw, err := json.Marshal(strategy)
+	if err != nil {
+		return err
+	}
+	operatorCsv.Spec.InstallStrategy.StrategySpecRaw = raw
+	return nil
 }

--- a/tools/manifest-templator/BUILD.bazel
+++ b/tools/manifest-templator/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",
+        "//tools/placement:go_default_library",
         "//tools/util:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -37,6 +37,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
+	"kubevirt.io/kubevirt/tools/placement"
 	"kubevirt.io/kubevirt/tools/util"
 )
 
@@ -83,6 +84,7 @@ type templateData struct {
 	PrHelperImage                      string
 	SidecarShimImage                   string
 	Hypervisor                         string
+	WithKubeVirtControlPlaneLabel      bool
 }
 
 func main() {
@@ -120,6 +122,7 @@ func main() {
 	prHelperImage := flag.String("pr-helper-image", "", "custom image for pr-helper. "+customImageExample)
 	sidecarShimImage := flag.String("sidecar-shim-image", "", "custom image for sidecar-shim. "+customImageExample)
 	hypervisor := flag.String("hypervisor", "", "hypervisor name (e.g., kvm or hyperv-direct).")
+	withKubeVirtControlPlaneLabel := flag.Bool("with-kubevirt-control-plane-label", false, "add node-role.kubevirt.io/control-plane as an additional node selector term for the operator deployment")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
@@ -173,6 +176,7 @@ func main() {
 		data.PrHelperImage = *prHelperImage
 		data.SidecarShimImage = *sidecarShimImage
 		data.Hypervisor = *hypervisor
+		data.WithKubeVirtControlPlaneLabel = *withKubeVirtControlPlaneLabel
 		if *featureGates != "" {
 			data.FeatureGates = strings.Split(*featureGates, ",")
 		}
@@ -285,6 +289,10 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		data.SidecarShimImage,
 		data.VirtOperatorImage,
 		v1.PullPolicy(data.ImagePullPolicy))
+
+	if data.WithKubeVirtControlPlaneLabel {
+		placement.InjectKubeVirtControlPlanePlacement(&deployment.Spec.Template.Spec)
+	}
 
 	writer := strings.Builder{}
 	err := util.MarshallObject(deployment.Spec, &writer)

--- a/tools/placement/BUILD.bazel
+++ b/tools/placement/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["placement.go"],
+    importpath = "kubevirt.io/kubevirt/tools/placement",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["placement_test.go"],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)

--- a/tools/placement/placement.go
+++ b/tools/placement/placement.go
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package placement
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const KubeVirtControlPlaneLabel = "node-role.kubevirt.io/control-plane"
+
+// InjectKubeVirtControlPlanePlacement appends a node-role.kubevirt.io/control-plane
+// NodeSelectorTerm and matching toleration to the given pod spec. The affinity
+// chain is initialized if nil so the NodeSelectorTerm is always added.
+func InjectKubeVirtControlPlanePlacement(podSpec *corev1.PodSpec) {
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = &corev1.Affinity{}
+	}
+	if podSpec.Affinity.NodeAffinity == nil {
+		podSpec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+	podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+		corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      KubeVirtControlPlaneLabel,
+					Operator: corev1.NodeSelectorOpExists,
+				},
+			},
+		},
+	)
+	podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{
+		Key:      KubeVirtControlPlaneLabel,
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	})
+}

--- a/tools/placement/placement_test.go
+++ b/tools/placement/placement_test.go
@@ -1,0 +1,146 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package placement
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestInjectKubeVirtControlPlanePlacement_FullAffinityChain(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{Key: "existing-key", Operator: corev1.NodeSelectorOpExists},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	InjectKubeVirtControlPlanePlacement(podSpec)
+
+	terms := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 2 {
+		t.Fatalf("expected 2 NodeSelectorTerms, got %d", len(terms))
+	}
+	if terms[1].MatchExpressions[0].Key != KubeVirtControlPlaneLabel {
+		t.Errorf("expected key %q, got %q", KubeVirtControlPlaneLabel, terms[1].MatchExpressions[0].Key)
+	}
+	if len(podSpec.Tolerations) != 1 || podSpec.Tolerations[0].Key != KubeVirtControlPlaneLabel {
+		t.Errorf("expected toleration with key %q", KubeVirtControlPlaneLabel)
+	}
+}
+
+func TestInjectKubeVirtControlPlanePlacement_NilAffinity(t *testing.T) {
+	podSpec := &corev1.PodSpec{}
+
+	InjectKubeVirtControlPlanePlacement(podSpec)
+
+	if podSpec.Affinity == nil || podSpec.Affinity.NodeAffinity == nil ||
+		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatal("expected affinity chain to be initialized")
+	}
+	terms := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 {
+		t.Fatalf("expected 1 NodeSelectorTerm, got %d", len(terms))
+	}
+	if terms[0].MatchExpressions[0].Key != KubeVirtControlPlaneLabel {
+		t.Errorf("expected key %q, got %q", KubeVirtControlPlaneLabel, terms[0].MatchExpressions[0].Key)
+	}
+	if len(podSpec.Tolerations) != 1 {
+		t.Fatalf("expected 1 toleration, got %d", len(podSpec.Tolerations))
+	}
+}
+
+func TestInjectKubeVirtControlPlanePlacement_NilNodeAffinity(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Affinity: &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{},
+		},
+	}
+
+	InjectKubeVirtControlPlanePlacement(podSpec)
+
+	if podSpec.Affinity.NodeAffinity == nil {
+		t.Fatal("expected NodeAffinity to be initialized")
+	}
+	terms := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 || terms[0].MatchExpressions[0].Key != KubeVirtControlPlaneLabel {
+		t.Error("expected NodeSelectorTerm with kubevirt control-plane label")
+	}
+	if podSpec.Affinity.PodAntiAffinity == nil {
+		t.Error("expected existing PodAntiAffinity to be preserved")
+	}
+	if len(podSpec.Tolerations) != 1 {
+		t.Fatalf("expected 1 toleration, got %d", len(podSpec.Tolerations))
+	}
+}
+
+func TestInjectKubeVirtControlPlanePlacement_NilRequiredDuring(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+					{Weight: 1},
+				},
+			},
+		},
+	}
+
+	InjectKubeVirtControlPlanePlacement(podSpec)
+
+	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatal("expected RequiredDuringSchedulingIgnoredDuringExecution to be initialized")
+	}
+	terms := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 || terms[0].MatchExpressions[0].Key != KubeVirtControlPlaneLabel {
+		t.Error("expected NodeSelectorTerm with kubevirt control-plane label")
+	}
+	if len(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+		t.Error("expected existing PreferredDuring terms to be preserved")
+	}
+}
+
+func TestInjectKubeVirtControlPlanePlacement_PreservesExistingTolerations(t *testing.T) {
+	podSpec := &corev1.PodSpec{
+		Tolerations: []corev1.Toleration{
+			{Key: "existing-taint", Operator: corev1.TolerationOpExists},
+		},
+	}
+
+	InjectKubeVirtControlPlanePlacement(podSpec)
+
+	if len(podSpec.Tolerations) != 2 {
+		t.Fatalf("expected 2 tolerations, got %d", len(podSpec.Tolerations))
+	}
+	if podSpec.Tolerations[0].Key != "existing-taint" {
+		t.Error("expected existing toleration to be preserved")
+	}
+	if podSpec.Tolerations[1].Key != KubeVirtControlPlaneLabel {
+		t.Error("expected kubevirt control-plane toleration to be appended")
+	}
+}


### PR DESCRIPTION
In some cluster topologies, there are cases in which the infrastructure hosting KubeVirt has no nodes labeled with the standard Kubernetes control-plane or master roles. The virt-operator deployment's node affinity requires one of these labels, which prevents it from being scheduled in such environments.

Add a `--with-kubevirt-control-plane-label` flag to the csv-generator and manifest-templator that, when set, appends an additional NodeSelectorTerm for `node-role.kubevirt.io/control-plane` and a matching toleration to the virt-operator deployment spec. This allows cluster administrators to label designated worker nodes with the KubeVirt-specific label so that virt-operator can be scheduled there without modifying the default control-plane scheduling rules.

The flag is gated behind the `KUBEVIRT_WITH_CONTROL_PLANE_LABEL` environment variable in the generation scripts and is off by default, preserving existing behavior.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

