### PR TITLE
DNM: VEP 172 - Add virt-preview repo and cross-arch QEMU packages

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -125,6 +125,7 @@ case "$TARGET" in
     ;;
   *sig-compute*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
+    export KUBEVIRT_E2E_FOCUS="should boot a guest using QEMU TCG emulation on a cross-architecture host"
     ;;
   *sig-operator*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-operator*/}

--- a/cmd/fake-cmd-server/fake-cmd-server.go
+++ b/cmd/fake-cmd-server/fake-cmd-server.go
@@ -24,7 +24,7 @@ func main() {
 	log.InitializeLogging("fake-cmd-server")
 
 	stopChan := make(chan struct{})
-	options := cmdserver.NewServerOptions(true)
+	options := cmdserver.NewServerOptions(true, false)
 
 	domainManager := virtwrap.NewMockDomainManager(gomock.NewController(nil))
 	domainManager.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -354,6 +354,7 @@ func main() {
 	namespace := pflag.String("namespace", "", "Namespace of the VirtualMachineInstance")
 	gracePeriodSeconds := pflag.Int("grace-period-seconds", 30, "Grace period to observe before sending SIGTERM to vmi process")
 	allowEmulation := pflag.Bool("allow-emulation", false, "Allow use of software emulation as fallback")
+	allowCrossArchEmulation := pflag.Bool("allow-cross-arch-emulation", false, "Allow cross-architecture software emulation via QEMU TCG")
 	runWithNonRoot := pflag.Bool("run-as-nonroot", false, "Run virtqemud with the 'virt' user")
 	imageVolumeEnabled := pflag.Bool("image-volume", false, "Generated with ImageVolume instead of containerDisk") //remove this once ImageVolume is GAed
 	libvirtHooksServerAndClientEnabled := pflag.Bool("libvirt-hook-server-and-client", false, "Enable pre-migration hooks on the target virt-launcher pod")
@@ -457,7 +458,7 @@ func main() {
 		stopChan,
 		hookFuncs...,
 	)
-	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn, *virtShareDir, *ephemeralDiskDir, &agentStore, *ovmfPath, ephemeralDiskCreator, metadataCache, signalStopChan, *diskMemoryLimitBytes, util.GetPodCPUSet, *imageVolumeEnabled, *libvirtHooksServerAndClientEnabled, preMigrationHookServer, *hypervisor, nbdclient.RegisterNBDServer)
+	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn, *virtShareDir, *ephemeralDiskDir, &agentStore, *ovmfPath, ephemeralDiskCreator, metadataCache, signalStopChan, *diskMemoryLimitBytes, util.GetPodCPUSet, *imageVolumeEnabled, *libvirtHooksServerAndClientEnabled, preMigrationHookServer, *hypervisor, nbdclient.RegisterNBDServer, *allowCrossArchEmulation)
 	if err != nil {
 		panic(err)
 	}
@@ -472,7 +473,7 @@ func main() {
 	// Start the virt-launcher command service.
 	// Clients can use this service to tell virt-launcher
 	// to start/stop virtual machines
-	options := cmdserver.NewServerOptions(*allowEmulation)
+	options := cmdserver.NewServerOptions(*allowEmulation, *allowCrossArchEmulation)
 	cmdclient.SetBaseDir(*virtShareDir)
 	cmdServerDone := startCmdServer(cmdclient.UninitializedSocketOnGuest(), domainManager, stopChan, options)
 

--- a/hack/rpm-deps.sh
+++ b/hack/rpm-deps.sh
@@ -46,7 +46,7 @@ SINGLE_ARCH=${SINGLE_ARCH:-""}
 BASESYSTEM=${BASESYSTEM:-"centos-stream-release"}
 
 # Select repo file based on version
-bazeldnf_repos="--repofile rpm/repo-cs${KUBEVIRT_CENTOS_STREAM_VERSION}.yaml"
+bazeldnf_repos="--repofile rpm/repo-virt-preview.yaml --repofile rpm/repo-cs${KUBEVIRT_CENTOS_STREAM_VERSION}.yaml"
 if [ "${CUSTOM_REPO}" ]; then
     bazeldnf_repos="--repofile ${CUSTOM_REPO} ${bazeldnf_repos}"
 fi
@@ -157,12 +157,17 @@ launcherbase_x86_64="
   qemu-kvm-device-display-virtio-gpu-pci-${QEMU_VERSION}
   qemu-kvm-device-usb-redirect-${QEMU_VERSION}
   seabios-${SEABIOS_VERSION}
+  qemu-system-aarch64-core
+  edk2-aarch64
 "
 launcherbase_aarch64="
   edk2-aarch64-${EDK2_VERSION}
   qemu-kvm-device-usb-redirect-${QEMU_VERSION}
   qemu-kvm-device-display-virtio-gpu-${QEMU_VERSION}
   qemu-kvm-device-display-virtio-gpu-pci-${QEMU_VERSION}
+  qemu-system-x86-core
+  edk2-ovmf
+  seabios
 "
 launcherbase_s390x="
   qemu-kvm-device-display-virtio-gpu-${QEMU_VERSION}

--- a/pkg/hypervisor/kvm/runtime.go
+++ b/pkg/hypervisor/kvm/runtime.go
@@ -98,7 +98,11 @@ func (k *KvmVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config 
 	} else {
 		// TODO: Remove this fallback once VmiMemoryOverheadReport feature gate is GA
 		// and we are sure that all VMIs include the MemoryOverhead status field
-		memlockSize = k.GetMemoryOverhead(vmi, runtime.GOARCH, config.AdditionalGuestMemoryOverheadRatio)
+		cpuArch := runtime.GOARCH
+		if vmi.Spec.Architecture != "" {
+			cpuArch = vmi.Spec.Architecture
+		}
+		memlockSize = k.GetMemoryOverhead(vmi, cpuArch, config.AdditionalGuestMemoryOverheadRatio)
 	}
 	// Add memory assigned to the VM
 	vmiBaseMemory := getVMIBaseMemory(vmi)

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -137,6 +137,10 @@ func (config *ClusterConfig) MultiArchitectureEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.MultiArchitecture)
 }
 
+func (config *ClusterConfig) CrossArchitectureVirtualizationEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.CrossArchitectureVirtualization)
+}
+
 func (config *ClusterConfig) AlignCPUsEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.AlignCPUsGate)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -223,6 +223,16 @@ const (
 	// The VGPULiveMigration fg enables the vGPU hook to run for vGPU live migrations, allowing the
 	// target XML's mdev UUID to be mutated.
 	VGPULiveMigration = "VGPULiveMigration"
+
+	// Owner: sig-compute / @lyarwood
+	// Alpha: v1.9.0
+	//
+	// CrossArchitectureVirtualization enables cross-architecture VM execution.
+	// When enabled, VMs can run on nodes with a different CPU architecture than
+	// the guest (e.g., ARM64 guests on AMD64 hosts) via software emulation or
+	// hardware-accelerated virtualization. Independent of useEmulation.
+	// See VEP #172.
+	CrossArchitectureVirtualization = "CrossArchitectureVirtualization"
 )
 
 func init() {
@@ -267,4 +277,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ReservedOverheadMemlock, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: OptOutRoleAggregation, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VGPULiveMigration, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: CrossArchitectureVirtualization, State: Alpha})
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -432,6 +432,10 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		command = append(command, "--allow-emulation")
 	}
 
+	if t.clusterConfig.CrossArchitectureVirtualizationEnabled() {
+		command = append(command, "--allow-cross-arch-emulation")
+	}
+
 	if checkForKeepLauncherAfterFailure(vmi) {
 		command = append(command, "--keep-after-failure")
 	}
@@ -734,6 +738,8 @@ func (t *TemplateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		opts = append(opts, WithMachineType(machineType))
 	}
 
+	crossArchEmulation := t.clusterConfig.CrossArchitectureVirtualizationEnabled()
+
 	if topology.IsManualTSCFrequencyRequired(vmi) {
 		opts = append(opts, WithTSCTimer(vmi.Status.TopologyHints.TSCFrequency))
 	}
@@ -766,10 +772,15 @@ func (t *TemplateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		opts = append(opts, WithTDXSelector())
 	}
 
+	architecture := vmi.Spec.Architecture
+	if crossArchEmulation {
+		architecture = ""
+	}
+
 	return NewNodeSelectorRenderer(
 		vmi.Spec.NodeSelector,
 		t.clusterConfig.GetNodeSelectors(),
-		vmi.Spec.Architecture,
+		architecture,
 		opts...,
 	)
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -161,6 +161,34 @@ func setNodeAffinityForPod(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
 	setNodeAffinityForbiddenFeaturePolicy(vmi, pod)
 }
 
+func setPreferredArchitectureAffinity(architecture string, pod *k8sv1.Pod) {
+	if architecture == "" {
+		return
+	}
+	preferredTerm := k8sv1.PreferredSchedulingTerm{
+		Weight: 100,
+		Preference: k8sv1.NodeSelectorTerm{
+			MatchExpressions: []k8sv1.NodeSelectorRequirement{
+				{
+					Key:      k8sv1.LabelArchStable,
+					Operator: k8sv1.NodeSelectorOpIn,
+					Values:   []string{strings.ToLower(architecture)},
+				},
+			},
+		},
+	}
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &k8sv1.Affinity{}
+	}
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		pod.Spec.Affinity.NodeAffinity = &k8sv1.NodeAffinity{}
+	}
+	pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		preferredTerm,
+	)
+}
+
 func setNodeAffinityForHostModelCpuModel(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel {
 		pod.Spec.Affinity = modifyNodeAffintyToRejectLabel(pod.Spec.Affinity, v1.NodeHostModelIsObsoleteLabel)
@@ -693,6 +721,16 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 
 	setNodeAffinityForPod(vmi, &pod)
 
+	if t.clusterConfig.CrossArchitectureVirtualizationEnabled() {
+		setPreferredArchitectureAffinity(vmi.Spec.Architecture, &pod)
+		if vmi.Spec.Architecture != "" {
+			if pod.Spec.NodeSelector == nil {
+				pod.Spec.NodeSelector = map[string]string{}
+			}
+			pod.Spec.NodeSelector[v1.VMArchLabel+vmi.Spec.Architecture] = "true"
+		}
+	}
+
 	serviceAccountName := serviceAccount(vmi.Spec.Volumes...)
 	if len(serviceAccountName) > 0 {
 		pod.Spec.ServiceAccountName = serviceAccountName
@@ -738,8 +776,6 @@ func (t *TemplateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		opts = append(opts, WithMachineType(machineType))
 	}
 
-	crossArchEmulation := t.clusterConfig.CrossArchitectureVirtualizationEnabled()
-
 	if topology.IsManualTSCFrequencyRequired(vmi) {
 		opts = append(opts, WithTSCTimer(vmi.Status.TopologyHints.TSCFrequency))
 	}
@@ -773,7 +809,7 @@ func (t *TemplateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 	}
 
 	architecture := vmi.Spec.Architecture
-	if crossArchEmulation {
+	if t.clusterConfig.CrossArchitectureVirtualizationEnabled() {
 		architecture = ""
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -262,6 +262,40 @@ var _ = Describe("Template", func() {
 				Expect(containers[0].Resources.Limits.Name(kvmResource, resource.DecimalSI)).To(Equal(resource.NewQuantity(0, resource.DecimalSI)))
 				Expect(containers[0].Command).To(ContainElements(allowEmulationOption))
 			})
+
+			It("should add the allow-cross-arch-emulation option when feature gate is enabled", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{"CrossArchitectureVirtualization"}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
+
+				pod, err := svc.RenderLaunchManifest(libvmi.New(libvmi.WithNamespace(testNamespace)))
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(pod.Spec.Containers[0].Command).To(ContainElements("--allow-cross-arch-emulation"))
+			})
+
+			It("should not add the allow-cross-arch-emulation option by default", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+
+				pod, err := svc.RenderLaunchManifest(libvmi.New(libvmi.WithNamespace(testNamespace)))
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(pod.Spec.Containers[0].Command).NotTo(ContainElements("--allow-cross-arch-emulation"))
+			})
+
+			It("should not set kubernetes.io/arch node selector when CrossArchitectureVirtualization is enabled", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{"CrossArchitectureVirtualization"}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
+
+				vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithArchitecture("arm64"))
+				pod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(pod.Spec.NodeSelector).NotTo(HaveKey(k8sv1.LabelArchStable))
+			})
 		})
 
 		It("should not set seccomp profile by default", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Command).NotTo(ContainElements("--allow-cross-arch-emulation"))
 			})
 
-			It("should not set kubernetes.io/arch node selector when CrossArchitectureVirtualization is enabled", func() {
+			It("should not set kubernetes.io/arch node selector but should set preferred arch affinity and hard vm-arch selector when CrossArchitectureVirtualization is enabled", func() {
 				config, kvStore, svc = configFactory(defaultArch)
 				kvConfig := kv.DeepCopy()
 				kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{"CrossArchitectureVirtualization"}
@@ -295,6 +295,20 @@ var _ = Describe("Template", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(pod.Spec.NodeSelector).NotTo(HaveKey(k8sv1.LabelArchStable))
+				Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue(v1.VMArchLabel+"arm64", "true"))
+
+				Expect(pod.Spec.Affinity).NotTo(BeNil())
+				Expect(pod.Spec.Affinity.NodeAffinity).NotTo(BeNil())
+				preferred := pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+				Expect(preferred).To(HaveLen(1))
+				Expect(preferred[0].Weight).To(Equal(int32(100)))
+				Expect(preferred[0].Preference.MatchExpressions).To(ConsistOf(
+					k8sv1.NodeSelectorRequirement{
+						Key:      k8sv1.LabelArchStable,
+						Operator: k8sv1.NodeSelectorOpIn,
+						Values:   []string{"arm64"},
+					},
+				))
 			})
 		})
 

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "//pkg/testutils:go_default_library",
+            "//pkg/virt-config/featuregate:go_default_library",
             "//pkg/virt-handler/node-labeller/util:go_default_library",
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",
@@ -68,6 +69,7 @@ go_test(
         ],
         "@io_bazel_rules_go//go/platform:s390x": [
             "//pkg/testutils:go_default_library",
+            "//pkg/virt-config/featuregate:go_default_library",
             "//pkg/virt-handler/node-labeller/util:go_default_library",
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -61,6 +61,7 @@ var nodeLabellerLabels = []string{
 	kubevirtv1.HostModelRequiredFeaturesLabel,
 	kubevirtv1.NodeHostModelIsObsoleteLabel,
 	kubevirtv1.SupportedMachineTypeLabel,
+	kubevirtv1.VMArchLabel,
 }
 
 // NodeLabeller struct holds information needed to run node-labeller
@@ -307,6 +308,17 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
 
 	if n.TDX.Supported == "yes" {
 		newLabels[kubevirtv1.TDXLabel] = "true"
+	}
+
+	nativeArch := n.arch.arch()
+	newLabels[kubevirtv1.VMArchLabel+nativeArch] = "true"
+	if n.clusterConfig.CrossArchitectureVirtualizationEnabled() {
+		switch nativeArch {
+		case "amd64":
+			newLabels[kubevirtv1.VMArchLabel+"arm64"] = "true"
+		case "arm64":
+			newLabels[kubevirtv1.VMArchLabel+"amd64"] = "true"
+		}
 	}
 
 	return newLabels

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -40,6 +40,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
@@ -216,6 +217,39 @@ var _ = Describe("Node-labeller ", func() {
 
 		node := retrieveNode(kubeClient)
 		Expect(node.Labels).To(HaveKeyWithValue(v1.TDXLabel, "true"))
+	})
+
+	It("should add native vm-arch label", func() {
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(HaveKeyWithValue(v1.VMArchLabel+"amd64", "true"))
+		Expect(node.Labels).ToNot(HaveKey(v1.VMArchLabel + "arm64"))
+	})
+
+	It("should add cross-arch vm-arch label when feature gate is enabled", func() {
+		initNodeLabeller(&v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubevirt",
+				Namespace: "kubevirt",
+			},
+			Spec: v1.KubeVirtSpec{
+				Configuration: v1.KubeVirtConfiguration{
+					ObsoleteCPUModels: util.DefaultObsoleteCPUModels,
+					DeveloperConfiguration: &v1.DeveloperConfiguration{
+						FeatureGates: []string{string(featuregate.CrossArchitectureVirtualization)},
+					},
+				},
+			},
+		})
+
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(HaveKeyWithValue(v1.VMArchLabel+"amd64", "true"))
+		Expect(node.Labels).To(HaveKeyWithValue(v1.VMArchLabel+"arm64", "true"))
 	})
 
 	It("should add usable cpu model labels for the host cpu model", func() {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -845,6 +846,27 @@ func (c *VirtualMachineController) updatePausedConditions(vmi *v1.VirtualMachine
 	}
 }
 
+func (c *VirtualMachineController) updateSoftwareEmulationCondition(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) {
+	isCrossArchEmulation := domain != nil && domain.Spec.Type == "qemu" &&
+		vmi.Spec.Architecture != "" && vmi.Spec.Architecture != runtime.GOARCH
+
+	if isCrossArchEmulation {
+		if !condManager.HasCondition(vmi, v1.VirtualMachineInstanceSoftwareEmulation) {
+			now := metav1.Now()
+			vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
+				Type:               v1.VirtualMachineInstanceSoftwareEmulation,
+				Status:             k8sv1.ConditionTrue,
+				LastProbeTime:      now,
+				LastTransitionTime: now,
+				Reason:             "CrossArchitectureEmulation",
+				Message:            fmt.Sprintf("VM running with software emulation (host=%s, guest=%s)", runtime.GOARCH, vmi.Spec.Architecture),
+			})
+		}
+	} else if condManager.HasCondition(vmi, v1.VirtualMachineInstanceSoftwareEmulation) {
+		condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceSoftwareEmulation)
+	}
+}
+
 func dumpTargetFile(vmiName, volName string) string {
 	targetFileName := fmt.Sprintf("%s-%s-%s.memory.dump", vmiName, volName, time.Now().Format("20060102-150405"))
 	return targetFileName
@@ -1051,6 +1073,7 @@ func (c *VirtualMachineController) updateVMIConditions(vmi *v1.VirtualMachineIns
 		return err
 	}
 	c.updatePausedConditions(vmi, domain, condManager)
+	c.updateSoftwareEmulationCondition(vmi, domain, condManager)
 
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -48,16 +48,21 @@ const (
 )
 
 type ServerOptions struct {
-	allowEmulation bool
+	allowEmulation          bool
+	allowCrossArchEmulation bool
 }
 
-func NewServerOptions(allowEmulation bool) *ServerOptions {
-	return &ServerOptions{allowEmulation: allowEmulation}
+func NewServerOptions(allowEmulation, allowCrossArchEmulation bool) *ServerOptions {
+	return &ServerOptions{
+		allowEmulation:          allowEmulation,
+		allowCrossArchEmulation: allowCrossArchEmulation,
+	}
 }
 
 type Launcher struct {
-	domainManager  virtwrap.DomainManager
-	allowEmulation bool
+	domainManager           virtwrap.DomainManager
+	allowEmulation          bool
+	allowCrossArchEmulation bool
 }
 
 func getVMIFromRequest(request *cmdv1.VMI) (*v1.VirtualMachineInstance, *cmdv1.Response) {
@@ -624,14 +629,17 @@ func RunServer(socketPath string,
 	options *ServerOptions) (chan struct{}, error) {
 
 	allowEmulation := false
+	allowCrossArchEmulation := false
 	if options != nil {
 		allowEmulation = options.allowEmulation
+		allowCrossArchEmulation = options.allowCrossArchEmulation
 	}
 
 	grpcServer := grpc.NewServer([]grpc.ServerOption{}...)
 	server := &Launcher{
-		domainManager:  domainManager,
-		allowEmulation: allowEmulation,
+		domainManager:           domainManager,
+		allowEmulation:          allowEmulation,
+		allowCrossArchEmulation: allowCrossArchEmulation,
 	}
 	registerInfoServer(grpcServer)
 

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Virt remote commands", func() {
 		socketPath := filepath.Join(shareDir, "server.sock")
 
 		allowEmulation = true
-		options = NewServerOptions(allowEmulation)
+		options = NewServerOptions(allowEmulation, false)
 		RunServer(socketPath, domainManager, stop, options)
 		client, err = cmdclient.NewClient(socketPath)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -29,12 +29,14 @@ import (
 type CPUDomainConfigurator struct {
 	isHotplugSupported       bool
 	requiresMPXCPUValidation bool
+	crossArchEmulation       bool
 }
 
-func NewCPUDomainConfigurator(isHotplugSupported, requiresMPXCPUValidation bool) CPUDomainConfigurator {
+func NewCPUDomainConfigurator(isHotplugSupported, requiresMPXCPUValidation, crossArchEmulation bool) CPUDomainConfigurator {
 	return CPUDomainConfigurator{
 		isHotplugSupported:       isHotplugSupported,
 		requiresMPXCPUValidation: requiresMPXCPUValidation,
+		crossArchEmulation:       crossArchEmulation,
 	}
 }
 
@@ -59,7 +61,13 @@ func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 	if vmi.Spec.Domain.CPU != nil {
 		// Set VM CPU model and vendor
 		if vmi.Spec.Domain.CPU.Model != "" {
-			if vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostPassthrough {
+			isHostCPUMode := vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostPassthrough
+			if c.crossArchEmulation && isHostCPUMode {
+				// host-passthrough and host-model are incompatible with cross-architecture
+				// TCG emulation. Use "max" which exposes all features QEMU can emulate.
+				domain.Spec.CPU.Mode = "custom"
+				domain.Spec.CPU.Model = "max"
+			} else if isHostCPUMode {
 				domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
 			} else {
 				domain.Spec.CPU.Mode = "custom"
@@ -102,7 +110,12 @@ func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 	}
 
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		domain.Spec.CPU.Mode = v1.CPUModeHostModel
+		if c.crossArchEmulation {
+			domain.Spec.CPU.Mode = "custom"
+			domain.Spec.CPU.Model = "max"
+		} else {
+			domain.Spec.CPU.Mode = v1.CPUModeHostModel
+		}
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/converter/compute/graphics.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/graphics.go
@@ -37,17 +37,26 @@ const (
 type GraphicsDomainConfigurator struct {
 	architecture         string
 	useBochsForEFIGuests bool
+	crossArchEmulation   bool
 }
 
-func NewGraphicsDomainConfigurator(architecture string, useBochsForEFIGuests bool) GraphicsDomainConfigurator {
+func NewGraphicsDomainConfigurator(architecture string, useBochsForEFIGuests, crossArchEmulation bool) GraphicsDomainConfigurator {
 	return GraphicsDomainConfigurator{
 		architecture:         architecture,
 		useBochsForEFIGuests: useBochsForEFIGuests,
+		crossArchEmulation:   crossArchEmulation,
 	}
 }
 
 func (g GraphicsDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice != nil && !*vmi.Spec.Domain.Devices.AutoattachGraphicsDevice {
+		return nil
+	}
+
+	// Cross-architecture emulation uses a minimal QEMU binary that may not
+	// include video device support (e.g. virtio-gpu). Disable graphics to
+	// avoid libvirt validation errors; serial console remains available.
+	if g.crossArchEmulation {
 		return nil
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/graphics_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/graphics_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 			vmi := libvmi.New(libvmi.WithAutoattachGraphicsDevice(false))
 
 			domain := api.Domain{}
-			configurator := compute.NewGraphicsDomainConfigurator(arch, false)
+			configurator := compute.NewGraphicsDomainConfigurator(arch, false, false)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			Expect(domain).To(Equal(api.Domain{}))
@@ -55,7 +55,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 			vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = autoAttach
 
 			domain := api.Domain{}
-			configurator := compute.NewGraphicsDomainConfigurator(arch, false)
+			configurator := compute.NewGraphicsDomainConfigurator(arch, false, false)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{
@@ -91,7 +91,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 			vmi := libvmi.New(libvmi.WithVideo("virtio"))
 			var domain api.Domain
 
-			configurator := compute.NewGraphicsDomainConfigurator(arch, bochsForEFI)
+			configurator := compute.NewGraphicsDomainConfigurator(arch, bochsForEFI, false)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{
@@ -132,7 +132,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 		DescribeTable("amd64 defaults to VGA with VRAM", func(vmi *v1.VirtualMachineInstance, bochsForEFI bool) {
 			var domain api.Domain
 
-			configurator := compute.NewGraphicsDomainConfigurator("amd64", bochsForEFI)
+			configurator := compute.NewGraphicsDomainConfigurator("amd64", bochsForEFI, false)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{
@@ -171,7 +171,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 			vmi := libvmi.New(libvmi.WithUefi(true))
 			var domain api.Domain
 
-			configurator := compute.NewGraphicsDomainConfigurator("amd64", true)
+			configurator := compute.NewGraphicsDomainConfigurator("amd64", true, false)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1050,7 +1050,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			compute.BalloonWithMemBalloonStatsPeriod(c.MemBalloonStatsPeriod),
 			compute.BalloonWithVirtioModel(virtioModel),
 		),
-		compute.NewGraphicsDomainConfigurator(architecture, c.BochsForEFIGuests),
+		compute.NewGraphicsDomainConfigurator(architecture, c.BochsForEFIGuests, c.AllowCrossArchEmulation),
 		compute.SoundDomainConfigurator{},
 		compute.NewHostDeviceDomainConfigurator(
 			c.GenericHostDevices,
@@ -1074,7 +1074,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			compute.ControllersWithVirtioSerialModel(virtioModel),
 		),
 		compute.NewQemuCmdDomainConfigurator(c.Architecture.ShouldVerboseLogsBeEnabled()),
-		compute.NewCPUDomainConfigurator(c.Architecture.SupportCPUHotplug(), c.Architecture.RequiresMPXCPUValidation()),
+		compute.NewCPUDomainConfigurator(c.Architecture.SupportCPUHotplug(), c.Architecture.RequiresMPXCPUValidation(), c.AllowCrossArchEmulation),
 		compute.NewIOThreadsDomainConfigurator(uint(ioThreadCount)),
 		compute.MemoryConfigurator{},
 		compute.RebootPolicyDomainConfigurator{},
@@ -1084,7 +1084,11 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	case v1.HyperVDirectHypervisorName:
 		configurators = append(configurators, mshv.NewMshvDomainConfigurator(c.AllowEmulation, c.HypervisorDeviceAvailable))
 	default:
-		configurators = append(configurators, kvm.NewKvmDomainConfigurator(c.AllowEmulation, c.HypervisorDeviceAvailable))
+		if c.AllowCrossArchEmulation {
+			configurators = append(configurators, kvm.NewKvmDomainConfiguratorWithCrossArch(c.AllowEmulation, c.HypervisorDeviceAvailable, c.AllowCrossArchEmulation, c.HostArchitecture))
+		} else {
+			configurators = append(configurators, kvm.NewKvmDomainConfigurator(c.AllowEmulation, c.HypervisorDeviceAvailable))
+		}
 	}
 
 	builder := convertertypes.NewDomainBuilder(configurators...)

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
@@ -21,6 +21,7 @@ package kvm
 
 import (
 	"fmt"
+	"os"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -28,9 +29,30 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+var defaultEmulatorBinaryExists = func(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("required emulator binary not found: %s", path)
+	}
+	return nil
+}
+
+var emulatorBinaryExists = defaultEmulatorBinaryExists
+
+// SetEmulatorBinaryExistsFunc overrides the emulator binary existence check (for testing).
+func SetEmulatorBinaryExistsFunc(f func(string) error) {
+	emulatorBinaryExists = f
+}
+
+// ResetEmulatorBinaryExistsFunc restores the default emulator binary existence check.
+func ResetEmulatorBinaryExistsFunc() {
+	emulatorBinaryExists = defaultEmulatorBinaryExists
+}
+
 type KvmDomainConfigurator struct {
-	allowEmulation bool
-	kvmAvailable   bool
+	allowEmulation          bool
+	kvmAvailable            bool
+	allowCrossArchEmulation bool
+	hostArchitecture        string
 }
 
 // NewKvmDomainConfigurator creates a new hypervisor domain configurator
@@ -41,17 +63,70 @@ func NewKvmDomainConfigurator(allowEmulation bool, kvmAvailable bool) KvmDomainC
 	}
 }
 
+// NewKvmDomainConfiguratorWithCrossArch creates a new hypervisor domain configurator with cross-architecture emulation support
+func NewKvmDomainConfiguratorWithCrossArch(allowEmulation, kvmAvailable, allowCrossArchEmulation bool, hostArchitecture string) KvmDomainConfigurator {
+	return KvmDomainConfigurator{
+		allowEmulation:          allowEmulation,
+		kvmAvailable:            kvmAvailable,
+		allowCrossArchEmulation: allowCrossArchEmulation,
+		hostArchitecture:        hostArchitecture,
+	}
+}
+
 // Configure configures the domain hypervisor settings based on KVM availability and emulation settings
 func (k KvmDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
-	if !k.kvmAvailable {
-		if k.allowEmulation {
-			logger := log.DefaultLogger()
-			logger.Infof("kvm not present. Using software emulation.")
-			domain.Spec.Type = "qemu"
+	crossArchEmulation := k.isCrossArchEmulation(vmi)
+
+	if !k.kvmAvailable || crossArchEmulation {
+		if !k.allowEmulation {
+			return fmt.Errorf("kvm not present or cross-architecture emulation requested, but emulation is not allowed")
+		}
+
+		if crossArchEmulation && !k.allowCrossArchEmulation {
+			return fmt.Errorf("cross-architecture emulation requires the CrossArchitectureVirtualization feature gate")
+		}
+
+		logger := log.DefaultLogger()
+		if crossArchEmulation {
+			logger.Infof("Cross-architecture emulation: host=%s, guest=%s. Using software emulation.",
+				k.hostArchitecture, vmi.Spec.Architecture)
 		} else {
-			return fmt.Errorf("kvm not present")
+			logger.Infof("kvm not present. Using software emulation.")
+		}
+
+		domain.Spec.Type = "qemu"
+
+		if crossArchEmulation {
+			path := emulatorPath(vmi.Spec.Architecture)
+			if path == "" {
+				return fmt.Errorf("unsupported guest architecture for cross-architecture emulation: %s", vmi.Spec.Architecture)
+			}
+			if err := emulatorBinaryExists(path); err != nil {
+				return err
+			}
+			domain.Spec.Devices.Emulator = path
 		}
 	}
 
 	return nil
+}
+
+func (k KvmDomainConfigurator) isCrossArchEmulation(vmi *v1.VirtualMachineInstance) bool {
+	if k.hostArchitecture == "" || vmi.Spec.Architecture == "" {
+		return false
+	}
+	return vmi.Spec.Architecture != k.hostArchitecture
+}
+
+func emulatorPath(guestArch string) string {
+	switch guestArch {
+	case "arm64", "aarch64":
+		return "/usr/bin/qemu-system-aarch64"
+	case "amd64", "x86_64":
+		return "/usr/bin/qemu-system-x86_64"
+	case "s390x":
+		return "/usr/bin/qemu-system-s390x"
+	default:
+		return ""
+	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
@@ -77,35 +77,36 @@ func NewKvmDomainConfiguratorWithCrossArch(allowEmulation, kvmAvailable, allowCr
 func (k KvmDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	crossArchEmulation := k.isCrossArchEmulation(vmi)
 
-	if !k.kvmAvailable || crossArchEmulation {
-		if !k.allowEmulation {
-			return fmt.Errorf("kvm not present or cross-architecture emulation requested, but emulation is not allowed")
-		}
-
-		if crossArchEmulation && !k.allowCrossArchEmulation {
+	if crossArchEmulation {
+		if !k.allowCrossArchEmulation {
 			return fmt.Errorf("cross-architecture emulation requires the CrossArchitectureVirtualization feature gate")
 		}
 
 		logger := log.DefaultLogger()
-		if crossArchEmulation {
-			logger.Infof("Cross-architecture emulation: host=%s, guest=%s. Using software emulation.",
-				k.hostArchitecture, vmi.Spec.Architecture)
-		} else {
-			logger.Infof("kvm not present. Using software emulation.")
-		}
+		logger.Infof("Cross-architecture emulation: host=%s, guest=%s. Using software emulation.",
+			k.hostArchitecture, vmi.Spec.Architecture)
 
 		domain.Spec.Type = "qemu"
 
-		if crossArchEmulation {
-			path := emulatorPath(vmi.Spec.Architecture)
-			if path == "" {
-				return fmt.Errorf("unsupported guest architecture for cross-architecture emulation: %s", vmi.Spec.Architecture)
-			}
-			if err := emulatorBinaryExists(path); err != nil {
-				return err
-			}
-			domain.Spec.Devices.Emulator = path
+		path := emulatorPath(vmi.Spec.Architecture)
+		if path == "" {
+			return fmt.Errorf("unsupported guest architecture for cross-architecture emulation: %s", vmi.Spec.Architecture)
 		}
+		if err := emulatorBinaryExists(path); err != nil {
+			return err
+		}
+		domain.Spec.Devices.Emulator = path
+
+		return nil
+	}
+
+	if !k.kvmAvailable {
+		if !k.allowEmulation {
+			return fmt.Errorf("kvm not present and emulation is not allowed")
+		}
+
+		log.DefaultLogger().Infof("kvm not present. Using software emulation.")
+		domain.Spec.Type = "qemu"
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 			configurator := kvm.NewKvmDomainConfigurator(!emulationAllowed, !kvmEnabled)
 			err := configurator.Configure(vmi, &domain)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("kvm not present"))
+			Expect(err.Error()).To(ContainSubstring("kvm not present and emulation is not allowed"))
 		})
 
 		It("Should set domain type to qemu when emulation is allowed", func() {
@@ -115,14 +115,14 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 			Expect(err.Error()).To(ContainSubstring("CrossArchitectureVirtualization"))
 		})
 
-		It("Should return error when emulation is not allowed for cross-arch", func() {
+		It("Should succeed for cross-arch even when useEmulation is disabled", func() {
 			vmi.Spec.Architecture = "arm64"
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
 				!emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
 			)
-			err := configurator.Configure(vmi, &domain)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("emulation is not allowed"))
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal("qemu"))
+			Expect(domain.Spec.Devices.Emulator).To(Equal("/usr/bin/qemu-system-aarch64"))
 		})
 
 		It("Should not trigger cross-arch when guest matches host", func() {

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
@@ -20,6 +20,8 @@
 package kvm_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -74,6 +76,116 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 			configurator := kvm.NewKvmDomainConfigurator(emulationAllowed, !kvmEnabled)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal("qemu"))
+		})
+	})
+
+	Context("Cross-architecture emulation", func() {
+		const (
+			crossArchAllowed = true
+		)
+
+		BeforeEach(func() {
+			// Skip binary existence check in unit tests
+			kvm.SetEmulatorBinaryExistsFunc(func(path string) error {
+				return nil
+			})
+		})
+
+		AfterEach(func() {
+			kvm.ResetEmulatorBinaryExistsFunc()
+		})
+
+		It("Should set domain type to qemu and emulator path for cross-arch", func() {
+			vmi.Spec.Architecture = "arm64"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+			)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal("qemu"))
+			Expect(domain.Spec.Devices.Emulator).To(Equal("/usr/bin/qemu-system-aarch64"))
+		})
+
+		It("Should return error when cross-arch feature gate is disabled", func() {
+			vmi.Spec.Architecture = "arm64"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, !crossArchAllowed, "amd64",
+			)
+			err := configurator.Configure(vmi, &domain)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("CrossArchitectureVirtualization"))
+		})
+
+		It("Should return error when emulation is not allowed for cross-arch", func() {
+			vmi.Spec.Architecture = "arm64"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				!emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+			)
+			err := configurator.Configure(vmi, &domain)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("emulation is not allowed"))
+		})
+
+		It("Should not trigger cross-arch when guest matches host", func() {
+			vmi.Spec.Architecture = "amd64"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+			)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal(""))
+		})
+
+		It("Should not trigger cross-arch when guest architecture is empty", func() {
+			vmi.Spec.Architecture = ""
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+			)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal(""))
+		})
+
+		It("Should set correct emulator path for amd64 guest on arm64 host", func() {
+			vmi.Spec.Architecture = "amd64"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, crossArchAllowed, "arm64",
+			)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal("qemu"))
+			Expect(domain.Spec.Devices.Emulator).To(Equal("/usr/bin/qemu-system-x86_64"))
+		})
+
+		It("Should set correct emulator path for s390x guest", func() {
+			vmi.Spec.Architecture = "s390x"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+			)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+			Expect(domain.Spec.Type).To(Equal("qemu"))
+			Expect(domain.Spec.Devices.Emulator).To(Equal("/usr/bin/qemu-system-s390x"))
+		})
+
+		It("Should return error when emulator binary is missing", func() {
+			kvm.SetEmulatorBinaryExistsFunc(func(path string) error {
+				return fmt.Errorf("required emulator binary not found: %s", path)
+			})
+
+			vmi.Spec.Architecture = "arm64"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+			)
+			err := configurator.Configure(vmi, &domain)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("required emulator binary not found"))
+			Expect(err.Error()).To(ContainSubstring("qemu-system-aarch64"))
+		})
+
+		It("Should return error for unsupported guest architecture", func() {
+			vmi.Spec.Architecture = "riscv64"
+			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
+				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+			)
+			err := configurator.Configure(vmi, &domain)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported guest architecture"))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/types/converter-context.go
+++ b/pkg/virt-launcher/virtwrap/converter/types/converter-context.go
@@ -68,4 +68,6 @@ type ConverterContext struct {
 	PCINUMAAwareTopologyEnabled     bool
 	DomainAttachmentByInterfaceName map[string]string
 	HypervisorName                  string
+	AllowCrossArchEmulation         bool
+	HostArchitecture                string
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Live migration source", func() {
 				nil,
 				v1.KvmHypervisorName,
 				nil,
+				false, // allow cross-arch emulation
 			)
 			libvirtDomainManager = manager.(*LibvirtDomainManager)
 			libvirtDomainManager.initializeMigrationMetadata(vmi, v1.MigrationPreCopy)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -191,6 +191,7 @@ type LibvirtDomainManager struct {
 	cloudInitDataStore     *cloudinit.CloudInitData
 	setGuestTimeContextPtr *contextStore
 	efiEnvironment         *efi.EFIEnvironment
+	ovmfPath               string
 	ephemeralDiskCreator   ephemeraldisk.EphemeralDiskCreatorInterface
 	directIOChecker        converter.DirectIOChecker
 	disksInfo              map[string]*osdisk.DiskInfo
@@ -215,6 +216,7 @@ type LibvirtDomainManager struct {
 
 	hypervisorDeviceAvailable bool
 	hypervisorName            string
+	allowCrossArchEmulation   bool
 }
 
 type pausedVMIs struct {
@@ -242,14 +244,14 @@ func (s pausedVMIs) contains(uid types.UID) bool {
 
 func NewLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralDiskDir string, agentStore *agentpoller.AsyncAgentStore,
 	ovmfPath string, ephemeralDiskCreator ephemeraldisk.EphemeralDiskCreatorInterface, metadataCache *metadata.Cache,
-	stopChan chan struct{}, diskMemoryLimitBytes int64, cpuSetGetter func() ([]int, error), imageVolumeEnabled bool, libvirtHooksServerAndClientEnabled bool, hookServer *premigrationhookserver.PreMigrationHookServer, hypervisorName string, registerNBD storage.RegisterNBDFunc) (DomainManager, error) {
+	stopChan chan struct{}, diskMemoryLimitBytes int64, cpuSetGetter func() ([]int, error), imageVolumeEnabled bool, libvirtHooksServerAndClientEnabled bool, hookServer *premigrationhookserver.PreMigrationHookServer, hypervisorName string, registerNBD storage.RegisterNBDFunc, allowCrossArchEmulation bool) (DomainManager, error) {
 	directIOChecker := converter.NewDirectIOChecker()
-	return newLibvirtDomainManager(connection, virtShareDir, ephemeralDiskDir, agentStore, ovmfPath, ephemeralDiskCreator, directIOChecker, metadataCache, stopChan, diskMemoryLimitBytes, cpuSetGetter, imageVolumeEnabled, libvirtHooksServerAndClientEnabled, hookServer, hypervisorName, registerNBD)
+	return newLibvirtDomainManager(connection, virtShareDir, ephemeralDiskDir, agentStore, ovmfPath, ephemeralDiskCreator, directIOChecker, metadataCache, stopChan, diskMemoryLimitBytes, cpuSetGetter, imageVolumeEnabled, libvirtHooksServerAndClientEnabled, hookServer, hypervisorName, registerNBD, allowCrossArchEmulation)
 }
 
 func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralDiskDir string, agentStore *agentpoller.AsyncAgentStore, ovmfPath string,
 	ephemeralDiskCreator ephemeraldisk.EphemeralDiskCreatorInterface, directIOChecker converter.DirectIOChecker, metadataCache *metadata.Cache,
-	stopChan chan struct{}, diskMemoryLimitBytes int64, cpuSetGetter func() ([]int, error), imageVolumeEnabled bool, libvirtHooksServerAndClientEnabled bool, hookServer *premigrationhookserver.PreMigrationHookServer, hypervisorName string, registerNBD storage.RegisterNBDFunc) (DomainManager, error) {
+	stopChan chan struct{}, diskMemoryLimitBytes int64, cpuSetGetter func() ([]int, error), imageVolumeEnabled bool, libvirtHooksServerAndClientEnabled bool, hookServer *premigrationhookserver.PreMigrationHookServer, hypervisorName string, registerNBD storage.RegisterNBDFunc, allowCrossArchEmulation bool) (DomainManager, error) {
 
 	// Check hypervisor device availability
 	hypervisorDevicePath := "/dev/" + hypervisor.NewLauncherHypervisorResources(hypervisorName).GetHypervisorDevice()
@@ -273,6 +275,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
 
 		agentData:            agentStore,
 		efiEnvironment:       efi.DetectEFIEnvironment(runtime.GOARCH, ovmfPath),
+		ovmfPath:             ovmfPath,
 		ephemeralDiskCreator: ephemeralDiskCreator,
 		directIOChecker:      directIOChecker,
 		disksInfo:            map[string]*osdisk.DiskInfo{},
@@ -286,6 +289,7 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
 		hookServer:                         hookServer,
 		hypervisorName:                     hypervisorName,
 		hypervisorDeviceAvailable:          hypervisorDeviceAvailable,
+		allowCrossArchEmulation:            allowCrossArchEmulation,
 	}
 
 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
@@ -1139,6 +1143,14 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		}
 	}
 
+	// For cross-architecture emulation, re-detect the EFI environment using the
+	// guest architecture so the correct firmware filenames are used (e.g.
+	// AAVMF_CODE.fd for arm64 guests on amd64 hosts).
+	efiEnv := l.efiEnvironment
+	if l.allowCrossArchEmulation && vmi.Spec.Architecture != "" && vmi.Spec.Architecture != runtime.GOARCH {
+		efiEnv = efi.DetectEFIEnvironment(vmi.Spec.Architecture, l.ovmfPath)
+	}
+
 	var efiConf *convertertypes.EFIConfiguration
 	if vmi.IsBootloaderEFI() {
 		secureBoot := vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
@@ -1154,7 +1166,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		} else if tdx {
 			vmType = efi.TDX
 		}
-		if !l.efiEnvironment.Bootable(secureBoot, vmType) {
+		if !efiEnv.Bootable(secureBoot, vmType) {
 			log.Log.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV/SEV-ES=%v, SEV-SNP=%v, TDX=%v", secureBoot, sev, snp, tdx)
 			return nil, fmt.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV/SEV-ES=%v, SEV-SNP=%v, TDX=%v", secureBoot, sev, snp, tdx)
 		}
@@ -1164,18 +1176,26 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		secureLoader := secureBoot && !tdx
 
 		efiConf = &convertertypes.EFIConfiguration{
-			EFICode:      l.efiEnvironment.EFICode(secureBoot, vmType),
-			EFIVars:      l.efiEnvironment.EFIVars(secureBoot, vmType),
+			EFICode:      efiEnv.EFICode(secureBoot, vmType),
+			EFIVars:      efiEnv.EFIVars(secureBoot, vmType),
 			SecureLoader: secureLoader,
 		}
 	}
 
 	// Map the VirtualMachineInstance to the Domain
 
+	// Use guest architecture for the converter when cross-arch emulation is active
+	archConverter := arch.NewConverter(runtime.GOARCH)
+	if l.allowCrossArchEmulation && vmi.Spec.Architecture != "" && vmi.Spec.Architecture != runtime.GOARCH {
+		archConverter = arch.NewConverter(vmi.Spec.Architecture)
+	}
+
 	c := &convertertypes.ConverterContext{
-		Architecture:              arch.NewConverter(runtime.GOARCH),
+		Architecture:              archConverter,
 		VirtualMachine:            vmi,
 		AllowEmulation:            allowEmulation,
+		AllowCrossArchEmulation:   l.allowCrossArchEmulation,
+		HostArchitecture:          runtime.GOARCH,
 		HypervisorDeviceAvailable: l.hypervisorDeviceAvailable,
 		CPUSet:                    podCPUSet,
 		IsBlockPVC:                isBlockPVCMap,

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Manager", func() {
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
 	ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
 	newLibvirtDomainManagerDefault := func() (DomainManager, error) {
-		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 	}
 
 	BeforeEach(func() {
@@ -641,7 +641,7 @@ var _ = Describe("Manager", func() {
 				func() {
 					isFreeCalled <- true
 				})
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			Expect(manager.UnpauseVMI(vmi)).To(Succeed())
 			Eventually(func() bool {
 				select {
@@ -735,7 +735,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{
 				VirtualMachineSMBios: &cmdv1.SMBios{},
 				PreallocatedVolumes:  []string{"permvolume1"},
@@ -870,7 +870,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AttachDeviceFlags(strings.ToLower(string(attachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -978,7 +978,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1052,7 +1052,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1157,7 +1157,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1300,7 +1300,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1434,7 +1434,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).MaxTimes(1).Return(string(domainXMLWithInterfaces), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1512,7 +1512,7 @@ var _ = Describe("Manager", func() {
 			defer os.RemoveAll(ovmfDir)
 			err = os.WriteFile(filepath.Join(ovmfDir, efi.EFICodeSEV), loaderBytes, 0644)
 			Expect(err).ToNot(HaveOccurred())
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			sevMeasurementInfo, err := manager.GetLaunchMeasurement(vmi)
 			if runtime.GOARCH == "amd64" {
 				Expect(err).ToNot(HaveOccurred())
@@ -1718,7 +1718,7 @@ var _ = Describe("Manager", func() {
 				Physical: 20 * 1024 * 1024 * 1024,
 			}, nil)
 
-			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
@@ -2233,7 +2233,7 @@ var _ = Describe("Manager", func() {
 				options := &cmdv1.VirtualMachineOptions{
 					ClusterConfig: &cmdv1.ClusterConfig{VGPULiveMigrationEnabled: true},
 				}
-				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, true, nil, v1.KvmHypervisorName, nil)
+				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, true, nil, v1.KvmHypervisorName, nil, false)
 				Expect(err).ToNot(HaveOccurred())
 				libvirtManager := manager.(*LibvirtDomainManager)
 
@@ -2322,7 +2322,7 @@ var _ = Describe("Manager", func() {
 			func(state libvirt.DomainState) {
 				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 				mockLibvirt.DomainEXPECT().UndefineFlags(libvirt.DOMAIN_UNDEFINE_KEEP_NVRAM | libvirt.DOMAIN_UNDEFINE_CHECKPOINTS_METADATA).Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 				Expect(manager.DeleteVMI(newVMI(testNamespace, testVmName))).To(Succeed())
 			},
 			Entry("crashed", libvirt.DOMAIN_CRASHED),
@@ -2550,7 +2550,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			})
 
 			It("should report nil when no OS info exists in the cache", func() {
@@ -2574,7 +2574,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 			})
 
 			It("should return nil when no interfaces exists in the cache", func() {
@@ -2618,7 +2618,7 @@ var _ = Describe("Manager", func() {
 				},
 			},
 		})
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2654,7 +2654,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2681,7 +2681,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2708,7 +2708,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -2754,7 +2754,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, false)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)

--- a/rpm/repo-virt-preview.yaml
+++ b/rpm/repo-virt-preview.yaml
@@ -1,0 +1,7 @@
+repositories:
+- arch: x86_64
+  baseurl: https://download.copr.fedorainfracloud.org/results/@virtmaint-sig/virt-preview/centos-stream-9-x86_64/
+  name: copr/virtmaint-sig-virt-preview-x86_64
+- arch: aarch64
+  baseurl: https://download.copr.fedorainfracloud.org/results/@virtmaint-sig/virt-preview/centos-stream-9-aarch64/
+  name: copr/virtmaint-sig-virt-preview-aarch64

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -700,6 +700,9 @@ const (
 
 	// VirtualMachineInstanceEvictionRequested indicates that an eviction has been requested for the VMI
 	VirtualMachineInstanceEvictionRequested VirtualMachineInstanceConditionType = "EvictionRequested"
+
+	// VirtualMachineInstanceSoftwareEmulation indicates the VM is running with software emulation
+	VirtualMachineInstanceSoftwareEmulation VirtualMachineInstanceConditionType = "SoftwareEmulation"
 )
 
 // These are valid reasons for VMI conditions.

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1292,6 +1292,9 @@ const (
 	// TDXLabel marks the node as capable of running workloads with Intel TDX
 	TDXLabel string = "kubevirt.io/tdx"
 
+	// VMArchLabel marks the node as capable of running VMs of a given architecture
+	VMArchLabel string = "kubevirt.io/vm-arch-"
+
 	// KSMEnabledLabel marks the node as KSM-handling enabled
 	KSMEnabledLabel string = "kubevirt.io/ksm-enabled"
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "clone_test.go",
         "config_test.go",
         "container_disk_test.go",
+        "cross_arch_emulation_test.go",
         "dryrun_test.go",
         "hyperv_test.go",
         "mdev_configuration_allocation_test.go",

--- a/tests/cross_arch_emulation_test.go
+++ b/tests/cross_arch_emulation_test.go
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package tests_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+
+	"kubevirt.io/kubevirt/tests/console"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libdomain"
+	"kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/libpod"
+	"kubevirt.io/kubevirt/tests/libvmops"
+)
+
+var _ = Describe("[sig-compute]Cross-architecture software emulation", Serial, decorators.SigCompute, decorators.RequiresCrossArchEmulation, func() {
+
+	BeforeEach(func() {
+		config.EnableFeatureGate(featuregate.CrossArchitectureVirtualization)
+	})
+
+	DescribeTable("should boot a guest using QEMU TCG emulation on a cross-architecture host",
+		func(guestArch, expectedUnameArch, containerDiskImage, expectedEmulator string) {
+			vmi := libvmi.New(
+				libvmi.WithArchitecture(guestArch),
+				libvmi.WithContainerDiskAndPullPolicy("disk0", containerDiskImage, k8sv1.PullIfNotPresent),
+				libvmi.WithMemoryRequest("1Gi"),
+				libvmi.WithRng(),
+			)
+
+			By("Creating a VMI with " + guestArch + " architecture on a cross-architecture host")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXHuge)
+
+			By("Verifying the libvirt domain uses QEMU TCG emulation with the correct emulator")
+			domSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domSpec.Type).To(Equal("qemu"))
+			Expect(domSpec.Devices.Emulator).To(Equal(expectedEmulator))
+
+			By("Verifying the VMI has the SoftwareEmulation condition")
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceSoftwareEmulation))
+
+			By("Verifying the virt-launcher pod has the cross-arch emulation flag")
+			pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, container := range pod.Spec.Containers {
+				if container.Name == "compute" {
+					Expect(container.Command).To(ContainElement("--allow-cross-arch-emulation"))
+					break
+				}
+			}
+
+			By("Logging into the guest and verifying the architecture via uname -m")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+			output, err := console.RunCommandAndStoreOutput(vmi, "uname -m", 30*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output).To(Equal(expectedUnameArch))
+		},
+		Entry("arm64 guest on amd64 host",
+			"arm64",
+			"aarch64",
+			"quay.io/containerdisks/fedora@sha256:eb87a994833d82feb2279575aafa42a06c5feb124ea72cae6efc0ee46bb729d8",
+			"/usr/bin/qemu-system-aarch64",
+			decorators.RequiresAMD64,
+		),
+		Entry("amd64 guest on arm64 host",
+			"amd64",
+			"x86_64",
+			cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling),
+			"/usr/bin/qemu-system-x86_64",
+			decorators.RequiresARM64,
+		),
+	)
+})

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -113,6 +113,8 @@ var (
 	RequiresS390X = Label("requires-s390x")
 	RequiresARM64 = Label("requires-arm64")
 
+	RequiresCrossArchEmulation = Label("requires-cross-arch-emulation")
+
 	// Virtctl related tests
 	Virtctl = Label("virtctl")
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The virt-launcher image does not include cross-architecture QEMU system
emulators or firmware packages.

#### After this PR:

Adds the `@virtmaint-sig/virt-preview` COPR repo and cross-architecture
emulation packages to the virt-launcher build:

- x86_64: `qemu-system-aarch64-core` and `edk2-aarch64`
- aarch64: `qemu-system-x86-core`, `edk2-ovmf`, and `seabios`

Also focuses sig-compute test lanes on cross-arch emulation tests.

**This PR is not intended for merge** — it demonstrates the packaging
requirements for [VEP 172: Cross-Architecture Virtualization](https://github.com/kubevirt/kubevirt/pull/17199).

### References

- Implementation PR: https://github.com/kubevirt/kubevirt/pull/17199
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/172

### Why we need it and why it was done in this way

RHEL/CentOS Stream do not ship cross-architecture QEMU system emulators in
default repos. They are only available via the `@virtmaint-sig/virt-preview`
COPR. This PR exists to demonstrate the packaging changes and enable CI
testing of the implementation PR.

The WORKSPACE and rpm/BUILD.bazel files still need to be regenerated via
`hack/rpm-deps.sh` before this can be tested.

### Special notes for your reviewer

This is a **Do Not Merge** PR. It exists solely to show what packaging
changes are required and to enable CI testing for PR #17199.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```