### PR TITLE
launcher, converter: Add unit tests for CPUDomainConfigurator

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "compute_suite_test.go",
         "console_test.go",
         "controllers_test.go",
+        "cpu_test.go",
         "graphics_test.go",
         "host_device_test.go",
         "input_device_test.go",

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
@@ -1,0 +1,296 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package compute_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
+)
+
+var _ = Describe("CPU Domain Configurator", func() {
+	const (
+		hotplugSupported         = true
+		requiresMPXCPUValidation = true
+	)
+
+	Context("CPU topology", func() {
+		DescribeTable("should set topology and VCPU count from VMI CPU spec",
+			func(vmi *v1.VirtualMachineInstance, expectedDomain api.Domain) {
+				var domain api.Domain
+
+				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation)
+				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+				Expect(domain).To(Equal(expectedDomain))
+			},
+			Entry("with no CPU spec",
+				libvmi.New(),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+			Entry("with explicit cores, threads, sockets",
+				libvmi.New(libvmi.WithCPUCount(4, 2, 6)),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 6, Cores: 4, Threads: 2}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 48},
+				}},
+			),
+			Entry("with CPU resource request only",
+				libvmi.New(libvmi.WithCPURequest("4")),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 4, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 4},
+				}},
+			),
+			Entry("with CPU resource limit only",
+				libvmi.New(libvmi.WithCPULimit("8")),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 8, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 8},
+				}},
+			),
+		)
+	})
+
+	Context("CPU model", func() {
+		DescribeTable("should set CPU mode and model",
+			func(vmi *v1.VirtualMachineInstance, expectedDomain api.Domain) {
+				var domain api.Domain
+
+				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation)
+				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+				Expect(domain).To(Equal(expectedDomain))
+			},
+			Entry("defaults to host-model when model is empty",
+				libvmi.New(libvmi.WithCPUCount(1, 1, 1)),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+			Entry("host-model sets mode directly",
+				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostModel)),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+			Entry("host-passthrough sets mode directly",
+				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostPassthrough)),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostPassthrough, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+			Entry("custom model sets mode to custom with model name",
+				libvmi.New(libvmi.WithCPUModel("Skylake-Server")),
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: "custom", Model: "Skylake-Server", Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+		)
+	})
+
+	Context("CPU features", func() {
+		It("should set features from VMI spec", func() {
+			vmi := libvmi.New(
+				libvmi.WithCPUModel("Skylake-Server"),
+				libvmi.WithCPUFeature("avx2", "require"),
+				libvmi.WithCPUFeature("vmx", "disable"),
+			)
+			var domain api.Domain
+
+			configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			expectedDomain := api.Domain{Spec: api.DomainSpec{
+				CPU: api.CPU{
+					Mode:     "custom",
+					Model:    "Skylake-Server",
+					Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1},
+					Features: []api.CPUFeature{
+						{Name: "avx2", Policy: "require"},
+						{Name: "vmx", Policy: "disable"},
+					},
+				},
+				VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+			}}
+			Expect(domain).To(Equal(expectedDomain))
+		})
+	})
+
+	Context("MPX CPU validation", func() {
+		DescribeTable("should add mpx disable feature only when required",
+			func(vmi *v1.VirtualMachineInstance, requiresMPX bool, expectedDomain api.Domain) {
+				var domain api.Domain
+
+				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, requiresMPX)
+				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+				Expect(domain).To(Equal(expectedDomain))
+			},
+			Entry("adds mpx disable for custom model when MPX validation is required",
+				libvmi.New(libvmi.WithCPUModel("Skylake-Server")),
+				requiresMPXCPUValidation,
+				api.Domain{Spec: api.DomainSpec{
+					CPU: api.CPU{
+						Mode:     "custom",
+						Model:    "Skylake-Server",
+						Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1},
+						Features: []api.CPUFeature{{Name: "mpx", Policy: "disable"}},
+					},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+			Entry("does not add mpx for host-model",
+				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostModel)),
+				requiresMPXCPUValidation,
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+			Entry("does not add mpx for host-passthrough",
+				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostPassthrough)),
+				requiresMPXCPUValidation,
+				api.Domain{Spec: api.DomainSpec{
+					CPU:  api.CPU{Mode: v1.CPUModeHostPassthrough, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+			Entry("does not add mpx when user already specifies it",
+				libvmi.New(
+					libvmi.WithCPUModel("Skylake-Server"),
+					libvmi.WithCPUFeature("mpx", "require"),
+				),
+				requiresMPXCPUValidation,
+				api.Domain{Spec: api.DomainSpec{
+					CPU: api.CPU{
+						Mode:     "custom",
+						Model:    "Skylake-Server",
+						Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1},
+						Features: []api.CPUFeature{{Name: "mpx", Policy: "require"}},
+					},
+					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				}},
+			),
+		)
+	})
+
+	Context("CPU hotplug", func() {
+		It("should configure VCPUs for hotplug when MaxSockets is set and hotplug is supported", func() {
+			vmi := libvmi.New(
+				libvmi.WithCPUCount(1, 1, 2),
+				withMaxSockets(4),
+			)
+			var domain api.Domain
+
+			configurator := compute.NewCPUDomainConfigurator(hotplugSupported, !requiresMPXCPUValidation)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			expectedDomain := api.Domain{Spec: api.DomainSpec{
+				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 4, Cores: 1, Threads: 1}},
+				VCPU: &api.VCPU{Placement: "static", CPUs: 4},
+				VCPUs: &api.VCPUs{VCPU: []api.VCPUsVCPU{
+					{ID: 0, Enabled: "yes", Hotpluggable: "no"},
+					{ID: 1, Enabled: "yes", Hotpluggable: "yes"},
+					{ID: 2, Enabled: "no", Hotpluggable: "yes"},
+					{ID: 3, Enabled: "no", Hotpluggable: "yes"},
+				}},
+			}}
+			Expect(domain).To(Equal(expectedDomain))
+		})
+
+		It("should not configure VCPUs for hotplug when hotplug is not supported", func() {
+			vmi := libvmi.New(
+				libvmi.WithCPUCount(1, 1, 2),
+				withMaxSockets(4),
+			)
+			var domain api.Domain
+
+			configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			expectedDomain := api.Domain{Spec: api.DomainSpec{
+				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 2, Cores: 1, Threads: 1}},
+				VCPU: &api.VCPU{Placement: "static", CPUs: 2},
+			}}
+			Expect(domain).To(Equal(expectedDomain))
+		})
+
+		It("should not configure VCPUs for hotplug when MaxSockets is zero", func() {
+			vmi := libvmi.New(libvmi.WithCPUCount(1, 1, 2))
+			var domain api.Domain
+
+			configurator := compute.NewCPUDomainConfigurator(hotplugSupported, !requiresMPXCPUValidation)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			expectedDomain := api.Domain{Spec: api.DomainSpec{
+				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 2, Cores: 1, Threads: 1}},
+				VCPU: &api.VCPU{Placement: "static", CPUs: 2},
+			}}
+			Expect(domain).To(Equal(expectedDomain))
+		})
+
+		It("should mark first socket vCPUs as non-hotpluggable", func() {
+			vmi := libvmi.New(
+				libvmi.WithCPUCount(2, 1, 1),
+				withMaxSockets(3),
+			)
+			var domain api.Domain
+
+			configurator := compute.NewCPUDomainConfigurator(hotplugSupported, !requiresMPXCPUValidation)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			expectedDomain := api.Domain{Spec: api.DomainSpec{
+				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 3, Cores: 2, Threads: 1}},
+				VCPU: &api.VCPU{Placement: "static", CPUs: 6},
+				VCPUs: &api.VCPUs{VCPU: []api.VCPUsVCPU{
+					{ID: 0, Enabled: "yes", Hotpluggable: "no"},
+					{ID: 1, Enabled: "yes", Hotpluggable: "no"},
+					{ID: 2, Enabled: "no", Hotpluggable: "yes"},
+					{ID: 3, Enabled: "no", Hotpluggable: "yes"},
+					{ID: 4, Enabled: "no", Hotpluggable: "yes"},
+					{ID: 5, Enabled: "no", Hotpluggable: "yes"},
+				}},
+			}}
+			Expect(domain).To(Equal(expectedDomain))
+		})
+	})
+})
+
+func withMaxSockets(maxSockets uint32) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.CPU == nil {
+			vmi.Spec.Domain.CPU = &v1.CPU{}
+		}
+		vmi.Spec.Domain.CPU.MaxSockets = maxSockets
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
CPUDomainConfigurator had no unit test coverage.
Add tests covering CPU topology, model and mode selection, CPU features, MPX CPU validation, and CPU hotplug.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

