### PR TITLE
dra/admitter: generalize cross-device duplicate pair detection

### DIFF
--- a/pkg/dra/admitter/dra_admitter.go
+++ b/pkg/dra/admitter/dra_admitter.go
@@ -83,15 +83,13 @@ func validateCreationDRA(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSp
 	hdCauses, hdClaimNames, hdClaimRequestPairs := validateDRAHostDevices(field, spec.Domain.Devices.HostDevices, checker)
 	causes = append(causes, hdCauses...)
 
-	for key, hdIdx := range hdClaimRequestPairs {
-		if gpuIdx, found := gpuClaimRequestPairs[key]; found {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueDuplicate,
-				Message: fmt.Sprintf("duplicate claimName/requestName pair %q between GPUs[%d] and HostDevices[%d]", key, gpuIdx, hdIdx),
-				Field:   field.Child("domain", "devices", "hostDevices").Index(hdIdx).String(),
-			})
-		}
-	}
+	state := newPairDuplicateChecker()
+	causes = append(causes,
+		state.detectDuplicatePairs(gpuClaimRequestPairs, field.Child("domain", "devices", "gpus"), "GPUs")...,
+	)
+	causes = append(causes,
+		state.detectDuplicatePairs(hdClaimRequestPairs, field.Child("domain", "devices", "hostDevices"), "HostDevices")...,
+	)
 
 	allClaimNames := gpuClaimNames.Union(hdClaimNames)
 
@@ -271,4 +269,33 @@ func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg de
 
 func ValidateCreation(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, clusterCfg *virtconfig.ClusterConfig) []metav1.StatusCause {
 	return NewValidator(field, vmiSpec, clusterCfg).ValidateCreation()
+}
+
+type pairOwner struct {
+	deviceType string
+	index      int
+}
+
+type pairDuplicateChecker struct {
+	seenPairs map[string]pairOwner
+}
+
+func newPairDuplicateChecker() *pairDuplicateChecker {
+	return &pairDuplicateChecker{seenPairs: map[string]pairOwner{}}
+}
+
+func (s *pairDuplicateChecker) detectDuplicatePairs(pairs map[string]int, devField *k8sfield.Path, typeName string) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	for key, idx := range pairs {
+		if prev, exists := s.seenPairs[key]; exists {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueDuplicate,
+				Message: fmt.Sprintf("duplicate claimName/requestName pair %q between %s[%d] and %s[%d]", key, prev.deviceType, prev.index, typeName, idx),
+				Field:   devField.Index(idx).String(),
+			})
+			continue
+		}
+		s.seenPairs[key] = pairOwner{deviceType: typeName, index: idx}
+	}
+	return causes
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Replace the hard-coded nested loop that checks GPU claimName/requestName pairs against HostDevice pairs with a reusable pairDuplicateChecker.

With network DRA devices being added, the current approach of adding another nested loop for each new device type doesn't scale. The new approach makes adding a device type a single call.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

