### PR TITLE
VEP 19: Graduate IBM Secure Execution feature

### DIFF
--- a/pkg/virt-api/webhooks/s390x.go
+++ b/pkg/virt-api/webhooks/s390x.go
@@ -27,9 +27,6 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
-
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 // ValidateVirtualMachineInstanceS390xSetting is a validation function for validating-webhook on s390x
@@ -78,18 +75,4 @@ func isOnlyDiag288Watchdog(watchdog *v1.Watchdog) bool {
 
 func IsS390X(spec *v1.VirtualMachineInstanceSpec) bool {
 	return spec.Architecture == "s390x"
-}
-
-func ValidateLaunchSecurityS390x(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
-	var causes []metav1.StatusCause
-
-	if !config.SecureExecutionEnabled() {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s feature gate is not enabled in kubevirt-config", featuregate.SecureExecution),
-			Field:   field.Child("launchSecurity").String(),
-		})
-	}
-
-	return causes
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -596,7 +596,7 @@ func validateLaunchSecurity(field *k8sfield.Path, spec *v1.VirtualMachineInstanc
 	case "amd64":
 		causes = append(causes, webhooks.ValidateLaunchSecurityAmd64(field, spec, config)...)
 	case "s390x":
-		causes = append(causes, webhooks.ValidateLaunchSecurityS390x(field, spec, config)...)
+		// No s390x specific settings for IBM Secure Execution
 	default:
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2860,19 +2860,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Architecture = "s390x"
 		})
 
-		It("should accept when the feature gate is enabled", func() {
-			enableFeatureGates(featuregate.SecureExecution)
+		It("should accept", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty())
-		})
-
-		It("should reject when the feature gate is disabled", func() {
-			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.SecureExecution}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.SecureExecution)))
 		})
 	})
 

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -147,10 +147,6 @@ func (config *ClusterConfig) DeclarativeHotplugVolumesEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.DeclarativeHotplugVolumesGate)
 }
 
-func (config *ClusterConfig) SecureExecutionEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.SecureExecution)
-}
-
 func (config *ClusterConfig) PasstBindingEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.PasstBinding)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -132,13 +132,6 @@ const (
 	// also implicitly handles inject/eject CDROM
 	DeclarativeHotplugVolumesGate = "DeclarativeHotplugVolumes"
 
-	// Owner: sig-conpute / @jschintag
-	// Alpha: v1.6.0
-	// Beta: v1.7.0
-	//
-	// SecureExecution introduces secure execution of VMs on IBM Z architecture
-	SecureExecution = "SecureExecution"
-
 	// Beta: v1.8.0
 	//
 	// PasstBinding enables the use of passt core network binding
@@ -299,7 +292,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: DecentralizedLiveMigration, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DeclarativeHotplugVolumesGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ObjectGraph, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: UtilityVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: ConfigurableHypervisor, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PasstBinding, State: Beta})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -170,6 +170,14 @@ const (
 	//
 	// PersistentReservation enables the use of the SCSI persistent reservation in VMs using the pr-helper daemon
 	PersistentReservation = "PersistentReservation"
+
+	// Owner: sig-compute / @jschintag
+	// Alpha: v1.6.0
+	// Beta: v1.7.0
+	// GA: v1.9.0
+	//
+	// SecureExecution introduces secure execution of VMs on IBM Z architecture
+	SecureExecution = "SecureExecution"
 )
 
 func init() {
@@ -212,4 +220,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: LiveUpdateNADRef, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: HotplugVolumesGate, State: Deprecated, Message: "HotplugVolumes has been deprecated since v1.9.0 and has been replaced by DeclarativeHotplugVolumes"})
 	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: GA})
 }

--- a/tests/launchsecurity/secure-execution.go
+++ b/tests/launchsecurity/secure-execution.go
@@ -26,12 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libconfigmap"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
@@ -64,7 +62,6 @@ var _ = Describe("[sig-compute]IBM Secure Execution",
 
 			const commandTimeout = 10 * time.Second
 			BeforeEach(func() {
-				config.EnableFeatureGate(featuregate.SecureExecution)
 				By("Reading the hostkey from the 'secex-hostkey' configmap in the 'kubevirt-prow-jobs' namespace")
 				cm, err := kubevirt.Client().CoreV1().ConfigMaps("kubevirt-prow-jobs").Get(context.Background(), "secex-hostkey", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Remove the "SecureExecution" feature gate to graduate the feature.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
IBM Secure Execution is behind a feature gate
#### After this PR:
IBM Secure Execution is always enabled.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/19
- Documentation update: https://github.com/kubevirt/user-guide/pull/991

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
IBM Secure Execution is now generally available
```
