### PR TITLE
[VEP10] dra/admitter: simplify duplicate pair validation flow

### DIFF
--- a/pkg/dra/admitter/dra_admitter.go
+++ b/pkg/dra/admitter/dra_admitter.go
@@ -83,15 +83,9 @@ func validateCreationDRA(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSp
 	hdCauses, hdClaimNames, hdClaimRequestPairs := validateDRAHostDevices(field, spec.Domain.Devices.HostDevices, checker)
 	causes = append(causes, hdCauses...)
 
-	for key, hdIdx := range hdClaimRequestPairs {
-		if gpuIdx, found := gpuClaimRequestPairs[key]; found {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueDuplicate,
-				Message: fmt.Sprintf("duplicate claimName/requestName pair %q between GPUs[%d] and HostDevices[%d]", key, gpuIdx, hdIdx),
-				Field:   field.Child("domain", "devices", "hostDevices").Index(hdIdx).String(),
-			})
-		}
-	}
+	duplicateChecker := newPairDuplicateChecker()
+	causes = append(causes, duplicateChecker.mergeTupleSource("GPUs", gpuClaimRequestPairs, field.Child("domain", "devices", "gpus"))...)
+	causes = append(causes, duplicateChecker.mergeTupleSource("HostDevices", hdClaimRequestPairs, field.Child("domain", "devices", "hostDevices"))...)
 
 	allClaimNames := gpuClaimNames.Union(hdClaimNames)
 
@@ -140,6 +134,43 @@ type deviceValidationConfig struct {
 type indexedDevice struct {
 	idx    int
 	device draCapableDevice
+}
+
+type claimRequestPairOwner struct {
+	deviceType string
+	index      int
+}
+
+type pairDuplicateChecker struct {
+	pairOwnerByKey map[string]claimRequestPairOwner
+}
+
+func newPairDuplicateChecker() *pairDuplicateChecker {
+	return &pairDuplicateChecker{
+		pairOwnerByKey: map[string]claimRequestPairOwner{},
+	}
+}
+
+func (s *pairDuplicateChecker) mergeTupleSource(deviceType string, firstIndexByTuple map[string]int, baseField *k8sfield.Path) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+
+	for tuple, idx := range firstIndexByTuple {
+		if previous, exists := s.pairOwnerByKey[tuple]; exists {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueDuplicate,
+				Message: fmt.Sprintf("duplicate claimName/requestName pair %q between %s[%d] and %s[%d]", tuple, previous.deviceType, previous.index, deviceType, idx),
+				Field:   baseField.Index(idx).String(),
+			})
+			continue
+		}
+
+		s.pairOwnerByKey[tuple] = claimRequestPairOwner{
+			deviceType: deviceType,
+			index:      idx,
+		}
+	}
+
+	return causes
 }
 
 func validateDRAGPUs(field *k8sfield.Path, gpus []v1.GPU, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string], map[string]int) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Refactor DRA duplicate tuple validation to use a shared validation flow.

The change introduces `pairDuplicateChecker.mergeTupleSource()` and processes
GPU and HostDevice tuple maps through the same flow, replacing the previous
special-case cross-map loop.

Behavior remains the same: duplicate `claimName/requestName` pairs across
devices are still reported as `FieldValueDuplicate`, with field paths resolved
from each source base path (`gpus` or `hostDevices`).

It allows adding new devices in a cleaner generic way.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

