### PR TITLE
Add removememorydump subresource to admin and edit RBAC roles

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1040,6 +1040,7 @@ spec:
           - virtualmachines/addvolume
           - virtualmachines/removevolume
           - virtualmachines/memorydump
+          - virtualmachines/removememorydump
           - virtualmachines/evacuate/cancel
           verbs:
           - update
@@ -1213,6 +1214,7 @@ spec:
           - virtualmachines/addvolume
           - virtualmachines/removevolume
           - virtualmachines/memorydump
+          - virtualmachines/removememorydump
           - virtualmachines/evacuate/cancel
           verbs:
           - update

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -1072,6 +1072,7 @@ rules:
   - virtualmachines/addvolume
   - virtualmachines/removevolume
   - virtualmachines/memorydump
+  - virtualmachines/removememorydump
   - virtualmachines/evacuate/cancel
   verbs:
   - update
@@ -1245,6 +1246,7 @@ rules:
   - virtualmachines/addvolume
   - virtualmachines/removevolume
   - virtualmachines/memorydump
+  - virtualmachines/removememorydump
   - virtualmachines/evacuate/cancel
   verbs:
   - update

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -65,17 +65,18 @@ const (
 	apiVMClones           = "virtualmachineclones"
 	apiVMPools            = "virtualmachinepools"
 
-	apiVMExpandSpec     = "virtualmachines/expand-spec"
-	apiVMPortForward    = "virtualmachines/portforward"
-	apiVMStart          = "virtualmachines/start"
-	apiVMStop           = "virtualmachines/stop"
-	apiVMRestart        = "virtualmachines/restart"
-	apiVMAddVolume      = "virtualmachines/addvolume"
-	apiVMRemoveVolume   = "virtualmachines/removevolume"
-	apiVMMigrate        = "virtualmachines/migrate"
-	apiVMMemoryDump     = "virtualmachines/memorydump"
-	apiVMObjectGraph    = "virtualmachines/objectgraph"
-	apiVMEvacuateCancel = "virtualmachines/evacuate/cancel"
+	apiVMExpandSpec       = "virtualmachines/expand-spec"
+	apiVMPortForward      = "virtualmachines/portforward"
+	apiVMStart            = "virtualmachines/start"
+	apiVMStop             = "virtualmachines/stop"
+	apiVMRestart          = "virtualmachines/restart"
+	apiVMAddVolume        = "virtualmachines/addvolume"
+	apiVMRemoveVolume     = "virtualmachines/removevolume"
+	apiVMMigrate          = "virtualmachines/migrate"
+	apiVMMemoryDump       = "virtualmachines/memorydump"
+	apiVMRemoveMemoryDump = "virtualmachines/removememorydump"
+	apiVMObjectGraph      = "virtualmachines/objectgraph"
+	apiVMEvacuateCancel   = "virtualmachines/evacuate/cancel"
 
 	apiVMInstancesConsole                   = "virtualmachineinstances/console"
 	apiVMInstancesVNC                       = "virtualmachineinstances/vnc"
@@ -268,6 +269,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					apiVMAddVolume,
 					apiVMRemoveVolume,
 					apiVMMemoryDump,
+					apiVMRemoveMemoryDump,
 					apiVMEvacuateCancel,
 				},
 				Verbs: []string{
@@ -476,6 +478,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					apiVMAddVolume,
 					apiVMRemoveVolume,
 					apiVMMemoryDump,
+					apiVMRemoveMemoryDump,
 					apiVMEvacuateCancel,
 				},
 				Verbs: []string{

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -117,6 +117,7 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMAddVolume), virtv1.SubresourceGroupName, apiVMRestart, "update"),
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRemoveVolume), virtv1.SubresourceGroupName, apiVMAddVolume, "update"),
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMMemoryDump), virtv1.SubresourceGroupName, apiVMMemoryDump, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRemoveMemoryDump), virtv1.SubresourceGroupName, apiVMRemoveMemoryDump, "update"),
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMEvacuateCancel), virtv1.SubresourceGroupName, apiVMEvacuateCancel, "update"),
 
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiExpandVmSpec), virtv1.SubresourceGroupName, apiExpandVmSpec, "update"),
@@ -185,6 +186,7 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMAddVolume), virtv1.SubresourceGroupName, apiVMRestart, "update"),
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRemoveVolume), virtv1.SubresourceGroupName, apiVMAddVolume, "update"),
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMMemoryDump), virtv1.SubresourceGroupName, apiVMMemoryDump, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRemoveMemoryDump), virtv1.SubresourceGroupName, apiVMRemoveMemoryDump, "update"),
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMEvacuateCancel), virtv1.SubresourceGroupName, apiVMEvacuateCancel, "update"),
 
 				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiExpandVmSpec), virtv1.SubresourceGroupName, apiExpandVmSpec, "update"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The removememorydump subresource was introduced without a corresponding
RBAC entry, leaving users unable to clean up memory dumps via virtctl
despite having permission to create them.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: admin can remove memory dump from their VM
```

