### PR TITLE
fix(operator): deep copy strategy to prevent in-place update cache

### DIFF
--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -911,7 +911,7 @@ func (c *KubeVirtController) loadInstallStrategy(kv *v1.KubeVirt) (*install.Stra
 	if err == nil {
 		c.cacheInstallStrategy(strategy, config, kv.Generation)
 		log.Log.Infof("Loaded install strategy for kubevirt version %s into cache", config.GetKubeVirtVersion())
-		return strategy, false, nil
+		return strategy.DeepCopy(), false, nil
 	}
 
 	log.Log.Infof("Install strategy config map not loaded. reason: %v", err)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -29,7 +29,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	routev1 "github.com/openshift/api/route/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	routev1fake "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1/fake"
@@ -1891,6 +1890,73 @@ func (k *KubeVirtTestData) getConfig(registry, version string) *util.KubeVirtDep
 
 var _ = Describe("KubeVirt Operator", func() {
 
+	Context("install strategy cache", func() {
+		It("should not be mutated when a CustomizeComponents patch is applied to a retrieved strategy", func() {
+			jp, err := patch.New(
+				patch.WithAdd("/spec/template/spec/containers/0/args/-", "--customized-arg"),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  NAMESPACE,
+					Generation: int64(1),
+				},
+				Spec: v1.KubeVirtSpec{
+					ImageRegistry: "fake-registry",
+					ImageTag:      "v9.9.9",
+					CustomizeComponents: v1.CustomizeComponents{
+						Patches: []v1.CustomizeComponentsPatch{{
+							ResourceName: components.VirtHandlerName,
+							ResourceType: "DaemonSet",
+							Type:         v1.JSONPatchType,
+							Patch:        string(jp),
+						}},
+					},
+				},
+			}
+			config := util.GetTargetConfigFromKV(kv)
+			strategy, err := install.GenerateCurrentInstallStrategy(config, "openshift-monitoring", NAMESPACE)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(strategy.DaemonSets()).ToNot(BeEmpty())
+
+			findVirtHandler := func(s *install.Strategy) *appsv1.DaemonSet {
+				GinkgoHelper()
+
+				daemonSets := s.DaemonSets()
+				Expect(daemonSets).To(ContainElement(HaveField("Name", components.VirtHandlerName)))
+
+				for _, ds := range s.DaemonSets() {
+					if ds.Name == components.VirtHandlerName {
+						return ds
+					}
+				}
+				return nil
+			}
+			Expect(findVirtHandler(strategy)).ToNot(BeNil())
+
+			controller := &KubeVirtController{}
+			controller.cacheInstallStrategy(strategy, config, kv.Generation)
+
+			// Drive the mutation through the real reconciliation path: a
+			// CustomizeComponents JSON patch applied to the retrieved strategy.
+			// Without a defensive copy in the cache getter, applyPatch rewrites
+			// the DaemonSet struct in place and corrupts the cached entry.
+			cachedStrategy, ok := controller.getCachedInstallStrategy(config, kv.Generation)
+			Expect(ok).To(BeTrue())
+			customizer, err := apply.NewCustomizer(kv.Spec.CustomizeComponents)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(customizer.Apply(cachedStrategy)).To(Succeed())
+			Expect(findVirtHandler(cachedStrategy).Spec.Template.Spec.Containers[0].Args).
+				To(ContainElement("--customized-arg"))
+
+			cachedStrategy, ok = controller.getCachedInstallStrategy(config, kv.Generation)
+			Expect(ok).To(BeTrue())
+			Expect(findVirtHandler(cachedStrategy).Spec.Template.Spec.Containers[0].Args).
+				ToNot(ContainElement("--customized-arg"))
+		})
+	})
+
 	Context("On valid KubeVirt object", func() {
 
 		It("Should not patch kubevirt namespace when labels are already defined", func() {
@@ -2269,6 +2335,125 @@ var _ = Describe("KubeVirt Operator", func() {
 			kv = kvTestData.getLatestKubeVirt(kv)
 			Expect(kv.Status.ObservedDeploymentID).NotTo(Equal(initialObservedID))
 			Expect(kv.Status.ObservedDeploymentID).To(Equal(kv.Status.TargetDeploymentID))
+		})
+
+		It("should produce the same virt-handler DaemonSet across multiple Execute() invocations", func() {
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Finalizers: []string{util.KubeVirtFinalizer},
+					Generation: int64(1),
+				},
+				Spec: v1.KubeVirtSpec{},
+				Status: v1.KubeVirtStatus{
+					Phase:           v1.KubeVirtPhaseDeployed,
+					OperatorVersion: version.Get().String(),
+				},
+			}
+
+			enableContainerPathVolumesFeatureGate(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
+			util.UpdateConditionsCreated(kv)
+			util.UpdateConditionsAvailable(kv)
+
+			// create all resources which should already exist
+			kubecontroller.SetLatestApiVersionAnnotation(kv)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
+			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeHandlerReady()
+
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates(kv)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(2) // expect to reconcile twice
+
+			patchingDaemonSetCount := 0
+			kvTestData.kubeClient.Fake.PrependReactor("patch", "daemonsets",
+				func(action testing.Action) (bool, runtime.Object, error) {
+					patchingDaemonSetCount++
+
+					patchAction, ok := action.(testing.PatchAction)
+					Expect(ok).To(BeTrue())
+					Expect(patchAction.GetName()).To(Equal(components.VirtHandlerName))
+					Expect(patchAction.GetPatchType()).To(Equal(types.JSONPatchType))
+
+					patches, err := patch.UnmarshalPatch(patchAction.GetPatch())
+					Expect(err).ToNot(HaveOccurred())
+
+					obj, exists, err := kvTestData.controller.stores.DaemonSetCache.GetByKey(fmt.Sprintf("%s/%s", NAMESPACE, patchAction.GetName()))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(exists).To(BeTrue())
+					patchedDaemonSet := obj.(*appsv1.DaemonSet).DeepCopy()
+
+					for _, p := range patches {
+						if p.Op != patch.PatchReplaceOp && p.Op != patch.PatchAddOp {
+							continue
+						}
+
+						patchValue, err := json.Marshal(p.Value)
+						Expect(err).ToNot(HaveOccurred())
+
+						switch p.Path {
+						case "/metadata/annotations":
+							Expect(json.Unmarshal(patchValue, &patchedDaemonSet.Annotations)).To(Succeed())
+						case "/metadata/labels":
+							Expect(json.Unmarshal(patchValue, &patchedDaemonSet.Labels)).To(Succeed())
+						case "/spec":
+							Expect(json.Unmarshal(patchValue, &patchedDaemonSet.Spec)).To(Succeed())
+						}
+					}
+
+					args := patchedDaemonSet.Spec.Template.Spec.Containers[0].Args
+
+					var flagIndexes []int
+					for i, arg := range args {
+						if strings.HasPrefix(arg, "--customized-arg") {
+							flagIndexes = append(flagIndexes, i)
+						}
+					}
+					Expect(flagIndexes).To(HaveLen(1), "patching should be idempotent")
+
+					patchedDaemonSet.Generation++
+					Expect(kvTestData.controller.stores.DaemonSetCache.Update(patchedDaemonSet)).To(Succeed())
+					return true, patchedDaemonSet, nil
+				},
+			)
+
+			reconcile := func() {
+				kv.Generation++
+				jp, err := patch.New(
+					patch.WithAdd("/spec/template/spec/containers/0/args/-", fmt.Sprintf("--customized-arg=%d", kv.Generation)),
+				).GeneratePayload()
+				Expect(err).ToNot(HaveOccurred())
+
+				kv.Spec.CustomizeComponents.Patches = []v1.CustomizeComponentsPatch{
+					{
+						ResourceName: components.VirtHandlerName,
+						ResourceType: "DaemonSet",
+						Type:         v1.JSONPatchType,
+						Patch:        string(jp),
+					},
+				}
+
+				Expect(kvTestData.controller.stores.KubeVirtCache.Update(kv)).ShouldNot(HaveOccurred())
+				key, err := kubecontroller.KeyFunc(kv)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvTestData.controller.execute(key)).To(Succeed())
+			}
+
+			reconcile()
+			reconcile()
+
+			Expect(patchingDaemonSetCount).To(Equal(2))
 		})
 
 		It("should update KubeVirt object if generation IDs do not match", func() {

--- a/pkg/virt-operator/resource/generate/install/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/install/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/sigs.k8s.io/randfill:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -131,6 +131,51 @@ type Strategy struct {
 	validatingAdmissionPolicies       []*admissionregistrationv1.ValidatingAdmissionPolicy
 }
 
+type deepCopyable[T any] interface {
+	DeepCopy() T
+}
+
+func deepCopySlice[T deepCopyable[T]](in []T) []T {
+	if in == nil {
+		return nil
+	}
+	out := make([]T, len(in))
+	for i, v := range in {
+		out[i] = v.DeepCopy()
+	}
+	return out
+}
+
+func (ins *Strategy) DeepCopy() *Strategy {
+	if ins == nil {
+		return nil
+	}
+	return &Strategy{
+		serviceAccounts:                   deepCopySlice(ins.serviceAccounts),
+		clusterRoles:                      deepCopySlice(ins.clusterRoles),
+		clusterRoleBindings:               deepCopySlice(ins.clusterRoleBindings),
+		roles:                             deepCopySlice(ins.roles),
+		roleBindings:                      deepCopySlice(ins.roleBindings),
+		crds:                              deepCopySlice(ins.crds),
+		services:                          deepCopySlice(ins.services),
+		deployments:                       deepCopySlice(ins.deployments),
+		daemonSets:                        deepCopySlice(ins.daemonSets),
+		validatingWebhookConfigurations:   deepCopySlice(ins.validatingWebhookConfigurations),
+		mutatingWebhookConfigurations:     deepCopySlice(ins.mutatingWebhookConfigurations),
+		apiServices:                       deepCopySlice(ins.apiServices),
+		certificateSecrets:                deepCopySlice(ins.certificateSecrets),
+		sccs:                              deepCopySlice(ins.sccs),
+		serviceMonitors:                   deepCopySlice(ins.serviceMonitors),
+		prometheusRules:                   deepCopySlice(ins.prometheusRules),
+		configMaps:                        deepCopySlice(ins.configMaps),
+		routes:                            deepCopySlice(ins.routes),
+		instancetypes:                     deepCopySlice(ins.instancetypes),
+		preferences:                       deepCopySlice(ins.preferences),
+		validatingAdmissionPolicyBindings: deepCopySlice(ins.validatingAdmissionPolicyBindings),
+		validatingAdmissionPolicies:       deepCopySlice(ins.validatingAdmissionPolicies),
+	}
+}
+
 func (ins *Strategy) ServiceAccounts() []*corev1.ServiceAccount {
 	return ins.serviceAccounts
 }

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -20,6 +20,7 @@
 package install
 
 import (
+	"reflect"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -29,6 +30,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/randfill"
 	"sigs.k8s.io/yaml"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -74,6 +76,63 @@ var _ = Describe("Install Strategy", func() {
 			},
 		})
 	}
+
+	Context("deep copy", func() {
+		It("should copy every strategy field", func() {
+			strategy := &Strategy{}
+
+			strategyValue := reflect.ValueOf(strategy).Elem()
+			strategyType := reflect.TypeOf(strategy).Elem()
+			fuzzer := randfill.NewWithSeed(GinkgoRandomSeed()).
+				NilChance(0).
+				NumElements(1, 3).
+				MaxDepth(2).
+				AllowUnexportedFields(true)
+
+			fuzzer.Fill(strategy)
+
+			copiedStrategy := strategy.DeepCopy()
+			Expect(copiedStrategy).To(Equal(strategy))
+
+			copiedStrategyValue := reflect.ValueOf(copiedStrategy).Elem()
+			for i := 0; i < strategyValue.NumField(); i++ {
+				fieldName := strategyType.Field(i).Name
+
+				field := strategyValue.Field(i)
+				Expect(field.IsNil()).To(BeFalse(), "field %s should not be nil after fuzzing", fieldName)
+
+				copiedField := copiedStrategyValue.Field(i)
+				Expect(copiedField.Pointer()).ToNot(Equal(field.Pointer()), "field %s should be a distinct copy", fieldName)
+			}
+		})
+
+		It("should isolate copied objects from the original strategy", func() {
+			strategy := &Strategy{
+				daemonSets: []*appsv1.DaemonSet{{
+					ObjectMeta: metav1.ObjectMeta{Name: "virt-handler"},
+					Spec: appsv1.DaemonSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "virt-handler",
+									Args: []string{"--existing-arg"},
+								}},
+							},
+						},
+					},
+				}},
+			}
+
+			copiedStrategy := strategy.DeepCopy()
+			copiedStrategy.DaemonSets()[0].Spec.Template.Spec.Containers[0].Args = append(
+				copiedStrategy.DaemonSets()[0].Spec.Template.Spec.Containers[0].Args,
+				"--custom-arg",
+			)
+
+			Expect(strategy.DaemonSets()[0].Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"--existing-arg"}))
+			Expect(copiedStrategy.DaemonSets()[0].Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"--existing-arg", "--custom-arg"}))
+		})
+	})
 
 	Context("monitoring detection", func() {
 		DescribeTable("should", func(expectedNS string, objects ...runtime.Object) {

--- a/pkg/virt-operator/strategy.go
+++ b/pkg/virt-operator/strategy.go
@@ -24,7 +24,7 @@ func (c *KubeVirtController) getCachedInstallStrategy(config *operatorutil.KubeV
 	}
 
 	if cachedEntry.key == fmt.Sprintf(installStrategyKeyTemplate, config.GetDeploymentID(), generation) {
-		return cachedEntry.value, true
+		return cachedEntry.value.DeepCopy(), true
 	}
 	return nil, false
 }


### PR DESCRIPTION
 ### What this PR does
#### Before this PR:
After virt-operator  do multiple reconciliations, the target DaemonSet/Deployment can end up with duplicated args.

#### After this PR:
deep copy before return from cache, to address the issue.

### References

- Fixes #17768

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where the virt-operator could append duplicate container arguments to DaemonSets/Deployments when using customizeComponents JSON patches with add operations across multiple reconciliations.
```

