### PR TITLE
fix: hotplug migration race

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1897,6 +1897,18 @@ func (c *Controller) sync(key string, migration *virtv1.VirtualMachineInstanceMi
 			}
 		}
 		if targetPodExists {
+			// if a vmi was hotplugged after the migration pending phase, we need to
+			// create the attachment pod here to avoid stalling the migration
+			if controller.IsPodReady(pod) && controller.VMIHasHotplugVolumes(vmi) {
+				attachmentPods, err := controller.AttachmentPods(pod, c.podIndexer)
+				if err != nil {
+					return fmt.Errorf(failedGetAttractionPodsFmt, err)
+				}
+				if len(attachmentPods) == 0 {
+					log.Log.Object(migration).V(5).Infof("Creating attachment pod for vmi %s/%s on node %s", vmi.Namespace, vmi.Name, pod.Spec.NodeName)
+					return c.createAttachmentPod(migration, vmi, pod)
+				}
+			}
 			return c.handlePendingPodTimeout(migration, vmi, pod)
 		}
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1421,6 +1421,36 @@ var _ = Describe(SIG("Hotplug", func() {
 				Entry("containerDisk VMI", containerDiskVMIFunc),
 				Entry("persistent disk VMI", persistentDiskVMIFunc),
 			)
+
+			It("should handle hotplug volume added immediately after migration is created", func() {
+				ns := testsuite.GetTestNamespace(nil)
+				vmiSpec := containerDiskVMIFunc()
+				vm, err := virtClient.VirtualMachine(ns).Create(context.Background(),
+					libvmi.NewVirtualMachine(vmiSpec, libvmi.WithRunStrategy(v1.RunStrategyAlways)),
+					metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(matcher.ThisVM(vm), 300*time.Second, 1*time.Second).Should(matcher.BeReady())
+
+				vmi, err = virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				libwait.WaitForSuccessfulVMIStart(vmi, libwait.WithTimeout(240))
+				Eventually(matcher.ThisVMI(vmi), 90*time.Second, 1*time.Second).Should(
+					matcher.HaveConditionTrue(v1.VirtualMachineInstanceIsMigratable))
+
+				volumeName := "testvolume"
+				dv := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeBlock)
+
+				By("Creating migration and immediately hotplugging a volume")
+				migration := libmigration.New(vmi.Name, ns)
+				migration, err = virtClient.VirtualMachineInstanceMigration(ns).Create(context.Background(), migration, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				addDVVolumeVM(vm.Name, ns, volumeName, dv.Name, v1.DiskBusSCSI, false, "")
+
+				By("Expecting migration to complete successfully")
+				migration = libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)
+				libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+			})
 		})
 
 		Context("disk mutating sidecar", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Race condition was found where if a VM is being hotplugged as a migration is being initialized, the resulting VMIM object can get stuck in `Scheduling` phase indefinitely. This seems to be because the migration controller only creates hotplug attachment pods on the target node once during the `Pending` phase. So there is a possible case where during the `Pending` phase of the migration, the controller sees the VMI has no hotplug volumes so it skips the attachment pod creation step however, if a hotplug volume appears in the VMI spec once the migration moves to `Scheduling`, the controller will not allow the migration phase to progress. This is because it is waiting for the new target attachment pod that will never be created.

To guard against this potential migration stall, we should also create attachment pods during `Scheduling` phase.

Fixes: https://redhat.atlassian.net/browse/CNV-85690

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

