### PR TITLE
Fix kube-burner prometheus endpoint ENV variable

### DIFF
--- a/hack/perfscale-kube-burner-test.sh
+++ b/hack/perfscale-kube-burner-test.sh
@@ -19,7 +19,7 @@
 set -e
 
 export PROMETHEUS_PORT=${PROMETHEUS_PORT:-30007}
-export PROMETHEUS_URL=${PROMETHEUS_URL:-http://127.0.0.1}
+export PROMETHEUS_ENDPOINT=${PROMETHEUS_ENDPOINT:-http://127.0.0.1}
 
 echo 'Preparing directory for artifacts'
 mkdir -p $ARTIFACTS
@@ -33,7 +33,7 @@ KUBE_DIR=${KUBE_DIR:-/tmp}
 # in kubevirt CI/CD the node we run the job is on a different cluster, so time is not synced across all nodes
 # as a workaround, we collect the timestamps by making a prometheus query, so we can use the exact time that prometheus is using
 function get_timestamp() {
-    curr_timestamp=$(curl -fs --data-urlencode 'query=container_cpu_usage_seconds_total{pod!="",container="prometheus"}' "${PROMETHEUS_URL}:${PROMETHEUS_PORT}/api/v1/query" | jq -r '.data.result[0] | .value[0]')
+    curr_timestamp=$(curl -fs --data-urlencode 'query=container_cpu_usage_seconds_total{pod!="",container="prometheus"}' "${PROMETHEUS_ENDPOINT}:${PROMETHEUS_PORT}/api/v1/query" | jq -r '.data.result[0] | .value[0]')
     date -u +%Y-%m-%dT%TZ -d @$curr_timestamp
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR: We were running into an issue ENV variable mismatch that helps kube-burner collect metrics.

#### After this PR: Fix in place: https://github.com/kubevirt/project-infra/pull/4703#issuecomment-4388745315

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes # https://github.com/kubevirt/project-infra/pull/4703#issuecomment-4388745315
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made: N/A

The following alternatives were considered: N/A

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

