### PR TITLE
Add subPath and readOnly mount options support for virtiofs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15316,7 +15316,17 @@
     }
    },
    "v1.FilesystemVirtiofs": {
-    "type": "object"
+    "type": "object",
+    "properties": {
+     "readOnly": {
+      "description": "ReadOnly mounts the filesystem as read-only inside the guest. Defaults to false (read-write).",
+      "type": "boolean"
+     },
+     "subPath": {
+      "description": "SubPath specifies a sub-directory within the source volume to be exposed to the guest, instead of the volume's root. Must be a relative path and must not contain '..' path elements. Defaults to \"\" (volume's root).",
+      "type": "string"
+     }
+    }
    },
    "v1.Firmware": {
     "type": "object",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15346,7 +15346,17 @@
     }
    },
    "v1.FilesystemVirtiofs": {
-    "type": "object"
+    "type": "object",
+    "properties": {
+     "readOnly": {
+      "description": "ReadOnly mounts the filesystem as read-only inside the guest. Defaults to false (read-write).",
+      "type": "boolean"
+     },
+     "subPath": {
+      "description": "SubPath specifies a sub-directory within the source volume to be exposed to the guest, instead of the volume's root. Must be a relative path and must not contain '..' path elements. Defaults to \"\" (volume's root).",
+      "type": "string"
+     }
+    }
    },
    "v1.Firmware": {
     "type": "object",

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -142,6 +142,17 @@ func WithFilesystemPVC(claimName string) Option {
 	}
 }
 
+// WithFilesystemPVCVirtiofs specifies a virtiofs filesystem backed by a PVC with mount options.
+func WithFilesystemPVCVirtiofs(claimName string, virtiofs v1.FilesystemVirtiofs) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addFilesystem(vmi, v1.Filesystem{
+			Name:     claimName,
+			Virtiofs: &virtiofs,
+		})
+		addVolume(vmi, newPersistentVolumeClaimVolume(claimName, claimName, false))
+	}
+}
+
 // WithFilesystemDV specifies a filesystem backed by a DV to be used.
 func WithFilesystemDV(dataVolumeName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -236,6 +236,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validatePersistentReservation(field, spec, config)...)
 	causes = append(causes, validateDownwardMetrics(field, spec, config)...)
 	causes = append(causes, validateFilesystemsWithVirtIOFSEnabled(field, spec, config)...)
+	causes = append(causes, validateVirtiofsSubPath(field, spec)...)
 	causes = append(causes, validateVideoConfig(field, spec)...)
 	causes = append(causes, validatePanicDevices(field, spec, config)...)
 	causes = append(causes, validateRebootPolicy(field, spec, config)...)
@@ -263,6 +264,66 @@ func validateFilesystemsWithVirtIOFSEnabled(field *k8sfield.Path, spec *v1.Virtu
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: "virtiofs is not allowed: virtiofs feature gate is not enabled for PVC",
 				Field:   field.Child("domain", "devices", "filesystems").String(),
+			})
+		}
+	}
+
+	return causes
+}
+
+// validateVirtiofsSubPath validates FilesystemVirtiofs.SubPath with the same semantics
+// as Kubernetes' validateLocalDescendingPath for VolumeMount.SubPath (see
+// k8s.io/kubernetes/pkg/apis/core/validation/validation.go):
+//   - must be a relative path (must not start with '/')
+//   - must not contain '..' as a path segment
+//
+// This is enforced here instead of in the CRD via x-kubernetes-validations to avoid
+// contributing to the CRD's CEL cost budget. At runtime the value is passed through
+// to Pod VolumeMount.SubPath, where kube-apiserver re-validates it and kubelet's
+// O_NOFOLLOW subpath resolution (CVE-2017-1002101 fix) provides defense-in-depth.
+//
+// It also rejects setting SubPath when the referenced volume uses ContainerPath,
+// because that volume type is handled by the virt-launcher pod mutating webhook,
+// which computes its own SubPath from ContainerPath.Path and would silently ignore
+// this field.
+func validateVirtiofsSubPath(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) (causes []metav1.StatusCause) {
+	if spec.Domain.Devices.Filesystems == nil {
+		return causes
+	}
+
+	volumes := storagetypes.GetVolumesByName(spec)
+
+	for i, fs := range spec.Domain.Devices.Filesystems {
+		if fs.Virtiofs == nil || fs.Virtiofs.SubPath == "" {
+			continue
+		}
+
+		fsField := field.Child("domain", "devices", "filesystems").Index(i).Child("virtiofs", "subPath")
+
+		if strings.HasPrefix(fs.Virtiofs.SubPath, "/") {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("virtiofs subPath %q must be a relative path", fs.Virtiofs.SubPath),
+				Field:   fsField.String(),
+			})
+		}
+
+		for _, seg := range strings.Split(fs.Virtiofs.SubPath, "/") {
+			if seg == ".." {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("virtiofs subPath %q must not contain '..'", fs.Virtiofs.SubPath),
+					Field:   fsField.String(),
+				})
+				break
+			}
+		}
+
+		if volume, ok := volumes[fs.Name]; ok && volume.ContainerPath != nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("virtiofs subPath is not supported when volume %q uses containerPath", fs.Name),
+				Field:   fsField.String(),
 			})
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -251,18 +251,48 @@ func validateFilesystemsWithVirtIOFSEnabled(field *k8sfield.Path, spec *v1.Virtu
 	}
 
 	volumes := storagetypes.GetVolumesByName(spec)
+	filesystemsField := field.Child("domain", "devices", "filesystems")
 
-	for _, fs := range spec.Domain.Devices.Filesystems {
+	for i, fs := range spec.Domain.Devices.Filesystems {
 		volume, ok := volumes[fs.Name]
-		if !ok {
-			continue
-		}
-
-		if storagetypes.IsStorageVolume(volume) && (!config.VirtiofsStorageEnabled()) {
+		if ok && storagetypes.IsStorageVolume(volume) && !config.VirtiofsStorageEnabled() {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: "virtiofs is not allowed: virtiofs feature gate is not enabled for PVC",
-				Field:   field.Child("domain", "devices", "filesystems").String(),
+				Field:   filesystemsField.String(),
+			})
+		}
+
+		if fs.Virtiofs == nil || fs.Virtiofs.SubPath == "" {
+			continue
+		}
+
+		subPathField := filesystemsField.Index(i).Child("virtiofs", "subPath")
+
+		if strings.HasPrefix(fs.Virtiofs.SubPath, "/") {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("virtiofs subPath %q must be a relative path", fs.Virtiofs.SubPath),
+				Field:   subPathField.String(),
+			})
+		}
+
+		for _, seg := range strings.Split(fs.Virtiofs.SubPath, "/") {
+			if seg == ".." {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("virtiofs subPath %q must not contain '..'", fs.Virtiofs.SubPath),
+					Field:   subPathField.String(),
+				})
+				break
+			}
+		}
+
+		if ok && volume.ContainerPath != nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("virtiofs subPath is not supported when volume %q uses containerPath", fs.Name),
+				Field:   subPathField.String(),
 			})
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2161,6 +2161,84 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 	})
 
+	Context("with virtiofs subPath", func() {
+		var vmi *v1.VirtualMachineInstance
+		validate := func() []metav1.StatusCause {
+			return validateVirtiofsSubPath(k8sfield.NewPath("fake"), &vmi.Spec)
+		}
+
+		BeforeEach(func() {
+			vmi = api.NewMinimalVMI("testvmi")
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "sharedvol",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+				},
+			})
+		})
+
+		setSubPath := func(subPath string) {
+			vmi.Spec.Domain.Devices.Filesystems = []v1.Filesystem{{
+				Name:     "sharedvol",
+				Virtiofs: &v1.FilesystemVirtiofs{SubPath: subPath},
+			}}
+		}
+
+		It("should accept an empty subPath", func() {
+			setSubPath("")
+			Expect(validate()).To(BeEmpty())
+		})
+
+		It("should accept a relative subPath", func() {
+			setSubPath("foo/bar")
+			Expect(validate()).To(BeEmpty())
+		})
+
+		It("should accept a subPath containing '..' inside a segment", func() {
+			// 'foo..bar' is a legal segment; K8s SubPath validation splits on '/'
+			// and only rejects '..' as a whole segment.
+			setSubPath("foo..bar")
+			Expect(validate()).To(BeEmpty())
+		})
+
+		It("should reject an absolute subPath", func() {
+			setSubPath("/abs/path")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("must be a relative path"))
+			Expect(causes[0].Field).To(Equal("fake.domain.devices.filesystems[0].virtiofs.subPath"))
+		})
+
+		It("should reject a subPath containing '..' as a segment", func() {
+			setSubPath("foo/../bar")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("must not contain '..'"))
+		})
+
+		It("should reject a subPath starting with '..'", func() {
+			setSubPath("../escape")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("must not contain '..'"))
+		})
+
+		It("should reject subPath when the referenced volume uses containerPath", func() {
+			vmi.Spec.Volumes = []v1.Volume{{
+				Name: "sharedvol",
+				VolumeSource: v1.VolumeSource{
+					ContainerPath: &v1.ContainerPathVolumeSource{
+						Path: "/injected/dir",
+					},
+				},
+			}}
+			setSubPath("foo/bar")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("not supported when volume"))
+		})
+	})
+
 	Context("with volume", func() {
 		var vmi *v1.VirtualMachineInstance
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2209,6 +2209,85 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 	})
 
+	Context("with virtiofs subPath", func() {
+		var vmi *v1.VirtualMachineInstance
+		validate := func() []metav1.StatusCause {
+			return validateFilesystemsWithVirtIOFSEnabled(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		}
+
+		BeforeEach(func() {
+			vmi = api.NewMinimalVMI("testvmi")
+			enableFeatureGates(featuregate.VirtIOFSStorageVolumeGate)
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "sharedvol",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+				},
+			})
+		})
+
+		setSubPath := func(subPath string) {
+			vmi.Spec.Domain.Devices.Filesystems = []v1.Filesystem{{
+				Name:     "sharedvol",
+				Virtiofs: &v1.FilesystemVirtiofs{SubPath: subPath},
+			}}
+		}
+
+		It("should accept an empty subPath", func() {
+			setSubPath("")
+			Expect(validate()).To(BeEmpty())
+		})
+
+		It("should accept a relative subPath", func() {
+			setSubPath("foo/bar")
+			Expect(validate()).To(BeEmpty())
+		})
+
+		It("should accept a subPath containing '..' inside a segment", func() {
+			// 'foo..bar' is a legal segment; K8s SubPath validation splits on '/'
+			// and only rejects '..' as a whole segment.
+			setSubPath("foo..bar")
+			Expect(validate()).To(BeEmpty())
+		})
+
+		It("should reject an absolute subPath", func() {
+			setSubPath("/abs/path")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("must be a relative path"))
+			Expect(causes[0].Field).To(Equal("fake.domain.devices.filesystems[0].virtiofs.subPath"))
+		})
+
+		It("should reject a subPath containing '..' as a segment", func() {
+			setSubPath("foo/../bar")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("must not contain '..'"))
+		})
+
+		It("should reject a subPath starting with '..'", func() {
+			setSubPath("../escape")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("must not contain '..'"))
+		})
+
+		It("should reject subPath when the referenced volume uses containerPath", func() {
+			vmi.Spec.Volumes = []v1.Volume{{
+				Name: "sharedvol",
+				VolumeSource: v1.VolumeSource{
+					ContainerPath: &v1.ContainerPathVolumeSource{
+						Path: "/injected/dir",
+					},
+				},
+			}}
+			setSubPath("foo/bar")
+			causes := validate()
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Message).To(ContainSubstring("not supported when volume"))
+		})
+	})
+
 	Context("with volume", func() {
 		var vmi *v1.VirtualMachineInstance
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3839,7 +3839,8 @@ var _ = Describe("Template", func() {
 								DisableHotplug: true,
 								Filesystems: []v1.Filesystem{
 									{
-										Name: "fakeVol1",
+										Name:     "fakeVol1",
+										Virtiofs: &v1.FilesystemVirtiofs{},
 									},
 								},
 							},

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3837,7 +3837,8 @@ var _ = Describe("Template", func() {
 								DisableHotplug: true,
 								Filesystems: []v1.Filesystem{
 									{
-										Name: "fakeVol1",
+										Name:     "fakeVol1",
+										Virtiofs: &v1.FilesystemVirtiofs{},
 									},
 								},
 							},

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -15,9 +15,15 @@ import (
 )
 
 func generateVirtioFSContainers(vmi *v1.VirtualMachineInstance, image string, config *virtconfig.ClusterConfig) []k8sv1.Container {
-	passthroughFSVolumes := make(map[string]struct{})
+	passthroughFSVolumes := make(map[string]v1.FilesystemVirtiofs)
 	for i := range vmi.Spec.Domain.Devices.Filesystems {
-		passthroughFSVolumes[vmi.Spec.Domain.Devices.Filesystems[i].Name] = struct{}{}
+		fs := vmi.Spec.Domain.Devices.Filesystems[i]
+		// Virtiofs presence is the type discriminator; align with
+		// VirtiofsConfigurator and util.IsVMIVirtiofsEnabled.
+		if fs.Virtiofs == nil {
+			continue
+		}
+		passthroughFSVolumes[fs.Name] = *fs.Virtiofs
 	}
 	if len(passthroughFSVolumes) == 0 {
 		return nil
@@ -25,14 +31,14 @@ func generateVirtioFSContainers(vmi *v1.VirtualMachineInstance, image string, co
 
 	containers := []k8sv1.Container{}
 	for _, volume := range vmi.Spec.Volumes {
-		if _, isPassthroughFSVolume := passthroughFSVolumes[volume.Name]; isPassthroughFSVolume {
+		if virtioFS, isPassthroughFSVolume := passthroughFSVolumes[volume.Name]; isPassthroughFSVolume {
 			// Skip ContainerPath volumes - they are handled by the pod mutating webhook
 			// because external mutators inject the actual volumes after pod creation
 			if volume.ContainerPath != nil {
 				continue
 			}
 			resources := virtiofs.ResourcesForVirtioFSContainer(vmi.IsCPUDedicated(), vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed(), config)
-			container := generateContainerFromVolume(&volume, image, resources)
+			container := generateContainerFromVolume(&volume, virtioFS, image, resources)
 			containers = append(containers, container)
 
 		}
@@ -62,7 +68,7 @@ func virtioFSMountPoint(volume *v1.Volume) string {
 	return volumeMountPoint
 }
 
-func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv1.ResourceRequirements) k8sv1.Container {
+func generateContainerFromVolume(volume *v1.Volume, virtioFS v1.FilesystemVirtiofs, image string, resources k8sv1.ResourceRequirements) k8sv1.Container {
 
 	socketPathArg := fmt.Sprintf("--socket-path=%s", virtiofs.VirtioFSSocketPath(volume.Name))
 	sourceArg := fmt.Sprintf("--shared-dir=%s", virtioFSMountPoint(volume))
@@ -108,6 +114,8 @@ func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv
 		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 			Name:      volume.Name,
 			MountPath: virtioFSMountPoint(volume),
+			SubPath:   virtioFS.SubPath,
+			ReadOnly:  virtioFS.ReadOnly,
 		})
 	}
 

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -15,9 +15,15 @@ import (
 )
 
 func generateVirtioFSContainers(vmi *v1.VirtualMachineInstance, image string, config *virtconfig.ClusterConfig) []k8sv1.Container {
-	passthroughFSVolumes := make(map[string]struct{})
+	passthroughFSVolumes := make(map[string]v1.FilesystemVirtiofs)
 	for i := range vmi.Spec.Domain.Devices.Filesystems {
-		passthroughFSVolumes[vmi.Spec.Domain.Devices.Filesystems[i].Name] = struct{}{}
+		fs := vmi.Spec.Domain.Devices.Filesystems[i]
+		// Virtiofs presence is the type discriminator; align with
+		// VirtiofsConfigurator and util.IsVMIVirtiofsEnabled.
+		if fs.Virtiofs == nil {
+			continue
+		}
+		passthroughFSVolumes[fs.Name] = *fs.Virtiofs
 	}
 	if len(passthroughFSVolumes) == 0 {
 		return nil
@@ -25,14 +31,14 @@ func generateVirtioFSContainers(vmi *v1.VirtualMachineInstance, image string, co
 
 	containers := []k8sv1.Container{}
 	for _, volume := range vmi.Spec.Volumes {
-		if _, isPassthroughFSVolume := passthroughFSVolumes[volume.Name]; isPassthroughFSVolume {
+		if virtioFS, isPassthroughFSVolume := passthroughFSVolumes[volume.Name]; isPassthroughFSVolume {
 			// Skip ContainerPath volumes - they are handled by the pod mutating webhook
 			// because external mutators inject the actual volumes after pod creation
 			if volume.ContainerPath != nil {
 				continue
 			}
 			resources := virtiofs.ResourcesForVirtioFSContainer(vmi.IsCPUDedicated(), vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed(), config)
-			container := generateContainerFromVolume(&volume, image, resources, config.GetImagePullPolicy())
+			container := generateContainerFromVolume(&volume, virtioFS, image, resources, config.GetImagePullPolicy())
 			containers = append(containers, container)
 
 		}
@@ -62,7 +68,7 @@ func virtioFSMountPoint(volume *v1.Volume) string {
 	return volumeMountPoint
 }
 
-func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv1.ResourceRequirements, imagePullPolicy k8sv1.PullPolicy) k8sv1.Container {
+func generateContainerFromVolume(volume *v1.Volume, virtioFS v1.FilesystemVirtiofs, image string, resources k8sv1.ResourceRequirements, imagePullPolicy k8sv1.PullPolicy) k8sv1.Container {
 
 	socketPathArg := fmt.Sprintf("--socket-path=%s", virtiofs.VirtioFSSocketPath(volume.Name))
 	sourceArg := fmt.Sprintf("--shared-dir=%s", virtioFSMountPoint(volume))
@@ -108,6 +114,8 @@ func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv
 		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 			Name:      volume.Name,
 			MountPath: virtioFSMountPoint(volume),
+			SubPath:   virtioFS.SubPath,
+			ReadOnly:  virtioFS.ReadOnly,
 		})
 	}
 

--- a/pkg/virt-controller/services/virtiofs_test.go
+++ b/pkg/virt-controller/services/virtiofs_test.go
@@ -96,6 +96,58 @@ var _ = Describe("virtiofs container", func() {
 		Expect(container[1].SecurityContext.AllowPrivilegeEscalation).To(HaveValue(BeFalse()))
 	})
 
+	It("should propagate SubPath and ReadOnly from FilesystemVirtiofs to the volume mount", func() {
+		vmi := api.NewMinimalVMI("testvm")
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "sharedtestdisk",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+			},
+		})
+		vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
+			Name: "sharedtestdisk",
+			Virtiofs: &v1.FilesystemVirtiofs{
+				SubPath:  "data/sub",
+				ReadOnly: true,
+			},
+		})
+
+		containers := generateVirtioFSContainers(vmi, "virtiofs-container", config)
+		Expect(containers).To(HaveLen(1))
+
+		// The first VolumeMount is the shared socket dir; the data volume mount is appended after it.
+		Expect(containers[0].VolumeMounts).To(HaveLen(2))
+		dataMount := containers[0].VolumeMounts[1]
+		Expect(dataMount.Name).To(Equal("sharedtestdisk"))
+		Expect(dataMount.SubPath).To(Equal("data/sub"))
+		Expect(dataMount.ReadOnly).To(BeTrue())
+	})
+
+	It("should default SubPath to empty and ReadOnly to false when FilesystemVirtiofs is empty", func() {
+		vmi := api.NewMinimalVMI("testvm")
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "sharedtestdisk",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+			},
+		})
+		vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
+			Name:     "sharedtestdisk",
+			Virtiofs: &v1.FilesystemVirtiofs{},
+		})
+
+		containers := generateVirtioFSContainers(vmi, "virtiofs-container", config)
+		Expect(containers).To(HaveLen(1))
+
+		Expect(containers[0].VolumeMounts).To(HaveLen(2))
+		dataMount := containers[0].VolumeMounts[1]
+		Expect(dataMount.Name).To(Equal("sharedtestdisk"))
+		Expect(dataMount.SubPath).To(BeEmpty())
+		Expect(dataMount.ReadOnly).To(BeFalse())
+	})
+
 	It("should skip ContainerPath volumes", func() {
 		vmi := api.NewMinimalVMI("testvm")
 

--- a/pkg/virt-controller/services/virtiofs_test.go
+++ b/pkg/virt-controller/services/virtiofs_test.go
@@ -144,6 +144,57 @@ var _ = Describe("virtiofs container", func() {
 		Expect(containers[0].ImagePullPolicy).To(Equal(k8sv1.PullAlways))
 	})
 
+	It("should propagate SubPath and ReadOnly from FilesystemVirtiofs to the volume mount", func() {
+		vmi := api.NewMinimalVMI("testvm")
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "sharedtestdisk",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+			},
+		})
+		vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
+			Name: "sharedtestdisk",
+			Virtiofs: &v1.FilesystemVirtiofs{
+				SubPath:  "data/sub",
+				ReadOnly: true,
+			},
+		})
+
+		containers := generateVirtioFSContainers(vmi, "virtiofs-container", config)
+		Expect(containers).To(HaveLen(1))
+
+		// The first VolumeMount is the shared socket dir; the data volume mount is appended after it.
+		Expect(containers[0].VolumeMounts).To(HaveLen(2))
+		dataMount := containers[0].VolumeMounts[1]
+		Expect(dataMount.Name).To(Equal("sharedtestdisk"))
+		Expect(dataMount.SubPath).To(Equal("data/sub"))
+		Expect(dataMount.ReadOnly).To(BeTrue())
+	})
+
+	It("should default SubPath to empty and ReadOnly to false when FilesystemVirtiofs is empty", func() {
+		vmi := api.NewMinimalVMI("testvm")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "sharedtestdisk",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+			},
+		})
+
+		vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
+			Name:     "sharedtestdisk",
+			Virtiofs: &v1.FilesystemVirtiofs{},
+		})
+
+		containers := generateVirtioFSContainers(vmi, "virtiofs-container", config)
+
+		Expect(containers[0].VolumeMounts).To(HaveLen(2))
+		dataMount := containers[0].VolumeMounts[1]
+		Expect(dataMount.Name).To(Equal("sharedtestdisk"))
+		Expect(dataMount.SubPath).To(BeEmpty())
+		Expect(dataMount.ReadOnly).To(BeFalse())
+	})
+
 	It("should skip ContainerPath volumes", func() {
 		vmi := api.NewMinimalVMI("testvm")
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6705,6 +6705,19 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: string
                               virtiofs:
                                 description: Virtiofs is supported
+                                properties:
+                                  readOnly:
+                                    description: |-
+                                      ReadOnly mounts the filesystem as read-only inside the guest.
+                                      Defaults to false (read-write).
+                                    type: boolean
+                                  subPath:
+                                    description: |-
+                                      SubPath specifies a sub-directory within the source volume to be
+                                      exposed to the guest, instead of the volume's root.
+                                      Must be a relative path and must not contain '..' path elements.
+                                      Defaults to "" (volume's root).
+                                    type: string
                                 type: object
                             required:
                             - name
@@ -12937,6 +12950,19 @@ var CRDsValidation map[string]string = map[string]string{
                         type: string
                       virtiofs:
                         description: Virtiofs is supported
+                        properties:
+                          readOnly:
+                            description: |-
+                              ReadOnly mounts the filesystem as read-only inside the guest.
+                              Defaults to false (read-write).
+                            type: boolean
+                          subPath:
+                            description: |-
+                              SubPath specifies a sub-directory within the source volume to be
+                              exposed to the guest, instead of the volume's root.
+                              Must be a relative path and must not contain '..' path elements.
+                              Defaults to "" (volume's root).
+                            type: string
                         type: object
                     required:
                     - name
@@ -17048,6 +17074,19 @@ var CRDsValidation map[string]string = map[string]string{
                         type: string
                       virtiofs:
                         description: Virtiofs is supported
+                        properties:
+                          readOnly:
+                            description: |-
+                              ReadOnly mounts the filesystem as read-only inside the guest.
+                              Defaults to false (read-write).
+                            type: boolean
+                          subPath:
+                            description: |-
+                              SubPath specifies a sub-directory within the source volume to be
+                              exposed to the guest, instead of the volume's root.
+                              Must be a relative path and must not contain '..' path elements.
+                              Defaults to "" (volume's root).
+                            type: string
                         type: object
                     required:
                     - name
@@ -19642,6 +19681,19 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: string
                               virtiofs:
                                 description: Virtiofs is supported
+                                properties:
+                                  readOnly:
+                                    description: |-
+                                      ReadOnly mounts the filesystem as read-only inside the guest.
+                                      Defaults to false (read-write).
+                                    type: boolean
+                                  subPath:
+                                    description: |-
+                                      SubPath specifies a sub-directory within the source volume to be
+                                      exposed to the guest, instead of the volume's root.
+                                      Must be a relative path and must not contain '..' path elements.
+                                      Defaults to "" (volume's root).
+                                    type: string
                                 type: object
                             required:
                             - name
@@ -24816,6 +24868,19 @@ var CRDsValidation map[string]string = map[string]string{
                                         type: string
                                       virtiofs:
                                         description: Virtiofs is supported
+                                        properties:
+                                          readOnly:
+                                            description: |-
+                                              ReadOnly mounts the filesystem as read-only inside the guest.
+                                              Defaults to false (read-write).
+                                            type: boolean
+                                          subPath:
+                                            description: |-
+                                              SubPath specifies a sub-directory within the source volume to be
+                                              exposed to the guest, instead of the volume's root.
+                                              Must be a relative path and must not contain '..' path elements.
+                                              Defaults to "" (volume's root).
+                                            type: string
                                         type: object
                                     required:
                                     - name
@@ -30497,6 +30562,19 @@ var CRDsValidation map[string]string = map[string]string{
                                             type: string
                                           virtiofs:
                                             description: Virtiofs is supported
+                                            properties:
+                                              readOnly:
+                                                description: |-
+                                                  ReadOnly mounts the filesystem as read-only inside the guest.
+                                                  Defaults to false (read-write).
+                                                type: boolean
+                                              subPath:
+                                                description: |-
+                                                  SubPath specifies a sub-directory within the source volume to be
+                                                  exposed to the guest, instead of the volume's root.
+                                                  Must be a relative path and must not contain '..' path elements.
+                                                  Defaults to "" (volume's root).
+                                                type: string
                                             type: object
                                         required:
                                         - name

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6758,6 +6758,19 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: string
                               virtiofs:
                                 description: Virtiofs is supported
+                                properties:
+                                  readOnly:
+                                    description: |-
+                                      ReadOnly mounts the filesystem as read-only inside the guest.
+                                      Defaults to false (read-write).
+                                    type: boolean
+                                  subPath:
+                                    description: |-
+                                      SubPath specifies a sub-directory within the source volume to be
+                                      exposed to the guest, instead of the volume's root.
+                                      Must be a relative path and must not contain '..' path elements.
+                                      Defaults to "" (volume's root).
+                                    type: string
                                 type: object
                             required:
                             - name
@@ -12967,6 +12980,19 @@ var CRDsValidation map[string]string = map[string]string{
                         type: string
                       virtiofs:
                         description: Virtiofs is supported
+                        properties:
+                          readOnly:
+                            description: |-
+                              ReadOnly mounts the filesystem as read-only inside the guest.
+                              Defaults to false (read-write).
+                            type: boolean
+                          subPath:
+                            description: |-
+                              SubPath specifies a sub-directory within the source volume to be
+                              exposed to the guest, instead of the volume's root.
+                              Must be a relative path and must not contain '..' path elements.
+                              Defaults to "" (volume's root).
+                            type: string
                         type: object
                     required:
                     - name
@@ -17171,6 +17197,19 @@ var CRDsValidation map[string]string = map[string]string{
                         type: string
                       virtiofs:
                         description: Virtiofs is supported
+                        properties:
+                          readOnly:
+                            description: |-
+                              ReadOnly mounts the filesystem as read-only inside the guest.
+                              Defaults to false (read-write).
+                            type: boolean
+                          subPath:
+                            description: |-
+                              SubPath specifies a sub-directory within the source volume to be
+                              exposed to the guest, instead of the volume's root.
+                              Must be a relative path and must not contain '..' path elements.
+                              Defaults to "" (volume's root).
+                            type: string
                         type: object
                     required:
                     - name
@@ -19765,6 +19804,19 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: string
                               virtiofs:
                                 description: Virtiofs is supported
+                                properties:
+                                  readOnly:
+                                    description: |-
+                                      ReadOnly mounts the filesystem as read-only inside the guest.
+                                      Defaults to false (read-write).
+                                    type: boolean
+                                  subPath:
+                                    description: |-
+                                      SubPath specifies a sub-directory within the source volume to be
+                                      exposed to the guest, instead of the volume's root.
+                                      Must be a relative path and must not contain '..' path elements.
+                                      Defaults to "" (volume's root).
+                                    type: string
                                 type: object
                             required:
                             - name
@@ -24939,6 +24991,19 @@ var CRDsValidation map[string]string = map[string]string{
                                         type: string
                                       virtiofs:
                                         description: Virtiofs is supported
+                                        properties:
+                                          readOnly:
+                                            description: |-
+                                              ReadOnly mounts the filesystem as read-only inside the guest.
+                                              Defaults to false (read-write).
+                                            type: boolean
+                                          subPath:
+                                            description: |-
+                                              SubPath specifies a sub-directory within the source volume to be
+                                              exposed to the guest, instead of the volume's root.
+                                              Must be a relative path and must not contain '..' path elements.
+                                              Defaults to "" (volume's root).
+                                            type: string
                                         type: object
                                     required:
                                     - name
@@ -30620,6 +30685,19 @@ var CRDsValidation map[string]string = map[string]string{
                                             type: string
                                           virtiofs:
                                             description: Virtiofs is supported
+                                            properties:
+                                              readOnly:
+                                                description: |-
+                                                  ReadOnly mounts the filesystem as read-only inside the guest.
+                                                  Defaults to false (read-write).
+                                                type: boolean
+                                              subPath:
+                                                description: |-
+                                                  SubPath specifies a sub-directory within the source volume to be
+                                                  exposed to the guest, instead of the volume's root.
+                                                  Must be a relative path and must not contain '..' path elements.
+                                                  Defaults to "" (volume's root).
+                                                type: string
                                             type: object
                                         required:
                                         - name

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -423,7 +423,10 @@
             "filesystems": [
               {
                 "name": "nameValue",
-                "virtiofs": {}
+                "virtiofs": {
+                  "readOnly": true,
+                  "subPath": "subPathValue"
+                }
               }
             ],
             "hostDevices": [

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -470,7 +470,9 @@ spec:
           downwardMetrics: {}
           filesystems:
           - name: nameValue
-            virtiofs: {}
+            virtiofs:
+              readOnly: true
+              subPath: subPathValue
           gpus:
           - claimName: claimNameValue
             deviceName: deviceNameValue

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -363,7 +363,10 @@
         "filesystems": [
           {
             "name": "nameValue",
-            "virtiofs": {}
+            "virtiofs": {
+              "readOnly": true,
+              "subPath": "subPathValue"
+            }
           }
         ],
         "hostDevices": [

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -273,7 +273,9 @@ spec:
       downwardMetrics: {}
       filesystems:
       - name: nameValue
-        virtiofs: {}
+        virtiofs:
+          readOnly: true
+          subPath: subPathValue
       gpus:
       - claimName: claimNameValue
         deviceName: deviceNameValue

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -687,7 +687,18 @@ type Filesystem struct {
 	Virtiofs *FilesystemVirtiofs `json:"virtiofs"`
 }
 
-type FilesystemVirtiofs struct{}
+type FilesystemVirtiofs struct {
+	// ReadOnly mounts the filesystem as read-only inside the guest.
+	// Defaults to false (read-write).
+	// +optional
+	ReadOnly bool `json:"readOnly,omitempty"`
+	// SubPath specifies a sub-directory within the source volume to be
+	// exposed to the guest, instead of the volume's root.
+	// Must be a relative path and must not contain '..' path elements.
+	// Defaults to "" (volume's root).
+	// +optional
+	SubPath string `json:"subPath,omitempty"`
+}
 
 type DownwardMetrics struct{}
 

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -336,7 +336,10 @@ func (Filesystem) SwaggerDoc() map[string]string {
 }
 
 func (FilesystemVirtiofs) SwaggerDoc() map[string]string {
-	return map[string]string{}
+	return map[string]string{
+		"readOnly": "ReadOnly mounts the filesystem as read-only inside the guest.\nDefaults to false (read-write).\n+optional",
+		"subPath":  "SubPath specifies a sub-directory within the source volume to be\nexposed to the guest, instead of the volume's root.\nMust be a relative path and must not contain '..' path elements.\nDefaults to \"\" (volume's root).\n+optional",
+	}
 }
 
 func (DownwardMetrics) SwaggerDoc() map[string]string {

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21351,6 +21351,22 @@ func schema_kubevirtio_api_core_v1_FilesystemVirtiofs(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"readOnly": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ReadOnly mounts the filesystem as read-only inside the guest. Defaults to false (read-write).",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"subPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SubPath specifies a sub-directory within the source volume to be exposed to the guest, instead of the volume's root. Must be a relative path and must not contain '..' path elements. Defaults to \"\" (volume's root).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21392,6 +21392,22 @@ func schema_kubevirtio_api_core_v1_FilesystemVirtiofs(ref common.ReferenceCallba
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"readOnly": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ReadOnly mounts the filesystem as read-only inside the guest. Defaults to false (read-write).",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"subPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SubPath specifies a sub-directory within the source volume to be exposed to the guest, instead of the volume's root. Must be a relative path and must not contain '..' path elements. Defaults to \"\" (volume's root).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/tests/virtiofs/BUILD.bazel
+++ b/tests/virtiofs/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "config.go",
         "containerpath.go",
         "datavolume.go",
+        "mount_options.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/virtiofs",
     visibility = ["//visibility:public"],

--- a/tests/virtiofs/mount_options.go
+++ b/tests/virtiofs/mount_options.go
@@ -1,0 +1,187 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virtiofs
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	expect "github.com/google/goexpect"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libpod"
+	"kubevirt.io/kubevirt/tests/libstorage"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libvmops"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe("[sig-storage] virtiofs mount options", decorators.SigStorage, decorators.StorageVolumesVirtiofs, func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		virtClient = kubevirt.Client()
+		checks.FailTestIfNoFeatureGate(featuregate.VirtIOFSStorageVolumeGate)
+	})
+
+	setupHostPathPVCWithContent := func(pvcBaseName, namespace string) (pvcName, pvHostPath string) {
+		pvHostPath = filepath.Join(testsuite.HostPathBase, pvcBaseName)
+		node := libstorage.CreateHostPathPv(pvcBaseName, namespace, pvHostPath)
+
+		nodeSelector := map[string]string{k8sv1.LabelHostname: node}
+		args := []string{fmt.Sprintf(
+			`mkdir -p %s/data/sub && echo sub-content > %s/data/sub/visible_file && echo root-content > %s/hidden_root_file && chown -R 107:107 %s`,
+			pvHostPath, pvHostPath, pvHostPath, pvHostPath,
+		)}
+		pod := libpod.RenderHostPathPod("virtiofs-mount-options-setup", pvHostPath, k8sv1.HostPathDirectoryOrCreate, k8sv1.MountPropagationNone, []string{"/bin/bash", "-c"}, args)
+		pod.Spec.NodeSelector = nodeSelector
+		pod, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(ThisPod(pod), 120).Should(BeInPhase(k8sv1.PodSucceeded))
+
+		libstorage.CreateHostPathPVC(pvcBaseName, namespace, "1G")
+		return fmt.Sprintf("disk-%s", pvcBaseName), pvHostPath
+	}
+
+	findVirtiofsDataVolumeMount := func(pod *k8sv1.Pod, volumeName string) k8sv1.VolumeMount {
+		virtiofsContainerName := fmt.Sprintf("virtiofs-%s", volumeName)
+		for _, container := range pod.Spec.Containers {
+			if container.Name != virtiofsContainerName {
+				continue
+			}
+			for _, mount := range container.VolumeMounts {
+				if mount.Name == volumeName {
+					return mount
+				}
+			}
+		}
+		Fail(fmt.Sprintf("virtiofs data volume mount for %s not found in pod %s", volumeName, pod.Name))
+		return k8sv1.VolumeMount{}
+	}
+
+	waitForGuestAgent := func(vmi *v1.VirtualMachineInstance) {
+		Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+		Expect(console.LoginToFedora(vmi)).To(Succeed())
+	}
+
+	Context("with subPath", func() {
+		const pvcBaseName = "virtiofs-subpath"
+
+		It("[Serial] should expose only the configured subdirectory to the guest", Serial, func() {
+			pvcName, _ := setupHostPathPVCWithContent(pvcBaseName, testsuite.NamespaceTestDefault)
+			defer func() {
+				libstorage.DeletePVC(pvcBaseName, testsuite.NamespaceTestDefault)
+				libstorage.DeletePV(pvcBaseName)
+			}()
+
+			virtiofsMountPath := fmt.Sprintf("/mnt/virtiofs_%s", pvcName)
+			mountScript := fmt.Sprintf(`#!/bin/bash
+mkdir %s
+mount -t virtiofs %s %s
+`, virtiofsMountPath, pvcName, virtiofsMountPath)
+
+			vmi := libvmifact.NewFedora(
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(mountScript)),
+				libvmi.WithFilesystemPVCVirtiofs(pvcName, v1.FilesystemVirtiofs{SubPath: "data/sub"}),
+				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
+			)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
+			waitForGuestAgent(vmi)
+
+			By("Verifying the virtiofs sidecar mounts only the configured subPath")
+			virtLauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+			dataMount := findVirtiofsDataVolumeMount(virtLauncherPod, pvcName)
+			Expect(dataMount.SubPath).To(Equal("data/sub"))
+			Expect(dataMount.ReadOnly).To(BeFalse())
+
+			By("Verifying the guest can access files from the subPath but not the volume root")
+			Expect(console.ExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: fmt.Sprintf("test -f %s/visible_file && echo visible\n", virtiofsMountPath)},
+				&expect.BExp{R: "visible"},
+				&expect.BSnd{S: fmt.Sprintf("test -f %s/hidden_root_file && echo hidden || echo not_visible\n", virtiofsMountPath)},
+				&expect.BExp{R: "not_visible"},
+			}, 30*time.Second)).To(Succeed())
+		})
+	})
+
+	Context("with readOnly", func() {
+		const pvcBaseName = "virtiofs-readonly"
+
+		It("[Serial] should prevent guest writes when readOnly is true", Serial, func() {
+			pvcName, _ := setupHostPathPVCWithContent(pvcBaseName, testsuite.NamespaceTestDefault)
+			defer func() {
+				libstorage.DeletePVC(pvcBaseName, testsuite.NamespaceTestDefault)
+				libstorage.DeletePV(pvcBaseName)
+			}()
+
+			virtiofsMountPath := fmt.Sprintf("/mnt/virtiofs_%s", pvcName)
+			mountScript := fmt.Sprintf(`#!/bin/bash
+mkdir %s
+mount -t virtiofs %s %s
+`, virtiofsMountPath, pvcName, virtiofsMountPath)
+
+			vmi := libvmifact.NewFedora(
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(mountScript)),
+				libvmi.WithFilesystemPVCVirtiofs(pvcName, v1.FilesystemVirtiofs{ReadOnly: true}),
+				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
+			)
+			vmi = libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
+			waitForGuestAgent(vmi)
+
+			By("Verifying the virtiofs sidecar mounts the source volume read-only")
+			virtLauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+			dataMount := findVirtiofsDataVolumeMount(virtLauncherPod, pvcName)
+			Expect(dataMount.ReadOnly).To(BeTrue())
+
+			By("Verifying the guest cannot create new files on the read-only virtiofs mount")
+			res, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
+				&expect.BSnd{S: fmt.Sprintf("touch %s/readonly_test 2>&1 || true\n", virtiofsMountPath)},
+				&expect.BExp{R: ""},
+			}, 30)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).ToNot(BeEmpty())
+			Expect(strings.ToLower(res[0].Output)).To(Or(
+				ContainSubstring("read-only"),
+				ContainSubstring("readonly"),
+			))
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does

#### Before this PR:
The `virtiofs` implementation in KubeVirt did not support `subPath` or `readOnly` options. Users were forced to mount the entire volume, and all mounts were effectively read-write from the virt-handler's perspective, limiting multi-tenant isolation and security.

#### After this PR:
- Added `SubPath` and `ReadOnly` fields to the `FilesystemVirtiofs` API.
- Updated `virt-handler` logic to propagate these settings to the container volume mounts.
- This allows mounting specific sub-directories of a volume and enforcing read-only access at the mount point level.

### Why we need it
This is a requirement for scenarios like CephFS multi-user directory isolation, where a single large volume is partitioned into sub-directories for different VMs, and for security-sensitive workloads that require immutable filesystem mounts.

### References
- Supersedes #10979

### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New code requires new unit tests.

### Release note

```release-note
VirtioFS filesystems now support `subPath` and `readOnly` options in
`spec.domain.devices.filesystems[].virtiofs`, allowing a subdirectory of the
source volume to be exposed read-only to the guest.
```