### PR TITLE
Remove legacy backend storage volume name code

### DIFF
--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -263,9 +263,7 @@ func (bs *BackendStorage) labelLegacyPVC(pvc *v1.PersistentVolumeClaim, name str
 }
 
 func IsBackendStorageVolume(v corev1.VolumeStatus) bool {
-	// TODO https://github.com/kubevirt/kubevirt/issues/17369
-	// simplify to volume.Name == VolumeName
-	return strings.HasPrefix(v.Name, PVCPrefix)
+	return v.Name == VolumeName
 }
 
 func CurrentPVCName(vmi *corev1.VirtualMachineInstance) string {

--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -278,16 +278,7 @@ func (c *Controller) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, virt
 
 	backendStoragePVC := backendstorage.PVCForVMI(c.pvcIndexer, vmi)
 	if backendStoragePVC != nil {
-		backendStorage, ok := oldStatusMap[backendstorage.VolumeName]
-		if !ok {
-			// TODO https://github.com/kubevirt/kubevirt/issues/17369
-			// Fall back to the legacy volume name (the PVC name itself) used by older VMIs
-			backendStorage, ok = oldStatusMap[backendStoragePVC.Name]
-			if ok {
-				backendStorage.Name = backendstorage.VolumeName
-			}
-		}
-		if ok {
+		if backendStorage, ok := oldStatusMap[backendstorage.VolumeName]; ok {
 			newStatus = append(newStatus, backendStorage)
 		}
 	}

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -3668,40 +3668,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(volumeStatus.PersistentVolumeClaimInfo.ClaimName).To(Equal("filesystem-pvc"))
 		})
 
-		// TODO drop test with legacy code https://github.com/kubevirt/kubevirt/issues/17369
-		It("Should normalize legacy backend storage volume name on upgrade", func() {
-			vmi := newPendingVirtualMachine("testvmi")
-			legacyPVCName := "persistent-state-for-testvmi"
-			// Simulate a VMI whose status was written by an older controller:
-			// the volume status entry uses the PVC name as the Name field.
-			vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
-				{
-					Name: legacyPVCName,
-					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
-						ClaimName: legacyPVCName,
-					},
-				},
-			}
-
-			pvc := &k8sv1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      legacyPVCName,
-					Namespace: k8sv1.NamespaceDefault,
-					Labels:    map[string]string{backendstorage.PVCPrefix: "testvmi"},
-				},
-			}
-			Expect(controller.pvcIndexer.Add(pvc)).To(Succeed())
-
-			virtlauncherPod := newPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			Expect(controller.updateVolumeStatus(vmi, virtlauncherPod)).To(Succeed())
-
-			// The legacy entry must be carried forward under the new static name,
-			// so that UpdateVolumeStatus can update it in-place on the same reconcile.
-			Expect(vmi.Status.VolumeStatus).To(HaveLen(1))
-			Expect(vmi.Status.VolumeStatus[0].Name).To(Equal(backendstorage.VolumeName))
-			Expect(vmi.Status.VolumeStatus[0].PersistentVolumeClaimInfo.ClaimName).To(Equal(legacyPVCName))
-		})
-
 		Context("isUtilityVolumeWithBlockPVC", func() {
 			It("should return true for a utility volume with block mode PVC", func() {
 				vmi := newPendingVirtualMachine("testvmi")

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -482,41 +482,6 @@ var _ = Describe("Volume Migration", func() {
 						},
 					},
 				})), fmt.Errorf("cannot migrate the VM. The volume disk1 is RWO and not included in the migration volumes")),
-			Entry("with valid migrated volumes and persistent storage (legacy volume name)", libvmi.New(libvmi.WithName("test"), libvmi.WithTPM(true),
-				libvmistatus.WithStatus(
-					v1.VirtualMachineInstanceStatus{
-						MigratedVolumes: []v1.StorageMigratedVolumeInfo{
-							{
-								VolumeName:         "disk0",
-								SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: "src"},
-								DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: "dst"},
-							},
-						},
-						Conditions: []v1.VirtualMachineInstanceCondition{
-							v1.VirtualMachineInstanceCondition{
-								Type:   v1.VirtualMachineInstanceIsMigratable,
-								Status: k8sv1.ConditionFalse,
-								Reason: v1.VirtualMachineInstanceReasonDisksNotMigratable,
-							},
-						},
-						VolumeStatus: []v1.VolumeStatus{
-							{
-								Name: "disk0",
-								PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
-									ClaimName:   "src",
-									AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-								},
-							},
-							{
-								// Legacy: volume status name equals the PVC claim name
-								Name: "persistent-state-for-test",
-								PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
-									ClaimName:   "persistent-state-for-test",
-									AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-								},
-							},
-						},
-					})), nil),
 			Entry("with valid migrated volumes and persistent storage (static volume name)", libvmi.New(libvmi.WithTPM(true),
 				libvmistatus.WithStatus(
 					v1.VirtualMachineInstanceStatus{


### PR DESCRIPTION
Fixes #17369

Removes legacy code that handled backward compatibility for backend storage volume naming.

Prior to PR #16853, KubeVirt assigned backend storage PVCs a volume name derived from the PVC name. This was problematic as VM names can be 253 chars but K8s volume names are limited to 53 chars.

PR #16853 changed to static name `persistent-state-for-this-vm` with compatibility code for old VMIs. Sufficient time has passed for all VMIs to sync to new naming.

Changes:
- storage.go: Removed fallback to legacy PVC-based volume names
- vmi_test.go: Removed legacy normalization test
- volume-migration_test.go: Removed legacy volume name test case
- backend-storage.go: Simplified IsBackendStorageVolume() to direct comparison

```release-note
Remove legacy backend storage volume name compatibility code
```