### PR TITLE
tests/vmlogchecker: refresh allowlist for new launcher error variants

### DIFF
--- a/tests/vmlogchecker/checker.go
+++ b/tests/vmlogchecker/checker.go
@@ -45,8 +45,8 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    3,
-		Regex: regexp.MustCompile(`"level":"error","msg":"(failed to get fs status before freeze vmi|Failed to (freeze|unfreeze) vmi).*Guest agent is not responding: QEMU guest agent is not connected`),
-		SIGs:  SIGCompute,
+		Regex: regexp.MustCompile(`"level":"error","msg":"(failed to get fs status before freeze vmi|Failed to (freeze|unfreeze) vmi|Failed to unfreeze filesystem after backup completion).*Guest agent is not responding: QEMU guest agent is not connected`),
+		SIGs:  SIGCompute | SIGStorage,
 	},
 	{
 		ID:    4,
@@ -85,12 +85,12 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    11,
-		Regex: regexp.MustCompile(`"level":"error","msg":"Connection to libvirt lost\.",".*"reason":".*(Connection reset by peer|End of file while reading data: Input/output error)`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"Connection to libvirt lost\.",".*"reason":".*(Connection reset by peer|End of file while reading data: Input/output error|internal error: client socket is closed|Failed to connect socket to '.*/virtqemud-sock': Connection refused)`),
 		SIGs:  SIGCompute | SIGNetwork | SIGStorage,
 	},
 	{
 		ID:    12,
-		Regex: regexp.MustCompile(`"level":"error","msg":"(Connection to libvirt lost\.|Getting the domain failed\.)",".*"reason":"virError\(Code=.*, Domain=.*, Message='internal error: client socket is closed'\)`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"Getting the domain failed\.",".*"reason":"virError\(Code=.*, Domain=.*, Message='(internal error: client socket is closed|Cannot recv data: Connection reset by peer|Cannot write data: Broken pipe|End of file while reading data: Input/output error|Failed to connect socket to '.*/virtqemud-sock': Connection refused)'\)"`),
 		SIGs:  SIGCompute | SIGNetwork | SIGStorage,
 	},
 	{
@@ -140,7 +140,7 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    22,
-		Regex: regexp.MustCompile(`"level":"error","msg":"(internal error: Child process|Hook script execution failed).*cannot touch '/run/kubevirt-private/backend-storage-meta/migrated'`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"(internal error: Child process|Hook script execution failed).*(cannot touch '/run/kubevirt-private/backend-storage-meta/migrated'|failed to create marker file: open /run/kubevirt-private/backend-storage-meta/migrated: no such file or directory)`),
 		SIGs:  SIGCompute | SIGNetwork | SIGStorage,
 	},
 	{
@@ -165,7 +165,7 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    27,
-		Regex: regexp.MustCompile(`"level":"error","msg":"(migration successfully aborted|operation aborted: migration out: canceled by client)","pos":"qemuMigration(DstFinish|SrcNBDStorageCopy)`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"(migration successfully aborted|operation aborted: (migration out: canceled by client|job 'migration out' canceled by client))","pos":"qemuMigration(DstFinish|SrcNBDStorageCopy|JobCheckStatus)`),
 		SIGs:  SIGCompute | SIGStorage,
 	},
 	{
@@ -275,12 +275,12 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    49,
-		Regex: regexp.MustCompile(`"level":"error","msg":"(Failed to connect to notify server|Could not send domain notify event\.)","pos":"client.go.*"reason":"context deadline exceeded"`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"(Failed to connect to notify server|Could not send domain notify event\.)","pos":"client.go.*"reason":"(context deadline exceeded|could not check cmd server version: rpc error: code = DeadlineExceeded desc = context deadline exceeded)"`),
 		SIGs:  SIGCompute | SIGPerformance | SIGStorage,
 	},
 	{
 		ID:    50,
-		Regex: regexp.MustCompile(`"level":"error","msg":"Failed to send domain notify event\. closing connection\.","pos":"client.go.*"reason":"rpc error: code = Unavailable desc = connection error:.*(connection reset by peer|connection refused)`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"Failed to send domain notify event\. closing connection\.","pos":"client.go.*"reason":"rpc error: code = (Unavailable desc = connection error:.*(connection reset by peer|connection refused)|Unavailable desc = error reading from server: read unix .*domain-notify-pipe\.sock: read: connection reset by peer|DeadlineExceeded desc = context deadline exceeded)`),
 		SIGs:  SIGCompute | SIGPerformance | SIGStorage,
 	},
 	{
@@ -310,7 +310,7 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    56,
-		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command 'migrate-start-postcopy': Postcopy must be started after migration has been started","pos":"qemuMonitorJSONCheckErrorFull`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command 'migrate-start-postcopy': (Postcopy must be started after migration has been started|Enable postcopy with migrate_set_capability before the start of migration)","pos":"qemuMonitorJSONCheckErrorFull`),
 		SIGs:  SIGCompute,
 	},
 	{
@@ -345,7 +345,7 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    63,
-		Regex: regexp.MustCompile(`"level":"error","msg":"Failed to run backup job".*"pos":"server\.go.*"reason":"(failed to abort backup: backup already completed|cannot abort backup, wrong operation or type: [0-9]+, [0-9]+)"`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"(Failed to run backup job|failed to abort backup, error calling abort job on domain)".*"pos":"(server|backup)\.go.*".*"reason":"(failed to abort backup: backup already completed|cannot abort backup, wrong operation or type: [0-9]+, [0-9]+|virError\(Code=.*, Domain=.*, Message='Requested operation is not valid: no job is active on the domain'\))"`),
 		SIGs:  SIGCompute | SIGStorage,
 	},
 	{
@@ -405,12 +405,12 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    75,
-		Regex: regexp.MustCompile(`"level":"error","msg":"error encountered during MigrateToURI3 libvirt api call: virError\(Code=.*Domain=.*, Message='(operation aborted: migration out: canceled by client|internal error: process exited while connecting to monitor: .*The sum of offset.*actual size of the containing file.*)'\)".*"pos":"live-migration-source\.go`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"error encountered during MigrateToURI3 libvirt api call: virError\(Code=.*Domain=.*, Message='(operation aborted: migration out: canceled by client|operation aborted: job 'migration out' canceled by client|internal error: (process exited while connecting to monitor|QEMU unexpectedly closed the monitor).*The sum of offset.*actual size of the containing file.*)'\)".*"pos":"live-migration-source\.go`),
 		SIGs:  SIGCompute | SIGStorage,
 	},
 	{
 		ID:    76,
-		Regex: regexp.MustCompile(`"level":"error","msg":"Live migration failed\.".*"pos":"live-migration-source\.go.*"reason":"virError\(.*Message='operation aborted: migration out: canceled by client'\)"`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"Live migration failed\.".*"pos":"live-migration-source\.go.*"reason":"virError\(.*Message='(operation aborted: migration out: canceled by client|operation aborted: job 'migration out' canceled by client)'\)"`),
 		SIGs:  SIGCompute | SIGStorage,
 	},
 	{
@@ -435,8 +435,8 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    81,
-		Regex: regexp.MustCompile(`"level":"error","msg":"Timed out during operation: cannot acquire state change lock \(held by agent=(remoteDispatchDomainGetGuestInfo|qemuDispatchDomainAgentCommand)\)","pos":"virDomainObjBeginJobInternal`),
-		SIGs:  SIGCompute,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Timed out during operation: cannot acquire state change lock \(held by agent=(remoteDispatchDomainGetGuestInfo|qemuDispatchDomainAgentCommand|remoteDispatchDomainFSFreeze)\)","pos":"virDomainObjBeginJobInternal`),
+		SIGs:  SIGCompute | SIGStorage,
 	},
 	{
 		ID:    82,
@@ -450,8 +450,8 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    84,
-		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command 'query-command-line-options': JSON parse error, expecting value","pos":"qemuMonitorJSONCheckErrorFull`),
-		SIGs:  SIGPerformance,
+		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command '(query-command-line-options': JSON parse error, expecting value|query-qmp-schema': (JSON parse error, stray '-qm'|The command [a-z-]+ has not been found)|device-list-properties': JSON parse error, expecting value)","pos":"qemuMonitorJSONCheckErrorFull`),
+		SIGs:  SIGPerformance | SIGStorage,
 	},
 	{
 		ID:    85,
@@ -485,12 +485,82 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 	},
 	{
 		ID:    91,
-		Regex: regexp.MustCompile(`"level":"error","msg":"Fetching guest info failed: virError\(Code=.*, Domain=.*, Message='(Domain not found: no domain with matching uuid '.*' \(kubevirt-test-.*\)|Timed out during operation: cannot acquire state change lock \(held by agent=qemuDispatchDomainAgentCommand\))'\)"`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"Fetching guest info failed: virError\(Code=.*, Domain=.*, Message='(Domain not found: no domain with matching uuid '.*' \(kubevirt-test-.*\)|Timed out during operation: cannot acquire state change lock \(held by agent=(qemuDispatchDomainAgentCommand|remoteDispatchDomainGetGuestInfo|remoteDispatchDomainFSFreeze)\))'\)"`),
 		SIGs:  SIGCompute | SIGNetwork | SIGStorage | SIGMonitoring,
 	},
 	{
 		ID:    92,
-		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command 'blockdev-add': Failed to read (initial magic|option reply): Unexpected end-of-file before all data were read","pos":"qemuMonitorJSONCheckErrorFull`),
+		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command 'blockdev-add': Failed to read ((initial magic|option reply): Unexpected end-of-file before all data were read|option reply: Unable to read from socket: Connection reset by peer)","pos":"qemuMonitorJSONCheckErrorFull`),
+		SIGs:  SIGCompute | SIGStorage,
+	},
+	{
+		ID:    93,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Error detecting pid \([0-9]+\) status\.","pos":"monitor\.go.*"reason":"(read|open) /proc/[0-9]+/status: (no such process|no such file or directory)"`),
+		SIGs:  SIGCompute | SIGNetwork | SIGStorage,
+	},
+	{
+		ID:    94,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Error encountered setting password for user \[[^"]+\]".*"pos":"access_credentials\.go.*"reason":"virError\(Code=.*, Domain=.*, Message='guest agent command failed: unable to execute QEMU agent command 'guest-set-user-password': Command guest-set-user-password has been disabled(: the command is not allowed)?'\)"`),
+		SIGs:  SIGCompute,
+	},
+	{
+		ID:    95,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Error encountered writing access credentials using guest agent".*"pos":"access_credentials\.go.*"reason":"failed to set SSH keys: error from guest-ssh-add-authorized-keys: virError\(Code=.*, Domain=.*, Message='guest agent command failed: unable to execute QEMU agent command 'guest-ssh-add-authorized-keys': Command guest-ssh-add-authorized-keys has been disabled(: the command is not allowed)?'\); error from using guest-file-write: unable to detect home directory of user .*guest-exec': Command guest-exec has been disabled(: the command is not allowed)?'\)"`),
+		SIGs:  SIGCompute,
+	},
+	{
+		ID:    96,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Timed out generating cloud-init iso at path .*","pos":"cloud-init\.go`),
+		SIGs:  SIGCompute | SIGPerformance,
+	},
+	{
+		ID:    97,
+		Regex: regexp.MustCompile(`"level":"error","msg":"xorrisofs returned non-zero exit code while generating iso file .*","pos":"cloud-init\.go.*"reason":"signal: killed"`),
+		SIGs:  SIGCompute | SIGPerformance,
+	},
+	{
+		ID:    98,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Failed to sync vmi",".*"pos":"server\.go.*"reason":"generating local cloud-init data failed: signal: killed"`),
+		SIGs:  SIGCompute | SIGPerformance,
+	},
+	{
+		ID:    99,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Fetching guest info failed: virError\(Code=.*, Domain=.*, Message='guest agent command failed: unable to execute QEMU agent command 'guest-get-(users|load|osinfo)': Command guest-get-(users|load|osinfo) has been disabled(: the command is not allowed)?'\)","pos":"agent_poller\.go`),
+		SIGs:  SIGCompute | SIGNetwork | SIGStorage | SIGMonitoring,
+	},
+	{
+		ID:    100,
+		Regex: regexp.MustCompile(`"level":"error","msg":"operation failed: Lost connection to destination host","pos":"qemuMigrationAnyCompleted`),
+		SIGs:  SIGCompute | SIGStorage,
+	},
+	{
+		ID:    101,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Failed to signal deletion for vmi",".*"reason":"virError\(Code=.*, Domain=.*, Message='(Cannot recv data: Connection reset by peer|Cannot write data: Broken pipe|internal error: client socket is closed|End of file while reading data: Input/output error)'\)"`),
+		SIGs:  SIGCompute | SIGNetwork | SIGStorage,
+	},
+	{
+		ID:    102,
+		Regex: regexp.MustCompile(`"level":"error","msg":"Failed to prepare migration target pod",".*"reason":"failed to find the status of volume cloudinitdisk"`),
+		SIGs:  SIGCompute,
+	},
+	{
+		ID:    103,
+		Regex: regexp.MustCompile(`"level":"error".*"msg":"Live migration failed\.".+"reason":"migration channel closed"`),
+		SIGs:  SIGCompute | SIGNetwork | SIGStorage,
+	},
+	{
+		ID:    104,
+		Regex: regexp.MustCompile(`"level":"error".*"msg":"Failed to send domain notify event\. closing connection\.".+"reason":"rpc error: code = Unavailable desc = write unix .*domain-notify-pipe\.sock: write: broken pipe"`),
+		SIGs:  SIGCompute,
+	},
+	{
+		ID:    105,
+		Regex: regexp.MustCompile(`"level":"error".*"msg":"internal error: unable to execute QEMU command 'qmp_capabilities': JSON parse error, stray '_c'"`),
+		SIGs:  SIGPerformance,
+	},
+	{
+		ID:    106,
+		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command 'block-job-cancel': Job '[^']+' in state 'concluded' cannot accept command verb 'cancel'"`),
 		SIGs:  SIGCompute | SIGStorage,
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Extend existing allowlist patterns and add minimal new entries for newly observed virt-launcher
errors so vm-log checks stay stable while preserving SIG attribution and non-overlapping matching.

Note: only the vm based lanes are in game, kind-* aren't,
just presumbit that start with `pull-kubevirt-e2e-k8s`, on main, excluding `windows2016`.
It means that once we enable it, we should not enable it for lanes that we didn't collect data for.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

