### PR TITLE
kvm: scale VFIO memory overhead for memlock accounting

### DIFF
--- a/pkg/hypervisor/kvm/hypervisorbackend_test.go
+++ b/pkg/hypervisor/kvm/hypervisorbackend_test.go
@@ -365,3 +365,58 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 		)
 	})
 })
+
+var _ = Describe("CalculateMemlockSize", func() {
+	var runtime *kvm.KvmVirtRuntime
+
+	BeforeEach(func() {
+		runtime = kvm.NewKvmVirtRuntime(nil, nil)
+	})
+
+	DescribeTable("should scale memlock per VFIO device", func(devices v1.Devices, expectedExtraDevices int) {
+		vmi := &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmi"},
+			Spec: v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					Resources: v1.ResourceRequirements{
+						Requests: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+					Devices: devices,
+				},
+			},
+		}
+		vmiBaseline := vmi.DeepCopy()
+		vmiBaseline.Spec.Domain.Devices = v1.Devices{}
+
+		config := &v1.KubeVirtConfiguration{}
+		size := runtime.CalculateMemlockSize(vmi, config)
+		baselineSize := runtime.CalculateMemlockSize(vmiBaseline, config)
+
+		guestMem := int64(8 * 1024 * 1024 * 1024)
+		vfioBase := int64(1024 * 1024 * 1024)
+		expectedDiff := vfioBase + guestMem*int64(expectedExtraDevices)
+
+		Expect(size.Value() - baselineSize.Value()).To(BeNumerically("~", expectedDiff, 1024*1024))
+	},
+		Entry("single GPU adds 1Gi VFIO overhead only",
+			v1.Devices{GPUs: []v1.GPU{{Name: "gpu1"}}}, 0),
+		Entry("2 GPUs add 1Gi + 1x guest_memory",
+			v1.Devices{GPUs: []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}}}, 1),
+		Entry("3 GPUs add 1Gi + 2x guest_memory",
+			v1.Devices{GPUs: []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}, {Name: "gpu3"}}}, 2),
+		Entry("2 HostDevices add 1Gi + 1x guest_memory",
+			v1.Devices{HostDevices: []v1.HostDevice{{Name: "dev1"}, {Name: "dev2"}}}, 1),
+		Entry("mixed GPU and HostDevice add 1Gi + 1x guest_memory",
+			v1.Devices{
+				GPUs:        []v1.GPU{{Name: "gpu1"}},
+				HostDevices: []v1.HostDevice{{Name: "dev1"}},
+			}, 1),
+		Entry("2 SRIOV interfaces add 1Gi + 1x guest_memory",
+			v1.Devices{Interfaces: []v1.Interface{
+				{Name: "sriov1", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "sriov2", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+			}}, 1),
+	)
+})

--- a/pkg/hypervisor/kvm/runtime.go
+++ b/pkg/hypervisor/kvm/runtime.go
@@ -92,18 +92,7 @@ func (k *KvmVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config 
 
 	targetProcessID := targetProcess.Pid()
 
-	var memlockSize resource.Quantity
-	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetMemoryOverhead != nil {
-		memlockSize = *vmi.Status.MigrationState.TargetMemoryOverhead
-	} else {
-		// TODO: Remove this fallback once VmiMemoryOverheadReport feature gate is GA
-		// and we are sure that all VMIs include the MemoryOverhead status field
-		memlockSize = k.GetMemoryOverhead(vmi, runtime.GOARCH, config.AdditionalGuestMemoryOverheadRatio)
-	}
-	// Add memory assigned to the VM
-	vmiBaseMemory := getVMIBaseMemory(vmi)
-
-	memlockSize.Add(*resource.NewScaledQuantity(vmiBaseMemory.ScaledValue(resource.Kilo), resource.Kilo))
+	memlockSize := k.CalculateMemlockSize(vmi, config)
 
 	if err := common.SetProcessMemoryLockRLimit(targetProcessID, memlockSize.Value()); err != nil {
 		return fmt.Errorf("failed to set process %d memlock rlimit to %d: %v", targetProcessID, memlockSize.Value(), err)
@@ -112,6 +101,39 @@ func (k *KvmVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config 
 		targetProcess, memlockSize.Value())
 
 	return nil
+}
+
+// CalculateMemlockSize computes the memlock rlimit needed for the QEMU process.
+// This includes the memory overhead, guest memory, and additional per-device
+// memory for multi-device VFIO passthrough.
+func (k *KvmVirtRuntime) CalculateMemlockSize(vmi *v1.VirtualMachineInstance, config *v1.KubeVirtConfiguration) resource.Quantity {
+	var memlockSize resource.Quantity
+	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetMemoryOverhead != nil {
+		memlockSize = *vmi.Status.MigrationState.TargetMemoryOverhead
+	} else {
+		// TODO: Remove this fallback once VmiMemoryOverheadReport feature gate is GA
+		// and we are sure that all VMIs include the MemoryOverhead status field
+		memlockSize = k.GetMemoryOverhead(vmi, runtime.GOARCH, config.AdditionalGuestMemoryOverheadRatio)
+	}
+
+	vmiBaseMemory := getVMIBaseMemory(vmi)
+	memlockSize.Add(*resource.NewScaledQuantity(vmiBaseMemory.ScaledValue(resource.Kilo), resource.Kilo))
+
+	// With a vIOMMU, libvirt locks N * guest_memory for N VFIO devices
+	// (qemuDomainGetMemLockLimitBytes, since libvirt v8.7.0). Each
+	// device gets a separate AddressSpace mapping full guest RAM. The
+	// base overhead already includes 1 * guest_memory, so add (N-1)
+	// more. We apply this unconditionally rather than checking for a
+	// vIOMMU because the domain XML is not yet available at this point
+	// and the over-reservation is harmless — it only raises the rlimit
+	// ceiling without consuming actual memory.
+	if numDevices := util.CountVFIODevices(vmi); numDevices > 1 {
+		extra := vmiBaseMemory.DeepCopy()
+		extra.Set(extra.Value() * int64(numDevices-1))
+		memlockSize.Add(extra)
+	}
+
+	return memlockSize
 }
 
 func getVMIBaseMemory(vmi *v1.VirtualMachineInstance) *resource.Quantity {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -41,15 +41,6 @@ const (
 	ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY = "VIRT_LAUNCHER_LOG_VERBOSITY"
 )
 
-func isSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.SRIOV != nil {
-			return true
-		}
-	}
-	return false
-}
-
 // Check if a VMI spec requests GPU
 func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
 	if vmi.Spec.Domain.Devices.GPUs != nil && len(vmi.Spec.Domain.Devices.GPUs) != 0 {
@@ -80,11 +71,17 @@ func IsHostDevVMI(vmi *v1.VirtualMachineInstance) bool {
 
 // Check if a VMI spec requests a VFIO device
 func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
+	return CountVFIODevices(vmi) > 0
+}
 
-	if IsHostDevVMI(vmi) || IsGPUVMI(vmi) || isSRIOVVmi(vmi) {
-		return true
+func CountVFIODevices(vmi *v1.VirtualMachineInstance) int {
+	count := len(vmi.Spec.Domain.Devices.GPUs) + len(vmi.Spec.Domain.Devices.HostDevices)
+	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+		if iface.SRIOV != nil {
+			count++
+		}
 	}
-	return false
+	return count
 }
 
 // Check if a VMI spec requests memory overhead

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -102,6 +102,52 @@ var _ = Describe("Host Device VMI Predicates", func() {
 	})
 })
 
+var _ = Describe("CountVFIODevices", func() {
+	DescribeTable("should count VFIO devices correctly",
+		func(devices v1.Devices, expected int) {
+			vmi := &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: devices,
+					},
+				},
+			}
+			Expect(CountVFIODevices(vmi)).To(Equal(expected))
+		},
+		Entry("no devices", v1.Devices{}, 0),
+		Entry("single GPU", v1.Devices{
+			GPUs: []v1.GPU{{Name: "gpu1"}},
+		}, 1),
+		Entry("multiple GPUs", v1.Devices{
+			GPUs: []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}},
+		}, 2),
+		Entry("single HostDevice", v1.Devices{
+			HostDevices: []v1.HostDevice{{Name: "dev1"}},
+		}, 1),
+		Entry("multiple HostDevices", v1.Devices{
+			HostDevices: []v1.HostDevice{{Name: "dev1"}, {Name: "dev2"}},
+		}, 2),
+		Entry("single SRIOV", v1.Devices{
+			Interfaces: []v1.Interface{
+				{Name: "sriov1", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+			},
+		}, 1),
+		Entry("non-SRIOV interfaces are not counted", v1.Devices{
+			Interfaces: []v1.Interface{
+				{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
+			},
+		}, 0),
+		Entry("mixed devices", v1.Devices{
+			GPUs:        []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}},
+			HostDevices: []v1.HostDevice{{Name: "dev1"}},
+			Interfaces: []v1.Interface{
+				{Name: "sriov1", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
+			},
+		}, 4),
+	)
+})
+
 var _ = DescribeTable("memory overhead reservation requirements",
 	func(vmi *v1.VirtualMachineInstance, expected bool) {
 		res := RequiresMemoryOverheadReservation(vmi)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

With a vIOMMU, libvirt locks `N * guest_memory` for N VFIO devices via `setrlimit` on the QEMU process ([`qemuDomainGetMemLockLimitBytes()`](https://github.com/libvirt/libvirt/blob/1b32fbdfca/src/qemu/qemu_domain.c#L8358-L8426), since v8.7.0 commit `8d5704e2c4`). Each device gets a separate AddressSpace mapping full guest RAM. virt-handler's `AdjustResources()` sets the memlock via privileged `prlimit64` but uses `GetMemoryOverhead() + guest_memory` which doesn't account for the per-device scaling, resulting in multi-device VMs with a vIOMMU failing with:

```
cannot limit locked memory of process to 18253611008: Operation not permitted
```

This has not been an issue for regular SR-IOV or single-device passthrough because without a vIOMMU, libvirt always uses `factor = 1`.

#### After this PR:

virt-handler's `AdjustResources()` adds `(N-1) * guest_memory` to the memlock value for N VFIO devices. This is applied unconditionally rather than checking for a vIOMMU because the domain XML is not yet available when `AdjustResources` runs (it executes before domain definition in `handleStartingVMI`). The over-reservation is harmless as it only raises the rlimit ceiling without consuming actual memory. The privileged `prlimit64` bypasses the container's cgroup memory limit, so virt-controller and pod memory requests are unchanged.

The memlock calculation is extracted into `CalculateMemlockSize()` for testability.

### References

- Libvirt commit introducing per-device factor: [`8d5704e2c4`](https://github.com/libvirt/libvirt/commit/8d5704e2c4) (v8.7.0), https://bugzilla.redhat.com/2111317
- Libvirt calculation: [`qemuDomainGetMemLockLimitBytes()`](https://github.com/libvirt/libvirt/blob/1b32fbdfca/src/qemu/qemu_domain.c#L8358-L8426)

### Why we need it and why it was done in this way
The following tradeoffs were made:
- The scaling is applied unconditionally for multiple VFIO devices rather than checking for a vIOMMU. The domain XML is not available when `AdjustResources` runs — it executes in `handleStartingVMI` before `syncVirtualMachine` where the domain is defined. Rearchitecting the handler/launcher flow to inspect the domain XML between define and start is out of scope for this bugfix.
- The over-reservation only raises the `RLIMIT_MEMLOCK` ceiling without consuming actual memory, so the cost of applying it without a vIOMMU is negligible.

The following alternatives were considered:
- Using a `hasVIOMMU` heuristic (checking for GPU devices or launch security): rejected per reviewer feedback as it would drift out of sync with future code paths that add a vIOMMU.
- Scaling in `GetMemoryOverhead()` (affects both virt-controller and virt-handler): tested and works but unnecessarily inflates pod memory requests/limits. The privileged `prlimit64` in virt-handler can set memlock independent of the cgroup.
- Inspecting the domain XML after definition: would require splitting the `SyncVMI` gRPC flow or adding a new callback between define and start, which is a significant refactor.

### Special notes for your reviewer

The libvirt memlock formula (`src/qemu/qemu_domain.c`, since v8.7.0) is:
```c
factor = nvdpa + nnvme;
if (nvfio) {
    if (def->niommus > 0)
        factor += nvfio;  // full guest memory per VFIO device with vIOMMU
    else
        factor += 1;      // single copy without vIOMMU
}
memKB = factor * virDomainDefGetMemoryTotal(def) + 1024 * 1024;
```

Tested on a GB200 system with 2x GPU passthrough, 8Gi guest memory, stock virt-controller (1528Mi pod memory limit). virt-handler successfully sets QEMU memlock to ~17Gi via prlimit64 and both GPUs pass through with iommufd.

### Checklist

- [ ] Design: Not required — bug fix aligning with existing libvirt behavior
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: No upgrade impact — only affects memlock rlimit set at VM start time
- [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Fixed multi-device VFIO passthrough VMs failing to start with "cannot limit locked memory" by scaling virt-handler's memlock rlimit to account for per-device memory locking, matching libvirt's calculation introduced in v8.7.0.
```