### PR TITLE
live-migration: drop stale cpu-feature node selectors for re-migrated host-model VMs

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -2533,9 +2533,18 @@ func prepareNodeSelectorForHostCpuModel(node *k8sv1.Node, pod *k8sv1.Pod, source
 	migratedAtLeastOnce := false
 	// if the vmi already migrated before it should include node selector that consider CPUModelLabel
 	for key, value := range sourcePodNodeSelector {
-		if strings.Contains(key, virtv1.CPUFeatureLabel) || strings.Contains(key, virtv1.SupportedHostModelMigrationCPU) {
+		if strings.Contains(key, virtv1.SupportedHostModelMigrationCPU) {
 			result[key] = value
 			migratedAtLeastOnce = true
+		} else if strings.Contains(key, virtv1.CPUFeatureLabel) {
+			migratedAtLeastOnce = true
+			// Only keep cpu-feature selectors that still exist on the source node.
+			// After a QEMU upgrade, the node labeller may remove features that are
+			// no longer in domcapabilities policy='require'. Carrying stale selectors
+			// forward would make the target pod permanently unschedulable.
+			if _, exists := node.Labels[key]; exists {
+				result[key] = value
+			}
 		}
 	}
 

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -2242,6 +2242,96 @@ var _ = Describe("Migration watcher", func() {
 			Entry("host-model should be targeted only to nodes which support the model", true),
 			Entry("non-host-model should not be targeted to nodes which support the model", false),
 		)
+
+		It("should drop stale cpu-feature nodeSelector entries when re-migrating host-model VMI", func() {
+			const nodeName = "testNode"
+
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			addNodeNameToVMI(vmi, nodeName)
+			vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+
+			migration := newMigration("testmigration", vmi.Name, v1.MigrationPending)
+
+			node := newNode(nodeName)
+			node.ObjectMeta.Labels = map[string]string{
+				v1.HostModelCPULabel + "FakeModel":              "true",
+				v1.SupportedHostModelMigrationCPU + "FakeModel": "true",
+				v1.HostModelRequiredFeaturesLabel + "feature1":  "true",
+				v1.HostModelRequiredFeaturesLabel + "feature2":  "true",
+				v1.CPUFeatureLabel + "feature1":                 "true",
+				v1.CPUFeatureLabel + "feature2":                 "true",
+			}
+
+			sourcePod := newSourcePodForVirtualMachine(vmi)
+			sourcePod.Spec.NodeSelector = map[string]string{
+				v1.CPUFeatureLabel + "feature1":                 "true",
+				v1.CPUFeatureLabel + "feature2":                 "true",
+				v1.CPUFeatureLabel + "stale-feature":            "true",
+				v1.SupportedHostModelMigrationCPU + "FakeModel": "true",
+			}
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			addPod(sourcePod)
+			addNode(node)
+
+			sanityExecute()
+
+			testutils.ExpectEvent(recorder, virtcontroller.SuccessfulCreatePodReason)
+			targetPod, err := getTargetPod(kubeClient, vmi.Namespace, vmi.UID, migration.UID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(targetPod).ToNot(BeNil())
+
+			Expect(targetPod.Spec.NodeSelector).To(HaveKeyWithValue(v1.CPUFeatureLabel+"feature1", "true"))
+			Expect(targetPod.Spec.NodeSelector).To(HaveKeyWithValue(v1.CPUFeatureLabel+"feature2", "true"))
+			Expect(targetPod.Spec.NodeSelector).To(HaveKeyWithValue(v1.SupportedHostModelMigrationCPU+"FakeModel", "true"))
+			Expect(targetPod.Spec.NodeSelector).NotTo(HaveKey(v1.CPUFeatureLabel + "stale-feature"))
+		})
+
+		It("should not add new cpu features from source node when re-migrating host-model VMI", func() {
+			const nodeName = "testNode"
+
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			addNodeNameToVMI(vmi, nodeName)
+			vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+
+			migration := newMigration("testmigration", vmi.Name, v1.MigrationPending)
+
+			node := newNode(nodeName)
+			node.ObjectMeta.Labels = map[string]string{
+				v1.HostModelCPULabel + "FakeModel":                "true",
+				v1.SupportedHostModelMigrationCPU + "FakeModel":   "true",
+				v1.HostModelRequiredFeaturesLabel + "feature1":    "true",
+				v1.HostModelRequiredFeaturesLabel + "feature2":    "true",
+				v1.HostModelRequiredFeaturesLabel + "new-feature": "true",
+				v1.CPUFeatureLabel + "feature1":                   "true",
+				v1.CPUFeatureLabel + "feature2":                   "true",
+				v1.CPUFeatureLabel + "new-feature":                "true",
+			}
+
+			sourcePod := newSourcePodForVirtualMachine(vmi)
+			sourcePod.Spec.NodeSelector = map[string]string{
+				v1.CPUFeatureLabel + "feature1":                 "true",
+				v1.CPUFeatureLabel + "feature2":                 "true",
+				v1.SupportedHostModelMigrationCPU + "FakeModel": "true",
+			}
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			addPod(sourcePod)
+			addNode(node)
+
+			sanityExecute()
+
+			testutils.ExpectEvent(recorder, virtcontroller.SuccessfulCreatePodReason)
+			targetPod, err := getTargetPod(kubeClient, vmi.Namespace, vmi.UID, migration.UID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(targetPod).ToNot(BeNil())
+
+			Expect(targetPod.Spec.NodeSelector).To(HaveKeyWithValue(v1.CPUFeatureLabel+"feature1", "true"))
+			Expect(targetPod.Spec.NodeSelector).To(HaveKeyWithValue(v1.CPUFeatureLabel+"feature2", "true"))
+			Expect(targetPod.Spec.NodeSelector).NotTo(HaveKey(v1.CPUFeatureLabel + "new-feature"))
+		})
 	})
 
 	Context("Migration policy", func() {

--- a/tests/migration/host_model.go
+++ b/tests/migration/host_model.go
@@ -345,6 +345,69 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			Expect(vmiToMigrate.Status.NodeName).To(Equal(targetNode.Name))
 			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
 		})
+
+		It("Should be able to migrate a previously-migrated host-model VMI after cpu features are removed from nodes", func() {
+			vmiToMigrate := libvmifact.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			vmiToMigrate.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+			nodeAffinityRule, err := libmigration.CreateNodeAffinityRuleToMigrateFromSourceToTargetAndBack(sourceNode, targetNode)
+			Expect(err).ToNot(HaveOccurred())
+			vmiToMigrate.Spec.Affinity = &k8sv1.Affinity{
+				NodeAffinity: nodeAffinityRule,
+			}
+
+			By("Starting the VirtualMachineInstance on source node")
+			vmiToMigrate = libvmops.RunVMIAndExpectLaunch(vmiToMigrate, libvmops.StartupTimeoutSecondsHuge)
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(sourceNode.Name))
+			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
+
+			By("Recording required features before first migration")
+			sourceNode, err = kubevirt.Client().CoreV1().Nodes().Get(context.Background(), sourceNode.Name, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			requiredFeatures := getNodeHostRequiredFeatures(sourceNode)
+			Expect(requiredFeatures).NotTo(BeEmpty(), "source node must have at least one required feature")
+
+			By("Migrating to target node (first migration)")
+			migration := libmigration.New(vmiToMigrate.Name, vmiToMigrate.Namespace)
+			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
+
+			vmiToMigrate, err = kubevirt.Client().VirtualMachineInstance(vmiToMigrate.Namespace).Get(
+				context.Background(), vmiToMigrate.GetName(), metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(targetNode.Name))
+
+			By("Stopping node labeller on source node")
+			sourceNode = libinfra.ExpectStoppingNodeLabellerToSucceed(sourceNode.Name, kubevirt.Client())
+			DeferCleanup(func() {
+				By("Resuming node labeller on source node")
+				libinfra.ExpectResumingNodeLabellerToSucceed(sourceNode.Name, kubevirt.Client())
+			})
+
+			By("Simulating QEMU upgrade: removing a required feature from both nodes")
+			featureToRemove := requiredFeatures[0]
+			libnode.RemoveLabelFromNode(sourceNode.Name, v1.HostModelRequiredFeaturesLabel+featureToRemove)
+			libnode.RemoveLabelFromNode(sourceNode.Name, v1.CPUFeatureLabel+featureToRemove)
+			libnode.RemoveLabelFromNode(targetNode.Name, v1.HostModelRequiredFeaturesLabel+featureToRemove)
+			libnode.RemoveLabelFromNode(targetNode.Name, v1.CPUFeatureLabel+featureToRemove)
+
+			By("Migrating back to source node (second migration should drop stale feature)")
+			migration2 := libmigration.New(vmiToMigrate.Name, vmiToMigrate.Namespace)
+			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration2)
+
+			vmiToMigrate, err = kubevirt.Client().VirtualMachineInstance(vmiToMigrate.Namespace).Get(
+				context.Background(), vmiToMigrate.GetName(), metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(sourceNode.Name))
+
+			By("Verifying the stale feature is not in the target pod's nodeSelector")
+			virtLauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmiToMigrate, vmiToMigrate.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(virtLauncherPod.Spec.NodeSelector).NotTo(
+				HaveKey(v1.CPUFeatureLabel+featureToRemove),
+				fmt.Sprintf("stale cpu-feature %s should have been dropped from nodeSelector", featureToRemove))
+		})
 	})
 }))
 


### PR DESCRIPTION
### What this PR does

When a host-model VM has been live-migrated at least once, subsequent migrationscopy the source pod's `cpu-feature.node.kubevirt.io/*` nodeSelector entries. If the underlying QEMU/libvirt version changes between migrations (e.g. a cluster upgrade that ships a newer QEMU), libvirt's domcapabilities may drop some features from `policy='require'` and the node labeller removes the corresponding labels from all nodes. The stale entries in the source pod's nodeSelector make the migration target pod permanently unschedulable.

This PR fixes `prepareNodeSelectorForHostCpuModel` to intersect the source pod's cpu-feature selectors with the current source node's labels. Features that no longer exist on the source node are dropped from the target pod's nodeSelector.
Features that still exist are preserved, maintaining the existing invariant that prevents adding new features from the current node (which could block migrating back to the original node).


#### Before this PR:

- Host-model VMs that were previously live-migrated become permanently unmigratable after a QEMU version bump that removes features from domcapabilities `policy='require'`.
- The migration target pod inherits the full set of cpu-feature nodeSelector entries from the old virt-launcher pod, but nodes no longer have the corresponding labels (e.g. Intel vulnerability-mitigation features like `arch-capabilities`, `gds-no`, `mds-no`, `pschange-mc-no`, `rdctl-no`, `rfds-no`, `skip-l1dfl-vmentry`), causing a NoSuitableNodesForHostModelMigration` event.

#### After this PR:

- Stale cpu-feature selectors are filtered out when building the migration target pod's nodeSelector.
- The target pod only requires features that currently exist on the source node, so migrations succeed after QEMU upgrades that change the required feature set.

### References

- https://redhat.atlassian.net/browse/CNV-87360

### Release note
```release-note
Fixed a bug where host-model VMs that were previously live-migrated become permanently unmigratable after a QEMU version upgrade removes cpu features from domcapabilities.
```

