### PR TITLE
fix: resolve lint issues in pkg/virt-operator/resource/placement

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -41,6 +41,7 @@ pkg/tpm
 pkg/util/ratelimiter
 pkg/virt-controller/leaderelectionconfig
 pkg/virt-controller/watch/common
+pkg/virt-operator/resource/placement
 pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/configuration

--- a/pkg/virt-operator/resource/placement/placement.go
+++ b/pkg/virt-operator/resource/placement/placement.go
@@ -224,8 +224,6 @@ func mergeTolerations(podSpec *corev1.PodSpec, nodePlacement *v1.NodePlacement) 
 	if len(nodePlacement.Tolerations) == 0 {
 		return
 	}
-	if len(podSpec.Tolerations) == 0 {
-		podSpec.Tolerations = []corev1.Toleration{}
-	}
+
 	podSpec.Tolerations = append(podSpec.Tolerations, nodePlacement.Tolerations...)
 }

--- a/pkg/virt-operator/resource/placement/placement.go
+++ b/pkg/virt-operator/resource/placement/placement.go
@@ -38,7 +38,11 @@ const (
 )
 
 // InjectPlacementMetadata merges all Tolerations, Affinity and NodeSelectors from NodePlacement into pod spec
-func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev1.PodSpec, nodePlacementOption DefaultInfraComponentsNodePlacement) {
+func InjectPlacementMetadata(
+	componentConfig *v1.ComponentConfig,
+	podSpec *corev1.PodSpec,
+	nodePlacementOption DefaultInfraComponentsNodePlacement,
+) {
 	if podSpec == nil {
 		podSpec = &corev1.PodSpec{}
 	}
@@ -104,22 +108,35 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 			}
 
 		default:
-			log.Log.Errorf("Unknown nodePlacementOption %d provided to InjectPlacementMetadata. Falling back to the AnyNode option", nodePlacementOption)
+			log.Log.Errorf(
+				"Unknown nodePlacementOption %d provided to InjectPlacementMetadata. Falling back to the AnyNode option",
+				nodePlacementOption,
+			)
 			componentConfig = &v1.ComponentConfig{NodePlacement: &v1.NodePlacement{}}
 		}
 	}
 
 	nodePlacement := componentConfig.NodePlacement
+	setDefaultNodeSelector(nodePlacement)
+	mergeNodeSelector(podSpec, nodePlacement)
+	mergeAffinity(podSpec, nodePlacement)
+	mergeTolerations(podSpec, nodePlacement)
+}
+
+func setDefaultNodeSelector(nodePlacement *v1.NodePlacement) {
 	if len(nodePlacement.NodeSelector) == 0 {
 		nodePlacement.NodeSelector = make(map[string]string)
 	}
+
 	if _, ok := nodePlacement.NodeSelector[KubernetesOSLabel]; !ok {
 		nodePlacement.NodeSelector[KubernetesOSLabel] = KubernetesOSLinux
 	}
+}
+
+func mergeNodeSelector(podSpec *corev1.PodSpec, nodePlacement *v1.NodePlacement) {
 	if len(podSpec.NodeSelector) == 0 {
 		podSpec.NodeSelector = make(map[string]string, len(nodePlacement.NodeSelector))
 	}
-	// podSpec.NodeSelector
 	for nsKey, nsVal := range nodePlacement.NodeSelector {
 		// Favor podSpec over NodePlacement. This prevents cluster admin from clobbering
 		// node selectors that KubeVirt intentionally set.
@@ -127,76 +144,88 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 			podSpec.NodeSelector[nsKey] = nsVal
 		}
 	}
+}
 
-	// podSpec.Affinity
-	if nodePlacement.Affinity != nil {
-		if podSpec.Affinity == nil {
-			podSpec.Affinity = nodePlacement.Affinity.DeepCopy()
+func mergeAffinity(podSpec *corev1.PodSpec, nodePlacement *v1.NodePlacement) {
+	if nodePlacement.Affinity == nil {
+		return
+	}
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = nodePlacement.Affinity.DeepCopy()
+		return
+	}
+	mergeNodeAffinity(podSpec, nodePlacement.Affinity.NodeAffinity)
+	mergePodAffinity(podSpec, nodePlacement.Affinity.PodAffinity)
+	mergePodAntiAffinity(podSpec, nodePlacement.Affinity.PodAntiAffinity)
+}
+
+func mergeNodeAffinity(podSpec *corev1.PodSpec, nodeAffinity *corev1.NodeAffinity) {
+	if nodeAffinity == nil {
+		return
+	}
+	if podSpec.Affinity.NodeAffinity == nil {
+		podSpec.Affinity.NodeAffinity = nodeAffinity.DeepCopy()
+		return
+	}
+	if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+			req := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
+			podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = req
 		} else {
-			// podSpec.Affinity.NodeAffinity
-			if nodePlacement.Affinity.NodeAffinity != nil {
-				if podSpec.Affinity.NodeAffinity == nil {
-					podSpec.Affinity.NodeAffinity = nodePlacement.Affinity.NodeAffinity.DeepCopy()
-				} else {
-					// need to copy all affinity terms one by one
-					if nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-						if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-							podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
-						} else {
-							// merge the list of terms from NodePlacement into podSpec
-							for _, term := range nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
-								podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, term)
-							}
-						}
-					}
-
-					//PreferredDuringSchedulingIgnoredDuringExecution
-					for _, term := range nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-						podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term)
-					}
-
-				}
-			}
-			// podSpec.Affinity.PodAffinity
-			if nodePlacement.Affinity.PodAffinity != nil {
-				if podSpec.Affinity.PodAffinity == nil {
-					podSpec.Affinity.PodAffinity = nodePlacement.Affinity.PodAffinity.DeepCopy()
-				} else {
-					//RequiredDuringSchedulingIgnoredDuringExecution
-					for _, term := range nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
-						podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, term)
-					}
-					//PreferredDuringSchedulingIgnoredDuringExecution
-					for _, term := range nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-						podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term)
-					}
-				}
-			}
-			// podSpec.Affinity.PodAntiAffinity
-			if nodePlacement.Affinity.PodAntiAffinity != nil {
-				if podSpec.Affinity.PodAntiAffinity == nil {
-					podSpec.Affinity.PodAntiAffinity = nodePlacement.Affinity.PodAntiAffinity.DeepCopy()
-				} else {
-					//RequiredDuringSchedulingIgnoredDuringExecution
-					for _, term := range nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
-						podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, term)
-					}
-					//PreferredDuringSchedulingIgnoredDuringExecution
-					for _, term := range nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-						podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term)
-					}
-				}
-			}
+			podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+				podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms...,
+			)
 		}
 	}
+	podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...,
+	)
+}
 
-	//podSpec.Tolerations
-	if len(nodePlacement.Tolerations) != 0 {
-		if len(podSpec.Tolerations) == 0 {
-			podSpec.Tolerations = []corev1.Toleration{}
-		}
-		for _, toleration := range nodePlacement.Tolerations {
-			podSpec.Tolerations = append(podSpec.Tolerations, toleration)
-		}
+func mergePodAffinity(podSpec *corev1.PodSpec, podAffinity *corev1.PodAffinity) {
+	if podAffinity == nil {
+		return
 	}
+	if podSpec.Affinity.PodAffinity == nil {
+		podSpec.Affinity.PodAffinity = podAffinity.DeepCopy()
+		return
+	}
+	podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+		podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+		podAffinity.RequiredDuringSchedulingIgnoredDuringExecution...,
+	)
+	podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		podAffinity.PreferredDuringSchedulingIgnoredDuringExecution...,
+	)
+}
+
+func mergePodAntiAffinity(podSpec *corev1.PodSpec, podAntiAffinity *corev1.PodAntiAffinity) {
+	if podAntiAffinity == nil {
+		return
+	}
+	if podSpec.Affinity.PodAntiAffinity == nil {
+		podSpec.Affinity.PodAntiAffinity = podAntiAffinity.DeepCopy()
+		return
+	}
+	podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+		podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+		podAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution...,
+	)
+	podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+		podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+		podAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution...,
+	)
+}
+
+func mergeTolerations(podSpec *corev1.PodSpec, nodePlacement *v1.NodePlacement) {
+	if len(nodePlacement.Tolerations) == 0 {
+		return
+	}
+	if len(podSpec.Tolerations) == 0 {
+		podSpec.Tolerations = []corev1.Toleration{}
+	}
+	podSpec.Tolerations = append(podSpec.Tolerations, nodePlacement.Tolerations...)
 }

--- a/pkg/virt-operator/resource/placement/placement_test.go
+++ b/pkg/virt-operator/resource/placement/placement_test.go
@@ -31,6 +31,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/placement"
 )
 
+const (
+	fooLabel       = "foo"
+	barValue       = "bar"
+	fromPodSpecVal = "from-podspec"
+	linuxCustomVal = "linux-custom"
+)
+
 var _ = Describe("Placement", func() {
 	Context("on calling InjectPlacementMetadata", func() {
 		var componentConfig *v1.ComponentConfig
@@ -59,140 +66,8 @@ var _ = Describe("Placement", func() {
 				Effect:   "NoSchedule",
 			}
 
-			affinity = &corev1.Affinity{
-				NodeAffinity: &corev1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{
-									{
-										Key:      "required",
-										Operator: "in",
-										Values:   []string{"test"},
-									},
-								},
-							},
-						},
-					},
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-						{
-							Preference: corev1.NodeSelectorTerm{
-								MatchExpressions: []corev1.NodeSelectorRequirement{
-									{
-										Key:      "preferred",
-										Operator: "in",
-										Values:   []string{"test"},
-									},
-								},
-							},
-						},
-					},
-				},
-				PodAffinity: &corev1.PodAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"required": "term"},
-							},
-						},
-					},
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-						{
-							PodAffinityTerm: corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"preferred": "term"},
-								},
-							},
-						},
-					},
-				},
-				PodAntiAffinity: &corev1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"anti-required": "term"},
-							},
-						},
-					},
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-						{
-							PodAffinityTerm: corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"anti-preferred": "term"},
-								},
-							},
-						},
-					},
-				},
-			}
-
-			affinity2 = &corev1.Affinity{
-				NodeAffinity: &corev1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{
-									{
-										Key:      "required2",
-										Operator: "in",
-										Values:   []string{"test"},
-									},
-								},
-							},
-						},
-					},
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-						{
-							Preference: corev1.NodeSelectorTerm{
-								MatchExpressions: []corev1.NodeSelectorRequirement{
-									{
-										Key:      "preferred2",
-										Operator: "in",
-										Values:   []string{"test"},
-									},
-								},
-							},
-						},
-					},
-				},
-				PodAffinity: &corev1.PodAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"required2": "term"},
-							},
-						},
-					},
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-						{
-							PodAffinityTerm: corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"preferred2": "term"},
-								},
-							},
-						},
-					},
-				},
-				PodAntiAffinity: &corev1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"anti-required2": "term"},
-							},
-						},
-					},
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-						{
-							PodAffinityTerm: corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"anti-preferred2": "term"},
-								},
-							},
-						},
-					},
-				},
-			}
-
+			affinity = newAffinity("")
+			affinity2 = newAffinity("2")
 		})
 
 		// Node Selectors
@@ -219,33 +94,33 @@ var _ = Describe("Placement", func() {
 
 		It("should copy NodeSelectors when podSpec is empty", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			nodePlacement.NodeSelector["foo"] = "bar"
+			nodePlacement.NodeSelector[fooLabel] = barValue
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
-			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
+			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(barValue))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
 		It("should merge NodeSelectors when podSpec is not empty", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			nodePlacement.NodeSelector["foo"] = "bar"
+			nodePlacement.NodeSelector[fooLabel] = barValue
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["existing"] = "value"
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(3))
-			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
+			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(barValue))
 			Expect(podSpec.NodeSelector["existing"]).To(Equal("value"))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
 		It("should favor podSpec if NodeSelectors collide", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			nodePlacement.NodeSelector["foo"] = "bar"
+			nodePlacement.NodeSelector[fooLabel] = barValue
 			podSpec.NodeSelector = make(map[string]string)
-			podSpec.NodeSelector["foo"] = "from-podspec"
+			podSpec.NodeSelector[fooLabel] = fromPodSpecVal
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
-			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
+			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(fromPodSpecVal))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
@@ -257,36 +132,31 @@ var _ = Describe("Placement", func() {
 
 		It("should favor NodeSelector OS label if present", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			nodePlacement.NodeSelector[placement.KubernetesOSLabel] = "linux-custom"
+			nodePlacement.NodeSelector[placement.KubernetesOSLabel] = linuxCustomVal
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
-			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal("linux-custom"))
+			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(linuxCustomVal))
 		})
 
 		It("should favor podSpec OS label if present", func() {
 			podSpec.NodeSelector = make(map[string]string)
-			podSpec.NodeSelector[placement.KubernetesOSLabel] = "linux-custom"
+			podSpec.NodeSelector[placement.KubernetesOSLabel] = linuxCustomVal
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
-			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal("linux-custom"))
+			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(linuxCustomVal))
 		})
 
 		It("should preserve NodeSelectors if nodePlacement has none", func() {
 			podSpec.NodeSelector = make(map[string]string)
-			podSpec.NodeSelector["foo"] = "from-podspec"
+			podSpec.NodeSelector[fooLabel] = fromPodSpecVal
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
-			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
+			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(fromPodSpecVal))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
 		// tolerations
 		It("should copy tolerations when podSpec is empty", func() {
-			toleration := corev1.Toleration{
-				Key:      "test-taint",
-				Operator: "Exists",
-				Effect:   "NoSchedule",
-			}
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Tolerations).To(HaveLen(1))
@@ -311,7 +181,6 @@ var _ = Describe("Placement", func() {
 			nodePlacement.Affinity = affinity
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeTrue())
-
 		})
 
 		It("It should copy NodePlacement if Node, Pod and Anti affinities are empty", func() {
@@ -319,7 +188,6 @@ var _ = Describe("Placement", func() {
 			podSpec.Affinity = &corev1.Affinity{}
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeTrue())
-
 		})
 
 		It("It should merge NodePlacement and podSpec affinity terms", func() {
@@ -338,7 +206,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Required NodeAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-			nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
+			req := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
+			nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = req
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 		})
@@ -346,7 +215,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Preferred NodeAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			v := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = v
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -354,7 +224,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Required PodAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
-			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			v := affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = v
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -362,7 +233,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Preferred PodAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
-			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			v := affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = v
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -370,7 +242,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Required PodAntiAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			v := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = v
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -378,7 +251,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Preferred PodAntiAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			v := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = v
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -462,7 +336,75 @@ var _ = Describe("Placement", func() {
 					Expect(podSpec.Affinity).To(BeNil())
 				})
 			})
-
 		})
 	})
 })
+
+func newAffinity(suffix string) *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "required" + suffix,
+								Operator: "in",
+								Values:   []string{"test"},
+							},
+						},
+					},
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Preference: corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "preferred" + suffix,
+								Operator: "in",
+								Values:   []string{"test"},
+							},
+						},
+					},
+				},
+			},
+		},
+		PodAffinity: &corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"required" + suffix: "term"},
+					},
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"preferred" + suffix: "term"},
+						},
+					},
+				},
+			},
+		},
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"anti-required" + suffix: "term"},
+					},
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"anti-preferred" + suffix: "term"},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/virt-operator/resource/placement/placement_test.go
+++ b/pkg/virt-operator/resource/placement/placement_test.go
@@ -17,6 +17,7 @@
  *
  */
 
+//nolint:goconst
 package placement_test
 
 import (
@@ -32,9 +33,6 @@ import (
 )
 
 const (
-	fooLabel       = "foo"
-	barValue       = "bar"
-	fromPodSpecVal = "from-podspec"
 	linuxCustomVal = "linux-custom"
 )
 
@@ -94,33 +92,33 @@ var _ = Describe("Placement", func() {
 
 		It("should copy NodeSelectors when podSpec is empty", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			nodePlacement.NodeSelector[fooLabel] = barValue
+			nodePlacement.NodeSelector["foo"] = "bar"
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
-			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(barValue))
+			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
 		It("should merge NodeSelectors when podSpec is not empty", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			nodePlacement.NodeSelector[fooLabel] = barValue
+			nodePlacement.NodeSelector["foo"] = "bar"
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["existing"] = "value"
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(3))
-			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(barValue))
+			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector["existing"]).To(Equal("value"))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
 		It("should favor podSpec if NodeSelectors collide", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			nodePlacement.NodeSelector[fooLabel] = barValue
+			nodePlacement.NodeSelector["foo"] = "bar"
 			podSpec.NodeSelector = make(map[string]string)
-			podSpec.NodeSelector[fooLabel] = fromPodSpecVal
+			podSpec.NodeSelector["foo"] = "from-podspec"
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
-			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(fromPodSpecVal))
+			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
@@ -148,10 +146,10 @@ var _ = Describe("Placement", func() {
 
 		It("should preserve NodeSelectors if nodePlacement has none", func() {
 			podSpec.NodeSelector = make(map[string]string)
-			podSpec.NodeSelector[fooLabel] = fromPodSpecVal
+			podSpec.NodeSelector["foo"] = "from-podspec"
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
-			Expect(podSpec.NodeSelector[fooLabel]).To(Equal(fromPodSpecVal))
+			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[placement.KubernetesOSLabel]).To(Equal(placement.KubernetesOSLinux))
 		})
 
@@ -215,8 +213,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Preferred NodeAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-			v := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = v
+			pref := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = pref
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -224,8 +222,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Required PodAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
-			v := affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = v
+			req := affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = req
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -233,8 +231,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Preferred PodAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
-			v := affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = v
+			pref := affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = pref
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -242,8 +240,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Required PodAntiAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-			v := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = v
+			req := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = req
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
@@ -251,8 +249,8 @@ var _ = Describe("Placement", func() {
 		It("It should copy Preferred PodAntiAffinity", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-			v := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = v
+			pref := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = pref
 			placement.InjectPlacementMetadata(componentConfig, podSpec, placement.AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
- Linter issue at pkg/virt-operator/resource/placement
#### After this PR:
- Linter issue solved at pkg/virt-operator/resource/placement
### References

  

- Partially addresses #17811 
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing:  Unit test passes for the for pkg/virtoperator/resource/placement
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

