### PR TITLE
Quarantine flaky ClusterProfiler pprof subresource access test

### DIFF
--- a/tests/infrastructure/cluster-profiler.go
+++ b/tests/infrastructure/cluster-profiler.go
@@ -20,6 +20,7 @@
 package infrastructure
 
 import (
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -58,7 +59,7 @@ var _ = Describe(SIGSerial("cluster profiler for pprof data aggregation", func()
 			_, err = virtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
 			Expect(err).To(HaveOccurred())
 		})
-		It("is enabled it should allow subresource access", func() {
+		It("[QUARANTINE]is enabled it should allow subresource access", decorators.Quarantine, func() {
 			kvConfig.DeveloperConfiguration.ClusterProfiler = true
 			config.UpdateKubeVirtConfigValueAndWait(kvConfig)
 


### PR DESCRIPTION
## Summary

- Quarantine the ClusterProfiler pprof subresource access test which is flaky across all periodic sig-compute lanes

## Evidence

**Flake overview (2026-05-15):**

| Lane | 28d Success Rate | 7d Success Rate | Trend |
|------|-----------------|-----------------|-------|
| periodic-kubevirt-e2e-k8s-1.36-sig-compute | 88.4% (76/86) | 70.8% (17/24) | Worsening |
| periodic-kubevirt-e2e-k8s-1.35-sig-compute | 94.5% (103/109) | 92.6% (25/27) | Stable |
| periodic-kubevirt-e2e-k8s-1.34-sig-compute | 92.6% (100/108) | 84.0% (21/25) | Worsening |
| pull-kubevirt-e2e-k8s-1.36-sig-compute | 84.6% (22/26) | 84.0% (21/25) | Stable |

**search.ci evidence (last 14 days):** [search.ci link](https://search.ci.kubevirt.io/?search=Infrastructure+cluster+profiler+for+pprof+data+aggregation+when+ClusterProfiler+configuration+is+enabled+it+should+allow+subresource+access&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=periodic-kubevirt-e2e-k8s-.*-sig-compute%24&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

| Job | Runs | Matching Failures |
|-----|------|-------------------|
| periodic-kubevirt-e2e-k8s-1.36-sig-compute | 54 | 9 (17%) |
| periodic-kubevirt-e2e-k8s-1.34-sig-compute | 55 | 5 (9%) |
| periodic-kubevirt-e2e-k8s-1.35-sig-compute | 56 | 3 (5%) |

Failures are dispersed across all k8s versions, worsening on k8s-1.36, and show a flaky (high flip-rate) pattern.

## Test plan

- [ ] Verify the test is properly tagged with `[QUARANTINE]` and `decorators.Quarantine`
- [ ] Confirm CI passes with the quarantine in place

Fixes https://github.com/kubevirt/kubevirt/issues/17819

🤖 Generated with [Claude Code](https://claude.com/claude-code)