### PR TITLE
handler: error if migrated hotplug disks are not accessible on target

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -311,7 +311,7 @@ func (m *volumeMounter) mountHotplugVolume(
 	mountDirectory bool,
 	cgroupManager cgroup.Manager,
 ) error {
-	logger := log.DefaultLogger()
+	logger := log.Log.Object(vmi)
 	logger.V(4).Infof("Hotplug check volume name: %s", volumeName)
 	if sourceUID != "" {
 		if m.isBlockVolume(&vmi.Status, volumeName) {
@@ -437,7 +437,7 @@ func (m *volumeMounter) mountBlockHotplugVolume(
 		if err := m.createBlockDeviceFile(targetPath, volume, dev, permissions); err != nil && !os.IsExist(err) {
 			return err
 		}
-		log.DefaultLogger().V(1).Infof("successfully created block device %v", volume)
+		log.Log.Object(vmi).V(1).Infof("successfully created block device %s", volume)
 	} else if err != nil {
 		return err
 	}
@@ -551,7 +551,7 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 	if !isMounted {
 		sourcePath, err := m.getSourcePodFilePath(sourceUID, vmi, volume)
 		if err != nil {
-			log.DefaultLogger().V(3).Infof("Error getting source path: %v", err)
+			log.Log.Object(vmi).V(3).Infof("Error getting source path for volume %s from source pod %s: %v", volume, sourceUID, err)
 			// We are eating the error to avoid spamming the log with errors, it might take a while for the volume
 			// to get mounted on the node, and this will error until the volume is mounted.
 			return nil
@@ -568,7 +568,7 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 		if out, err := mountCommand(sourcePath, target); err != nil {
 			return fmt.Errorf("failed to bindmount hotplug volume source from %v to %v: %v : %v", sourcePath, target, string(out), err)
 		}
-		log.DefaultLogger().V(1).Infof("successfully mounted %v", volume)
+		log.Log.Object(vmi).V(1).Infof("successfully mounted hotplug volume %s", volume)
 	}
 
 	return m.ownershipManager.SetFileOwnership(target)

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -52,6 +52,8 @@ import (
 
 //go:generate mockgen -source $GOFILE -package=$GOPACKAGE -destination=generated_mock_$GOFILE
 
+var ErrWaitingForHotplugMount = errors.New("waiting for hotplug mount")
+
 const (
 	unableFindHotplugMountedDir = "unable to find hotplug mounted directories for vmi without uid"
 )
@@ -551,10 +553,7 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 	if !isMounted {
 		sourcePath, err := m.getSourcePodFilePath(sourceUID, vmi, volume)
 		if err != nil {
-			log.Log.Object(vmi).V(3).Infof("Error getting source path for volume %s from source pod %s: %v", volume, sourceUID, err)
-			// We are eating the error to avoid spamming the log with errors, it might take a while for the volume
-			// to get mounted on the node, and this will error until the volume is mounted.
-			return nil
+			return fmt.Errorf("failed to get source path for volume %s from source pod %s: %v: %w", volume, sourceUID, err, ErrWaitingForHotplugMount)
 		}
 		if err := m.writePathToMountRecord(unsafepath.UnsafeAbsolute(target.Raw()), vmi, record); err != nil {
 			return err

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -708,6 +708,18 @@ var _ = Describe("HotplugVolume", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("mountFileSystemHotplugVolume should return error if getSourcePodFilePath fails", func() {
+			isolationDetector = func() isolation.PodIsolationDetector {
+				return &mockIsolationDetector{
+					pid: 9999,
+				}
+			}
+
+			err = m.mountFileSystemHotplugVolume(vmi, "testvolume", types.UID("ghfjk"), record, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ErrWaitingForHotplugMount), "expected error waiting for hotplug mount")
+		})
+
 		It("unmountFileSystemHotplugVolumes should return error if isMounted returns error", func() {
 			testPath, err := newFile(tempDir, "test")
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -708,6 +708,16 @@ var _ = Describe("HotplugVolume", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("mountFileSystemHotplugVolume should return os.ErrNotExist if disk.img is missing", func() {
+			findMntByVolume = func(volumeName string, pid int) ([]byte, error) {
+				return []byte(fmt.Sprintf(findmntByVolumeRes, "testvolume", tempDir)), nil
+			}
+
+			err = m.mountFileSystemHotplugVolume(vmi, "testvolume", types.UID("ghfjk"), record, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(os.ErrNotExist), "expected os.ErrNotExist for missing disk.img")
+		})
+
 		It("mountFileSystemHotplugVolume should return error if getSourcePodFilePath fails", func() {
 			isolationDetector = func() isolation.PodIsolationDetector {
 				return &mockIsolationDetector{

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -826,6 +826,11 @@ func (c *MigrationTargetController) processVMI(vmi *v1.VirtualMachineInstance) (
 		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 		return nil, true
 	}
+	if goerror.Is(err, hotplugvolume.ErrWaitingForHotplugMount) {
+		c.logger.Object(vmi).V(4).Infof("waiting for hotplug volumes to be mounted: %v", err)
+		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+		return nil, true
+	}
 	if err != nil {
 		c.logger.Object(vmi).Reason(err).Error("Failed to sync Volumes")
 		return err, false

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1931,10 +1931,15 @@ func (c *VirtualMachineController) handleRunningVMI(vmi *v1.VirtualMachineInstan
 	}
 
 	if err := c.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
-		if !goerror.Is(err, os.ErrNotExist) {
+		switch {
+		case goerror.Is(err, hotplugvolume.ErrWaitingForHotplugMount):
+			c.logger.Object(vmi).V(4).Infof("waiting for hotplug volumes to be mounted: %v", err)
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+		case goerror.Is(err, os.ErrNotExist):
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, "HotplugFailed", err.Error())
+		default:
 			return err
 		}
-		c.recorder.Event(vmi, k8sv1.EventTypeWarning, "HotplugFailed", err.Error())
 	}
 
 	if err := c.getMemoryDump(vmi); err != nil {
@@ -1980,10 +1985,15 @@ func (c *VirtualMachineController) handleStartingVMI(
 	}
 
 	if err := c.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
-		if !goerror.Is(err, os.ErrNotExist) {
+		switch {
+		case goerror.Is(err, hotplugvolume.ErrWaitingForHotplugMount):
+			c.logger.Object(vmi).V(4).Infof("waiting for hotplug volumes to be mounted: %v", err)
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+		case goerror.Is(err, os.ErrNotExist):
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, "HotplugFailed", err.Error())
+		default:
 			return false, err
 		}
-		c.recorder.Event(vmi, k8sv1.EventTypeWarning, "HotplugFailed", err.Error())
 	}
 
 	if !c.hotplugVolumesReady(vmi) {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -648,6 +648,29 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(updatedVMI.Status.Machine).To(Equal(&v1.Machine{Type: "q35-123"}))
 		})
 
+		It("should continue sync when hotplug mount returns ErrWaitingForHotplugMount", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Running
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Running
+
+			addVMI(vmi, domain)
+
+			unmountCalled := false
+			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
+			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(hotplugvolume.ErrWaitingForHotplugMount)
+			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Do(func(_ *v1.VirtualMachineInstance, _ cgroup.Manager) {
+				unmountCalled = true
+			}).Return(nil)
+
+			sanityExecute()
+			Expect(unmountCalled).To(BeTrue(), "Unmount should still be called when Mount returns ErrWaitingForHotplugMount")
+		})
+
 		It("should update from Scheduled to Running, if it sees a running Domain", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -671,6 +671,26 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(unmountCalled).To(BeTrue(), "Unmount should still be called when Mount returns ErrWaitingForHotplugMount")
 		})
 
+		It("should emit HotplugFailed event when hotplug mount returns os.ErrNotExist", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Running
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Running
+
+			addVMI(vmi, domain)
+
+			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
+			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(os.ErrNotExist)
+			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), mockCgroupManager).Return(nil)
+
+			sanityExecute()
+			testutils.ExpectEvent(recorder, "HotplugFailed")
+		})
+
 		It("should update from Scheduled to Running, if it sees a running Domain", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
k8s 1.36 exposed a timing issue where hotplug not occurring yet
could lead to an endless cycle of attachment deletion/creation

### References
Fixes #17724 
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- 
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Example occurrence https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.36-sig-storage/2055520009878245376

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: endless cycle of attachment pod deletion/creation
```

