### PR TITLE
storage, validation: Reject LUN disk with virtio bus

### DIFF
--- a/pkg/storage/admitters/disks.go
+++ b/pkg/storage/admitters/disks.go
@@ -199,13 +199,6 @@ func validateBusSupport(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.St
 				Field:   field.Index(idx).Child("cdrom", "bus").String(),
 			})
 		}
-		if diskType == "lun" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Bus type %s is invalid for LUN device. Only 'scsi' bus is supported.", bus),
-				Field:   field.Index(idx).Child("lun", "bus").String(),
-			})
-		}
 	case v1.DiskBusSATA:
 		// sata disks (in contrast to sata cdroms) don't support readOnly
 		if disk.Disk != nil && disk.Disk.ReadOnly {
@@ -223,6 +216,13 @@ func validateBusSupport(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.St
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s is set with an unrecognized bus %s, must be one of: %v", field.Index(idx).String(), bus, supportedBuses),
 			Field:   field.Index(idx).Child(diskType, "bus").String(),
+		})
+	}
+	if diskType == "lun" && bus != v1.DiskBusSCSI {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("Bus type %s is invalid for LUN device. Only 'scsi' bus is supported.", bus),
+			Field:   field.Index(idx).Child("lun", "bus").String(),
 		})
 	}
 	// Reject defining DedicatedIOThread to a disk without VirtIO bus since this configuration

--- a/pkg/storage/admitters/disks.go
+++ b/pkg/storage/admitters/disks.go
@@ -199,6 +199,13 @@ func validateBusSupport(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.St
 				Field:   field.Index(idx).Child("cdrom", "bus").String(),
 			})
 		}
+		if diskType == "lun" {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("Bus type %s is invalid for LUN device. Only 'scsi' bus is supported.", bus),
+				Field:   field.Index(idx).Child("lun", "bus").String(),
+			})
+		}
 	case v1.DiskBusSATA:
 		// sata disks (in contrast to sata cdroms) don't support readOnly
 		if disk.Disk != nil && disk.Disk.ReadOnly {

--- a/pkg/storage/admitters/disks_test.go
+++ b/pkg/storage/admitters/disks_test.go
@@ -236,6 +236,22 @@ var _ = Describe("Disk Validation", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
+		It("should reject LUN disk with virtio bus", func() {
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{
+						Bus: v1.DiskBusVirtio,
+					},
+				},
+			})
+
+			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("fake[0].lun.bus"))
+			Expect(causes[0].Message).To(ContainSubstring("invalid for LUN device"))
+		})
+
 		It("should reject disks with unsupported buses", func() {
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testdisk1",

--- a/pkg/storage/admitters/disks_test.go
+++ b/pkg/storage/admitters/disks_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Disk Validation", func() {
 				Name: "testdisk2",
 				DiskDevice: v1.DiskDevice{
 					LUN: &v1.LunTarget{
-						Bus: v1.DiskBusSATA,
+						Bus: v1.DiskBusSCSI,
 					},
 				},
 			})
@@ -236,21 +236,25 @@ var _ = Describe("Disk Validation", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
-		It("should reject LUN disk with virtio bus", func() {
+		DescribeTable("should reject LUN disk with non-scsi bus", func(bus v1.DiskBus) {
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testdisk",
 				DiskDevice: v1.DiskDevice{
 					LUN: &v1.LunTarget{
-						Bus: v1.DiskBusVirtio,
+						Bus: bus,
 					},
 				},
 			})
 
 			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(1))
+			Expect(causes).ToNot(BeEmpty())
 			Expect(causes[0].Field).To(Equal("fake[0].lun.bus"))
 			Expect(causes[0].Message).To(ContainSubstring("invalid for LUN device"))
-		})
+		},
+			Entry("virtio bus", v1.DiskBusVirtio),
+			Entry("sata bus", v1.DiskBusSATA),
+			Entry("usb bus", v1.DiskBusUSB),
+		)
 
 		It("should reject disks with unsupported buses", func() {
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
@@ -271,9 +275,10 @@ var _ = Describe("Disk Validation", func() {
 			})
 
 			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(2))
+			Expect(causes).To(HaveLen(3))
 			Expect(causes[0].Field).To(Equal("fake[0].disk.bus"))
 			Expect(causes[1].Field).To(Equal("fake[1].lun.bus"))
+			Expect(causes[2].Field).To(Equal("fake[1].lun.bus"))
 		})
 
 		It("should reject disks with unsupported I/O modes", func() {


### PR DESCRIPTION
QEMU does not support device=lun with the virtio bus. The hotplug path already rejects this combination, but VM creation did not. Add validation in validateBusSupport to reject it at creation time.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
We could create VM with LUN disk with virtio bus.

#### After this PR:
The PR will block the LUN disk creation with virtio bus.
There were already validations but not in the VM creation.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
-->
- Fixes #17826

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

