### PR TITLE
featuregate: fix typo in NetworkBindingPluginsGate constant name

### DIFF
--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -58,11 +58,11 @@ const (
 	// Deprecated: v1.4.0
 	DockerSELinuxMCSWorkaround = "DockerSELinuxMCSWorkaround"
 
-	// NetworkBindingPlugingsGate enables using a plugin to bind the pod and the VM network
+	// NetworkBindingPluginsGate enables using a plugin to bind the pod and the VM network
 	// Alpha: v1.1.0
 	// Beta:  v1.4.0
 	// GA:    v1.5.0
-	NetworkBindingPlugingsGate = "NetworkBindingPlugins"
+	NetworkBindingPluginsGate = "NetworkBindingPlugins"
 
 	// DynamicPodInterfaceNamingGate enables a mechanism to dynamically determine the primary pod interface for KubeVirt virtual machines.
 	// Beta:  v1.4.0
@@ -164,7 +164,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HotplugNetworkIfacesGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: BochsDisplayForEFIGuests, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VMLiveUpdateFeaturesGate, State: GA})
-	RegisterFeatureGate(FeatureGate{Name: NetworkBindingPlugingsGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: NetworkBindingPluginsGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: DynamicPodInterfaceNamingGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VolumesUpdateStrategy, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VolumeMigration, State: GA})


### PR DESCRIPTION
 Description:

  ### What this PR does
  #### Before this PR:
  The constant was misspelled as `NetworkBindingPlugingsGate` ("Plugings").

  #### After this PR:
  Renamed to `NetworkBindingPluginsGate` ("Plugins") — correct spelling.
  The actual feature gate string value `"NetworkBindingPlugins"` is unchanged,
  so there is no runtime or API impact.

  ### References
  N/A

  ### Why we need it and why it was done in this way
  The following tradeoffs were made: None — pure rename, no logic changed.

  The following alternatives were considered: None.

  ### Special notes for your reviewer
  Only the Go constant name is renamed. The string value `"NetworkBindingPlugins"`
  passed to RegisterFeatureGate remains unchanged, so there is zero runtime impact.

  ### Checklist
  - [x] Design: not required (typo fix)
  - [x] PR: description is expressive enough
  - [x] Code: simple rename
  - [x] Refactor: left the code cleaner (Boy Scout Rule)
  - [x] Upgrade: no impact
  - [x] Testing: not required (no logic changed)
  - [x] Documentation: not required
  - [x] Community: not required
  - [x] AI Contributions: not applicable

 ### Release note
 ```release-note
 NONE
 ```
