### PR TITLE
tests: add T1 alert-firing e2e tests

### DIFF
--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -368,6 +368,33 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			checkRESTErrorsBurst(virtClient, "kubevirt-handler", virtHandler.restErrorsBurtsAlert)
 		})
 	})
+
+	Context("Virt-handler alerts", func() {
+		It("VirtHandlerDaemonSetRolloutFailing should be triggered when virt-handler pods are not ready", func() {
+			const alertName = "VirtHandlerDaemonSetRolloutFailing"
+
+			virtHandlerDS, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), virtHandler.deploymentName, metav1.GetOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			originalVirtHandlerDS := virtHandlerDS.DeepCopy()
+			defer func() {
+				restoreDaemonSetImage(virtClient, virtHandler.deploymentName, originalVirtHandlerDS, alertName)
+			}()
+
+			By("Patching virt-handler DaemonSet with a non-existent image to cause ImagePullBackOff")
+			container := &virtHandlerDS.Spec.Template.Spec.Containers[0]
+			container.Image = "registry.example.com/nonexistent:v0.0.0"
+
+			Expect(mergePatchDaemonSet(
+				context.Background(), virtClient, flags.KubeVirtInstallNamespace, virtHandlerDS,
+			)).To(Succeed())
+
+			By("Verifying the alert exists")
+			libmonitoring.VerifyAlertExist(virtClient, alertName)
+		})
+	})
 })
 
 func restoreOperator(virtClient kubecli.KubevirtClient, scales *libmonitoring.Scaling) {

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -294,7 +294,7 @@ func setupSharedVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
 
 	vmi := libvmifact.NewFedora(
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-		libvmi.WithMemoryLimit("512Mi"),
+		libvmi.WithMemoryLimit(libvmifact.FedoraMemory),
 		libvmi.WithDataVolume("testdisk", dv.Name),
 		libvmi.WithInterface(iface),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -21,6 +21,7 @@ package monitoring
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -40,6 +41,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -504,13 +506,13 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 		})
 
 		AfterEach(func() {
-			scales.RestoreAllScales()
+			restoreOperator(virtClient, scales)
 		})
 
 		It("[test_id:9260] should fire OrphanedVirtualMachineInstances alert", func() {
 			By("starting VMI")
 			vmi := libvmifact.NewGuestless()
-			libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
 
 			By("delete virt-handler daemonset")
 			err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Delete(
@@ -520,6 +522,72 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 
 			By("waiting for OrphanedVirtualMachineInstances alert")
 			libmonitoring.VerifyAlertExist(virtClient, "OrphanedVirtualMachineInstances")
+
+			By("Deleting the VMI")
+			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(
+				context.Background(), vmi.Name, metav1.DeleteOptions{},
+			)).To(Succeed())
+
+			By("Waiting for OrphanedVirtualMachineInstances alert to clear")
+			libmonitoring.WaitUntilAlertDoesNotExist(virtClient, "OrphanedVirtualMachineInstances")
+		})
+
+		It("OutdatedVirtualMachineInstanceWorkloads should be triggered when VMIs run outdated launcher images", func() {
+			const alertName = "OutdatedVirtualMachineInstanceWorkloads"
+
+			By("Starting a VMI and waiting for it to be running")
+			vmi := libvmifact.NewGuestless()
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+
+			By("Waiting for LauncherContainerImageVersion to be populated")
+			Eventually(func(g Gomega) {
+				var err error
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(
+					context.Background(), vmi.Name, metav1.GetOptions{},
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(vmi.Status.LauncherContainerImageVersion).ToNot(BeEmpty())
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("Getting the virt-controller deployment")
+			virtControllerDep, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), virtController.deploymentName, metav1.GetOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Patching virt-controller --launcher-image arg to a fake image")
+			args := virtControllerDep.Spec.Template.Spec.Containers[0].Args
+			found := false
+			for i, arg := range args {
+				if arg == "--launcher-image" && i+1 < len(args) {
+					args[i+1] = "registry.example.com/fake-launcher:v0.0.0"
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "--launcher-image arg not found in virt-controller deployment")
+			virtControllerDep.Spec.Template.Spec.Containers[0].Args = args
+
+			patchBytes, patchErr := json.Marshal(virtControllerDep)
+			Expect(patchErr).ToNot(HaveOccurred())
+
+			_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(
+				context.Background(), virtControllerDep.Name, k8stypes.MergePatchType, patchBytes, metav1.PatchOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for outdated VMI metric and alert to fire")
+			Eventually(func(g Gomega) {
+				v, metricErr := libmonitoring.GetMetricValueWithLabels(virtClient, "kubevirt_vmi_number_of_outdated", nil)
+				g.Expect(metricErr).ToNot(HaveOccurred())
+				g.Expect(v).To(BeNumerically(">", 0))
+				g.Expect(libmonitoring.CheckAlertExists(virtClient, alertName)).To(BeTrue())
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+			By("Deleting the VMI")
+			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(
+				context.Background(), vmi.Name, metav1.DeleteOptions{},
+			)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
### What this PR does

Add new Serial e2e tests that verify the following
alerts fire correctly:

- VirtHandlerDaemonSetRolloutFailing
- OutdatedVirtualMachineInstanceWorkloads

Move VirtHandlerDaemonSetRolloutFailing into the
existing Component Monitoring Describe to share its
setup/teardown hooks.

Add VMI cleanup to the OrphanedVirtualMachineInstances
test.

Drop LowKVMNodesCount e2e test -- alert logic is
covered by prom-rules-tests.yaml and the e2e test
requires destructive DaemonSet deletion that cannot
be cleanly restored within the test lifecycle.

### References
```jira-ticket: 
- https://redhat.atlassian.net/browse/CNV-54878
- https://redhat.atlassian.net/browse/CNV-54879
- https://redhat.atlassian.net/browse/CNV-54884
```
### Why we need it and why it was done in this way

### Special notes for your reviewer

### Checklist

- [x] Design: VEP not required (documentation cleanup only)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: N/A
- [x] Refactor: N/A
- [x] Upgrade: No impact
- [x] Testing: Documentation only, no test changes required
- [x] Documentation: This PR *is* the documentation update
- [x] Community: Announcement not required (no user-facing API/feature change)
- [x] AI Contributions: PR abides by the KubeVirt AI Contribution Policy

### Release note
```release-note
NONE
```
Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: Cursor <cursoragent@cursor.com>