### PR TITLE
fix: Fix a typo in the VMI unfreeze log message

### DIFF
--- a/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
+++ b/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
@@ -114,7 +114,7 @@ func (m *StorageManager) scheduleSafetyVMIUnfreeze(vmi *v1.VirtualMachineInstanc
 			vmi.Name, unfreezeTimeout)
 		m.UnfreezeVMI(vmi)
 	case <-m.cancelSafetyUnfreezeChan:
-		log.Log.V(3).Infof("Canceling schedualed Unfreeze for vmi %s", vmi.Name)
+		log.Log.V(3).Infof("Canceling scheduled Unfreeze for vmi %s", vmi.Name)
 		// aborted
 	}
 }


### PR DESCRIPTION
### What this PR does
Change typo `schedualed` to `scheduled`.

#### Before this PR:
The log message when a VMI unfreeze is cancelled contained a typo.

#### After this PR:
The typo in the log message is fixed.

### References
N/A

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered: Keep the typo.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

