### PR TITLE
[WIP] handler waits for hotplug properly

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -130,6 +130,9 @@ until _kubectl wait -n ${namespace} kv kubevirt --for condition=Available --time
     sleep 1m
 done
 
+# debug sig-storage flake where console log container dies without any logs
+_kubectl patch kv -n ${namespace} kubevirt --type merge -p '{"spec": {"configuration": {"developerConfiguration": {"logVerbosity": {"virtHandler": 3}}}}}'
+
 configure_prometheus
 
 echo "Done $0"

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -311,7 +311,7 @@ func (m *volumeMounter) mountHotplugVolume(
 	mountDirectory bool,
 	cgroupManager cgroup.Manager,
 ) error {
-	logger := log.DefaultLogger()
+	logger := log.Log.Object(vmi)
 	logger.V(4).Infof("Hotplug check volume name: %s", volumeName)
 	if sourceUID != "" {
 		if m.isBlockVolume(&vmi.Status, volumeName) {
@@ -437,7 +437,7 @@ func (m *volumeMounter) mountBlockHotplugVolume(
 		if err := m.createBlockDeviceFile(targetPath, volume, dev, permissions); err != nil && !os.IsExist(err) {
 			return err
 		}
-		log.DefaultLogger().V(1).Infof("successfully created block device %v", volume)
+		log.Log.Object(vmi).V(1).Infof("successfully created block device %s", volume)
 	} else if err != nil {
 		return err
 	}
@@ -551,7 +551,7 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 	if !isMounted {
 		sourcePath, err := m.getSourcePodFilePath(sourceUID, vmi, volume)
 		if err != nil {
-			log.DefaultLogger().V(3).Infof("Error getting source path: %v", err)
+			log.Log.Object(vmi).V(3).Infof("Error getting source path for volume %s from source pod %s: %v", volume, sourceUID, err)
 			// We are eating the error to avoid spamming the log with errors, it might take a while for the volume
 			// to get mounted on the node, and this will error until the volume is mounted.
 			return nil
@@ -568,7 +568,7 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 		if out, err := mountCommand(sourcePath, target); err != nil {
 			return fmt.Errorf("failed to bindmount hotplug volume source from %v to %v: %v : %v", sourcePath, target, string(out), err)
 		}
-		log.DefaultLogger().V(1).Infof("successfully mounted %v", volume)
+		log.Log.Object(vmi).V(1).Infof("successfully mounted hotplug volume %s", volume)
 	}
 
 	return m.ownershipManager.SetFileOwnership(target)

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -551,10 +551,7 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 	if !isMounted {
 		sourcePath, err := m.getSourcePodFilePath(sourceUID, vmi, volume)
 		if err != nil {
-			log.Log.Object(vmi).V(3).Infof("Error getting source path for volume %s from source pod %s: %v", volume, sourceUID, err)
-			// We are eating the error to avoid spamming the log with errors, it might take a while for the volume
-			// to get mounted on the node, and this will error until the volume is mounted.
-			return nil
+			return fmt.Errorf("failed to get source path for volume %s from source pod %s: %v", volume, sourceUID, err)
 		}
 		if err := m.writePathToMountRecord(unsafepath.UnsafeAbsolute(target.Raw()), vmi, record); err != nil {
 			return err

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -708,6 +708,18 @@ var _ = Describe("HotplugVolume", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("mountFileSystemHotplugVolume should return error if getSourcePodFilePath fails", func() {
+			isolationDetector = func() isolation.PodIsolationDetector {
+				return &mockIsolationDetector{
+					pid: 9999,
+				}
+			}
+
+			err = m.mountFileSystemHotplugVolume(vmi, "testvolume", types.UID("ghfjk"), record, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get source path"))
+		})
+
 		It("unmountFileSystemHotplugVolumes should return error if isMounted returns error", func() {
 			testPath, err := newFile(tempDir, "test")
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -258,10 +258,8 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 		}
 	}
 
-	if vmi.IsDecentralizedMigration() {
-		if err := checkIfHotplugDisksReadyToUse(vmi); err != nil {
-			return err
-		}
+	if err := checkIfHotplugDisksReadyToUse(vmi); err != nil {
+		return err
 	}
 
 	// since the source vmi is paused, add the vmi uuid to the pausedVMIs as

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -258,8 +258,10 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 		}
 	}
 
-	if err := checkIfHotplugDisksReadyToUse(vmi); err != nil {
-		return err
+	if vmi.IsDecentralizedMigration() {
+		if err := checkIfHotplugDisksReadyToUse(vmi); err != nil {
+			return err
+		}
 	}
 
 	// since the source vmi is paused, add the vmi uuid to the pausedVMIs as


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

