### PR TITLE
libvmi: replace WithoutSerialConsole with WithAutoattachSerialConsole

### DIFF
--- a/pkg/libvmi/devices.go
+++ b/pkg/libvmi/devices.go
@@ -100,10 +100,9 @@ func WithDownwardMetricsChannel() Option {
 	}
 }
 
-func WithoutSerialConsole() Option {
+func WithAutoattachSerialConsole(enable bool) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		enabled := false
-		vmi.Spec.Domain.Devices.AutoattachSerialConsole = &enabled
+		vmi.Spec.Domain.Devices.AutoattachSerialConsole = &enable
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
@@ -25,8 +25,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	v1 "kubevirt.io/api/core/v1"
-
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -83,7 +81,7 @@ var _ = Describe("Console Domain Configurator", func() {
 	)
 
 	It("should NOT configure serial console when AutoattachSerialConsole is explicitly false", func() {
-		vmi := libvmi.New(withAutoattachSerialConsole(false))
+		vmi := libvmi.New(libvmi.WithAutoattachSerialConsole(false))
 		var domain api.Domain
 
 		Expect(compute.NewConsoleDomainConfigurator(false).Configure(vmi, &domain)).To(Succeed())
@@ -132,9 +130,3 @@ var _ = Describe("Console Domain Configurator", func() {
 		Expect(domain).To(Equal(expectedDomain))
 	})
 })
-
-func withAutoattachSerialConsole(enabled bool) libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Devices.AutoattachSerialConsole = pointer.P(enabled)
-	}
-}

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -257,13 +257,13 @@ var _ = Describe("Controllers Domain Configurator", func() {
 				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when serial console is explicitly enabled",
-			[]libvmi.Option{withSerialConsole()},
+			[]libvmi.Option{libvmi.WithAutoattachSerialConsole(true)},
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when serial console is disabled",
-			[]libvmi.Option{libvmi.WithoutSerialConsole()},
+			[]libvmi.Option{libvmi.WithAutoattachSerialConsole(false)},
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 			}),
@@ -283,12 +283,5 @@ func newDomainWithControllers(controllers []api.Controller) api.Domain {
 func withHotplugDisabled() libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Devices.DisableHotplug = true
-	}
-}
-
-func withSerialConsole() libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		enabled := true
-		vmi.Spec.Domain.Devices.AutoattachSerialConsole = &enabled
 	}
 }

--- a/tests/compute/console.go
+++ b/tests/compute/console.go
@@ -127,7 +127,7 @@ var _ = Describe(SIG("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@r
 
 		Context("without a serial console", func() {
 			It("[test_id:4118]should run but not be connectable via the serial console", decorators.Conformance, func() {
-				vmi := libvmifact.NewAlpine(libvmi.WithoutSerialConsole())
+				vmi := libvmifact.NewAlpine(libvmi.WithAutoattachSerialConsole(false))
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsSmall)
 
 				By("failing to connect to serial console")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Replace the inflexible WithoutSerialConsole() with a parameterized WithAutoattachSerialConsole that supports both enabling and disabling, following the existing WithAutoattachGraphicsDevice and WithAutoattachMemBalloon convention.

This also removes the private test helpers withAutoattachSerialConsole and withSerialConsole, as all callers now use the shared public function.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/16575#discussion_r3169566190

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

