### PR TITLE
network/downwardapi: expose MTU in network-info annotation

### DIFF
--- a/pkg/network/downwardapi/networkinfo.go
+++ b/pkg/network/downwardapi/networkinfo.go
@@ -57,6 +57,7 @@ func generateNetworkInfo(networkStatusesByNetworkName map[string]networkv1.Netwo
 				Network:    networkName,
 				DeviceInfo: networkStatus.DeviceInfo,
 				Mac:        networkStatus.Mac,
+				Mtu:        networkStatus.Mtu,
 			},
 		)
 	}

--- a/pkg/network/downwardapi/networkinfo_test.go
+++ b/pkg/network/downwardapi/networkinfo_test.go
@@ -35,12 +35,12 @@ var _ = Describe("Network info", func() {
 		deviceInfoFoo := &networkv1.DeviceInfo{Type: "fooType"}
 
 		networkStatusByNetworkName := map[string]networkv1.NetworkStatus{
-			"foo": {Interface: "pod2c26b46b68f", DeviceInfo: deviceInfoFoo},
+			"foo": {Interface: "pod2c26b46b68f", DeviceInfo: deviceInfoFoo, Mtu: 1500},
 			"boo": {Interface: "pod6446d58d6df"},
 		}
 
 		expectedInterfaces := []downwardapi.Interface{
-			{Network: "foo", DeviceInfo: deviceInfoFoo},
+			{Network: "foo", DeviceInfo: deviceInfoFoo, Mtu: 1500},
 			{Network: "boo"},
 		}
 
@@ -63,15 +63,15 @@ var _ = Describe("Network info", func() {
 		deviceInfo3 := &networkv1.DeviceInfo{Type: "type3"}
 
 		networkStatusByNetworkName1 := map[string]networkv1.NetworkStatus{
-			"netA": {Interface: "pod33219a16a42", Mac: "0c:42:a1:22:a3:52", DeviceInfo: deviceInfo1},
-			"netB": {Interface: "pod034d3d19642", Mac: "0c:42:a1:22:a3:53", DeviceInfo: deviceInfo2},
+			"netA": {Interface: "pod33219a16a42", Mac: "0c:42:a1:22:a3:52", DeviceInfo: deviceInfo1, Mtu: 1500},
+			"netB": {Interface: "pod034d3d19642", Mac: "0c:42:a1:22:a3:53", DeviceInfo: deviceInfo2, Mtu: 9000},
 			"netC": {Interface: "pod01783857d47", Mac: "0c:42:a1:22:a3:54", DeviceInfo: deviceInfo3},
 		}
 
 		networkStatusByNetworkName2 := map[string]networkv1.NetworkStatus{
 			"netC": {Interface: "pod01783857d47", Mac: "0c:42:a1:22:a3:54", DeviceInfo: deviceInfo3},
-			"netB": {Interface: "pod034d3d19642", Mac: "0c:42:a1:22:a3:53", DeviceInfo: deviceInfo2},
-			"netA": {Interface: "pod33219a16a42", Mac: "0c:42:a1:22:a3:52", DeviceInfo: deviceInfo1},
+			"netB": {Interface: "pod034d3d19642", Mac: "0c:42:a1:22:a3:53", DeviceInfo: deviceInfo2, Mtu: 9000},
+			"netA": {Interface: "pod33219a16a42", Mac: "0c:42:a1:22:a3:52", DeviceInfo: deviceInfo1, Mtu: 1500},
 		}
 
 		annotationValue1 := downwardapi.CreateNetworkInfoAnnotationValue(networkStatusByNetworkName1)
@@ -84,8 +84,8 @@ var _ = Describe("Network info", func() {
 
 		expectedNetworkInfo := downwardapi.NetworkInfo{
 			Interfaces: []downwardapi.Interface{
-				{Network: "netA", Mac: "0c:42:a1:22:a3:52", DeviceInfo: &networkv1.DeviceInfo{Type: "type1"}},
-				{Network: "netB", Mac: "0c:42:a1:22:a3:53", DeviceInfo: &networkv1.DeviceInfo{Type: "type2"}},
+				{Network: "netA", Mac: "0c:42:a1:22:a3:52", DeviceInfo: &networkv1.DeviceInfo{Type: "type1"}, Mtu: 1500},
+				{Network: "netB", Mac: "0c:42:a1:22:a3:53", DeviceInfo: &networkv1.DeviceInfo{Type: "type2"}, Mtu: 9000},
 				{Network: "netC", Mac: "0c:42:a1:22:a3:54", DeviceInfo: &networkv1.DeviceInfo{Type: "type3"}},
 			},
 		}

--- a/pkg/network/downwardapi/types.go
+++ b/pkg/network/downwardapi/types.go
@@ -25,6 +25,7 @@ type Interface struct {
 	Network    string         `json:"network"`
 	DeviceInfo *v1.DeviceInfo `json:"deviceInfo,omitempty"`
 	Mac        string         `json:"mac,omitempty"`
+	Mtu        int            `json:"mtu,omitempty"`
 }
 
 type NetworkInfo struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Some network binding plugins need the interface MTU to configure guest networking correctly. CNI plugins already report it in the Multus network status annotation, but the network-info downward API did not propagate it.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

~~Depends on #17980, please skip the first commit.~~

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network binding plugins can now read the interface MTU from the network-info downward API annotation.
```

