### PR TITLE
virt-api: add X-Content-Type-Options: nosniff security header on all subresource API responses

### DIFF
--- a/pkg/rest/filter/BUILD.bazel
+++ b/pkg/rest/filter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -8,5 +8,21 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/emicklei/go-restful/v3:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "filter_suite_test.go",
+        "filter_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/emicklei/go-restful/v3:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/rest/filter/filter.go
+++ b/pkg/rest/filter/filter.go
@@ -27,6 +27,13 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
+func SecurityHeadersFilter() restful.FilterFunction {
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		resp.Header().Set("X-Content-Type-Options", "nosniff")
+		chain.ProcessFilter(req, resp)
+	}
+}
+
 func RequestLoggingFilter() restful.FilterFunction {
 	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 		var username = "-"

--- a/pkg/rest/filter/filter_suite_test.go
+++ b/pkg/rest/filter/filter_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package filter
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestFilter(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/rest/filter/filter_test.go
+++ b/pkg/rest/filter/filter_test.go
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package filter_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	restful "github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/rest/filter"
+)
+
+const (
+	xContentTypeOptions      = "X-Content-Type-Options"
+	xContentTypeOptionsValue = "nosniff"
+	someOtherValue           = "some-other-value"
+)
+
+var _ = Describe("SecurityHeadersFilter", func() {
+	var (
+		recorder *httptest.ResponseRecorder
+		req      *restful.Request
+		resp     *restful.Response
+	)
+
+	BeforeEach(func() {
+		recorder = httptest.NewRecorder()
+		req = restful.NewRequest(&http.Request{})
+		resp = restful.NewResponse(recorder)
+	})
+
+	It("should set X-Content-Type-Options to nosniff", func() {
+		chain := &restful.FilterChain{
+			Filters: []restful.FilterFunction{filter.SecurityHeadersFilter()},
+			Target:  func(_ *restful.Request, _ *restful.Response) {},
+		}
+		chain.ProcessFilter(req, resp)
+
+		Expect(recorder.Header().Get(xContentTypeOptions)).To(Equal(xContentTypeOptionsValue))
+	})
+
+	It("should allow a target handler to override X-Content-Type-Options", func() {
+		// SecurityHeadersFilter sets the header before calling the chain, so a target
+		// handler that explicitly sets the same header afterwards takes precedence.
+		// Handlers in this codebase should not override this header.
+		chain := &restful.FilterChain{
+			Filters: []restful.FilterFunction{filter.SecurityHeadersFilter()},
+			Target: func(_ *restful.Request, resp *restful.Response) {
+				resp.Header().Set(xContentTypeOptions, someOtherValue)
+			},
+		}
+		chain.ProcessFilter(req, resp)
+
+		Expect(recorder.Header().Get(xContentTypeOptions)).To(Equal(someOtherValue))
+	})
+})

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -897,6 +897,10 @@ func (app *virtAPIApp) Compose() {
 
 	app.composeSubresources()
 
+	// SecurityHeadersFilter is registered first so security headers are set before
+	// any other filter runs, ensuring they are present even if a later filter
+	// (e.g. OPTIONSFilter) short-circuits the chain without calling the handler.
+	restful.Filter(filter.SecurityHeadersFilter())
 	restful.Filter(filter.RequestLoggingFilter())
 	restful.Filter(restful.OPTIONSFilter())
 	restful.Filter(func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {


### PR DESCRIPTION
## What this PR does
Adds a SecurityHeadersFilter to the virt-api go-restful filter chain that sets the X-Content-Type-Options: nosniff response header on all subresource API endpoints.

#### Before this PR:
The virt-api subresource endpoints (/healthz, /version, /guestfs, and all v1/v1alpha3 subresource routes) did not include the X-Content-Type-Options header in their responses.
This allowed browsers to perform MIME-type sniffing on responses, which was flagged as a security finding by ZAP (OWASP Zed Attack Proxy).

#### After this PR:
All responses from virt-api subresource endpoints include the X-Content-Type-Options: nosniff header. This instructs browsers not to sniff the MIME type of responses, preventing potential content-type confusion attacks. The filter is registered globally in the go-restful filter chain, so it applies to all routes automatically. Unit tests are included to verify the filter sets the header correctly.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
fix/x-content-type-options-headerApprovers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
virt-api: add X-Content-Type-Options: nosniff security header
```

