### PR TITLE
DNM - virt-launcher: add duration logging to SyncVMI call chain

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -823,6 +823,10 @@ func (l *LibvirtDomainManager) generateCloudInitEmptyISO(vmi *v1.VirtualMachineI
 // made to the domain will get set in libvirt after this function exits.
 func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, domain *api.Domain, generateEmptyIsos bool, options *cmdv1.VirtualMachineOptions) (*api.Domain, error) {
 	logger := log.Log.Object(vmi)
+	preStartHookStart := time.Now()
+	defer func() {
+		logger.Infof("preStartHook completed in %v", time.Since(preStartHookStart))
+	}()
 
 	logger.Info("Executing PreStartHook on VMI pod environment")
 
@@ -1274,6 +1278,10 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 	defer l.domainModifyLock.Unlock()
 
 	logger := log.Log.Object(vmi)
+	syncStart := time.Now()
+	defer func() {
+		logger.Infof("SyncVMI total time: %v", time.Since(syncStart))
+	}()
 
 	domain := &api.Domain{}
 
@@ -1475,18 +1483,21 @@ func (l *LibvirtDomainManager) startDomain(
 	dom cli.VirDomain,
 ) error {
 	logger := log.Log.Object(vmi)
+	startDomainStart := time.Now()
 	if err := l.generateCloudInitISO(vmi, &dom); err != nil {
 		return err
 	}
+	logger.Infof("startDomain: generateCloudInitISO completed in %v", time.Since(startDomainStart))
 
 	createFlags := getDomainCreateFlags(vmi)
+	createStart := time.Now()
 	if err := dom.CreateWithFlags(createFlags); err != nil {
 		logger.Reason(err).
 			Errorf("Failed to start VirtualMachineInstance with flags %v.", createFlags)
 		return err
 	}
 
-	logger.Info("Domain started.")
+	logger.Infof("startDomain: CreateWithFlags completed in %v (total: %v)", time.Since(createStart), time.Since(startDomainStart))
 	if vmi.ShouldStartPaused() {
 		l.paused.add(vmi.UID)
 	}
@@ -1499,9 +1510,11 @@ func (l *LibvirtDomainManager) lookupOrCreateVirDomain(
 	options *cmdv1.VirtualMachineOptions,
 ) (cli.VirDomain, error) {
 	logger := log.Log.Object(vmi)
+	start := time.Now()
 
 	dom, err := l.virConn.LookupDomainByName(domain.Spec.Name)
 	if err == nil {
+		logger.Infof("lookupOrCreateVirDomain found existing domain in %v", time.Since(start))
 		return dom, nil
 	}
 
@@ -1525,7 +1538,7 @@ func (l *LibvirtDomainManager) lookupOrCreateVirDomain(
 	l.metadataCache.GracePeriod.Set(
 		api.GracePeriodMetadata{DeletionGracePeriodSeconds: converter.GracePeriodSeconds(vmi)},
 	)
-	logger.Info("Domain defined.")
+	logger.Infof("lookupOrCreateVirDomain created new domain in %v", time.Since(start))
 	return dom, err
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

No timing instrumentation in the SyncVMI call chain. When the 20s gRPC deadline is exceeded we cannot tell which step is slow from virt-launcher pod logs.

#### After this PR:

Elapsed-time logging is added to the key functions in the SyncVMI call chain:
- `SyncVMI()` — total duration
- `preStartHook()` — pre-start setup (networking, disks, cloud-init, etc.)
- `lookupOrCreateVirDomain()` — domain lookup vs creation (includes preStartHook + DomainDefineXML)
- `startDomain()` — generateCloudInitISO + CreateWithFlags (QEMU start) broken out separately

### References

- Partially addresses the ARM64 CI flake pattern where SyncVMI hits DeadlineExceeded:
  `unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded`
- Related existing ignore in SR-IOV tests: https://github.com/kubevirt/kubevirt/issues/5027

### Why we need it and why it was done in this way

ARM64 CI lanes (`pull-kubevirt-e2e-kind-1.35-sig-compute-arm64`) are intermittently hitting the hardcoded 20s SyncVMI gRPC deadline during initial domain creation. The VMI recovers on retry but the tests fail due to `FailOnWarnings` catching the transient `SyncFailed` warning event.

The 20s timeout is hardcoded in `pkg/virt-handler/cmd-client/client.go` (`longTimeout`). Before considering making it configurable or increasing it, we need to understand **which step** in the SyncVMI path is slow on ARM64. This PR adds the minimum instrumentation needed to get that data from CI artifacts.

The following tradeoffs were made:
- Only top-level function timing, not per-step within `preStartHook` (which has ~15 sub-steps). If `preStartHook` shows as the bottleneck, we can add finer-grained logging in a follow-up.

The following alternatives were considered:
- Ignoring the SyncVMI DeadlineExceeded warning in affected tests (pattern already used in SR-IOV tests). Rejected because it masks the symptom without understanding the root cause.
- Increasing the `longTimeout` constant. Rejected as premature without profiling data.

### Special notes for your reviewer

This is a draft to run the ARM64 CI lane and capture timing data from a failure. The logging is lightweight (one Info-level line per function) and uses the existing `log.Log.Object(vmi).Infof()` pattern.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```