### PR TITLE
featuregate: warn when enabled gate is missing a dependency

### DIFF
--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 const (
@@ -316,6 +317,10 @@ func setConfigFromKubeVirt(config *v1.KubeVirtConfiguration, kv *v1.KubeVirt) er
 	}
 	// set default architecture from status of CR
 	config.ArchitectureConfiguration.DefaultArchitecture = kv.Status.DefaultArchitecture
+
+	for _, warning := range featuregate.DependencyWarnings(config.DeveloperConfiguration.FeatureGates) {
+		log.DefaultLogger().Warning(warning)
+	}
 
 	return validateConfig(config)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -267,5 +267,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ContainerPathVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: ReservedOverheadMemlock, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: OptOutRoleAggregation, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: VGPULiveMigration, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: VGPULiveMigration, State: Alpha, Dependencies: []string{LibvirtHooksServerAndClient}})
 }

--- a/pkg/virt-config/featuregate/feature-gates.go
+++ b/pkg/virt-config/featuregate/feature-gates.go
@@ -51,10 +51,11 @@ const (
 )
 
 type FeatureGate struct {
-	Name        string
-	State       State
-	VmiSpecUsed func(spec *v1.VirtualMachineInstanceSpec) bool
-	Message     string
+	Name         string
+	State        State
+	VmiSpecUsed  func(spec *v1.VirtualMachineInstanceSpec) bool
+	Message      string
+	Dependencies []string
 }
 
 var featureGates = map[string]FeatureGate{}
@@ -66,6 +67,11 @@ var featureGates = map[string]FeatureGate{}
 func RegisterFeatureGate(fg FeatureGate) {
 	if fg.State != Alpha && fg.State != Beta && fg.Message == "" {
 		fg.Message = fmt.Sprintf(WarningPattern, fg.Name, fg.State)
+	}
+	for _, dep := range fg.Dependencies {
+		if _, exists := featureGates[dep]; !exists {
+			panic(fmt.Sprintf("feature gate %q declares dependency on unregistered gate %q", fg.Name, dep))
+		}
 	}
 	featureGates[fg.Name] = fg
 }
@@ -109,4 +115,32 @@ func IsEnabled(gate string, devConfig *v1.DeveloperConfiguration) bool {
 	}
 
 	return fg.State == Beta
+}
+
+// DependencyWarnings returns a warning message for each enabled feature gate
+// whose declared dependencies are not also enabled.
+func DependencyWarnings(enabledGates []string) []string {
+	enabledSet := make(map[string]struct{}, len(enabledGates))
+	for _, g := range enabledGates {
+		enabledSet[g] = struct{}{}
+	}
+
+	var warnings []string
+	for _, name := range enabledGates {
+		fg := FeatureGateInfo(name)
+		if fg == nil {
+			continue
+		}
+		for _, dep := range fg.Dependencies {
+			depFG := FeatureGateInfo(dep)
+			if depFG != nil && depFG.State == GA {
+				continue
+			}
+			if _, enabled := enabledSet[dep]; !enabled {
+				warnings = append(warnings, fmt.Sprintf(
+					"feature gate %q requires %q to also be enabled", name, dep))
+			}
+		}
+	}
+	return warnings
 }

--- a/pkg/virt-config/featuregate/feature-gates_test.go
+++ b/pkg/virt-config/featuregate/feature-gates_test.go
@@ -134,4 +134,50 @@ var _ = Describe("Feature Gate", func() {
 		Expect(featuregate.FeatureGateInfo(fg1.Name)).To(Equal(&fg1clone))
 		Expect(featuregate.FeatureGateInfo(fg2.Name)).To(Equal(&fg2))
 	})
+
+	Context("DependencyWarnings", func() {
+		const (
+			fgA = "fg-a"
+			fgB = "fg-b"
+		)
+
+		BeforeEach(func() {
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: fgB, State: featuregate.Alpha})
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: fgA, State: featuregate.Alpha, Dependencies: []string{fgB}})
+			DeferCleanup(featuregate.UnregisterFeatureGate, fgA)
+			DeferCleanup(featuregate.UnregisterFeatureGate, fgB)
+		})
+
+		It("returns no warnings when all dependencies are enabled", func() {
+			Expect(featuregate.DependencyWarnings([]string{fgA, fgB})).To(BeEmpty())
+		})
+
+		It("returns a warning when a dependency is missing", func() {
+			warnings := featuregate.DependencyWarnings([]string{fgA})
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring(fgA))
+			Expect(warnings[0]).To(ContainSubstring(fgB))
+		})
+
+		It("returns no warnings when no feature gates are enabled", func() {
+			Expect(featuregate.DependencyWarnings([]string{})).To(BeEmpty())
+		})
+
+		It("panics when registering a gate with an unknown dependency", func() {
+			Expect(func() {
+				featuregate.RegisterFeatureGate(featuregate.FeatureGate{
+					Name: "fg-bad", State: featuregate.Alpha, Dependencies: []string{"nonexistent-gate"},
+				})
+			}).To(Panic())
+		})
+
+		It("returns no warnings when a dependency is GA", func() {
+			const fgGA = "fg-ga"
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: fgGA, State: featuregate.GA})
+			DeferCleanup(featuregate.UnregisterFeatureGate, fgGA)
+
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: fgA, State: featuregate.Alpha, Dependencies: []string{fgGA}})
+			Expect(featuregate.DependencyWarnings([]string{fgA})).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
### What this PR does

#### Before this PR
Enabling a feature gate that depends on another feature gate (for example, `VGPULiveMigration` requiring `LibvirtHooksServerAndClient`) could silently fail at migration time with a cryptic error.

#### After this PR
A warning is logged during config load time to clearly indicate which dependency is missing before any VM migration is attempted.

### Why we need it and why it was implemented this way

The following tradeoffs were made:

- A warning is logged instead of blocking configuration validation. The dependency is already enforced at runtime in `manager.go`, so this change improves early visibility rather than introducing a new constraint.

The following alternatives were considered:

- Surfacing the issue as a KubeVirt CR status condition. This was left for a follow-up since it requires additional plumbing.

### Special notes for your reviewer

`DependencyWarnings` skips GA dependencies because they are always enabled and never need to be declared explicitly.

### Checklist

- [x] Design: not required — no API change
- [x] PR description covers motivation and tradeoffs
- [x] Code is single-purpose with no unnecessary abstractions
- [x] Unit tests added for `DependencyWarnings`
- [x] Documentation: not required — operator-facing via logs only

```release-note
Feature gates can now declare dependencies. A warning is logged when an
enabled feature gate does not have its required dependency enabled.
```