### PR TITLE
Add links to AI contribution policy (k/community) in kubevirt docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,16 @@ This can be done by adding [`--signoff`](https://git-scm.com/docs/git-commit#Doc
 
 For commit message formatting guidelines, see [Commit message guidelines](docs/commit-message-guidelines.md).
 
+### AI-assisted contributions
+
+Contributors using AI tools (LLMs, code generation, etc.) should familiarize themselves with the project's [AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md). Key requirements include:
+
+- Disclosure of AI tool use via commit trailers (e.g., `Assisted-by: Code Assistant <noreply@example.com>`)
+- Thorough review and ownership of all AI-generated content
+- Compliance with DCO requirements
+
+See the full policy for details on when disclosure is required and acceptable uses of AI tools.
+
 ### Getting your code reviewed/merged
 
 Maintainers are here to help you enabling your use-case in a reasonable amount

--- a/README.md
+++ b/README.md
@@ -108,11 +108,16 @@ they have the legal right to submit the code. This is achieved by adding a line
     Signed-off-by: Real Name <email@address.com>
 
 to the bottom of every commit message. Existence of such a line certifies
-that the submitter has complied with the Developer's Certificate of Origin 1.1,
-(as defined in the file docs/developer-certificate-of-origin).
+that the submitter has complied with the [Developer's Certificate of Origin](docs/developer-certificate-of-origin).
 
 This line can be automatically added to a commit in the correct format, by
 using the '-s' option to 'git commit'.
+
+For more details on contributing, see the [contribution guide](https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md).
+
+### AI-assisted contributions
+
+Contributors using AI tools should review and follow the [AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md), which includes disclosure requirements and guidelines for responsible AI use.
 
 ## License
 


### PR DESCRIPTION
Updating the README.md and CONTRIBUTING.md to reference and link to our (relatively) new AI Contribution Policy in k/community.

* README.md: High-level overview and link. Also added relevant missing links in Submitting patches section.
* CONTRIBUTING.md: More detailed summary and link.


### Special notes for your reviewer

I was tempted to change the "Co-authored-by: Claude <noreply@anthropic.com>" to a generic "Co-authored-by: _agent_@_email_>" so as not to promote a single company/agent but thought it looked a bit naff. Happy to change it though. 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

