### PR TITLE
[release-1.8] kvm: scale VFIO memory overhead for memlock accounting

### DIFF
--- a/pkg/hypervisor/kvm/hypervisorbackend_test.go
+++ b/pkg/hypervisor/kvm/hypervisorbackend_test.go
@@ -365,3 +365,58 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 		)
 	})
 })
+
+var _ = Describe("CalculateMemlockSize", func() {
+	var runtime *kvm.KvmVirtRuntime
+
+	BeforeEach(func() {
+		runtime = kvm.NewKvmVirtRuntime(nil, nil)
+	})
+
+	DescribeTable("should scale memlock per VFIO device", func(devices v1.Devices, expectedExtraDevices int) {
+		vmi := &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmi"},
+			Spec: v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					Resources: v1.ResourceRequirements{
+						Requests: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+					Devices: devices,
+				},
+			},
+		}
+		vmiBaseline := vmi.DeepCopy()
+		vmiBaseline.Spec.Domain.Devices = v1.Devices{}
+
+		config := &v1.KubeVirtConfiguration{}
+		size := runtime.CalculateMemlockSize(vmi, config)
+		baselineSize := runtime.CalculateMemlockSize(vmiBaseline, config)
+
+		guestMem := int64(8 * 1024 * 1024 * 1024)
+		vfioBase := int64(1024 * 1024 * 1024)
+		expectedDiff := vfioBase + guestMem*int64(expectedExtraDevices)
+
+		Expect(size.Value() - baselineSize.Value()).To(BeNumerically("~", expectedDiff, 1024*1024))
+	},
+		Entry("single GPU adds 1Gi VFIO overhead only",
+			v1.Devices{GPUs: []v1.GPU{{Name: "gpu1"}}}, 0),
+		Entry("2 GPUs add 1Gi + 1x guest_memory",
+			v1.Devices{GPUs: []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}}}, 1),
+		Entry("3 GPUs add 1Gi + 2x guest_memory",
+			v1.Devices{GPUs: []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}, {Name: "gpu3"}}}, 2),
+		Entry("2 HostDevices add 1Gi + 1x guest_memory",
+			v1.Devices{HostDevices: []v1.HostDevice{{Name: "dev1"}, {Name: "dev2"}}}, 1),
+		Entry("mixed GPU and HostDevice add 1Gi + 1x guest_memory",
+			v1.Devices{
+				GPUs:        []v1.GPU{{Name: "gpu1"}},
+				HostDevices: []v1.HostDevice{{Name: "dev1"}},
+			}, 1),
+		Entry("2 SRIOV interfaces add 1Gi + 1x guest_memory",
+			v1.Devices{Interfaces: []v1.Interface{
+				{Name: "sriov1", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "sriov2", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+			}}, 1),
+	)
+})

--- a/pkg/hypervisor/kvm/runtime.go
+++ b/pkg/hypervisor/kvm/runtime.go
@@ -88,18 +88,7 @@ func (k *KvmVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config 
 
 	targetProcessID := targetProcess.Pid()
 
-	var memlockSize resource.Quantity
-	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetMemoryOverhead != nil {
-		memlockSize = *vmi.Status.MigrationState.TargetMemoryOverhead
-	} else {
-		// TODO: Remove this fallback once VmiMemoryOverheadReport feature gate is GA
-		// and we are sure that all VMIs include the MemoryOverhead status field
-		memlockSize = k.GetMemoryOverhead(vmi, runtime.GOARCH, config.AdditionalGuestMemoryOverheadRatio)
-	}
-	// Add memory assigned to the VM
-	vmiBaseMemory := getVMIBaseMemory(vmi)
-
-	memlockSize.Add(*resource.NewScaledQuantity(vmiBaseMemory.ScaledValue(resource.Kilo), resource.Kilo))
+	memlockSize := k.CalculateMemlockSize(vmi, config)
 
 	if err := common.SetProcessMemoryLockRLimit(targetProcessID, memlockSize.Value()); err != nil {
 		return fmt.Errorf("failed to set process %d memlock rlimit to %d: %v", targetProcessID, memlockSize.Value(), err)
@@ -108,6 +97,39 @@ func (k *KvmVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config 
 		targetProcess, memlockSize.Value())
 
 	return nil
+}
+
+// CalculateMemlockSize computes the memlock rlimit needed for the QEMU process.
+// This includes the memory overhead, guest memory, and additional per-device
+// memory for multi-device VFIO passthrough.
+func (k *KvmVirtRuntime) CalculateMemlockSize(vmi *v1.VirtualMachineInstance, config *v1.KubeVirtConfiguration) resource.Quantity {
+	var memlockSize resource.Quantity
+	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetMemoryOverhead != nil {
+		memlockSize = *vmi.Status.MigrationState.TargetMemoryOverhead
+	} else {
+		// TODO: Remove this fallback once VmiMemoryOverheadReport feature gate is GA
+		// and we are sure that all VMIs include the MemoryOverhead status field
+		memlockSize = k.GetMemoryOverhead(vmi, runtime.GOARCH, config.AdditionalGuestMemoryOverheadRatio)
+	}
+
+	vmiBaseMemory := getVMIBaseMemory(vmi)
+	memlockSize.Add(*resource.NewScaledQuantity(vmiBaseMemory.ScaledValue(resource.Kilo), resource.Kilo))
+
+	// With a vIOMMU, libvirt locks N * guest_memory for N VFIO devices
+	// (qemuDomainGetMemLockLimitBytes, since libvirt v8.7.0). Each
+	// device gets a separate AddressSpace mapping full guest RAM. The
+	// base overhead already includes 1 * guest_memory, so add (N-1)
+	// more. We apply this unconditionally rather than checking for a
+	// vIOMMU because the domain XML is not yet available at this point
+	// and the over-reservation is harmless — it only raises the rlimit
+	// ceiling without consuming actual memory.
+	if numDevices := util.CountVFIODevices(vmi); numDevices > 1 {
+		extra := vmiBaseMemory.DeepCopy()
+		extra.Set(extra.Value() * int64(numDevices-1))
+		memlockSize.Add(extra)
+	}
+
+	return memlockSize
 }
 
 func getVMIBaseMemory(vmi *v1.VirtualMachineInstance) *resource.Quantity {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -46,15 +46,6 @@ func IsNonRootVMI(vmi *v1.VirtualMachineInstance) bool {
 	return ok || nonRoot
 }
 
-func isSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.SRIOV != nil {
-			return true
-		}
-	}
-	return false
-}
-
 // Check if a VMI spec requests GPU
 func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
 	if vmi.Spec.Domain.Devices.GPUs != nil && len(vmi.Spec.Domain.Devices.GPUs) != 0 {
@@ -85,11 +76,17 @@ func IsHostDevVMI(vmi *v1.VirtualMachineInstance) bool {
 
 // Check if a VMI spec requests a VFIO device
 func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
+	return CountVFIODevices(vmi) > 0
+}
 
-	if IsHostDevVMI(vmi) || IsGPUVMI(vmi) || isSRIOVVmi(vmi) {
-		return true
+func CountVFIODevices(vmi *v1.VirtualMachineInstance) int {
+	count := len(vmi.Spec.Domain.Devices.GPUs) + len(vmi.Spec.Domain.Devices.HostDevices)
+	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+		if iface.SRIOV != nil {
+			count++
+		}
 	}
-	return false
+	return count
 }
 
 // Check if a VMI spec requests memory overhead

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -102,6 +102,52 @@ var _ = Describe("Host Device VMI Predicates", func() {
 	})
 })
 
+var _ = Describe("CountVFIODevices", func() {
+	DescribeTable("should count VFIO devices correctly",
+		func(devices v1.Devices, expected int) {
+			vmi := &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: devices,
+					},
+				},
+			}
+			Expect(CountVFIODevices(vmi)).To(Equal(expected))
+		},
+		Entry("no devices", v1.Devices{}, 0),
+		Entry("single GPU", v1.Devices{
+			GPUs: []v1.GPU{{Name: "gpu1"}},
+		}, 1),
+		Entry("multiple GPUs", v1.Devices{
+			GPUs: []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}},
+		}, 2),
+		Entry("single HostDevice", v1.Devices{
+			HostDevices: []v1.HostDevice{{Name: "dev1"}},
+		}, 1),
+		Entry("multiple HostDevices", v1.Devices{
+			HostDevices: []v1.HostDevice{{Name: "dev1"}, {Name: "dev2"}},
+		}, 2),
+		Entry("single SRIOV", v1.Devices{
+			Interfaces: []v1.Interface{
+				{Name: "sriov1", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+			},
+		}, 1),
+		Entry("non-SRIOV interfaces are not counted", v1.Devices{
+			Interfaces: []v1.Interface{
+				{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
+			},
+		}, 0),
+		Entry("mixed devices", v1.Devices{
+			GPUs:        []v1.GPU{{Name: "gpu1"}, {Name: "gpu2"}},
+			HostDevices: []v1.HostDevice{{Name: "dev1"}},
+			Interfaces: []v1.Interface{
+				{Name: "sriov1", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
+			},
+		}, 4),
+	)
+})
+
 var _ = DescribeTable("memory overhead reservation requirements",
 	func(vmi *v1.VirtualMachineInstance, expected bool) {
 		res := RequiresMemoryOverheadReservation(vmi)


### PR DESCRIPTION
This is a manual cherrypick of https://github.com/kubevirt/kubevirt/pull/17805

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed multi-device VFIO passthrough VMs failing to start with "cannot limit locked memory" by scaling virt-handler's memlock rlimit to account for per-device memory locking, matching libvirt's calculation introduced in v8.7.0.
```

