### PR TITLE
[POC] dynamic hugepages device plugin

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -235,6 +235,15 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() []Device {
 		}
 	}
 
+	// Dynamic hugepages device plugins: expose dynamically-allocatable hugepages
+	// as device resources so kubelet doesn't subtract them from allocatable memory.
+	// For 2Mi: uses buddy allocator surplus (nr_overcommit_hugepages > 0).
+	// For 1Gi+: requires hugetlb_cma and hugetlb_cma_only kernel params.
+	// TODO: gate behind a feature gate (e.g., DynamicHugepagesDevicePlugin)
+	for _, plugin := range DiscoverHugepageDevicePlugins("") {
+		permittedDevices = append(permittedDevices, plugin)
+	}
+
 	if c.virtConfig.PersistentReservationEnabled() {
 		d, err := NewSocketDevicePlugin(reservation.GetPrResourceName(), reservation.GetPrHelperSocketDir(), reservation.GetPrHelperSocket(), c.maxDevices, selinux.SELinuxExecutor{}, NewPermissionManager(), false)
 		if err != nil {

--- a/pkg/virt-handler/device-manager/hugepages_device.go
+++ b/pkg/virt-handler/device-manager/hugepages_device.go
@@ -1,0 +1,491 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package device_manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"google.golang.org/grpc"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/util"
+	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
+)
+
+const (
+	dynamicHugepageResourcePrefix = "dynamic-hugepages"
+
+	// Kernel sysfs path (relative to host root).
+	hugepagesSysfsBase = "sys/kernel/mm/hugepages"
+
+	procCmdline = "proc/cmdline"
+
+	overcommitFile = "nr_overcommit_hugepages"
+	nrFile         = "nr_hugepages"
+
+	// Pages with order > giganticOrderThreshold require CMA for runtime
+	// allocation. Order = log2(page_size_bytes / 4096).
+	// Order 10 = 4MiB (still buddy-allocatable). 1Gi = order 18 (CMA).
+	giganticOrderThreshold = 10
+	basePageSizeBytes      = 4096
+)
+
+// HugepagesDevicePlugin exposes dynamically-allocatable hugepages as a
+// Kubernetes device plugin resource. One instance per page size.
+// Each "device" represents one hugepage of that size.
+//
+// For non-gigantic pages (order < 10, e.g. 2Mi): capacity comes from
+// nr_overcommit_hugepages (buddy allocator surplus).
+//
+// For gigantic pages (order >= 10, e.g. 1Gi): capacity comes from
+// hugetlb_cma reservation and requires both hugetlb_cma and
+// hugetlb_cma_only kernel params.
+type HugepagesDevicePlugin struct {
+	devs         []*pluginapi.Device
+	server       *grpc.Server
+	socketPath   string
+	stop         <-chan struct{}
+	health       chan deviceHealth
+	resourceName string
+	done         chan struct{}
+	initialized  bool
+	lock         *sync.Mutex
+	deregistered chan struct{}
+
+	pageSizeKB int64  // page size in kB (e.g., 2048, 1048576)
+	pageLabel  string // normalized label (e.g., "2mi", "1gi")
+	sysfsDir   string // kernel directory name (e.g., "hugepages-2048kB")
+	hostRoot   string // host filesystem root
+}
+
+// DiscoverHugepageDevicePlugins scans the host for dynamically-allocatable
+// hugepage capacity and returns a device plugin for each supported page size.
+//
+//   - Non-gigantic pages (order < 10): enabled if nr_overcommit_hugepages > 0
+//   - Gigantic pages (order >= 10): enabled only if hugetlb_cma AND
+//     hugetlb_cma_only are both set in kernel cmdline
+func DiscoverHugepageDevicePlugins(hostRoot string) []*HugepagesDevicePlugin {
+	if hostRoot == "" {
+		hostRoot = util.HostRootMount
+	}
+
+	cmaConfig := detectCMAConfig(hostRoot)
+
+	sysfsBase := filepath.Join(hostRoot, hugepagesSysfsBase)
+	entries, err := os.ReadDir(sysfsBase)
+	if err != nil {
+		log.DefaultLogger().V(4).Infof("failed to read hugepages sysfs at %s: %v", sysfsBase, err)
+		return nil
+	}
+
+	var plugins []*HugepagesDevicePlugin
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dirName := entry.Name()
+		pageSizeKB, ok := parseHugepageDirName(dirName)
+		if !ok {
+			continue
+		}
+
+		plugin := newDynamicHugepagesPlugin(pageSizeKB, dirName, hostRoot, cmaConfig)
+		if plugin == nil || len(plugin.devs) == 0 {
+			continue
+		}
+		plugins = append(plugins, plugin)
+	}
+
+	return plugins
+}
+
+// cmaConfiguration holds the parsed hugetlb CMA kernel parameters.
+type cmaConfiguration struct {
+	sizeMiB int64 // hugetlb_cma size in MiB (0 if not set)
+	cmaOnly bool  // hugetlb_cma_only is present
+}
+
+// detectCMAConfig reads the kernel command line for hugetlb_cma= and
+// hugetlb_cma_only parameters.
+func detectCMAConfig(hostRoot string) cmaConfiguration {
+	cmdlinePath := filepath.Join(hostRoot, procCmdline)
+	data, err := os.ReadFile(cmdlinePath)
+	if err != nil {
+		log.DefaultLogger().V(4).Infof("failed to read %s: %v", cmdlinePath, err)
+		return cmaConfiguration{}
+	}
+
+	var config cmaConfiguration
+	for _, param := range strings.Fields(string(data)) {
+		if strings.HasPrefix(param, "hugetlb_cma=") {
+			sizeStr := strings.TrimPrefix(param, "hugetlb_cma=")
+			config.sizeMiB = parseMemorySize(sizeStr)
+		}
+		if param == "hugetlb_cma_only" {
+			config.cmaOnly = true
+		}
+	}
+
+	return config
+}
+
+// isGigantic returns true if the page size requires CMA for runtime allocation
+// (order > 10, i.e., page size > 4MiB with 4kB base pages).
+func isGigantic(pageSizeKB int64) bool {
+	pageSizeBytes := pageSizeKB * 1024
+	order := 0
+	for s := int64(basePageSizeBytes); s < pageSizeBytes; s <<= 1 {
+		order++
+	}
+	return order > giganticOrderThreshold
+}
+
+func newDynamicHugepagesPlugin(pageSizeKB int64, sysfsDir, hostRoot string, cma cmaConfiguration) *HugepagesDevicePlugin {
+	pageLabel := pageSizeToLabel(pageSizeKB)
+	deviceName := fmt.Sprintf("%s-%s", dynamicHugepageResourcePrefix, pageLabel)
+
+	var capacity int64
+
+	if isGigantic(pageSizeKB) {
+		// Gigantic pages require both hugetlb_cma and hugetlb_cma_only
+		if cma.sizeMiB <= 0 || !cma.cmaOnly {
+			log.DefaultLogger().V(4).Infof(
+				"skipping gigantic page size %s: requires hugetlb_cma and hugetlb_cma_only (cma=%dMiB, cma_only=%v)",
+				pageLabel, cma.sizeMiB, cma.cmaOnly)
+			return nil
+		}
+		pageSizeMiB := pageSizeKB / 1024
+		capacity = cma.sizeMiB / pageSizeMiB
+	} else {
+		// Non-gigantic pages: use nr_overcommit_hugepages from sysfs
+		sysfsPath := filepath.Join(hostRoot, hugepagesSysfsBase, sysfsDir)
+		overcommit := readSysfsInt(filepath.Join(sysfsPath, overcommitFile))
+		if overcommit <= 0 {
+			log.DefaultLogger().V(4).Infof(
+				"skipping page size %s: nr_overcommit_hugepages is 0", pageLabel)
+			return nil
+		}
+		capacity = overcommit
+	}
+
+	if capacity <= 0 {
+		return nil
+	}
+
+	dpi := &HugepagesDevicePlugin{
+		devs:         make([]*pluginapi.Device, 0, capacity),
+		socketPath:   SocketPath(deviceName),
+		health:       make(chan deviceHealth),
+		resourceName: fmt.Sprintf("%s/%s", DeviceNamespace, deviceName),
+		initialized:  false,
+		lock:         &sync.Mutex{},
+		pageSizeKB:   pageSizeKB,
+		pageLabel:    pageLabel,
+		sysfsDir:     sysfsDir,
+		hostRoot:     hostRoot,
+	}
+
+	for i := int64(0); i < capacity; i++ {
+		dpi.devs = append(dpi.devs, &pluginapi.Device{
+			ID:     fmt.Sprintf("%s-%d", deviceName, i),
+			Health: pluginapi.Healthy,
+		})
+	}
+
+	return dpi
+}
+
+// parseMemorySize parses a kernel memory size string like "16G", "4096M",
+// "8388608K" into MiB.
+func parseMemorySize(s string) int64 {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return 0
+	}
+
+	suffix := s[len(s)-1]
+	numStr := s[:len(s)-1]
+
+	switch suffix {
+	case 'G', 'g':
+		val, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return val * 1024
+	case 'M', 'm':
+		val, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return val
+	case 'K', 'k':
+		val, err := strconv.ParseInt(numStr, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return val / 1024
+	default:
+		val, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return val / (1024 * 1024)
+	}
+}
+
+// parseHugepageDirName extracts the page size in kB from "hugepages-2048kB" → 2048.
+func parseHugepageDirName(dirName string) (int64, bool) {
+	if !strings.HasPrefix(dirName, "hugepages-") || !strings.HasSuffix(dirName, "kB") {
+		return 0, false
+	}
+	sizeStr := dirName[len("hugepages-") : len(dirName)-len("kB")]
+	size, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil || size <= 0 {
+		return 0, false
+	}
+	return size, true
+}
+
+// pageSizeToLabel converts a page size in kB to a Kubernetes-friendly label.
+// Examples: 2048 → "2mi", 1048576 → "1gi", 32768 → "32mi"
+func pageSizeToLabel(pageSizeKB int64) string {
+	sizeMiB := pageSizeKB / 1024
+	if sizeMiB >= 1024 && sizeMiB%1024 == 0 {
+		return fmt.Sprintf("%dgi", sizeMiB/1024)
+	}
+	return fmt.Sprintf("%dmi", sizeMiB)
+}
+
+func readSysfsInt(path string) int64 {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.DefaultLogger().V(4).Infof("failed to read %s: %v", path, err)
+		return 0
+	}
+	val, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		log.DefaultLogger().V(4).Infof("failed to parse %s: %v", path, err)
+		return 0
+	}
+	return val
+}
+
+func (dpi *HugepagesDevicePlugin) GetDeviceName() string {
+	return fmt.Sprintf("%s-%s", dynamicHugepageResourcePrefix, dpi.pageLabel)
+}
+
+func (dpi *HugepagesDevicePlugin) Start(stop <-chan struct{}) (err error) {
+	logger := log.DefaultLogger()
+	dpi.stop = stop
+	dpi.done = make(chan struct{})
+	dpi.deregistered = make(chan struct{})
+
+	if err := dpi.cleanup(); err != nil {
+		return err
+	}
+
+	sock, err := net.Listen("unix", dpi.socketPath)
+	if err != nil {
+		return fmt.Errorf("error creating GRPC server socket: %v", err)
+	}
+
+	dpi.server = grpc.NewServer([]grpc.ServerOption{}...)
+	defer dpi.stopDevicePlugin()
+
+	pluginapi.RegisterDevicePluginServer(dpi.server, dpi)
+
+	errChan := make(chan error, 2)
+
+	go func() {
+		errChan <- dpi.server.Serve(sock)
+	}()
+
+	if err := waitForGRPCServer(dpi.socketPath, connectionTimeout); err != nil {
+		return fmt.Errorf("error starting the GRPC server: %v", err)
+	}
+
+	if err := dpi.register(); err != nil {
+		return fmt.Errorf("error registering with device plugin manager: %v", err)
+	}
+
+	go func() {
+		errChan <- dpi.healthCheck()
+	}()
+
+	dpi.setInitialized(true)
+	logger.Infof("dynamic hugepages device plugin started: %s (pageSize=%s, gigantic=%v, capacity=%d pages)",
+		dpi.resourceName, dpi.pageLabel, isGigantic(dpi.pageSizeKB), len(dpi.devs))
+
+	err = <-errChan
+	return err
+}
+
+func (dpi *HugepagesDevicePlugin) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
+	s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+
+	done := false
+	for {
+		select {
+		case devHealth := <-dpi.health:
+			for _, dev := range dpi.devs {
+				if devHealth.DevId == dev.ID || devHealth.DevId == "" {
+					dev.Health = devHealth.Health
+				}
+			}
+			s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+		case <-dpi.stop:
+			done = true
+		case <-dpi.done:
+			done = true
+		}
+		if done {
+			break
+		}
+	}
+
+	emptyList := []*pluginapi.Device{}
+	if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: emptyList}); err != nil {
+		log.DefaultLogger().Reason(err).Infof("%s device plugin failed to deregister", dpi.pageLabel)
+	}
+	close(dpi.deregistered)
+	return nil
+}
+
+func (dpi *HugepagesDevicePlugin) Allocate(_ context.Context, r *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
+	logger := log.DefaultLogger()
+	logger.Infof("Dynamic Hugepages Allocate: resource=%s, requests=%d", dpi.resourceName, len(r.ContainerRequests))
+
+	response := pluginapi.AllocateResponse{}
+	for _, req := range r.ContainerRequests {
+		logger.Infof("Dynamic Hugepages Allocate: %d x %s pages", len(req.DevicesIDs), dpi.pageLabel)
+		response.ContainerResponses = append(response.ContainerResponses, &pluginapi.ContainerAllocateResponse{})
+	}
+
+	return &response, nil
+}
+
+func (dpi *HugepagesDevicePlugin) PreStartContainer(_ context.Context, _ *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
+	return &pluginapi.PreStartContainerResponse{}, nil
+}
+
+func (dpi *HugepagesDevicePlugin) GetDevicePluginOptions(_ context.Context, _ *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
+	return &pluginapi.DevicePluginOptions{PreStartRequired: false}, nil
+}
+
+func (dpi *HugepagesDevicePlugin) GetInitialized() bool {
+	dpi.lock.Lock()
+	defer dpi.lock.Unlock()
+	return dpi.initialized
+}
+
+func (dpi *HugepagesDevicePlugin) setInitialized(initialized bool) {
+	dpi.lock.Lock()
+	defer dpi.lock.Unlock()
+	dpi.initialized = initialized
+}
+
+func (dpi *HugepagesDevicePlugin) register() error {
+	conn, err := gRPCConnect(pluginapi.KubeletSocket, connectionTimeout)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := pluginapi.NewRegistrationClient(conn)
+	reqt := &pluginapi.RegisterRequest{
+		Version:      pluginapi.Version,
+		Endpoint:     filepath.Base(dpi.socketPath),
+		ResourceName: dpi.resourceName,
+	}
+
+	_, err = client.Register(context.Background(), reqt)
+	return err
+}
+
+func (dpi *HugepagesDevicePlugin) stopDevicePlugin() error {
+	defer func() {
+		if !IsChanClosed(dpi.done) {
+			close(dpi.done)
+		}
+	}()
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	select {
+	case <-dpi.deregistered:
+	case <-ticker.C:
+	}
+
+	dpi.server.Stop()
+	dpi.setInitialized(false)
+	return dpi.cleanup()
+}
+
+func (dpi *HugepagesDevicePlugin) cleanup() error {
+	if err := os.Remove(dpi.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (dpi *HugepagesDevicePlugin) healthCheck() error {
+	logger := log.DefaultLogger()
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create fsnotify watcher: %v", err)
+	}
+	defer watcher.Close()
+
+	socketDir := filepath.Dir(dpi.socketPath)
+	if err := watcher.Add(socketDir); err != nil {
+		return fmt.Errorf("failed to watch socket dir: %v", err)
+	}
+
+	sysfsPath := filepath.Join(dpi.hostRoot, hugepagesSysfsBase, dpi.sysfsDir)
+	if err := watcher.Add(sysfsPath); err != nil {
+		logger.V(4).Infof("failed to watch sysfs hugepages dir %s: %v (non-fatal)", sysfsPath, err)
+	}
+
+	for {
+		select {
+		case <-dpi.stop:
+			return nil
+		case err := <-watcher.Errors:
+			logger.Reason(err).Errorf("error watching dynamic hugepages device plugin")
+		case event := <-watcher.Events:
+			if event.Name == dpi.socketPath && event.Op == fsnotify.Remove {
+				logger.Infof("dynamic hugepages device socket removed, kubelet probably restarted")
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/virt-handler/device-manager/hugepages_device_test.go
+++ b/pkg/virt-handler/device-manager/hugepages_device_test.go
@@ -1,0 +1,269 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package device_manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
+)
+
+var _ = Describe("Dynamic Hugepages Device Plugin", func() {
+
+	Context("isGigantic", func() {
+		It("should classify 2Mi as non-gigantic (order 9)", func() {
+			Expect(isGigantic(2048)).To(BeFalse())
+		})
+
+		It("should classify 4Mi as non-gigantic (order 10)", func() {
+			Expect(isGigantic(4096)).To(BeFalse())
+		})
+
+		It("should classify 1Gi as gigantic (order 18)", func() {
+			Expect(isGigantic(1048576)).To(BeTrue())
+		})
+
+		It("should classify 32Mi as gigantic (order 13)", func() {
+			Expect(isGigantic(32768)).To(BeTrue())
+		})
+	})
+
+	Context("CMA config detection", func() {
+		It("should detect hugetlb_cma and hugetlb_cma_only", func() {
+			tmpDir := setupFakeProc("BOOT_IMAGE=/vmlinuz hugetlb_cma=16G hugetlb_cma_only quiet")
+			cfg := detectCMAConfig(tmpDir + "/")
+			Expect(cfg.sizeMiB).To(Equal(int64(16 * 1024)))
+			Expect(cfg.cmaOnly).To(BeTrue())
+		})
+
+		It("should detect hugetlb_cma without cma_only", func() {
+			tmpDir := setupFakeProc("hugetlb_cma=8G quiet")
+			cfg := detectCMAConfig(tmpDir + "/")
+			Expect(cfg.sizeMiB).To(Equal(int64(8 * 1024)))
+			Expect(cfg.cmaOnly).To(BeFalse())
+		})
+
+		It("should return zeros when neither is set", func() {
+			tmpDir := setupFakeProc("quiet splash")
+			cfg := detectCMAConfig(tmpDir + "/")
+			Expect(cfg.sizeMiB).To(Equal(int64(0)))
+			Expect(cfg.cmaOnly).To(BeFalse())
+		})
+	})
+
+	Context("parseMemorySize", func() {
+		It("should parse G suffix", func() {
+			Expect(parseMemorySize("16G")).To(Equal(int64(16384)))
+			Expect(parseMemorySize("1g")).To(Equal(int64(1024)))
+		})
+
+		It("should parse M suffix", func() {
+			Expect(parseMemorySize("4096M")).To(Equal(int64(4096)))
+		})
+
+		It("should parse K suffix", func() {
+			Expect(parseMemorySize("1048576K")).To(Equal(int64(1024)))
+		})
+
+		It("should return 0 for invalid input", func() {
+			Expect(parseMemorySize("")).To(Equal(int64(0)))
+			Expect(parseMemorySize("abc")).To(Equal(int64(0)))
+		})
+	})
+
+	Context("sysfs directory parsing", func() {
+		It("should parse hugepages-2048kB", func() {
+			size, ok := parseHugepageDirName("hugepages-2048kB")
+			Expect(ok).To(BeTrue())
+			Expect(size).To(Equal(int64(2048)))
+		})
+
+		It("should parse hugepages-1048576kB", func() {
+			size, ok := parseHugepageDirName("hugepages-1048576kB")
+			Expect(ok).To(BeTrue())
+			Expect(size).To(Equal(int64(1048576)))
+		})
+
+		It("should reject invalid names", func() {
+			_, ok := parseHugepageDirName("not-hugepages")
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Context("page size labels", func() {
+		It("should produce correct labels", func() {
+			Expect(pageSizeToLabel(2048)).To(Equal("2mi"))
+			Expect(pageSizeToLabel(1048576)).To(Equal("1gi"))
+			Expect(pageSizeToLabel(32768)).To(Equal("32mi"))
+		})
+	})
+
+	Context("discovery — non-gigantic (2Mi)", func() {
+		It("should create plugin when nr_overcommit_hugepages > 0", func() {
+			tmpDir := setupDynamicNode("quiet", map[string]map[string]string{
+				"hugepages-2048kB": {overcommitFile: "4096", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(HaveLen(1))
+			Expect(plugins[0].pageLabel).To(Equal("2mi"))
+			// 4096 overcommit pages = 4096 devices (one per page)
+			Expect(plugins[0].devs).To(HaveLen(4096))
+			Expect(plugins[0].GetDeviceName()).To(Equal("dynamic-hugepages-2mi"))
+			Expect(plugins[0].resourceName).To(Equal("devices.kubevirt.io/dynamic-hugepages-2mi"))
+		})
+
+		It("should skip when nr_overcommit_hugepages is 0", func() {
+			tmpDir := setupDynamicNode("quiet", map[string]map[string]string{
+				"hugepages-2048kB": {overcommitFile: "0", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(BeEmpty())
+		})
+
+		It("should not require CMA for 2Mi pages", func() {
+			// No hugetlb_cma in cmdline, but overcommit is set
+			tmpDir := setupDynamicNode("quiet", map[string]map[string]string{
+				"hugepages-2048kB": {overcommitFile: "2048", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(HaveLen(1))
+			Expect(plugins[0].devs).To(HaveLen(2048))
+		})
+	})
+
+	Context("discovery — gigantic (1Gi)", func() {
+		It("should create plugin when both hugetlb_cma and hugetlb_cma_only are set", func() {
+			tmpDir := setupDynamicNode("hugetlb_cma=16G hugetlb_cma_only", map[string]map[string]string{
+				"hugepages-1048576kB": {overcommitFile: "0", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(HaveLen(1))
+			Expect(plugins[0].pageLabel).To(Equal("1gi"))
+			// 16Gi = 16384MiB / 1024MiB per page = 16 devices
+			Expect(plugins[0].devs).To(HaveLen(16))
+		})
+
+		It("should skip 1Gi when hugetlb_cma_only is missing", func() {
+			tmpDir := setupDynamicNode("hugetlb_cma=16G", map[string]map[string]string{
+				"hugepages-1048576kB": {overcommitFile: "0", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(BeEmpty())
+		})
+
+		It("should skip 1Gi when hugetlb_cma is missing", func() {
+			tmpDir := setupDynamicNode("hugetlb_cma_only", map[string]map[string]string{
+				"hugepages-1048576kB": {overcommitFile: "0", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(BeEmpty())
+		})
+	})
+
+	Context("discovery — mixed page sizes", func() {
+		It("should create both 2Mi and 1Gi plugins when properly configured", func() {
+			tmpDir := setupDynamicNode("hugetlb_cma=16G hugetlb_cma_only", map[string]map[string]string{
+				"hugepages-2048kB":    {overcommitFile: "8192", nrFile: "0"},
+				"hugepages-1048576kB": {overcommitFile: "0", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(HaveLen(2))
+
+			labels := map[string]int{}
+			for _, p := range plugins {
+				labels[p.pageLabel] = len(p.devs)
+			}
+			// 2Mi: 8192 overcommit pages
+			Expect(labels["2mi"]).To(Equal(8192))
+			// 1Gi: 16Gi CMA / 1Gi = 16
+			Expect(labels["1gi"]).To(Equal(16))
+		})
+
+		It("should only create 2Mi when CMA is not configured", func() {
+			tmpDir := setupDynamicNode("quiet", map[string]map[string]string{
+				"hugepages-2048kB":    {overcommitFile: "4096", nrFile: "0"},
+				"hugepages-1048576kB": {overcommitFile: "0", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(HaveLen(1))
+			Expect(plugins[0].pageLabel).To(Equal("2mi"))
+		})
+	})
+
+	Context("Allocate", func() {
+		It("should return empty response (no mounts — virt-controller handles volumes)", func() {
+			tmpDir := setupDynamicNode("quiet", map[string]map[string]string{
+				"hugepages-2048kB": {overcommitFile: "512", nrFile: "0"},
+			})
+
+			plugins := DiscoverHugepageDevicePlugins(tmpDir + "/")
+			Expect(plugins).To(HaveLen(1))
+
+			req := &pluginapi.AllocateRequest{
+				ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+					{DevicesIDs: []string{"dynamic-hugepages-2mi-0", "dynamic-hugepages-2mi-1"}},
+				},
+			}
+			resp, err := plugins[0].Allocate(context.Background(), req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.ContainerResponses).To(HaveLen(1))
+			Expect(resp.ContainerResponses[0].Mounts).To(BeEmpty())
+		})
+	})
+})
+
+func setupFakeProc(cmdline string) string {
+	tmpDir := GinkgoT().TempDir()
+	procDir := filepath.Join(tmpDir, "proc")
+	Expect(os.MkdirAll(procDir, 0755)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(procDir, "cmdline"), []byte(cmdline), 0644)).To(Succeed())
+	return tmpDir
+}
+
+func setupDynamicNode(cmdline string, pageSizes map[string]map[string]string) string {
+	tmpDir := GinkgoT().TempDir()
+
+	procDir := filepath.Join(tmpDir, "proc")
+	Expect(os.MkdirAll(procDir, 0755)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(procDir, "cmdline"), []byte(cmdline), 0644)).To(Succeed())
+
+	for dirName, files := range pageSizes {
+		sysfsDir := filepath.Join(tmpDir, hugepagesSysfsBase, dirName)
+		Expect(os.MkdirAll(sysfsDir, 0755)).To(Succeed())
+		for name, content := range files {
+			Expect(os.WriteFile(filepath.Join(sysfsDir, name), []byte(content+"\n"), 0644)).To(Succeed())
+		}
+	}
+
+	return tmpDir
+}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1999,6 +1999,10 @@ func (c *VirtualMachineController) handleStartingVMI(
 		return false, err
 	}
 
+	if err := c.setDynamicHugepagesCgroupLimit(vmi, cgroupManager); err != nil {
+		return false, err
+	}
+
 	if err := c.adjustResources(vmi); err != nil {
 		return false, err
 	}
@@ -2017,6 +2021,76 @@ func (c *VirtualMachineController) adjustResources(vmi *v1.VirtualMachineInstanc
 		return fmt.Errorf("failed to adjust resources: %v", err)
 	}
 	return nil
+}
+
+const dynamicHugepagesResourcePrefix = "devices.kubevirt.io/dynamic-hugepages-"
+
+// setDynamicHugepagesCgroupLimit overrides the pod's hugetlb cgroup limit when
+// dynamic hugepages are requested. Kubelet explicitly sets hugetlb limits to 0
+// for page sizes not in the pod's native hugepage resources. Since we bypass
+// native hugepage requests, we must set the cgroup limit ourselves.
+func (c *VirtualMachineController) setDynamicHugepagesCgroupLimit(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	if cgroupManager == nil {
+		return nil
+	}
+
+	var pagesizes []string
+	for resourceName := range vmi.Spec.Domain.Resources.Limits {
+		name := string(resourceName)
+		if !strings.HasPrefix(name, dynamicHugepagesResourcePrefix) {
+			continue
+		}
+		label := strings.TrimPrefix(name, dynamicHugepagesResourcePrefix)
+		pagesize := labelToCgroupPagesize(label)
+		if pagesize == "" {
+			continue
+		}
+		pagesizes = append(pagesizes, pagesize)
+	}
+
+	if len(pagesizes) == 0 {
+		return nil
+	}
+
+	if cgroupManager.GetCgroupVersion() != cgroup.V2 {
+		log.Log.Object(vmi).Warningf("dynamic hugepages cgroup override not supported on cgroups v1, skipping")
+		return nil
+	}
+
+	containerCgroupPath, err := cgroupManager.GetBasePathToHostSubsystem("")
+	if err != nil {
+		return fmt.Errorf("failed to get cgroup path for hugetlb override: %w", err)
+	}
+	podCgroupPath := filepath.Dir(containerCgroupPath)
+
+	for _, pagesize := range pagesizes {
+		maxFile := fmt.Sprintf("hugetlb.%s.max", pagesize)
+		rsvdFile := fmt.Sprintf("hugetlb.%s.rsvd.max", pagesize)
+		log.Log.Object(vmi).Infof("setting dynamic hugepages cgroup limit: writing \"max\" to pod=%s and container=%s", podCgroupPath, containerCgroupPath)
+		for _, file := range []string{maxFile, rsvdFile} {
+			if err := cgroups.WriteFile(podCgroupPath, file, "max"); err != nil {
+				return fmt.Errorf("failed to set hugetlb cgroup limit (pod) %s: %w", file, err)
+			}
+			if err := cgroups.WriteFile(containerCgroupPath, file, "max"); err != nil {
+				return fmt.Errorf("failed to set hugetlb cgroup limit (container) %s: %w", file, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// labelToCgroupPagesize converts a label like "2mi" or "1gi" to the cgroup
+// pagesize format (e.g., "2MB", "1GB").
+func labelToCgroupPagesize(label string) string {
+	label = strings.ToLower(label)
+	if strings.HasSuffix(label, "gi") {
+		return strings.TrimSuffix(label, "gi") + "GB"
+	}
+	if strings.HasSuffix(label, "mi") {
+		return strings.TrimSuffix(label, "mi") + "MB"
+	}
+	return ""
 }
 
 func (c *VirtualMachineController) shouldWaitForSEVAttestation(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1100,6 +1100,13 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		if val := vmi.Annotations[v1.MemfdMemoryBackend]; val != "false" {
 			isMemfdRequired = true
 		}
+	} else if vcpu.DynamicHugepagePageSizeBytes(vmi) > 0 {
+		domain.Spec.MemoryBacking = &api.MemoryBacking{
+			HugePages: &api.HugePages{},
+		}
+		if val := vmi.Annotations[v1.MemfdMemoryBackend]; val != "false" {
+			isMemfdRequired = true
+		}
 	}
 	// virtiofs require shared access
 	if util.IsVMIVirtiofsEnabled(vmi) || netvmispec.HasPasstBinding(vmi) {
@@ -1128,6 +1135,21 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 						Unit:   "KiB",
 					},
 				},
+			}
+		}
+
+		// For dynamic hugepages, explicitly specify the page size per NUMA cell
+		// since there is no hugetlbfs mount for libvirt to infer it from.
+		if pageSize := vcpu.DynamicHugepagePageSizeBytes(vmi); pageSize > 0 {
+			for _, cell := range domain.Spec.CPU.NUMA.Cells {
+				domain.Spec.MemoryBacking.HugePages.HugePage = append(
+					domain.Spec.MemoryBacking.HugePages.HugePage,
+					api.HugePage{
+						Size:    strconv.FormatUint(pageSize/1024, 10),
+						Unit:    "KiB",
+						NodeSet: cell.ID,
+					},
+				)
 			}
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -653,6 +653,8 @@ func numaMapping(vmi *v12.VirtualMachineInstance, domain *api.DomainSpec, topolo
 		return fmt.Errorf("passing through a numa topology is restricted to VMIs with hugepages enabled")
 	}
 	domain.MemoryBacking.Allocation = &api.MemoryAllocation{Mode: api.MemoryAllocationModeImmediate}
+	// Reset any pre-populated page entries; NUMA passthrough sets per-node entries below.
+	domain.MemoryBacking.HugePages.HugePage = nil
 
 	memory, err := QuantityToByte(*GetVirtualMemory(vmi))
 	if err != nil {
@@ -711,9 +713,11 @@ func numaMapping(vmi *v12.VirtualMachineInstance, domain *api.DomainSpec, topolo
 	return nil
 }
 
+const DynamicHugepagesPrefix = "devices.kubevirt.io/dynamic-hugepages-"
+
 func hugePagesInfo(vmi *v12.VirtualMachineInstance, domain *api.DomainSpec) (size uint64, unit string, enabled bool, err error) {
 	if domain.MemoryBacking != nil && domain.MemoryBacking.HugePages != nil {
-		if vmi.Spec.Domain.Memory.Hugepages != nil {
+		if vmi.Spec.Domain.Memory != nil && vmi.Spec.Domain.Memory.Hugepages != nil {
 			quantity, err := resource.ParseQuantity(vmi.Spec.Domain.Memory.Hugepages.PageSize)
 			if err != nil {
 				return 0, "", false, fmt.Errorf("could not parse hugepage value %v: %v", vmi.Spec.Domain.Memory.Hugepages.PageSize, err)
@@ -724,8 +728,47 @@ func hugePagesInfo(vmi *v12.VirtualMachineInstance, domain *api.DomainSpec) (siz
 			}
 			return size.Value, "b", true, nil
 		}
+		if pageSize := DynamicHugepagePageSizeBytes(vmi); pageSize > 0 {
+			return pageSize, "b", true, nil
+		}
 	}
 	return 0, "b", false, nil
+}
+
+// DynamicHugepagePageSizeBytes inspects the VMI resource limits/requests for a
+// dynamic-hugepages-* device and returns the page size in bytes.
+func DynamicHugepagePageSizeBytes(vmi *v12.VirtualMachineInstance) uint64 {
+	for resourceName := range vmi.Spec.Domain.Resources.Limits {
+		if strings.HasPrefix(string(resourceName), DynamicHugepagesPrefix) {
+			return LabelToBytes(strings.TrimPrefix(string(resourceName), DynamicHugepagesPrefix))
+		}
+	}
+	for resourceName := range vmi.Spec.Domain.Resources.Requests {
+		if strings.HasPrefix(string(resourceName), DynamicHugepagesPrefix) {
+			return LabelToBytes(strings.TrimPrefix(string(resourceName), DynamicHugepagesPrefix))
+		}
+	}
+	return 0
+}
+
+// LabelToBytes converts a resource label suffix like "2mi" or "1gi" to bytes.
+func LabelToBytes(label string) uint64 {
+	label = strings.ToLower(label)
+	if strings.HasSuffix(label, "gi") {
+		val, err := strconv.ParseUint(strings.TrimSuffix(label, "gi"), 10, 64)
+		if err != nil {
+			return 0
+		}
+		return val * 1024 * 1024 * 1024
+	}
+	if strings.HasSuffix(label, "mi") {
+		val, err := strconv.ParseUint(strings.TrimSuffix(label, "mi"), 10, 64)
+		if err != nil {
+			return 0
+		}
+		return val * 1024 * 1024
+	}
+	return 0
 }
 
 func isAMD64VMI(vmi *v12.VirtualMachineInstance) bool {


### PR DESCRIPTION
dynamically allocated hugepages via overcommit.

Set desired capacity on a node in nr_overcommit_hugepages per hugepage size, e.g. echo 8192 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_overcommit_hugepages

Gigapages need CMA, e.g. cmdline "hugetlb_cma=64G hugetlb_cma_only" and kernel 6.19+.

match the pages to the size like:
domain:
  memory:
    guest: 8Gi
  resources:
    limits:
      devices.kubevirt.io/dynamic-hugepages-2mi: "4096"  # 4096 x 2Mi = 8Gi
or
      devices.kubevirt.io/dynamic-hugepages-1gi: "8"  # 8 x 1Gi = 8Gi


Assisted-by: claude-4.6-opus

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

