### PR TITLE
Add kubevirt_vmi_host_device_info metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -41,6 +41,7 @@
 | kubevirt_vmi_guest_load_1m | Metric | Gauge | Guest system load average over 1 minute as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above. |
 | kubevirt_vmi_guest_load_5m | Metric | Gauge | Guest system load average over 5 minutes as reported by the guest agent. Load is defined as the number of processes in the runqueue or waiting for disk I/O. Requires qemu-guest-agent version 10.0.0 or above. |
 | kubevirt_vmi_guest_os_panic_total | Metric | Counter | Total number of guest OS panic events detected, partitioned by VMI and panic type. |
+| kubevirt_vmi_host_device_info | Metric | Gauge | Information about host devices assigned to the VMI. |
 | kubevirt_vmi_info | Metric | Gauge | Information about VirtualMachineInstances. |
 | kubevirt_vmi_last_api_connection_timestamp_seconds | Metric | Gauge | Virtual Machine Instance last API connection timestamp. Including VNC, console, portforward, SSH and usbredir connections. |
 | kubevirt_vmi_launcher_memory_overhead_bytes | Metric | Gauge | Estimation of the memory amount required for virt-launcher's infrastructure components (e.g. libvirt, QEMU). |

--- a/pkg/monitoring/metrics/virt-handler/domainstats/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "dirty_rate_scrapper.go",
         "domainstats.go",
         "filesystem_metrics.go",
+        "hostdevice_metrics.go",
         "memory_metrics.go",
         "network_metrics.go",
         "node_cpu_affinity_metrics.go",
@@ -23,6 +24,7 @@ go_library(
     deps = [
         "//pkg/monitoring/metrics/virt-handler/collector:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
@@ -41,6 +43,7 @@ go_test(
         "domainstats_suite_test.go",
         "domainstats_test.go",
         "filesystem_metrics_test.go",
+        "hostdevice_metrics_test.go",
         "memory_metrics_test.go",
         "network_metrics_test.go",
         "node_cpu_affinity_metrics_test.go",
@@ -51,6 +54,7 @@ go_test(
     deps = [
         "//pkg/monitoring/metrics/testing:go_default_library",
         "//pkg/monitoring/metrics/virt-handler/collector:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",

--- a/pkg/monitoring/metrics/virt-handler/domainstats/collector.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/collector.go
@@ -42,6 +42,7 @@ var (
 		networkMetrics{},
 		cpuAffinityMetrics{},
 		filesystemMetrics{},
+		hostDeviceMetrics{},
 	}
 
 	Collector = operatormetrics.Collector{

--- a/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/domainstats.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 	k6tv1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
 
@@ -43,6 +44,7 @@ type VirtualMachineInstanceReport struct {
 }
 
 type VirtualMachineInstanceStats struct {
+	Domain      *api.Domain
 	DomainStats *stats.DomainStats
 	FsStats     k6tv1.VirtualMachineInstanceFileSystemList
 }

--- a/pkg/monitoring/metrics/virt-handler/domainstats/hostdevice_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/hostdevice_metrics.go
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package domainstats
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+var hostDeviceInfo = operatormetrics.NewGauge(
+	operatormetrics.MetricOpts{
+		Name: "kubevirt_vmi_host_device_info",
+		Help: "Information about host devices assigned to the VMI.",
+	},
+)
+
+type hostDeviceMetrics struct{}
+
+func (hostDeviceMetrics) Describe() []operatormetrics.Metric {
+	return []operatormetrics.Metric{
+		hostDeviceInfo,
+	}
+}
+
+func (hostDeviceMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operatormetrics.CollectorResult {
+	var crs []operatormetrics.CollectorResult
+
+	if vmiReport.vmiStats.Domain == nil {
+		return crs
+	}
+
+	for _, hostDev := range vmiReport.vmiStats.Domain.Spec.Devices.HostDevices {
+		labels := map[string]string{}
+
+		if hostDev.Alias != nil {
+			labels["alias"] = hostDev.Alias.GetName()
+		}
+
+		if hostDev.Address != nil && hostDev.Address.Type == api.AddressPCI {
+			labels["pci_bus_id"] = formatPCIBusID(hostDev.Address)
+		}
+
+		crs = append(crs, vmiReport.newCollectorResultWithLabels(hostDeviceInfo, 1, labels))
+	}
+
+	return crs
+}
+
+func formatPCIBusID(addr *api.Address) string {
+	domain, errDomain := parseHex(addr.Domain)
+	bus, errBus := parseHex(addr.Bus)
+	slot, errSlot := parseHex(addr.Slot)
+	function, errFunction := parseHex(addr.Function)
+
+	if errDomain != nil || errBus != nil || errSlot != nil || errFunction != nil {
+		log.Log.Errorf(
+			"failed to parse PCI address components: domain=%q (err=%v), bus=%q (err=%v), slot=%q (err=%v), function=%q (err=%v)",
+			addr.Domain, errDomain, addr.Bus, errBus, addr.Slot, errSlot, addr.Function, errFunction,
+		)
+	}
+
+	return fmt.Sprintf(
+		"%08x:%02x:%02x.%01x",
+		domain, bus, slot, function,
+	)
+}
+
+func parseHex(s string) (uint64, error) {
+	s = strings.TrimPrefix(s, "0x")
+	return strconv.ParseUint(s, 16, 64)
+}

--- a/pkg/monitoring/metrics/virt-handler/domainstats/hostdevice_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/hostdevice_metrics_test.go
@@ -1,0 +1,227 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package domainstats
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k6tv1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+var _ = Describe("host device metrics", func() {
+	Context("on Collect", func() {
+		vmi := &k6tv1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-vmi-1",
+				Namespace: "test-ns-1",
+			},
+		}
+
+		It("should return empty when Domain is nil", func() {
+			vmiStats := &VirtualMachineInstanceStats{Domain: nil}
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := hostDeviceMetrics{}.Collect(vmiReport)
+			Expect(crs).To(BeEmpty())
+		})
+
+		It("should return empty when there are no host devices", func() {
+			vmiStats := &VirtualMachineInstanceStats{
+				Domain: &api.Domain{},
+			}
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := hostDeviceMetrics{}.Collect(vmiReport)
+			Expect(crs).To(BeEmpty())
+		})
+
+		It("should collect metric with alias and pci_bus_id labels", func() {
+			vmiStats := &VirtualMachineInstanceStats{
+				Domain: &api.Domain{
+					Spec: api.DomainSpec{
+						Devices: api.Devices{
+							HostDevices: []api.HostDevice{
+								{
+									Alias: api.NewUserDefinedAlias("gpu-0"),
+									Address: &api.Address{
+										Type:     api.AddressPCI,
+										Domain:   "0000",
+										Bus:      "09",
+										Slot:     "00",
+										Function: "0",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := hostDeviceMetrics{}.Collect(vmiReport)
+			Expect(crs).To(HaveLen(1))
+			Expect(crs[0].Value).To(Equal(float64(1)))
+			Expect(crs[0].ConstLabels).To(HaveKeyWithValue("alias", "gpu-0"))
+			Expect(crs[0].ConstLabels).To(HaveKeyWithValue("pci_bus_id", "00000000:09:00.0"))
+		})
+
+		It("should omit alias label when Alias is nil", func() {
+			vmiStats := &VirtualMachineInstanceStats{
+				Domain: &api.Domain{
+					Spec: api.DomainSpec{
+						Devices: api.Devices{
+							HostDevices: []api.HostDevice{
+								{
+									Address: &api.Address{
+										Type:     api.AddressPCI,
+										Domain:   "0000",
+										Bus:      "81",
+										Slot:     "01",
+										Function: "0",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := hostDeviceMetrics{}.Collect(vmiReport)
+			Expect(crs).To(HaveLen(1))
+			Expect(crs[0].ConstLabels).NotTo(HaveKey("alias"))
+			Expect(crs[0].ConstLabels).To(HaveKeyWithValue("pci_bus_id", "00000000:81:01.0"))
+		})
+
+		It("should omit pci_bus_id label when Address is nil", func() {
+			vmiStats := &VirtualMachineInstanceStats{
+				Domain: &api.Domain{
+					Spec: api.DomainSpec{
+						Devices: api.Devices{
+							HostDevices: []api.HostDevice{
+								{
+									Alias: api.NewUserDefinedAlias("dev-0"),
+								},
+							},
+						},
+					},
+				},
+			}
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := hostDeviceMetrics{}.Collect(vmiReport)
+			Expect(crs).To(HaveLen(1))
+			Expect(crs[0].ConstLabels).To(HaveKeyWithValue("alias", "dev-0"))
+			Expect(crs[0].ConstLabels).NotTo(HaveKey("pci_bus_id"))
+		})
+
+		It("should omit pci_bus_id label when Address type is not PCI", func() {
+			vmiStats := &VirtualMachineInstanceStats{
+				Domain: &api.Domain{
+					Spec: api.DomainSpec{
+						Devices: api.Devices{
+							HostDevices: []api.HostDevice{
+								{
+									Alias: api.NewUserDefinedAlias("mdev-0"),
+									Address: &api.Address{
+										Type:   "mdev",
+										Domain: "0000",
+										Bus:    "00",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := hostDeviceMetrics{}.Collect(vmiReport)
+			Expect(crs).To(HaveLen(1))
+			Expect(crs[0].ConstLabels).To(HaveKeyWithValue("alias", "mdev-0"))
+			Expect(crs[0].ConstLabels).NotTo(HaveKey("pci_bus_id"))
+		})
+
+		It("should collect metrics for multiple host devices", func() {
+			vmiStats := &VirtualMachineInstanceStats{
+				Domain: &api.Domain{
+					Spec: api.DomainSpec{
+						Devices: api.Devices{
+							HostDevices: []api.HostDevice{
+								{
+									Alias: api.NewUserDefinedAlias("gpu-0"),
+									Address: &api.Address{
+										Type:     api.AddressPCI,
+										Domain:   "0000",
+										Bus:      "09",
+										Slot:     "00",
+										Function: "0",
+									},
+								},
+								{
+									Alias: api.NewUserDefinedAlias("gpu-1"),
+									Address: &api.Address{
+										Type:     api.AddressPCI,
+										Domain:   "0000",
+										Bus:      "0a",
+										Slot:     "00",
+										Function: "0",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			vmiReport := newVirtualMachineInstanceReport(vmi, vmiStats)
+
+			crs := hostDeviceMetrics{}.Collect(vmiReport)
+			Expect(crs).To(HaveLen(2))
+			Expect(crs[0].ConstLabels).To(HaveKeyWithValue("pci_bus_id", "00000000:09:00.0"))
+			Expect(crs[1].ConstLabels).To(HaveKeyWithValue("pci_bus_id", "00000000:0a:00.0"))
+		})
+	})
+
+	Context("formatPCIBusID", func() {
+		DescribeTable("should format address to DCGM-compatible PCI bus ID",
+			func(domain, bus, slot, function, expected string) {
+				addr := &api.Address{
+					Type:     api.AddressPCI,
+					Domain:   domain,
+					Bus:      bus,
+					Slot:     slot,
+					Function: function,
+				}
+				Expect(formatPCIBusID(addr)).To(Equal(expected))
+			},
+			Entry("standard GPU address", "0000", "09", "00", "0", "00000000:09:00.0"),
+			Entry("with 0x prefix", "0x0000", "0x09", "0x00", "0x0", "00000000:09:00.0"),
+			Entry("uppercase hex", "0000", "0A", "1F", "0", "00000000:0a:1f.0"),
+			Entry("higher bus number", "0000", "81", "01", "0", "00000000:81:01.0"),
+			Entry("multi-function device", "0000", "09", "00", "1", "00000000:09:00.1"),
+			Entry("malformed values default to zero", "zz", "zz", "zz", "zz", "00000000:00:00.0"),
+			Entry("empty strings default to zero", "", "", "", "", "00000000:00:00.0"),
+		)
+	})
+})

--- a/pkg/monitoring/metrics/virt-handler/domainstats/scrapper.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/scrapper.go
@@ -95,6 +95,11 @@ func (d DomainstatsScraper) gatherMetrics(socketFile string) (bool, *VirtualMach
 	vmStats := &VirtualMachineInstanceStats{}
 	var exists bool
 
+	vmStats.Domain, _, err = cli.GetDomain()
+	if err != nil {
+		log.Log.V(logVerbosityWarning).Reason(err).Infof("failed to get domain from socket %s, continuing without domain info", socketFile)
+	}
+
 	vmStats.DomainStats, exists, err = cli.GetDomainStats()
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to update domain stats from socket %s: %w", socketFile, err)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -151,6 +151,7 @@ go_test(
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmigration:go_default_library",
+        "//tests/libmonitoring:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnet/cloudinit:go_default_library",
         "//tests/libnode:go_default_library",

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -108,6 +108,9 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 
 			// needs GPU - tested in MediatedDevices
 			"kubevirt_vmi_gpu_info": true,
+
+			// needs a host device (GPU/SRIOV) assigned to the VMI
+			"kubevirt_vmi_host_device_info": true,
 		}
 
 		BeforeAll(func() {

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -24,6 +24,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/libmonitoring"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -103,6 +104,14 @@ var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func
 					&expect.BExp{R: console.RetValue("1")},
 				}, 15)).To(Succeed(), "Device not found")
 			}
+
+			By("Verifying the host device info metric is reported")
+			labels := map[string]string{
+				"namespace": vmi.Namespace,
+				"name":      vmi.Name,
+			}
+			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_host_device_info", 1, labels, 1)
+
 			// Make sure to delete the VMI before ending the test otherwise a device could still be taken
 			err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Delete(context.Background(), vmi.ObjectMeta.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

No host-device info that we can use to track for example GPUs attached to the guest

#### After this PR:

kubevirt_vmi_host_device_info with device alias and address pci bus id info 

### References

jira-ticket: https://redhat.atlassian.net/browse/CNV-86656

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vmi_host_device_info metric
```

