### PR TITLE
net, netpod: Remove caching of IPv6 from bridge binding ifaces

### DIFF
--- a/pkg/network/setup/netpod/discover.go
+++ b/pkg/network/setup/netpod/discover.go
@@ -55,6 +55,11 @@ func (n NetPod) discover(currentStatus *nmstate.Status) error {
 				return fmt.Errorf("pod link (%s) is missing", podIfaceName)
 			}
 
+			// Bridge binding doesn't support DHCPv6, so the pod's IPv6 is never reachable
+			// from the guest. Drop it because pod IPs are used for reporting
+			// VMI.Status.Interfaces[].IPs and take precedence over guest agent data.
+			podIfaceStatus.IPv6 = nmstate.IP{}
+
 			if err := n.storePodInterfaceData(vmiSpecIface, podIfaceStatus); err != nil {
 				return err
 			}

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -409,7 +409,7 @@ var _ = Describe("netpod", func() {
 		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
 			PodIP:  primaryIPv4Address,
-			PodIPs: []string{primaryIPv4Address, primaryIPv6Address},
+			PodIPs: []string{primaryIPv4Address},
 		}))
 
 		expDHCPConfig, err := expectedDHCPConfig(
@@ -562,7 +562,7 @@ var _ = Describe("netpod", func() {
 		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
 			PodIP:  primaryIPv4Address,
-			PodIPs: []string{primaryIPv4Address, primaryIPv6Address},
+			PodIPs: []string{primaryIPv4Address},
 		}))
 
 		expDHCPConfig, err := expectedDHCPConfig(


### PR DESCRIPTION
### What this PR does
In bridge binding, the pod interface IPv6 address is never
authoritative.
KubeVirt does not support DHCP6, and the guest can never be
reachable by the pods ipv6 address.

Currently KubeVirt reports the pod IPv6 address in VMI status,
instead of the guest IP, a bug that has been observed in [1].

Remove the pod's IPv6 addresses from the cache, such that they
are not considered for VMI status reporting.

Other binding types are not filtered:

- Masquerade: Uses the pod's IPv6 address for guest networking via NAT
- Passt: Provides the pod's IPv6 address to the guest via DHCPv6 [2]
- Binding plugins: KubeVirt doesn't cache or create dummy interfaces.
  External sidecars manage their own network setup
- ManagedTap: Designed for network providers with dedicated CNI.
  They use managed IPAM that control IPv6 autoconfiguration per their need

[1] https://redhat.atlassian.net/browse/CNV-80582
[2] https://passt.top/passt/tree/dhcpv6.c

> **Note:** This is a recreation of #17536 which was accidentally closed when the branch was deleted.

### Why we need it and why it was done in this way

### Special notes for your reviewer

### Checklist

- [x] Design: A VEP was not required (bug fix)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Code is clear and maintainable
- [x] Refactor: Code is cleaner than before
- [ ] Upgrade: No upgrade impact (internal behavior fix)
- [x] Testing: Unit tests and e2e test added
- [ ] Documentation: No user-guide update required (internal fix)
- [ ] Community: No announcement required
- [x] AI Contributions: Abides by KubeVirt AI Contribution Policy

### Release note
```
Fixed VMI status reporting the pod's IPv6 address instead of the guest's when using bridge binding on a network ```