### PR TITLE
[release-1.8] net, netpod: Remove caching of IPv6 from bridge binding ifaces

### DIFF
--- a/pkg/network/setup/netpod/discover.go
+++ b/pkg/network/setup/netpod/discover.go
@@ -55,6 +55,11 @@ func (n NetPod) discover(currentStatus *nmstate.Status) error {
 				return fmt.Errorf("pod link (%s) is missing", podIfaceName)
 			}
 
+			// Bridge binding doesn't support DHCPv6, so the pod's IPv6 is never reachable
+			// from the guest. Drop it because pod IPs are used for reporting
+			// VMI.Status.Interfaces[].IPs and take precedence over guest agent data.
+			podIfaceStatus.IPv6 = nmstate.IP{}
+
 			if err := n.storePodInterfaceData(vmiSpecIface, podIfaceStatus); err != nil {
 				return err
 			}

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -409,7 +409,7 @@ var _ = Describe("netpod", func() {
 		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
 			PodIP:  primaryIPv4Address,
-			PodIPs: []string{primaryIPv4Address, primaryIPv6Address},
+			PodIPs: []string{primaryIPv4Address},
 		}))
 
 		expDHCPConfig, err := expectedDHCPConfig(
@@ -562,7 +562,7 @@ var _ = Describe("netpod", func() {
 		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
 			PodIP:  primaryIPv4Address,
-			PodIPs: []string{primaryIPv4Address, primaryIPv6Address},
+			PodIPs: []string{primaryIPv4Address},
 		}))
 
 		expDHCPConfig, err := expectedDHCPConfig(

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -33,6 +33,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -64,22 +65,8 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 
 		Context("VMI connected to the pod network using bridge binding", func() {
 			When("Guest Agent exists", func() {
-				var (
-					vmi   *v1.VirtualMachineInstance
-					vmiIP = func() string {
-						var err error
-						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-						ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving VMI to get IP")
-						return vmi.Status.Interfaces[0].IP
-					}
+				var vmi *v1.VirtualMachineInstance
 
-					vmiIPs = func() []string {
-						var err error
-						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-						ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving VMI to get IPs")
-						return vmi.Status.Interfaces[0].IPs
-					}
-				)
 				BeforeEach(func() {
 					libnet.SkipWhenClusterNotSupportIpv4()
 					var err error
@@ -94,16 +81,16 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				})
 
-				It("should report PodIP/s on interface status", func() {
+				It("should report PodIP on interface status, with GuestAgent infoSource", func() {
 					vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Expect(err).NotTo(HaveOccurred())
 
-					Eventually(vmiIP, 2*time.Minute, 5*time.Second).Should(Equal(vmiPod.Status.PodIP), "should contain VMI Status IP as Pod status ip")
-					var podIPs []string
-					for _, ip := range vmiPod.Status.PodIPs {
-						podIPs = append(podIPs, ip.IP)
-					}
-					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(Equal(podIPs), "should contain VMI Status IP as Pod status IPs")
+					Eventually(func(g Gomega) {
+						updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(vmispec.ContainsInfoSource(updatedVMI.Status.Interfaces[0].InfoSource, vmispec.InfoSourceGuestAgent)).To(BeTrue(), "interface infoSource should include guest agent")
+						g.Expect(updatedVMI.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP))
+					}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 				})
 			})
 		})

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -157,7 +158,12 @@ var _ = Describe(SIG("Infosource", func() {
 
 			networkInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceMac)
 			Expect(networkInterface).NotTo(BeNil(), "interface not found")
-			Expect(networkInterface.IP).NotTo(BeEmpty())
+
+			supportsIpv4, err := cluster.SupportsIpv4()
+			Expect(err).NotTo(HaveOccurred())
+			if supportsIpv4 {
+				Expect(networkInterface.IP).NotTo(BeEmpty(), "IP address not present in IPv4 cluster for MAC %s", networkInterface.MAC)
+			}
 
 			guestInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceNewMac)
 			Expect(guestInterface).NotTo(BeNil(), "interface not found")

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -82,8 +82,14 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		})
 		Context("with a test outbound VMI", func() {
 			BeforeEach(func() {
-				inboundVMI = libvmifact.NewCirros()
-				outboundVMI = libvmifact.NewCirros()
+				inboundVMI = libvmifact.NewCirros(
+					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				outboundVMI = libvmifact.NewCirros(
+					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
 				inboundVMIWithCustomMacAddress = vmiWithCustomMacAddress("de:ad:00:00:be:af")
 				inboundVMIWithMultiQueueSingleCPU = vmiWithMultiQueue()
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -106,7 +106,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				vmiPod, err := libpod.GetPodByVirtualMachineInstance(outboundVMI, outboundVMI.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(libnet.ValidateVMIandPodIPMatch(outboundVMI, vmiPod)).To(Succeed(), "Should have matching IP/s between pod and vmi")
+				Expect(outboundVMI.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP), "Should have matching IP between pod and vmi")
 
 				var mtu int
 				for _, ifaceName := range []string{"k6t-eth0", "tap0"} {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/17680/ and https://github.com/kubevirt/kubevirt/pull/17536 
Backport is required because the bug [1] was discovered in release-1.8 hence its fix is required in 

[1] https://redhat.atlassian.net/browse/CNV-80582
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed VMI status reporting the pod's IPv6 address instead of the guest's when using bridge binding on a network with IPv6 IPAM.
```

