### PR TITLE
tests: Add context-aware failure messages to e2e storage test assertions

### DIFF
--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -744,12 +744,11 @@ var _ = Describe(SIG("Backup", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying launcher pod Velero annotations are removed")
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				pod = getPodByVMI(vmi)
-				_, hasPreHook := pod.Annotations[velero.PreBackupHookContainerAnnotation]
-				_, hasPostHook := pod.Annotations[velero.PostBackupHookContainerAnnotation]
-				return !hasPreHook && !hasPostHook
-			}, 60*time.Second, 1*time.Second).Should(BeTrue(), "Velero hook annotations should be removed from launcher pod when KubeVirt CR annotation is set")
+				g.Expect(pod.Annotations).ToNot(HaveKey(velero.PreBackupHookContainerAnnotation))
+				g.Expect(pod.Annotations).ToNot(HaveKey(velero.PostBackupHookContainerAnnotation))
+			}, 60*time.Second, 1*time.Second).Should(Succeed(), "Velero hook annotations should be removed from launcher pod when KubeVirt CR annotation is set")
 
 			By("Restoring KubeVirt CR annotations to original state")
 			if hadSkipAnnotation {
@@ -761,11 +760,11 @@ var _ = Describe(SIG("Backup", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying launcher pod Velero annotations are added back")
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				pod = getPodByVMI(vmi)
-				return pod.Annotations[velero.PreBackupHookContainerAnnotation] == "compute" &&
-					pod.Annotations[velero.PostBackupHookContainerAnnotation] == "compute"
-			}, 60*time.Second, 1*time.Second).Should(BeTrue())
+				g.Expect(pod.Annotations).To(HaveKeyWithValue(velero.PreBackupHookContainerAnnotation, "compute"))
+				g.Expect(pod.Annotations).To(HaveKeyWithValue(velero.PostBackupHookContainerAnnotation, "compute"))
+			}, 60*time.Second, 1*time.Second).Should(Succeed())
 		})
 
 		It("VMI annotation should take precedence over KubeVirt CR annotation", func() {

--- a/tests/storage/cbt.go
+++ b/tests/storage/cbt.go
@@ -135,7 +135,7 @@ var _ = Describe(SIG("CBT", func() {
 		libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 		pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(pod).NotTo(BeNil())
+		Expect(pod).NotTo(BeNil(), "expected pod for VMI %s/%s not to be nil", vmi.Namespace, vmi.Name)
 
 		var cmdOutput string
 		cmdOutput, err = exec.ExecuteCommandOnPod(pod, "compute", []string{"ls", "-d", cbt.PathForCBT(vmi)})

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -164,7 +164,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			origSize, exists := pvc.Status.Capacity[k8sv1.ResourceStorage]
-			Expect(exists).To(BeTrue())
+			Expect(exists).To(BeTrue(), "expected PVC %s/%s to report storage capacity", pvc.Namespace, pvc.Name)
 			newSize := *resource.NewQuantity(2*origSize.Value(), origSize.Format)
 			patchSet := patch.New(
 				patch.WithAdd("/spec/resources/requests/storage", newSize),
@@ -247,16 +247,13 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 500)
 
 			// Let's wait for VMI to be ready
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for _, volStatus := range vmi.Status.VolumeStatus {
-					if volStatus.Name == "disk0" {
-						return true
-					}
-				}
-				return false
-			}, 30*time.Second, time.Second).Should(BeTrue(), "Expected VolumeStatus for 'disk0' to be available")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(vmi.Status.VolumeStatus).To(ContainElement(
+					WithTransform(func(volumeStatus v1.VolumeStatus) string { return volumeStatus.Name }, Equal("disk0")),
+				))
+			}, 30*time.Second, time.Second).Should(Succeed())
 
 			virtualSize := getQemuImgInfo(vmi).VirtualSize
 			Expect(virtualSize).ToNot(BeNumerically(">", freeSize))
@@ -734,14 +731,13 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 
 			createVMSuccess := func() {
 				// sometimes it takes a bit for permission to actually be applied so eventually
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					_, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
 					if err != nil {
 						fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
-						return false
 					}
-					return true
-				}, 90*time.Second, 1*time.Second).Should(BeTrue())
+					g.Expect(err).ToNot(HaveOccurred())
+				}, 90*time.Second, 1*time.Second).Should(Succeed())
 
 				// start vm and check dv clone succeeded
 				vm = libvmops.StartVirtualMachine(vm)
@@ -908,16 +904,13 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 
 				// We check the expected event
 				By("Expecting SourcePVCNotAvailabe event")
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					events, err := virtClient.CoreV1().Events(vm.Namespace).List(context.Background(), metav1.ListOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					for _, e := range events.Items {
-						if e.Reason == "SourcePVCNotAvailabe" {
-							return true
-						}
-					}
-					return false
-				}, 30*time.Second, 5*time.Second).Should(BeTrue())
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(events.Items).To(ContainElement(
+						WithTransform(func(event k8sv1.Event) string { return event.Reason }, Equal("SourcePVCNotAvailabe")),
+					))
+				}, 30*time.Second, 5*time.Second).Should(Succeed())
 			})
 
 			DescribeTable("[storage-req] deny then allow clone request", decorators.Conformance, decorators.StorageReq, func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool, cloneMutateFunc func(), fail bool) {
@@ -1073,7 +1066,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 
 			if preallocated {
 				// Preallocation means no changes to disk size
-				Eventually(imageSizeEqual, 120*time.Second).WithArguments(getImageActualSize(vmi), imageSizeAfterBoot).Should(BeTrue())
+				Eventually(imageSizeEqual, 120*time.Second).WithArguments(getImageActualSize(vmi), imageSizeAfterBoot).Should(BeTrue(), "expected preallocated image size to stay within 1 MiB of boot size")
 			} else {
 				Eventually(getImageActualSize, 120*time.Second).WithArguments(vmi).Should(BeNumerically(">", imageSizeAfterBoot))
 			}
@@ -1093,7 +1086,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 				&expect.BExp{R: ""},
 			}, 60)).To(Succeed(), "should trim within the VM")
 
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				By("Running trim")
 				err := console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo fstrim -v /\n"},
@@ -1101,22 +1094,21 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 					&expect.BSnd{S: syncName},
 					&expect.BExp{R: ""},
 				}, 60)
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				currentImageSize := getImageActualSize(vmi)
 				if expectSmaller {
 					// Trim should make the space usage go down
 					By(fmt.Sprintf("We expect disk usage to go down from the use of trim.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-					return currentImageSize < imageSizeBeforeTrim
+					g.Expect(currentImageSize).To(BeNumerically("<", imageSizeBeforeTrim))
 				} else if preallocated {
 					By(fmt.Sprintf("Trim shouldn't do anything, and preallocation should mean no change to disk usage.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-					return imageSizeEqual(currentImageSize, imageSizeBeforeTrim)
-
+					g.Expect(imageSizeEqual(currentImageSize, imageSizeBeforeTrim)).To(BeTrue(), "expected preallocated image size to stay within 1 MiB of size before trim")
 				} else {
 					By(fmt.Sprintf("Trim shouldn't do anything, but we expect size usage to go up, because we wrote another small file.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-					return currentImageSize > imageSizeBeforeTrim
+					g.Expect(currentImageSize).To(BeNumerically(">", imageSizeBeforeTrim))
 				}
-			}, 120*time.Second).Should(BeTrue())
+			}, 120*time.Second).Should(Succeed())
 
 			err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1036,11 +1036,11 @@ var _ = Describe(SIG("Export", func() {
 			err = virtClient.CoreV1().Pods(newExportPod.Namespace).Delete(context.Background(), newExportPod.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		}()
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			p, err := virtClient.CoreV1().Pods(exporterPod.Namespace).Get(context.TODO(), newExportPod.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return p.Status.Phase == k8sv1.PodSucceeded
-		}, 90*time.Second, 1*time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(p.Status.Phase).To(Equal(k8sv1.PodSucceeded))
+		}, 90*time.Second, 1*time.Second).Should(Succeed())
 	})
 
 	It("Should handle populating an export without a previously defined tokenSecretRef", func() {
@@ -1233,7 +1233,7 @@ var _ = Describe(SIG("Export", func() {
 					matchesCNOrAltName = true
 				}
 			}
-			Expect(matchesCNOrAltName).To(BeTrue())
+			Expect(matchesCNOrAltName).To(BeTrue(), "expected export certificate to match ingress domain %s", domainName)
 			Expect(vmExport.Status.Links.External.Volumes[0].Formats[0].Url).To(ContainSubstring(ingress.Spec.Rules[0].Host))
 		})
 	})
@@ -1269,7 +1269,7 @@ var _ = Describe(SIG("Export", func() {
 					matchesCNOrAltName = true
 				}
 			}
-			Expect(matchesCNOrAltName).To(BeTrue())
+			Expect(matchesCNOrAltName).To(BeTrue(), "expected export certificate to match route domain %s", domainName)
 			Expect(vmExport.Status.Links.External.Volumes[0].Formats[0].Url).To(ContainSubstring(host))
 
 		})
@@ -1346,11 +1346,12 @@ var _ = Describe(SIG("Export", func() {
 	}
 
 	waitSnapshotReady := func(snapshot *snapshotv1.VirtualMachineSnapshot) {
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			snapshot, err := virtClient.VirtualMachineSnapshot(snapshot.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return snapshot.Status != nil && snapshot.Status.ReadyToUse != nil && *snapshot.Status.ReadyToUse
-		}, 180*time.Second, time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(snapshot.Status).ToNot(BeNil())
+			g.Expect(snapshot.Status.ReadyToUse).To(HaveValue(BeTrue()))
+		}, 180*time.Second, time.Second).Should(Succeed())
 	}
 
 	createAndVerifyVMSnapshot := func(vm *v1.VirtualMachine) *snapshotv1.VirtualMachineSnapshot {
@@ -1497,11 +1498,12 @@ var _ = Describe(SIG("Export", func() {
 		restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			restore, err = virtClient.VirtualMachineRestore(restore.Namespace).Get(context.Background(), restore.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return restore.Status != nil && restore.Status.Complete != nil && *restore.Status.Complete
-		}, 180*time.Second, time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(restore.Status).ToNot(BeNil())
+			g.Expect(restore.Status.Complete).To(HaveValue(BeTrue()))
+		}, 180*time.Second, time.Second).Should(Succeed())
 
 		By("Getting the restored PVC name from the VM spec")
 		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -699,10 +699,11 @@ var _ = Describe(SIG("Hotplug", func() {
 			}, 60*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "virt-handler pod is expected to be deleted")
 
 			By("Waiting for virt-handler pod to restart")
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				virtHandlerPod, err = libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)
-				return err == nil && virtHandlerPod.Status.Phase == k8sv1.PodRunning
-			}, 60*time.Second, 1*time.Second).Should(BeTrue(), "virt-handler pod is expected to be restarted")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(virtHandlerPod.Status.Phase).To(Equal(k8sv1.PodRunning))
+			}, 60*time.Second, 1*time.Second).Should(Succeed(), "virt-handler pod is expected to be restarted")
 
 			By("Adding another hotplug block volume")
 			dv = createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeBlock)
@@ -1670,13 +1671,12 @@ var _ = Describe(SIG("Hotplug", func() {
 
 			_, err = virtClient.CdiClient().CdiV1beta1().CDIs().Patch(context.Background(), cdi.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred(), "failed to patch CDI")
-			Eventually(func() bool {
-				cdiConfig, _ := virtClient.CdiClient().CdiV1beta1().CDIConfigs().Get(context.Background(), "config", metav1.GetOptions{})
-				if cdiConfig == nil {
-					return false
-				}
-				return cdiConfig.Generation > orgCdiConfig.Generation
-			}, 30*time.Second, 1*time.Second).Should(BeTrue(), "timed out waiting for CDI config generation to be updated")
+			Eventually(func(g Gomega) {
+				cdiConfig, err := virtClient.CdiClient().CdiV1beta1().CDIConfigs().Get(context.Background(), "config", metav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(cdiConfig).ToNot(BeNil())
+				g.Expect(cdiConfig.Generation).To(BeNumerically(">", orgCdiConfig.Generation))
+			}, 30*time.Second, 1*time.Second).Should(Succeed(), "timed out waiting for CDI config generation to be updated")
 		}
 
 		updateCDIToRatio := func(memRatio, cpuRatio float64) {
@@ -2348,14 +2348,13 @@ func getAttachmentPodsForVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualM
 }
 
 func waitForAttachmentPodToRun(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-	Eventually(func() bool {
+	Eventually(func(g Gomega) {
 		attachmentPods := getAttachmentPodsForVMI(virtClient, vmi)
-		for _, pod := range attachmentPods {
-			By(fmt.Sprintf("Attachment pod %s phase: %s", pod.Name, pod.Status.Phase))
-			return pod.Status.Phase == k8sv1.PodRunning
-		}
-		return false
-	}, 270*time.Second, 2*time.Second).Should(BeTrue(), "timed out waiting for attachment pod to reach Running phase for VMI %s/%s", vmi.Namespace, vmi.Name)
+		g.Expect(attachmentPods).ToNot(BeEmpty())
+		pod := attachmentPods[0]
+		By(fmt.Sprintf("Attachment pod %s phase: %s", pod.Name, pod.Status.Phase))
+		g.Expect(pod.Status.Phase).To(Equal(k8sv1.PodRunning))
+	}, 270*time.Second, 2*time.Second).Should(Succeed(), "timed out waiting for attachment pod to reach Running phase for VMI %s/%s", vmi.Namespace, vmi.Name)
 }
 
 func verifySingleAttachmentPod(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -85,16 +85,14 @@ var _ = Describe(SIG("Memory dump", func() {
 		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			if errors.IsNotFound(err) {
-				return false
-			}
-			Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return vm.Status.Ready && vmi.Status.Phase == v1.Running
-		}, 180*time.Second, time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(vm.Status.Ready).To(BeTrue(), "expected VM %s to be ready", vm.Name)
+			g.Expect(vmi.Status.Phase).To(Equal(v1.Running))
+		}, 180*time.Second, time.Second).Should(Succeed())
 
 		return vm
 	}
@@ -168,8 +166,8 @@ var _ = Describe(SIG("Memory dump", func() {
 			if err != nil {
 				return err
 			}
-			Expect(pvc.GetAnnotations()).ToNot(BeNil())
-			Expect(pvc.Annotations[v1.PVCMemoryDumpAnnotation]).To(Equal(*updatedVM.Status.MemoryDumpRequest.FileName))
+			Expect(pvc.GetAnnotations()).ToNot(BeNil(), "expected PVC %s to have annotations", pvc.Name)
+			Expect(pvc.Annotations[v1.PVCMemoryDumpAnnotation]).To(Equal(*updatedVM.Status.MemoryDumpRequest.FileName), "expected PVC %s annotation to match memory dump file name", pvc.Name)
 
 			return nil
 		}, 90*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
@@ -222,17 +220,17 @@ var _ = Describe(SIG("Memory dump", func() {
 		log.Log.Infof("%s", wcOutput)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(strings.Contains(lsOutput, "memory.dump")).To(BeTrue())
+		Expect(lsOutput).To(ContainSubstring("memory.dump"), "expected 'memory.dump' file in PVC %s, got: %s", memoryDumpPVC.Name, lsOutput)
 		// Could be that a 'lost+found' directory is in it, check if the
 		// response is more then 1 then it is only 2 with `lost+found` directory
 		if strings.Compare("1", wcOutput) != 0 {
-			Expect(wcOutput).To(Equal("2"))
-			Expect(strings.Contains(lsOutput, "lost+found")).To(BeTrue())
+			Expect(wcOutput).To(Equal("2"), "expected at most 2 files in PVC %s, got: %s", memoryDumpPVC.Name, wcOutput)
+			Expect(lsOutput).To(ContainSubstring("lost+found"), "expected 'lost+found' file in PVC %s, got: %s", memoryDumpPVC.Name, lsOutput)
 		}
 		if previousOutput != "" && shouldEqual {
-			Expect(lsOutput).To(Equal(previousOutput))
+			Expect(lsOutput).To(Equal(previousOutput), "expected ls output to match previous output")
 		} else {
-			Expect(lsOutput).ToNot(Equal(previousOutput))
+			Expect(lsOutput).ToNot(Equal(previousOutput), "expected ls output to be different from previous output")
 		}
 
 		deletePod(executorPod)
@@ -402,9 +400,10 @@ var _ = Describe(SIG("Memory dump", func() {
 			waitAndVerifyMemoryDumpDissociation(vm, memoryDumpPVCName)
 			memoryDumpPVC2, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), memoryDumpPVC2.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			if memoryDumpPVC2.Annotations != nil {
-				Expect(memoryDumpPVC2.Annotations[v1.PVCMemoryDumpAnnotation]).To(BeNil())
-			}
+			Expect(memoryDumpPVC2.Annotations).To(Or(
+				BeNil(),
+				Not(HaveKey(v1.PVCMemoryDumpAnnotation)),
+			), "expected memory dump annotation on PVC %s to be removed", memoryDumpPVC2.Name)
 		})
 	})
 }))

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -152,7 +152,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 		)
 
 		waitMigrationToNotExist := func(vmiName, ns string) {
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				ls := labels.Set{
 					virtv1.VolumesUpdateMigration: vmiName,
 				}
@@ -160,13 +160,9 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 					metav1.ListOptions{
 						LabelSelector: ls.String(),
 					})
-				Expect(err).ToNot(HaveOccurred())
-				if len(migList.Items) == 0 {
-					return true
-				}
-				return false
-
-			}, 120*time.Second, time.Second).Should(BeTrue())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(migList.Items).To(BeEmpty())
+			}, 120*time.Second, time.Second).Should(Succeed())
 		}
 		waitVMIToHaveVolumeChangeCond := func(vmiName, ns string) {
 			Eventually(matcher.ThisVMIWith(ns, vmiName), 120*time.Second, time.Second).Should(matcher.HaveConditionTrue(virtv1.VirtualMachineInstanceVolumesChange))
@@ -174,7 +170,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 
 		createDV := func() *cdiv1.DataVolume {
 			sc, exist := libstorage.GetRWOFileSystemStorageClass()
-			Expect(exist).To(BeTrue())
+			Expect(exist).To(BeTrue(), "expected an RWO filesystem storage class")
 			dv := libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
@@ -402,7 +398,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			var metricsIPs []string
 			volName := "disk0"
 			sc, exist := libstorage.GetRWOFileSystemStorageClass()
-			Expect(exist).To(BeTrue())
+			Expect(exist).To(BeTrue(), "expected an RWO filesystem storage class")
 			srcDV := libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling)),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
@@ -604,7 +600,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 		It("should migrate the source volume from a block source and filesystem destination DVs", decorators.RequiresBlockStorage, func() {
 			volName := "disk0"
 			sc, exist := libstorage.GetRWOBlockStorageClass()
-			Expect(exist).To(BeTrue())
+			Expect(exist).To(BeTrue(), "expected an RWO block storage class")
 			srcDV := libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
@@ -697,21 +693,17 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			// After the volume migration abortion the VMI should have:
 			// 1. the source volume restored
 			// 2. condition VolumesChange set to false
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
 					metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
-				if claim != dv.Name {
-					return false
-				}
+				g.Expect(claim).To(Equal(dv.Name))
 				conditionManager := controller.NewVirtualMachineInstanceConditionManager()
 				c := conditionManager.GetCondition(vmi, virtv1.VirtualMachineInstanceVolumesChange)
-				if c == nil {
-					return false
-				}
-				return c.Status == k8sv1.ConditionFalse
-			}, 120*time.Second, time.Second).Should(BeTrue())
+				g.Expect(c).ToNot(BeNil())
+				g.Expect(c.Status).To(Equal(k8sv1.ConditionFalse))
+			}, 120*time.Second, time.Second).Should(Succeed())
 			waitMigrationToNotExist(vm.Name, ns)
 		})
 
@@ -1177,7 +1169,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 					sc, exist = libstorage.GetRWOFileSystemStorageClass()
 					volumeMode = k8sv1.PersistentVolumeFilesystem
 				}
-				Expect(exist).To(BeTrue())
+				Expect(exist).To(BeTrue(), "expected an RWO storage class for volume mode %s", volumeMode)
 				rootDV := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
 					libdv.WithStorage(libdv.StorageWithStorageClass(sc),
@@ -1228,7 +1220,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				if dstBlock {
 					sc, exist = libstorage.GetRWOBlockStorageClass()
 					volumeMode = k8sv1.PersistentVolumeBlock
-					Expect(exist).To(BeTrue())
+					Expect(exist).To(BeTrue(), "expected an RWO block storage class for the destination volume")
 				} else {
 					sc = testSc
 					volumeMode = k8sv1.PersistentVolumeFilesystem

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -162,7 +162,7 @@ var _ = Describe(SIG("SCSI persistent reservation", decorators.RequiresPersisten
 			// Avoid races if there is some delay in the device creation
 			Eventually(findSCSIdisk, 20*time.Second, 1*time.Second).WithArguments(targetCliPod, backendDisk).ShouldNot(BeEmpty())
 			device = findSCSIdisk(targetCliPod, backendDisk)
-			Expect(device).ToNot(BeEmpty())
+			Expect(device).ToNot(BeEmpty(), "expected to find a SCSI device for backend disk %s on targetcli pod %s", backendDisk, targetCliPod)
 			By(fmt.Sprintf("Create PVC with SCSI disk %s", device))
 			pv, pvc, err = CreatePVandPVCwithSCSIDisk(node, device, testsuite.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")
 			Expect(err).ToNot(HaveOccurred())
@@ -194,13 +194,13 @@ var _ = Describe(SIG("SCSI persistent reservation", decorators.RequiresPersisten
 			By("Requesting SCSI persistent reservation")
 			Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 			Expect(checkResultCommand(vmi, "sg_persist -i -k /dev/sda",
-				"there are NO registered reservation keys")).To(BeTrue())
+				"there are NO registered reservation keys")).To(BeTrue(), "expected sg_persist to report no registered reservation keys")
 			Expect(checkResultCommand(vmi, "sg_persist -o -G  --param-sark=12345678 /dev/sda",
-				"Peripheral device type: disk")).To(BeTrue())
+				"Peripheral device type: disk")).To(BeTrue(), "expected sg_persist to report Peripheral device type: disk")
 			Eventually(func(g Gomega) {
 				g.Expect(
 					checkResultCommand(vmi, "sg_persist -i -k /dev/sda", "1 registered reservation key follows:\r\n    0x12345678\r\n"),
-				).To(BeTrue())
+				).To(BeTrue(), "expected sg_persist to report 1 registered reservation key follows: 0x12345678")
 			}).
 				Within(60 * time.Second).
 				WithPolling(10 * time.Second).
@@ -216,15 +216,16 @@ var _ = Describe(SIG("SCSI persistent reservation", decorators.RequiresPersisten
 			Expect(err).ToNot(HaveOccurred())
 			// Wait unti new handler pod is ready
 			oldPodName := pod.Name
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				pod, err = libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)
 				g.Expect(err).To(Or(Succeed(), MatchError("Expected to find one Pod, found 2 Pods")))
 				if err != nil {
-					return false
+					return
 				}
 				pod, err = virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
-				return pod.Name != oldPodName
-			}).WithTimeout(time.Minute).WithPolling(time.Second).Should(BeTrue())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pod.Name).ToNot(Equal(oldPodName))
+			}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Succeed())
 			Eventually(matcher.ThisPod(pod)).WithTimeout(30 * time.Second).
 				WithPolling(1 * time.Second).Should(matcher.HaveConditionTrue(k8sv1.PodReady))
 
@@ -232,7 +233,7 @@ var _ = Describe(SIG("SCSI persistent reservation", decorators.RequiresPersisten
 			Eventually(func(g Gomega) {
 				g.Expect(
 					checkResultCommand(vmi, "sg_persist -i -k /dev/sda", "1 registered reservation key follows:\r\n    0x12345678\r\n"),
-				).To(BeTrue())
+				).To(BeTrue(), "expected sg_persist to report 1 registered reservation key follows: 0x12345678")
 			}).
 				Within(60 * time.Second).
 				WithPolling(10 * time.Second).

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"kubevirt.io/kubevirt/tests/events"
@@ -119,13 +118,15 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 		s, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Create(context.Background(), s, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			s, err = virtClient.VirtualMachineSnapshot(s.Namespace).Get(context.Background(), s.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return s.Status != nil && s.Status.ReadyToUse != nil && *s.Status.ReadyToUse && vm.Status.SnapshotInProgress == nil
-		}, 180*time.Second, time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s.Status).ToNot(BeNil())
+			g.Expect(s.Status.ReadyToUse).To(HaveValue(BeTrue()))
+			g.Expect(vm.Status.SnapshotInProgress).To(BeNil())
+		}, 180*time.Second, time.Second).Should(Succeed())
 
 		return s
 	}
@@ -138,37 +139,31 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 		vm.Spec.Template.Spec.TerminationGracePeriodSeconds = &gracePeriod
 
 		// sometimes it takes a bit for permission to actually be applied so eventually
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-			if err != nil {
-				fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
-				return false
-			}
-			return true
-		}, 90*time.Second, time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+		}, 90*time.Second, time.Second).Should(Succeed())
 
 		vm, err := ThisVM(vm)()
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			if errors.IsNotFound(err) {
-				return false
-			}
-			Expect(err).ToNot(HaveOccurred())
-			return vmi.Status.Phase == v1.Running
-		}, 360*time.Second, time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(vmi.Status.Phase).To(Equal(v1.Running))
+		}, 360*time.Second, time.Second).Should(Succeed())
 
 		return vm, vmi
 	}
 
 	waitRestoreComplete := func(r *snapshotv1.VirtualMachineRestore, vmName string, vmUID *types.UID) *snapshotv1.VirtualMachineRestore {
 		var err error
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			r, err = virtClient.VirtualMachineRestore(r.Namespace).Get(context.Background(), r.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return r.Status != nil && r.Status.Complete != nil && *r.Status.Complete
-		}, 180*time.Second, time.Second).Should(BeTrue())
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(r.Status).ToNot(BeNil())
+			g.Expect(r.Status.Complete).To(HaveValue(BeTrue()))
+		}, 180*time.Second, time.Second).Should(Succeed())
 		Expect(r.OwnerReferences).To(HaveLen(1))
 		Expect(r.OwnerReferences[0].APIVersion).To(Equal(v1.GroupVersion.String()))
 		Expect(r.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
@@ -416,16 +411,16 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					restore, err = virtClient.VirtualMachineRestore(restore.Namespace).Get(context.Background(), restore.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return restore.Status != nil &&
-						len(restore.Status.Conditions) == 2 &&
-						restore.Status.Conditions[0].Status == corev1.ConditionFalse &&
-						restore.Status.Conditions[1].Status == corev1.ConditionFalse &&
-						strings.Contains(restore.Status.Conditions[0].Reason, whName) &&
-						strings.Contains(restore.Status.Conditions[1].Reason, whName)
-				}, 180*time.Second, time.Second).Should(BeTrue())
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(restore.Status).ToNot(BeNil())
+					g.Expect(restore.Status.Conditions).To(HaveLen(2))
+					g.Expect(restore.Status.Conditions[0].Status).To(Equal(corev1.ConditionFalse))
+					g.Expect(restore.Status.Conditions[1].Status).To(Equal(corev1.ConditionFalse))
+					g.Expect(restore.Status.Conditions[0].Reason).To(ContainSubstring(whName))
+					g.Expect(restore.Status.Conditions[1].Reason).To(ContainSubstring(whName))
+				}, 180*time.Second, time.Second).Should(Succeed())
 
 				r2 := restore.DeepCopy()
 				r2.ObjectMeta = metav1.ObjectMeta{
@@ -1473,20 +1468,19 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					restore, err = virtClient.VirtualMachineRestore(restore.Namespace).Get(context.Background(), restore.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).ToNot(HaveOccurred())
 					updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return restore.Status != nil &&
-						len(restore.Status.Conditions) == 2 &&
-						restore.Status.Conditions[0].Status == corev1.ConditionFalse &&
-						restore.Status.Conditions[1].Status == corev1.ConditionFalse &&
-						strings.Contains(restore.Status.Conditions[0].Reason, whName) &&
-						strings.Contains(restore.Status.Conditions[1].Reason, whName) &&
-						updatedVM.Status.RestoreInProgress != nil &&
-						*updatedVM.Status.RestoreInProgress == restore.Name
-				}, 180*time.Second, 3*time.Second).Should(BeTrue())
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(restore.Status).ToNot(BeNil())
+					g.Expect(restore.Status.Conditions).To(HaveLen(2))
+					g.Expect(restore.Status.Conditions[0].Status).To(Equal(corev1.ConditionFalse))
+					g.Expect(restore.Status.Conditions[1].Status).To(Equal(corev1.ConditionFalse))
+					g.Expect(restore.Status.Conditions[0].Reason).To(ContainSubstring(whName))
+					g.Expect(restore.Status.Conditions[1].Reason).To(ContainSubstring(whName))
+					g.Expect(updatedVM.Status.RestoreInProgress).To(HaveValue(Equal(restore.Name)))
+				}, 180*time.Second, 3*time.Second).Should(Succeed())
 
 				err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Cannot update VM runStrategy until restore %q completes", restore.Name)))
@@ -1503,11 +1497,11 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					Fail("Delete function not valid")
 				}
 
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return updatedVM.Status.RestoreInProgress == nil
-				}, 30*time.Second, 3*time.Second).Should(BeTrue())
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(updatedVM.Status.RestoreInProgress).To(BeNil())
+				}, 30*time.Second, 3*time.Second).Should(Succeed())
 
 				vm = libvmops.StartVirtualMachine(vm)
 				deleteRestore(restore)
@@ -1678,7 +1672,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 						foundHotPlug = true
 					}
 				}
-				Expect(foundHotPlug).To(BeTrue())
+				Expect(foundHotPlug).To(BeTrue(), "expected restored VMI to include hotplug volume %s", persistVolName)
 			},
 				Entry("[test_id:7425] to the same VM", false),
 				Entry("to a new VM", true),
@@ -2012,16 +2006,12 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				}
 
 				waitMemoryDumpCompletion := func(vm *v1.VirtualMachine) {
-					Eventually(func() bool {
+					Eventually(func(g Gomega) {
 						updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-						if updatedVM.Status.MemoryDumpRequest == nil ||
-							updatedVM.Status.MemoryDumpRequest.Phase != v1.MemoryDumpCompleted {
-							return false
-						}
-
-						return true
-					}, 60*time.Second, time.Second).Should(BeTrue())
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(updatedVM.Status.MemoryDumpRequest).ToNot(BeNil())
+						g.Expect(updatedVM.Status.MemoryDumpRequest.Phase).To(Equal(v1.MemoryDumpCompleted))
+					}, 60*time.Second, time.Second).Should(Succeed())
 				}
 
 				DescribeTable("should not restore memory dump volume", func(restoreToNewVM bool) {
@@ -2063,7 +2053,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 							break
 						}
 					}
-					Expect(foundMemoryDump).To(BeFalse())
+					Expect(foundMemoryDump).To(BeFalse(), "expected restored VMI to exclude memory dump volume %s", memoryDumpPVCName)
 				},
 					Entry("[test_id:8923]to the same VM", false),
 					Entry("[test_id:8924]to a new VM", true),

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -597,7 +597,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 						foundHotPlug = true
 					}
 				}
-				Expect(foundHotPlug).To(BeTrue())
+				Expect(foundHotPlug).To(BeTrue(), "expected snapshot content to include hotplug volume %s", persistVolName)
 
 				Expect(content.Spec.VolumeBackups).Should(HaveLen(len(updatedVM.Spec.Template.Spec.Volumes)))
 				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes).Should(HaveLen(len(content.Spec.VolumeBackups)))
@@ -625,10 +625,10 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 							Expect(err).ToNot(HaveOccurred())
 							Expect(*vs.Spec.Source.PersistentVolumeClaimName).Should(Equal(vol.DataVolume.Name))
 							Expect(vs.Status.Error).To(BeNil())
-							Expect(*vs.Status.ReadyToUse).To(BeTrue())
+							Expect(vs.Status.ReadyToUse).To(HaveValue(BeTrue()), "expected VolumeSnapshot %s to be ready", vs.Name)
 						}
 					}
-					Expect(found).To(BeTrue())
+					Expect(found).To(BeTrue(), "expected snapshot content to include a volume backup for DataVolume %s", vol.DataVolume.Name)
 				}
 			})
 
@@ -768,7 +768,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 							foundMemoryDump = true
 						}
 					}
-					Expect(foundMemoryDump).To(BeTrue())
+					Expect(foundMemoryDump).To(BeTrue(), "expected snapshot content to include memory dump volume %s", memoryDumpPVCName)
 
 					Expect(content.Spec.VolumeBackups).Should(HaveLen(len(updatedVM.Spec.Template.Spec.Volumes)))
 					for _, vol := range updatedVM.Spec.Template.Spec.Volumes {
@@ -794,10 +794,10 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 								Expect(err).ToNot(HaveOccurred())
 								Expect(*vs.Spec.Source.PersistentVolumeClaimName).Should(Equal(vol.MemoryDump.ClaimName))
 								Expect(vs.Status.Error).To(BeNil())
-								Expect(*vs.Status.ReadyToUse).To(BeTrue())
+								Expect(vs.Status.ReadyToUse).To(HaveValue(BeTrue()), "expected VolumeSnapshot %s to be ready", vs.Name)
 							}
 						}
-						Expect(found).To(BeTrue())
+						Expect(found).To(BeTrue(), "expected snapshot content to include a volume backup for memory dump PVC %s", vol.MemoryDump.ClaimName)
 					}
 				})
 			})
@@ -867,10 +867,10 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 							Expect(*vs.Spec.Source.PersistentVolumeClaimName).Should(Equal(vol.DataVolume.Name))
 							Expect(vs.Labels["snapshot.kubevirt.io/source-vm-name"]).Should(Equal(vm.Name))
 							Expect(vs.Status.Error).To(BeNil())
-							Expect(*vs.Status.ReadyToUse).To(BeTrue())
+							Expect(vs.Status.ReadyToUse).To(HaveValue(BeTrue()), "expected VolumeSnapshot %s to be ready", vs.Name)
 						}
 					}
-					Expect(found).To(BeTrue())
+					Expect(found).To(BeTrue(), "expected snapshot content to include a volume backup for DataVolume %s", vol.DataVolume.Name)
 				}
 			})
 
@@ -984,12 +984,12 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				Expect(vb.VolumeSnapshotName).ToNot(BeNil())
 
 				m := "bad stuff"
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					vs, err := virtClient.KubernetesSnapshotClient().
 						SnapshotV1().
 						VolumeSnapshots(vm.Namespace).
 						Get(context.Background(), *vb.VolumeSnapshotName, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).ToNot(HaveOccurred())
 
 					vsc := vs.DeepCopy()
 					t := metav1.Now()
@@ -1002,12 +1002,8 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 						SnapshotV1().
 						VolumeSnapshots(vs.Namespace).
 						UpdateStatus(context.Background(), vsc, metav1.UpdateOptions{})
-					if errors.IsConflict(err) {
-						return false
-					}
-					Expect(err).ToNot(HaveOccurred())
-					return true
-				}, 180*time.Second, time.Second).Should(BeTrue())
+					g.Expect(err).ToNot(HaveOccurred())
+				}, 180*time.Second, time.Second).Should(Succeed())
 
 				Eventually(func() *snapshotv1.VirtualMachineSnapshotContentStatus {
 					vmSnapshotContent, err = virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), *cn, metav1.GetOptions{})
@@ -1027,7 +1023,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(snapshot.Status.Error).To(BeNil())
-				Expect(*snapshot.Status.ReadyToUse).To(BeTrue())
+				Expect(snapshot.Status.ReadyToUse).To(HaveValue(BeTrue()), "expected VirtualMachineSnapshot %s to be ready", snapshot.Name)
 			})
 
 			It("[test_id:6838]snapshot should fail when deadline exceeded due to volume snapshots failure", func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -742,7 +742,7 @@ var _ = Describe(SIG("Storage", func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						By("Checking if a disk image for PVC has been created")
-						Expect(strings.Contains(output, diskImgName)).To(BeTrue())
+						Expect(output).To(ContainSubstring(diskImgName), "expected disk.img to be present in PVC for VMI %s", vmi.Name)
 					}
 				})
 			})
@@ -939,36 +939,19 @@ var _ = Describe(SIG("Storage", func() {
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func(g Gomega) {
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					if vmi.Status.Phase != v1.Pending {
-						return false
-					}
-					if len(vmi.Status.Conditions) == 0 {
-						return false
-					}
-
-					expectPodScheduledCondition := func(vmi *v1.VirtualMachineInstance) {
-						getType := func(c v1.VirtualMachineInstanceCondition) string { return string(c.Type) }
-						getReason := func(c v1.VirtualMachineInstanceCondition) string { return c.Reason }
-						getStatus := func(c v1.VirtualMachineInstanceCondition) k8sv1.ConditionStatus { return c.Status }
-						getMessage := func(c v1.VirtualMachineInstanceCondition) string { return c.Message }
-						Expect(vmi.Status.Conditions).To(
-							ContainElement(
-								And(
-									WithTransform(getType, Equal(string(k8sv1.PodScheduled))),
-									WithTransform(getReason, Equal(k8sv1.PodReasonUnschedulable)),
-									WithTransform(getStatus, Equal(k8sv1.ConditionFalse)),
-									WithTransform(getMessage, Equal(fmt.Sprintf("PVC %v/%v does not exist, waiting for it to appear", vmi.Namespace, pvcName))),
-								),
-							),
-						)
-					}
-					expectPodScheduledCondition(vmi)
-					return true
-				}, time.Duration(10)*time.Second).Should(BeTrue(), "Timed out waiting for VMI to get Unschedulable condition")
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(vmi.Status.Phase).To(Equal(v1.Pending))
+					g.Expect(vmi.Status.Conditions).To(ContainElement(
+						And(
+							WithTransform(func(c v1.VirtualMachineInstanceCondition) string { return string(c.Type) }, Equal(string(k8sv1.PodScheduled))),
+							WithTransform(func(c v1.VirtualMachineInstanceCondition) string { return c.Reason }, Equal(k8sv1.PodReasonUnschedulable)),
+							WithTransform(func(c v1.VirtualMachineInstanceCondition) k8sv1.ConditionStatus { return c.Status }, Equal(k8sv1.ConditionFalse)),
+							WithTransform(func(c v1.VirtualMachineInstanceCondition) string { return c.Message }, Equal(fmt.Sprintf("PVC %v/%v does not exist, waiting for it to appear", vmi.Namespace, pvcName))),
+						),
+					))
+				}, time.Duration(10)*time.Second).Should(Succeed(), "Timed out waiting for VMI to get Unschedulable condition")
 
 			})
 		})
@@ -1341,6 +1324,6 @@ func runPodAndExpectPhase(pod *k8sv1.Pod, phase k8sv1.PodPhase) *k8sv1.Pod {
 
 	pod, err = ThisPod(pod)()
 	Expect(err).ToNot(HaveOccurred())
-	Expect(pod).ToNot(BeNil())
+	Expect(pod).ToNot(BeNil(), "pod should not be nil after reaching phase %s", phase)
 	return pod
 }

--- a/tests/storage/utility-volumes.go
+++ b/tests/storage/utility-volumes.go
@@ -213,17 +213,18 @@ var _ = Describe(SIG("Utility Volumes", func() {
 			}, 30*time.Second, 1*time.Second).Should(Equal(v1.MigrationPending))
 
 			// Verify condition is set to indicate utility volumes are blocking
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				migration, err = virtClient.VirtualMachineInstanceMigration(testNamespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for _, condition := range migration.Status.Conditions {
-					if condition.Type == v1.VirtualMachineInstanceMigrationBlockedByUtilityVolumes &&
-						condition.Status == k8sv1.ConditionTrue {
-						return true
-					}
-				}
-				return false
-			}, 30*time.Second, 1*time.Second).Should(BeTrue(), "Should have condition indicating utility volumes are blocking")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(migration.Status.Conditions).To(ContainElement(And(
+					WithTransform(func(condition v1.VirtualMachineInstanceMigrationCondition) v1.VirtualMachineInstanceMigrationConditionType {
+						return condition.Type
+					}, Equal(v1.VirtualMachineInstanceMigrationBlockedByUtilityVolumes)),
+					WithTransform(func(condition v1.VirtualMachineInstanceMigrationCondition) k8sv1.ConditionStatus {
+						return condition.Status
+					}, Equal(k8sv1.ConditionTrue)),
+				)))
+			}, 30*time.Second, 1*time.Second).Should(Succeed(), "Should have condition indicating utility volumes are blocking")
 
 			events.ExpectEvent(migration, k8sv1.EventTypeWarning, controller.UtilityVolumeMigrationPendingReason)
 
@@ -232,16 +233,15 @@ var _ = Describe(SIG("Utility Volumes", func() {
 			verifyUtilityVolumeRemovedFromVMI(virtClient, vmi, utilityVolumeName)
 
 			// Verify condition is removed after utility volumes are detached
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				migration, err = virtClient.VirtualMachineInstanceMigration(testNamespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for _, condition := range migration.Status.Conditions {
-					if condition.Type == v1.VirtualMachineInstanceMigrationBlockedByUtilityVolumes {
-						return false
-					}
-				}
-				return true
-			}, 30*time.Second, 1*time.Second).Should(BeTrue(), "Utility volumes condition should be removed after volumes are detached")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(migration.Status.Conditions).ToNot(ContainElement(
+					WithTransform(func(condition v1.VirtualMachineInstanceMigrationCondition) v1.VirtualMachineInstanceMigrationConditionType {
+						return condition.Type
+					}, Equal(v1.VirtualMachineInstanceMigrationBlockedByUtilityVolumes)),
+				))
+			}, 30*time.Second, 1*time.Second).Should(Succeed(), "Utility volumes condition should be removed after volumes are detached")
 
 			// Wait for migration to succeed
 			Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
@@ -301,27 +301,19 @@ func verifyUtilityVolumeInVMISpec(virtClient kubecli.KubevirtClient, vmi *v1.Vir
 }
 
 func verifyUtilityVolumeRemovedFromVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, utilityVolumeName string) {
-	Eventually(func() bool {
+	Eventually(func(g Gomega) {
 		currentVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(currentVMI.Spec.UtilityVolumes).ToNot(ContainElement(
+			WithTransform(func(utilityVolume v1.UtilityVolume) string { return utilityVolume.Name }, Equal(utilityVolumeName)),
+		))
+	}, 30*time.Second, 1*time.Second).Should(Succeed())
 
-		for _, utilityVolume := range currentVMI.Spec.UtilityVolumes {
-			if utilityVolume.Name == utilityVolumeName {
-				return false
-			}
-		}
-		return true
-	}, 30*time.Second, 1*time.Second).Should(BeTrue())
-
-	Eventually(func() bool {
+	Eventually(func(g Gomega) {
 		currentVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		for _, volumeStatus := range currentVMI.Status.VolumeStatus {
-			if volumeStatus.Name == utilityVolumeName {
-				return false
-			}
-		}
-		return true
-	}, 30*time.Second, 1*time.Second).Should(BeTrue())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(currentVMI.Status.VolumeStatus).ToNot(ContainElement(
+			WithTransform(func(volumeStatus v1.VolumeStatus) string { return volumeStatus.Name }, Equal(utilityVolumeName)),
+		))
+	}, 30*time.Second, 1*time.Second).Should(Succeed())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Many E2E storage tests used `Eventually`/`Consistently` polling loops that either:
* Returned booleans from standard anonymous functions (e.g. `Eventually(func() bool { ... }).Should(BeTrue())`), resulting in generic `"Expected false to be true"` errors upon failure.
* Made standard `Expect` calls within the anonymous functions, which did not provide the full contextual failure information when nested assertions failed.
* Dereferenced optional status/condition pointers (e.g., `*vs.Status.ReadyToUse`) inside tests, risking a nil-pointer dereference panic if the status field was not populated at the time of evaluation.

#### After this PR:
The storage E2E tests across 12 main test suites have been refactored for robustness and improved error readability:
* **Context-aware assertions with `g Gomega`**: Refactored `Eventually`/`Consistently` loops to receive `g Gomega` as an argument (e.g., `Eventually(func(g Gomega) { ... })`) and replaced standard assertions with context-aware assertions (`g.Expect(...)`). This allows Gomega to print precise and descriptive failure messages indicating exactly which inner condition failed, along with the actual and expected values at the moment of failure.
* **Safe Pointer Assertions**: Replaced unsafe pointer dereferences (like `*vs.Status.ReadyToUse`) with Gomega's `HaveValue` matcher (e.g., `Expect(vs.Status.ReadyToUse).To(HaveValue(BeTrue()))`), mitigating potential test-runner panics due to nil pointers.
* **Descriptive Failure Messages**: Added meaningful error descriptions to multiple key assertion calls to guide developers directly to the root cause when a test fails.

The refactor targets the assertions within these 12 files:
* `tests/storage/backup.go`
* `tests/storage/cbt.go`
* `tests/storage/datavolume.go`
* `tests/storage/export.go`
* `tests/storage/hotplug.go`
* `tests/storage/memorydump.go`
* `tests/storage/migration.go`
* `tests/storage/reservation.go`
* `tests/storage/restore.go`
* `tests/storage/snapshot.go`
* `tests/storage/storage.go`
* `tests/storage/utility-volumes.go`

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
 
- Partially addresses #10347 
-->
None

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
This is a pure test-utility and E2E robustness change. It simplifies debugging CI failure logs by providing clear details instead of generic timeouts or boolean assertion failures.

The following alternatives were considered:
Continuing to use boolean return checks in `Eventually`, which requires adding custom failure strings for every assertion manually. Using Gomega's built-in `Eventually(func(g Gomega))` pattern is much more idiomatic, robust, and maintains cleaner code.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```