### PR TITLE
virt-config: handle tombstone objects in crdAddedDeleted handler

### DIFF
--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -138,7 +138,19 @@ func isPrometheusRules(crd *extv1.CustomResourceDefinition) bool {
 
 func (c *ClusterConfig) crdAddedDeleted(obj interface{}) {
 	go c.GetConfig()
-	crd := obj.(*extv1.CustomResourceDefinition)
+	crd, ok := obj.(*extv1.CustomResourceDefinition)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			log.Log.Errorf("couldn't get object from tombstone %+v", obj)
+			return
+		}
+		crd, ok = tombstone.Obj.(*extv1.CustomResourceDefinition)
+		if !ok {
+			log.Log.Errorf("tombstone contained object that is not a CRD %#v", obj)
+			return
+		}
+	}
 	if !isDataVolumeCrd(crd) && !isDataSourceCrd(crd) &&
 		!isServiceMonitor(crd) && !isPrometheusRules(crd) {
 		return


### PR DESCRIPTION
### What this PR does

#### Before this PR
The `crdAddedDeleted` handler performed an unsafe type assertion on the incoming object. When a CRD delete event was missed (for example during a controller restart or network partition), the informer delivered `cache.DeletedFinalStateUnknown` tombstone instead of the actual CRD object, causing a panic.

#### After this PR
The handler now safely checks whether the object is a tombstone and extracts the CRD from it, matching the pattern already used in other delete handlers across the codebase.

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Log an error and return early if the tombstone cannot be unwrapped, instead of panicking.
- The `go c.GetConfig()` call still executes in all cases, so config refresh  behavior remains unchanged.

The following alternatives were considered:
- Recovering from panic was rejected because it masks bugs, is harder to debug, and is not the established pattern used in this codebase.

### Special notes for your reviewer

This change follows the same tombstone-handling pattern already used in:
- `pkg/virt-controller/watch/pool/pool.go` (`deleteVMHandler`)
- `pkg/virt-controller/watch/drain/evacuation/evacuation.go`

### Checklist

- [x] Design: not required — bug fix with no API change
- [x] PR: description covers the bug and the fix
- [x] Code: follows the existing tombstone-handling pattern in this repo
- [x] Refactor: left the code safer than found
- [x] Upgrade: no impact
- [ ] Testing: adding a unit test for the tombstone path would strengthen this PR
- [x] Documentation: not required — internal bug fix
- [x] Community: not required
- [x] AI Contributions: PR abides by the KubeVirt AI Contribution Policy

```release-note
Fix panic in ClusterConfig CRD delete handler when the informer delivers a tombstone object instead of the deleted CRD.
```