### PR TITLE
migration: Prevent hotplug mount leaks during failed migration cleanup

### DIFF
--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -108,7 +108,6 @@ func NewMigrationTargetController(
 	netBindingPluginMemoryCalculator netBindingPluginMemoryCalculator,
 	passtRepairHandler passtRepairTargetHandler,
 ) (*MigrationTargetController, error) {
-
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig[string](
 		workqueue.DefaultTypedControllerRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-handler-target"},
@@ -139,12 +138,12 @@ func NewMigrationTargetController(
 	}
 
 	containerDiskState := filepath.Join(virtPrivateDir, "container-disk-mount-state")
-	if err := os.MkdirAll(containerDiskState, 0700); err != nil {
+	if err := os.MkdirAll(containerDiskState, 0o700); err != nil {
 		return nil, err
 	}
 
 	hotplugState := filepath.Join(virtPrivateDir, "hotplug-volume-mount-state")
-	if err := os.MkdirAll(hotplugState, 0700); err != nil {
+	if err := os.MkdirAll(hotplugState, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -195,7 +194,6 @@ func domainIsActiveOnTarget(domain *api.Domain) bool {
 		return true
 	}
 	return false
-
 }
 
 func (c *MigrationTargetController) ackMigrationCompletion(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
@@ -737,14 +735,14 @@ func (c *MigrationTargetController) unmountVolumes(originalVMI *v1.VirtualMachin
 		return err
 	}
 
-	// Mount hotplug disk
+	// Unmount all hotplug volumes
 	if attachmentPodUID := vmiCopy.Status.MigrationState.TargetAttachmentPodUID; attachmentPodUID != "" {
 		cgroupManager, err := getCgroupManager(vmiCopy, c.host, c.hypervisorNodeInfo, c.clusterConfig.AllowEmulation())
 		if err != nil {
 			return err
 		}
-		if err = c.hotplugVolumeMounter.Unmount(vmiCopy, cgroupManager); err != nil {
-			return fmt.Errorf("failed to unmount hotplug volumes: %v", err)
+		if err = c.hotplugVolumeMounter.UnmountAll(vmiCopy, cgroupManager); err != nil {
+			return fmt.Errorf("failed to unmount all hotplug volumes: %v", err)
 		}
 	}
 
@@ -896,6 +894,7 @@ func (c *MigrationTargetController) addDomainFunc(obj interface{}) {
 		c.queue.Add(key)
 	}
 }
+
 func (c *MigrationTargetController) deleteDomainFunc(obj interface{}) {
 	domain, ok := obj.(*api.Domain)
 	if !ok {
@@ -916,6 +915,7 @@ func (c *MigrationTargetController) deleteDomainFunc(obj interface{}) {
 		c.queue.Add(key)
 	}
 }
+
 func (c *MigrationTargetController) updateDomainFunc(old, new interface{}) {
 	newDomain := new.(*api.Domain)
 	oldDomain := old.(*api.Domain)


### PR DESCRIPTION
### What this PR does
#### Before this PR:
When migration does not complete on the target (including `migrate-cancel`), target-side hotplug mounts may remain leaked.

#### After this PR:
Target-side hotplug mounts are fully cleaned up on failed/incomplete migration paths, preventing leaked mounts immediately after migration failure.

### References
- Fixes #17882

### Why we need it and why it was done in this way
See issue details and full reproduction in #17882.

### Special notes for your reviewer

### Checklist
- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fixed a target-side hotplug mount leak that could remain after failed or canceled live migration.
```
