### PR TITLE
Disable multifd migration for VMs with dedicated CPU placement

### DIFF
--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -643,6 +643,10 @@ func configureParallelMigrationThreads(options *cmdclient.MigrationOptions, vm *
 	if cpuLimit, cpuLimitExists := vm.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU]; cpuLimitExists && !cpuLimit.IsZero() {
 		return
 	}
+	// Dedicated CPUs are also fully allocating each vCPU for compute.
+	if vm.IsCPUDedicated() {
+		return
+	}
 
 	options.ParallelMigrationThreads = pointer.P(parallelMultifdMigrationThreads)
 }

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -528,18 +528,9 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 				Entry("with a zero CPU quantity", pointer.P(resource.MustParse("0"))),
 			)
 
-			DescribeTable("should not configure multiple threads", func(allowPostcopy bool, vmiLimits k8sv1.ResourceList) {
-				var migrationConfiguration = &v1.MigrationConfiguration{
-					BandwidthPerMigration:   pointer.P(resource.MustParse("0Mi")),
-					ProgressTimeout:         pointer.P(int64(150)),
-					AllowAutoConverge:       pointer.P(false),
-					CompletionTimeoutPerGiB: pointer.P(int64(50)),
-					UnsafeMigrationOverride: pointer.P(false),
-					AllowPostCopy:           pointer.P(allowPostcopy),
-					AllowWorkloadDisruption: pointer.P(true),
-				}
-				vmi.Status.MigrationState.MigrationConfiguration = migrationConfiguration
+			DescribeTable("should not configure multiple threads", func(vmiLimits k8sv1.ResourceList, cpu *v1.CPU) {
 				vmi.Spec.Domain.Resources.Limits = vmiLimits
+				vmi.Spec.Domain.CPU = cpu
 
 				client.EXPECT().MigrateVirtualMachine(gomock.Any(), gomock.Any()).Do(func(_ *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions) {
 					Expect(options.ParallelMigrationThreads).To(BeNil())
@@ -548,7 +539,8 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 				controller.Execute()
 				testutils.ExpectEvent(recorder, VMIMigrating)
 			},
-				Entry("if CPU is limited", false, k8sv1.ResourceList{k8sv1.ResourceCPU: resource.MustParse("4")}),
+				Entry("if CPU is limited", k8sv1.ResourceList{k8sv1.ResourceCPU: resource.MustParse("4")}, nil),
+				Entry("if CPU is dedicated", nil, &v1.CPU{DedicatedCPUPlacement: true, Cores: 2, Sockets: 1, Threads: 1}),
 			)
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The configureParallelMigrationThreads function only checked domain.resources.limits.cpu to decide whether to skip multifd, missing the case where CPU is constrained via DedicatedCPUPlacement with an explicit core/socket/thread topology.

#### Before this PR:
multifd enabled for Dedicated CPUs via topology config as per https://kubevirt.io/user-guide/compute/dedicated_cpu_resources/

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #17879

-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Disable parallel migration threads by default when dedicated CPUs are used. Similar to defining CPU limits in .resources.limits the dedicated CPUs are fully allocated for compute.
```

