### PR TITLE
Increase cluster profiler dump timeout from 5s to 15s

### DIFF
--- a/pkg/virt-api/rest/profiler.go
+++ b/pkg/virt-api/rest/profiler.go
@@ -257,7 +257,7 @@ func (app *SubresourceAPIApp) DumpClusterProfilerHandler(request *restful.Reques
 			},
 		}
 		client = http.Client{
-			Timeout:   5 * time.Second,
+			Timeout:   15 * time.Second,
 			Transport: tr,
 		}
 		results = v1.ClusterProfilerResults{

--- a/tests/infrastructure/cluster-profiler.go
+++ b/tests/infrastructure/cluster-profiler.go
@@ -45,8 +45,8 @@ var _ = Describe(SIGSerial("cluster profiler for pprof data aggregation", func()
 		}
 	})
 
-	Context("when ClusterProfiler configuration", func() {
-		It("is disabled it should prevent subresource access", func() {
+	Context("when the ClusterProfiler configuration", func() {
+		It("is disabled, it should prevent subresource access", func() {
 			kvConfig.DeveloperConfiguration.ClusterProfiler = false
 			config.UpdateKubeVirtConfigValueAndWait(kvConfig)
 
@@ -59,7 +59,7 @@ var _ = Describe(SIGSerial("cluster profiler for pprof data aggregation", func()
 			_, err = virtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
 			Expect(err).To(HaveOccurred())
 		})
-		It("[QUARANTINE]is enabled it should allow subresource access", decorators.Quarantine, func() {
+		It("[QUARANTINE]is enabled, it should allow subresource access", decorators.Quarantine, func() {
 			kvConfig.DeveloperConfiguration.ClusterProfiler = true
 			config.UpdateKubeVirtConfigValueAndWait(kvConfig)
 


### PR DESCRIPTION
### What this PR does
The DumpClusterProfilerHandler fans out HTTP requests to each component pod, which runs runtime.GC() before collecting 7 pprof profiles. On loaded CI nodes, GC alone can consume several seconds, causing the 5-second timeout to expire and the dump request to fail. This is the root cause of the flaky ClusterProfiler pprof subresource access test.

15 seconds provides a comfortable margin for GC plus profile collection on the slowest pod, without being excessive for this developer-only debugging API.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
-->
  
- Fixes #17906

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
