### PR TITLE
VEP-115: harden PCI NUMA-aware topology placement (PR1)

### DIFF
--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -133,6 +133,9 @@ func GetDeviceNumaNode(pciAddress string) (*uint32, error) {
 	if err != nil {
 		return nil, err
 	}
+	if numaNodeInt < 0 {
+		return nil, fmt.Errorf("device %s has no NUMA node affinity", pciAddress)
+	}
 	numaNode := uint32(numaNodeInt)
 	return &numaNode, nil
 }
@@ -197,14 +200,34 @@ func PCIAddressToString(pciBusID *api.Address) string {
 		strings.TrimPrefix(pciBusID.Function, prefix))
 }
 
-// LookupDevicesNumaNodes looks up the NUMA nodes of multiple devices based on
-// their PCI addresses and the domain spec of the virtual machine.
-//
-// It returns a map of PCI addresses to their corresponding NUMA node IDs.
+// DeviceNUMANodeLookupWarning explains why a device or mapping input could not
+// be used for PCI NUMA-aware placement.
+type DeviceNUMANodeLookupWarning struct {
+	PCIAddress string
+	Reason     string
+}
+
+func (w DeviceNUMANodeLookupWarning) String() string {
+	if w.PCIAddress == "" {
+		return w.Reason
+	}
+	return fmt.Sprintf("device %s: %s", w.PCIAddress, w.Reason)
+}
+
+// LookupDevicesNumaNodes looks up the guest NUMA cells for multiple PCI devices.
 func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) map[string]uint32 {
+	numaNodes, _ := LookupDevicesNumaNodesWithWarnings(pciAddresses, domainSpec)
+	return numaNodes
+}
+
+// LookupDevicesNumaNodesWithWarnings looks up the guest NUMA cells that should
+// host PCI devices based on the devices' host NUMA affinity and the domain's
+// host-to-guest NUMA mapping.
+func LookupDevicesNumaNodesWithWarnings(pciAddresses []string, domainSpec *api.DomainSpec) (map[string]uint32, []DeviceNUMANodeLookupWarning) {
 	results := make(map[string]uint32)
+	var warnings []DeviceNUMANodeLookupWarning
 	if len(pciAddresses) == 0 || domainSpec == nil || domainSpec.CPU.NUMA == nil || domainSpec.CPUTune == nil {
-		return results
+		return results, warnings
 	}
 
 	// pcpu -> vcpu mapping
@@ -213,6 +236,9 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 	for _, vcpuPin := range cpuTune {
 		pc, err := ParseCPUSetLine(vcpuPin.CPUSet, MAX_CPU_LIMIT)
 		if err != nil {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				Reason: fmt.Sprintf("ignoring invalid vCPU pinning for vCPU %d: %v", vcpuPin.VCPU, err),
+			})
 			continue
 		}
 		for _, p := range pc {
@@ -225,11 +251,17 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 	for _, cell := range domainSpec.CPU.NUMA.Cells {
 		vcpusInCell, err := ParseCPUSetLine(cell.CPUs, MAX_CPU_LIMIT)
 		if err != nil {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				Reason: fmt.Sprintf("ignoring guest NUMA cell %q with invalid CPU set %q: %v", cell.ID, cell.CPUs, err),
+			})
 			continue
 		}
 
 		cellID, err := strconv.Atoi(cell.ID)
 		if err != nil {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				Reason: fmt.Sprintf("ignoring guest NUMA cell with invalid ID %q: %v", cell.ID, err),
+			})
 			continue
 		}
 
@@ -243,6 +275,10 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 	for _, pciAddress := range pciAddresses {
 		deviceNuma, err := GetDeviceNumaNode(pciAddress)
 		if err != nil {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				PCIAddress: pciAddress,
+				Reason:     fmt.Sprintf("failed to read host NUMA affinity: %v", err),
+			})
 			continue
 		}
 		var pcpus []uint32
@@ -252,6 +288,10 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 		} else {
 			pcpusNuma, err := GetNumaNodeCPUList(int(*deviceNuma))
 			if err != nil {
+				warnings = append(warnings, DeviceNUMANodeLookupWarning{
+					PCIAddress: pciAddress,
+					Reason:     fmt.Sprintf("failed to read CPU list for host NUMA node %d: %v", *deviceNuma, err),
+				})
 				continue
 			}
 			for _, pcpu := range pcpusNuma {
@@ -262,11 +302,18 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 
 		for _, pcpu := range pcpus {
 			if vCPU, exist := p2vCPUMap[pcpu]; exist {
-				cellID := vCPUToCellMap[vCPU]
-				results[pciAddress] = cellID
-				break
+				if cellID, exists := vCPUToCellMap[vCPU]; exists {
+					results[pciAddress] = cellID
+					break
+				}
 			}
 		}
+		if _, exists := results[pciAddress]; !exists {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				PCIAddress: pciAddress,
+				Reason:     fmt.Sprintf("host NUMA node %d cannot be mapped to a guest NUMA cell", *deviceNuma),
+			})
+		}
 	}
-	return results
+	return results, warnings
 }

--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -226,24 +226,34 @@ func LookupDevicesNumaNodes(pciAddresses []string, domainSpec *api.DomainSpec) m
 func LookupDevicesNumaNodesWithWarnings(pciAddresses []string, domainSpec *api.DomainSpec) (map[string]uint32, []DeviceNUMANodeLookupWarning) {
 	results := make(map[string]uint32)
 	var warnings []DeviceNUMANodeLookupWarning
-	if len(pciAddresses) == 0 || domainSpec == nil || domainSpec.CPU.NUMA == nil || domainSpec.CPUTune == nil {
+	if len(pciAddresses) == 0 || domainSpec == nil || domainSpec.CPU.NUMA == nil {
 		return results, warnings
 	}
 
+	// Prefer NUMATune memnodes when present because they encode the explicit
+	// guest-cell to host-node memory binding.
+	memNodeMap, memNodeWarnings := memNodeHostToGuestNUMAMap(domainSpec.CPU.NUMA, domainSpec.NUMATune)
+	warnings = append(warnings, memNodeWarnings...)
+
 	// pcpu -> vcpu mapping
 	p2vCPUMap := make(map[uint32]uint32)
-	cpuTune := domainSpec.CPUTune.VCPUPin
-	for _, vcpuPin := range cpuTune {
-		pc, err := ParseCPUSetLine(vcpuPin.CPUSet, MAX_CPU_LIMIT)
-		if err != nil {
-			warnings = append(warnings, DeviceNUMANodeLookupWarning{
-				Reason: fmt.Sprintf("ignoring invalid vCPU pinning for vCPU %d: %v", vcpuPin.VCPU, err),
-			})
-			continue
+	if domainSpec.CPUTune != nil {
+		cpuTune := domainSpec.CPUTune.VCPUPin
+		for _, vcpuPin := range cpuTune {
+			pc, err := ParseCPUSetLine(vcpuPin.CPUSet, MAX_CPU_LIMIT)
+			if err != nil {
+				warnings = append(warnings, DeviceNUMANodeLookupWarning{
+					Reason: fmt.Sprintf("ignoring invalid vCPU pinning for vCPU %d: %v", vcpuPin.VCPU, err),
+				})
+				continue
+			}
+			for _, p := range pc {
+				p2vCPUMap[uint32(p)] = vcpuPin.VCPU
+			}
 		}
-		for _, p := range pc {
-			p2vCPUMap[uint32(p)] = vcpuPin.VCPU
-		}
+	}
+	if len(memNodeMap) == 0 && len(p2vCPUMap) == 0 {
+		return results, warnings
 	}
 
 	// vcpu -> vnuma mapping
@@ -281,6 +291,11 @@ func LookupDevicesNumaNodesWithWarnings(pciAddresses []string, domainSpec *api.D
 			})
 			continue
 		}
+		if cellID, exists := memNodeMap[*deviceNuma]; exists {
+			results[pciAddress] = cellID
+			continue
+		}
+
 		var pcpus []uint32
 		// if another device is already on this NUMA node, use the same pcpu set
 		if res, exists := pNumaToPCPUSetMap[*deviceNuma]; exists {
@@ -315,5 +330,77 @@ func LookupDevicesNumaNodesWithWarnings(pciAddresses []string, domainSpec *api.D
 			})
 		}
 	}
+	return results, warnings
+}
+
+func memNodeHostToGuestNUMAMap(numa *api.NUMA, numaTune *api.NUMATune) (map[uint32]uint32, []DeviceNUMANodeLookupWarning) {
+	results := make(map[uint32]uint32)
+	var warnings []DeviceNUMANodeLookupWarning
+	if numa == nil || numaTune == nil {
+		return results, warnings
+	}
+
+	// NUMATune memnodes are emitted as guest-cell -> host-node memory bindings.
+	// PCI placement needs the reverse mapping: host NUMA node -> guest NUMA cell.
+	// A host node that is assigned to multiple guest cells is ambiguous, so it is
+	// excluded and the caller may fall back to vCPU pinning inference per device.
+	guestCells := make(map[uint32]struct{})
+	for _, cell := range numa.Cells {
+		cellID, err := strconv.Atoi(cell.ID)
+		if err != nil || cellID < 0 {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				Reason: fmt.Sprintf("ignoring guest NUMA cell with invalid ID %q", cell.ID),
+			})
+			continue
+		}
+		guestCells[uint32(cellID)] = struct{}{}
+	}
+	if len(guestCells) == 0 {
+		return results, warnings
+	}
+
+	ambiguousHostNodes := make(map[uint32]struct{})
+	for _, memNode := range numaTune.MemNodes {
+		if _, exists := guestCells[memNode.CellID]; !exists {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				Reason: fmt.Sprintf("ignoring NUMATune memnode for unknown guest NUMA cell %d", memNode.CellID),
+			})
+			continue
+		}
+
+		hostNodes, err := ParseCPUSetLine(memNode.NodeSet, MAX_CPU_LIMIT)
+		if err != nil {
+			warnings = append(warnings, DeviceNUMANodeLookupWarning{
+				Reason: fmt.Sprintf("ignoring NUMATune memnode for guest NUMA cell %d with invalid nodeset %q: %v", memNode.CellID, memNode.NodeSet, err),
+			})
+			continue
+		}
+		for _, hostNode := range hostNodes {
+			if hostNode < 0 {
+				warnings = append(warnings, DeviceNUMANodeLookupWarning{
+					Reason: fmt.Sprintf("ignoring negative host NUMA node %d in NUMATune memnode for guest NUMA cell %d", hostNode, memNode.CellID),
+				})
+				continue
+			}
+
+			hostNodeID := uint32(hostNode)
+			if _, ambiguous := ambiguousHostNodes[hostNodeID]; ambiguous {
+				continue
+			}
+
+			guestCellID, exists := results[hostNodeID]
+			if exists && guestCellID != memNode.CellID {
+				delete(results, hostNodeID)
+				ambiguousHostNodes[hostNodeID] = struct{}{}
+				warnings = append(warnings, DeviceNUMANodeLookupWarning{
+					Reason: fmt.Sprintf("host NUMA node %d is mapped to multiple guest NUMA cells (%d and %d); ignoring NUMATune mapping for that host node", hostNodeID, guestCellID, memNode.CellID),
+				})
+				continue
+			}
+
+			results[hostNodeID] = memNode.CellID
+		}
+	}
+
 	return results, warnings
 }

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -35,7 +35,8 @@ import (
 
 var _ = Describe("Hardware utils test", func() {
 	const (
-		testPCIAddress = "0000:00:01.0"
+		testPCIAddress      = "0000:00:01.0"
+		testPCIAddressNUMA1 = "0000:00:02.0"
 	)
 
 	var (
@@ -61,6 +62,14 @@ var _ = Describe("Hardware utils test", func() {
 
 		numaNodeFile := filepath.Join(pciDevicePath, "numa_node")
 		err = os.WriteFile(numaNodeFile, []byte("0\n"), 0o644)
+		Expect(err).ToNot(HaveOccurred())
+
+		pciDevicePath = filepath.Join(fakePciBasePath, testPCIAddressNUMA1)
+		err = os.MkdirAll(pciDevicePath, 0o755)
+		Expect(err).ToNot(HaveOccurred())
+
+		numaNodeFile = filepath.Join(pciDevicePath, "numa_node")
+		err = os.WriteFile(numaNodeFile, []byte("1\n"), 0o644)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create NUMA node 0 with cpulist
@@ -358,6 +367,158 @@ var _ = Describe("Hardware utils test", func() {
 			Expect(devicesNumaNodes[testPCIAddress]).To(Equal(uint32(0)))
 		})
 
+		It("should use NUMATune memnode mapping without vCPU affinity", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0-3"},
+							{ID: "1", CPUs: "4-7"},
+						},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 1, Mode: "strict", NodeSet: "0"},
+					},
+				},
+			}
+
+			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 1}))
+		})
+
+		It("should prefer NUMATune memnode mapping over vCPU pinning", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0"},
+							{ID: "1", CPUs: "1"},
+						},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{VCPU: 0, CPUSet: "0"},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 1, Mode: "strict", NodeSet: "0"},
+					},
+				},
+			}
+
+			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 1}))
+		})
+
+		It("should fall back to vCPU pinning when NUMATune memnode mapping is ambiguous", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0"},
+							{ID: "1", CPUs: "1"},
+						},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{VCPU: 0, CPUSet: "0"},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 0, Mode: "strict", NodeSet: "0"},
+						{CellID: 1, Mode: "strict", NodeSet: "0"},
+					},
+				},
+			}
+
+			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 0}))
+		})
+
+		It("should report warnings for ambiguous NUMATune memnode mapping", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0"},
+							{ID: "1", CPUs: "1"},
+						},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "0"}},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 0, Mode: "strict", NodeSet: "0"},
+						{CellID: 1, Mode: "strict", NodeSet: "0"},
+					},
+				},
+			}
+
+			devicesNumaNodes, warnings := LookupDevicesNumaNodesWithWarnings([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 0}))
+
+			warningMessages := []string{}
+			for _, warning := range warnings {
+				warningMessages = append(warningMessages, warning.String())
+			}
+			Expect(warningMessages).To(ContainElement(ContainSubstring("mapped to multiple guest NUMA cells")))
+		})
+
+		It("should fall back to vCPU pinning when NUMATune memnode references an unknown guest cell", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0"},
+						},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{VCPU: 0, CPUSet: "0"},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 1, Mode: "strict", NodeSet: "0"},
+					},
+				},
+			}
+
+			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 0}))
+		})
+
+		It("should keep unambiguous NUMATune memnode mappings when another host node is ambiguous", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0"},
+							{ID: "1", CPUs: "1"},
+						},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 0, Mode: "strict", NodeSet: "0"},
+						{CellID: 1, Mode: "strict", NodeSet: "0-1"},
+					},
+				},
+			}
+
+			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress, testPCIAddressNUMA1}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddressNUMA1: 1}))
+		})
+
 		It("should report warnings for devices without host NUMA affinity", func() {
 			domainSpec := &api.DomainSpec{
 				CPU: api.CPU{
@@ -400,6 +561,29 @@ var _ = Describe("Hardware utils test", func() {
 				warningMessages = append(warningMessages, warning.String())
 			}
 			Expect(warningMessages).To(ContainElement(ContainSubstring("cannot be mapped to a guest NUMA cell")))
+		})
+
+		It("should keep valid NUMATune memnode mappings when another memnode is invalid", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0"},
+							{ID: "1", CPUs: "1"},
+						},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 0, Mode: "strict", NodeSet: "invalid"},
+						{CellID: 2, Mode: "strict", NodeSet: "0"},
+						{CellID: 1, Mode: "strict", NodeSet: "1"},
+					},
+				},
+			}
+
+			devicesNumaNodes := LookupDevicesNumaNodes([]string{testPCIAddress, testPCIAddressNUMA1}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddressNUMA1: 1}))
 		})
 	})
 })

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -208,6 +208,23 @@ var _ = Describe("Hardware utils test", func() {
 		})
 	})
 
+	Context("get device numa node", func() {
+		It("should reject devices without usable NUMA affinity", func() {
+			pciAddress := "0000:00:03.0"
+			pciDevicePath := filepath.Join(fakePciBasePath, pciAddress)
+			err := os.MkdirAll(pciDevicePath, 0o755)
+			Expect(err).ToNot(HaveOccurred())
+
+			numaNodeFile := filepath.Join(pciDevicePath, "numa_node")
+			err = os.WriteFile(numaNodeFile, []byte("-1\n"), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = GetDeviceNumaNode(pciAddress)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has no NUMA node affinity"))
+		})
+	})
+
 	Context("get device aligned CPUs", func() {
 		It("should return device aligned CPUs", func() {
 			alignedCPUs, err := GetDeviceAlignedCPUs(testPCIAddress)
@@ -339,6 +356,50 @@ var _ = Describe("Hardware utils test", func() {
 			Expect(devicesNumaNodes).ToNot(BeEmpty())
 			Expect(devicesNumaNodes).To(HaveKey(testPCIAddress))
 			Expect(devicesNumaNodes[testPCIAddress]).To(Equal(uint32(0)))
+		})
+
+		It("should report warnings for devices without host NUMA affinity", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{{ID: "0", CPUs: "0"}},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "0"}},
+				},
+			}
+
+			devicesNumaNodes, warnings := LookupDevicesNumaNodesWithWarnings([]string{"0000:ff:00.0"}, domainSpec)
+			Expect(devicesNumaNodes).To(BeEmpty())
+
+			warningMessages := []string{}
+			for _, warning := range warnings {
+				warningMessages = append(warningMessages, warning.String())
+			}
+			Expect(warningMessages).To(ContainElement(ContainSubstring("failed to read host NUMA affinity")))
+		})
+
+		It("should not map a device through a pinned vCPU outside guest NUMA cells", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{{ID: "0", CPUs: "1"}},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "0"}},
+				},
+			}
+
+			devicesNumaNodes, warnings := LookupDevicesNumaNodesWithWarnings([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(BeEmpty())
+
+			warningMessages := []string{}
+			for _, warning := range warnings {
+				warningMessages = append(warningMessages, warning.String())
+			}
+			Expect(warningMessages).To(ContainElement(ContainSubstring("cannot be mapped to a guest NUMA cell")))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1190,7 +1190,20 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 
 			if c.PCINUMAAwareTopologyEnabled {
 				if c.Architecture.SupportPCIePlacement() {
-					if err := PlacePCIDevicesWithNUMAAlignment(&domain.Spec); err != nil {
+					// Strict PCI placement is tied to the VMI API request. At this
+					// point the request has already been converted into domain NUMA
+					// state, but deriving strictness from the XML shape would make
+					// other NUMATune users strict by accident.
+					strictPCIPlacement := vmi.Spec.Domain.CPU.NUMA != nil &&
+						vmi.Spec.Domain.CPU.NUMA.GuestMappingPassthrough != nil
+					var opts []PCIPlacementOption
+					if strictPCIPlacement {
+						opts = append(opts, WithStrictPCINUMAPlacement())
+					}
+					if err := PlacePCIDevicesWithNUMAAlignment(&domain.Spec, opts...); err != nil {
+						if strictPCIPlacement {
+							return fmt.Errorf("failed to process strict PCIe NUMA-aware topology: %w", err)
+						}
 						log.Log.Reason(err).Warningf("Failed to process PCIe NUMA-aware topology, falling back to default placement")
 					}
 				} else {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1907,6 +1907,25 @@ var _ = Describe("Converter", func() {
 					Expect(rootPort.Address.Bus).To(Equal(numaExpander.Index), "root port %d should be attached to the expander bus", i)
 				}
 			})
+
+			It("should fail conversion when guest NUMA passthrough host devices cannot be NUMA placed", func() {
+				if cleanup != nil {
+					cleanup()
+				}
+				cleanup = setupMockHardwarePaths(map[string]string{
+					"0000:81:01.0": "0",
+					"0000:81:02.0": "0",
+					"0000:82:01.0": "0",
+				}, map[string]string{"0": "0-1"})
+
+				c = createContextWithDevices(vmi, c)
+				domain := &api.Domain{}
+				err := Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, domain, c)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to process strict PCIe NUMA-aware topology"))
+				Expect(err.Error()).To(ContainSubstring("0000:82:02.0"))
+			})
 		})
 
 		Context("with PCINUMAAwareTopology feature gate disabled", func() {

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -1,7 +1,10 @@
 package converter
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
+	"sort"
 	"strconv"
 
 	"k8s.io/utils/ptr"
@@ -277,9 +280,11 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 		devicesByAddress[address] = &devices[i]
 	}
 
+	slices.Sort(pciAddresses)
 	numaNodes := hardware.LookupDevicesNumaNodes(pciAddresses, a.domainSpec)
 
-	for address, device := range devicesByAddress {
+	for _, address := range pciAddresses {
+		device := devicesByAddress[address]
 		if numaNode, exists := numaNodes[address]; exists {
 			a.devices[address] = device
 			a.devicesNUMANodes[address] = numaNode
@@ -301,6 +306,12 @@ func (a *expanderBusAssigner) groupDevicesByNUMA() numaDeviceGroups {
 			continue
 		}
 		groups[numaNode] = append(groups[numaNode], device)
+	}
+	for numaNode := range groups {
+		sort.Slice(groups[numaNode], func(i, j int) bool {
+			return hardware.PCIAddressToString(groups[numaNode][i].Source.Address) <
+				hardware.PCIAddressToString(groups[numaNode][j].Source.Address)
+		})
 	}
 	return groups
 }
@@ -353,7 +364,8 @@ func (a *expanderBusAssigner) placeDevice(topology *numaAwareTopology, device *a
 func (a *expanderBusAssigner) buildTopology() error {
 	numaDeviceGroups := a.groupDevicesByNUMA()
 
-	for numaKey, devices := range numaDeviceGroups {
+	for _, numaKey := range sortedKeys(numaDeviceGroups) {
+		devices := numaDeviceGroups[numaKey]
 		topology := a.getNumaAwareTopology(numaKey)
 
 		for _, device := range devices {
@@ -385,14 +397,16 @@ func (a *expanderBusAssigner) PlaceNumaAlignedDevices() error {
 		return fmt.Errorf("failed to create PCIe topology with NUMA alignment: %w", err)
 	}
 
-	for _, topology := range a.topologyMap {
+	for _, numaKey := range sortedKeys(a.topologyMap) {
+		topology := a.topologyMap[numaKey]
 		a.domainSpec.Devices.Controllers = append(a.domainSpec.Devices.Controllers, *topology.expanderBus)
 
 		for _, rootPort := range topology.rootPorts {
 			a.domainSpec.Devices.Controllers = append(a.domainSpec.Devices.Controllers, *rootPort)
 		}
 
-		for sourceAddress, address := range topology.addressPerDeviceSourcePCI {
+		for _, sourceAddress := range sortedKeys(topology.addressPerDeviceSourcePCI) {
+			address := topology.addressPerDeviceSourcePCI[sourceAddress]
 			if device, exists := a.devices[sourceAddress]; exists {
 				device.Address = address
 			}
@@ -403,4 +417,13 @@ func (a *expanderBusAssigner) PlaceNumaAlignedDevices() error {
 	}
 
 	return nil
+}
+
+func sortedKeys[K cmp.Ordered, V any](values map[K]V) []K {
+	keys := make([]K, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 
 	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
@@ -271,7 +272,7 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 		}
 
 		if devices[i].Source.Address == nil {
-			log.Log.Infof("device has no source address, skipping for pcie-expander-bus assignment")
+			log.Log.Warningf("PCI host device has no source address, skipping pcie-expander-bus assignment")
 			continue
 		}
 
@@ -286,15 +287,26 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 	}
 
 	slices.Sort(pciAddresses)
-	numaNodes := hardware.LookupDevicesNumaNodes(pciAddresses, a.domainSpec)
+	devicesNUMANodes, warnings := hardware.LookupDevicesNumaNodesWithWarnings(pciAddresses, a.domainSpec)
+	warningsByAddress := make(map[string][]string)
+	for _, warning := range warnings {
+		log.Log.Warningf("PCI NUMA-aware placement: %s", warning.String())
+		if warning.PCIAddress != "" {
+			warningsByAddress[warning.PCIAddress] = append(warningsByAddress[warning.PCIAddress], warning.Reason)
+		}
+	}
 
 	for _, address := range pciAddresses {
 		device := devicesByAddress[address]
-		if numaNode, exists := numaNodes[address]; exists {
+		if numaNode, exists := devicesNUMANodes[address]; exists {
 			a.devices[address] = device
 			a.devicesNUMANodes[address] = numaNode
 		} else {
-			log.Log.Infof("device %s has no NUMA affinity information, skipping for pcie-expander-bus assignment", address)
+			reason := "no guest NUMA node mapping is available"
+			if warningReasons := warningsByAddress[address]; len(warningReasons) > 0 {
+				reason = strings.Join(warningReasons, "; ")
+			}
+			log.Log.Warningf("device %s cannot be placed on a NUMA-aware PCIe topology: %s", address, reason)
 		}
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -21,6 +21,21 @@ const (
 	maxExpanderBusNr = 255
 )
 
+type pciNUMAPlacementOptions struct {
+	strict bool
+}
+
+// PCIPlacementOption configures PCI NUMA-aware placement behavior.
+type PCIPlacementOption func(*pciNUMAPlacementOptions)
+
+// WithStrictPCINUMAPlacement makes placement fail when a PCI host device cannot
+// be represented in the NUMA-aware PCI topology.
+func WithStrictPCINUMAPlacement() PCIPlacementOption {
+	return func(options *pciNUMAPlacementOptions) {
+		options.strict = true
+	}
+}
+
 // iteratePCIAddresses invokes the callback function for each PCI device specified in the domain
 func iteratePCIAddresses(spec *api.DomainSpec, callback func(address *api.Address) (*api.Address, error)) (err error) {
 	fn := func(address *api.Address) (*api.Address, error) {
@@ -186,6 +201,8 @@ type expanderBusAssigner struct {
 	topologyMap      map[uint32]*numaAwareTopology
 	devices          map[string]*api.HostDevice
 	devicesNUMANodes map[string]uint32
+	strict           bool
+	strictFailures   []string
 
 	// lastAssignedBusNr tracks the last assigned bus number for expander buses.
 	// It starts from maxExpanderBusNr and decreases as expander buses are assigned
@@ -208,7 +225,12 @@ func getCurrentControllerIndex(domainSpec *api.DomainSpec) uint32 {
 }
 
 // newExpanderBusAssigner creates a new PCIe expander bus assigner.
-func newExpanderBusAssigner(domainSpec *api.DomainSpec) *expanderBusAssigner {
+func newExpanderBusAssigner(domainSpec *api.DomainSpec, opts ...PCIPlacementOption) *expanderBusAssigner {
+	options := pciNUMAPlacementOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	currentControllerIndex := getCurrentControllerIndex(domainSpec)
 	log.Log.Infof("Current max controller index: %d", currentControllerIndex)
 
@@ -217,6 +239,7 @@ func newExpanderBusAssigner(domainSpec *api.DomainSpec) *expanderBusAssigner {
 		topologyMap:       make(map[uint32]*numaAwareTopology),
 		devices:           make(map[string]*api.HostDevice),
 		devicesNUMANodes:  make(map[string]uint32),
+		strict:            options.strict,
 		controllerIndex:   currentControllerIndex,
 		controllerCount:   0,
 		lastAssignedBusNr: maxExpanderBusNr,
@@ -228,8 +251,8 @@ func newExpanderBusAssigner(domainSpec *api.DomainSpec) *expanderBusAssigner {
 // PlacePCIDevicesWithNUMAAlignment places PCI devices in the domainSpec with
 // NUMA alignment using PCIe expander buses. It modifies the domainSpec in place
 // or leaves it unchanged in case of an error.
-func PlacePCIDevicesWithNUMAAlignment(domainSpec *api.DomainSpec) error {
-	assigner := newExpanderBusAssigner(domainSpec)
+func PlacePCIDevicesWithNUMAAlignment(domainSpec *api.DomainSpec, opts ...PCIPlacementOption) error {
+	assigner := newExpanderBusAssigner(domainSpec, opts...)
 	return assigner.PlaceNumaAlignedDevices()
 }
 
@@ -262,9 +285,10 @@ func (a *expanderBusAssigner) createController(model string, parentBus string, s
 	return controller
 }
 
-func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
+func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) error {
 	var pciAddresses []string
 	devicesByAddress := make(map[string]*api.HostDevice)
+	a.strictFailures = nil
 
 	for i := range devices {
 		if devices[i].Type != api.HostDevicePCI {
@@ -272,13 +296,13 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 		}
 
 		if devices[i].Source.Address == nil {
-			log.Log.Warningf("PCI host device has no source address, skipping pcie-expander-bus assignment")
+			a.handlePlacementWarning("PCI host device has no source address, skipping pcie-expander-bus assignment")
 			continue
 		}
 
 		address := hardware.PCIAddressToString(devices[i].Source.Address)
 		if hasGuestPCIAddress(devices[i].Address) {
-			log.Log.Warningf("device %s already has a guest PCI address, skipping pcie-expander-bus assignment", address)
+			a.handlePlacementWarning("device %s already has a guest PCI address, skipping pcie-expander-bus assignment", address)
 			continue
 		}
 
@@ -293,6 +317,8 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 		log.Log.Warningf("PCI NUMA-aware placement: %s", warning.String())
 		if warning.PCIAddress != "" {
 			warningsByAddress[warning.PCIAddress] = append(warningsByAddress[warning.PCIAddress], warning.Reason)
+		} else if a.strict {
+			a.addStrictFailure(warning.String())
 		}
 	}
 
@@ -306,8 +332,25 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 			if warningReasons := warningsByAddress[address]; len(warningReasons) > 0 {
 				reason = strings.Join(warningReasons, "; ")
 			}
-			log.Log.Warningf("device %s cannot be placed on a NUMA-aware PCIe topology: %s", address, reason)
+			a.handlePlacementWarning("device %s cannot be placed on a NUMA-aware PCIe topology: %s", address, reason)
 		}
+	}
+
+	if len(a.strictFailures) > 0 {
+		return fmt.Errorf("strict PCI NUMA-aware placement failed: %s", strings.Join(a.strictFailures, "; "))
+	}
+	return nil
+}
+
+func (a *expanderBusAssigner) handlePlacementWarning(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	log.Log.Warningf("%s", message)
+	a.addStrictFailure(message)
+}
+
+func (a *expanderBusAssigner) addStrictFailure(message string) {
+	if a.strict {
+		a.strictFailures = append(a.strictFailures, message)
 	}
 }
 
@@ -408,7 +451,9 @@ func (a *expanderBusAssigner) buildTopology() error {
 // into a PCIe topology aligned to their NUMA node. It modifies the domainSpec
 // in place or leaves it unchanged in case of an error.
 func (a *expanderBusAssigner) PlaceNumaAlignedDevices() error {
-	a.addDevices(a.domainSpec.Devices.HostDevices)
+	if err := a.addDevices(a.domainSpec.Devices.HostDevices); err != nil {
+		return err
+	}
 
 	if err := a.buildTopology(); err != nil {
 		return fmt.Errorf("failed to create PCIe topology with NUMA alignment: %w", err)

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -276,6 +276,11 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) {
 		}
 
 		address := hardware.PCIAddressToString(devices[i].Source.Address)
+		if hasGuestPCIAddress(devices[i].Address) {
+			log.Log.Warningf("device %s already has a guest PCI address, skipping pcie-expander-bus assignment", address)
+			continue
+		}
+
 		pciAddresses = append(pciAddresses, address)
 		devicesByAddress[address] = &devices[i]
 	}
@@ -426,4 +431,15 @@ func sortedKeys[K cmp.Ordered, V any](values map[K]V) []K {
 	}
 	slices.Sort(keys)
 	return keys
+}
+
+func hasGuestPCIAddress(address *api.Address) bool {
+	if address == nil {
+		return false
+	}
+
+	// Any populated PCI coordinate is treated as explicit guest placement.
+	// This planner must not complete or relocate partially populated addresses;
+	// malformed addresses are left to the normal domain validation path.
+	return address.Domain != "" || address.Bus != "" || address.Slot != "" || address.Function != ""
 }

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -356,7 +356,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 					Expect(controller.Target.BusNr).ToNot(BeNil())
 					busNr := *controller.Target.BusNr
 					_, expected := expectedBusNumbers[busNr]
-					Expect(expected).To(BeTrue(), "Bus number %d should be one of the expected values (253, 251)", busNr)
+					Expect(expected).To(BeTrue(), "Bus number %d should be one of the expected values (254, 252)", busNr)
 					expectedBusNumbers[busNr] = true
 				}
 			}
@@ -382,6 +382,79 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 				Expect(device.Address.Bus).ToNot(BeEmpty())
 				Expect(device.Address.Slot).To(Equal("0x00"))
 			}
+		})
+
+		It("should place NUMA groups and devices in deterministic order", func() {
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("numa1_b", "0x04"),
+				createPCIDevice("numa0_b", "0x03"),
+				createPCIDevice("numa0_a", "0x01"),
+				createPCIDevice("numa1_a", "0x02"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(domainSpec.Devices.Controllers).To(HaveLen(6))
+
+			Expect(domainSpec.Devices.Controllers[0].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
+			Expect(domainSpec.Devices.Controllers[0].Index).To(Equal("1"))
+			Expect(*domainSpec.Devices.Controllers[0].Target.NUMANode).To(Equal(uint32(0)))
+			Expect(*domainSpec.Devices.Controllers[0].Target.BusNr).To(Equal(uint32(253)))
+
+			Expect(domainSpec.Devices.Controllers[1].Model).To(Equal(api.ControllerModelPCIeRootPort))
+			Expect(domainSpec.Devices.Controllers[1].Index).To(Equal("2"))
+			Expect(domainSpec.Devices.Controllers[1].Address.Bus).To(Equal("1"))
+			Expect(domainSpec.Devices.Controllers[1].Address.Slot).To(Equal("0x00"))
+
+			Expect(domainSpec.Devices.Controllers[2].Model).To(Equal(api.ControllerModelPCIeRootPort))
+			Expect(domainSpec.Devices.Controllers[2].Index).To(Equal("3"))
+			Expect(domainSpec.Devices.Controllers[2].Address.Bus).To(Equal("1"))
+			Expect(domainSpec.Devices.Controllers[2].Address.Slot).To(Equal("0x01"))
+
+			Expect(domainSpec.Devices.Controllers[3].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
+			Expect(domainSpec.Devices.Controllers[3].Index).To(Equal("4"))
+			Expect(*domainSpec.Devices.Controllers[3].Target.NUMANode).To(Equal(uint32(1)))
+			Expect(*domainSpec.Devices.Controllers[3].Target.BusNr).To(Equal(uint32(250)))
+
+			Expect(domainSpec.Devices.Controllers[4].Model).To(Equal(api.ControllerModelPCIeRootPort))
+			Expect(domainSpec.Devices.Controllers[4].Index).To(Equal("5"))
+			Expect(domainSpec.Devices.Controllers[4].Address.Bus).To(Equal("4"))
+			Expect(domainSpec.Devices.Controllers[4].Address.Slot).To(Equal("0x00"))
+
+			Expect(domainSpec.Devices.Controllers[5].Model).To(Equal(api.ControllerModelPCIeRootPort))
+			Expect(domainSpec.Devices.Controllers[5].Index).To(Equal("6"))
+			Expect(domainSpec.Devices.Controllers[5].Address.Bus).To(Equal("4"))
+			Expect(domainSpec.Devices.Controllers[5].Address.Slot).To(Equal("0x01"))
+
+			deviceBusBySource := map[string]string{}
+			for _, device := range domainSpec.Devices.HostDevices {
+				deviceBusBySource[hardware.PCIAddressToString(device.Source.Address)] = device.Address.Bus
+			}
+			Expect(deviceBusBySource).To(Equal(map[string]string{
+				"0000:01:00.0": "2",
+				"0000:03:00.0": "3",
+				"0000:02:00.0": "5",
+				"0000:04:00.0": "6",
+			}))
+		})
+
+		It("should allocate new controller indexes after existing controllers", func() {
+			domainSpec.Devices.Controllers = []api.Controller{
+				{Model: api.ControllerModelPCIeRoot, Index: "0"},
+				{Model: api.ControllerModelPCIeRootPort, Index: "7"},
+			}
+			domainSpec.Devices.HostDevices = []api.HostDevice{createPCIDevice("device1", "0x01")}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(domainSpec.Devices.Controllers).To(HaveLen(4))
+			Expect(domainSpec.Devices.Controllers[2].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
+			Expect(domainSpec.Devices.Controllers[2].Index).To(Equal("8"))
+			Expect(domainSpec.Devices.Controllers[3].Model).To(Equal(api.ControllerModelPCIeRootPort))
+			Expect(domainSpec.Devices.Controllers[3].Index).To(Equal("9"))
+			Expect(domainSpec.Devices.HostDevices[0].Address.Bus).To(Equal("9"))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -358,6 +358,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 
 			// Add a device, this would require creating new controllers
 			domainSpec.Devices.HostDevices = []api.HostDevice{createPCIDevice("device1", "0x01")}
+			originalDomainSpec := domainSpec.DeepCopy()
 
 			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
 
@@ -365,6 +366,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 			Expect(err.Error()).To(ContainSubstring("insufficient bus numbers for NUMA-aligned PCIe topology"))
 			Expect(err.Error()).To(ContainSubstring("current controller index 256"))
 			Expect(err.Error()).To(ContainSubstring("last assigned expander bus number 255"))
+			Expect(domainSpec).To(Equal(originalDomainSpec))
 		})
 
 		It("should assign bus numbers for expander buses calculated as maxBusNr - controllerCount + 1", func() {
@@ -429,6 +431,36 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 			Expect(domainSpec.Devices.Controllers[1].Model).To(Equal(api.ControllerModelPCIeRootPort))
 
 			Expect(domainSpec.Devices.HostDevices[0].Address).To(Equal(newPCIAddress("0x00", "0x07")))
+			Expect(domainSpec.Devices.HostDevices[1].Address).To(Equal(newPCIAddress("2", "0x00")))
+		})
+
+		It("should leave devices without host NUMA affinity for default placement", func() {
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("missing_numa", "0x06"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(domainSpec.Devices.Controllers).To(BeEmpty())
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(BeNil())
+		})
+
+		It("should place only devices with host NUMA affinity", func() {
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("missing_numa", "0x06"),
+				createPCIDevice("numa0", "0x01"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(domainSpec.Devices.Controllers).To(HaveLen(2))
+			Expect(domainSpec.Devices.Controllers[0].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
+			Expect(*domainSpec.Devices.Controllers[0].Target.NUMANode).To(Equal(uint32(0)))
+			Expect(domainSpec.Devices.Controllers[1].Model).To(Equal(api.ControllerModelPCIeRootPort))
+
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(BeNil())
 			Expect(domainSpec.Devices.HostDevices[1].Address).To(Equal(newPCIAddress("2", "0x00")))
 		})
 

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -70,6 +70,18 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 		}
 	}
 
+	createPCIDeviceWithGuestAddress := func(alias, hostBus, guestBus, guestSlot string) api.HostDevice {
+		device := createPCIDevice(alias, hostBus)
+		device.Address = newPCIAddress(guestBus, guestSlot)
+		return device
+	}
+
+	createPCIDeviceWithPartialGuestAddress := func(alias, hostBus string) api.HostDevice {
+		device := createPCIDevice(alias, hostBus)
+		device.Address = &api.Address{Type: api.AddressPCI, Bus: "0x00"}
+		return device
+	}
+
 	createNonPCIDevice := func(deviceType string) api.HostDevice {
 		return api.HostDevice{
 			Type: deviceType,
@@ -199,6 +211,24 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 				},
 				expectedDevices: 1,
 				description:     "should skip devices without source address",
+			}),
+			Entry("filters devices with existing guest PCI addresses", addDevicesTestCase{
+				name: "devices with guest PCI addresses",
+				devices: []api.HostDevice{
+					createPCIDevice("pci1", "0x01"),
+					createPCIDeviceWithGuestAddress("pci2", "0x02", "0x00", "0x07"),
+				},
+				expectedDevices: 1,
+				description:     "should skip devices that already have a guest PCI address",
+			}),
+			Entry("filters devices with partial guest PCI addresses", addDevicesTestCase{
+				name: "devices with partial guest PCI addresses",
+				devices: []api.HostDevice{
+					createPCIDevice("pci1", "0x01"),
+					createPCIDeviceWithPartialGuestAddress("pci2", "0x02"),
+				},
+				expectedDevices: 1,
+				description:     "should skip devices that already have any guest PCI coordinate",
 			}),
 			Entry("filters devices without NUMA affinity", addDevicesTestCase{
 				name:            "devices without NUMA topology",
@@ -382,6 +412,24 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 				Expect(device.Address.Bus).ToNot(BeEmpty())
 				Expect(device.Address.Slot).To(Equal("0x00"))
 			}
+		})
+
+		It("should preserve existing hostdev guest PCI addresses", func() {
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDeviceWithGuestAddress("addressed", "0x01", "0x00", "0x07"),
+				createPCIDevice("unaddressed", "0x02"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(domainSpec.Devices.Controllers).To(HaveLen(2))
+			Expect(domainSpec.Devices.Controllers[0].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
+			Expect(*domainSpec.Devices.Controllers[0].Target.NUMANode).To(Equal(uint32(1)))
+			Expect(domainSpec.Devices.Controllers[1].Model).To(Equal(api.ControllerModelPCIeRootPort))
+
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(Equal(newPCIAddress("0x00", "0x07")))
+			Expect(domainSpec.Devices.HostDevices[1].Address).To(Equal(newPCIAddress("2", "0x00")))
 		})
 
 		It("should place NUMA groups and devices in deterministic order", func() {

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -464,6 +464,45 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 			Expect(domainSpec.Devices.HostDevices[1].Address).To(Equal(newPCIAddress("2", "0x00")))
 		})
 
+		It("should prefer NUMATune memnode mapping for guest NUMA placement", func() {
+			domainSpec.NUMATune = &api.NUMATune{
+				MemNodes: []api.MemNode{
+					{CellID: 1, Mode: "strict", NodeSet: "0"},
+				},
+			}
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("numa0", "0x01"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(domainSpec.Devices.Controllers).To(HaveLen(2))
+			Expect(domainSpec.Devices.Controllers[0].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
+			Expect(*domainSpec.Devices.Controllers[0].Target.NUMANode).To(Equal(uint32(1)))
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(Equal(newPCIAddress("2", "0x00")))
+		})
+
+		It("should fall back to vCPU pinning for ambiguous NUMATune memnode mapping", func() {
+			domainSpec.NUMATune = &api.NUMATune{
+				MemNodes: []api.MemNode{
+					{CellID: 0, Mode: "strict", NodeSet: "0"},
+					{CellID: 1, Mode: "strict", NodeSet: "0"},
+				},
+			}
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("numa0", "0x01"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(domainSpec.Devices.Controllers).To(HaveLen(2))
+			Expect(domainSpec.Devices.Controllers[0].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
+			Expect(*domainSpec.Devices.Controllers[0].Target.NUMANode).To(Equal(uint32(0)))
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(Equal(newPCIAddress("2", "0x00")))
+		})
+
 		It("should place NUMA groups and devices in deterministic order", func() {
 			domainSpec.Devices.HostDevices = []api.HostDevice{
 				createPCIDevice("numa1_b", "0x04"),

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -189,7 +189,8 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 					assigner = newExpanderBusAssigner(domainSpec)
 				}
 
-				assigner.addDevices(testCase.devices)
+				err := assigner.addDevices(testCase.devices)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(assigner.devices).To(HaveLen(testCase.expectedDevices), testCase.description)
 			},
 			Entry("filters non-PCI devices", addDevicesTestCase{
@@ -463,6 +464,46 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 			Expect(domainSpec.Devices.HostDevices[0].Address).To(BeNil())
 			Expect(domainSpec.Devices.HostDevices[1].Address).To(Equal(newPCIAddress("2", "0x00")))
 		})
+		It("should fail strict placement when a device has no host NUMA affinity", func() {
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("missing_numa", "0x06"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec, WithStrictPCINUMAPlacement())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("strict PCI NUMA-aware placement failed"))
+			Expect(err.Error()).To(ContainSubstring("0000:06:00.0"))
+			Expect(domainSpec.Devices.Controllers).To(BeEmpty())
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(BeNil())
+		})
+
+		It("should fail strict placement when a device has an explicit guest PCI address", func() {
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDeviceWithGuestAddress("addressed", "0x01", "0x00", "0x07"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec, WithStrictPCINUMAPlacement())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already has a guest PCI address"))
+			Expect(domainSpec.Devices.Controllers).To(BeEmpty())
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(Equal(newPCIAddress("0x00", "0x07")))
+		})
+
+		It("should fail strict placement when a device NUMA node cannot be mapped to a guest NUMA cell", func() {
+			domainSpec = createDomainSpecWithNUMA(
+				[]api.NUMACell{{ID: "0", CPUs: "0-1"}},
+				[]api.CPUTuneVCPUPin{{VCPU: 0, CPUSet: "4"}},
+			)
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("numa0", "0x01"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec, WithStrictPCINUMAPlacement())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be mapped to a guest NUMA cell"))
+			Expect(domainSpec.Devices.Controllers).To(BeEmpty())
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(BeNil())
+		})
 
 		It("should prefer NUMATune memnode mapping for guest NUMA placement", func() {
 			domainSpec.NUMATune = &api.NUMATune{
@@ -501,6 +542,24 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 			Expect(domainSpec.Devices.Controllers[0].Model).To(Equal(api.ControllerModelPCIeExpanderBus))
 			Expect(*domainSpec.Devices.Controllers[0].Target.NUMANode).To(Equal(uint32(0)))
 			Expect(domainSpec.Devices.HostDevices[0].Address).To(Equal(newPCIAddress("2", "0x00")))
+		})
+
+		It("should fail strict placement for ambiguous NUMATune memnode mapping", func() {
+			domainSpec.NUMATune = &api.NUMATune{
+				MemNodes: []api.MemNode{
+					{CellID: 0, Mode: "strict", NodeSet: "0"},
+					{CellID: 1, Mode: "strict", NodeSet: "0"},
+				},
+			}
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("numa0", "0x01"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec, WithStrictPCINUMAPlacement())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mapped to multiple guest NUMA cells"))
+			Expect(domainSpec.Devices.Controllers).To(BeEmpty())
+			Expect(domainSpec.Devices.HostDevices[0].Address).To(BeNil())
 		})
 
 		It("should place NUMA groups and devices in deterministic order", func() {


### PR DESCRIPTION
### What this PR does

It implements the PR1 of [NVIDIA Grace Virtualization Upstreaming Plan](https://docs.google.com/document/d/1pJBirt79ZJLb8qXNje1sKj_U8IdYjinkKInQLbV0Zjw/edit?tab=t.0#heading=h.czlquu3cqsra), hardens the generic `PCINUMAAwareTopology` placement path, extended VEP-115 https://github.com/kubevirt/enhancements/issues/115 

The existing planner creates a `pcie-expander-bus` per guest NUMA cell and places PCI host devices behind root ports attached to the matching expander bus. This PR keeps that model, but tightens several correctness and reviewability issues:

- makes NUMA group and PCI device placement deterministic,
- preserves PCI host devices that already have an explicit guest PCI address,
- documents and tests fallback behavior for devices without host NUMA affinity,
- verifies failed placement does not partially mutate the domain spec,
- prefers `NUMATune.MemNodes` as the host-to-guest NUMA mapping source when it is valid and unambiguous,
- falls back to the existing vCPU pinning based inference when `NUMATune.MemNodes` is absent, ambiguous, or invalid.

`NUMATune.MemNodes` is still treated as memory placement metadata. The PCI planner only reuses it as an explicit mapping from host NUMA node to guest NUMA cell when the mapping is safe to use.

### Why this is needed

`PCINUMAAwareTopology` should be stable and predictable before additional platform-specific PCI topology work builds on top of it.

The previous behavior had a few weak spots:

- map iteration could produce unstable controller/device XML ordering,
- PCI hostdevs with an already assigned guest PCI address could be moved by the NUMA planner,
- devices with missing NUMA information were not covered clearly by tests,
- placement errors needed explicit no-partial-mutation coverage,
- the planner inferred host-to-guest NUMA mapping from vCPU pinning even when libvirt/KubeVirt already had an explicit `NUMATune.MemNodes` mapping.

This is generic VEP-115 hardening. It does not introduce NVIDIA Grace-specific behavior.

### Scope notes

This PR does not implement the Grace/Blackwell SMMUv3 topology. In particular, it does not change the generic planner to allocate one `pcie-expander-bus` per GPU. That belongs in a later Grace-specific conversion PR, where verified Grace GPUs can be given dedicated PXB/SMMUv3 buses.

### Release notes

```release-note
PCI NUMA-aware placement (PCINUMAAwareTopology) now fails with an error for VMIs using numa.guestMappingPassthrough when a host device cannot be placed on a NUMA-aligned PCIe topology. Non-passthrough VMIs retain the existing fallback behavior.
```