### PR TITLE
Fix race condition in UEFI online snapshot 

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/os.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os.go
@@ -120,7 +120,7 @@ func (o OSDomainConfigurator) configureEFI(vmi *v1.VirtualMachineInstance, domai
 		domain.Spec.OS.BootLoader.Type = "pflash"
 		domain.Spec.OS.NVRam = &api.NVRam{
 			Template: o.efiConfiguration.EFIVars,
-			NVRam:    filepath.Join(util.PathForNVram(vmi), vmi.Name+"_VARS.fd"),
+			NVRam:    filepath.Join(util.PathForNVram(vmi), GetEFIVarsFileName(vmi)),
 		}
 	}
 }
@@ -221,4 +221,8 @@ func createACPITable(tableType, volumeName string, volumes []v1.Volume) (*api.AC
 	}
 
 	return nil, fmt.Errorf("Firmware's volume for %s was not found", tableType)
+}
+
+func GetEFIVarsFileName(vmi *v1.VirtualMachineInstance) string {
+	return fmt.Sprintf("%s_VARS.fd", vmi.Name)
 }

--- a/pkg/virt-launcher/virtwrap/storage/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/storage/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/os/disk:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/cbt:go_default_library",
         "//pkg/tpm:go_default_library",
         "//pkg/util:go_default_library",
@@ -22,6 +23,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/compute:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/types:go_default_library",
         "//pkg/virt-launcher/virtwrap/util:go_default_library",
         "//staging/src/kubevirt.io/api/backup/v1alpha1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
+++ b/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
@@ -21,16 +21,20 @@ package storage
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	"kubevirt.io/kubevirt/pkg/tpm"
 	"kubevirt.io/kubevirt/pkg/util"
 	agentpoller "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent-poller"
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
 func (m *StorageManager) FreezeVMI(vmi *v1.VirtualMachineInstance, unfreezeTimeoutSeconds int32) error {
@@ -61,6 +65,25 @@ func (m *StorageManager) FreezeVMI(vmi *v1.VirtualMachineInstance, unfreezeTimeo
 			log.Log.Errorf("fsync error to TPM state directory: %s, output: %s", err.Error(), out)
 			return err
 		}
+	}
+
+	// The fsfreeze doesn't apply to the NVRAM directory, so we explicitly sync the NVRAM file
+	// to ensure data integrity.
+	if backendstorage.HasPersistentEFI(&vmi.Spec) {
+		nvramFile := filepath.Join(util.PathForNVram(vmi), compute.GetEFIVarsFileName(vmi))
+
+		f, err := os.Open(nvramFile)
+		if err != nil {
+			log.Log.Errorf("could not open NVRAM file %s for fsync: %s", nvramFile, err.Error())
+			return err
+		}
+
+		// Force fsync on the file descriptor
+		// This should flush any pending writes from QEMU's pflash device
+		if err := f.Sync(); err != nil {
+			log.Log.Warningf("fsync failed on NVRAM file %s: %s", nvramFile, err.Error())
+		}
+		f.Close()
 	}
 
 	domain, err := m.virConn.LookupDomainByName(domainName)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -747,7 +747,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				webhook = nil
 			})
 
-			createMessageWithInitialValue := func(login console.LoginToFunction, device string, tpm bool, vmis ...*v1.VirtualMachineInstance) {
+			createMessageWithInitialValue := func(login console.LoginToFunction, device string, tpm, efi bool, vmis ...*v1.VirtualMachineInstance) {
 				for _, vmi := range vmis {
 					if vmi == nil {
 						continue
@@ -821,11 +821,24 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 						}...)
 					}
 
+					if efi {
+						batch = append(batch, []expect.Batcher{
+							&expect.BSnd{S: "{ printf \"\\x07\\x00\\x00\\x00\"; cat /test/data/message; } | sudo tee /sys/firmware/efi/efivars/kvtest-12345678-1234-1234-1234-123456789abc >/dev/null\n"},
+							&expect.BExp{R: ""},
+							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BExp{R: console.RetValue("0")},
+							&expect.BSnd{S: syncName},
+							&expect.BExp{R: ""},
+							&expect.BSnd{S: syncName},
+							&expect.BExp{R: ""},
+						}...)
+					}
+
 					Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 				}
 			}
 
-			updateMessage := func(device string, onlineSnapshot, tpm bool, vmis ...*v1.VirtualMachineInstance) {
+			updateMessage := func(device string, onlineSnapshot, tpm, efi bool, vmis ...*v1.VirtualMachineInstance) {
 				for _, vmi := range vmis {
 					if vmi == nil {
 						continue
@@ -884,11 +897,32 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 						}...)
 					}
 
+					if efi {
+						batch = append(batch, []expect.Batcher{
+							&expect.BSnd{S: "sudo chattr -i /sys/firmware/efi/efivars/kvtest-12345678-1234-1234-1234-123456789abc\n"},
+							&expect.BExp{R: ""},
+							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BExp{R: console.RetValue("0")},
+							&expect.BSnd{S: "sudo rm /sys/firmware/efi/efivars/kvtest-12345678-1234-1234-1234-123456789abc\n"},
+							&expect.BExp{R: ""},
+							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BExp{R: console.RetValue("0")},
+							&expect.BSnd{S: "{ printf \"\\x07\\x00\\x00\\x00\"; cat /test/data/message; } | sudo tee /sys/firmware/efi/efivars/kvtest-12345678-1234-1234-1234-123456789abc >/dev/null\n"},
+							&expect.BExp{R: ""},
+							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BExp{R: console.RetValue("0")},
+							&expect.BSnd{S: syncName},
+							&expect.BExp{R: ""},
+							&expect.BSnd{S: syncName},
+							&expect.BExp{R: ""},
+						}...)
+					}
+
 					Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 				}
 			}
 
-			verifyOriginalContent := func(device string, tpm bool, vmis ...*v1.VirtualMachineInstance) {
+			verifyOriginalContent := func(device string, tpm, efi bool, vmis ...*v1.VirtualMachineInstance) {
 				for _, vmi := range vmis {
 					if vmi == nil {
 						continue
@@ -936,6 +970,15 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 						}...)
 					}
 
+					if efi {
+						batch = append(batch, []expect.Batcher{
+							&expect.BSnd{S: "sudo dd if=/sys/firmware/efi/efivars/kvtest-12345678-1234-1234-1234-123456789abc bs=1 skip=4 2>/dev/null\n"},
+							&expect.BExp{R: string(vm.UID)},
+							&expect.BSnd{S: console.EchoLastReturnValue},
+							&expect.BExp{R: console.RetValue("0")},
+						}...)
+					}
+
 					Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 				}
 			}
@@ -968,7 +1011,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.TPM).To(Equal(vm.Spec.Template.Spec.Domain.Devices.TPM))
 			}
 
-			createSnapshotAndRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool, tpm bool, targetVMName string, stopVMBeforeRestore bool) {
+			createSnapshotAndRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool, tpm, efi bool, targetVMName string, stopVMBeforeRestore bool) {
 				isRestoreToDifferentVM := targetVMName != vm.Name
 
 				var targetUID *types.UID
@@ -976,7 +1019,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					targetUID = &vm.UID
 				}
 
-				createMessageWithInitialValue(login, device, tpm, vmi)
+				createMessageWithInitialValue(login, device, tpm, efi, vmi)
 
 				if !onlineSnapshot {
 					By(stoppingVM)
@@ -996,7 +1039,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				}
 
 				if !isRestoreToDifferentVM {
-					updateMessage(device, onlineSnapshot, tpm, vmi)
+					updateMessage(device, onlineSnapshot, tpm, efi, vmi)
 				}
 
 				if stopVMBeforeRestore {
@@ -1022,15 +1065,15 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				restore = waitRestoreComplete(restore, targetVMName, targetUID)
 			}
 
-			doRestoreNoVMStart := func(device string, login console.LoginToFunction, onlineSnapshot, tpm bool, targetVMName string) {
-				createSnapshotAndRestore(device, login, onlineSnapshot, tpm, targetVMName, stopVMBeforeRestore)
+			doRestoreNoVMStart := func(device string, login console.LoginToFunction, onlineSnapshot, tpm, efi bool, targetVMName string) {
+				createSnapshotAndRestore(device, login, onlineSnapshot, tpm, efi, targetVMName, stopVMBeforeRestore)
 			}
 
 			doRestoreStopVMAfterRestoreCreate := func(device string, login console.LoginToFunction, onlineSnapshot bool, targetVMName string) {
-				createSnapshotAndRestore(device, login, onlineSnapshot, false, targetVMName, stopVMAfterRestore)
+				createSnapshotAndRestore(device, login, onlineSnapshot, false, false, targetVMName, stopVMAfterRestore)
 			}
 
-			startVMAfterRestore := func(targetVMName, device string, tpm bool, login console.LoginToFunction) {
+			startVMAfterRestore := func(targetVMName, device string, tpm, efi bool, login console.LoginToFunction) {
 				isRestoreToDifferentVM := targetVMName != vm.Name
 				targetVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), targetVMName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1042,7 +1085,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				By("Verifying original file contents")
 				Expect(login(targetVMI)).To(Succeed())
 
-				verifyOriginalContent(device, tpm, targetVMI)
+				verifyOriginalContent(device, tpm, efi, targetVMI)
 
 				if isRestoreToDifferentVM {
 					newVM = targetVM
@@ -1052,8 +1095,8 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			}
 
 			doRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool, targetVMName string) {
-				doRestoreNoVMStart(device, login, onlineSnapshot, false, targetVMName)
-				startVMAfterRestore(targetVMName, device, false, login)
+				doRestoreNoVMStart(device, login, onlineSnapshot, false, false, targetVMName)
+				startVMAfterRestore(targetVMName, device, false, false, login)
 			}
 
 			orphanDataVolumeTemplate := func(vm *v1.VirtualMachine, index int) *cdiv1.DataVolume {
@@ -1385,6 +1428,22 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			DescribeTable("Should restore a vm with backend storage", func(onlineSnapshot bool) {
 				vm = createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)
 				vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+				vm.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{
+					Bootloader: &v1.Bootloader{
+						EFI: &v1.EFI{
+							SecureBoot: pointer.P(true),
+							Persistent: pointer.P(true),
+						},
+					},
+				}
+				if vm.Spec.Template.Spec.Domain.Features == nil {
+					vm.Spec.Template.Spec.Domain.Features = &v1.Features{}
+				}
+				if vm.Spec.Template.Spec.Domain.Features.SMM == nil {
+					vm.Spec.Template.Spec.Domain.Features.SMM = &v1.FeatureState{}
+				}
+				vm.Spec.Template.Spec.Domain.Features.SMM.Enabled = pointer.P(true)
+
 				vm, vmi = createAndStartVM(vm)
 				Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
 
@@ -1402,8 +1461,8 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					return console.LoginToFedora(vmi)
 				}
 
-				doRestoreNoVMStart("", loginFunc, onlineSnapshot, true, vm.Name)
-				startVMAfterRestore(vm.Name, "", true, loginFunc)
+				doRestoreNoVMStart("", loginFunc, onlineSnapshot, true, true, getTargetVMName(false, newVmName))
+				startVMAfterRestore(getTargetVMName(false, newVmName), "", true, true, loginFunc)
 				Expect(restore.Status.Restores).To(HaveLen(2))
 
 				By("Expect original backend PVC to be deleted")
@@ -1530,9 +1589,9 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					// continue and complete successfully
 					doRestoreStopVMAfterRestoreCreate("", login, onlineSnapshot, targetVMName)
 				} else {
-					doRestoreNoVMStart("", login, onlineSnapshot, false, targetVMName)
+					doRestoreNoVMStart("", login, onlineSnapshot, false, false, targetVMName)
 				}
-				startVMAfterRestore(targetVMName, "", false, login)
+				startVMAfterRestore(targetVMName, "", false, false, login)
 				Expect(restore.Status.Restores).To(HaveLen(1))
 				if restoreToNewVM {
 					checkNewVMEquality()
@@ -1993,7 +2052,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				vm = libvmops.StartVirtualMachine(vm)
 				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
 				Expect(vm.Spec.RunStrategy).To(HaveValue(Equal(v1.RunStrategyRerunOnFailure)))
-				doRestoreNoVMStart("", console.LoginToFedora, onlineSnapshot, false, vm.Name)
+				doRestoreNoVMStart("", console.LoginToFedora, onlineSnapshot, false, false, vm.Name)
 				Expect(restore.Status.Restores).To(HaveLen(1))
 				restoredVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -2034,7 +2093,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					getMemoryDump(vm.Name, vm.Namespace, memoryDumpPVCName)
 					waitMemoryDumpCompletion(vm)
 
-					doRestoreNoVMStart("", console.LoginToFedora, onlineSnapshot, false, getTargetVMName(restoreToNewVM, newVmName))
+					doRestoreNoVMStart("", console.LoginToFedora, onlineSnapshot, false, false, getTargetVMName(restoreToNewVM, newVmName))
 					Expect(restore.Status.Restores).To(HaveLen(1))
 					Expect(restore.Status.Restores[0].VolumeName).ToNot(Equal(memoryDumpPVCName))
 
@@ -2050,7 +2109,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					}
 					Expect(restorePVC.Spec.DataSource.Name).To(Equal(expectedSource))
 
-					startVMAfterRestore(getTargetVMName(restoreToNewVM, newVmName), "", false, console.LoginToFedora)
+					startVMAfterRestore(getTargetVMName(restoreToNewVM, newVmName), "", false, false, console.LoginToFedora)
 
 					targetVM := getTargetVM(restoreToNewVM)
 					targetVMI, err := virtClient.VirtualMachineInstance(targetVM.Namespace).Get(context.Background(), targetVM.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

When using persistent EFI, modifications to the pflash-backed NVRAM may not be fully flushed to disk at the time an online snapshot is taken.

This PR forces a sync on the file descriptor to flush pending writes to the disk.

### References
  
Should fix both:
- Fixes # https://redhat.atlassian.net/browse/CNV-87182
- Fixes # https://redhat.atlassian.net/browse/CNV-87183

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix race condition in UEFI online snapshot
```

