### PR TITLE
Support adding SupplementalGroups

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19689,6 +19689,16 @@
       "description": "If specified, the fully qualified vmi hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi, no matter if the vmi itself can pick up a hostname.",
       "type": "string"
      },
+     "supplementalGroups": {
+      "description": "SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID. These are propagated to the virt-launcher pod.",
+      "type": "array",
+      "items": {
+       "type": "integer",
+       "format": "int64",
+       "default": 0
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "terminationGracePeriodSeconds": {
       "description": "Grace period observed after signalling a VirtualMachineInstance to stop after which the VirtualMachineInstance is force terminated.",
       "type": "integer",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -325,6 +325,10 @@ func computePodSecurityContext(vmi *v1.VirtualMachineInstance, seccomp *k8sv1.Se
 	}
 	psc.SeccompProfile = seccomp
 
+	if len(vmi.Spec.SupplementalGroups) > 0 {
+		psc.SupplementalGroups = vmi.Spec.SupplementalGroups
+	}
+
 	return psc
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -326,7 +326,7 @@ func computePodSecurityContext(vmi *v1.VirtualMachineInstance, seccomp *k8sv1.Se
 	psc.SeccompProfile = seccomp
 
 	if len(vmi.Spec.SupplementalGroups) > 0 {
-		psc.SupplementalGroups = vmi.Spec.SupplementalGroups
+		psc.SupplementalGroups = slices.Clone(vmi.Spec.SupplementalGroups)
 	}
 
 	return psc

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4448,6 +4448,15 @@ var _ = Describe("Template", func() {
 				RunAsNonRoot: pointer.P(true),
 				FSGroup:      &nonRootUser,
 			}),
+			Entry("with supplemental groups", func() *v1.VirtualMachineInstance {
+				vmi := api.NewMinimalVMI("fake-vmi")
+				vmi.Spec.SupplementalGroups = []int64{1000, 2000}
+				return vmi
+			}, &k8sv1.PodSecurityContext{
+				RunAsUser:          new(int64),
+				FSGroup:            pointer.P(int64(util.NonRootUID)),
+				SupplementalGroups: []int64{1000, 2000},
+			}),
 		)
 
 		It("should compute the correct security context when rendering hotplug attachment pods", func() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7760,6 +7760,15 @@ var CRDsValidation map[string]string = map[string]string{
                     If not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi,
                     no matter if the vmi itself can pick up a hostname.
                   type: string
+                supplementalGroups:
+                  description: |-
+                    SupplementalGroups is a list of groups applied to the first process run in each container,
+                    in addition to the container's primary GID. These are propagated to the virt-launcher pod.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: atomic
                 terminationGracePeriodSeconds:
                   description: Grace period observed after signalling a VirtualMachineInstance
                     to stop after which the VirtualMachineInstance is force terminated.
@@ -13878,6 +13887,15 @@ var CRDsValidation map[string]string = map[string]string{
             If not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi,
             no matter if the vmi itself can pick up a hostname.
           type: string
+        supplementalGroups:
+          description: |-
+            SupplementalGroups is a list of groups applied to the first process run in each container,
+            in addition to the container's primary GID. These are propagated to the virt-launcher pod.
+          items:
+            format: int64
+            type: integer
+          type: array
+          x-kubernetes-list-type: atomic
         terminationGracePeriodSeconds:
           description: Grace period observed after signalling a VirtualMachineInstance
             to stop after which the VirtualMachineInstance is force terminated.
@@ -20335,6 +20353,15 @@ var CRDsValidation map[string]string = map[string]string{
                     If not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi,
                     no matter if the vmi itself can pick up a hostname.
                   type: string
+                supplementalGroups:
+                  description: |-
+                    SupplementalGroups is a list of groups applied to the first process run in each container,
+                    in addition to the container's primary GID. These are propagated to the virt-launcher pod.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: atomic
                 terminationGracePeriodSeconds:
                   description: Grace period observed after signalling a VirtualMachineInstance
                     to stop after which the VirtualMachineInstance is force terminated.
@@ -25473,6 +25500,15 @@ var CRDsValidation map[string]string = map[string]string{
                             If not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi,
                             no matter if the vmi itself can pick up a hostname.
                           type: string
+                        supplementalGroups:
+                          description: |-
+                            SupplementalGroups is a list of groups applied to the first process run in each container,
+                            in addition to the container's primary GID. These are propagated to the virt-launcher pod.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                          x-kubernetes-list-type: atomic
                         terminationGracePeriodSeconds:
                           description: Grace period observed after signalling a VirtualMachineInstance
                             to stop after which the VirtualMachineInstance is force
@@ -31073,6 +31109,15 @@ var CRDsValidation map[string]string = map[string]string{
                                 If not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi,
                                 no matter if the vmi itself can pick up a hostname.
                               type: string
+                            supplementalGroups:
+                              description: |-
+                                SupplementalGroups is a list of groups applied to the first process run in each container,
+                                in addition to the container's primary GID. These are propagated to the virt-launcher pod.
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                              x-kubernetes-list-type: atomic
                             terminationGracePeriodSeconds:
                               description: Grace period observed after signalling
                                 a VirtualMachineInstance to stop after which the VirtualMachineInstance

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -981,6 +981,9 @@
             "readOnly": true,
             "type": "typeValue"
           }
+        ],
+        "supplementalGroups": [
+          -18
         ]
       }
     },

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -704,6 +704,8 @@ spec:
       schedulerName: schedulerNameValue
       startStrategy: startStrategyValue
       subdomain: subdomainValue
+      supplementalGroups:
+      - -18
       terminationGracePeriodSeconds: -29
       tolerations:
       - effect: effectValue

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -921,6 +921,9 @@
         "readOnly": true,
         "type": "typeValue"
       }
+    ],
+    "supplementalGroups": [
+      -18
     ]
   },
   "status": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -507,6 +507,8 @@ spec:
   schedulerName: schedulerNameValue
   startStrategy: startStrategyValue
   subdomain: subdomainValue
+  supplementalGroups:
+  - -18
   terminationGracePeriodSeconds: -29
   tolerations:
   - effect: effectValue

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -6464,6 +6464,11 @@ func (in *VirtualMachineInstanceSpec) DeepCopyInto(out *VirtualMachineInstanceSp
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SupplementalGroups != nil {
+		in, out := &in.SupplementalGroups, &out.SupplementalGroups
+		*out = make([]int64, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -195,6 +195,11 @@ type VirtualMachineInstanceSpec struct {
 	// +listMapKey=name
 	// +optional
 	UtilityVolumes []UtilityVolume `json:"utilityVolumes,omitempty"`
+	// SupplementalGroups is a list of groups applied to the first process run in each container,
+	// in addition to the container's primary GID. These are propagated to the virt-launcher pod.
+	// +optional
+	// +listType=atomic
+	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
 }
 
 func (vmiSpec *VirtualMachineInstanceSpec) UnmarshalJSON(data []byte) error {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -41,6 +41,7 @@ func (VirtualMachineInstanceSpec) SwaggerDoc() map[string]string {
 		"architecture":                  "Specifies the architecture of the vm guest you are attempting to run. Defaults to the compiled architecture of the KubeVirt components",
 		"resourceClaims":                "ResourceClaims define which ResourceClaims must be allocated\nand reserved before the VMI, hence virt-launcher pod is allowed to start. The resources\nwill be made available to the domain which consumes them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate in kubernetes\n https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/\nThis field should only be configured if one of the feature-gates GPUsWithDRA or HostDevicesWithDRA is enabled.\nThis feature is in alpha.\n\n+listType=map\n+listMapKey=name\n+optional",
 		"utilityVolumes":                "List of utility volumes that can be mounted to the vmi virt-launcher pod\nwithout having a matching disk in the domain.\nUsed to collect data for various operational workflows.\n+kubebuilder:validation:MaxItems:=256\n+listType=map\n+listMapKey=name\n+optional",
+		"supplementalGroups":            "SupplementalGroups is a list of groups applied to the first process run in each container,\nin addition to the container's primary GID. These are propagated to the virt-launcher pod.\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -29063,6 +29063,26 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceSpec(ref common.Referen
 							},
 						},
 					},
+					"supplementalGroups": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID. These are propagated to the virt-launcher pod.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: 0,
+										Type:    []string{"integer"},
+										Format:  "int64",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"domain"},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

The motive behind this PR is to allow the `compute` container read/write access to a specific device node with a non-root group

#### Before this PR:

Unable to specify `SupplementalGroups` on the `VirtualMachineInstance` (VMI) type (and hence the `VirtualMachine`'s template spec)

#### After this PR:

Can specify `spec.supplementalGroups` on the VMI which will be passed to the `virt-launcher` Pod's `spec.securityContext.supplementalGroups` field (see https://pkg.go.dev/k8s.io/api/core/v1#PodSecurityContext)

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #14016 
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

The following alternatives were considered:
- Allowing the `virt-launcher` Pod to be modified by a mutating webhook in order to inject fields such as the supplemental groups -- this would likely be out of scope of this kind of change, instead requiring more of a rethink of the approach to mutations
- Adding the entire `SecurityContext` field on the VMI's `spec` (with type https://pkg.go.dev/k8s.io/api/core/v1#PodSecurityContext)

The following tradeoffs were made:
- Only adding what is necessary for this issue (`spec.supplementalGroups`) without adding complexity of every field of `SecurityContext`, especially since some of these fields are already calculated in internal kubevirt code e.g., https://github.com/kubevirt/kubevirt/blob/501de9572358f1b306aac25dd6eda7bc664f3ef0/pkg/virt-controller/services/template.go#L310-L329. This means we differ slightly in hierarchy from the Pod's spec, but this should be worth it for the  benefit of reduced complexity.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added ability to specify `spec.supplementalGroups` on the `VirtualMachineInstance`, which get passed on to the `virt-launcher` Pod's `spec.securityContext.supplementalGroups`
```

