### PR TITLE
vm controller: handle deletion before checking expectations

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3221,17 +3221,10 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 		startVMSpec *virtv1.VirtualMachineSpec
 	)
 
-	if !c.satisfiedExpectations(key) {
-		return vm, vmi, nil, nil
-	}
-
-	if vmi != nil {
-		startVMSpec, err = c.getLastVMRevisionSpec(vm)
-		if err != nil {
-			return vm, vmi, nil, err
-		}
-	}
-
+	// Handle deletion before checking expectations: a deleted VM must have
+	// its finalizer removed even when expectations from a previous reconcile
+	// cycle are still pending (e.g. because the namespace is terminating and
+	// object creation was rejected).
 	if vm.DeletionTimestamp != nil {
 		if vmi == nil || controller.HasFinalizer(vm, metav1.FinalizerOrphanDependents) {
 			vm, err = c.removeVMFinalizer(vm)
@@ -3246,11 +3239,22 @@ func (c *Controller) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 			}
 		}
 		return vm, vmi, nil, nil
-	} else {
-		vm, err = c.addVMFinalizer(vm)
+	}
+
+	if !c.satisfiedExpectations(key) {
+		return vm, vmi, nil, nil
+	}
+
+	if vmi != nil {
+		startVMSpec, err = c.getLastVMRevisionSpec(vm)
 		if err != nil {
 			return vm, vmi, nil, err
 		}
+	}
+
+	vm, err = c.addVMFinalizer(vm)
+	if err != nil {
+		return vm, vmi, nil, err
 	}
 
 	vmi, err = c.conditionallyBumpGenerationAnnotationOnVmi(vm, vmi)

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -2703,6 +2703,49 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(vm.Finalizers).To(BeEmpty())
 		})
 
+		It("should remove controller finalizer even when expectations are not satisfied", func() {
+			vm, _ := watchtesting.DefaultVirtualMachine(true)
+			vm.DeletionTimestamp = pointer.P(metav1.Now())
+
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+			addVirtualMachine(vm)
+
+			key, err := virtcontroller.KeyFunc(vm)
+			Expect(err).To(Not(HaveOccurred()))
+			controller.expectations.ExpectCreations(key, 1)
+
+			sanityExecute(vm)
+
+			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).To(Succeed())
+			Expect(vm.Finalizers).To(BeEmpty())
+		})
+
+		It("should stop VirtualMachineInstance when VM is deleted with unsatisfied expectations", func() {
+			vm, vmi := watchtesting.DefaultVirtualMachine(true)
+			vm.DeletionTimestamp = pointer.P(metav1.Now())
+
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+			addVirtualMachine(vm)
+
+			_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.TODO(), vmi, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			controller.vmiIndexer.Add(vmi)
+
+			key, err := virtcontroller.KeyFunc(vm)
+			Expect(err).To(Not(HaveOccurred()))
+			controller.expectations.ExpectCreations(key, 1)
+
+			sanityExecute(vm)
+
+			testutils.ExpectEvent(recorder, common.SuccessfulDeleteVirtualMachineReason)
+
+			_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).To(MatchError(ContainSubstring("not found")))
+		})
+
 		DescribeTable("should not delete VirtualMachineInstance when vmi failed", func(runStrategy v1.VirtualMachineRunStrategy) {
 			vm, vmi := watchtesting.DefaultVirtualMachine(true)
 


### PR DESCRIPTION
When a namespace is terminating, the VM controller may fail to create ControllerRevisions or VMIs, leaving unsatisfied expectations. If the VM then receives its own deletionTimestamp via cascade deletion, the satisfiedExpectations check in sync() returns early, preventing the deletion path from ever removing the VM's finalizer. This deadlocks the namespace: the VM can't be garbage-collected, and the namespace can't finish terminating.

Move the DeletionTimestamp check ahead of the satisfiedExpectations and getLastVMRevisionSpec checks so that a deleted VM always reaches its finalization logic, regardless of pending expectations.

Note to reviewer: vm controller is a delicate place. I don't think I'm qualified to propose code there.

Fixes: https://redhat.atlassian.net/browse/CNV-88876

```release-note
NONE
```

