### PR TITLE
Fix/empty feature gate warnings

### DIFF
--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -457,11 +457,10 @@ func featureGatesChanged(currKVSpec, newKVSpec *v1.KubeVirtSpec) bool {
 
 func warnDeprecatedFeatureGates(featureGates []string) (warnings []string) {
 	for _, featureGate := range featureGates {
-		deprectedFeature := featuregate.FeatureGateInfo(featureGate)
-		if deprectedFeature != nil {
-			warning := deprectedFeature.Message
-			warnings = append(warnings, warning)
-			log.Log.Warning(warning)
+		fg := featuregate.FeatureGateInfo(featureGate)
+		if fg != nil && fg.Message != "" {
+			warnings = append(warnings, fg.Message)
+			log.Log.Warning(fg.Message)
 		}
 	}
 

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -501,6 +501,19 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				[]string{"Gate1", "Gate2", "Gate3"},
 				"Gate1", "Gate2", "Gate3"),
 		)
+
+		DescribeTable("should not emit empty warnings for Alpha/Beta feature gates in FeatureGates", func(gate string) {
+			devConfig := &v1.DeveloperConfiguration{FeatureGates: []string{gate}}
+			response := admitUpdate(devConfig)
+			Expect(response.Allowed).To(BeTrue())
+			for _, w := range response.Warnings {
+				Expect(w).NotTo(BeEmpty(), "got empty-string warning for gate %q", gate)
+			}
+		},
+			Entry("Alpha gate CPUManager", featuregate.CPUManager),
+			Entry("Beta gate KubevirtSeccompProfile", featuregate.KubevirtSeccompProfile),
+			Entry("Beta gate NodeRestrictionGate", featuregate.NodeRestrictionGate),
+		)
 	})
 })
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`warnDeprecatedFeatureGates` appended a warning for every feature gate returned by `FeatureGateInfo()`, including Alpha and Beta gates whose `Message` field is empty. This caused empty strings to appear in the admission response `Warnings` list whenever an Alpha or Beta gate was listed in `FeatureGates`.

#### After this PR:
Warnings are only emitted when the feature gate has a non-empty `Message` (i.e. Deprecated, Discontinued, or GA gates).
Alpha and Beta gates produce no warning.

### References

### Why we need it and why it was done in this way `RegisterFeatureGate` only sets a default `Message` for non-Alpha, non-Beta gates. The existing check `if deprectedFeature != nil` was too broad — it fired on every known gate, not just deprecated ones. The fix adds a `fg.Message != ""` guard, which matches the convention used by `RegisterFeatureGate`.

The following tradeoffs were made: none, this is a pure bug fix with no behavior change for deprecated/discontinued gates.

The following alternatives were considered: filtering by `fg.State` explicitly, but checking `Message != ""` is simpler and
stays consistent with how `RegisterFeatureGate` decides which gates carry a user-facing message.
 
### Checklist

- [ ] Design: not required, bug fix
- [x] PR: description covers before/after and reasoning
- [x] Code: minimal targeted fix
- [x] Refactor: left the code cleaner (removed dead warning path for Alpha/Beta gates)
- [ ] Upgrade: no impact
- [x] Testing: regression table added for Alpha and Beta gates
- [ ] Documentation: not required, internal webhook behavior
- [ ] Community: not required
- [ ] AI Contributions: N/A

### Release note
```release-note
NONE
```