### PR TITLE
tests: collect artifacts on teardown failures

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -178,6 +178,7 @@ go_test(
         "//vendor/github.com/gorilla/websocket:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2/reporters:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2/types:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/format:go_default_library",
         "//vendor/github.com/onsi/gomega/gmeasure:go_default_library",

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/ginkgo/v2/types"
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -67,6 +68,7 @@ import (
 var afterSuiteReporters = []Reporter{}
 var k8sReporter *reporter.KubernetesReporter
 var etcdProfiler *reporter.EtcdProfiler
+var postCleanupReporter *reporter.KubernetesReporter
 
 func TestTests(t *testing.T) {
 	flags.NormalizeFlags()
@@ -104,6 +106,10 @@ func TestTests(t *testing.T) {
 		}
 		etcdProfiler = reporter.NewEtcdProfiler(etcdArtifactsDir)
 	}
+
+	postCleanupPath := filepath.Join(artifactsPath, "cleanup_failures")
+	postCleanupReporter = reporter.NewKubernetesReporter(postCleanupPath, maxFails, alwaysCollect)
+	postCleanupReporter.Cleanup()
 
 	vmsgeneratorutils.DockerPrefix = flags.KubeVirtUtilityRepoPrefix
 	vmsgeneratorutils.DockerTag = flags.KubeVirtVersionTag
@@ -190,6 +196,7 @@ var _ = ReportAfterSuite("TestTests", func(report Report) {
 
 var _ = ReportBeforeSuite(func(report Report) {
 	k8sReporter.ConfigurePerSpecReporting(report)
+	postCleanupReporter.ConfigurePerSpecReporting(report)
 })
 
 var _ = BeforeEach(func() {
@@ -217,6 +224,35 @@ var _ = JustAfterEach(func() {
 		etcdProfiler.RecordSpec(CurrentSpecReport())
 	}
 })
+
+var _ = ReportAfterEach(func(specReport SpecReport) {
+	if flags.DeployFakeKWOKNodesFlag {
+		return
+	}
+	if !specReport.Failed() {
+		return
+	}
+	if hasTeardownFailure(specReport) {
+		postCleanupReporter.ReportSpec(specReport)
+	}
+})
+
+func isTeardownNodeType(nt types.NodeType) bool {
+	return nt == types.NodeTypeAfterEach || nt == types.NodeTypeCleanupAfterEach ||
+		nt == types.NodeTypeAfterAll || nt == types.NodeTypeCleanupAfterAll
+}
+
+func hasTeardownFailure(specReport SpecReport) bool {
+	if isTeardownNodeType(specReport.Failure.FailureNodeType) {
+		return true
+	}
+	for _, af := range specReport.AdditionalFailures {
+		if isTeardownNodeType(af.Failure.FailureNodeType) {
+			return true
+		}
+	}
+	return false
+}
 
 func testCleanup() {
 	GinkgoWriter.Println("Global test cleanup started.")


### PR DESCRIPTION
### What this PR does
Currently, test artifacts are only collected in `JustAfterEach`, which runs before `AfterEach` cleanup nodes. When a test body passes but the subsequent `AfterEach` cleanup fails (e.g. testCleanup encounters leftover resources from a previous test), the test spec itself remains green and only the `AfterEach` block is displayed as failed. No artifacts are collected because `JustAfterEach` already ran and saw the spec as passing. Without artifacts at the point of failure, it is impossible to inspect the cluster state and determine which earlier test left the resources that caused the cleanup failure.

This PR adds a `ReportAfterEach` hook that catches failures occurring during teardown (AfterEach, cleanup nodes). `ReportAfterEach` runs after all teardown nodes complete and receives the final spec report, so it can detect teardown-phase failures that JustAfterEach cannot see.

To avoid double-collection, the hook only triggers when the primary failure occurred in a teardown node type (AfterEach, CleanupAfterEach, AfterAll, CleanupAfterAll). Test body failures continue to be handled by JustAfterEach, which captures cluster state before cleanup runs.

#### Before this PR:
- if some test passes but cleanup fails in AfterEach, there is no artifacts to track the leftover resources that were not got cleaned in timeout

#### After this PR:
- if AfterEach block fails, the privious test spec which techinically passed will collect what ever artifacts left in the cluster to debug why there are still there.


### New Path Example:

```shell
k8s-reporter/cleanup_failures/1_*   first cleanup failure
k8s-reporter/cleanup_failures/2_*   second cleanup failure
  
Or in parallel:

k8s-reporter/{worker}/cleanup_failures/1_*
k8s-reporter/{worker}/cleanup_failures/1_*
```
### References

### Why we need it and why it was done in this way
The following tradeoffs were made:
  - ReportAfterEach runs after AfterEach cleanup, so some test namespace resources may already be partially cleaned up. However, in the teardown-failure scenario, the resources that caused the failure are typically still present (since cleanup failed to remove them). Events, node-level data (dmesg, journal), and infrastructure pod logs are unaffected by namespace cleanup.

The following alternatives were considered:
  - Wrapping testCleanup() with a defer to collect artifacts at the exact point of failure, before subsequent cleanup steps destroy evidence. This was rejected because it couples artifact collection into the cleanup path. Since the resources that caused the cleanup failure are still present when `ReportAfterEach` runs, the simpler hook-based approach provides sufficient diagnostic data without modifying cleanup logic.


### Special notes for your reviewer

### Release note
```release-note
none
```

