### PR TITLE
e2e, net, nad-hp: Verify iface name and mac remains same after nad hp

### DIFF
--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -147,15 +148,19 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 	})
 
 	It("should modify VM network", func() {
+		const ifaceName = "net1"
+
+		vmi, err := kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		ifaceInfoBeforeUpdate := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, ifaceName)
+		Expect(ifaceInfoBeforeUpdate).NotTo(BeNil())
+
 		vm, err := kubevirt.Client().VirtualMachine(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		err = updateNADNameAndRemoveAffinityRules(vm, targetNAD)
 		Expect(err).NotTo(HaveOccurred())
-
-		var vmi *v1.VirtualMachineInstance
-		vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
 
 		By("Waiting for migration condition to appear and disappear")
 		Eventually(matcher.ThisVMI(vmi)).
@@ -181,6 +186,13 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 				Not(BeEmpty()),
 				Not(Equal(sourceNodeName)),
 			))
+
+		By("Verifying guest interface properties remain unchanged after update")
+		ifaceInfoAfterUpdate := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, ifaceName)
+		Expect(ifaceInfoAfterUpdate).NotTo(BeNil())
+
+		Expect(ifaceInfoAfterUpdate.InterfaceName).To(Equal(ifaceInfoBeforeUpdate.InterfaceName))
+		Expect(ifaceInfoAfterUpdate.MAC).To(Equal(ifaceInfoBeforeUpdate.MAC))
 
 		targetNode := vmi.Status.NodeName
 


### PR DESCRIPTION
Verify that the guest iface name and mac remains same after nad hotplug completes. We are not verifying the IP explicitly as the ping test later
 covers it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

