### PR TITLE
DNM migration annotations

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -846,6 +846,7 @@ func (c *Controller) processMigrationPhase(
 			migrationCopy.Status.Phase = virtv1.MigrationSucceeded
 			c.recorder.Eventf(migration, k8sv1.EventTypeNormal, controller.SuccessfulMigrationReason, "Source node reported migration succeeded")
 		}
+
 	}
 
 	return nil
@@ -854,6 +855,7 @@ func (c *Controller) processMigrationPhase(
 func (c *Controller) updateMigrationAnnotations(migration virtv1.VirtualMachineInstanceMigration, vmi virtv1.VirtualMachineInstance) error {
 	sourcePodName := vmi.Status.MigrationState.SourcePod
 	targetPodName := vmi.Status.MigrationState.TargetPod
+	migrationCompleted := vmi.IsMigrationCompleted()
 
 	podNameByMigrationEnd := map[string]string{}
 	if migration.IsDecentralizedSource() {
@@ -865,12 +867,18 @@ func (c *Controller) updateMigrationAnnotations(migration virtv1.VirtualMachineI
 		podNameByMigrationEnd["target"] = targetPodName
 	}
 
-	targetReadyTS := ""
-	if vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
-		targetReadyTS = vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String()
-	}
-	if err := c.setMigrationAnnotations(&migration, podNameByMigrationEnd, targetReadyTS); err != nil {
-		return fmt.Errorf("failed to set migration pods annotations: %w", err)
+	if migrationCompleted {
+		if err := c.removeMigrationAnnotations(migration.Namespace, sourcePodName, targetPodName); err != nil {
+			return fmt.Errorf("failed to remove migration pods annotations: %w", err)
+		}
+	} else {
+		targetReadyTS := ""
+		if vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
+			targetReadyTS = vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String()
+		}
+		if err := c.setMigrationAnnotations(&migration, podNameByMigrationEnd, targetReadyTS); err != nil {
+			return fmt.Errorf("failed to set migration pods annotations: %w", err)
+		}
 	}
 
 	return nil
@@ -900,6 +908,24 @@ func (c *Controller) setMigrationAnnotations(
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to set migration annotations for pod %s: %w", podName, err))
 		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (c *Controller) removeMigrationAnnotations(namespace string, podNames ...string) error {
+	var errs []error
+	for _, podName := range podNames {
+		p := `{"metadata":{"annotations":{
+			"` + virtv1.MigrationRole + `":null,
+			"` + virtv1.MigrationScope + `":null,
+			"` + virtv1.MigrationTargetReadyTimestamp + `":null
+		}}}`
+		_, err := c.clientset.CoreV1().Pods(namespace).Patch(context.Background(), podName, types.MergePatchType, []byte(p), v1.PatchOptions{})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove migration annotations for pod %s: %w", podName, err))
+		}
+		log.Log.Infof("DEBUG:removed migration annotations for pod %s", podName)
 	}
 
 	return errors.Join(errs...)

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -823,6 +823,10 @@ func (c *Controller) processMigrationPhase(
 			migrationCopy.Status.Phase = virtv1.MigrationRunning
 		}
 	case virtv1.MigrationRunning:
+		if err := c.updateMigrationAnnotations(*migration, *vmi); err != nil {
+			return fmt.Errorf("failed to update migration pods annotations: %w", err)
+		}
+
 		if migration.IsLocalOrDecentralizedTarget() {
 			_, exists := pod.Annotations[virtv1.MigrationTargetReadyTimestamp]
 			if !exists && vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
@@ -831,10 +835,6 @@ func (c *Controller) processMigrationPhase(
 					if err != nil {
 						return err
 					}
-				}
-
-				if err := c.setMigrationAnnotations(vmi.Namespace, *vmi.Status.MigrationState, pod.Name); err != nil {
-					return err
 				}
 			}
 		}
@@ -850,25 +850,50 @@ func (c *Controller) processMigrationPhase(
 	return nil
 }
 
-func (c *Controller) setMigrationAnnotations(
-	namespace string,
-	vmiMigrationState virtv1.VirtualMachineInstanceMigrationState,
-	targetPodName string,
-) error {
-	targetReadyTS := ""
-	if vmiMigrationState.TargetNodeDomainReadyTimestamp != nil {
-		targetReadyTS = vmiMigrationState.TargetNodeDomainReadyTimestamp.String()
+func (c *Controller) updateMigrationAnnotations(migration virtv1.VirtualMachineInstanceMigration, vmi virtv1.VirtualMachineInstance) error {
+	sourcePodName := vmi.Status.MigrationState.SourcePod
+	targetPodName := vmi.Status.MigrationState.TargetPod
+
+	podNames := []string{}
+	if migration.IsDecentralizedSource() {
+		podNames = append(podNames, sourcePodName)
+	} else if migration.IsDecentralizedTarget() {
+		podNames = append(podNames, targetPodName)
+	} else { // cluster-local migration
+		podNames = append(podNames, sourcePodName)
+		podNames = append(podNames, targetPodName)
 	}
 
-	p := `{"metadata":{"annotations":{
-			"` + virtv1.MigrationTargetReadyTimestamp + `":"` + targetReadyTS + `"
-		}}}`
-	_, err := c.clientset.CoreV1().Pods(namespace).Patch(context.Background(), targetPodName, types.MergePatchType, []byte(p), v1.PatchOptions{})
-	if err != nil {
-		return err
+	targetReadyTS := ""
+	if vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
+		targetReadyTS = vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String()
+	}
+	if err := c.setMigrationAnnotations(migration.Namespace, podNames, targetReadyTS); err != nil {
+		return fmt.Errorf("failed to set migration pods annotations: %w", err)
 	}
 
 	return nil
+}
+
+func (c *Controller) setMigrationAnnotations(
+	namespace string,
+	podNames []string,
+	targetReadyTS string,
+) error {
+	var errs []error
+	for _, podName := range podNames {
+		p := `{"metadata":{"annotations":{`
+		if targetReadyTS != "" {
+			p += fmt.Sprintf(`"%s":"%s"`, virtv1.MigrationTargetReadyTimestamp, targetReadyTS)
+		}
+		p += `}}}`
+		_, err := c.clientset.CoreV1().Pods(namespace).Patch(context.Background(), podName, types.MergePatchType, []byte(p), v1.PatchOptions{})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to set migration annotations for pod %s: %w", podName, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func setTargetPodSELinuxLevel(pod *k8sv1.Pod, vmiSeContext string) error {

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -833,14 +833,7 @@ func (c *Controller) processMigrationPhase(
 					}
 				}
 
-				patchBytes, err := patch.New(
-					patch.WithAdd(fmt.Sprintf("/metadata/annotations/%s", patch.EscapeJSONPointer(virtv1.MigrationTargetReadyTimestamp)), vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String()),
-				).GeneratePayload()
-				if err != nil {
-					return err
-				}
-
-				if _, err = c.clientset.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{}); err != nil {
+				if err := c.setMigrationAnnotations(vmi.Namespace, *vmi.Status.MigrationState, pod.Name); err != nil {
 					return err
 				}
 			}
@@ -854,6 +847,27 @@ func (c *Controller) processMigrationPhase(
 			c.recorder.Eventf(migration, k8sv1.EventTypeNormal, controller.SuccessfulMigrationReason, "Source node reported migration succeeded")
 		}
 	}
+	return nil
+}
+
+func (c *Controller) setMigrationAnnotations(
+	namespace string,
+	vmiMigrationState virtv1.VirtualMachineInstanceMigrationState,
+	targetPodName string,
+) error {
+	targetReadyTS := ""
+	if vmiMigrationState.TargetNodeDomainReadyTimestamp != nil {
+		targetReadyTS = vmiMigrationState.TargetNodeDomainReadyTimestamp.String()
+	}
+
+	p := `{"metadata":{"annotations":{
+			"` + virtv1.MigrationTargetReadyTimestamp + `":"` + targetReadyTS + `"
+		}}}`
+	_, err := c.clientset.CoreV1().Pods(namespace).Patch(context.Background(), targetPodName, types.MergePatchType, []byte(p), v1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -847,6 +847,7 @@ func (c *Controller) processMigrationPhase(
 			c.recorder.Eventf(migration, k8sv1.EventTypeNormal, controller.SuccessfulMigrationReason, "Source node reported migration succeeded")
 		}
 	}
+
 	return nil
 }
 
@@ -868,7 +869,7 @@ func (c *Controller) updateMigrationAnnotations(migration virtv1.VirtualMachineI
 	if vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
 		targetReadyTS = vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String()
 	}
-	if err := c.setMigrationAnnotations(migration.Namespace, podNameByMigrationEnd, targetReadyTS); err != nil {
+	if err := c.setMigrationAnnotations(&migration, podNameByMigrationEnd, targetReadyTS); err != nil {
 		return fmt.Errorf("failed to set migration pods annotations: %w", err)
 	}
 
@@ -876,19 +877,26 @@ func (c *Controller) updateMigrationAnnotations(migration virtv1.VirtualMachineI
 }
 
 func (c *Controller) setMigrationAnnotations(
-	namespace string,
+	migration *virtv1.VirtualMachineInstanceMigration,
 	podNameByMigrationEnd map[string]string,
 	targetReadyTS string,
 ) error {
+	isDecentralized := migration.IsDecentralized()
+	migrationScope := "local"
+	if isDecentralized {
+		migrationScope = "decentralized"
+	}
+
 	var errs []error
 	for migrationEnd, podName := range podNameByMigrationEnd {
 		p := `{"metadata":{"annotations":{`
 		if targetReadyTS != "" {
 			p += fmt.Sprintf(`"%s":"%s",`, virtv1.MigrationTargetReadyTimestamp, targetReadyTS)
 		}
-		p += fmt.Sprintf(`"%s":"%s"`, virtv1.MigrationRole, migrationEnd)
+		p += fmt.Sprintf(`"%s":"%s",`, virtv1.MigrationRole, migrationEnd)
+		p += fmt.Sprintf(`"%s":"%s"`, virtv1.MigrationScope, migrationScope)
 		p += `}}}`
-		_, err := c.clientset.CoreV1().Pods(namespace).Patch(context.Background(), podName, types.MergePatchType, []byte(p), v1.PatchOptions{})
+		_, err := c.clientset.CoreV1().Pods(migration.Namespace).Patch(context.Background(), podName, types.MergePatchType, []byte(p), v1.PatchOptions{})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to set migration annotations for pod %s: %w", podName, err))
 		}

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -854,21 +854,21 @@ func (c *Controller) updateMigrationAnnotations(migration virtv1.VirtualMachineI
 	sourcePodName := vmi.Status.MigrationState.SourcePod
 	targetPodName := vmi.Status.MigrationState.TargetPod
 
-	podNames := []string{}
+	podNameByMigrationEnd := map[string]string{}
 	if migration.IsDecentralizedSource() {
-		podNames = append(podNames, sourcePodName)
+		podNameByMigrationEnd["source"] = sourcePodName
 	} else if migration.IsDecentralizedTarget() {
-		podNames = append(podNames, targetPodName)
-	} else { // cluster-local migration
-		podNames = append(podNames, sourcePodName)
-		podNames = append(podNames, targetPodName)
+		podNameByMigrationEnd["target"] = targetPodName
+	} else { // local migration
+		podNameByMigrationEnd["source"] = sourcePodName
+		podNameByMigrationEnd["target"] = targetPodName
 	}
 
 	targetReadyTS := ""
 	if vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
 		targetReadyTS = vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String()
 	}
-	if err := c.setMigrationAnnotations(migration.Namespace, podNames, targetReadyTS); err != nil {
+	if err := c.setMigrationAnnotations(migration.Namespace, podNameByMigrationEnd, targetReadyTS); err != nil {
 		return fmt.Errorf("failed to set migration pods annotations: %w", err)
 	}
 
@@ -877,15 +877,16 @@ func (c *Controller) updateMigrationAnnotations(migration virtv1.VirtualMachineI
 
 func (c *Controller) setMigrationAnnotations(
 	namespace string,
-	podNames []string,
+	podNameByMigrationEnd map[string]string,
 	targetReadyTS string,
 ) error {
 	var errs []error
-	for _, podName := range podNames {
+	for migrationEnd, podName := range podNameByMigrationEnd {
 		p := `{"metadata":{"annotations":{`
 		if targetReadyTS != "" {
-			p += fmt.Sprintf(`"%s":"%s"`, virtv1.MigrationTargetReadyTimestamp, targetReadyTS)
+			p += fmt.Sprintf(`"%s":"%s",`, virtv1.MigrationTargetReadyTimestamp, targetReadyTS)
 		}
+		p += fmt.Sprintf(`"%s":"%s"`, virtv1.MigrationRole, migrationEnd)
 		p += `}}}`
 		_, err := c.clientset.CoreV1().Pods(namespace).Patch(context.Background(), podName, types.MergePatchType, []byte(p), v1.PatchOptions{})
 		if err != nil {

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -586,6 +586,7 @@ var _ = Describe("Migration watcher", func() {
 				runningMigration := newMigration("testmigration", vmi.Name, v1.MigrationRunning)
 				runningTargetPod := newTargetPodForVirtualMachine(vmi, runningMigration, k8sv1.PodRunning)
 				runningTargetPod.Spec.NodeName = "node01"
+				sourcePod := newSourcePodForVirtualMachine(vmi)
 
 				vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 					MigrationUID:      runningMigration.UID,
@@ -596,10 +597,12 @@ var _ = Describe("Migration watcher", func() {
 					EndTimestamp:      pointer.P(metav1.Now()),
 					Failed:            false,
 					Completed:         true,
+					SourcePod:         sourcePod.Name,
+					TargetPod:         runningTargetPod.Name,
 				}
 				addMigration(runningMigration)
 				addVirtualMachineInstance(vmi)
-				addPod(newSourcePodForVirtualMachine(vmi))
+				addPod(sourcePod)
 				addPod(runningTargetPod)
 
 				sanityExecute()
@@ -1931,6 +1934,7 @@ var _ = Describe("Migration watcher", func() {
 			migration := newMigration("testmigration", vmi.Name, v1.MigrationRunning)
 			targetPod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
 			targetPod.Spec.NodeName = "node01"
+			sourcePod := newSourcePodForVirtualMachine(vmi)
 
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				MigrationUID:                   migration.UID,
@@ -1942,10 +1946,12 @@ var _ = Describe("Migration watcher", func() {
 				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
 				Failed:                         false,
 				Completed:                      true,
+				SourcePod:                      sourcePod.Name,
+				TargetPod:                      targetPod.Name,
 			}
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
-			addPod(newSourcePodForVirtualMachine(vmi))
+			addPod(sourcePod)
 			addPod(targetPod)
 
 			sanityExecute()
@@ -2000,6 +2006,7 @@ var _ = Describe("Migration watcher", func() {
 			migration := newMigration("testmigration", vmi.Name, v1.MigrationRunning)
 			targetPod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
 			targetPod.Spec.NodeName = "node01"
+			sourcePod := newSourcePodForVirtualMachine(vmi)
 
 			for _, c := range conditions {
 				vmi.Status.Conditions = append(vmi.Status.Conditions,
@@ -2020,10 +2027,12 @@ var _ = Describe("Migration watcher", func() {
 				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
 				Failed:                         false,
 				Completed:                      true,
+				SourcePod:                      sourcePod.Name,
+				TargetPod:                      targetPod.Name,
 			}
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
-			addPod(newSourcePodForVirtualMachine(vmi))
+			addPod(sourcePod)
 			addPod(targetPod)
 
 			sanityExecute()
@@ -3181,7 +3190,8 @@ var _ = Describe("Migration watcher", func() {
 			Entry("local migration, phase is running",
 				newMigration(migrationUID, vmiName, v1.MigrationRunning),
 				map[string]string{
-					v1.DomainAnnotation: "testvmi",
+					v1.DomainAnnotation:              "testvmi",
+					v1.MigrationTargetReadyTimestamp: "",
 				},
 				map[string]string{
 					v1.DomainAnnotation:              "testvmi",
@@ -3192,7 +3202,8 @@ var _ = Describe("Migration watcher", func() {
 			Entry("decentralized sender migration is running (handles source pod)",
 				newDecentralizedSenderMigration(migrationUID, vmiName, v1.MigrationRunning),
 				map[string]string{
-					v1.DomainAnnotation: "testvmi",
+					v1.DomainAnnotation:              "testvmi",
+					v1.MigrationTargetReadyTimestamp: "",
 				},
 				map[string]string{
 					v1.DomainAnnotation:           "testvmi",

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -131,13 +131,6 @@ var _ = Describe("Migration watcher", func() {
 		Expect(pods.Items[0].Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 	}
 
-	expectPodAnnotationTimestamp := func(namespace, name, expectedTimestamp string) {
-		updatedPod, err := kubeClient.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(updatedPod).ToNot(BeNil())
-		Expect(updatedPod.Annotations).To(HaveKeyWithValue(v1.MigrationTargetReadyTimestamp, expectedTimestamp))
-	}
-
 	expectMigrationSchedulingState := func(namespace, name string) {
 		updatedVMIM, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -1957,7 +1950,6 @@ var _ = Describe("Migration watcher", func() {
 			sanityExecute()
 
 			testutils.ExpectEvent(recorder, virtcontroller.SuccessfulMigrationReason)
-			expectPodAnnotationTimestamp(targetPod.Namespace, targetPod.Name, vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String())
 			expectMigrationCompletedState(migration.Namespace, migration.Name)
 		})
 
@@ -2038,7 +2030,6 @@ var _ = Describe("Migration watcher", func() {
 			sanityExecute()
 
 			expectMigrationRunningState(migration.Namespace, migration.Name)
-			expectPodAnnotationTimestamp(targetPod.Namespace, targetPod.Name, vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String())
 		},
 			Entry("CPU change condition", []v1.VirtualMachineInstanceConditionType{v1.VirtualMachineInstanceVCPUChange}),
 			Entry("Memory change condition", []v1.VirtualMachineInstanceConditionType{v1.VirtualMachineInstanceMemoryChange}),
@@ -3135,6 +3126,7 @@ var _ = Describe("Migration watcher", func() {
 				mig *v1.VirtualMachineInstanceMigration,
 				expectedSourceAnnotations map[string]string,
 				expectedTargetAnnotations map[string]string,
+				expectEvents ...string,
 			) {
 				vmi := newVirtualMachine(vmiName, v1.Running)
 				expectedTargetReadyTs := metav1.Now()
@@ -3186,6 +3178,8 @@ var _ = Describe("Migration watcher", func() {
 				updatedSourcePod, err := kubeClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), sourcePod.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedSourcePod.Annotations).To(Equal(expectedSourceAnnotations))
+
+				testutils.ExpectEvents(recorder, expectEvents...)
 			},
 			Entry("local migration, phase is running",
 				newMigration(migrationUID, vmiName, v1.MigrationRunning),
@@ -3228,6 +3222,68 @@ var _ = Describe("Migration watcher", func() {
 					v1.MigrationRole:                 "target",
 					v1.MigrationScope:                "decentralized",
 				},
+			),
+			Entry("local migration succeeded",
+				newMigration(migrationUID, vmiName, v1.MigrationSucceeded),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:           "testvmi",
+					v1.MigrationJobNameAnnotation: "testmigrationuid",
+				},
+			),
+			Entry("decentralized sender migration succeeded (handles source pod)",
+				newDecentralizedSenderMigration(migrationUID, vmiName, v1.MigrationSucceeded),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:           "testvmi",
+					v1.MigrationJobNameAnnotation: "testmigrationuid",
+				},
+			),
+			Entry("decentralized receiver migration succeeded (handles target pod)",
+				newDecentralizedReceiverMigration(migrationUID, vmiName, v1.MigrationSucceeded),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:           "testvmi",
+					v1.MigrationJobNameAnnotation: "testmigrationuid",
+				},
+			),
+			Entry("local migration failed",
+				newMigration(migrationUID, vmiName, v1.MigrationFailed),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:           "testvmi",
+					v1.MigrationJobNameAnnotation: "testmigrationuid",
+				},
+				virtcontroller.FailedMigrationReason,
+			),
+			Entry("decentralized sender migration failed (handles source pod)",
+				newDecentralizedSenderMigration(migrationUID, vmiName, v1.MigrationFailed),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:           "testvmi",
+					v1.MigrationJobNameAnnotation: "testmigrationuid",
+				},
+			),
+			Entry("decentralized receiver migration failed (handles target pod)",
+				newDecentralizedReceiverMigration(migrationUID, vmiName, v1.MigrationFailed),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:           "testvmi",
+					v1.MigrationJobNameAnnotation: "testmigrationuid",
+				},
+				virtcontroller.FailedMigrationReason,
 			),
 		)
 	})

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -3113,6 +3113,105 @@ var _ = Describe("Migration watcher", func() {
 			Expect(conditionManager.HasCondition(migration, v1.VirtualMachineInstanceDecentralizedMigrationBlocked)).To(BeFalse(), "Condition should not be set when VMI does not have the condition")
 		})
 	})
+
+	Context("Annotations", func() {
+		const (
+			vmiName      = "testvmi"
+			sourceNode   = "sourceNode"
+			targetNode   = "targetNode"
+			migrationUID = "testmigrationuid"
+		)
+		DescribeTable("should update migration pods migration annotations",
+			func(
+				mig *v1.VirtualMachineInstanceMigration,
+				expectedSourceAnnotations map[string]string,
+				expectedTargetAnnotations map[string]string,
+			) {
+				vmi := newVirtualMachine(vmiName, v1.Running)
+				expectedTargetReadyTs := metav1.Now()
+				vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+					TargetNodeDomainReadyTimestamp: pointer.P(expectedTargetReadyTs),
+					TargetNode:                     targetNode,
+					SourceNode:                     sourceNode,
+					MigrationUID:                   migrationUID,
+					TargetNodeAddress:              "10.10.10.10:1234",
+				}
+				if mig.IsDecentralized() {
+					vmi.Status.MigrationState.SourceState = &v1.VirtualMachineInstanceMigrationSourceState{
+						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+							MigrationUID: migrationUID,
+						},
+					}
+					vmi.Status.MigrationState.TargetState = &v1.VirtualMachineInstanceMigrationTargetState{
+						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+							MigrationUID: migrationUID,
+						},
+					}
+				}
+				sourcePod := newSourcePodForVirtualMachine(vmi)
+				targetPod := newTargetPodForVirtualMachine(vmi, mig, k8sv1.PodRunning)
+				sourcePod.Spec.NodeName = sourceNode
+				targetPod.Spec.NodeName = targetNode
+
+				vmi.Status.MigrationState.SourcePod = sourcePod.Name
+				vmi.Status.MigrationState.TargetPod = targetPod.Name
+
+				addMigration(mig)
+				addVirtualMachineInstance(vmi)
+				addPod(sourcePod)
+				addPod(targetPod)
+
+				sanityExecute()
+
+				if _, exist := expectedTargetAnnotations[v1.MigrationTargetReadyTimestamp]; exist {
+					expectedTargetAnnotations[v1.MigrationTargetReadyTimestamp] = expectedTargetReadyTs.String()
+				}
+				if _, exist := expectedSourceAnnotations[v1.MigrationTargetReadyTimestamp]; exist {
+					expectedSourceAnnotations[v1.MigrationTargetReadyTimestamp] = expectedTargetReadyTs.String()
+				}
+
+				updatedTargetPod, err := kubeClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), targetPod.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedTargetPod.Annotations).To(Equal(expectedTargetAnnotations))
+
+				updatedSourcePod, err := kubeClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), sourcePod.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedSourcePod.Annotations).To(Equal(expectedSourceAnnotations))
+			},
+			Entry("local migration, phase is running",
+				newMigration(migrationUID, vmiName, v1.MigrationRunning),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:              "testvmi",
+					v1.MigrationJobNameAnnotation:    "testmigrationuid",
+					v1.MigrationTargetReadyTimestamp: "",
+				},
+			),
+			Entry("decentralized sender migration is running (handles source pod)",
+				newDecentralizedSenderMigration(migrationUID, vmiName, v1.MigrationRunning),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:           "testvmi",
+					v1.MigrationJobNameAnnotation: "testmigrationuid",
+				},
+			),
+			Entry("decentralized receiver migration is running (handles target pod)",
+				newDecentralizedReceiverMigration(migrationUID, vmiName, v1.MigrationRunning),
+				map[string]string{
+					v1.DomainAnnotation: "testvmi",
+				},
+				map[string]string{
+					v1.DomainAnnotation:              "testvmi",
+					v1.MigrationJobNameAnnotation:    "testmigrationuid",
+					v1.MigrationTargetReadyTimestamp: "",
+				},
+			),
+		)
+	})
 })
 
 func newMigration(name string, vmiName string, phase v1.VirtualMachineInstanceMigrationPhase) *v1.VirtualMachineInstanceMigration {
@@ -3137,6 +3236,14 @@ func newMigration(name string, vmiName string, phase v1.VirtualMachineInstanceMi
 	}
 	migration.UID = types.UID(name)
 	migration.Status.Phase = phase
+	return migration
+}
+
+func newDecentralizedSenderMigration(name string, vmiName string, phase v1.VirtualMachineInstanceMigrationPhase) *v1.VirtualMachineInstanceMigration {
+	migration := newMigration(name, vmiName, phase)
+	migration.Spec.SendTo = &v1.VirtualMachineInstanceMigrationSource{
+		MigrationID: vmiName,
+	}
 	return migration
 }
 

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -3192,11 +3192,13 @@ var _ = Describe("Migration watcher", func() {
 				map[string]string{
 					v1.DomainAnnotation:              "testvmi",
 					v1.MigrationTargetReadyTimestamp: "",
+					v1.MigrationRole:                 "source",
 				},
 				map[string]string{
 					v1.DomainAnnotation:              "testvmi",
 					v1.MigrationJobNameAnnotation:    "testmigrationuid",
 					v1.MigrationTargetReadyTimestamp: "",
+					v1.MigrationRole:                 "target",
 				},
 			),
 			Entry("decentralized sender migration is running (handles source pod)",
@@ -3204,6 +3206,7 @@ var _ = Describe("Migration watcher", func() {
 				map[string]string{
 					v1.DomainAnnotation:              "testvmi",
 					v1.MigrationTargetReadyTimestamp: "",
+					v1.MigrationRole:                 "source",
 				},
 				map[string]string{
 					v1.DomainAnnotation:           "testvmi",
@@ -3219,6 +3222,7 @@ var _ = Describe("Migration watcher", func() {
 					v1.DomainAnnotation:              "testvmi",
 					v1.MigrationJobNameAnnotation:    "testmigrationuid",
 					v1.MigrationTargetReadyTimestamp: "",
+					v1.MigrationRole:                 "target",
 				},
 			),
 		)

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -3193,12 +3193,14 @@ var _ = Describe("Migration watcher", func() {
 					v1.DomainAnnotation:              "testvmi",
 					v1.MigrationTargetReadyTimestamp: "",
 					v1.MigrationRole:                 "source",
+					v1.MigrationScope:                "local",
 				},
 				map[string]string{
 					v1.DomainAnnotation:              "testvmi",
 					v1.MigrationJobNameAnnotation:    "testmigrationuid",
 					v1.MigrationTargetReadyTimestamp: "",
 					v1.MigrationRole:                 "target",
+					v1.MigrationScope:                "local",
 				},
 			),
 			Entry("decentralized sender migration is running (handles source pod)",
@@ -3207,6 +3209,7 @@ var _ = Describe("Migration watcher", func() {
 					v1.DomainAnnotation:              "testvmi",
 					v1.MigrationTargetReadyTimestamp: "",
 					v1.MigrationRole:                 "source",
+					v1.MigrationScope:                "decentralized",
 				},
 				map[string]string{
 					v1.DomainAnnotation:           "testvmi",
@@ -3223,6 +3226,7 @@ var _ = Describe("Migration watcher", func() {
 					v1.MigrationJobNameAnnotation:    "testmigrationuid",
 					v1.MigrationTargetReadyTimestamp: "",
 					v1.MigrationRole:                 "target",
+					v1.MigrationScope:                "decentralized",
 				},
 			),
 		)

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1370,6 +1370,9 @@ const (
 	// MigrationRole indidcrate the pod role in the migration - migration source or migration target.
 	MigrationRole string = "kubevirt.io/migration-role"
 
+	// MigrationScope indicates the migration scope decentralized or local.
+	MigrationScope string = "kubevirt.io/migration-scope"
+
 	// FreePageReportingDisabledAnnotation indicates if the the vmi wants to explicitly disable
 	// the freePageReporting feature of the memballooning.
 	// This annotation only allows to opt-out from freePageReporting in those cases where it is

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1367,6 +1367,9 @@ const (
 	// detected that the VMI became active on the target during live migration.
 	MigrationTargetReadyTimestamp string = "kubevirt.io/migration-target-ready-timestamp"
 
+	// MigrationRole indidcrate the pod role in the migration - migration source or migration target.
+	MigrationRole string = "kubevirt.io/migration-role"
+
 	// FreePageReportingDisabledAnnotation indicates if the the vmi wants to explicitly disable
 	// the freePageReporting feature of the memballooning.
 	// This annotation only allows to opt-out from freePageReporting in those cases where it is


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Enable third-party controller act on decentralized migration pod event: 
enable a controller running on source cluster act when cross-cluster live-migration (CCLM) target pod is ready (running the target cluster).

#### Before this PR:
Migration source pods has no migration related annotations.
Migration target pods are annotated with `migration-target-ready-timestamp` as soon the migration target become ready.

The migration-target-ready-ts annotation was added long time ago to allow third-party components act on migration pod events, allowing OVN-Kubernetes support Kubevirt Live-Migration feature https://github.com/kubevirt/kubevirt/pull/9290

#### After this PR:
Migration pods will have the following annotations while the migration is running:
Source (decentralized migration)
```
kubevirt.io/migration-scope=decentralized
kubevirt.io/migration-role=source
kubevirt.io/migration-target-ready-timestamp=<t1>
```
Target (decentralized migration)
```
kubevirt.io/migration-scope=decentralized
kubevirt.io/migration-role=target
kubevirt.io/migration-target-ready-timestamp=<t1>
```

Non-decentralized migration pods will have the same annotation set, except for the `migration-scope` value, it will be `local`.

Once the migration is completed (failed or succeeded) the mentioned annotation are removed from the migration pods.
This is crucial to enable second migration scenario, where a migrated VM is migrated again.
The migration source (previous target) will "start fresh" with no out-dated annotation set, 
allowing third-party components act on CCLM events correctly.
Or in a the first migration attempt failed, the migration source (same as previous source)  will have no out-dated annotation set.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

