### PR TITLE
fix: skip repetition count check in dequarantine lane

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -190,7 +190,9 @@ fi
 NUM_TESTS=${NUM_TESTS-5}
 echo "Number of per lane runs: $NUM_TESTS"
 
-if should_skip_test_run_due_to_too_many_tests "${NEW_TESTS}"; then
+if [[ "${JOB_NAME-}" == *dequarantine* ]]; then
+    echo "Dequarantine lane: skipping repetition count check"
+elif should_skip_test_run_due_to_too_many_tests "${NEW_TESTS}"; then
     echo "Skipping run due to number of tests in total being too high for repeated run."
     exit 0
 fi


### PR DESCRIPTION
## Summary
- The dequarantine lane (`pull-kubevirt-check-dequarantine-test`) sets `NUM_TESTS=500` to verify quarantined test stability before removing the quarantine label
- The `should_skip_test_run_due_to_too_many_tests` check in `repeated_test.sh` compares `changed_tests * NUM_TESTS` against the total suite size and aborts when it's too high
- With 500 repetitions this check almost always triggers, causing the dequarantine lane to skip without actually running the tests
- Skip this check when `JOB_NAME` contains "dequarantine"

## Test plan
- [ ] Verify the dequarantine lane no longer skips due to the repetition count check
- [ ] Verify the regular `pull-kubevirt-check-tests-for-flakes` lane still enforces the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)