### PR TITLE
tests/infrastructure: remove redundant TSC label e2e test

### DIFF
--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -205,16 +204,6 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 					return nil
 				}).WithTimeout(timeout).WithPolling(1 * time.Second).ShouldNot(HaveOccurred())
 			})
-
-		It("[test_id:6995]should expose tsc frequency and tsc scalability", func() {
-			node := nodesWithHypervisor[0]
-			Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-frequency"))
-			Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-scalable"))
-			Expect(node.Labels["cpu-timer.node.kubevirt.io/tsc-scalable"]).To(Or(Equal(trueStr), Equal("false")))
-			val, err := strconv.ParseInt(node.Labels["cpu-timer.node.kubevirt.io/tsc-frequency"], 10, 64)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(val).To(BeNumerically(">", 0))
-		})
 	})
 
 	Context("advanced labeling", func() {


### PR DESCRIPTION
### What this PR does
Decorates test_id:6995 (TSC frequency and scalability) with `RequiresAMD64`. TSC labels are only populated on AMD64 nodes and this test will never apply to other architectures.

#### Before this PR:
- The test takes `nodesWithHypervisor[0]` which may be a non-AMD64 node, causing the test to fail on mixed-arch clusters

#### After this PR:
- The test is skipped on non-AMD64 clusters via `RequiresAMD64` and explicitly selects an AMD64 node from the hypervisor list

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```