### PR TITLE
tests: decorate CPU features Context with RequiresAMD64

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -979,7 +979,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 		})
 
-		Context("with node feature discovery", Serial, decorators.CPUModel, func() {
+		Context("with node feature discovery", Serial, decorators.CPUModel, decorators.RequiresAMD64, func() {
 			var node *k8sv1.Node
 			var supportedCPU string
 			var supportedCPUs []string


### PR DESCRIPTION
### What this PR does
Adds `decorators.RequiresAMD64` to the "with node feature discovery" Context in `vmi_lifecycle_test.go`, skipping it on clusters without AMD64 nodes.

#### Before this PR:
- On multi-arch clusters with ARM64 nodes, the BeforeEach panics because ARM64 nodes lack CPU model/feature labels
- The intersection logic in test_id:3203 hits "index out of range [0] with length 0"

#### After this PR:
- The entire Context is skipped on non-AMD64 clusters via the decorator

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```