### PR TITLE
tools/vms-generator: remove redundant memory resource from fedora isolated example

### DIFF
--- a/examples/vmi-fedora-isolated.yaml
+++ b/examples/vmi-fedora-isolated.yaml
@@ -24,9 +24,7 @@ spec:
       rng: {}
     memory:
       guest: 1024M
-    resources:
-      requests:
-        memory: 1024M
+    resources: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -431,11 +431,6 @@ func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 func GetVMIEphemeralFedoraIsolated() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiFedora)
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
-	vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-		Requests: k8sv1.ResourceList{
-			k8sv1.ResourceMemory: resource.MustParse("1024M"),
-		},
-	}
 	initFedoraIsolated(&vmi.Spec)
 	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi


### PR DESCRIPTION
### What this PR does

Priviously the `GetVMIEphemeralFedoraIsolated` function redundantly sets both `Memory.Guest` and `Resources.Requests[memory]`. 
So we should remove the Resources block since guest memory is the preferred field.

#### Before this PR:
- Example displays both Guest.Memory and Resources.Requests.

#### After this PR:
- Only Guest.Memory is used.

### References
This is releted to #14648 , #12285

Links to places where the discussion took place:
https://github.com/kubevirt/kubevirt/pull/14648#discussion_r2093037895


### Release note
```release-note
None
```