### PR TITLE
[release-1.7] Use safepath for virt-launcher console socket paths

### DIFF
--- a/pkg/virt-handler/rest/BUILD.bazel
+++ b/pkg/virt-handler/rest/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/rest",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",

--- a/pkg/virt-handler/rest/BUILD.bazel
+++ b/pkg/virt-handler/rest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -26,5 +26,25 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "console_test.go",
+        "rest_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//pkg/safepath:go_default_library",
+        "//pkg/unsafepath:go_default_library",
+        "//pkg/virt-handler/isolation:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/go.uber.org/mock/gomock:go_default_library",
     ],
 )

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -26,8 +26,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
-	"path"
 	"strconv"
 	"sync"
 
@@ -41,6 +39,7 @@ import (
 	kvcorev1 "kubevirt.io/client-go/kubevirt/typed/core/v1"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
@@ -86,7 +85,7 @@ func (t *ConsoleHandler) USBRedirHandler(request *restful.Request, response *res
 	uid := vmi.GetUID()
 	stopChan := make(chan struct{})
 	var slotId int
-	var unixSocketPath string
+	var unixSocketPath *safepath.Path
 	ok := func() bool {
 		// For simplicity, we handle one usbredir request at the time, for all VMIs
 		// handled by virt-handler
@@ -287,30 +286,33 @@ func deleteStopChan(uid types.UID, stopChn chan struct{}, lock *sync.Mutex, stop
 	}
 }
 
-func (t *ConsoleHandler) getUnixSocketPath(vmi *v1.VirtualMachineInstance, socketName string) (string, error) {
+func (t *ConsoleHandler) getUnixSocketPath(vmi *v1.VirtualMachineInstance, socketName string) (*safepath.Path, error) {
 	result, err := t.podIsolationDetector.Detect(vmi)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	socketDir := path.Join("/proc", strconv.Itoa(result.Pid()), "root", "var", "run", "kubevirt-private", string(vmi.GetUID()))
-	socketPath := path.Join(socketDir, socketName)
-	if _, err = os.Stat(socketPath); errors.Is(err, os.ErrNotExist) {
-		return "", err
+	root, err := result.MountRoot()
+	if err != nil {
+		return nil, err
 	}
-
-	return socketPath, nil
+	return root.AppendAndResolveWithRelativeRoot("run", "kubevirt-private", string(vmi.GetUID()), socketName)
 }
 
-func unixSocketDialer(vmi *v1.VirtualMachineInstance, unixSocketPath string) func() (net.Conn, error) {
+func unixSocketDialer(vmi *v1.VirtualMachineInstance, socketPath *safepath.Path) func() (net.Conn, error) {
 	return func() (net.Conn, error) {
-		log.Log.Object(vmi).Infof("Connecting to %s", unixSocketPath)
-		fd, err := net.Dial("unix", unixSocketPath)
-		if err != nil {
-			log.Log.Object(vmi).Reason(err).Errorf("failed to dial unix socket %s", unixSocketPath)
-			return nil, err
-		}
-		log.Log.Object(vmi).Infof("Connected to %s", unixSocketPath)
-		return fd, nil
+		var conn net.Conn
+		err := socketPath.ExecuteNoFollow(func(safePath string) error {
+			log.Log.Object(vmi).Infof("Connecting to %s", safePath)
+			var dialErr error
+			conn, dialErr = net.Dial("unix", safePath)
+			if dialErr != nil {
+				log.Log.Object(vmi).Reason(dialErr).Errorf("failed to dial unix socket %s", safePath)
+				return dialErr
+			}
+			log.Log.Object(vmi).Infof("Connected to %s", safePath)
+			return nil
+		})
+		return conn, err
 	}
 }
 

--- a/pkg/virt-handler/rest/console_test.go
+++ b/pkg/virt-handler/rest/console_test.go
@@ -1,0 +1,175 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package rest
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomock "go.uber.org/mock/gomock"
+
+	"kubevirt.io/client-go/api"
+
+	"kubevirt.io/kubevirt/pkg/safepath"
+	"kubevirt.io/kubevirt/pkg/unsafepath"
+	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
+)
+
+var _ = Describe("Console handler", func() {
+	var (
+		ctrl                  *gomock.Controller
+		mockIsolationDetector *isolation.MockPodIsolationDetector
+		mockIsolationResult   *isolation.MockIsolationResult
+		handler               *ConsoleHandler
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockIsolationDetector = isolation.NewMockPodIsolationDetector(ctrl)
+		mockIsolationResult = isolation.NewMockIsolationResult(ctrl)
+		handler = NewConsoleHandler(mockIsolationDetector, nil, nil)
+	})
+
+	Describe("getUnixSocketPath", func() {
+		It("should resolve the socket path via safepath", func() {
+			tmpDir := GinkgoT().TempDir()
+			vmi := api.NewMinimalVMI("testvmi")
+			vmi.UID = "test-uid-1234"
+
+			socketDir := filepath.Join(tmpDir, "run", "kubevirt-private", string(vmi.UID))
+			Expect(os.MkdirAll(socketDir, 0755)).To(Succeed())
+
+			socketFile := filepath.Join(socketDir, "virt-serial0")
+			l, err := net.Listen("unix", socketFile)
+			Expect(err).ToNot(HaveOccurred())
+			defer l.Close()
+
+			root, err := safepath.JoinAndResolveWithRelativeRoot(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			mockIsolationDetector.EXPECT().Detect(vmi).Return(mockIsolationResult, nil)
+			mockIsolationResult.EXPECT().MountRoot().Return(root, nil)
+
+			p, err := handler.getUnixSocketPath(vmi, "virt-serial0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unsafepath.UnsafeAbsolute(p.Raw())).To(Equal(filepath.Join(tmpDir, "run", "kubevirt-private", string(vmi.UID), "virt-serial0")))
+		})
+
+		It("should fail when Detect returns an error", func() {
+			vmi := api.NewMinimalVMI("testvmi")
+			mockIsolationDetector.EXPECT().Detect(vmi).Return(nil, fmt.Errorf("detect failed"))
+
+			_, err := handler.getUnixSocketPath(vmi, "virt-serial0")
+			Expect(err).To(MatchError("detect failed"))
+		})
+
+		It("should fail when MountRoot returns an error", func() {
+			vmi := api.NewMinimalVMI("testvmi")
+			mockIsolationDetector.EXPECT().Detect(vmi).Return(mockIsolationResult, nil)
+			mockIsolationResult.EXPECT().MountRoot().Return(nil, fmt.Errorf("mountroot failed"))
+
+			_, err := handler.getUnixSocketPath(vmi, "virt-serial0")
+			Expect(err).To(MatchError("mountroot failed"))
+		})
+
+		It("should fail when the socket does not exist", func() {
+			tmpDir := GinkgoT().TempDir()
+			vmi := api.NewMinimalVMI("testvmi")
+			vmi.UID = "test-uid-1234"
+
+			root, err := safepath.JoinAndResolveWithRelativeRoot(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			mockIsolationDetector.EXPECT().Detect(vmi).Return(mockIsolationResult, nil)
+			mockIsolationResult.EXPECT().MountRoot().Return(root, nil)
+
+			_, err = handler.getUnixSocketPath(vmi, "virt-serial0")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject a path containing a symlink", func() {
+			tmpDir := GinkgoT().TempDir()
+			vmi := api.NewMinimalVMI("testvmi")
+			vmi.UID = "test-uid-1234"
+
+			realDir := filepath.Join(tmpDir, "real-run", "kubevirt-private", string(vmi.UID))
+			Expect(os.MkdirAll(realDir, 0755)).To(Succeed())
+
+			socketFile := filepath.Join(realDir, "virt-serial0")
+			l, err := net.Listen("unix", socketFile)
+			Expect(err).ToNot(HaveOccurred())
+			defer l.Close()
+
+			// Create "run" as a symlink to "real-run" to simulate an attack
+			Expect(os.Symlink(filepath.Join(tmpDir, "real-run"), filepath.Join(tmpDir, "run"))).To(Succeed())
+
+			root, err := safepath.JoinAndResolveWithRelativeRoot(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			mockIsolationDetector.EXPECT().Detect(vmi).Return(mockIsolationResult, nil)
+			mockIsolationResult.EXPECT().MountRoot().Return(root, nil)
+
+			_, err = handler.getUnixSocketPath(vmi, "virt-serial0")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("unixSocketDialer", func() {
+		It("should connect to a unix socket via safepath", func() {
+			tmpDir := GinkgoT().TempDir()
+			vmi := api.NewMinimalVMI("testvmi")
+
+			socketFile := filepath.Join(tmpDir, "test.sock")
+			l, err := net.Listen("unix", socketFile)
+			Expect(err).ToNot(HaveOccurred())
+			defer l.Close()
+
+			socketPath, err := safepath.JoinAndResolveWithRelativeRoot(tmpDir, "test.sock")
+			Expect(err).ToNot(HaveOccurred())
+
+			dial := unixSocketDialer(vmi, socketPath)
+			conn, err := dial()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(conn).ToNot(BeNil())
+			conn.Close()
+		})
+
+		It("should fail when the socket path is invalid", func() {
+			tmpDir := GinkgoT().TempDir()
+			vmi := api.NewMinimalVMI("testvmi")
+
+			// Create the file so safepath resolves, then close the listener
+			// (Go's UnixListener unlinks the socket on Close)
+			socketFile := filepath.Join(tmpDir, "gone.sock")
+			l, err := net.Listen("unix", socketFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			socketPath, err := safepath.JoinAndResolveWithRelativeRoot(tmpDir, "gone.sock")
+			Expect(err).ToNot(HaveOccurred())
+
+			l.Close()
+
+			dial := unixSocketDialer(vmi, socketPath)
+			_, err = dial()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/virt-handler/rest/rest_suite_test.go
+++ b/pkg/virt-handler/rest/rest_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package rest
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestRest(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/17916

```release-note
NONE
```
