### PR TITLE
vep-10: add dra packages to lint configuration and fix linting errors

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -7,6 +7,7 @@ cmd/virtctl
 cmd/virt-exportserver
 cmd/virt-operator
 pkg/controller/testing
+pkg/dra
 pkg/downwardmetrics/scraper
 pkg/instancetype
 pkg/libvmi

--- a/pkg/dra/admitter/BUILD.bazel
+++ b/pkg/dra/admitter/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     race = "on",
     deps = [
         "//pkg/libvmi:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/dra/admitter/dra_admitter.go
+++ b/pkg/dra/admitter/dra_admitter.go
@@ -84,8 +84,16 @@ func validateCreationDRA(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSp
 
 	duplicateChecker := newPairDuplicateChecker()
 	causes = append(causes, duplicateChecker.mergeTupleSource("GPUs", gpuClaimRequestPairs, field.Child("domain", "devices", "gpus"))...)
-	causes = append(causes, duplicateChecker.mergeTupleSource("HostDevices", hdClaimRequestPairs, field.Child("domain", "devices", "hostDevices"))...)
-	causes = append(causes, duplicateChecker.mergeTupleSource("Networks", netClaimRequestPairs, field.Child("networks"))...)
+	causes = append(causes, duplicateChecker.mergeTupleSource(
+		"HostDevices",
+		hdClaimRequestPairs,
+		field.Child("domain", "devices", "hostDevices"),
+	)...)
+	causes = append(causes, duplicateChecker.mergeTupleSource(
+		"Networks",
+		netClaimRequestPairs,
+		field.Child("networks"),
+	)...)
 
 	allClaimNames := gpuClaimNames.Union(hdClaimNames)
 
@@ -127,7 +135,7 @@ func validateResourceClaims(field *k8sfield.Path, resourceClaims []v1.VirtualMac
 			if errs := utilvalidation.IsDNS1123Label(claim.Name); len(errs) != 0 {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("%s does not conform to the kubernetes DNS_LABEL rules : %s", claimField.Child("name"), strings.Join(errs, ", ")),
+					Message: fmt.Sprintf("%s does not conform to the kubernetes DNS_LABEL rules: %s", claimField.Child("name"), strings.Join(errs, ", ")),
 					Field:   claimField.Child("name").String(),
 				})
 			}
@@ -217,15 +225,26 @@ func newPairDuplicateChecker() *pairDuplicateChecker {
 	}
 }
 
-func (s *pairDuplicateChecker) mergeTupleSource(deviceType string, firstIndexByTuple map[string]int, baseField *k8sfield.Path) []metav1.StatusCause {
+func (s *pairDuplicateChecker) mergeTupleSource(
+	deviceType string,
+	firstIndexByTuple map[string]int,
+	baseField *k8sfield.Path,
+) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	for tuple, idx := range firstIndexByTuple {
 		if previous, exists := s.pairOwnerByKey[tuple]; exists {
 			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueDuplicate,
-				Message: fmt.Sprintf("duplicate claimName/requestName pair %q between %s[%d] and %s[%d]", tuple, previous.deviceType, previous.index, deviceType, idx),
-				Field:   baseField.Index(idx).String(),
+				Type: metav1.CauseTypeFieldValueDuplicate,
+				Message: fmt.Sprintf(
+					"duplicate claimName/requestName pair %q between %s[%d] and %s[%d]",
+					tuple,
+					previous.deviceType,
+					previous.index,
+					deviceType,
+					idx,
+				),
+				Field: baseField.Index(idx).String(),
 			})
 			continue
 		}
@@ -239,7 +258,11 @@ func (s *pairDuplicateChecker) mergeTupleSource(deviceType string, firstIndexByT
 	return causes
 }
 
-func validateDRAGPUs(field *k8sfield.Path, gpus []v1.GPU, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
+func validateDRAGPUs(
+	field *k8sfield.Path,
+	gpus []v1.GPU,
+	checker DRAConfigChecker,
+) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
 	devices := make([]draCapableDevice, len(gpus))
 	for i, g := range gpus {
 		devices[i] = gpuAdapter(g)
@@ -252,7 +275,11 @@ func validateDRAGPUs(field *k8sfield.Path, gpus []v1.GPU, checker DRAConfigCheck
 	})
 }
 
-func validateDRAHostDevices(field *k8sfield.Path, hostDevices []v1.HostDevice, checker DRAConfigChecker) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
+func validateDRAHostDevices(
+	field *k8sfield.Path,
+	hostDevices []v1.HostDevice,
+	checker DRAConfigChecker,
+) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
 	devices := make([]draCapableDevice, len(hostDevices))
 	for i, hd := range hostDevices {
 		devices[i] = hostDeviceAdapter(hd)
@@ -265,46 +292,30 @@ func validateDRAHostDevices(field *k8sfield.Path, hostDevices []v1.HostDevice, c
 	})
 }
 
-func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg deviceValidationConfig) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
-	var (
-		causes     []metav1.StatusCause
-		draDevs    []indexedDevice
-		nonDRADevs []indexedDevice
-	)
+func validateDRADevices(
+	field *k8sfield.Path,
+	devices []draCapableDevice,
+	cfg deviceValidationConfig,
+) ([]metav1.StatusCause, sets.Set[string], map[string]int) {
 	devField := field.Child("domain", "devices", cfg.fieldPath)
+	draDevs, nonDRADevs := splitDRADevices(devices)
 
-	for i, d := range devices {
-		if d.isDRA() {
-			draDevs = append(draDevs, indexedDevice{i, d})
-		} else {
-			nonDRADevs = append(nonDRADevs, indexedDevice{i, d})
-		}
-	}
-
+	var causes []metav1.StatusCause
 	if cfg.rejectMixed && len(nonDRADevs) > 0 && len(draDevs) > 0 {
 		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains both DRA and non-DRA %ss; each %s must be either DRA or non-DRA", cfg.fieldPath, cfg.typeName, cfg.typeName),
-			Field:   devField.String(),
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf(
+				"vmi.spec.domain.devices.%s contains both DRA and non-DRA %ss; each %s must be either DRA or non-DRA",
+				cfg.fieldPath,
+				cfg.typeName,
+				cfg.typeName,
+			),
+			Field: devField.String(),
 		})
 		return causes, sets.New[string](), map[string]int{}
 	}
 
-	for _, nd := range nonDRADevs {
-		if nd.device.getDeviceName() == "" {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains %ss without deviceName or claimRequest; each %s must specify either a deviceName or a claimRequest", cfg.fieldPath, cfg.typeName, cfg.typeName),
-				Field:   devField.String(),
-			})
-		} else if nd.device.getClaimRequest() != nil {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains %ss with both deviceName and claimRequest", cfg.fieldPath, cfg.typeName),
-				Field:   devField.String(),
-			})
-		}
-	}
+	causes = append(causes, validateNonDRADevices(devField, nonDRADevs, cfg)...)
 
 	if len(draDevs) > 0 && !cfg.gateEnabled {
 		causes = append(causes, metav1.StatusCause{
@@ -315,35 +326,33 @@ func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg de
 		return causes, sets.New[string](), map[string]int{}
 	}
 
-	var validDRA []indexedDevice
+	claimNames := sets.New[string]()
+	claimRequestPairs := sets.New[string]()
+	validPairFirstIndexByKey := map[string]int{}
 	for _, id := range draDevs {
-		valid := true
 		cr := id.device.getClaimRequest()
-		if cr.ClaimName == "" {
+		missingClaimName := cr.ClaimName == ""
+		missingRequestName := cr.RequestName == ""
+
+		if missingClaimName {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueRequired,
 				Message: fmt.Sprintf("claimName is required for DRA %s", cfg.typeName),
 				Field:   devField.Index(id.idx).Child("claimName").String(),
 			})
-			valid = false
 		}
-		if cr.RequestName == "" {
+		if missingRequestName {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueRequired,
 				Message: fmt.Sprintf("requestName is required for DRA %s", cfg.typeName),
 				Field:   devField.Index(id.idx).Child("requestName").String(),
 			})
-			valid = false
 		}
-		if valid {
-			validDRA = append(validDRA, id)
+		if missingClaimName || missingRequestName {
+			continue
 		}
-	}
 
-	claimRequestPairs := sets.New[string]()
-	validPairFirstIndexByKey := map[string]int{}
-	for _, id := range validDRA {
-		cr := id.device.getClaimRequest()
+		claimNames.Insert(cr.ClaimName)
 		key := cr.ClaimName + "/" + cr.RequestName
 		if _, exists := validPairFirstIndexByKey[key]; !exists {
 			validPairFirstIndexByKey[key] = id.idx
@@ -358,14 +367,57 @@ func validateDRADevices(field *k8sfield.Path, devices []draCapableDevice, cfg de
 		claimRequestPairs.Insert(key)
 	}
 
-	claimNames := sets.New[string]()
-	for _, id := range validDRA {
-		claimNames.Insert(id.device.getClaimRequest().ClaimName)
-	}
-
 	return causes, claimNames, validPairFirstIndexByKey
 }
 
-func ValidateCreation(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, clusterCfg *virtconfig.ClusterConfig) []metav1.StatusCause {
+func splitDRADevices(devices []draCapableDevice) (draDevs, nonDRADevs []indexedDevice) {
+	for i, d := range devices {
+		indexed := indexedDevice{idx: i, device: d}
+		if d.isDRA() {
+			draDevs = append(draDevs, indexed)
+			continue
+		}
+		nonDRADevs = append(nonDRADevs, indexed)
+	}
+	return draDevs, nonDRADevs
+}
+
+func validateNonDRADevices(
+	devField *k8sfield.Path,
+	nonDRADevs []indexedDevice,
+	cfg deviceValidationConfig,
+) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	for _, nd := range nonDRADevs {
+		if nd.device.getDeviceName() == "" {
+			causes = append(causes, metav1.StatusCause{
+				Type: metav1.CauseTypeFieldValueRequired,
+				Message: fmt.Sprintf(
+					"vmi.spec.domain.devices.%s contains %ss without deviceName or claimRequest; "+
+						"each %s must specify either a deviceName or a claimRequest",
+					cfg.fieldPath,
+					cfg.typeName,
+					cfg.typeName,
+				),
+				Field: devField.String(),
+			})
+			continue
+		}
+		if nd.device.getClaimRequest() != nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("vmi.spec.domain.devices.%s contains %ss with both deviceName and claimRequest", cfg.fieldPath, cfg.typeName),
+				Field:   devField.String(),
+			})
+		}
+	}
+	return causes
+}
+
+func ValidateCreation(
+	field *k8sfield.Path,
+	vmiSpec *v1.VirtualMachineInstanceSpec,
+	clusterCfg *virtconfig.ClusterConfig,
+) []metav1.StatusCause {
 	return NewValidator(field, vmiSpec, clusterCfg).ValidateCreation()
 }

--- a/pkg/dra/admitter/dra_admitter_test.go
+++ b/pkg/dra/admitter/dra_admitter_test.go
@@ -28,6 +28,15 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/pointer"
+)
+
+const (
+	claim1    = "claim1"
+	claim2    = "claim2"
+	req1      = "req1"
+	req2      = "req2"
+	template1 = "template1"
 )
 
 type fakeConfigChecker struct {
@@ -38,7 +47,80 @@ type fakeConfigChecker struct {
 func resourceClaim(name string) v1.VirtualMachineInstanceResourceClaim {
 	return v1.VirtualMachineInstanceResourceClaim{
 		Name:              name,
-		ResourceClaimName: &name,
+		ResourceClaimName: pointer.P(name),
+	}
+}
+
+func claimRequest(claimName, requestName string) *v1.ClaimRequest {
+	return &v1.ClaimRequest{
+		ClaimName:   claimName,
+		RequestName: requestName,
+	}
+}
+
+func gpuWithClaimRequest(name, claimName, requestName string) v1.GPU {
+	return v1.GPU{
+		Name:         name,
+		ClaimRequest: claimRequest(claimName, requestName),
+	}
+}
+
+func gpuWithDeviceName(name, deviceName string) v1.GPU {
+	return v1.GPU{
+		Name:       name,
+		DeviceName: deviceName,
+	}
+}
+
+func gpuWithDeviceNameAndClaimRequest(name, deviceName string, claimRequest *v1.ClaimRequest) v1.GPU {
+	return v1.GPU{
+		Name:         name,
+		DeviceName:   deviceName,
+		ClaimRequest: claimRequest,
+	}
+}
+
+func hostDeviceWithClaimRequest(name, claimName, requestName string) v1.HostDevice {
+	return v1.HostDevice{
+		Name:         name,
+		ClaimRequest: claimRequest(claimName, requestName),
+	}
+}
+
+func hostDeviceWithDeviceName(name, deviceName string) v1.HostDevice {
+	return v1.HostDevice{
+		Name:       name,
+		DeviceName: deviceName,
+	}
+}
+
+func hostDeviceWithDeviceNameAndClaimRequest(name, deviceName string, claimRequest *v1.ClaimRequest) v1.HostDevice {
+	return v1.HostDevice{
+		Name:         name,
+		DeviceName:   deviceName,
+		ClaimRequest: claimRequest,
+	}
+}
+
+func gpuSpec(resourceClaims []v1.VirtualMachineInstanceResourceClaim, gpus ...v1.GPU) *v1.VirtualMachineInstanceSpec {
+	return &v1.VirtualMachineInstanceSpec{
+		ResourceClaims: resourceClaims,
+		Domain: v1.DomainSpec{
+			Devices: v1.Devices{
+				GPUs: gpus,
+			},
+		},
+	}
+}
+
+func hostDeviceSpec(resourceClaims []v1.VirtualMachineInstanceResourceClaim, hostDevices ...v1.HostDevice) *v1.VirtualMachineInstanceSpec {
+	return &v1.VirtualMachineInstanceSpec{
+		ResourceClaims: resourceClaims,
+		Domain: v1.DomainSpec{
+			Devices: v1.Devices{
+				HostDevices: hostDevices,
+			},
+		},
 	}
 }
 
@@ -78,7 +160,7 @@ var _ = Describe("DRA Admitter", func() {
 	Context("resource claim validation", func() {
 		It("should accept a direct resource claim reference", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
 			}
 
 			causes := validateCreationDRA(field, spec, checker)
@@ -86,11 +168,10 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should accept a resource claim template reference", func() {
-			templateName := "template1"
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-					Name:                      "claim1",
-					ResourceClaimTemplateName: &templateName,
+					Name:                      claim1,
+					ResourceClaimTemplateName: pointer.P(template1),
 				}},
 			}
 
@@ -99,10 +180,9 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject a resource claim without name", func() {
-			claimName := "claim1"
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-					ResourceClaimName: &claimName,
+					ResourceClaimName: pointer.P(claim1),
 				}},
 			}
 
@@ -117,8 +197,8 @@ var _ = Describe("DRA Admitter", func() {
 		It("should reject a duplicate resource claim name", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
-					resourceClaim("claim1"),
-					resourceClaim("claim1"),
+					resourceClaim(claim1),
+					resourceClaim(claim1),
 				},
 			}
 
@@ -131,12 +211,11 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject an invalid resource claim name", func() {
-			claimName := "claim1"
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
 					{
 						Name:              "../claim1",
-						ResourceClaimName: &claimName,
+						ResourceClaimName: pointer.P(claim1),
 					},
 				},
 			}
@@ -146,11 +225,10 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject an invalid resourceClaimName", func() {
-			claimName := "../claim1"
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-					Name:              "claim1",
-					ResourceClaimName: &claimName,
+					Name:              claim1,
+					ResourceClaimName: pointer.P("../claim1"),
 				}},
 			}
 
@@ -159,11 +237,10 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject an invalid resourceClaimTemplateName", func() {
-			templateName := "../claim-template"
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-					Name:                      "claim1",
-					ResourceClaimTemplateName: &templateName,
+					Name:                      claim1,
+					ResourceClaimTemplateName: pointer.P("../claim-template"),
 				}},
 			}
 
@@ -172,13 +249,11 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject when both claim sources are set", func() {
-			claimName := "claim1"
-			templateName := "template1"
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-					Name:                      "claim1",
-					ResourceClaimName:         &claimName,
-					ResourceClaimTemplateName: &templateName,
+					Name:                      claim1,
+					ResourceClaimName:         pointer.P(claim1),
+					ResourceClaimTemplateName: pointer.P(template1),
 				}},
 			}
 
@@ -193,7 +268,7 @@ var _ = Describe("DRA Admitter", func() {
 		It("should reject when no claim source is set", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-					Name: "claim1",
+					Name: claim1,
 				}},
 			}
 
@@ -206,61 +281,51 @@ var _ = Describe("DRA Admitter", func() {
 		})
 	})
 
-	Context("non-DRA (device-plugin) GPUs", func() {
-		It("should accept a GPU with deviceName", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name:       "gpu1",
-							DeviceName: "vfio.gpu.example.com",
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+	DescribeTable("non-DRA device-plugin device with deviceName",
+		func(spec func() *v1.VirtualMachineInstanceSpec) {
+			causes := validateCreationDRA(field, spec(), checker)
 			Expect(causes).To(BeEmpty())
-		})
+		},
+		Entry("GPU",
+			func() *v1.VirtualMachineInstanceSpec {
+				return gpuSpec(nil, gpuWithDeviceName("gpu1", "vfio.gpu.example.com"))
+			},
+		),
+		Entry("HostDevice",
+			func() *v1.VirtualMachineInstanceSpec {
+				return hostDeviceSpec(nil, hostDeviceWithDeviceName("hd1", "vfio.device.example.com"))
+			},
+		),
+	)
 
-		It("should reject a GPU with both deviceName and claimRequest", func() {
-			checker.gpuDRAEnabled = true
-			spec := &v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name:       "gpu1",
-							DeviceName: "vfio.gpu.example.com",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+	DescribeTable("non-DRA device-plugin device with deviceName and claimRequest",
+		func(enableGate func(), spec func() *v1.VirtualMachineInstanceSpec, fieldPath string) {
+			enableGate()
+			causes := validateCreationDRA(field, spec(), checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("both deviceName and claimRequest"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus"))
-		})
-	})
+			Expect(causes[0].Field).To(Equal(fieldPath))
+		},
+		Entry("GPU",
+			func() { checker.gpuDRAEnabled = true },
+			func() *v1.VirtualMachineInstanceSpec {
+				return gpuSpec(nil, gpuWithDeviceNameAndClaimRequest("gpu1", "vfio.gpu.example.com", claimRequest(claim1, req1)))
+			},
+			"spec.domain.devices.gpus",
+		),
+		Entry("HostDevice",
+			func() { checker.hostDeviceDRAEnabled = true },
+			func() *v1.VirtualMachineInstanceSpec {
+				return hostDeviceSpec(nil, hostDeviceWithDeviceNameAndClaimRequest("hd1", "vfio.device.example.com", claimRequest(claim1, req1)))
+			},
+			"spec.domain.devices.hostDevices",
+		),
+	)
 
 	Context("DRA GPUs with feature gate disabled", func() {
 		It("should reject DRA GPUs when the feature gate is off", func() {
 			checker.gpuDRAEnabled = false
-			spec := &v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name: "gpu1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
+			spec := gpuSpec(nil, gpuWithClaimRequest("gpu1", claim1, req1))
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("feature gate is not enabled"))
@@ -268,73 +333,100 @@ var _ = Describe("DRA Admitter", func() {
 		})
 	})
 
-	Context("DRA GPU field validation", func() {
-		BeforeEach(func() {
-			checker.gpuDRAEnabled = true
-		})
+	DescribeTable("DRA device with empty claimName",
+		func(enableGate func(), specForClaimRequest func(*v1.ClaimRequest) *v1.VirtualMachineInstanceSpec, fieldPrefix string) {
+			enableGate()
 
-		It("should reject when claimName is empty string", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name: "gpu1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+			causes := validateCreationDRA(field, specForClaimRequest(claimRequest("", req1)), checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueRequired))
 			Expect(causes[0].Message).To(ContainSubstring("claimName is required"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus[0].claimName"))
-		})
+			Expect(causes[0].Field).To(Equal(fieldPrefix + ".claimName"))
+		},
+		Entry("GPU",
+			func() { checker.gpuDRAEnabled = true },
+			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
+				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.GPU{
+					Name:         "gpu1",
+					ClaimRequest: claimRequest,
+				})
+			},
+			"spec.domain.devices.gpus[0]",
+		),
+		Entry("HostDevice",
+			func() { checker.hostDeviceDRAEnabled = true },
+			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
+				return hostDeviceSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.HostDevice{
+					Name:         "hd1",
+					ClaimRequest: claimRequest,
+				})
+			},
+			"spec.domain.devices.hostDevices[0]",
+		),
+	)
 
-		It("should reject when requestName is empty string", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name: "gpu1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+	DescribeTable("DRA device with empty requestName",
+		func(enableGate func(), specForClaimRequest func(*v1.ClaimRequest) *v1.VirtualMachineInstanceSpec, fieldPrefix string) {
+			enableGate()
+
+			causes := validateCreationDRA(field, specForClaimRequest(claimRequest(claim1, "")), checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueRequired))
 			Expect(causes[0].Message).To(ContainSubstring("requestName is required"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus[0].requestName"))
-		})
+			Expect(causes[0].Field).To(Equal(fieldPrefix + ".requestName"))
+		},
+		Entry("GPU",
+			func() { checker.gpuDRAEnabled = true },
+			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
+				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.GPU{
+					Name:         "gpu1",
+					ClaimRequest: claimRequest,
+				})
+			},
+			"spec.domain.devices.gpus[0]",
+		),
+		Entry("HostDevice",
+			func() { checker.hostDeviceDRAEnabled = true },
+			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
+				return hostDeviceSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.HostDevice{
+					Name:         "hd1",
+					ClaimRequest: claimRequest,
+				})
+			},
+			"spec.domain.devices.hostDevices[0]",
+		),
+	)
 
-		It("should report two causes when both claimName and requestName are missing", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name:         "gpu1",
-							ClaimRequest: &v1.ClaimRequest{},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+	DescribeTable("DRA device with empty claimName and requestName",
+		func(enableGate func(), specForClaimRequest func(*v1.ClaimRequest) *v1.VirtualMachineInstanceSpec, fieldPrefix string) {
+			enableGate()
+
+			causes := validateCreationDRA(field, specForClaimRequest(&v1.ClaimRequest{}), checker)
 			Expect(causes).To(HaveLen(2))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus[0].claimName"))
-			Expect(causes[1].Field).To(Equal("spec.domain.devices.gpus[0].requestName"))
-		})
-	})
+			Expect(causes[0].Field).To(Equal(fieldPrefix + ".claimName"))
+			Expect(causes[1].Field).To(Equal(fieldPrefix + ".requestName"))
+		},
+		Entry("GPU",
+			func() { checker.gpuDRAEnabled = true },
+			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
+				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.GPU{
+					Name:         "gpu1",
+					ClaimRequest: claimRequest,
+				})
+			},
+			"spec.domain.devices.gpus[0]",
+		),
+		Entry("HostDevice",
+			func() { checker.hostDeviceDRAEnabled = true },
+			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
+				return hostDeviceSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.HostDevice{
+					Name:         "hd1",
+					ClaimRequest: claimRequest,
+				})
+			},
+			"spec.domain.devices.hostDevices[0]",
+		),
+	)
 
 	Context("resourceClaims cross-validation", func() {
 		BeforeEach(func() {
@@ -342,23 +434,13 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject duplicate names in spec.resourceClaims", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
-					resourceClaim("claim1"),
-					resourceClaim("claim1"),
+			spec := gpuSpec(
+				[]v1.VirtualMachineInstanceResourceClaim{
+					resourceClaim(claim1),
+					resourceClaim(claim1),
 				},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name: "gpu1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
+				gpuWithClaimRequest("gpu1", claim1, req1),
+			)
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueDuplicate))
@@ -367,20 +449,10 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject when GPU claimName is not listed in spec.resourceClaims", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("other-claim")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name: "gpu1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
+			spec := gpuSpec(
+				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim("other-claim")},
+				gpuWithClaimRequest("gpu1", claim1, req1),
+			)
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("resourceClaims must specify all claims"))
@@ -388,29 +460,11 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject when one of multiple claims is missing from spec.resourceClaims", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{
-							{
-								Name: "gpu1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-							{
-								Name: "gpu2",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim2",
-									RequestName: "req2",
-								},
-							},
-						},
-					},
-				},
-			}
+			spec := gpuSpec(
+				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
+				gpuWithClaimRequest("gpu1", claim1, req1),
+				gpuWithClaimRequest("gpu2", claim2, req2),
+			)
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("resourceClaims must specify all claims"))
@@ -418,126 +472,92 @@ var _ = Describe("DRA Admitter", func() {
 		})
 	})
 
-	Context("fully valid DRA GPU specs", func() {
-		BeforeEach(func() {
-			checker.gpuDRAEnabled = true
-		})
+	DescribeTable("valid and duplicate DRA device claimName/requestName pairs",
+		func(
+			enableGate func(),
+			singleSpec func() *v1.VirtualMachineInstanceSpec,
+			pairSpec func([]v1.VirtualMachineInstanceResourceClaim, string, string, string, string) *v1.VirtualMachineInstanceSpec,
+			duplicateField string,
+		) {
+			enableGate()
 
-		It("should accept a single valid DRA GPU", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{{
-							Name: "gpu1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+			causes := validateCreationDRA(field, singleSpec(), checker)
 			Expect(causes).To(BeEmpty())
-		})
 
-		It("should accept multiple valid DRA GPUs with matching resourceClaims", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
-					resourceClaim("claim1"),
-					resourceClaim("claim2"),
-				},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{
-							{
-								Name: "gpu1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-							{
-								Name: "gpu2",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim2",
-									RequestName: "req2",
-								},
-							},
-						},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+			causes = validateCreationDRA(field, pairSpec(
+				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1), resourceClaim(claim2)},
+				claim1,
+				req1,
+				claim2,
+				req2,
+			), checker)
 			Expect(causes).To(BeEmpty())
-		})
-	})
 
-	Context("duplicate claimName/requestName pairs for GPUs", func() {
-		BeforeEach(func() {
-			checker.gpuDRAEnabled = true
-		})
-
-		It("should reject two GPUs referencing the same claimName/requestName pair", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{
-							{
-								Name: "gpu1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-							{
-								Name: "gpu2",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-						},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+			causes = validateCreationDRA(field, pairSpec(
+				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
+				claim1,
+				req1,
+				claim1,
+				req1,
+			), checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueDuplicate))
 			Expect(causes[0].Message).To(ContainSubstring("duplicate claimName/requestName"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus[1]"))
-		})
+			Expect(causes[0].Field).To(Equal(duplicateField))
 
-		It("should accept two GPUs referencing the same claim but different requests", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						GPUs: []v1.GPU{
-							{
-								Name: "gpu1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-							{
-								Name: "gpu2",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req2",
-								},
-							},
-						},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
+			causes = validateCreationDRA(field, pairSpec(
+				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
+				claim1,
+				req1,
+				claim1,
+				req2,
+			), checker)
 			Expect(causes).To(BeEmpty())
-		})
-	})
+		},
+		Entry("GPU",
+			func() { checker.gpuDRAEnabled = true },
+			func() *v1.VirtualMachineInstanceSpec {
+				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, gpuWithClaimRequest("gpu1", claim1, req1))
+			},
+			func(
+				resourceClaims []v1.VirtualMachineInstanceResourceClaim,
+				firstClaim string,
+				firstRequest string,
+				secondClaim string,
+				secondRequest string,
+			) *v1.VirtualMachineInstanceSpec {
+				return gpuSpec(
+					resourceClaims,
+					gpuWithClaimRequest("gpu1", firstClaim, firstRequest),
+					gpuWithClaimRequest("gpu2", secondClaim, secondRequest),
+				)
+			},
+			"spec.domain.devices.gpus[1]",
+		),
+		Entry("HostDevice",
+			func() { checker.hostDeviceDRAEnabled = true },
+			func() *v1.VirtualMachineInstanceSpec {
+				return hostDeviceSpec(
+					[]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
+					hostDeviceWithClaimRequest("hd1", claim1, req1),
+				)
+			},
+			func(
+				resourceClaims []v1.VirtualMachineInstanceResourceClaim,
+				firstClaim string,
+				firstRequest string,
+				secondClaim string,
+				secondRequest string,
+			) *v1.VirtualMachineInstanceSpec {
+				return hostDeviceSpec(
+					resourceClaims,
+					hostDeviceWithClaimRequest("hd1", firstClaim, firstRequest),
+					hostDeviceWithClaimRequest("hd2", secondClaim, secondRequest),
+				)
+			},
+			"spec.domain.devices.hostDevices[1]",
+		),
+	)
 
 	Context("mixed DRA and non-DRA GPUs", func() {
 		It("should reject a VMI with both DRA and non-DRA GPUs", func() {
@@ -553,7 +573,7 @@ var _ = Describe("DRA Admitter", func() {
 							{
 								Name: "dra-gpu",
 								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
+									ClaimName:   claim1,
 									RequestName: "req1",
 								},
 							},
@@ -576,7 +596,7 @@ var _ = Describe("DRA Admitter", func() {
 
 		It("should report correct index for duplicate when an invalid DRA GPU precedes it", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						GPUs: []v1.GPU{
@@ -587,14 +607,14 @@ var _ = Describe("DRA Admitter", func() {
 							{
 								Name: "gpu-a",
 								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
+									ClaimName:   claim1,
 									RequestName: "req1",
 								},
 							},
 							{
 								Name: "gpu-dup",
 								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
+									ClaimName:   claim1,
 									RequestName: "req1",
 								},
 							},
@@ -606,10 +626,10 @@ var _ = Describe("DRA Admitter", func() {
 
 			var claimNameCause, dupCause *metav1.StatusCause
 			for i := range causes {
-				switch causes[i].Type {
-				case metav1.CauseTypeFieldValueRequired:
+				if causes[i].Type == metav1.CauseTypeFieldValueRequired {
 					claimNameCause = &causes[i]
-				case metav1.CauseTypeFieldValueDuplicate:
+				}
+				if causes[i].Type == metav1.CauseTypeFieldValueDuplicate {
 					dupCause = &causes[i]
 				}
 			}
@@ -622,133 +642,14 @@ var _ = Describe("DRA Admitter", func() {
 		})
 	})
 
-	Context("non-DRA (device-plugin) HostDevices", func() {
-		It("should accept a HostDevice with deviceName", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name:       "hd1",
-							DeviceName: "vfio.device.example.com",
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(BeEmpty())
-		})
-
-		It("should reject a HostDevice with both deviceName and claimRequest", func() {
-			checker.hostDeviceDRAEnabled = true
-			spec := &v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name:       "hd1",
-							DeviceName: "vfio.device.example.com",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Message).To(ContainSubstring("both deviceName and claimRequest"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices"))
-		})
-	})
-
 	Context("DRA HostDevices with feature gate disabled", func() {
 		It("should reject DRA HostDevices when the feature gate is off", func() {
 			checker.hostDeviceDRAEnabled = false
-			spec := &v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
+			spec := hostDeviceSpec(nil, hostDeviceWithClaimRequest("hd1", claim1, req1))
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("feature gate is not enabled"))
 			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices"))
-		})
-	})
-
-	Context("DRA HostDevice field validation", func() {
-		BeforeEach(func() {
-			checker.hostDeviceDRAEnabled = true
-		})
-
-		It("should reject when claimName is empty string", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueRequired))
-			Expect(causes[0].Message).To(ContainSubstring("claimName is required"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[0].claimName"))
-		})
-
-		It("should reject when requestName is empty string", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueRequired))
-			Expect(causes[0].Message).To(ContainSubstring("requestName is required"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[0].requestName"))
-		})
-
-		It("should report two causes when both claimName and requestName are missing", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name:         "hd1",
-							ClaimRequest: &v1.ClaimRequest{},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(HaveLen(2))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[0].claimName"))
-			Expect(causes[1].Field).To(Equal("spec.domain.devices.hostDevices[0].requestName"))
 		})
 	})
 
@@ -758,20 +659,10 @@ var _ = Describe("DRA Admitter", func() {
 		})
 
 		It("should reject when HostDevice claimName is not listed in spec.resourceClaims", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("other-claim")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
+			spec := hostDeviceSpec(
+				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim("other-claim")},
+				hostDeviceWithClaimRequest("hd1", claim1, req1),
+			)
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("resourceClaims must specify all claims"))
@@ -779,132 +670,11 @@ var _ = Describe("DRA Admitter", func() {
 		})
 	})
 
-	Context("fully valid DRA HostDevice specs", func() {
-		BeforeEach(func() {
-			checker.hostDeviceDRAEnabled = true
-		})
-
-		It("should accept a single valid DRA HostDevice", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
-							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "req1",
-							},
-						}},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(BeEmpty())
-		})
-
-		It("should accept multiple valid DRA HostDevices with matching resourceClaims", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
-					resourceClaim("claim1"),
-					resourceClaim("claim2"),
-				},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{
-							{
-								Name: "hd1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-							{
-								Name: "hd2",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim2",
-									RequestName: "req2",
-								},
-							},
-						},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(BeEmpty())
-		})
-	})
-
-	Context("duplicate claimName/requestName pairs for HostDevices", func() {
-		BeforeEach(func() {
-			checker.hostDeviceDRAEnabled = true
-		})
-
-		It("should reject two HostDevices referencing the same claimName/requestName pair", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{
-							{
-								Name: "hd1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-							{
-								Name: "hd2",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-						},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueDuplicate))
-			Expect(causes[0].Message).To(ContainSubstring("duplicate claimName/requestName"))
-			Expect(causes[0].Field).To(Equal("spec.domain.devices.hostDevices[1]"))
-		})
-
-		It("should accept two HostDevices referencing the same claim but different requests", func() {
-			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						HostDevices: []v1.HostDevice{
-							{
-								Name: "hd1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							},
-							{
-								Name: "hd2",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req2",
-								},
-							},
-						},
-					},
-				},
-			}
-			causes := validateCreationDRA(field, spec, checker)
-			Expect(causes).To(BeEmpty())
-		})
-	})
-
 	Context("mixed DRA and non-DRA HostDevices", func() {
 		It("should accept a VMI with both DRA and non-DRA HostDevices", func() {
 			checker.hostDeviceDRAEnabled = true
 			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						HostDevices: []v1.HostDevice{
@@ -915,7 +685,7 @@ var _ = Describe("DRA Admitter", func() {
 							{
 								Name: "dra-hd",
 								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
+									ClaimName:   claim1,
 									RequestName: "req1",
 								},
 							},
@@ -935,7 +705,7 @@ var _ = Describe("DRA Admitter", func() {
 
 		It("should report correct index when non-DRA devices precede a DRA device with missing claimName", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						HostDevices: []v1.HostDevice{
@@ -960,7 +730,7 @@ var _ = Describe("DRA Admitter", func() {
 
 		It("should report correct index for duplicate when non-DRA devices are interspersed", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						HostDevices: []v1.HostDevice{
@@ -971,7 +741,7 @@ var _ = Describe("DRA Admitter", func() {
 							{
 								Name: "dra-hd-a",
 								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
+									ClaimName:   claim1,
 									RequestName: "req1",
 								},
 							},
@@ -982,7 +752,7 @@ var _ = Describe("DRA Admitter", func() {
 							{
 								Name: "dra-hd-dup",
 								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
+									ClaimName:   claim1,
 									RequestName: "req1",
 								},
 							},
@@ -999,7 +769,7 @@ var _ = Describe("DRA Admitter", func() {
 
 		It("should report correct index for invalid DRA HostDevice after non-DRA devices", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						HostDevices: []v1.HostDevice{
@@ -1150,13 +920,13 @@ var _ = Describe("DRA Admitter", func() {
 		It("ValidateCreation should delegate to validateCreationDRA", func() {
 			checker.gpuDRAEnabled = true
 			spec := &v1.VirtualMachineInstanceSpec{
-				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim("claim1")},
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						GPUs: []v1.GPU{{
 							Name: "gpu1",
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
+								ClaimName:   claim1,
 								RequestName: "req1",
 							},
 						}},
@@ -1176,7 +946,7 @@ var _ = Describe("DRA Admitter", func() {
 						GPUs: []v1.GPU{{
 							Name: "gpu1",
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "claim1",
+								ClaimName:   claim1,
 								RequestName: "req1",
 							},
 						}},

--- a/pkg/dra/utils.go
+++ b/pkg/dra/utils.go
@@ -54,7 +54,12 @@ const (
 
 // GetPCIAddressForClaim returns the PCI address for a device in the given claim and request.
 // It lazily reads the KEP-5304 metadata file at lookup time.
-func GetPCIAddressForClaim(basePath string, resourceClaims []v1.VirtualMachineInstanceResourceClaim, claimRefName, requestName string) (string, error) {
+func GetPCIAddressForClaim(
+	basePath string,
+	resourceClaims []v1.VirtualMachineInstanceResourceClaim,
+	claimRefName,
+	requestName string,
+) (string, error) {
 	device, err := resolveDevice(basePath, resourceClaims, claimRefName, requestName)
 	if err != nil {
 		return "", err
@@ -70,7 +75,12 @@ func GetPCIAddressForClaim(basePath string, resourceClaims []v1.VirtualMachineIn
 
 // GetMDevUUIDForClaim returns the mdev UUID for a device in the given claim and request.
 // It lazily reads the KEP-5304 metadata file at lookup time.
-func GetMDevUUIDForClaim(basePath string, resourceClaims []v1.VirtualMachineInstanceResourceClaim, claimRefName, requestName string) (string, error) {
+func GetMDevUUIDForClaim(
+	basePath string,
+	resourceClaims []v1.VirtualMachineInstanceResourceClaim,
+	claimRefName,
+	requestName string,
+) (string, error) {
 	device, err := resolveDevice(basePath, resourceClaims, claimRefName, requestName)
 	if err != nil {
 		return "", err
@@ -86,7 +96,12 @@ func GetMDevUUIDForClaim(basePath string, resourceClaims []v1.VirtualMachineInst
 
 // resolveDevice finds and reads the metadata file for a specific claim ref and
 // request, returning the single device from that request.
-func resolveDevice(basePath string, resourceClaims []v1.VirtualMachineInstanceResourceClaim, claimRefName, requestName string) (*metadata.Device, error) {
+func resolveDevice(
+	basePath string,
+	resourceClaims []v1.VirtualMachineInstanceResourceClaim,
+	claimRefName,
+	requestName string,
+) (*metadata.Device, error) {
 	md, err := resolveClaimMetadata(basePath, resourceClaims, claimRefName, requestName)
 	if err != nil {
 		return nil, err
@@ -98,18 +113,32 @@ func resolveDevice(basePath string, resourceClaims []v1.VirtualMachineInstanceRe
 				return nil, fmt.Errorf("request %q has no devices", requestName)
 			}
 			if len(req.Devices) > 1 {
-				return nil, fmt.Errorf("request %q has %d devices but KubeVirt only supports exactly one device per request (count > 1 is not supported)", requestName, len(req.Devices))
+				return nil, fmt.Errorf(
+					"request %q has %d devices but KubeVirt only supports exactly one device per request (count > 1 is not supported)",
+					requestName,
+					len(req.Devices),
+				)
 			}
 			return &req.Devices[0], nil
 		}
 	}
-	return nil, fmt.Errorf("request %q not found in metadata for claim %q (available requests: %v)", requestName, md.Name, metadataRequestNames(md))
+	return nil, fmt.Errorf(
+		"request %q not found in metadata for claim %q (available requests: %v)",
+		requestName,
+		md.Name,
+		metadataRequestNames(md),
+	)
 }
 
 // resolveClaimMetadata reads the metadata file for a claim ref + request pair.
 // Direct claims:   {base}/resourceclaims/{claimName}/{requestName}/{driverName}-metadata.json
 // Template claims: {base}/resourceclaimtemplates/{podClaimName}/{requestName}/{driverName}-metadata.json
-func resolveClaimMetadata(basePath string, resourceClaims []v1.VirtualMachineInstanceResourceClaim, claimRefName, requestName string) (*metadata.DeviceMetadata, error) {
+func resolveClaimMetadata(
+	basePath string,
+	resourceClaims []v1.VirtualMachineInstanceResourceClaim,
+	claimRefName,
+	requestName string,
+) (*metadata.DeviceMetadata, error) {
 	for _, rc := range resourceClaims {
 		if rc.Name != claimRefName {
 			continue
@@ -136,7 +165,12 @@ func readMetadataFromDir(basePath, claimName, requestName string) (*metadata.Dev
 		return nil, fmt.Errorf("failed to read metadata for claim %q request %q: no files matching %s", claimName, requestName, pattern)
 	}
 	if len(matches) > 1 {
-		return nil, fmt.Errorf("found %d metadata files for claim %q request %q but KubeVirt only supports exactly one driver per request", len(matches), claimName, requestName)
+		return nil, fmt.Errorf(
+			"found %d metadata files for claim %q request %q but KubeVirt only supports exactly one driver per request",
+			len(matches),
+			claimName,
+			requestName,
+		)
 	}
 	log.Log.Infof("Reading DRA device metadata file %s", matches[0])
 	return readMetadataFile(matches[0])

--- a/pkg/dra/utils_test.go
+++ b/pkg/dra/utils_test.go
@@ -37,10 +37,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/dra/metadata"
 )
 
+const (
+	pciAddr0300 = "0000:03:00.0"
+	pciAddr0400 = "0000:04:00.0"
+)
+
 var _ = Describe("DownwardAPIAttributes", func() {
-	var (
-		tempDir string
-	)
+	var tempDir string
 
 	BeforeEach(func() {
 		var err error
@@ -55,12 +58,12 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	// Direct claims:   {base}/resourceclaims/{claimName}/{requestName}/{driverName}-metadata.json
 	// Template claims: {base}/resourceclaimtemplates/{podClaimName}/{requestName}/{driverName}-metadata.json
 	writeMetadataJSON := func(dir, driverName string, md *metadata.DeviceMetadata) {
-		Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
 		md.APIVersion = metadata.APIVersionV1Alpha1
 		md.Kind = "DeviceMetadata"
 		data, err := json.Marshal(md)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(os.WriteFile(filepath.Join(dir, driverName+metadataFileSuffix), data, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dir, driverName+metadataFileSuffix), data, 0o600)).To(Succeed())
 	}
 
 	createMetadataFile := func(claimName, requestName string, md *metadata.DeviceMetadata) {
@@ -71,6 +74,49 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	createTemplateMetadataFile := func(podClaimName, requestName string, md *metadata.DeviceMetadata) {
 		dir := filepath.Join(tempDir, resourceClaimTemplatesSubdir, podClaimName, requestName)
 		writeMetadataJSON(dir, "gpu.example.com", md)
+	}
+
+	metadataWithAttributes := func(
+		name string,
+		requestName string,
+		attributes map[resourcev1.QualifiedName]resourcev1.DeviceAttribute,
+	) *metadata.DeviceMetadata {
+		return &metadata.DeviceMetadata{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Requests: []metadata.DeviceMetadataRequest{{
+				Name: requestName,
+				Devices: []metadata.Device{{
+					Attributes: attributes,
+				}},
+			}},
+		}
+	}
+
+	metadataWithoutAttributes := func(name, requestName string) *metadata.DeviceMetadata {
+		return metadataWithAttributes(name, requestName, map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{})
+	}
+
+	metadataWithStringAttribute := func(
+		name string,
+		requestName string,
+		attribute resourcev1.QualifiedName,
+		value string,
+	) *metadata.DeviceMetadata {
+		return metadataWithAttributes(name, requestName, map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+			attribute: {StringValue: ptr.To(value)},
+		})
+	}
+
+	templateMetadataWithStringAttribute := func(
+		name string,
+		podClaimName string,
+		requestName string,
+		attribute resourcev1.QualifiedName,
+		value string,
+	) *metadata.DeviceMetadata {
+		md := metadataWithStringAttribute(name, requestName, attribute, value)
+		md.PodClaimName = ptr.To(podClaimName)
+		return md
 	}
 
 	Context("lazy resolution", func() {
@@ -143,7 +189,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 	Context("GetPCIAddressForClaim", func() {
 		It("should return the PCI address when present", func() {
-			pciAddr := "0000:03:00.0"
+			pciAddr := pciAddr0300
 			createMetadataFile("pci-claim", "req1", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "pci-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
@@ -173,15 +219,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		})
 
 		It("should return error when request not found in metadata file", func() {
-			createMetadataFile("claim1", "other-req", &metadata.DeviceMetadata{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
-				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "other-req",
-					Devices: []metadata.Device{{
-						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{},
-					}},
-				}},
-			})
+			createMetadataFile("claim1", "other-req", metadataWithoutAttributes("claim1", "other-req"))
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
 				Name:              "my-claim",
@@ -194,13 +232,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		})
 
 		It("should return error when pciBusID attribute not present", func() {
-			createMetadataFile("claim1", "req1", &metadata.DeviceMetadata{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
-				Requests: []metadata.DeviceMetadataRequest{{
-					Name:    "req1",
-					Devices: []metadata.Device{{Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{}}},
-				}},
-			})
+			createMetadataFile("claim1", "req1", metadataWithoutAttributes("claim1", "req1"))
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
 				Name:              "my-claim",
@@ -213,8 +245,8 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		})
 
 		It("should return error when request has multiple devices (count > 1)", func() {
-			pciAddr1 := "0000:03:00.0"
-			pciAddr2 := "0000:04:00.0"
+			pciAddr1 := pciAddr0300
+			pciAddr2 := pciAddr0400
 			createMetadataFile("claim1", "req1", &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
 				Requests: []metadata.DeviceMetadataRequest{{
@@ -299,7 +331,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 	Context("multiple claims and requests", func() {
 		It("should handle multiple claims with different device types", func() {
-			pciAddr := "0000:04:00.0"
+			pciAddr := pciAddr0400
 			mdevUUID := "11111111-2222-3333-4444-555555555555"
 
 			createMetadataFile("gpu-claim", "gpu-req", &metadata.DeviceMetadata{
@@ -344,18 +376,17 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	Context("ResourceClaimTemplateName claims", func() {
 		It("should return PCI address for template-generated claim", func() {
 			pciAddr := "0000:05:00.0"
-			createTemplateMetadataFile("template-gpu-claim", "pci-req", &metadata.DeviceMetadata{
-				ObjectMeta:   metav1.ObjectMeta{Name: "generated-pci-claim-xyz"},
-				PodClaimName: ptr.To("template-gpu-claim"),
-				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "pci-req",
-					Devices: []metadata.Device{{
-						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
-						},
-					}},
-				}},
-			})
+			createTemplateMetadataFile(
+				"template-gpu-claim",
+				"pci-req",
+				templateMetadataWithStringAttribute(
+					"generated-pci-claim-xyz",
+					"template-gpu-claim",
+					"pci-req",
+					metadata.PCIBusIDAttribute,
+					pciAddr,
+				),
+			)
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
 				Name:                      "template-gpu-claim",
@@ -369,18 +400,17 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 		It("should return mdev UUID for template-generated claim", func() {
 			mdevUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-			createTemplateMetadataFile("template-vgpu-claim", "vgpu-req", &metadata.DeviceMetadata{
-				ObjectMeta:   metav1.ObjectMeta{Name: "generated-vgpu-claim-abc"},
-				PodClaimName: ptr.To("template-vgpu-claim"),
-				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "vgpu-req",
-					Devices: []metadata.Device{{
-						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-							metadata.MDevUUIDAttribute: {StringValue: &mdevUUID},
-						},
-					}},
-				}},
-			})
+			createTemplateMetadataFile(
+				"template-vgpu-claim",
+				"vgpu-req",
+				templateMetadataWithStringAttribute(
+					"generated-vgpu-claim-abc",
+					"template-vgpu-claim",
+					"vgpu-req",
+					metadata.MDevUUIDAttribute,
+					mdevUUID,
+				),
+			)
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
 				Name:                      "template-vgpu-claim",
@@ -521,12 +551,12 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	Context("JSON stream version negotiation", func() {
 		writeRawStreamFile := func(claimName, requestName, driverName string, objects ...string) {
 			dir := filepath.Join(tempDir, resourceClaimsSubdir, claimName, requestName)
-			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
 			var content []byte
 			for _, obj := range objects {
 				content = append(content, []byte(obj+"\n")...)
 			}
-			Expect(os.WriteFile(filepath.Join(dir, driverName+metadataFileSuffix), content, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, driverName+metadataFileSuffix), content, 0o600)).To(Succeed())
 		}
 
 		It("should skip unknown apiVersion and decode v1alpha1 from stream", func() {
@@ -568,7 +598,9 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			}}
 			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no compatible metadata version found in stream (unknown versions: metadata.resource.k8s.io/v99)"))
+			Expect(err.Error()).To(ContainSubstring(
+				"no compatible metadata version found in stream (unknown versions: metadata.resource.k8s.io/v99)",
+			))
 		})
 
 		It("should return error on empty stream", func() {
@@ -614,7 +646,10 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 		It("should fail if a supported-version entry fails to unmarshal even when a later entry is valid", func() {
 			pciAddr := "0000:0b:00.0"
-			badV1 := fmt.Sprintf(`{"apiVersion":%q,"kind":"DeviceMetadata","metadata":{"name":"claim5"},"requests":"this-should-be-an-array"}`, metadata.APIVersionV1Alpha1)
+			badV1 := fmt.Sprintf(
+				`{"apiVersion":%q,"kind":"DeviceMetadata","metadata":{"name":"claim5"},"requests":"this-should-be-an-array"}`,
+				metadata.APIVersionV1Alpha1,
+			)
 			goodV1, err := json.Marshal(&metadata.DeviceMetadata{
 				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: "DeviceMetadata"},
 				ObjectMeta: metav1.ObjectMeta{Name: "claim5"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Linter was not running on DRA packages

#### After this PR:
This PR adds dra packages to lint configuration

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

VEP tracking issue: 
- https://github.com/kubevirt/enhancements/issues/10

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vep-10: add dra packages to lint configuration and fix linter errors
```

