### PR TITLE
virt-operator: add relationship labels to install-strategy configmap

### DIFF
--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -347,6 +347,16 @@ func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, 
 			"manifests": manifests,
 		},
 	}
+	if productComponent := config.GetProductComponent(); productComponent != "" && operatorutil.IsValidLabel(productComponent) {
+		configMap.Labels[v1.AppComponentLabel] = productComponent
+	}
+	if productVersion := config.AdditionalProperties[operatorutil.ProductVersionKey]; productVersion != "" && operatorutil.IsValidLabel(productVersion) {
+		configMap.Labels[v1.AppVersionLabel] = productVersion
+	}
+	if productName := config.GetProductName(); productName != "" && operatorutil.IsValidLabel(productName) {
+		configMap.Labels[v1.AppPartOfLabel] = productName
+	}
+
 	return configMap, nil
 }
 

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -350,7 +350,7 @@ func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, 
 	if productComponent := config.GetProductComponent(); productComponent != "" && operatorutil.IsValidLabel(productComponent) {
 		configMap.Labels[v1.AppComponentLabel] = productComponent
 	}
-	if productVersion := config.AdditionalProperties[operatorutil.ProductVersionKey]; productVersion != "" && operatorutil.IsValidLabel(productVersion) {
+	if productVersion := config.GetProductVersion(); productVersion != "" && operatorutil.IsValidLabel(productVersion) {
 		configMap.Labels[v1.AppVersionLabel] = productVersion
 	}
 	if productName := config.GetProductName(); productName != "" && operatorutil.IsValidLabel(productName) {

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -349,6 +349,23 @@ var _ = Describe("Install Strategy", func() {
 		})
 	})
 
+	Context("install strategy configmap labels", func() {
+		It("should include product relationship labels when set", func() {
+			productConfig := &util.KubeVirtDeploymentConfig{
+				AdditionalProperties: map[string]string{
+					"productVersion":   "test-version",
+					"productName":      "test-product",
+					"productComponent": "test-component",
+				},
+			}
+			configMap, err := NewInstallStrategyConfigMap(productConfig, "monitoring", namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppVersionLabel, "test-version"))
+			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppPartOfLabel, "test-product"))
+			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, "test-component"))
+		})
+	})
+
 	Describe("Config json with default value", func() {
 		It("should be parsed", func() {
 			envVarManager := &util.EnvVarManagerMock{}

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -351,18 +351,23 @@ var _ = Describe("Install Strategy", func() {
 
 	Context("install strategy configmap labels", func() {
 		It("should include product relationship labels when set", func() {
+			const (
+				testVersion   = "test-version"
+				testProduct   = "test-product"
+				testComponent = "test-component"
+			)
 			productConfig := &util.KubeVirtDeploymentConfig{
 				AdditionalProperties: map[string]string{
-					"productVersion":   "test-version",
-					"productName":      "test-product",
-					"productComponent": "test-component",
+					util.ProductVersionKey:   testVersion,
+					util.ProductNameKey:      testProduct,
+					util.ProductComponentKey: testComponent,
 				},
 			}
 			configMap, err := NewInstallStrategyConfigMap(productConfig, "monitoring", namespace)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppVersionLabel, "test-version"))
-			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppPartOfLabel, "test-product"))
-			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, "test-component"))
+			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppVersionLabel, testVersion))
+			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppPartOfLabel, testProduct))
+			Expect(configMap.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, testComponent))
 		})
 	})
 


### PR DESCRIPTION
### What this PR does
Adds the missing `app.kubernetes.io/version`, `app.kubernetes.io/component`, and `app.kubernetes.io/part-of` relationship labels to the `kubevirt-install-strategy-*` configmap.

#### Before this PR:
The install-strategy configmap was the only virt-operator managed resource missing these labels. All other operator-managed resources (deployments, daemonsets, CA configmaps, certificate secrets) receive them through the central reconciliation path in `injectOperatorMetadata`, but the install-strategy configmap is created by a job and never goes through that reconciler.

#### After this PR:
The install-strategy configmap includes the same relationship labels as all other virt-operator managed resources, following the same conditional logic used by `injectOperatorMetadata`.

### References
- Fixes: https://redhat.atlassian.net/browse/CNV-28182

### Release note
```release-note
NONE
```