### PR TITLE
tests: let VMI schedule freely in migration abort test

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2014,18 +2014,6 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 				var nodesSetUnschedulable []string
 
-				BeforeEach(func() {
-					By("Keeping only one schedulable node")
-					schedulableNodes := libnode.GetAllSchedulableNodes(virtClient).Items
-					Expect(schedulableNodes).NotTo(And(BeEmpty(), HaveLen(1)))
-
-					// Iterate on all schedulable nodes but one
-					for _, schedulableNode := range schedulableNodes[:len(schedulableNodes)-1] {
-						libnode.SetNodeUnschedulable(schedulableNode.Name, virtClient)
-						nodesSetUnschedulable = append(nodesSetUnschedulable, schedulableNode.Name)
-					}
-				})
-
 				AfterEach(func() {
 					By("Restoring nodes to be schedulable")
 					for _, schedulableNodeName := range nodesSetUnschedulable {
@@ -2040,6 +2028,16 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
 					vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsHuge)
+
+					By("Making all other nodes unschedulable so migration target cannot be placed")
+					schedulableNodes := libnode.GetAllSchedulableNodes(virtClient).Items
+					for _, schedulableNode := range schedulableNodes {
+						if schedulableNode.Name == vmi.Status.NodeName {
+							continue
+						}
+						libnode.SetNodeUnschedulable(schedulableNode.Name, virtClient)
+						nodesSetUnschedulable = append(nodesSetUnschedulable, schedulableNode.Name)
+					}
 
 					By("Trying to migrate VM and expect for the migration to get stuck")
 					migration := libmigration.New(vmi.Name, vmi.Namespace)


### PR DESCRIPTION
### What this PR does
Fixes the migration abort test ("should be able to properly abort migration") failing on multi-arch clusters.

In `tests/migration/migration.go`, the test's `BeforeEach` calls `GetAllSchedulableNodes()` and marks all nodes except the last one as unschedulable — before the VMI is created. The VMI is then created without an explicit architecture, so it defaults to the control plane's architecture (amd64). On a multi-arch cluster, the only remaining schedulable node may be ARM64. The VMI's pod gets `kubernetes.io/arch=amd64` in its nodeSelector (added by the mutating webhook), which conflicts with the ARM64 node — the VMI becomes Unschedulable and the test fails before it even reaches the migration logic.

The fix moves the node-unschedulable setup into the test body, after the VMI has started. The VMI schedules freely on any compatible node first, then all other schedulable nodes are marked unschedulable so the migration target cannot be placed — which is the actual test precondition.

#### Before this PR:
- `BeforeEach` marks all nodes except the last as unschedulable
- VMI is created without explicit architecture (defaults to amd64)
- On multi-arch clusters, the remaining node may be ARM64
- Pod gets `kubernetes.io/arch=amd64` nodeSelector → conflicts with the ARM64 node → Unschedulable

#### After this PR:
- VMI is created and schedules on any compatible node
- After VMI is running, all other nodes are marked unschedulable
- Migration attempt correctly gets stuck (no target node available)
- No architecture assumptions needed

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```