### PR TITLE
tools/vms-generator: fix typo in addNoCloudDisk function names

### DIFF
--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -258,10 +258,10 @@ func addKernelBootContainer(spec *v1.VirtualMachineInstanceSpec, image, kernelAr
 }
 
 func addNoCloudDisk(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec {
-	return addNoCloudDiskWitUserData(spec, "#!/bin/sh\n\necho 'printed from cloud-init userdata'\n")
+	return addNoCloudDiskWithUserData(spec, "#!/bin/sh\n\necho 'printed from cloud-init userdata'\n")
 }
 
-func addNoCloudDiskWitUserData(spec *v1.VirtualMachineInstanceSpec, data string) *v1.VirtualMachineInstanceSpec {
+func addNoCloudDiskWithUserData(spec *v1.VirtualMachineInstanceSpec, data string) *v1.VirtualMachineInstanceSpec {
 	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
 		Name: "cloudinitdisk",
 		DiskDevice: v1.DiskDevice{
@@ -282,7 +282,7 @@ func addNoCloudDiskWitUserData(spec *v1.VirtualMachineInstanceSpec, data string)
 	return spec
 }
 
-func addNoCloudDiskWitUserDataNetworkData(spec *v1.VirtualMachineInstanceSpec, userData string, networkData string) *v1.VirtualMachineInstanceSpec {
+func addNoCloudDiskWithUserDataNetworkData(spec *v1.VirtualMachineInstanceSpec, userData string, networkData string) *v1.VirtualMachineInstanceSpec {
 	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
 		Name: "cloudinitdisk",
 		DiskDevice: v1.DiskDevice{
@@ -424,7 +424,7 @@ func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 	makeMigratable(vmi)
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi
 }
 
@@ -437,7 +437,7 @@ func GetVMIEphemeralFedoraIsolated() *v1.VirtualMachineInstance {
 		},
 	}
 	initFedoraIsolated(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi
 }
 
@@ -487,7 +487,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vmi.Spec.Networks = []v1.Network{{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 	initFedora(&vmi.Spec)
 	networkData := "version: 2\nethernets:\n  eth0:\n    addresses: [ fd10:0:2::2/120 ]\n    dhcp4: true\n    routes:\n    - to: ::/0\n      via: fd10:0:2::1\n"
-	addNoCloudDiskWitUserDataNetworkData(
+	addNoCloudDiskWithUserDataNetworkData(
 		&vmi.Spec,
 		generateCloudConfigString(cloudConfigUserPassword, cloudConfigInstallAndStartService),
 		networkData)
@@ -504,7 +504,7 @@ func GetVMISRIOV() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "sriov/sriov-network"}}}}
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserDataNetworkData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword), secondaryIfaceDhcpNetworkData)
+	addNoCloudDiskWithUserDataNetworkData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword), secondaryIfaceDhcpNetworkData)
 
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "sriov-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}}
@@ -517,7 +517,7 @@ func GetVMIMultusPtp() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 	vmi.Spec.Networks = []v1.Network{{Name: "ptp", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ptp-conf"}}}}
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 
@@ -529,7 +529,7 @@ func GetVMIMultusMultipleNet() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "ptp", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ptp-conf"}}}}
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserDataNetworkData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword), secondaryIfaceDhcpNetworkData)
+	addNoCloudDiskWithUserDataNetworkData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword), secondaryIfaceDhcpNetworkData)
 
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -936,7 +936,7 @@ func GetVMIWithHookSidecar() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 
 	vmi.ObjectMeta.Annotations = map[string]string{
 		"hooks.kubevirt.io/hookSidecars":              fmt.Sprintf("[{\"args\": [\"--version\", \"v1alpha2\"], \"image\": \"%s/example-hook-sidecar:%s\"}]", DockerPrefix, DockerTag),
@@ -950,7 +950,7 @@ func GetVmiWithHookSidecarConfigMap() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 
 	annotation := `[{"args": ["--version", "v1alpha2"], "configMap": {"name": "my-config-map",` +
 		`"key": "my_script.sh", "hookPath": "/usr/bin/onDefineDomain"}}]`
@@ -973,7 +973,7 @@ func GetVMIGPU() *v1.VirtualMachineInstance {
 	}
 	vmi.Spec.Domain.Devices.GPUs = GPUs
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi
 }
 
@@ -1031,7 +1031,7 @@ func GetVMIDRAGPU() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.GPUs = getDRAGPUDevice(DRAResourceClaimName)
 
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi
 }
 
@@ -1049,7 +1049,7 @@ func GetVMIUSB() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiUSB)
 	vmi.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1024M"))
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword, cloudConfigInstallAndStartService))
+	addNoCloudDiskWithUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword, cloudConfigInstallAndStartService))
 
 	vmi.Spec.Domain.Devices.HostDevices = append(vmi.Spec.Domain.Devices.HostDevices,
 		v1.HostDevice{


### PR DESCRIPTION
### What this PR does
This PR fixes a typo in two function names: `addNoCloudDiskWitUserData` and
`addNoCloudDiskWitUserDataNetworkData` - "Wit" should be "With".
Renames the function definitions and all call sites.
#### Before this PR:
Functions are named `addNoCloudDiskWitUserData` and
`addNoCloudDiskWitUserDataNetworkData` (missing the 'h').

#### After this PR:
Functions are named `addNoCloudDiskWithUserData` and
`addNoCloudDiskWithUserDataNetworkData`.

### Release note
```release-note
None
```