### PR TITLE
tests: use alpine-with-test-tooling for graceful shutdown test [test_id:1655]

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -110,7 +110,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			sc, foundSC := libstorage.GetAvailableRWFileSystemStorageClass()
 			Expect(foundSC).To(BeTrue(), "Filesystem storage is not present")
 
-			return newVirtualMachineInstanceWithDV(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), sc)
+			return newVirtualMachineInstanceWithDV(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpineTestTooling), sc)
 		}
 
 		validateGenerationState := func(vm *v1.VirtualMachine, expectedGeneration int, expectedDesiredGeneration int, expectedObservedGeneration int, expectedGenerationAnnotation int) {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1633,7 +1633,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Context("with grace period greater than 0", func() {
 			It("[test_id:1655]should run graceful shutdown", decorators.Conformance, decorators.WgS390x, func() {
 				By("Setting a VirtualMachineInstance termination grace period to 5")
-				vmi := libvmifact.NewFedora(libvmi.WithTerminationGracePeriod(5))
+				vmi := libvmifact.NewAlpineWithTestTooling(libvmi.WithTerminationGracePeriod(5))
 
 				By("Creating the VirtualMachineInstance")
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)


### PR DESCRIPTION
### What this PR does
Switches from plain Alpine/Fedora to `alpine-with-test-tooling` in two tests:
1. **Graceful shutdown test (test_id:1655)** in `vmi_lifecycle_test.go` — switches from Fedora to alpine-with-test-tooling, since the image already has acpid enabled for ACPI shutdown support.
2. **VM test `newVirtualMachineInstanceWithFileDisk` helper** in `vm_test.go` — switches from `ContainerDiskAlpine` to `ContainerDiskAlpineTestTooling`, since it benefits from the same test tooling.

As @akalenyu pointed out in #17193, the alpine-with-test-tooling image already has acpid enabled (kubevirt/kubevirtci#1274), making it a lighter-weight alternative to Fedora for ACPI shutdown verification.

#### Before this PR:
- Graceful shutdown test uses Fedora (~1GB image) for ACPI support
- VM test helper uses plain Alpine without test tooling

#### After this PR:
- Both tests use alpine-with-test-tooling, which supports ACPI via acpid and includes test utilities, resulting in faster image pulls and boot times

### References
- #17193 — original fix that switched Alpine → Fedora for ACPI support
- https://github.com/kubevirt/kubevirt/pull/17193#issuecomment-4615824467 — @akalenyu's comment about acpid in alpine-with-test-tooling
- kubevirt/kubevirtci#1274 — PR that enabled acpid in the alpine test image

### Release note
```release-note
NONE
```