### PR TITLE
Use factory index function for migration informer in synchronization controller

### DIFF
--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -142,7 +142,6 @@ func NewSynchronizationController(
 	}
 
 	if err := syncController.migrationInformer.AddIndexers(map[string]cache.IndexFunc{
-		"byUID":               indexByMigrationUID,
 		"byActiveVMIName":     indexByActiveVmiName,
 		"byTargetMigrationID": indexByTargetMigrationID,
 		"bySourceMigrationID": indexBySourceMigrationID,
@@ -518,7 +517,7 @@ func (s *SynchronizationController) cancelRemoteMigration(migrationUID types.UID
 }
 
 func (s *SynchronizationController) getMigrationIDFromUID(migrationUID types.UID) (string, error) {
-	objs, err := s.migrationInformer.GetIndexer().ByIndex("byUID", string(migrationUID))
+	objs, err := s.migrationInformer.GetIndexer().ByIndex(controller.ByMigrationUIDIndex, string(migrationUID))
 	if err != nil {
 		return "", err
 	}
@@ -1278,14 +1277,6 @@ func patchMigrationStateField[T any](patchSet *patch.PatchSet, field string, ori
 	}
 }
 
-func indexByMigrationUID(obj interface{}) ([]string, error) {
-	migration, ok := obj.(*virtv1.VirtualMachineInstanceMigration)
-	if !ok {
-		return nil, nil
-	}
-	return []string{string(migration.UID)}, nil
-}
-
 func indexByActiveVmiName(obj interface{}) ([]string, error) {
 	migration, ok := obj.(*virtv1.VirtualMachineInstanceMigration)
 	if !ok {
@@ -1397,7 +1388,7 @@ func (s *SynchronizationController) runConnectionCleanup() {
 func (s *SynchronizationController) CancelMigration(ctx context.Context, request *syncv1.MigrationCancelRequest) (*syncv1.MigrationCancelResponse, error) {
 	migrationUID := request.MigrationUID
 
-	migration, err := s.findMigrationFromMigrationIDByIndex("byUID", migrationUID)
+	migration, err := s.findMigrationFromMigrationIDByIndex(controller.ByMigrationUIDIndex, migrationUID)
 	if err != nil {
 		return &syncv1.MigrationCancelResponse{
 			Message: fmt.Sprintf("unable to find migration to cancel for migrationUID %s", migrationUID),

--- a/pkg/synchronization-controller/synchronization-controller_test.go
+++ b/pkg/synchronization-controller/synchronization-controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("VMI status synchronization controller", func() {
 		virtClient.EXPECT().VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault)).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstanceMigration(targetNamespace).Return(virtfakeClient.KubevirtV1().VirtualMachineInstanceMigrations(targetNamespace)).AnyTimes()
 		vmiInformer, _ = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())
-		migrationInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
+		migrationInformer, _ = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstanceMigration{}, kvcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 		tmpDir, err := os.MkdirTemp("", "synchronizationcontrollertest")
 		Expect(err).ToNot(HaveOccurred())
 		store, err := certificates.GenerateSelfSignedCert(tmpDir, "test", "test")
@@ -960,7 +960,7 @@ var _ = Describe("VMI status synchronization controller", func() {
 		)
 
 		BeforeEach(func() {
-			remoteMigrationInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
+			remoteMigrationInformer, _ := testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstanceMigration{}, kvcontroller.GetVirtualMachineInstanceMigrationInformerIndexers())
 			remoteController, err = NewSynchronizationController(virtClient, vmiInformer, remoteMigrationInformer, tlsConfig, tlsConfig, "0.0.0.0", 9186, "")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1282,10 +1282,7 @@ var _ = Describe("VMI status synchronization controller", func() {
 	})
 
 	It("should return nil, nil if invalid resource type passed into index function", func() {
-		res, err := indexByMigrationUID("invalid")
-		Expect(res).To(BeNil())
-		Expect(err).ToNot(HaveOccurred())
-		res, err = indexByActiveVmiName("invalid")
+		res, err := indexByActiveVmiName("invalid")
 		Expect(res).To(BeNil())
 		Expect(err).ToNot(HaveOccurred())
 		res, err = indexBySourceMigrationID("invalid")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Didn't realize there was a factory index function and created my own instead. Removed the extra index function and updated the tests to use the factory index.

#### Before this PR:
Two indexes in the synchronization controller doing the same thing.

#### After this PR:
Only the factory created index is used.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

