### PR TITLE
node-labeller: Use --expand-cpu-features and --supported-cpu-features when available

### DIFF
--- a/cmd/virt-launcher/node-labeller/node-labeller.sh
+++ b/cmd/virt-launcher/node-labeller/node-labeller.sh
@@ -47,11 +47,21 @@ fi
 
 virtqemud -d
 
-virsh domcapabilities --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE > /var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml
+EXPAND_CPU_FEATURES=""
+if virsh domcapabilities --help 2>&1 | grep -q -- '--expand-cpu-features'; then
+   EXPAND_CPU_FEATURES="--expand-cpu-features"
+fi
+
+SUPPORTED_CPU_FEATURES=""
+if virsh domcapabilities --help 2>&1 | grep -q -- '--supported-cpu-features'; then
+   SUPPORTED_CPU_FEATURES="--supported-cpu-features"
+fi
+
+virsh domcapabilities --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE $EXPAND_CPU_FEATURES > /var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml
 
 # hypervisor-cpu-baseline command only works on x86 and s390x
 if [ "$ARCH" == "x86_64" ] || [ "$ARCH" == "s390x" ]; then
-   virsh domcapabilities --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE | virsh hypervisor-cpu-baseline --features /dev/stdin --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE > /var/lib/kubevirt-node-labeller/supported_features.xml
+   virsh domcapabilities --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE $EXPAND_CPU_FEATURES $SUPPORTED_CPU_FEATURES | virsh hypervisor-cpu-baseline --features /dev/stdin --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE > /var/lib/kubevirt-node-labeller/supported_features.xml
 fi
 
 virsh capabilities > /var/lib/kubevirt-node-labeller/capabilities.xml


### PR DESCRIPTION
Without the new flags, `virsh domcapabilities` only lists CPU features that
explicitly differ from the base CPU model. When libvirt upgrades its `cpu_map`, a feature
previously listed as an explicit addition can get folded into the model definition and
disappear from the output , even though the host CPU hasn't changed. This causes incomplete
`host-model-required-features.node.kubevirt.io/*` and `cpu-feature.node.kubevirt.io/*` labels, which can allow migration to a target node that doesn't support all required features.


Fixes: https://redhat.atlassian.net/browse/CNV-81458 , https://redhat.atlassian.net/browse/CNV-87360
 

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use --expand-cpu-features and --supported-cpu-features in node-labeller for
complete CPU feature reporting when available
```

