### PR TITLE
Fix symlink traversal in VMExport dir handler

### DIFF
--- a/pkg/storage/export/virt-exportserver/BUILD.bazel
+++ b/pkg/storage/export/virt-exportserver/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/storage/export/virt-exportserver",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/safepath:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/storage/cbt/nbd/v1:go_default_library",
         "//pkg/storage/export/export:go_default_library",

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -61,6 +61,7 @@ import (
 
 	backupv1 "kubevirt.io/api/backup/v1alpha1"
 
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
 	storageutils "kubevirt.io/kubevirt/pkg/storage/utils"
@@ -773,8 +774,37 @@ func resourceToBytesYaml(resources []runtime.Object) ([]byte, error) {
 	return data, nil
 }
 
+// symlinkSafeDir is an http.FileSystem that prevents symlink traversal outside root.
+// Unlike http.Dir, it resolves symlinks via safepath and rejects any that escape the
+// root boundary, preventing attackers from reading files outside the exported PVC.
+type symlinkSafeDir struct {
+	root string
+}
+
+func (d symlinkSafeDir) Open(name string) (http.File, error) {
+	cleanName := path.Clean("/" + name)
+	if cleanName == "/" {
+		cleanName = "."
+	} else {
+		cleanName = cleanName[1:]
+	}
+
+	resolved, err := safepath.JoinAndResolveWithRelativeRoot(d.root, cleanName)
+	if err != nil {
+		return nil, err
+	}
+
+	fd, err := safepath.OpenAtNoFollow(resolved)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	return os.Open(fd.SafePath())
+}
+
 func dirHandler(uri, mountPoint string) http.Handler {
-	return http.StripPrefix(uri, http.FileServer(http.Dir(mountPoint)))
+	return http.StripPrefix(uri, http.FileServer(symlinkSafeDir{root: mountPoint}))
 }
 
 func fileHandler(file string) http.Handler {

--- a/pkg/storage/export/virt-exportserver/exportserver_test.go
+++ b/pkg/storage/export/virt-exportserver/exportserver_test.go
@@ -33,6 +33,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -1261,6 +1263,83 @@ var _ = Describe("exportserver", func() {
 			err = conn.Close()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(canceled).To(BeTrue())
+		})
+	})
+
+	Context("dirHandler symlink safety", func() {
+		It("should serve files within the mount root", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(root, "hello.txt"), []byte("hello"), 0644)).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/hello.txt", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(Equal("hello"))
+		})
+
+		It("should block symlinks pointing outside the mount root", func() {
+			root := GinkgoT().TempDir()
+			outside := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(outside, "secret"), []byte("ESCAPED"), 0600)).To(Succeed())
+			Expect(os.Symlink(filepath.Join(outside, "secret"), filepath.Join(root, "escape-link"))).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/escape-link", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("should allow symlinks that stay within the mount root", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.MkdirAll(filepath.Join(root, "subdir"), 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(root, "subdir", "data.txt"), []byte("internal"), 0644)).To(Succeed())
+			Expect(os.Symlink("subdir/data.txt", filepath.Join(root, "internal-link"))).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/internal-link", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(Equal("internal"))
+		})
+
+		It("should block path traversal via dot-dot segments", func() {
+			root := GinkgoT().TempDir()
+			outside := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(outside, "secret"), []byte("ESCAPED"), 0600)).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/../../"+filepath.Base(outside)+"/secret", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+			Expect(rec.Body.String()).ToNot(ContainSubstring("ESCAPED"))
+		})
+
+		It("should block symlink to absolute path outside root", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.Symlink("/etc/hostname", filepath.Join(root, "host-link"))).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/host-link", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("should serve the root directory listing", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(root, "file.txt"), []byte("content"), 0644)).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(ContainSubstring("file.txt"))
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

The VMExport dirHandler uses http.FileServer(http.Dir(mountPoint)) to serve filesystem PVC contents. http.Dir follows symlinks without restriction, so an attacker who can control files inside an exported filesystem PVC can place a symlink pointing outside the PVC mount root and retrieve files from the exporter pod filesystem through the VMExport directory endpoint

#### After this PR:

The dirHandler uses a symlinkSafeDir implementation that resolves symlinks safely using KubeVirt's existing safepath package:

  1. safepath.JoinAndResolveWithRelativeRoot resolves symlinks chroot-style — symlinks within the PVC root are followed normally, but any symlink that would escape the root boundary is rejected.
  2. safepath.OpenAtNoFollow opens the resolved path component-by-component via openat(O_NOFOLLOW), preventing TOCTOU attacks where a symlink is injected after resolution

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix symlink traversal in VMExport dir handler
```

