### PR TITLE
virtctl image-upload command need to handle auth error properly in retries

### DIFF
--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -435,62 +435,100 @@ func ConstructUploadProxyPathAsync(uploadProxyURL, token string, insecure bool) 
 	return u.String(), nil
 }
 
-func (c *command) uploadData(token string, file *os.File) error {
+func (c *command) newUploadRequest(token string, reader io.Reader, length int64) (*http.Request, error) {
 	uploadURL, err := ConstructUploadProxyPathAsync(c.uploadProxyURL, token, c.insecure)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	req, err := http.NewRequest("POST", uploadURL, io.NopCloser(reader))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Content-Type", "application/octet-stream")
+	req.ContentLength = length
+	return req, nil
+}
 
+func (c *command) uploadData(initToken string, file *os.File) error {
 	fi, err := file.Stat()
 	if err != nil {
 		return err
 	}
 
-	bar := pb.New64(fi.Size())
+	length := fi.Size()
+
+	bar := pb.New64(length)
 	bar.SetTemplate(pb.Full)
 	bar.SetWriter(os.Stdout)
 	bar.Set(pb.Bytes, true)
+
 	reader := bar.NewProxyReader(file)
 
 	client := GetHTTPClientFn(c.insecure)
-	req, _ := http.NewRequest("POST", uploadURL, io.NopCloser(reader))
 
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/octet-stream")
-	req.ContentLength = fi.Size()
-
-	clientDo := func() error {
+	// clientDo returns http status code and error
+	// in case of an error, it may return the
+	// relevant http status code for further processing
+	clientDo := func(req *http.Request) (httpCode int, err error) {
 		if _, err := file.Seek(0, io.SeekStart); err != nil {
-			return err
+			return 0, err
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
-				return err
+				return resp.StatusCode, err
 			}
-			return fmt.Errorf("unexpected return value %d, %s", resp.StatusCode, string(body))
+			return resp.StatusCode, fmt.Errorf("unexpected return value %d, %s", resp.StatusCode, string(body))
 		}
-		return nil
+		return resp.StatusCode, nil
 	}
 
 	c.cmd.Println()
 	bar.Start()
 
 	retry := uint(0)
+	maxTokenRefreshes := 3
+	token := initToken
+
 	for retry < c.uploadRetries {
-		if err = clientDo(); err == nil {
-			break
+		req, reqErr := c.newUploadRequest(token, reader, length)
+		if reqErr != nil {
+			return reqErr
 		}
-		retry++
-		if retry < c.uploadRetries {
+
+		if retry > 0 {
 			bar.SetCurrent(0)
 			time.Sleep(time.Duration(retry*rand.UintN(50)) * time.Millisecond)
 		}
+
+		code, retryErr := clientDo(req)
+		if retryErr == nil {
+			break
+		}
+
+		err = retryErr
+
+		if code == http.StatusUnauthorized {
+			// if we get a 401 on the first request, don't refresh token as this is likely
+			// an authentication error rather than a token timeout. Also fail if we've
+			// exceeded our maxTokenRefreshes
+			if retry == 0 || maxTokenRefreshes == 0 {
+				return fmt.Errorf("authentication failed: %w", retryErr)
+			}
+			refreshedToken, tErr := c.getUploadToken()
+			if tErr != nil {
+				return fmt.Errorf("failed to get upload token: %w", tErr)
+			}
+			token = refreshedToken
+			maxTokenRefreshes--
+		}
+		retry++
 	}
 
 	bar.Finish()
@@ -506,7 +544,7 @@ func (c *command) uploadData(token string, file *os.File) error {
 func (c *command) getUploadToken() (string, error) {
 	request := &uploadcdiv1.UploadTokenRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "token-for-virtctl",
+			GenerateName: "token-for-virtctl-",
 		},
 		Spec: uploadcdiv1.UploadTokenRequestSpec{
 			PvcName: c.name,

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -797,6 +798,118 @@ var _ = Describe("ImageUpload", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			assertDataSource(ds, targetName, targetNamespace)
+		})
+
+		Context("with token refresh", func() {
+			var postCount int
+
+			// creates upload server that takes in list of status codes that it will return as responses for each post request
+			newUploadServer := func(statusCodes ...int) *httptest.Server {
+				return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == "POST" {
+						if postCount < len(statusCodes) {
+							w.WriteHeader(statusCodes[postCount])
+						} else {
+							// if we exhausted our statusCode list, repeat the last code
+							w.WriteHeader(statusCodes[len(statusCodes)-1])
+						}
+						postCount++
+					} else {
+						w.WriteHeader(http.StatusOK)
+					}
+				}))
+			}
+
+			BeforeEach(func() {
+				postCount = 0
+				testInit(http.StatusOK)
+				cdiClient.Fake.PrependReactor("create", "uploadtokenrequests", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					obj := action.(k8stesting.CreateAction).GetObject()
+					meta := obj.(metav1.ObjectMetaAccessor).GetObjectMeta()
+					if meta.GetGenerateName() != "" && meta.GetName() == "" {
+						meta.SetName(meta.GetGenerateName() + rand.String(5))
+					}
+					return false, obj, nil
+				})
+			})
+
+			It("Should retry with a new token on authorization error", func() {
+				tokenRequests := 0
+				cdiClient.Fake.PrependReactor("create", "uploadtokenrequests", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					tokenRequests++
+					return false, nil, nil
+				})
+
+				// return 400 on first POST, then 401 to trigger token refresh,
+				// then 400 for remaining retries
+				server := newUploadServer(http.StatusBadRequest, http.StatusUnauthorized, http.StatusBadRequest)
+				args := []string{
+					commandName,
+					"--pvc-name", targetName,
+					"--size", pvcSize,
+					"--uploadproxy-url", server.URL,
+					"--insecure",
+					"--image-path", imagePath,
+					"--retry=5"}
+
+				cmd := testing.NewRepeatableVirtctlCommand(args...)
+				reqErr := cmd()
+				Expect(reqErr).To(HaveOccurred())
+				Expect(reqErr.Error()).To(ContainSubstring("error uploading image after 5 retries"))
+				Expect(reqErr.Error()).To(ContainSubstring("unexpected return value 400"))
+				Expect(reqErr.Error()).NotTo(ContainSubstring("unexpected return value 401"))
+				// 1 initial token + 1 refresh from the 401
+				Expect(tokenRequests).To(Equal(2), "should have refreshed the token once")
+				Expect(postCount).To(Equal(5))
+			})
+
+			It("Should fail fast on first-attempt 401", func() {
+				server := newUploadServer(http.StatusUnauthorized)
+				args := []string{
+					commandName,
+					"--pvc-name", targetName,
+					"--size", pvcSize,
+					"--uploadproxy-url", server.URL,
+					"--insecure",
+					"--image-path", imagePath,
+					"--retry=5"}
+
+				cmd := testing.NewRepeatableVirtctlCommand(args...)
+				reqErr := cmd()
+				Expect(reqErr).To(HaveOccurred())
+				Expect(reqErr.Error()).To(ContainSubstring("authentication failed"))
+				Expect(reqErr.Error()).To(ContainSubstring("unexpected return value 401"))
+				Expect(postCount).To(Equal(1), "should fail fast on first-attempt 401")
+			})
+
+			It("Should not exceed max token refreshes", func() {
+				tokenRequests := 0
+				cdiClient.Fake.PrependReactor("create", "uploadtokenrequests", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					tokenRequests++
+					return false, nil, nil
+				})
+
+				// return 400 on first POST to get past fail-fast,
+				// then 401 on all remaining to exhaust token refreshes
+				server := newUploadServer(http.StatusBadRequest, http.StatusUnauthorized)
+				args := []string{
+					commandName,
+					"--pvc-name", targetName,
+					"--size", pvcSize,
+					"--uploadproxy-url", server.URL,
+					"--insecure",
+					"--image-path", imagePath,
+					"--retry=10"}
+
+				cmd := testing.NewRepeatableVirtctlCommand(args...)
+				reqErr := cmd()
+				Expect(reqErr).To(HaveOccurred())
+				Expect(reqErr.Error()).To(ContainSubstring("authentication failed"))
+				// 1 initial token + 3 refreshes (capped at maxTokenRefreshes)
+				Expect(tokenRequests).To(Equal(4), "should create initial token plus 3 refreshes")
+				// 1 POST(400) + 3 POST(401 with refresh) + 1 POST(401 fail fast)
+				Expect(postCount).To(Equal(5))
+			})
 		})
 
 		DescribeTable("Should retry on server returning error code", func(expected int, extraArgs ...string) {


### PR DESCRIPTION
Note: this PR is a continuation of #16813

virtctl image-upload retries uploading on failures. However those retries uses the same token. If the each retry takes a long time the token may expires at some point and remaining retries will always fail with auth error (401). It should try refresh the token when it expires before next retry.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The virtctl image-upload command uses one token during the uploading and retry operations.
There is a risk of the token being expired causing any remaining retries to fail with 401 auth error.

#### After this PR:
Token will be refreshed on auth 401 error before next retry.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses #
-->
- Fixes #16811 
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the virtctl image-upload command token expiry issue by refreshing the token.
```


