### PR TITLE
tools/vms-generator: fix preemptible spelling

### DIFF
--- a/examples/non-preemptible.yaml
+++ b/examples/non-preemptible.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: scheduling.k8s.io/v1
-description: Priority class for VMs which should not be preemtited.
+description: Priority class for VMs which should not be preemptited.
 kind: PriorityClass
 metadata:
   name: non-preemptible

--- a/examples/non-preemptible.yaml
+++ b/examples/non-preemptible.yaml
@@ -3,6 +3,6 @@ apiVersion: scheduling.k8s.io/v1
 description: Priority class for VMs which should not be preemtited.
 kind: PriorityClass
 metadata:
-  name: non-preemtible
+  name: non-preemptible
 preemptionPolicy: Never
 value: 999999999

--- a/examples/preemptible.yaml
+++ b/examples/preemptible.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: scheduling.k8s.io/v1
-description: Priority class for VMs which are allowed to be preemtited.
+description: Priority class for VMs which are allowed to be preemptited.
 kind: PriorityClass
 metadata:
   name: preemptible

--- a/examples/preemptible.yaml
+++ b/examples/preemptible.yaml
@@ -3,6 +3,6 @@ apiVersion: scheduling.k8s.io/v1
 description: Priority class for VMs which are allowed to be preemtited.
 kind: PriorityClass
 metadata:
-  name: preemtible
+  name: preemptible
 preemptionPolicy: PreemptLowerPriority
 value: 1000000

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -4,7 +4,7 @@ kind: VirtualMachine
 metadata:
   labels:
     kubevirt.io/vm: vm-cirros
-  name: vm-non-preemtible
+  name: vm-non-preemptible
 spec:
   runStrategy: Halted
   template:
@@ -24,7 +24,7 @@ spec:
         memory:
           guest: 128Mi
         resources: {}
-      priorityClassName: non-preemtible
+      priorityClassName: non-preemptible
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -82,8 +82,8 @@ const (
 )
 
 const (
-	Preemtible    = "preemtible"
-	NonPreemtible = "non-preemtible"
+	Preemptible    = "preemptible"
+	NonPreemptible = "non-preemptible"
 )
 
 const (
@@ -661,7 +661,7 @@ func getBaseVM(name string, labels map[string]string) *v1.VirtualMachine {
 	}
 }
 
-func GetPreemtible() *schedulingv1.PriorityClass {
+func GetPreemptible() *schedulingv1.PriorityClass {
 	preemtionPolicy := k8sv1.PreemptLowerPriority
 	pc := schedulingv1.PriorityClass{
 		TypeMeta: metav1.TypeMeta{
@@ -673,11 +673,11 @@ func GetPreemtible() *schedulingv1.PriorityClass {
 		PreemptionPolicy: &preemtionPolicy,
 		Value:            1000000,
 	}
-	pc.ObjectMeta.Name = "preemtible"
+	pc.ObjectMeta.Name = "preemptible"
 	return &pc
 }
 
-func GetNonPreemtible() *schedulingv1.PriorityClass {
+func GetNonPreemptible() *schedulingv1.PriorityClass {
 	preemtionPolicy := k8sv1.PreemptNever
 	pc := schedulingv1.PriorityClass{
 		TypeMeta: metav1.TypeMeta{
@@ -689,14 +689,14 @@ func GetNonPreemtible() *schedulingv1.PriorityClass {
 		PreemptionPolicy: &preemtionPolicy,
 		Value:            999999999,
 	}
-	pc.ObjectMeta.Name = NonPreemtible
+	pc.ObjectMeta.Name = NonPreemptible
 	return &pc
 }
 
 func GetVMPriorityClass() *v1.VirtualMachine {
 	vm := GetVMCirros()
-	vm.Spec.Template.Spec.PriorityClassName = NonPreemtible
-	vm.ObjectMeta.Name = "vm-non-preemtible"
+	vm.Spec.Template.Spec.PriorityClassName = NonPreemptible
+	vm.ObjectMeta.Name = "vm-non-preemptible"
 	return vm
 }
 

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -662,15 +662,15 @@ func getBaseVM(name string, labels map[string]string) *v1.VirtualMachine {
 }
 
 func GetPreemptible() *schedulingv1.PriorityClass {
-	preemtionPolicy := k8sv1.PreemptLowerPriority
+	preemptionPolicy := k8sv1.PreemptLowerPriority
 	pc := schedulingv1.PriorityClass{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: schedulingv1.SchemeGroupVersion.String(),
 			Kind:       "PriorityClass",
 		},
 		GlobalDefault:    false,
-		Description:      "Priority class for VMs which are allowed to be preemtited.",
-		PreemptionPolicy: &preemtionPolicy,
+		Description:      "Priority class for VMs which are allowed to be preemptited.",
+		PreemptionPolicy: &preemptionPolicy,
 		Value:            1000000,
 	}
 	pc.ObjectMeta.Name = "preemptible"
@@ -678,15 +678,15 @@ func GetPreemptible() *schedulingv1.PriorityClass {
 }
 
 func GetNonPreemptible() *schedulingv1.PriorityClass {
-	preemtionPolicy := k8sv1.PreemptNever
+	preemptionPolicy := k8sv1.PreemptNever
 	pc := schedulingv1.PriorityClass{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: schedulingv1.SchemeGroupVersion.String(),
 			Kind:       "PriorityClass",
 		},
 		GlobalDefault:    false,
-		Description:      "Priority class for VMs which should not be preemtited.",
-		PreemptionPolicy: &preemtionPolicy,
+		Description:      "Priority class for VMs which should not be preemptited.",
+		PreemptionPolicy: &preemptionPolicy,
 		Value:            999999999,
 	}
 	pc.ObjectMeta.Name = NonPreemptible

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -87,8 +87,8 @@ func main() {
 	}
 
 	var priorityClasses = map[string]*schedulingv1.PriorityClass{
-		utils.Preemtible:    utils.GetPreemtible(),
-		utils.NonPreemtible: utils.GetNonPreemtible(),
+		utils.Preemptible:    utils.GetPreemptible(),
+		utils.NonPreemptible: utils.GetNonPreemptible(),
 	}
 
 	var vms = map[string]*v1.VirtualMachine{


### PR DESCRIPTION
### What this PR does
This PR fixes the spelling of "preemptible" throughout the vms-generator code.
The word was misspelled as "preemtible" (missing the 'p') in constant
names, function names and generated resource names.

#### Before this PR:
Constants, functions, and generated resources use "preemtible"
(e.g., `GetPreemtible`, `Preemtible`, `vm-preemtible.yaml`).

#### After this PR:
All instances corrected to "preemptible"
(e.g., `GetPreemptible`, `Preemptible`, `vm-preemptible.yaml`).

### Release note
```release-note
None
```

