### PR TITLE
virt-operator: apply customizeComponents to install job

### DIFF
--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -111,6 +111,7 @@ go_test(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -30,6 +30,7 @@ import (
 
 	"golang.org/x/time/rate"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -968,6 +969,13 @@ func (c *KubeVirtController) loadInstallStrategy(kv *v1.KubeVirt) (*install.Stra
 	// 4. execute a job to generate the install strategy for the target version of KubeVirt that's being installed/updated
 	job, err := c.generateInstallStrategyJob(kv.Spec.Infra, config)
 	if err != nil {
+		return nil, true, err
+	}
+	customizer, err := apply.NewCustomizer(kv.Spec.CustomizeComponents)
+	if err != nil {
+		return nil, true, err
+	}
+	if err := customizer.GenericApplyPatches([]*batchv1.Job{job}); err != nil {
 		return nil, true, err
 	}
 	c.kubeVirtExpectations.InstallStrategyJob.RaiseExpectations(kvkey, 1, 0)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -47,6 +47,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -2507,6 +2508,54 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(job.Spec.Template.Spec.Affinity).To(Equal(affinity))
 
+		})
+
+		It("should apply customizeComponents.Patches targeting the install job", func() {
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Finalizers: []string{util.KubeVirtFinalizer},
+				},
+				Spec: v1.KubeVirtSpec{
+					CustomizeComponents: v1.CustomizeComponents{
+						Patches: []v1.CustomizeComponentsPatch{
+							{
+								ResourceType: "Job",
+								ResourceName: "virt-operator-install-strategy",
+								Patch:        `{"spec":{"template":{"spec":{"containers":[{"name":"install-strategy-upload","resources":{"requests":{"cpu":"10m","memory":"64Mi"}}}]}}}}`,
+								Type:         v1.StrategicMergePatchType,
+							},
+						},
+					},
+				},
+			}
+
+			job, err := kvTestData.controller.generateInstallStrategyJob(kv.Spec.Infra, util.GetTargetConfigFromKV(kv))
+			Expect(err).ToNot(HaveOccurred())
+
+			customizer, err := apply.NewCustomizer(kv.Spec.CustomizeComponents)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(customizer.GenericApplyPatches([]*batchv1.Job{job})).To(Succeed())
+
+			var uploadContainer *k8sv1.Container
+			for i := range job.Spec.Template.Spec.Containers {
+				if job.Spec.Template.Spec.Containers[i].Name == "install-strategy-upload" {
+					uploadContainer = &job.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+
+			Expect(uploadContainer).ToNot(BeNil(), "expected container 'install-strategy-upload' to be present in job pod spec")
+
+			Expect(uploadContainer.Resources.Requests).To(Equal(k8sv1.ResourceList{
+				k8sv1.ResourceCPU:    resource.MustParse("10m"),
+				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+			}))
 		})
 
 		It("should label install strategy creation job", func() {

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -128,6 +128,7 @@ go_test(
         "//vendor/k8s.io/api/admissionregistration/v1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/coordination/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1:go_default_library",

--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -113,8 +113,11 @@ func (c *Customizer) GenericApplyPatches(objects interface{}) error {
 
 			kind := obj.GetObjectKind().GroupVersionKind().Kind
 
-			v := reflect.Indirect(o).FieldByName("ObjectMeta").FieldByName("Name")
-			name := v.String()
+			meta := reflect.Indirect(o).FieldByName("ObjectMeta")
+			name := meta.FieldByName("Name").String()
+			if name == "" {
+				name = strings.TrimSuffix(meta.FieldByName("GenerateName").String(), "-")
+			}
 
 			patches := c.GetPatchesForResource(kind, name)
 

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -99,6 +100,27 @@ var _ = Describe("Patches", func() {
 
 			err = config.GenericApplyPatches([]string{"string"})
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should match objects by GenerateName when Name is unset", func() {
+			c, err := NewCustomizer(v1.CustomizeComponents{
+				Patches: []v1.CustomizeComponentsPatch{
+					{
+						ResourceType: "Job",
+						ResourceName: "my-job",
+						Patch:        `{"metadata":{"labels":{"patched":"true"}}}`,
+						Type:         v1.StrategicMergePatchType,
+					},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			job := &batchv1.Job{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "batch/v1", Kind: "Job"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, GenerateName: "my-job-"},
+			}
+			Expect(c.GenericApplyPatches([]*batchv1.Job{job})).To(Succeed())
+			Expect(job.Labels).To(HaveKeyWithValue("patched", "true"))
 		})
 	})
 

--- a/pkg/virt-operator/strategy_job.go
+++ b/pkg/virt-operator/strategy_job.go
@@ -37,7 +37,7 @@ func (c *KubeVirtController) generateInstallStrategyJob(infraPlacement *v1.Compo
 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    c.operatorNamespace,
-			GenerateName: fmt.Sprintf("kubevirt-%s-job", config.GetDeploymentID()),
+			GenerateName: "virt-operator-install-strategy-",
 			Labels: map[string]string{
 				v1.AppLabel:             "",
 				v1.ManagedByLabel:       v1.ManagedByLabelOperatorValue,


### PR DESCRIPTION
### What this PR does
The install-strategy job is the one workload virt-operator creates outside the install strategy itself: it is generated on the fly and submitted directly, so it never passes through Customizer.Apply the way Deployments, DaemonSets and the other components do. As a result it could not be customized at all, and in particular there was no way to give its container resource requests and limits. On clusters that enforce an "every container must declare resources" admission policy this forced operators to exempt the whole KubeVirt namespace or relax the policy during upgrades.

Run the customizer over the job before submitting it so that
customizeComponents.Patches with resourceType "Job" now apply to it.

#### Before this PR:
`customizeComponents.Patches` can't touch the install-strategy job. It's built ad-hoc and submitted directly, outside the targetStrategy path that `Customizer.Apply` iterates, so any patch targeting it is silently ignored. The job container has no resource requests/limits and no way to set them, so clusters that enforce a "containers must declare resources" admission policy have to either exempt the whole KubeVirt namespace or disable the check during upgrades.

#### After this PR:
A patch with `resourceType: Job` and `resourceName: virt-operator-install-strategy` is applied to the install-strategy job before it's submitted.

### References
None — happy to file an issue if needed for tracking.

### Why we need it and why it was done in this way
`GenericApplyPatches` derives the match name from `ObjectMeta.Name`, which is empty for the install-strategy job since it uses `GenerateName`. So this does two things: falls back to `GenerateName` (minus the trailing `-`) when `Name` is unset, and gives the job a stable `GenerateName` so it's actually matchable.

The following tradeoffs were made:
- The job's `GenerateName` changes from `kubevirt-<deploymentID>-job` to a stable `virt-operator-install-strategy-`. The old name embedded a SHA1 of the deployment config, so it changed on every version bump — making pinning a patch not possible. The job is correlated by the `kubevirt.io/install-strategy-identifier` annotation, not its name, and I couldn't find anything in-tree that keys on the old name pattern, so I believe this is safe. The one risk is an external consumer doing a prefix match on `kubevirt-*-job` e.g. (log scraping, a Kyverno/OPA rule, a runbook). I think that's unlikely for an ephemeral operator-managed job, but it's a behavior change. The associated install-strategy ConfigMap already uses a stable `kubevirt-install-strategy-` GenerateName.
- Reused the existing `customizeComponents.Patches` mechanism instead of adding a typed field. Costs the name change above, but you get full control of the job (resources, env, securityContext, ...) rather than just one field, and there's no new API surface.

The following alternatives were considered:
- A typed `spec.infra.resources` field on `ComponentConfig`. Rejected: it lives
  on the struct shared with `spec.workloads`, where it'd silently no-op, and the
  API shape (one field that only affects a single Job) doesn't match the
  behavior.
- A dedicated `spec.installStrategy` struct. Over-engineered for something only
  relevant during install/upgrade.
- Matching by the job's pod label (`virt-operator-strategy-dumper`) instead of its name, which would avoid the GenerateName change entirely. It needs a complex apply method rather than reusing `GenericApplyPatches`; I went with a name-based approach to keep it concise. 

### Special notes for your reviewer
- The `GenericApplyPatches` GenerateName fallback is generic — any `GenerateName`-only object now matches by its prefix, not just this job.
- Heads up on the `GenerateName` change described above in case you feel differently about the external-matcher risk.
<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-operator: customizeComponents.Patches now apply to the install-strategy job (match it with resourceType "Job" and resourceName "virt-operator-install-strategy"). The job's generated name changed from "kubevirt-<id>-job" to "virt-operator-install-strategy-".
```

