### PR TITLE
make access credential secret optional to allow migration even if secret

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -188,7 +188,7 @@ func resolveSSHPublicKeys(accessCredentials []v1.AccessCredential, secretSourceD
 		baseDir := filepath.Join(secretSourceDir, secretName+"-access-cred")
 		files, err := os.ReadDir(baseDir)
 		if err != nil {
-			return keys, err
+			return keys, fmt.Errorf("Unable to read access creds directory %s: %w", baseDir, err)
 		}
 
 		for _, file := range files {

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -365,11 +365,13 @@ func withAccessCredentials(accessCredentials []v1.AccessCredential) VolumeRender
 				continue
 			}
 			volumeName := secretName + "-access-cred"
+			optional := true
 			renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 				Name: volumeName,
 				VolumeSource: k8sv1.VolumeSource{
 					Secret: &k8sv1.SecretVolumeSource{
 						SecretName: secretName,
+						Optional:   &optional,
 					},
 				},
 			})

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -351,7 +351,7 @@ func hotplugVolumes(vmiVolumeStatus []v1.VolumeStatus, vmiSpecVolumes []v1.Volum
 	return hotplugVolumeSet
 }
 
-func withAccessCredentials(accessCredentials []v1.AccessCredential) VolumeRendererOption {
+func withAccessCredentials(accessCredentials []v1.AccessCredential, optional bool) VolumeRendererOption {
 	return func(renderer *VolumeRenderer) error {
 		for _, accessCred := range accessCredentials {
 			secretName := ""
@@ -365,13 +365,16 @@ func withAccessCredentials(accessCredentials []v1.AccessCredential) VolumeRender
 				continue
 			}
 			volumeName := secretName + "-access-cred"
-			optional := true
+			var optionalPointer *bool
+			if optional {
+				optionalPointer = &optional
+			}
 			renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 				Name: volumeName,
 				VolumeSource: k8sv1.VolumeSource{
 					Secret: &k8sv1.SecretVolumeSource{
 						SecretName: secretName,
-						Optional:   &optional,
+						Optional:   optionalPointer,
 					},
 				},
 			})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -254,7 +254,7 @@ func (t *TemplateService) RenderLaunchManifestNoVm(vmi *v1.VirtualMachineInstanc
 		backendStoragePVCName = backendStoragePVC.Name
 	}
 	memoryOverhead := CalculateMemoryOverhead(t.clusterConfig, t.netMemoryCalculator, vmi, t.launcherHypervisorResources)
-	return t.renderLaunchManifest(vmi, nil, backendStoragePVCName, true, memoryOverhead)
+	return t.renderLaunchManifest(vmi, nil, backendStoragePVCName, true, false, memoryOverhead)
 }
 
 func (t *TemplateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance, migration *v1.VirtualMachineInstanceMigration, sourcePod *k8sv1.Pod) (*k8sv1.Pod, error) {
@@ -271,7 +271,7 @@ func (t *TemplateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance
 		backendStoragePVCName = backendStoragePVC.Name
 	}
 	memoryOverhead := CalculateMemoryOverhead(t.clusterConfig, t.netMemoryCalculator, vmi, t.launcherHypervisorResources)
-	targetPod, err := t.renderLaunchManifest(vmi, reproducibleImageIDs, backendStoragePVCName, false, memoryOverhead)
+	targetPod, err := t.renderLaunchManifest(vmi, reproducibleImageIDs, backendStoragePVCName, false, true, memoryOverhead)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func (t *TemplateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		backendStoragePVCName = backendStoragePVC.Name
 	}
 	memoryOverhead := CalculateMemoryOverhead(t.clusterConfig, t.netMemoryCalculator, vmi, t.launcherHypervisorResources)
-	return t.renderLaunchManifest(vmi, nil, backendStoragePVCName, false, memoryOverhead)
+	return t.renderLaunchManifest(vmi, nil, backendStoragePVCName, false, false, memoryOverhead)
 }
 
 func generateQemuTimeoutWithJitter(qemuTimeoutBaseSeconds int) string {
@@ -328,7 +328,7 @@ func computePodSecurityContext(vmi *v1.VirtualMachineInstance, seccomp *k8sv1.Se
 	return psc
 }
 
-func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, imageIDs map[string]string, backendStoragePVCName string, tempPod bool, memoryOverhead resource.Quantity) (*k8sv1.Pod, error) {
+func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, imageIDs map[string]string, backendStoragePVCName string, tempPod, migrationTarget bool, memoryOverhead resource.Quantity) (*k8sv1.Pod, error) {
 	precond.MustNotBeNil(vmi)
 	domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
 	namespace := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())
@@ -444,7 +444,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		command = append(command, "--simulate-crash")
 	}
 
-	volumeRenderer, err := t.newVolumeRenderer(vmi, imageIDs, namespace, requestedHookSidecarList, backendStoragePVCName)
+	volumeRenderer, err := t.newVolumeRenderer(vmi, imageIDs, namespace, requestedHookSidecarList, backendStoragePVCName, migrationTarget)
 	if err != nil {
 		return nil, err
 	}
@@ -865,12 +865,12 @@ func (t *TemplateService) newContainerSpecRenderer(vmi *v1.VirtualMachineInstanc
 	return containerRenderer
 }
 
-func (t *TemplateService) newVolumeRenderer(vmi *v1.VirtualMachineInstance, imageIDs map[string]string, namespace string, requestedHookSidecarList hooks.HookSidecarList, backendStoragePVCName string) (*VolumeRenderer, error) {
+func (t *TemplateService) newVolumeRenderer(vmi *v1.VirtualMachineInstance, imageIDs map[string]string, namespace string, requestedHookSidecarList hooks.HookSidecarList, backendStoragePVCName string, migrationTarget bool) (*VolumeRenderer, error) {
 	imageVolumeFeatureGateEnabled := t.clusterConfig.ImageVolumeEnabled()
 	volumeOpts := []VolumeRendererOption{
 		withVMIConfigVolumes(vmi.Spec.Domain.Devices.Disks, vmi.Spec.Volumes),
 		withVMIVolumes(t.persistentVolumeClaimStore, vmi.Spec.Volumes, vmi.Status.VolumeStatus),
-		withAccessCredentials(vmi.Spec.AccessCredentials),
+		withAccessCredentials(vmi.Spec.AccessCredentials, migrationTarget),
 		withBackendStorage(vmi, backendStoragePVCName),
 	}
 	if imageVolumeFeatureGateEnabled {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -723,7 +723,7 @@ var _ = Describe("Template", func() {
 		})
 
 		Context("with access credentials", func() {
-			It("should add volume with secret referenced by cloud-init user secret ref", func() {
+			It("should add a required volume with secret referenced by cloud-init user secret ref", func() {
 				config, kvStore, svc = configFactory(defaultArch)
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -767,6 +767,7 @@ var _ = Describe("Template", func() {
 				for _, volume := range pod.Spec.Volumes {
 					if volume.Name == "my-pkey-access-cred" {
 						volumeFound = true
+						Expect(volume.Secret.Optional).To(BeNil())
 					}
 				}
 				Expect(volumeFound).To(BeTrue(), "could not find ssh key secret volume")
@@ -778,6 +779,44 @@ var _ = Describe("Template", func() {
 					}
 				}
 				Expect(volumeMountFound).To(BeTrue(), "could not find ssh key secret volume mount")
+			})
+			It("should make the access credential secret volume optional on a migration target pod", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						AccessCredentials: []v1.AccessCredential{
+							{
+								SSHPublicKey: &v1.SSHPublicKeyAccessCredential{
+									Source: v1.SSHPublicKeyAccessCredentialSource{
+										Secret: &v1.AccessCredentialSecretSource{
+											SecretName: "my-pkey",
+										},
+									},
+									PropagationMethod: v1.SSHPublicKeyAccessCredentialPropagationMethod{
+										QemuGuestAgent: &v1.QemuGuestAgentSSHPublicKeyAccessCredentialPropagation{},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderMigrationManifest(&vmi, nil, &k8sv1.Pod{})
+				Expect(err).ToNot(HaveOccurred())
+
+				volumeFound := false
+				for _, volume := range pod.Spec.Volumes {
+					if volume.Name == "my-pkey-access-cred" {
+						volumeFound = true
+						Expect(volume.Secret.Optional).To(HaveValue(BeTrue()))
+					}
+				}
+				Expect(volumeFound).To(BeTrue(), "could not find ssh key secret volume")
 			})
 			It("should add volume with secret referenced by qemu agent access cred", func() {
 				config, kvStore, svc = configFactory(defaultArch)


### PR DESCRIPTION
deleted

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
If a VM referenced a secret and that secret was deleted, the VM could not be live migrated and if it were to be rebooted it would not turn on. This is because pods will not start if a secret they reference is not available.
#### After this PR:
`virt-launcher` pods mount secret as `optional`, so new pods's containers can start even if the secret was deleted

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
- Fixes #17977
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

Secrets are mounted as optional

The following alternatives were considered:


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
I considered implementing a test if secret exists and don't include it in the `virt-launcher`'s pod spec, but this would require granting `list` of secrets.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X ] PR: The PR description is expressive enough and will help future contributors
- [ X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration-target launch pods now treat access-credential secrets as optional, preventing failures when those secrets are unavailable.
  * Normal launch pods continue to require access-credential secrets.
  * Improved error messages when access-credential directories cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->