### PR TITLE
tests: use cluster default arch for CDI registry imports

### DIFF
--- a/pkg/libdv/dv.go
+++ b/pkg/libdv/dv.go
@@ -138,23 +138,43 @@ func withSource(s v1beta1.DataVolumeSource) dvOption {
 	}
 }
 
-// WithRegistryURLSource is a dvOption to add a DataVolumeSource to the DataVolume, with a registry and a URL
-func WithRegistryURLSource(imageURL string) dvOption {
-	return withSource(v1beta1.DataVolumeSource{
-		Registry: &v1beta1.DataVolumeSourceRegistry{
-			URL: &imageURL,
-		},
-	})
+type RegistryOption func(*v1beta1.DataVolumeSourceRegistry)
+
+func WithURL(imageURL string) RegistryOption {
+	return func(r *v1beta1.DataVolumeSourceRegistry) {
+		r.URL = &imageURL
+	}
+}
+
+func WithPullMethod(pullMethod v1beta1.RegistryPullMethod) RegistryOption {
+	return func(r *v1beta1.DataVolumeSourceRegistry) {
+		r.PullMethod = &pullMethod
+	}
+}
+
+func WithPlatformArch(arch string) RegistryOption {
+	return func(r *v1beta1.DataVolumeSourceRegistry) {
+		r.Platform = &v1beta1.PlatformOptions{Architecture: arch}
+	}
+}
+
+// WithRegistrySource is a dvOption to add a registry DataVolumeSource to the DataVolume
+func WithRegistrySource(opts ...RegistryOption) dvOption {
+	registry := &v1beta1.DataVolumeSourceRegistry{}
+	for _, opt := range opts {
+		opt(registry)
+	}
+	return withSource(v1beta1.DataVolumeSource{Registry: registry})
+}
+
+// WithRegistryURLSource is a dvOption to add a registry DataVolumeSource to the DataVolume
+func WithRegistryURLSource(imageURL string, opts ...RegistryOption) dvOption {
+	return WithRegistrySource(append([]RegistryOption{WithURL(imageURL)}, opts...)...)
 }
 
 // WithRegistryURLSourceAndPullMethod is a dvOption to add a DataVolumeSource to the DataVolume, with a registry and URL + pull method
 func WithRegistryURLSourceAndPullMethod(imageURL string, pullMethod v1beta1.RegistryPullMethod) dvOption {
-	return withSource(v1beta1.DataVolumeSource{
-		Registry: &v1beta1.DataVolumeSourceRegistry{
-			URL:        &imageURL,
-			PullMethod: &pullMethod,
-		},
-	})
+	return WithRegistrySource(WithURL(imageURL), WithPullMethod(pullMethod))
 }
 
 // WithBlankImageSource is a dvOption to add a blank DataVolumeSource to the DataVolume

--- a/tests/libkubevirt/kubevirt.go
+++ b/tests/libkubevirt/kubevirt.go
@@ -21,6 +21,7 @@ package libkubevirt
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -35,6 +36,14 @@ func GetCurrentKv(virtClient kubecli.KubevirtClient) *v1.KubeVirt {
 	kvs := GetKvList(virtClient)
 	gomega.Expect(kvs).To(gomega.HaveLen(1))
 	return &kvs[0]
+}
+
+func GetDefaultArchitecture(virtClient kubecli.KubevirtClient) (string, error) {
+	kv := GetCurrentKv(virtClient)
+	if kv.Status.DefaultArchitecture == "" {
+		return "", fmt.Errorf("KubeVirt CR %s/%s has no default architecture set in status", kv.Namespace, kv.Name)
+	}
+	return kv.Status.DefaultArchitecture, nil
 }
 
 func GetKvList(virtClient kubecli.KubevirtClient) []v1.KubeVirt {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -108,6 +108,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 	var (
 		virtClient              kubecli.KubevirtClient
 		migrationBandwidthLimit resource.Quantity
+		defaultArch             string
 	)
 
 	const (
@@ -157,6 +158,9 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 		migrationBandwidthLimit = resource.MustParse("1Ki")
+		var err error
+		defaultArch, err = libkubevirt.GetDefaultArchitecture(virtClient)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("with Headless service", func() {
@@ -370,7 +374,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					Fail("Failed test when RWX Block storage is not present")
 				}
 				dv := libdv.NewDataVolume(
-					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
+					libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 					libdv.WithStorage(
 						libdv.StorageWithStorageClass(sc),
 						libdv.StorageWithVolumeSize(cd.CirrosVolumeSize),
@@ -851,7 +855,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}
 
 				dataVolume := libdv.NewDataVolume(
-					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
+					libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 					libdv.WithStorage(
 						libdv.StorageWithStorageClass(sc),
 						libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
@@ -1023,7 +1027,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			createDV := func(namespace string) {
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 				dv = libdv.NewDataVolume(
-					libdv.WithRegistryURLSourceAndPullMethod(url, cdiv1.RegistryPullNode),
+					libdv.WithRegistrySource(libdv.WithURL(url), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 					libdv.WithStorage(
 						libdv.StorageWithStorageClass(storageClass),
 						libdv.StorageWithVolumeSize(cd.FedoraVolumeSize),
@@ -1085,7 +1089,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			}
 
 			dv := libdv.NewDataVolume(
-				libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
+				libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 				libdv.WithStorage(
 					libdv.StorageWithStorageClass(sc),
 					libdv.StorageWithVolumeSize(size),
@@ -1828,7 +1832,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}
 
 				dv := libdv.NewDataVolume(
-					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), cdiv1.RegistryPullNode),
+					libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 					libdv.WithStorage(
 						libdv.StorageWithStorageClass(sc),
 						libdv.StorageWithVolumeSize(cd.FedoraVolumeSize),
@@ -3143,8 +3147,11 @@ func runCommandOnVmiTargetPod(vmi *v1.VirtualMachineInstance, command []string) 
 func newVMIWithDataVolumeForMigration(containerDisk cd.ContainerDisk, accessMode k8sv1.PersistentVolumeAccessMode, storageClass string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
 	virtClient := kubevirt.Client()
 
+	arch, err := libkubevirt.GetDefaultArchitecture(virtClient)
+	Expect(err).ToNot(HaveOccurred())
+
 	dv := libdv.NewDataVolume(
-		libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(containerDisk), cdiv1.RegistryPullNode),
+		libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(containerDisk)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(arch)),
 		libdv.WithStorage(
 			libdv.StorageWithStorageClass(storageClass),
 			libdv.StorageWithVolumeSize(cd.ContainerDiskSizeBySourceURL(cd.DataVolumeImportUrlForContainerDisk(containerDisk))),
@@ -3153,7 +3160,7 @@ func newVMIWithDataVolumeForMigration(containerDisk cd.ContainerDisk, accessMode
 		),
 	)
 
-	dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
+	dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	libstorage.EventuallyDV(dv, 240, Or(matcher.HaveSucceeded(), matcher.WaitForFirstConsumer()))
 

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -67,6 +67,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 		virtClient    kubecli.KubevirtClient
 		connectionURL string
 		err           error
+		defaultArch   string
 	)
 
 	BeforeEach(func() {
@@ -74,6 +75,9 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			Fail("Fail DataVolume tests when CDI is not present")
 		}
 		virtClient = kubevirt.Client()
+		var err error
+		defaultArch, err = libkubevirt.GetDefaultArchitecture(virtClient)
+		Expect(err).ToNot(HaveOccurred())
 		connectionURL, err = getKubevirtSynchronizationSyncAddress(virtClient)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -739,7 +743,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 
 		It("should live migrate block to filesystem", decorators.RequiresBlockStorage, func() {
 			sourceDV := libdv.NewDataVolume(
-				libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
+				libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 				libdv.WithStorage(
 					libdv.StorageWithVolumeSize(cd.AlpineVolumeSize),
 					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeBlock),
@@ -782,7 +786,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 		It("should live migrate regular disk several times", decorators.RequiresBlockStorage, func() {
 			var targetVM *virtv1.VirtualMachine
 			sourceDV := libdv.NewDataVolume(
-				libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
+				libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 				libdv.WithStorage(
 					libdv.StorageWithVolumeSize(cd.AlpineVolumeSize),
 					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeBlock),

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -65,10 +66,14 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 		virtClient      kubecli.KubevirtClient
 		err             error
 		migrationPolicy *migrationsv1.MigrationPolicy
+		defaultArch     string
 	)
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
+		var err error
+		defaultArch, err = libkubevirt.GetDefaultArchitecture(virtClient)
+		Expect(err).ToNot(HaveOccurred())
 
 		By("Allowing post-copy and limiting migration bandwidth")
 		policyName := fmt.Sprintf("testpolicy-%s", rand.String(5))
@@ -88,7 +93,7 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 			}
 
 			dv = libdv.NewDataVolume(
-				libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), cdiv1.RegistryPullNode),
+				libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 				libdv.WithStorage(
 					libdv.StorageWithStorageClass(sc),
 					libdv.StorageWithVolumeSize(cd.FedoraVolumeSize),


### PR DESCRIPTION
### What this PR does
Sets `Platform.Architecture` on DataVolume registry sources in migration tests using the cluster's default architecture (`kv.Status.DefaultArchitecture`) instead of reading a random node's arch via `nodes.Items[0]`.

When CDI imports a container disk image using `RegistryPullNode`, the importer pod can land on any node in the cluster. The node's container runtime pulls the image variant matching its own architecture. On a multi-arch cluster, if the importer lands on an ARM64 node, it pulls the ARM64 disk image into the shared PVC. The VMI then defaults to amd64 (set by the mutating webhook) and tries to boot the ARM64 disk — QEMU starts but the OS never boots, causing login timeouts.

The fix uses `kv.Status.DefaultArchitecture` — the same value the mutating webhook assigns to VMIs without an explicit architecture. Setting `Platform.Architecture` on the DataVolume to this value tells CDI to constrain the importer pod to nodes of the matching architecture, guaranteeing the imported disk matches what the VMI will boot. No `WithArchitecture` is needed on the VMIs themselves since the webhook already defaults them to this value.

#### Before this PR:
- DataVolumes with `RegistryPullNode` don't specify a platform architecture
- On multi-arch clusters, the importer pod can land on any node and pull the wrong architecture's disk image
- The VMI defaults to amd64 but may boot an ARM64 disk → login timeout

#### After this PR:
- All DataVolume registry sources specify `Platform.Architecture` from `kv.Status.DefaultArchitecture`
- CDI constrains the importer pod to nodes matching the cluster's default architecture
- The imported disk image is guaranteed to match the VMI's architecture
- Adds `GetDefaultArchitecture()` helper in `tests/libkubevirt/`
- Adds composable `RegistryOption` functions (`RegistryWithPullMethod`, `RegistryWithPlatformArch`) in `pkg/libdv/`
- Refactors `WithRegistryURLSourceAndPullMethod` to compose from `WithRegistryURLSource` + options

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```