### PR TITLE
VEP-141 : Migrate disk source path modification to target-side pre-migration hook

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/virt-launcher/notify-client:go_default_library",
         "//pkg/virt-launcher/premigration-hook-server:go_default_library",
         "//pkg/virt-launcher/premigration-hook-server/cpuhook:go_default_library",
+        "//pkg/virt-launcher/premigration-hook-server/disk:go_default_library",
         "//pkg/virt-launcher/premigration-hook-server/network:go_default_library",
         "//pkg/virt-launcher/premigration-hook-server/vgpuhook:go_default_library",
         "//pkg/virt-launcher/standalone:go_default_library",

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -58,6 +58,7 @@ import (
 	notifyclient "kubevirt.io/kubevirt/pkg/virt-launcher/notify-client"
 	premigrationhookserver "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/cpuhook"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/disk"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/network"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/vgpuhook"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/standalone"
@@ -446,6 +447,7 @@ func main() {
 
 	hookFuncs := []premigrationhookserver.HookFunc{
 		cpuhook.CPUDedicatedHook,
+		disk.DiskSourcePathHook,
 	}
 	if *ifacesOrdinalNamingUpgradeEnabled {
 		hookFuncs = append(hookFuncs, network.UpgradeOrdinalNamingScheme)

--- a/docs/devel/migration-premigration-hooks.md
+++ b/docs/devel/migration-premigration-hooks.md
@@ -1,0 +1,80 @@
+# Pre-Migration Target-Side Hooks
+
+## Overview
+
+During live migration, the domain XML that describes the VM must be adjusted
+to match the target node's environment. Historically, these modifications were
+applied on the source virt-launcher pod before the XML was sent to the
+target. This is problematic because during rolling upgrades, only the target
+pod runs the new virt-launcher image while the source pod still runs the old
+one. If a bug fix is applied to the XML modification logic, it will not take
+effect until the source pod is also updated, which may not happen until the
+second migration or restart.
+
+To address this, VEP-141 introduces **target-side pre-migration hooks**,
+built on top of [libvirt's QEMU hook mechanism](https://libvirt.org/hooks.html).
+Libvirt invokes the `/etc/libvirt/hooks/qemu` executable on the destination host
+with the `migrate` operation at the beginning of incoming migration, passing
+the domain XML via stdin and reading the modified XML from stdout. KubeVirt
+places its hook client binary at that path, which forwards the domain XML to
+a hook server running on the target virt-launcher pod over a unix socket.
+The hook server applies the registered modifications and returns the updated
+XML before the VM starts on the target node.
+With target-side hooks, target-based XML modifications are applied by
+the target pod itself, which always runs the latest virt-launcher image during upgrade.
+
+## Architecture
+
+The pre-migration hook system consists of:
+
+1. **Hook Server** (`pkg/virt-launcher/premigration-hook-server/hook_server.go`):
+   Runs on the target virt-launcher pod. Listens on a unix socket, receives
+   the domain XML, applies all registered hooks, and returns the modified XML.
+
+2. **Hook Functions**: Each hook implements the `HookFunc` signature:
+   ```go
+   type HookFunc func(c *ConverterContext, vmi *v1.VirtualMachineInstance, domain *libvirtxml.Domain) error
+   ```
+   Hooks modify the `domain` in-place. They are called in registration order.
+   The `domain` is the source XML from libvirt. The `vmi` is passed
+   from virt-handler on the target pod, and the `ConverterContext` is
+   generated locally on the target pod.
+
+3. **Hook Client** (`cmd/virt-launcher/libvirt-hook-client/main.go`):
+   Triggered by libvirt's `qemu` hook during the `migrate` operation
+   on the destination host. The hook client connects to the hook server's
+   unix socket, sends the domain XML for modification, and returns the
+   modified XML back to libvirt.
+
+## Migration Flow
+
+```
+Source virt-launcher                          Target virt-launcher
+─────────────────                          ──────────────────────
+                                            Start hook server
+                                            (listen on unix socket)
+                                                   │
+Prepare domain XML ──── send XML ──────────────▶  │
+                                            Receive XML
+                                            Apply hooks:
+                                              1. disk source path
+                                              2. CPU
+                                              3. vGPU
+                                              4. network naming
+                                            Return modified XML
+         ◀──────────── receive XML ────────────  │
+Continue migration
+with modified XML
+```
+
+## Adding a New Hook
+
+1. Create a new package under `pkg/virt-launcher/premigration-hook-server/`.
+2. Implement a function matching the `HookFunc` signature.
+3. Register the hook in the virt-launcher startup
+   (`cmd/virt-launcher/virt-launcher.go`) by passing it to
+   `NewPreMigrationHookServer()`.
+
+## References
+
+- [VEP-141: Target-Side Pre-Migration Hooks](https://github.com/kubevirt/enhancements/issues/141)

--- a/pkg/virt-launcher/premigration-hook-server/disk/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/disk/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["source_path.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/disk",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virt-launcher/virtwrap/converter/types:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "disk_suite_test.go",
+        "source_path_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)

--- a/pkg/virt-launcher/premigration-hook-server/disk/disk_suite_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/disk/disk_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package disk_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestDisk(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-launcher/premigration-hook-server/disk/source_path.go
+++ b/pkg/virt-launcher/premigration-hook-server/disk/source_path.go
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package disk
+
+import (
+	"strings"
+
+	"libvirt.org/go/libvirtxml"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	convertertypes "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/types"
+)
+
+// DiskSourcePathHook updates disk source file paths in the domain XML by
+// replacing the VMI namespace with the target domain namespace.
+// This is the target-side equivalent of the source-side
+// updateFilePathsToNewDomain() + convertDisks() functions.
+func DiskSourcePathHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachineInstance, domain *libvirtxml.Domain) error {
+	if domain.Devices == nil {
+		return nil
+	}
+
+	targetDomainNamespace := getTargetDomainNamespace(vmi)
+	if targetDomainNamespace == "" || targetDomainNamespace == vmi.Namespace {
+		return nil
+	}
+
+	oldSegment := "/" + vmi.Namespace + "/"
+	newSegment := "/" + targetDomainNamespace + "/"
+
+	for i := range domain.Devices.Disks {
+		disk := &domain.Devices.Disks[i]
+		if disk.Source == nil {
+			continue
+		}
+		if disk.Source.File != nil && strings.Contains(disk.Source.File.File, oldSegment) {
+			oldPath := disk.Source.File.File
+			newPath := strings.Replace(oldPath, oldSegment, newSegment, 1)
+			log.Log.Object(vmi).V(4).Infof("diskSourcePathHook: updating disk file path from %s to %s", oldPath, newPath)
+			disk.Source.File.File = newPath
+		}
+		if disk.Source.DataStore != nil && disk.Source.DataStore.Source != nil &&
+			disk.Source.DataStore.Source.File != nil &&
+			strings.Contains(disk.Source.DataStore.Source.File.File, oldSegment) {
+			oldPath := disk.Source.DataStore.Source.File.File
+			newPath := strings.Replace(oldPath, oldSegment, newSegment, 1)
+			log.Log.Object(vmi).V(4).Infof("diskSourcePathHook: updating datastore file path from %s to %s", oldPath, newPath)
+			disk.Source.DataStore.Source.File.File = newPath
+		}
+	}
+
+	return nil
+}
+
+func getTargetDomainNamespace(vmi *v1.VirtualMachineInstance) string {
+	if vmi.Status.MigrationState != nil &&
+		vmi.Status.MigrationState.TargetState != nil &&
+		vmi.Status.MigrationState.TargetState.DomainNamespace != nil {
+		return *vmi.Status.MigrationState.TargetState.DomainNamespace
+	}
+	return ""
+}

--- a/pkg/virt-launcher/premigration-hook-server/disk/source_path_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/disk/source_path_test.go
@@ -1,0 +1,212 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package disk_test
+
+import (
+	"libvirt.org/go/libvirtxml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/disk"
+)
+
+const (
+	sourceNamespace      = "source-ns"
+	targetNamespace      = "target-ns"
+	cloudInitPathWithSrc = "/var/run/libvirt/cloud-init-dir/source-ns/vmi-test/noCloud.iso"
+	cloudInitPathWithDst = "/var/run/libvirt/cloud-init-dir/target-ns/vmi-test/noCloud.iso"
+	pvcDiskPath          = "/var/run/kubevirt-private/vmi-disks/pvc/disk.img"
+)
+
+var _ = Describe("DiskSourcePathHook", func() {
+	var vmi *v1.VirtualMachineInstance
+
+	BeforeEach(func() {
+		targetNs := targetNamespace
+		vmi = libvmi.New(
+			libvmi.WithNamespace(sourceNamespace),
+			libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+					TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
+						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+							DomainNamespace: &targetNs,
+						},
+					},
+				}),
+			)),
+		)
+	})
+
+	It("should replace namespace in file paths", func() {
+		domain := &libvirtxml.Domain{
+			Devices: &libvirtxml.DomainDeviceList{
+				Disks: []libvirtxml.DomainDisk{
+					{
+						Alias: &libvirtxml.DomainAlias{Name: "ua-cloudinit"},
+						Source: &libvirtxml.DomainDiskSource{
+							File: &libvirtxml.DomainDiskSourceFile{
+								File: cloudInitPathWithSrc,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+		Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithDst))
+	})
+
+	It("should not modify paths that don't contain the namespace", func() {
+		domain := &libvirtxml.Domain{
+			Devices: &libvirtxml.DomainDeviceList{
+				Disks: []libvirtxml.DomainDisk{
+					{
+						Alias: &libvirtxml.DomainAlias{Name: "ua-pvc"},
+						Source: &libvirtxml.DomainDiskSource{
+							File: &libvirtxml.DomainDiskSourceFile{
+								File: pvcDiskPath,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+		Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(pvcDiskPath))
+	})
+
+	It("should replace namespace in datastore file paths", func() {
+		domain := &libvirtxml.Domain{
+			Devices: &libvirtxml.DomainDeviceList{
+				Disks: []libvirtxml.DomainDisk{
+					{
+						Alias: &libvirtxml.DomainAlias{Name: "ua-cbt-disk"},
+						Source: &libvirtxml.DomainDiskSource{
+							DataStore: &libvirtxml.DomainDiskDataStore{
+								Source: &libvirtxml.DomainDiskSource{
+									File: &libvirtxml.DomainDiskSourceFile{
+										File: cloudInitPathWithSrc,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+		Expect(domain.Devices.Disks[0].Source.DataStore.Source.File.File).To(Equal(cloudInitPathWithDst))
+	})
+
+	It("should return nil when domain has no devices", func() {
+		Expect(disk.DiskSourcePathHook(nil, vmi, &libvirtxml.Domain{})).To(Succeed())
+	})
+
+	Context("early-return when migration state is incomplete", func() {
+		It("should return nil when MigrationState is nil", func() {
+			vmi = libvmi.New(
+				libvmi.WithNamespace(sourceNamespace),
+				libvmistatus.WithStatus(libvmistatus.New()),
+			)
+			domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
+
+			Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithSrc))
+		})
+
+		It("should return nil when TargetState is nil", func() {
+			vmi = libvmi.New(
+				libvmi.WithNamespace(sourceNamespace),
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+						TargetState: nil,
+					}),
+				)),
+			)
+			domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
+
+			Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithSrc))
+		})
+
+		It("should return nil when DomainNamespace is nil", func() {
+			vmi = libvmi.New(
+				libvmi.WithNamespace(sourceNamespace),
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+						TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
+							VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+								DomainNamespace: nil,
+							},
+						},
+					}),
+				)),
+			)
+			domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
+
+			Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithSrc))
+		})
+
+		It("should return nil when source and target namespace are the same", func() {
+			sameNs := sourceNamespace
+			vmi = libvmi.New(
+				libvmi.WithNamespace(sourceNamespace),
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+						TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
+							VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+								DomainNamespace: &sameNs,
+							},
+						},
+					}),
+				)),
+			)
+			domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
+
+			Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithSrc))
+		})
+	})
+})
+
+func domainWithCloudInitDisk(path string) *libvirtxml.Domain {
+	return &libvirtxml.Domain{
+		Devices: &libvirtxml.DomainDeviceList{
+			Disks: []libvirtxml.DomainDisk{
+				{
+					Alias: &libvirtxml.DomainAlias{Name: "ua-cloudinit"},
+					Source: &libvirtxml.DomainDiskSource{
+						File: &libvirtxml.DomainDiskSourceFile{
+							File: path,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -143,7 +143,7 @@ func hotUnplugHostDevices(virConn cli.Connection, dom cli.VirDomain) error {
 
 // This returns domain xml without the metadata section, as it is only relevant to the source domain
 // Note: Unfortunately we can't just use UnMarshall + Marshall here, as that leads to unwanted XML alterations
-func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec) (string, error) {
+func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec, libvirtHooksEnabled bool) (string, error) {
 	var domain *api.Domain
 	var err error
 
@@ -158,13 +158,15 @@ func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, domSpec
 	}
 	// TODO: Once LibvirtHooksServerAndClient feature gate is GA, remove
 	// convertDisks, replaced by DiskSourcePathHook on the target.
-	if err = convertDisks(domSpec, domcfg); err != nil {
-		return "", err
+	if !libvirtHooksEnabled {
+		if err = convertDisks(domSpec, domcfg); err != nil {
+			return "", err
+		}
 	}
 	// TODO: Once the LibvirtHooksServerAndClient feature gate is GA,
 	// this logic in the source can be removed, as XML modifications
 	// for dedicated CPUs will always be handled on the target side.
-	if vmi.IsCPUDedicated() {
+	if !libvirtHooksEnabled && vmi.IsCPUDedicated() {
 		// If the VMI has dedicated CPUs, we need to replace the old CPUs that were
 		// assigned in the source node with the new CPUs assigned in the target node
 		err = xml.Unmarshal([]byte(xmlstr), &domain)
@@ -763,7 +765,7 @@ func updateFilePathsToNewDomain(vmi *v1.VirtualMachineInstance, domSpec *api.Dom
 	}
 }
 
-func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions, virtShareDir string, domSpec *api.DomainSpec) (*libvirt.DomainMigrateParameters, error) {
+func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions, virtShareDir string, domSpec *api.DomainSpec, libvirtHooksEnabled bool) (*libvirt.DomainMigrateParameters, error) {
 	bandwidth, err := vcpu.QuantityToMebiByte(options.Bandwidth)
 	if err != nil {
 		return nil, err
@@ -771,8 +773,10 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 
 	// TODO: Once LibvirtHooksServerAndClient feature gate is GA, remove
 	// updateFilePathsToNewDomain, replaced by DiskSourcePathHook on the target.
-	updateFilePathsToNewDomain(vmi, domSpec)
-	xmlstr, err := migratableDomXML(dom, vmi, domSpec)
+	if !libvirtHooksEnabled {
+		updateFilePathsToNewDomain(vmi, domSpec)
+	}
+	xmlstr, err := migratableDomXML(dom, vmi, domSpec, libvirtHooksEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -1035,7 +1039,7 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 		if err != nil {
 			return fmt.Errorf("failed to get domain spec: %v", err)
 		}
-		params, err = generateMigrationParams(dom, vmi, options, l.virtShareDir, domSpec)
+		params, err = generateMigrationParams(dom, vmi, options, l.virtShareDir, domSpec, l.libvirtHooksServerAndClientEnabled)
 		if err != nil {
 			return fmt.Errorf("error encountered while generating migration parameters: %v", err)
 		}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -156,6 +156,8 @@ func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, domSpec
 	if err := domcfg.Unmarshal(xmlstr); err != nil {
 		return "", err
 	}
+	// TODO: Once LibvirtHooksServerAndClient feature gate is GA, remove
+	// convertDisks, replaced by DiskSourcePathHook on the target.
 	if err = convertDisks(domSpec, domcfg); err != nil {
 		return "", err
 	}
@@ -767,6 +769,8 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 		return nil, err
 	}
 
+	// TODO: Once LibvirtHooksServerAndClient feature gate is GA, remove
+	// updateFilePathsToNewDomain, replaced by DiskSourcePathHook on the target.
 	updateFilePathsToNewDomain(vmi, domSpec)
 	xmlstr, err := migratableDomXML(dom, vmi, domSpec)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -757,7 +757,7 @@ var _ = Describe("migratableDomXML", func() {
 		mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
 		domSpec := &api.DomainSpec{}
 		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec)
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	})
@@ -819,7 +819,7 @@ var _ = Describe("migratableDomXML", func() {
 		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
 		Expect(domSpec.VCPU).NotTo(BeNil())
 		Expect(domSpec.CPUTune).NotTo(BeNil())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec)
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
 		Expect(err).ToNot(HaveOccurred(), "failed to generate target domain XML")
 
 		By("ensuring the generated XML is accurate")
@@ -878,7 +878,7 @@ var _ = Describe("migratableDomXML", func() {
 		mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
 		domSpec := &api.DomainSpec{}
 		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec)
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	},
@@ -947,7 +947,7 @@ var _ = Describe("migratableDomXML", func() {
 		mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
 		domSpec := &api.DomainSpec{}
 		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec)
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	})


### PR DESCRIPTION
Add DiskSourcePathHook that updates disk source file paths in the
domain XML on the target virt-launcher pod by replacing the VMI
namespace segment with the target domain namespace.

Currently, disk source path adjustments happen on the migration
source side. This is problematic because during upgrades, only the
target pod runs the new virt-launcher image while the source pod
still runs the old one. If a bug fix is applied to this logic, it
will not take effect during rolling upgrades since the source pod
cannot be updated. Moving these modifications to the target side
ensures that fixes are always applied by the new code.

As part of VEP-141 Beta, all target-specific domain XML modifications
are being moved to target-side pre-migration hooks.

The source-side logic is kept (with a TODO to remove post-GA)
because it is still needed when the LibvirtHooksServerAndClient
feature gate is disabled.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

## VEP Reference
https://github.com/kubevirt/enhancements/issues/141


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Functional tests: No new e2e tests are needed. The existing migration
e2e tests already cover disk path correctness during live migration.
This change applies the same transformation on the target side, so the
existing tests validate the end result.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

