### PR TITLE
nbdclient: add dual-context map for discard-aware incremental backup

### DIFF
--- a/pkg/storage/nbdclient/nbdclient.go
+++ b/pkg/storage/nbdclient/nbdclient.go
@@ -21,8 +21,6 @@ package nbdclient
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
 	"google.golang.org/grpc"
 	"libguestfs.org/libnbd"
@@ -52,76 +50,54 @@ func NewNBDClient(socketPath string) *NBDClient {
 }
 
 type sendFn func(*nbdv1.MapResponse) error
+type descFn func(uint64) string
 
-// mapBuilder accumulates, coalesces, and batches extents.
-type mapBuilder struct {
-	endOffset   uint64
-	send        sendFn
-	lastExtents map[string]*nbdv1.Extent
-	batch       []*nbdv1.Extent
-	batchSize   int
+type mapHandler interface {
+	HandleExtents(metacontext string, offset uint64, entries []libnbd.LibnbdExtent) (uint64, error)
+	Merge() error
+	Flush() error
 }
 
-func newMapBuilder(endOffset uint64, batchSize int, send sendFn) *mapBuilder {
-	return &mapBuilder{
-		endOffset:   endOffset,
-		send:        send,
-		lastExtents: make(map[string]*nbdv1.Extent),
-		batch:       make([]*nbdv1.Extent, 0, batchSize),
-		batchSize:   batchSize,
-	}
+type extentBatcher struct {
+	endOffset uint64
+	batch     []*nbdv1.Extent
+	batchSize int
+	last      *nbdv1.Extent
+	send      sendFn
+	desc      descFn
 }
 
-func (b *mapBuilder) HandleExtents(metacontext string, offset uint64, entries []libnbd.LibnbdExtent) (uint64, error) {
-	localOffset := offset
-	for _, e := range entries {
-		length := e.Length
-		if localOffset+length > b.endOffset {
-			length = b.endOffset - localOffset
-		}
-		if length == 0 {
-			continue
-		}
-		if err := b.coalesce(metacontext, localOffset, length, e.Flags); err != nil {
-			return localOffset, err
-		}
-		localOffset += length
-	}
-	return localOffset, nil
-}
-
-func (b *mapBuilder) coalesce(metacontext string, offset, length, flags uint64) error {
-	last := b.lastExtents[metacontext]
-	if last != nil && last.Flags == flags && last.Offset+last.Length == offset {
-		last.Length += length
+func (b *extentBatcher) coalesce(offset, length, flags uint64) error {
+	if b.last != nil && b.last.Flags == flags && b.last.Offset+b.last.Length == offset {
+		b.last.Length += length
 		return nil
 	}
-	if err := b.flushContext(metacontext); err != nil {
+	if err := b.flushLast(); err != nil {
 		return err
 	}
-	b.lastExtents[metacontext] = &nbdv1.Extent{
+	b.last = &nbdv1.Extent{
 		Offset:      offset,
 		Length:      length,
 		Flags:       flags,
-		Description: getExtentDescription(metacontext, flags),
+		Description: b.desc(flags),
 	}
 	return nil
 }
 
-func (b *mapBuilder) flushContext(metacontext string) error {
-	e, ok := b.lastExtents[metacontext]
-	if !ok || e == nil {
+func (b *extentBatcher) flushLast() error {
+	if b.last == nil {
 		return nil
 	}
+	e := b.last
+	b.last = nil
 	b.batch = append(b.batch, e)
-	delete(b.lastExtents, metacontext)
 	if len(b.batch) >= b.batchSize {
-		return b.Flush()
+		return b.sendBatch()
 	}
 	return nil
 }
 
-func (b *mapBuilder) Flush() error {
+func (b *extentBatcher) sendBatch() error {
 	if len(b.batch) == 0 {
 		return nil
 	}
@@ -134,53 +110,198 @@ func (b *mapBuilder) Flush() error {
 	return err
 }
 
-func (b *mapBuilder) FlushAll() error {
-	contexts := sortedContextsByOffset(b.lastExtents)
-	for _, ctxName := range contexts {
-		if err := b.flushContext(ctxName); err != nil {
-			return fmt.Errorf("flushing final extent for context %s: %w", ctxName, err)
-		}
+func (b *extentBatcher) Flush() error {
+	if err := b.flushLast(); err != nil {
+		return err
 	}
-	return b.Flush()
+	return b.sendBatch()
 }
 
-func sortedContextsByOffset(lastExtents map[string]*nbdv1.Extent) []string {
-	contexts := make([]string, 0, len(lastExtents))
-	for k := range lastExtents {
-		contexts = append(contexts, k)
+// singleContextMapper accumulates, coalesces, and batches extents from a single
+// base:allocation context (full backup path).
+type singleContextMapper struct {
+	extentBatcher
+}
+
+func newSingleContextMapper(endOffset uint64, batchSize int, send sendFn) *singleContextMapper {
+	return &singleContextMapper{
+		extentBatcher: extentBatcher{
+			endOffset: endOffset,
+			batch:     make([]*nbdv1.Extent, 0, batchSize),
+			batchSize: batchSize,
+			send:      send,
+			desc:      allocDescription,
+		},
 	}
-	sort.Slice(contexts, func(i, j int) bool {
-		return lastExtents[contexts[i]].Offset < lastExtents[contexts[j]].Offset
-	})
-	return contexts
+}
+
+func (b *singleContextMapper) HandleExtents(_ string, offset uint64, entries []libnbd.LibnbdExtent) (uint64, error) {
+	localOffset := offset
+	for _, e := range entries {
+		if localOffset >= b.endOffset {
+			break
+		}
+		length := e.Length
+		if localOffset+length > b.endOffset {
+			length = b.endOffset - localOffset
+		}
+		if length == 0 {
+			continue
+		}
+		if err := b.coalesce(localOffset, length, e.Flags); err != nil {
+			return localOffset, err
+		}
+		localOffset += length
+	}
+	return localOffset, nil
+}
+
+func (b *singleContextMapper) Merge() error { return nil }
+
+// mergedContextMapper merges extents from base:allocation and qemu:dirty-bitmap
+// contexts into a single stream with combined flags, replicating client-side
+// what QEMU does internally for push-mode backups (block/backup.c).
+//
+// BlockStatus64 delivers both contexts' callbacks sequentially within a
+// single call. The merger buffers each context's extents during the
+// callbacks, then runs a two-pointer walk to merge at boundary splits.
+//
+// Flag remapping avoids the STATE_HOLE/STATE_DIRTY bit collision (both
+// value 1 in different contexts) following the same approach as oVirt's
+// ovirt-imageio client:
+// https://github.com/oVirt/ovirt-imageio/blob/master/ovirt_imageio/_internal/nbdutil.py
+// https://gitlab.com/qemu-project/qemu/-/blob/master/block/backup.c
+type mergedContextMapper struct {
+	extentBatcher
+	allocExtents []nbdv1.Extent
+	dirtyExtents []nbdv1.Extent
+}
+
+func newMergedContextMapper(endOffset uint64, batchSize int, send sendFn) *mergedContextMapper {
+	return &mergedContextMapper{
+		extentBatcher: extentBatcher{
+			endOffset: endOffset,
+			batch:     make([]*nbdv1.Extent, 0, batchSize),
+			batchSize: batchSize,
+			send:      send,
+			desc:      mergedDescription,
+		},
+	}
+}
+
+func (m *mergedContextMapper) HandleExtents(metacontext string, offset uint64, entries []libnbd.LibnbdExtent) (uint64, error) {
+	localOffset := offset
+	for _, e := range entries {
+		if localOffset >= m.endOffset {
+			break
+		}
+		length := e.Length
+		if localOffset+length > m.endOffset {
+			length = m.endOffset - localOffset
+		}
+		if length == 0 {
+			continue
+		}
+		if metacontext == libnbd.CONTEXT_BASE_ALLOCATION {
+			var flags uint64
+			if e.Flags&uint64(libnbd.STATE_ZERO) != 0 {
+				flags = uint64(libnbd.STATE_ZERO)
+			}
+			m.allocExtents = append(m.allocExtents, nbdv1.Extent{Offset: localOffset, Length: length, Flags: flags})
+		} else {
+			m.dirtyExtents = append(m.dirtyExtents, nbdv1.Extent{Offset: localOffset, Length: length, Flags: e.Flags})
+		}
+		localOffset += length
+	}
+	return localOffset, nil
+}
+
+func (m *mergedContextMapper) Merge() error {
+	defer func() {
+		m.allocExtents = m.allocExtents[:0]
+		m.dirtyExtents = m.dirtyExtents[:0]
+	}()
+
+	if len(m.allocExtents) == 0 || len(m.dirtyExtents) == 0 {
+		return nil
+	}
+
+	a, b := 0, 0
+	for a < len(m.allocExtents) && b < len(m.dirtyExtents) {
+		alloc := &m.allocExtents[a]
+		dirty := &m.dirtyExtents[b]
+		n := min(alloc.Length, dirty.Length)
+
+		if err := m.coalesce(alloc.Offset, n, alloc.Flags|dirty.Flags); err != nil {
+			return err
+		}
+
+		alloc.Offset += n
+		alloc.Length -= n
+		if alloc.Length == 0 {
+			a++
+		}
+		dirty.Offset += n
+		dirty.Length -= n
+		if dirty.Length == 0 {
+			b++
+		}
+	}
+
+	return nil
+}
+
+func (c *NBDClient) connectForMap(req *nbdv1.MapRequest) (*libnbd.Libnbd, bool, error) {
+	l, err := libnbd.Create()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create libnbd handle: %w", err)
+	}
+
+	if err := l.AddMetaContext(libnbd.CONTEXT_BASE_ALLOCATION); err != nil {
+		log.Log.Reason(err).Warningf("AddMetaContext(%s) failed", libnbd.CONTEXT_BASE_ALLOCATION)
+	}
+
+	incremental := req.BitmapName != ""
+	if incremental {
+		bitmapContext := libnbd.CONTEXT_QEMU_DIRTY_BITMAP + req.BitmapName
+		if err := l.AddMetaContext(bitmapContext); err != nil {
+			log.Log.Reason(err).Warningf("AddMetaContext(%s) failed", bitmapContext)
+		}
+	}
+
+	if err := c.connect(l, req.ExportName); err != nil {
+		l.Close()
+		return nil, false, err
+	}
+
+	if err := verifyContexts(l, req.BitmapName); err != nil {
+		l.Close()
+		return nil, false, err
+	}
+
+	return l, incremental, nil
+}
+
+func verifyContexts(l *libnbd.Libnbd, bitmapName string) error {
+	if can, err := l.CanMetaContext(libnbd.CONTEXT_BASE_ALLOCATION); err != nil || !can {
+		return fmt.Errorf("server does not support requested context: %s", libnbd.CONTEXT_BASE_ALLOCATION)
+	}
+	if bitmapName != "" {
+		ctx := libnbd.CONTEXT_QEMU_DIRTY_BITMAP + bitmapName
+		if can, err := l.CanMetaContext(ctx); err != nil || !can {
+			return fmt.Errorf("server does not support requested context: %s", ctx)
+		}
+	}
+	return nil
 }
 
 // based on https://gitlab.com/nbdkit/libnbd/-/blob/master/info/map.c
 func (c *NBDClient) Map(req *nbdv1.MapRequest, stream nbdv1.NBD_MapServer) error {
-	l, err := libnbd.Create()
+	l, incremental, err := c.connectForMap(req)
 	if err != nil {
-		return fmt.Errorf("failed to create libnbd handle: %w", err)
-	}
-	defer l.Close()
-
-	requestedContext := libnbd.CONTEXT_BASE_ALLOCATION
-	if req.BitmapName != "" {
-		requestedContext = libnbd.CONTEXT_QEMU_DIRTY_BITMAP + req.BitmapName
-	}
-
-	if err := l.AddMetaContext(requestedContext); err != nil {
-		log.Log.Reason(err).Warningf("AddMetaContext(%s) failed: %v", requestedContext, err)
-	}
-
-	if err := c.connect(l, req.ExportName); err != nil {
 		return err
 	}
-
-	// if the export lacks the requested context error out
-	// falling back to base:allocation is misleading
-	if can, err := l.CanMetaContext(requestedContext); err != nil || !can {
-		return fmt.Errorf("server does not support requested context: %s", requestedContext)
-	}
+	defer l.Close()
 
 	size, err := l.GetSize()
 	if err != nil {
@@ -192,7 +313,12 @@ func (c *NBDClient) Map(req *nbdv1.MapRequest, stream nbdv1.NBD_MapServer) error
 		return err
 	}
 
-	builder := newMapBuilder(endOffset, mapResponseBatchSize, stream.Send)
+	var handler mapHandler
+	if incremental {
+		handler = newMergedContextMapper(endOffset, mapResponseBatchSize, stream.Send)
+	} else {
+		handler = newSingleContextMapper(endOffset, mapResponseBatchSize, stream.Send)
+	}
 
 	for currentOffset < endOffset {
 		select {
@@ -201,27 +327,29 @@ func (c *NBDClient) Map(req *nbdv1.MapRequest, stream nbdv1.NBD_MapServer) error
 		default:
 		}
 		prevOffset := currentOffset
-		err := l.BlockStatus64(endOffset-currentOffset, currentOffset,
+		if err := l.BlockStatus64(endOffset-currentOffset, currentOffset,
 			func(metacontext string, offset uint64, entries []libnbd.LibnbdExtent, nbdErr *int) int {
-				maxOffset, err := builder.HandleExtents(metacontext, offset, entries)
+				maxOff, err := handler.HandleExtents(metacontext, offset, entries)
 				if err != nil {
 					*nbdErr = 1
 					return -1
 				}
-				if maxOffset > currentOffset {
-					currentOffset = maxOffset
+				if maxOff > currentOffset {
+					currentOffset = maxOff
 				}
 				return 0
-			}, nil)
-		if err != nil {
+			}, nil); err != nil {
 			return fmt.Errorf("BlockStatus64 at offset %d: %w", prevOffset, err)
 		}
+		if err := handler.Merge(); err != nil {
+			return err
+		}
 		if currentOffset <= prevOffset {
-			return fmt.Errorf("BlockStatus64 returned no forward progress at offset %d for context %s", prevOffset, requestedContext)
+			return fmt.Errorf("BlockStatus64 returned no forward progress at offset %d", prevOffset)
 		}
 	}
 
-	return builder.FlushAll()
+	return handler.Flush()
 }
 
 type readChunk struct {
@@ -315,32 +443,34 @@ func (c *NBDClient) connect(l *libnbd.Libnbd, exportName string) error {
 	return nil
 }
 
-func getExtentDescription(metacontext string, flags uint64) string {
-	if metacontext == libnbd.CONTEXT_BASE_ALLOCATION {
-		switch flags {
-		case 0:
-			return "data"
-		case uint64(libnbd.STATE_HOLE):
-			return "hole"
-		case uint64(libnbd.STATE_ZERO):
-			return "zero"
-		case uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO):
-			return "hole,zero"
-		default:
-			return "unknown"
-		}
+func allocDescription(flags uint64) string {
+	switch flags {
+	case 0:
+		return "data"
+	case uint64(libnbd.STATE_HOLE):
+		return "hole"
+	case uint64(libnbd.STATE_ZERO):
+		return "zero"
+	case uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO):
+		return "hole,zero"
+	default:
+		return "unknown"
 	}
-	if strings.HasPrefix(metacontext, libnbd.CONTEXT_QEMU_DIRTY_BITMAP) {
-		switch flags {
-		case 0:
-			return "clean"
-		case uint64(libnbd.STATE_DIRTY):
-			return "dirty"
-		default:
-			return "unknown"
-		}
+}
+
+func mergedDescription(flags uint64) string {
+	switch flags {
+	case 0:
+		return "clean"
+	case uint64(libnbd.STATE_DIRTY):
+		return "dirty"
+	case uint64(libnbd.STATE_ZERO):
+		return "zero"
+	case uint64(libnbd.STATE_DIRTY) | uint64(libnbd.STATE_ZERO):
+		return "dirty,zero"
+	default:
+		return "unknown"
 	}
-	return "unknown"
 }
 
 func resolveRange(offset, length, size uint64) (uint64, uint64, error) {

--- a/pkg/storage/nbdclient/nbdclient_test.go
+++ b/pkg/storage/nbdclient/nbdclient_test.go
@@ -31,12 +31,10 @@ import (
 )
 
 var _ = Describe("NBDClient", func() {
-	Context("getExtentDescription", func() {
-		const bitmap = libnbd.CONTEXT_QEMU_DIRTY_BITMAP + "checkpoint"
-
-		DescribeTable("base:allocation",
+	Context("allocDescription", func() {
+		DescribeTable("should return correct description",
 			func(flags uint64, expected string) {
-				Expect(getExtentDescription(libnbd.CONTEXT_BASE_ALLOCATION, flags)).To(Equal(expected))
+				Expect(allocDescription(flags)).To(Equal(expected))
 			},
 			Entry("data", uint64(0), "data"),
 			Entry("hole", uint64(libnbd.STATE_HOLE), "hole"),
@@ -44,19 +42,19 @@ var _ = Describe("NBDClient", func() {
 			Entry("hole,zero", uint64(libnbd.STATE_HOLE|libnbd.STATE_ZERO), "hole,zero"),
 			Entry("unknown flags", uint64(99), "unknown"),
 		)
+	})
 
-		DescribeTable("qemu:dirty-bitmap",
+	Context("mergedDescription", func() {
+		DescribeTable("should return correct description",
 			func(flags uint64, expected string) {
-				Expect(getExtentDescription(bitmap, flags)).To(Equal(expected))
+				Expect(mergedDescription(flags)).To(Equal(expected))
 			},
 			Entry("clean", uint64(0), "clean"),
 			Entry("dirty", uint64(libnbd.STATE_DIRTY), "dirty"),
-			Entry("unknown flags", uint64(3), "unknown"),
+			Entry("zero", uint64(libnbd.STATE_ZERO), "zero"),
+			Entry("dirty,zero", uint64(libnbd.STATE_DIRTY)|uint64(libnbd.STATE_ZERO), "dirty,zero"),
+			Entry("unknown flags", uint64(99), "unknown"),
 		)
-
-		It("returns unknown for an unrecognised metacontext", func() {
-			Expect(getExtentDescription("some:other:context", 0)).To(Equal("unknown"))
-		})
 	})
 
 	Context("clampLength", func() {
@@ -120,21 +118,10 @@ var _ = Describe("NBDClient", func() {
 		})
 	})
 
-	Context("sortedContextsByOffset", func() {
-		It("should return contexts ordered by their extent offset ascending", func() {
-			extents := map[string]*nbdv1.Extent{
-				"ext-c": {Offset: 300},
-				"ext-a": {Offset: 100},
-				"ext-b": {Offset: 200},
-			}
-			Expect(sortedContextsByOffset(extents)).To(Equal([]string{"ext-a", "ext-b", "ext-c"}))
-		})
-	})
-
-	Context("mapBuilder", func() {
+	Context("singleContextMapper", func() {
 		var (
 			sent    []*nbdv1.MapResponse
-			builder *mapBuilder
+			builder *singleContextMapper
 		)
 
 		sendFn := func(r *nbdv1.MapResponse) error {
@@ -150,7 +137,7 @@ var _ = Describe("NBDClient", func() {
 
 		Context("HandleExtents and coalescing", func() {
 			It("should coalesce adjacent extents with the same flags", func() {
-				builder = newMapBuilder(1024, 512, sendFn)
+				builder = newSingleContextMapper(1024, 512, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				_, err := builder.HandleExtents(ctx, 0, []libnbd.LibnbdExtent{
@@ -160,13 +147,13 @@ var _ = Describe("NBDClient", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(builder.batch).To(BeEmpty(), "coalesced extent should not be flushed yet")
 
-				Expect(builder.FlushAll()).To(Succeed())
+				Expect(builder.Flush()).To(Succeed())
 				Expect(sent).To(HaveLen(1))
 				Expect(sent[0].Extents[0].Length).To(Equal(uint64(512)))
 			})
 
 			It("should not coalesce adjacent extents with different flags", func() {
-				builder = newMapBuilder(1024, 512, sendFn)
+				builder = newSingleContextMapper(1024, 512, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				_, err := builder.HandleExtents(ctx, 0, []libnbd.LibnbdExtent{
@@ -175,7 +162,7 @@ var _ = Describe("NBDClient", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(builder.FlushAll()).To(Succeed())
+				Expect(builder.Flush()).To(Succeed())
 				Expect(sent).To(HaveLen(1))
 				Expect(sent[0].Extents).To(HaveLen(2))
 				Expect(sent[0].Extents[0].Flags).To(Equal(uint64(0)))
@@ -183,7 +170,7 @@ var _ = Describe("NBDClient", func() {
 			})
 
 			It("should clip extents that extend beyond endOffset", func() {
-				builder = newMapBuilder(300, 512, sendFn)
+				builder = newSingleContextMapper(300, 512, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				_, err := builder.HandleExtents(ctx, 0, []libnbd.LibnbdExtent{
@@ -191,24 +178,24 @@ var _ = Describe("NBDClient", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(builder.FlushAll()).To(Succeed())
+				Expect(builder.Flush()).To(Succeed())
 				Expect(sent[0].Extents[0].Length).To(Equal(uint64(300)))
 			})
 
 			It("should skip zero-length extents after clipping", func() {
-				builder = newMapBuilder(256, 512, sendFn)
+				builder = newSingleContextMapper(256, 512, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				_, err := builder.HandleExtents(ctx, 256, []libnbd.LibnbdExtent{
 					{Length: 128, Flags: 0},
 				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(builder.FlushAll()).To(Succeed())
+				Expect(builder.Flush()).To(Succeed())
 				Expect(sent).To(BeEmpty())
 			})
 
 			It("should return the highest offset advanced by entries", func() {
-				builder = newMapBuilder(1024, 512, sendFn)
+				builder = newSingleContextMapper(1024, 512, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				maxOffset, err := builder.HandleExtents(ctx, 0, []libnbd.LibnbdExtent{
@@ -221,8 +208,8 @@ var _ = Describe("NBDClient", func() {
 		})
 
 		Context("Flush and batching", func() {
-			It("should send a batch when batchSize is reached", func() {
-				builder = newMapBuilder(4096, 2, sendFn)
+			It("should send a batch when batchSize is reached and flush the trailing extent", func() {
+				builder = newSingleContextMapper(4096, 2, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				_, err := builder.HandleExtents(ctx, 0, []libnbd.LibnbdExtent{
@@ -233,30 +220,35 @@ var _ = Describe("NBDClient", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(sent).To(HaveLen(1), "one batch should already have been sent")
 				Expect(sent[0].Extents).To(HaveLen(2))
+
+				Expect(builder.Flush()).To(Succeed())
+				Expect(sent).To(HaveLen(2), "trailing extent should be flushed")
+				Expect(sent[1].Extents).To(HaveLen(1))
+				Expect(sent[1].Extents[0].Flags).To(Equal(uint64(libnbd.STATE_ZERO)))
 			})
 
 			It("should be a no-op when the batch is empty", func() {
-				builder = newMapBuilder(1024, 512, sendFn)
+				builder = newSingleContextMapper(1024, 512, sendFn)
 				Expect(builder.Flush()).To(Succeed())
 				Expect(sent).To(BeEmpty())
 			})
 
 			It("should send remaining extents", func() {
-				builder = newMapBuilder(1024, 512, sendFn)
+				builder = newSingleContextMapper(1024, 512, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				_, err := builder.HandleExtents(ctx, 0, []libnbd.LibnbdExtent{
 					{Length: 512, Flags: 0},
 				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(sent).To(BeEmpty(), "nothing sent before FlushAll")
+				Expect(sent).To(BeEmpty(), "nothing sent before Flush")
 
-				Expect(builder.FlushAll()).To(Succeed())
+				Expect(builder.Flush()).To(Succeed())
 				Expect(sent).To(HaveLen(1))
 			})
 
 			It("should set NextOffset to end of last extent in the batch", func() {
-				builder = newMapBuilder(1024, 512, sendFn)
+				builder = newSingleContextMapper(1024, 512, sendFn)
 				ctx := libnbd.CONTEXT_BASE_ALLOCATION
 
 				_, err := builder.HandleExtents(ctx, 0, []libnbd.LibnbdExtent{
@@ -265,8 +257,301 @@ var _ = Describe("NBDClient", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(builder.FlushAll()).To(Succeed())
+				Expect(builder.Flush()).To(Succeed())
 				Expect(sent[0].NextOffset).To(Equal(uint64(768)))
+			})
+		})
+	})
+
+	Context("mergedContextMapper", func() {
+		var (
+			sent   []*nbdv1.MapResponse
+			merger *mergedContextMapper
+		)
+
+		mergeSendFn := func(r *nbdv1.MapResponse) error {
+			extCopy := make([]*nbdv1.Extent, len(r.Extents))
+			copy(extCopy, r.Extents)
+			sent = append(sent, &nbdv1.MapResponse{Extents: extCopy, NextOffset: r.NextOffset})
+			return nil
+		}
+
+		BeforeEach(func() {
+			sent = nil
+		})
+
+		allExtents := func() []*nbdv1.Extent {
+			var result []*nbdv1.Extent
+			for _, r := range sent {
+				result = append(result, r.Extents...)
+			}
+			return result
+		}
+
+		Context("HandleExtents", func() {
+			It("should buffer allocation extents separately from dirty extents", func() {
+				merger = newMergedContextMapper(1024, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 512, Flags: 0},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 512, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(merger.allocExtents).To(HaveLen(1))
+				Expect(merger.dirtyExtents).To(HaveLen(1))
+			})
+
+			It("should clip extents beyond endOffset", func() {
+				merger = newMergedContextMapper(300, 512, mergeSendFn)
+
+				maxOff, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 512, Flags: 0},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(maxOff).To(Equal(uint64(300)))
+				Expect(merger.allocExtents[0].Length).To(Equal(uint64(300)))
+			})
+
+			It("should skip zero-length extents after clipping", func() {
+				merger = newMergedContextMapper(256, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 256, []libnbd.LibnbdExtent{
+					{Length: 128, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.allocExtents).To(BeEmpty())
+			})
+		})
+
+		Context("Merge", func() {
+			It("should merge aligned extents with combined flags", func() {
+				merger = newMergedContextMapper(1024, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 512, Flags: 0},
+					{Length: 512, Flags: uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 512, Flags: uint64(libnbd.STATE_DIRTY)},
+					{Length: 512, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(merger.Flush()).To(Succeed())
+
+				extents := allExtents()
+				Expect(extents).To(HaveLen(2))
+				Expect(extents[0].Flags).To(Equal(uint64(libnbd.STATE_DIRTY)))
+				Expect(extents[0].Description).To(Equal("dirty"))
+				Expect(extents[0].Length).To(Equal(uint64(512)))
+				Expect(extents[1].Flags).To(Equal(uint64(libnbd.STATE_DIRTY) | uint64(libnbd.STATE_ZERO)))
+				Expect(extents[1].Description).To(Equal("dirty,zero"))
+				Expect(extents[1].Length).To(Equal(uint64(512)))
+			})
+
+			It("should split at misaligned boundaries", func() {
+				merger = newMergedContextMapper(16384, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 8192, Flags: 0},
+					{Length: 8192, Flags: uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 16384, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(merger.Flush()).To(Succeed())
+
+				extents := allExtents()
+				Expect(extents).To(HaveLen(2))
+				Expect(extents[0].Offset).To(Equal(uint64(0)))
+				Expect(extents[0].Length).To(Equal(uint64(8192)))
+				Expect(extents[0].Flags).To(Equal(uint64(libnbd.STATE_DIRTY)))
+				Expect(extents[0].Description).To(Equal("dirty"))
+				Expect(extents[1].Offset).To(Equal(uint64(8192)))
+				Expect(extents[1].Length).To(Equal(uint64(8192)))
+				Expect(extents[1].Flags).To(Equal(uint64(libnbd.STATE_DIRTY) | uint64(libnbd.STATE_ZERO)))
+				Expect(extents[1].Description).To(Equal("dirty,zero"))
+			})
+
+			It("should coalesce adjacent merged extents with the same flags", func() {
+				merger = newMergedContextMapper(1024, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 256, Flags: 0},
+					{Length: 256, Flags: 0},
+					{Length: 512, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(merger.Flush()).To(Succeed())
+
+				extents := allExtents()
+				Expect(extents).To(HaveLen(1))
+				Expect(extents[0].Length).To(Equal(uint64(1024)))
+				Expect(extents[0].Flags).To(Equal(uint64(libnbd.STATE_DIRTY)))
+			})
+
+			It("should produce clean extents for non-dirty allocated data", func() {
+				merger = newMergedContextMapper(1024, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(merger.Flush()).To(Succeed())
+
+				extents := allExtents()
+				Expect(extents).To(HaveLen(1))
+				Expect(extents[0].Flags).To(Equal(uint64(0)))
+				Expect(extents[0].Description).To(Equal("clean"))
+			})
+
+			It("should produce zero extents for non-dirty holes", func() {
+				merger = newMergedContextMapper(1024, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(merger.Flush()).To(Succeed())
+
+				extents := allExtents()
+				Expect(extents).To(HaveLen(1))
+				Expect(extents[0].Flags).To(Equal(uint64(libnbd.STATE_ZERO)))
+				Expect(extents[0].Description).To(Equal("zero"))
+			})
+
+			It("should correctly handle a block discard", func() {
+				merger = newMergedContextMapper(32768, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 4096, Flags: 0},
+					{Length: 24576, Flags: uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO)},
+					{Length: 4096, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 32768, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(merger.Flush()).To(Succeed())
+
+				extents := allExtents()
+				Expect(extents).To(HaveLen(3))
+
+				Expect(extents[0].Offset).To(Equal(uint64(0)))
+				Expect(extents[0].Length).To(Equal(uint64(4096)))
+				Expect(extents[0].Description).To(Equal("dirty"))
+
+				Expect(extents[1].Offset).To(Equal(uint64(4096)))
+				Expect(extents[1].Length).To(Equal(uint64(24576)))
+				Expect(extents[1].Description).To(Equal("dirty,zero"))
+
+				Expect(extents[2].Offset).To(Equal(uint64(28672)))
+				Expect(extents[2].Length).To(Equal(uint64(4096)))
+				Expect(extents[2].Description).To(Equal("dirty"))
+			})
+
+			It("should trigger batch send when batchSize is reached", func() {
+				merger = newMergedContextMapper(4096, 2, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: 0},
+					{Length: 1024, Flags: uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO)},
+					{Length: 1024, Flags: 0},
+					{Length: 1024, Flags: uint64(libnbd.STATE_HOLE | libnbd.STATE_ZERO)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 4096, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(sent).To(HaveLen(1), "one batch should have been sent mid-merge")
+				Expect(sent[0].Extents).To(HaveLen(2))
+
+				Expect(merger.Flush()).To(Succeed())
+				extents := allExtents()
+				Expect(extents).To(HaveLen(4))
+			})
+
+			It("should be a no-op when one context is empty", func() {
+				merger = newMergedContextMapper(1024, 512, mergeSendFn)
+
+				merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: 0},
+				})
+
+				Expect(merger.Merge()).To(Succeed())
+				Expect(merger.Flush()).To(Succeed())
+				Expect(sent).To(BeEmpty())
+			})
+
+			It("should be a no-op when both contexts are empty", func() {
+				merger = newMergedContextMapper(1024, 512, mergeSendFn)
+				Expect(merger.Merge()).To(Succeed())
+			})
+
+			It("should handle multiple Merge calls with coalescing across calls", func() {
+				merger = newMergedContextMapper(2048, 512, mergeSendFn)
+
+				_, err := merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 0, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(merger.Merge()).To(Succeed())
+
+				_, err = merger.HandleExtents(libnbd.CONTEXT_BASE_ALLOCATION, 1024, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: 0},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = merger.HandleExtents(libnbd.CONTEXT_QEMU_DIRTY_BITMAP+"checkpoint", 1024, []libnbd.LibnbdExtent{
+					{Length: 1024, Flags: uint64(libnbd.STATE_DIRTY)},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(merger.Merge()).To(Succeed())
+
+				Expect(merger.Flush()).To(Succeed())
+
+				extents := allExtents()
+				Expect(extents).To(HaveLen(1))
+				Expect(extents[0].Length).To(Equal(uint64(2048)))
+				Expect(extents[0].Description).To(Equal("dirty"))
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
QEMU marks discarded blocks as dirty in the checkpoint bitmap. Previously, the `Map()` endpoint queried only a single metadata context so these trimmed blocks appeared as regular dirty extents which caused incremental backups to transfer an additional amount of zeros.

#### After this PR:
This PR registers both `base:allocation` and `qemu:dirty-bitmap` contexts for incremental backups. It introduces `mergedContextMapper` which buffers both contexts' extents per `BlockStatus64` call, then merges them inline using a two-pointer walk with flag remapping (allocation hole/zero collapsed to bit 1, dirty stays on bit 0). The merged output distinguishes clean (0), dirty (1), zero (2), and dirty,zero (3).

Additionally extracted shared batching and coalescing logic into `extentBatcher`.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- Fixes https://redhat.atlassian.net/browse/CNV-88844
- Fixes https://github.com/kubevirt/kubevirt/issues/17963

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Incremental backups now distinguish discarded blocks from data changes by merging base:allocation and qemu:dirty-bitmap contexts, reducing transfer size by skipping dirty extents that read as zero.
```

