### PR TITLE
monitoring: self-diagnosing Virt*Down alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -33,12 +33,13 @@ tests:
       - eval_time: 8m
         alertname: VirtHandlerDown
         exp_alerts: [ ]
-      # it must trigger when there is no data
+      # it must trigger when there is no data (fallback branch — no pods exist)
       - eval_time: 10m
         alertname: VirtAPIDown
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-api pods were detected for the last 10 min."
+              description: "No running virt-api pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
@@ -51,6 +52,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-controller was detected for the last 10 min."
+              description: "No running virt-controller pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
@@ -63,6 +65,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-operator pods were detected for the last 10 min."
+              description: "No running virt-operator pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
@@ -75,6 +78,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-handler pods were detected for the last 10 min."
+              description: "No running virt-handler pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
             exp_labels:
               severity: "critical"
@@ -82,12 +86,13 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
-      # it must trigger when operators are not healthy
+      # it must trigger when operators are not healthy (fallback branch — phase=0, no waiting reason)
       - eval_time: 16m
         alertname: VirtAPIDown
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-api pods were detected for the last 10 min."
+              description: "No running virt-api pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
@@ -100,6 +105,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-controller was detected for the last 10 min."
+              description: "No running virt-controller pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
@@ -112,6 +118,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-operator pods were detected for the last 10 min."
+              description: "No running virt-operator pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
@@ -124,6 +131,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-handler pods were detected for the last 10 min."
+              description: "No running virt-handler pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
             exp_labels:
               severity: "critical"
@@ -142,6 +150,227 @@ tests:
         alertname: VirtOperatorDown
         exp_alerts: [ ]
       - eval_time: 17m
+        alertname: VirtHandlerDown
+        exp_alerts: [ ]
+
+  # Virt*Down self-diagnosing: pods in Pending with ImagePullBackOff (withReason branch)
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-api-1", container="virt-api", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-handler-1", container="virt-handler", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-1", node="node01"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: VirtAPIDown
+        exp_alerts: [ ]
+      - eval_time: 8m
+        alertname: VirtHandlerDown
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-api pods were detected for the last 10 min."
+              description: "Pod virt-api-1 is unhealthy (reason: ImagePullBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-api-1"
+              reason: "ImagePullBackOff"
+      - eval_time: 10m
+        alertname: VirtHandlerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-handler pods were detected for the last 10 min."
+              description: "Pod virt-handler-1 on node node01 is unhealthy (reason: ImagePullBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-handler-1"
+              reason: "ImagePullBackOff"
+              node: "node01"
+
+  # Virt*Down: CrashLoopBackOff with pod phase=Running — alert must still fire
+  # A container in CrashLoopBackOff is non-functional regardless of pod phase.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-controller-1", container="virt-controller", reason="CrashLoopBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: VirtControllerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-controller was detected for the last 10 min."
+              description: "Pod virt-controller-1 is unhealthy (reason: CrashLoopBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-controller-1"
+              reason: "CrashLoopBackOff"
+
+  # Virt*Down: multi-reason dedup — topk(1) picks exactly one reason per pod.
+  # ErrImagePull and ImagePullBackOff are the same root cause at different retry
+  # stages; firing two alerts for the same pod would cause alert fatigue.
+  # ErrImagePull has a higher value (2 vs 1) so topk deterministically selects it.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-operator-1", container="virt-operator", reason="ErrImagePull"}'
+        values: "2 2 2 2 2 2 2 2 2 2 2 2 2 2 2"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-operator-1", container="virt-operator", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: VirtOperatorDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-operator pods were detected for the last 10 min."
+              description: "Pod virt-operator-1 is unhealthy (reason: ErrImagePull)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-operator-1"
+              reason: "ErrImagePull"
+
+  # Virt*Down: pod in Failed phase with waiting_reason (fix #6/#7 — no gap)
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Failed"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-api-1", container="virt-api", reason="CrashLoopBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      # Pod is Failed, has waiting_reason — withReason branch should fire (not suppressed)
+      - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-api pods were detected for the last 10 min."
+              description: "Pod virt-api-1 is unhealthy (reason: CrashLoopBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-api-1"
+              reason: "CrashLoopBackOff"
+
+  # Virt*Down: pod in Failed phase without waiting_reason (fallback fires)
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Failed"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      # Pod is Failed, no waiting_reason — fallback should fire
+      - eval_time: 10m
+        alertname: VirtControllerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-controller was detected for the last 10 min."
+              description: "No running virt-controller pods detected and no container waiting reasons reported."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+
+  # Virt*Down: alert resolves when waiting_reason disappears and pod becomes Running.
+  # The waiting_reason series is present for 12m, then absent (value 0) from 12m onward
+  # while the pod transitions to Running.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-api-1", container="virt-api", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      # Alert fires while pod is Pending+ImagePullBackOff
+      - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-api pods were detected for the last 10 min."
+              description: "Pod virt-api-1 is unhealthy (reason: ImagePullBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-api-1"
+              reason: "ImagePullBackOff"
+      # Alert resolves after pod transitions to Running and waiting_reason drops to 0
+      - eval_time: 22m
+        alertname: VirtAPIDown
+        exp_alerts: [ ]
+
+  # Virt*Down: happy path — all components Running, no waiting reasons.
+  # No Virt*Down alert should fire.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: VirtAPIDown
+        exp_alerts: [ ]
+      - eval_time: 12m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
+      - eval_time: 12m
+        alertname: VirtOperatorDown
+        exp_alerts: [ ]
+      - eval_time: 12m
         alertname: VirtHandlerDown
         exp_alerts: [ ]
 
@@ -250,6 +479,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt controllers are running but not ready."
+              description: "virt-controller pod virt-controller-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtControllersCount"
             exp_labels:
               severity: "warning"
@@ -257,6 +487,7 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-controller-2"
 
   # Some virt operators are not ready
   - interval: 1m
@@ -280,6 +511,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt-operators are running but not ready."
+              description: "virt-operator pod virt-operator-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtOperatorsCount"
             exp_labels:
               severity: "warning"
@@ -287,6 +519,7 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-operator-2"
 
   # Some virt-api pods are not ready
   - interval: 1m
@@ -310,6 +543,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt-api pods are running but not ready."
+              description: "virt-api pod virt-api-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtAPICount"
             exp_labels:
               severity: "warning"
@@ -317,6 +551,7 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-api-2"
 
   # All virt-api are not ready
   - interval: 1m
@@ -363,6 +598,10 @@ tests:
         values: '1+0x11'
       - series: 'kube_pod_status_ready{namespace="ci", pod="virt-handler-2", condition="true"}'
         values: '0+0x11'
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-1", node="node-1"}'
+        values: '1+0x11'
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-2", node="node-2"}'
+        values: '1+0x11'
 
     alert_rule_test:
       - eval_time: 10m
@@ -370,6 +609,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt-handlers are running but not ready."
+              description: "virt-handler pod virt-handler-2 on node node-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtHandlerCount"
             exp_labels:
               severity: "warning"
@@ -377,6 +617,8 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-handler-2"
+              node: "node-2"
 
   # All virt-handlers are not ready
   - interval: 1m
@@ -439,29 +681,16 @@ tests:
         alertname: LowReadyVirtControllersCount
         exp_alerts: [ ]
 
-  # All virt controllers are not ready (ImagePullBackOff)
+  # All virt controllers are not ready (ImagePullBackOff) - stale metrics must NOT trigger false positive
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_controller_ready_status{namespace="ci", pod="virt-controller-1"}'
         values: "stale stale stale stale stale stale stale stale stale stale"
 
     alert_rule_test:
-      # no alert before 10 minutes
-      - eval_time: 9m
-        alertname: NoReadyVirtController
-        exp_alerts: [ ]
       - eval_time: 10m
         alertname: NoReadyVirtController
-        exp_alerts:
-          - exp_annotations:
-              summary: "No ready virt-controller was detected for the last 10 min."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
-            exp_labels:
-              severity: "critical"
-              operator_health_impact: "critical"
-              kubernetes_operator_part_of: "kubevirt"
-              kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
+        exp_alerts: [ ]
 
   # No virt-controller is leading
   - interval: 1m
@@ -585,7 +814,7 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
 
-  # All virt operators are not ready (ImagePullBackOff)
+  # All virt operators are not ready (ImagePullBackOff) - stale metrics must NOT trigger false positive
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_operator_ready_status{namespace="ci", pod="virt-operator-1"}'
@@ -594,29 +823,16 @@ tests:
         values: "stale stale stale stale stale stale stale stale stale stale"
 
     alert_rule_test:
-      # no alert before 10 minutes
-      - eval_time: 9m
-        alertname: NoReadyVirtOperator
-        exp_alerts: [ ]
       - eval_time: 10m
         alertname: NoReadyVirtOperator
-        exp_alerts:
-          - exp_annotations:
-              summary: "No ready virt-operator was detected for the last 10 min."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
-            exp_labels:
-              severity: "critical"
-              operator_health_impact: "critical"
-              kubernetes_operator_part_of: "kubevirt"
-              kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
+        exp_alerts: [ ]
 
   # All virt operators are not ready
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_operator_ready_status{namespace="ci", pod="virt-operator-1"}'
         values: "0x10"
-      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1"}'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1", condition="true"}'
         values: "0x10"
       - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
         values: "1x10"
@@ -647,7 +863,7 @@ tests:
     input_series:
       - series: 'kubevirt_virt_operator_ready_status{namespace="ci", pod="virt-operator-1"}'
         values: "0x10"
-      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1"}'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1", condition="true"}'
         values: "1x10"
       - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
         values: "1x10"
@@ -718,6 +934,40 @@ tests:
         alertname: NoReadyVirtOperator
         exp_alerts: [ ]
 
+
+  # Absent ready_status metric (e.g. scrape failure) must NOT trigger false positive
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-handler-1", condition="true"}'
+        values: '1+0x11'
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-1", node="node-1"}'
+        values: '1+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NoReadyVirtHandler
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: LowReadyVirtHandlerCount
+        exp_alerts: [ ]
+
+  # Absent ready_status for virt-api must NOT trigger false positive
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-api-1", condition="true"}'
+        values: '1+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NoReadyVirtAPI
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: LowReadyVirtAPICount
+        exp_alerts: [ ]
 
   # Burst REST errors
   # values: '0+10x20' == values: "0 10 20 30 40 ... 190"
@@ -1103,9 +1353,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
       # has kvm allocatable and schedulable label
       - eval_time: 7m
@@ -1122,9 +1372,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
   - interval: 1m
     input_series:
@@ -1148,9 +1398,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
       # has schedulable label and emulation enabled
       - eval_time: 8m
@@ -1167,9 +1417,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
   # Test case: node has schedulable label but is unschedulable
   - interval: 1m
@@ -1194,9 +1444,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
   # Deprecated APIs being requested.
   - interval: 1m

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -33,12 +33,13 @@ tests:
       - eval_time: 8m
         alertname: VirtHandlerDown
         exp_alerts: [ ]
-      # it must trigger when there is no data
+      # it must trigger when there is no data (fallback branch — no pods exist)
       - eval_time: 10m
         alertname: VirtAPIDown
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-api pods were detected for the last 10 min."
+              description: "No running virt-api pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
@@ -51,6 +52,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-controller was detected for the last 10 min."
+              description: "No running virt-controller pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
@@ -63,6 +65,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-operator pods were detected for the last 10 min."
+              description: "No running virt-operator pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
@@ -75,6 +78,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-handler pods were detected for the last 10 min."
+              description: "No running virt-handler pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
             exp_labels:
               severity: "critical"
@@ -92,12 +96,13 @@ tests:
       - eval_time: 10m
         alertname: NoReadyVirtHandler
         exp_alerts: [ ]
-      # it must trigger when operators are not healthy
+      # it must trigger when operators are not healthy (fallback branch — phase=0, no waiting reason)
       - eval_time: 16m
         alertname: VirtAPIDown
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-api pods were detected for the last 10 min."
+              description: "No running virt-api pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
@@ -110,6 +115,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-controller was detected for the last 10 min."
+              description: "No running virt-controller pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
@@ -122,6 +128,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-operator pods were detected for the last 10 min."
+              description: "No running virt-operator pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
@@ -134,6 +141,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-handler pods were detected for the last 10 min."
+              description: "No running virt-handler pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
             exp_labels:
               severity: "critical"
@@ -161,6 +169,261 @@ tests:
         alertname: VirtOperatorDown
         exp_alerts: [ ]
       - eval_time: 17m
+        alertname: VirtHandlerDown
+        exp_alerts: [ ]
+
+  # Virt*Down self-diagnosing: pods in Pending with ImagePullBackOff (withReason branch)
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-api-1", container="virt-api", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-handler-1", container="virt-handler", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-1", node="node01"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: VirtAPIDown
+        exp_alerts: [ ]
+      - eval_time: 8m
+        alertname: VirtHandlerDown
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-api pods were detected for the last 10 min."
+              description: "Pod virt-api-1 is unhealthy (reason: ImagePullBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-api-1"
+              reason: "ImagePullBackOff"
+      - eval_time: 10m
+        alertname: VirtHandlerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-handler pods were detected for the last 10 min."
+              description: "Pod virt-handler-1 on node node01 is unhealthy (reason: ImagePullBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-handler-1"
+              reason: "ImagePullBackOff"
+              node: "node01"
+
+  # Virt*Down: CrashLoopBackOff with pod phase=Running — alert must still fire
+  # A container in CrashLoopBackOff is non-functional regardless of pod phase.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-controller-1", container="virt-controller", reason="CrashLoopBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: VirtControllerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-controller was detected for the last 10 min."
+              description: "Pod virt-controller-1 is unhealthy (reason: CrashLoopBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-controller-1"
+              reason: "CrashLoopBackOff"
+
+  # Virt*Down must NOT fire when a healthy ready peer remains.
+  # Partial failure belongs to LowReadyVirt*Count (warning), not Virt*Down.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-api-1", container="virt-api", reason="CrashLoopBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kubevirt_virt_api_ready_status{namespace="ci", pod="virt-api-1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-2", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kubevirt_virt_api_ready_status{namespace="ci", pod="virt-api-2"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: LowReadyVirtAPICount
+        exp_alerts:
+          - exp_annotations:
+              summary: "Some virt-api pods are running but not ready."
+              description: "virt-api pod virt-api-1 has been running but not ready for more than 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtAPICount"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-api-1"
+
+  # Virt*Down: multi-reason dedup — topk(1) picks exactly one reason per pod.
+  # ErrImagePull and ImagePullBackOff are the same root cause at different retry
+  # stages; firing two alerts for the same pod would cause alert fatigue.
+  # ErrImagePull has a higher value (2 vs 1) so topk deterministically selects it.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-operator-1", container="virt-operator", reason="ErrImagePull"}'
+        values: "2 2 2 2 2 2 2 2 2 2 2 2 2 2 2"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-operator-1", container="virt-operator", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: VirtOperatorDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-operator pods were detected for the last 10 min."
+              description: "Pod virt-operator-1 is unhealthy (reason: ErrImagePull)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-operator-1"
+              reason: "ErrImagePull"
+
+  # Virt*Down: pod in Failed phase with waiting_reason (fix #6/#7 — no gap)
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Failed"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-api-1", container="virt-api", reason="CrashLoopBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      # Pod is Failed, has waiting_reason — withReason branch should fire (not suppressed)
+      - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-api pods were detected for the last 10 min."
+              description: "Pod virt-api-1 is unhealthy (reason: CrashLoopBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-api-1"
+              reason: "CrashLoopBackOff"
+
+  # Virt*Down: pod in Failed phase without waiting_reason (fallback fires)
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Failed"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      # Pod is Failed, no waiting_reason — fallback should fire
+      - eval_time: 10m
+        alertname: VirtControllerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-controller was detected for the last 10 min."
+              description: "No running virt-controller pods detected and no container waiting reasons reported."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+
+  # Virt*Down: alert resolves when waiting_reason disappears and pod becomes Running.
+  # The waiting_reason series is present for 12m, then absent (value 0) from 12m onward
+  # while the pod transitions to Running.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Pending"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_container_status_waiting_reason{namespace="ci", pod="virt-api-1", container="virt-api", reason="ImagePullBackOff"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      # Alert fires while pod is Pending+ImagePullBackOff
+      - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-api pods were detected for the last 10 min."
+              description: "Pod virt-api-1 is unhealthy (reason: ImagePullBackOff)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+              pod: "virt-api-1"
+              reason: "ImagePullBackOff"
+      # Alert resolves after pod transitions to Running and waiting_reason drops to 0
+      - eval_time: 22m
+        alertname: VirtAPIDown
+        exp_alerts: [ ]
+
+  # Virt*Down: happy path — all components Running, no waiting reasons.
+  # No Virt*Down alert should fire.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: VirtAPIDown
+        exp_alerts: [ ]
+      - eval_time: 12m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
+      - eval_time: 12m
+        alertname: VirtOperatorDown
+        exp_alerts: [ ]
+      - eval_time: 12m
         alertname: VirtHandlerDown
         exp_alerts: [ ]
 
@@ -318,6 +581,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt controllers are running but not ready."
+              description: "virt-controller pod virt-controller-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtControllersCount"
             exp_labels:
               severity: "warning"
@@ -325,6 +589,7 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-controller-2"
 
   # Some virt operators are not ready
   - interval: 1m
@@ -348,6 +613,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt-operators are running but not ready."
+              description: "virt-operator pod virt-operator-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtOperatorsCount"
             exp_labels:
               severity: "warning"
@@ -355,6 +621,7 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-operator-2"
 
   # Some virt-api pods are not ready
   - interval: 1m
@@ -378,6 +645,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt-api pods are running but not ready."
+              description: "virt-api pod virt-api-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtAPICount"
             exp_labels:
               severity: "warning"
@@ -385,6 +653,7 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-api-2"
 
   # All virt-api are not ready
   - interval: 1m
@@ -434,6 +703,10 @@ tests:
         values: '1+0x11'
       - series: 'kube_pod_status_ready{namespace="ci", pod="virt-handler-2", condition="true"}'
         values: '0+0x11'
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-1", node="node-1"}'
+        values: '1+0x11'
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-2", node="node-2"}'
+        values: '1+0x11'
 
     alert_rule_test:
       - eval_time: 10m
@@ -441,6 +714,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt-handlers are running but not ready."
+              description: "virt-handler pod virt-handler-2 on node node-2 has been running but not ready for more than 10 minutes."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtHandlerCount"
             exp_labels:
               severity: "warning"
@@ -448,6 +722,8 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+              pod: "virt-handler-2"
+              node: "node-2"
 
   # All virt-handlers are not ready
   - interval: 1m
@@ -537,6 +813,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-controller was detected for the last 10 min."
+              description: "No running virt-controller pods detected and no container waiting reasons reported."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
@@ -667,7 +944,7 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
 
-  # All virt operators are not ready (ImagePullBackOff)
+  # All virt operators are not ready (ImagePullBackOff) - stale metrics must NOT trigger false positive
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_operator_ready_status{namespace="ci", pod="virt-operator-1"}'
@@ -676,29 +953,16 @@ tests:
         values: "stale stale stale stale stale stale stale stale stale stale"
 
     alert_rule_test:
-      # no alert before 10 minutes
-      - eval_time: 9m
-        alertname: NoReadyVirtOperator
-        exp_alerts: [ ]
       - eval_time: 10m
         alertname: NoReadyVirtOperator
-        exp_alerts:
-          - exp_annotations:
-              summary: "No ready virt-operator was detected for the last 10 min."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
-            exp_labels:
-              severity: "critical"
-              operator_health_impact: "critical"
-              kubernetes_operator_part_of: "kubevirt"
-              kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
+        exp_alerts: [ ]
 
   # All virt operators are not ready
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_operator_ready_status{namespace="ci", pod="virt-operator-1"}'
         values: "0x10"
-      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1"}'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1", condition="true"}'
         values: "0x10"
       - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
         values: "1x10"
@@ -729,7 +993,7 @@ tests:
     input_series:
       - series: 'kubevirt_virt_operator_ready_status{namespace="ci", pod="virt-operator-1"}'
         values: "0x10"
-      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1"}'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1", condition="true"}'
         values: "1x10"
       - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
         values: "1x10"
@@ -800,6 +1064,40 @@ tests:
         alertname: NoReadyVirtOperator
         exp_alerts: [ ]
 
+
+  # Absent ready_status metric (e.g. scrape failure) must NOT trigger false positive
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-handler-1", condition="true"}'
+        values: '1+0x11'
+      - series: 'kube_pod_info{namespace="ci", pod="virt-handler-1", node="node-1"}'
+        values: '1+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NoReadyVirtHandler
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: LowReadyVirtHandlerCount
+        exp_alerts: [ ]
+
+  # Absent ready_status for virt-api must NOT trigger false positive
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-api-1", condition="true"}'
+        values: '1+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NoReadyVirtAPI
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: LowReadyVirtAPICount
+        exp_alerts: [ ]
 
   # Burst REST errors
   # values: '0+10x20' == values: "0 10 20 30 40 ... 190"
@@ -1215,9 +1513,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
       # has kvm allocatable and schedulable label
       - eval_time: 7m
@@ -1234,9 +1532,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
   - interval: 1m
     input_series:
@@ -1260,9 +1558,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
       # has schedulable label and emulation enabled
       - eval_time: 8m
@@ -1279,9 +1577,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
   # Test case: node has schedulable label but is unschedulable
   - interval: 1m
@@ -1306,9 +1604,9 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
-              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+              namespace: "ci"
 
   # Deprecated APIs being requested.
   - interval: 1m

--- a/pkg/monitoring/rules/alerts/BUILD.bazel
+++ b/pkg/monitoring/rules/alerts/BUILD.bazel
@@ -1,8 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
+        "alert_expressions.go",
         "alerts.go",
         "system.go",
         "virt-api.go",
@@ -18,5 +19,18 @@ go_library(
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatorrules:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/utils/ptr:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "alert_expressions_test.go",
+        "alerts_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
     ],
 )

--- a/pkg/monitoring/rules/alerts/BUILD.bazel
+++ b/pkg/monitoring/rules/alerts/BUILD.bazel
@@ -1,8 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
+        "alert_expressions.go",
         "alerts.go",
         "system.go",
         "virt-api.go",
@@ -18,5 +19,20 @@ go_library(
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatorrules:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/utils/ptr:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "alert_expressions_test.go",
+        "alerts_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/monitoring/rules/alerts/alert_expressions.go
+++ b/pkg/monitoring/rules/alerts/alert_expressions.go
@@ -1,0 +1,148 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package alerts
+
+import "fmt"
+
+func lowReadyAlertExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"kubevirt_virt_%s_ready_status{namespace='%s'} == 0 "+
+			"and on(pod, namespace) "+
+			"kube_pod_status_phase{pod=~'virt-%s-.*', namespace='%s', phase='Running'} == 1 "+
+			"and on() "+
+			"count(kubevirt_virt_%s_ready_status{namespace='%s'} == 1) > 0",
+		component, namespace, component, namespace, component, namespace,
+	)
+}
+
+func lowReadyWithNodeAlertExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"(kubevirt_virt_%s_ready_status{namespace='%s'} == 0 "+
+			"and on(pod, namespace) "+
+			"kube_pod_status_phase{pod=~'virt-%s-.*', namespace='%s', phase='Running'} == 1) "+
+			"* on(pod, namespace) group_left(node) kube_pod_info{namespace='%s'} "+
+			"and on() "+
+			"count(kubevirt_virt_%s_ready_status{namespace='%s'} == 1) > 0",
+		component, namespace, component, namespace, namespace, component, namespace,
+	)
+}
+
+func noReadyAlertExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"count by (namespace) (kubevirt_virt_%s_ready_status{namespace='%s'}) > 0 "+
+			"unless on(namespace) "+
+			"count by (namespace) ("+
+			"kube_pod_status_ready{pod=~'virt-%s-.*', namespace='%s', condition='true'} "+
+			"* on(pod, namespace) "+
+			"kubevirt_virt_%s_ready_status{namespace='%s'} "+
+			"== 1"+
+			") > 0",
+		component, namespace, component, namespace, component, namespace,
+	)
+}
+
+// componentDownWithReasonExpr returns a per-pod expression that fires
+// when a virt-* container has a waiting reason (ImagePullBackOff,
+// CrashLoopBackOff, ErrImagePull, etc.).
+//
+// A container with a waiting reason is non-functional regardless of
+// pod phase — CrashLoopBackOff pods can have phase=Running while the
+// container restarts repeatedly. The metric only exists when a
+// container is genuinely in a waiting state, so no phase guard is
+// needed.
+//
+// Inner topk-by selects exactly one reason per pod, avoiding
+// duplicate alerts when kube-state-metrics reports multiple
+// reasons for the same failure (e.g. ErrImagePull + ImagePullBackOff).
+// When values tie, topk's selection is deterministic per series
+// fingerprint but not alphabetical. Outer max-by strips the
+// container label so it doesn't leak into alert routing or grouping.
+//
+// Filters on container='virt-<component>' to ignore init containers
+// and injected sidecars (e.g. service-mesh proxies).
+func componentDownWithReasonExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"max by(pod, namespace, reason) (topk by(pod, namespace) (1, "+
+			"kube_pod_container_status_waiting_reason"+
+			"{pod=~'virt-%s-.*', container='virt-%s', namespace='%s'} > 0))",
+		component, component, namespace,
+	)
+}
+
+// componentDownFallbackExpr returns an instant-vector expression that
+// fires when no virt-* pods are running AND the withReason branch
+// produced nothing (i.e. no waiting_reason metrics exist — pods are
+// entirely absent or haven't registered container status yet). Uses raw
+// metrics instead of recording rules to stay consistent with the
+// withReason branch.
+func componentDownFallbackExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"(count(kube_pod_status_phase{pod=~'virt-%s-.*', namespace='%s', phase='Running'} == 1) or vector(0)) == 0 "+
+			"unless on() "+
+			"(count(kube_pod_container_status_waiting_reason{pod=~'virt-%s-.*', container='virt-%s', namespace='%s'} > 0) > 0)",
+		component, namespace, component, component, namespace,
+	)
+}
+
+// componentDownExpr builds an expression for Virt*Down alerts.
+//
+// Branch 1 (diagnostic): any virt-* pod has a container in a
+// waiting state — fires per-pod with pod and reason labels.
+// Covers CrashLoopBackOff (even with pod phase=Running),
+// ImagePullBackOff, ErrImagePull, and any other waiting reason.
+//
+// Branch 2 (fallback): no pods are running AND branch 1 produced
+// nothing — covers pods entirely absent, or pods in Failed/Unknown
+// state without a waiting reason.
+//
+// The fallback suppresses itself whenever any waiting_reason metric
+// exists, so exactly one branch fires at a time.
+func componentDownExpr(namespace, component string) string {
+	return fmt.Sprintf("(%s) or (%s)",
+		componentDownWithReasonExpr(namespace, component),
+		componentDownFallbackExpr(namespace, component),
+	)
+}
+
+// daemonSetDownExpr is like componentDownExpr but also joins kube_pod_info
+// to include the node label, since virt-handler runs as a DaemonSet.
+func daemonSetDownExpr(namespace, component string) string {
+	withReason := fmt.Sprintf(
+		"(%s) * on(pod, namespace) group_left(node) kube_pod_info{namespace='%s'}",
+		componentDownWithReasonExpr(namespace, component), namespace,
+	)
+
+	return fmt.Sprintf("(%s) or (%s)",
+		withReason,
+		componentDownFallbackExpr(namespace, component),
+	)
+}
+
+func getErrorRatio(ns, podName, errorCodeRegex string, durationInMinutes int) string {
+	errorRatioQuery := "sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\",code=~\"%s\"} [%dm] ) )  / " +
+		" sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\"} [%dm] ) )"
+	return fmt.Sprintf(errorRatioQuery, ns, podName, errorCodeRegex, durationInMinutes, ns, podName, durationInMinutes)
+}
+
+func getRestCallsFailedWarning(failingCallsPercentage int, component string, durationInMinutes int) string {
+	duration := fmt.Sprintf("%d minutes", durationInMinutes)
+
+	const restCallsFailWarningTemplate = "More than %d%% of the rest calls failed in %s for the last %s"
+	return fmt.Sprintf(restCallsFailWarningTemplate, failingCallsPercentage, component, duration)
+}

--- a/pkg/monitoring/rules/alerts/alert_expressions.go
+++ b/pkg/monitoring/rules/alerts/alert_expressions.go
@@ -1,0 +1,160 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package alerts
+
+import "fmt"
+
+func lowReadyAlertExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"kubevirt_virt_%s_ready_status{namespace='%s'} == 0 "+
+			"and on(pod, namespace) "+
+			"kube_pod_status_phase{pod=~'virt-%s-.*', namespace='%s', phase='Running'} == 1 "+
+			"and on() "+
+			"count(kubevirt_virt_%s_ready_status{namespace='%s'} == 1) > 0",
+		component, namespace, component, namespace, component, namespace,
+	)
+}
+
+func lowReadyWithNodeAlertExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"(kubevirt_virt_%s_ready_status{namespace='%s'} == 0 "+
+			"and on(pod, namespace) "+
+			"kube_pod_status_phase{pod=~'virt-%s-.*', namespace='%s', phase='Running'} == 1) "+
+			"* on(pod, namespace) group_left(node) kube_pod_info{namespace='%s'} "+
+			"and on() "+
+			"count(kubevirt_virt_%s_ready_status{namespace='%s'} == 1) > 0",
+		component, namespace, component, namespace, namespace, component, namespace,
+	)
+}
+
+func noReadyAlertExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"count by (namespace) (kubevirt_virt_%s_ready_status{namespace='%s'}) > 0 "+
+			"unless on(namespace) "+
+			"count by (namespace) ("+
+			"kube_pod_status_ready{pod=~'virt-%s-.*', namespace='%s', condition='true'} "+
+			"* on(pod, namespace) "+
+			"kubevirt_virt_%s_ready_status{namespace='%s'} "+
+			"== 1"+
+			") > 0",
+		component, namespace, component, namespace, component, namespace,
+	)
+}
+
+// componentDownWithReasonExpr returns a per-pod expression that fires
+// when a virt-* container has a waiting reason (ImagePullBackOff,
+// CrashLoopBackOff, ErrImagePull, etc.) AND no ready peer remains for
+// the component.
+//
+// A container with a waiting reason is non-functional regardless of
+// pod phase — CrashLoopBackOff pods can have phase=Running while the
+// container restarts repeatedly. The metric only exists when a
+// container is genuinely in a waiting state, so no phase guard is
+// needed on the waiting-reason side.
+//
+// The ready-status gate keeps Virt*Down critical for total component
+// failure. A single crash-looping or image-pulling pod while peers are
+// still ready is covered by LowReadyVirt*Count (warning), not Virt*Down.
+//
+// Inner topk-by selects exactly one reason per pod, avoiding
+// duplicate alerts when kube-state-metrics reports multiple
+// reasons for the same failure (e.g. ErrImagePull + ImagePullBackOff).
+// When values tie, topk's selection is deterministic per series
+// fingerprint but not alphabetical. Outer max-by strips the
+// container label so it doesn't leak into alert routing or grouping.
+//
+// Filters on container='virt-<component>' to ignore init containers
+// and injected sidecars (e.g. service-mesh proxies).
+func componentDownWithReasonExpr(namespace, component string) string {
+	waitingReason := fmt.Sprintf(
+		"max by(pod, namespace, reason) (topk by(pod, namespace) (1, "+
+			"kube_pod_container_status_waiting_reason"+
+			"{pod=~'virt-%s-.*', container='virt-%s', namespace='%s'} > 0))",
+		component, component, namespace,
+	)
+	return fmt.Sprintf(
+		"(%s) and on() ((count(kubevirt_virt_%s_ready_status{namespace='%s'} == 1) or vector(0)) == 0)",
+		waitingReason, component, namespace,
+	)
+}
+
+// componentDownFallbackExpr returns an instant-vector expression that
+// fires when no virt-* pods are running AND the withReason branch
+// produced nothing (i.e. no waiting_reason metrics exist — pods are
+// entirely absent or haven't registered container status yet). Uses raw
+// metrics instead of recording rules to stay consistent with the
+// withReason branch.
+func componentDownFallbackExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"(count(kube_pod_status_phase{pod=~'virt-%s-.*', namespace='%s', phase='Running'} == 1) or vector(0)) == 0 "+
+			"unless on() "+
+			"(count(kube_pod_container_status_waiting_reason{pod=~'virt-%s-.*', container='virt-%s', namespace='%s'} > 0) > 0)",
+		component, namespace, component, component, namespace,
+	)
+}
+
+// componentDownExpr builds an expression for Virt*Down alerts.
+//
+// Branch 1 (diagnostic): virt-* pods have a container in a waiting
+// state and no ready peer remains — fires per-pod with pod and reason
+// labels. Covers CrashLoopBackOff (even with pod phase=Running),
+// ImagePullBackOff, ErrImagePull, and any other waiting reason when
+// the component is fully unavailable.
+//
+// Branch 2 (fallback): no pods are running AND branch 1 produced
+// nothing — covers pods entirely absent, or pods in Failed/Unknown
+// state without a waiting reason.
+//
+// The fallback suppresses itself whenever any waiting_reason metric
+// exists, so exactly one branch fires at a time.
+func componentDownExpr(namespace, component string) string {
+	return fmt.Sprintf("(%s) or (%s)",
+		componentDownWithReasonExpr(namespace, component),
+		componentDownFallbackExpr(namespace, component),
+	)
+}
+
+// daemonSetDownExpr is like componentDownExpr but also joins kube_pod_info
+// to include the node label, since virt-handler runs as a DaemonSet.
+func daemonSetDownExpr(namespace, component string) string {
+	withReason := fmt.Sprintf(
+		"(%s) * on(pod, namespace) group_left(node) kube_pod_info{namespace='%s'}",
+		componentDownWithReasonExpr(namespace, component), namespace,
+	)
+
+	return fmt.Sprintf("(%s) or (%s)",
+		withReason,
+		componentDownFallbackExpr(namespace, component),
+	)
+}
+
+func getErrorRatio(ns, podName, errorCodeRegex string, durationInMinutes int) string {
+	return fmt.Sprintf(
+		"sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\",code=~\"%s\"} [%dm] ) )  / "+
+			" sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\"} [%dm] ) )",
+		ns, podName, errorCodeRegex, durationInMinutes, ns, podName, durationInMinutes,
+	)
+}
+
+func getRestCallsFailedWarning(failingCallsPercentage int, component string, durationInMinutes int) string {
+	return fmt.Sprintf(
+		"More than %d%% of the rest calls failed in %s for the last %d minutes",
+		failingCallsPercentage, component, durationInMinutes,
+	)
+}

--- a/pkg/monitoring/rules/alerts/alert_expressions_test.go
+++ b/pkg/monitoring/rules/alerts/alert_expressions_test.go
@@ -1,0 +1,171 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package alerts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComponentDownWithReasonExpr(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		component string
+		expect    []string
+	}{
+		{
+			name:      "api expression filters on correct pod and container",
+			namespace: "kubevirt",
+			component: "api",
+			expect: []string{
+				"pod=~'virt-api-.*'",
+				"container='virt-api'",
+				"namespace='kubevirt'",
+				"kube_pod_container_status_waiting_reason",
+				"topk by(pod, namespace)",
+				"max by(pod, namespace, reason)",
+			},
+		},
+		{
+			name:      "handler expression filters on correct pod and container",
+			namespace: "test-ns",
+			component: "handler",
+			expect: []string{
+				"pod=~'virt-handler-.*'",
+				"container='virt-handler'",
+				"namespace='test-ns'",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expr := componentDownWithReasonExpr(tc.namespace, tc.component)
+			for _, substr := range tc.expect {
+				if !strings.Contains(expr, substr) {
+					t.Errorf("expected expression to contain %q, got:\n%s", substr, expr)
+				}
+			}
+		})
+	}
+}
+
+func TestComponentDownFallbackExpr(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		component string
+		expect    []string
+	}{
+		{
+			name:      "controller fallback uses raw metrics and unless clause",
+			namespace: "kubevirt",
+			component: "controller",
+			expect: []string{
+				"kube_pod_status_phase{pod=~'virt-controller-.*'",
+				"phase='Running'",
+				"namespace='kubevirt'",
+				"or vector(0)",
+				"unless on()",
+				"kube_pod_container_status_waiting_reason{pod=~'virt-controller-.*'",
+				"container='virt-controller'",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expr := componentDownFallbackExpr(tc.namespace, tc.component)
+			for _, substr := range tc.expect {
+				if !strings.Contains(expr, substr) {
+					t.Errorf("expected expression to contain %q, got:\n%s", substr, expr)
+				}
+			}
+		})
+	}
+}
+
+func TestComponentDownExpr(t *testing.T) {
+	expr := componentDownExpr("ci", "api")
+	if !strings.Contains(expr, ") or (") {
+		t.Error("expected componentDownExpr to combine two branches with 'or'")
+	}
+	if !strings.Contains(expr, "topk by(pod, namespace)") {
+		t.Error("expected withReason branch in componentDownExpr")
+	}
+	if !strings.Contains(expr, "vector(0)") {
+		t.Error("expected fallback branch in componentDownExpr")
+	}
+}
+
+func TestDaemonSetDownExpr(t *testing.T) {
+	expr := daemonSetDownExpr("ci", "handler")
+	if !strings.Contains(expr, "group_left(node)") {
+		t.Error("expected daemonSetDownExpr to join kube_pod_info for node label")
+	}
+	if !strings.Contains(expr, "kube_pod_info{namespace='ci'}") {
+		t.Error("expected kube_pod_info with correct namespace")
+	}
+	if !strings.Contains(expr, ") or (") {
+		t.Error("expected daemonSetDownExpr to combine two branches with 'or'")
+	}
+}
+
+func TestLowReadyAlertExpr(t *testing.T) {
+	expr := lowReadyAlertExpr("ci", "api")
+	expect := []string{
+		"kubevirt_virt_api_ready_status{namespace='ci'}",
+		"kube_pod_status_phase{pod=~'virt-api-.*'",
+		"phase='Running'",
+		"count(kubevirt_virt_api_ready_status{namespace='ci'} == 1) > 0",
+	}
+	for _, substr := range expect {
+		if !strings.Contains(expr, substr) {
+			t.Errorf("expected expression to contain %q, got:\n%s", substr, expr)
+		}
+	}
+}
+
+func TestLowReadyWithNodeAlertExpr(t *testing.T) {
+	expr := lowReadyWithNodeAlertExpr("ci", "handler")
+	expect := []string{
+		"kubevirt_virt_handler_ready_status{namespace='ci'}",
+		"group_left(node) kube_pod_info{namespace='ci'}",
+	}
+	for _, substr := range expect {
+		if !strings.Contains(expr, substr) {
+			t.Errorf("expected expression to contain %q, got:\n%s", substr, expr)
+		}
+	}
+}
+
+func TestNoReadyAlertExpr(t *testing.T) {
+	expr := noReadyAlertExpr("ci", "operator")
+	expect := []string{
+		"kubevirt_virt_operator_ready_status{namespace='ci'}",
+		"kube_pod_status_ready{pod=~'virt-operator-.*'",
+		"unless on(namespace)",
+	}
+	for _, substr := range expect {
+		if !strings.Contains(expr, substr) {
+			t.Errorf("expected expression to contain %q, got:\n%s", substr, expr)
+		}
+	}
+}

--- a/pkg/monitoring/rules/alerts/alert_expressions_test.go
+++ b/pkg/monitoring/rules/alerts/alert_expressions_test.go
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package alerts
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("alert expressions", func() {
+	expectContains := func(expr string, substrings []string) {
+		for _, substr := range substrings {
+			Expect(expr).To(ContainSubstring(substr), "expression missing %q:\n%s", substr, expr)
+		}
+	}
+
+	DescribeTable("componentDownWithReasonExpr",
+		func(namespace, component string, expect []string) {
+			expectContains(componentDownWithReasonExpr(namespace, component), expect)
+		},
+		Entry("api filters on correct pod and container", "kubevirt", "api", []string{
+			"pod=~'virt-api-.*'",
+			"container='virt-api'",
+			"namespace='kubevirt'",
+			"kube_pod_container_status_waiting_reason",
+			"topk by(pod, namespace)",
+			"max by(pod, namespace, reason)",
+			"kubevirt_virt_api_ready_status{namespace='kubevirt'}",
+			"or vector(0)) == 0",
+		}),
+		Entry("handler filters on correct pod and container", "test-ns", "handler", []string{
+			"pod=~'virt-handler-.*'",
+			"container='virt-handler'",
+			"namespace='test-ns'",
+			"kubevirt_virt_handler_ready_status{namespace='test-ns'}",
+		}),
+	)
+
+	DescribeTable("componentDownFallbackExpr",
+		func(namespace, component string, expect []string) {
+			expectContains(componentDownFallbackExpr(namespace, component), expect)
+		},
+		Entry("controller fallback uses raw metrics and unless clause", "kubevirt", "controller", []string{
+			"kube_pod_status_phase{pod=~'virt-controller-.*'",
+			"phase='Running'",
+			"namespace='kubevirt'",
+			"or vector(0)",
+			"unless on()",
+			"kube_pod_container_status_waiting_reason{pod=~'virt-controller-.*'",
+			"container='virt-controller'",
+		}),
+	)
+
+	It("combines withReason and fallback branches in componentDownExpr", func() {
+		expr := componentDownExpr("ci", "api")
+		Expect(expr).To(ContainSubstring(") or ("))
+		Expect(expr).To(ContainSubstring("topk by(pod, namespace)"))
+		Expect(expr).To(ContainSubstring("vector(0)"))
+	})
+
+	It("joins kube_pod_info for node label in daemonSetDownExpr", func() {
+		expr := daemonSetDownExpr("ci", "handler")
+		Expect(expr).To(ContainSubstring("group_left(node)"))
+		Expect(expr).To(ContainSubstring("kube_pod_info{namespace='ci'}"))
+		Expect(expr).To(ContainSubstring(") or ("))
+	})
+
+	It("builds lowReadyAlertExpr with ready peer gate", func() {
+		expectContains(lowReadyAlertExpr("ci", "api"), []string{
+			"kubevirt_virt_api_ready_status{namespace='ci'}",
+			"kube_pod_status_phase{pod=~'virt-api-.*'",
+			"phase='Running'",
+			"count(kubevirt_virt_api_ready_status{namespace='ci'} == 1) > 0",
+		})
+	})
+
+	It("builds lowReadyWithNodeAlertExpr with node join", func() {
+		expectContains(lowReadyWithNodeAlertExpr("ci", "handler"), []string{
+			"kubevirt_virt_handler_ready_status{namespace='ci'}",
+			"group_left(node) kube_pod_info{namespace='ci'}",
+		})
+	})
+
+	It("builds noReadyAlertExpr with unless clause", func() {
+		expectContains(noReadyAlertExpr("ci", "operator"), []string{
+			"kubevirt_virt_operator_ready_status{namespace='ci'}",
+			"kube_pod_status_ready{pod=~'virt-operator-.*'",
+			"unless on(namespace)",
+		})
+	})
+})

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -80,6 +80,16 @@ func Register(registry *operatorrules.Registry, namespace string) error {
 	return registry.RegisterAlerts(allAlerts...)
 }
 
+func componentDownDescription(component, extra string) string {
+	return "{{ if $labels.pod }}" +
+		"Pod {{ $labels.pod }}" + extra +
+		" is unhealthy (reason: {{ $labels.reason }})." +
+		"{{ else }}" +
+		"No running " + component + " pods detected " +
+		"and no container waiting reasons reported." +
+		"{{ end }}"
+}
+
 func getRunbookURLTemplate() string {
 	runbookURLTemplate, exists := os.LookupEnv(runbookURLTemplateEnv)
 	if !exists {
@@ -91,17 +101,4 @@ func getRunbookURLTemplate() string {
 	}
 
 	return runbookURLTemplate
-}
-
-func getErrorRatio(ns, podName, errorCodeRegex string, durationInMinutes int) string {
-	errorRatioQuery := "sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\",code=~\"%s\"} [%dm] ) )  / " +
-		" sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\"} [%dm] ) )"
-	return fmt.Sprintf(errorRatioQuery, ns, podName, errorCodeRegex, durationInMinutes, ns, podName, durationInMinutes)
-}
-
-func getRestCallsFailedWarning(failingCallsPercentage int, component string, durationInMinutes int) string {
-	duration := fmt.Sprintf("%d minutes", durationInMinutes)
-
-	const restCallsFailWarningTemplate = "More than %d%% of the rest calls failed in %s for the last %s"
-	return fmt.Sprintf(restCallsFailWarningTemplate, failingCallsPercentage, component, duration)
 }

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -80,6 +80,16 @@ func Register(registry *operatorrules.Registry, namespace string) error {
 	return registry.RegisterAlerts(allAlerts...)
 }
 
+func componentDownDescription(component, extra string) string {
+	return "{{ if $labels.pod }}" +
+		"Pod {{ $labels.pod }}" + extra +
+		" is unhealthy (reason: {{ $labels.reason }})." +
+		"{{ else }}" +
+		"No running " + component + " pods detected " +
+		"and no container waiting reasons reported." +
+		"{{ end }}"
+}
+
 func getRunbookURLTemplate() string {
 	runbookURLTemplate, exists := os.LookupEnv(runbookURLTemplateEnv)
 	if !exists {
@@ -92,4 +102,3 @@ func getRunbookURLTemplate() string {
 
 	return runbookURLTemplate
 }
-

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -93,15 +93,3 @@ func getRunbookURLTemplate() string {
 	return runbookURLTemplate
 }
 
-func getErrorRatio(ns, podName, errorCodeRegex string, durationInMinutes int) string {
-	errorRatioQuery := "sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\",code=~\"%s\"} [%dm] ) )  / " +
-		" sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\"} [%dm] ) )"
-	return fmt.Sprintf(errorRatioQuery, ns, podName, errorCodeRegex, durationInMinutes, ns, podName, durationInMinutes)
-}
-
-func getRestCallsFailedWarning(failingCallsPercentage int, component string, durationInMinutes int) string {
-	duration := fmt.Sprintf("%d minutes", durationInMinutes)
-
-	const restCallsFailWarningTemplate = "More than %d%% of the rest calls failed in %s for the last %s"
-	return fmt.Sprintf(restCallsFailWarningTemplate, failingCallsPercentage, component, duration)
-}

--- a/pkg/monitoring/rules/alerts/alerts_suite_test.go
+++ b/pkg/monitoring/rules/alerts/alerts_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package alerts
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestAlerts(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -30,10 +30,11 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtAPIDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_api_pods_running:count == 0"),
+			Expr:  intstr.FromString(componentDownExpr(namespace, "api")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "No running virt-api pods were detected for the last 10 min.",
+				summaryAnnotationKey:     "No running virt-api pods were detected for the last 10 min.",
+				descriptionAnnotationKey: componentDownDescription("virt-api", ""),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",
@@ -42,13 +43,11 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowReadyVirtAPICount",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_api_ready:sum < cluster:kubevirt_virt_api_pods_running:count " +
-					"and cluster:kubevirt_virt_api_ready:sum > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(lowReadyAlertExpr(namespace, "api")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "Some virt-api pods are running but not ready.",
+				summaryAnnotationKey:     "Some virt-api pods are running but not ready.",
+				descriptionAnnotationKey: "virt-api pod {{ $labels.pod }} has been running but not ready for more than 10 minutes.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",
@@ -57,7 +56,7 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtAPI",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_api_ready:sum == 0"),
+			Expr:  intstr.FromString(noReadyAlertExpr(namespace, "api")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-api was detected for the last 10 min.",

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -30,10 +30,11 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtAPIDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_api_pods_running:count == 0"),
+			Expr:  intstr.FromString(componentDownExpr(namespace, "api")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "No running virt-api pods were detected for the last 10 min.",
+				summaryAnnotationKey:     "No running virt-api pods were detected for the last 10 min.",
+				descriptionAnnotationKey: componentDownDescription("virt-api", ""),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",
@@ -42,13 +43,11 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowReadyVirtAPICount",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_api_ready:sum < cluster:kubevirt_virt_api_pods_running:count " +
-					"and cluster:kubevirt_virt_api_ready:sum > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(lowReadyAlertExpr(namespace, "api")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "Some virt-api pods are running but not ready.",
+				summaryAnnotationKey:     "Some virt-api pods are running but not ready.",
+				descriptionAnnotationKey: "virt-api pod {{ $labels.pod }} has been running but not ready for more than 10 minutes.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",
@@ -57,11 +56,8 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtAPI",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_api_ready:sum == 0 " +
-					"and cluster:kubevirt_virt_api_pods_running:count > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(noReadyAlertExpr(namespace, "api")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-api was detected for the last 10 min.",
 			},

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -30,13 +30,11 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "LowReadyVirtControllersCount",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_controller_ready:sum < cluster:kubevirt_virt_controller_pods_running:count " +
-					"and cluster:kubevirt_virt_controller_ready:sum > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(lowReadyAlertExpr(namespace, "controller")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "Some virt controllers are running but not ready.",
+				summaryAnnotationKey:     "Some virt controllers are running but not ready.",
+				descriptionAnnotationKey: "virt-controller pod {{ $labels.pod }} has been running but not ready for more than 10 minutes.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",
@@ -45,7 +43,7 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtController",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_ready:sum == 0"),
+			Expr:  intstr.FromString(noReadyAlertExpr(namespace, "controller")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-controller was detected for the last 10 min.",
@@ -69,10 +67,11 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "VirtControllerDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_pods_running:count == 0"),
+			Expr:  intstr.FromString(componentDownExpr(namespace, "controller")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "No running virt-controller was detected for the last 10 min.",
+				summaryAnnotationKey:     "No running virt-controller was detected for the last 10 min.",
+				descriptionAnnotationKey: componentDownDescription("virt-controller", ""),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -30,13 +30,11 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "LowReadyVirtControllersCount",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_controller_ready:sum < cluster:kubevirt_virt_controller_pods_running:count " +
-					"and cluster:kubevirt_virt_controller_ready:sum > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(lowReadyAlertExpr(namespace, "controller")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "Some virt controllers are running but not ready.",
+				summaryAnnotationKey:     "Some virt controllers are running but not ready.",
+				descriptionAnnotationKey: "virt-controller pod {{ $labels.pod }} has been running but not ready for more than 10 minutes.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",
@@ -45,11 +43,8 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtController",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_controller_ready:sum == 0 " +
-					"and cluster:kubevirt_virt_controller_pods_running:count > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(noReadyAlertExpr(namespace, "controller")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-controller was detected for the last 10 min.",
 			},
@@ -72,10 +67,11 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "VirtControllerDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_pods_running:count == 0"),
+			Expr:  intstr.FromString(componentDownExpr(namespace, "controller")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "No running virt-controller was detected for the last 10 min.",
+				summaryAnnotationKey:     "No running virt-controller was detected for the last 10 min.",
+				descriptionAnnotationKey: componentDownDescription("virt-controller", ""),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -30,10 +30,11 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtHandlerDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_handler_pods_running:count == 0"),
+			Expr:  intstr.FromString(daemonSetDownExpr(namespace, "handler")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "No running virt-handler pods were detected for the last 10 min.",
+				summaryAnnotationKey:     "No running virt-handler pods were detected for the last 10 min.",
+				descriptionAnnotationKey: componentDownDescription("virt-handler", " on node {{ $labels.node }}"),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",
@@ -42,13 +43,12 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowReadyVirtHandlerCount",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_handler_ready:sum < cluster:kubevirt_virt_handler_pods_running:count " +
-					"and cluster:kubevirt_virt_handler_ready:sum > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(lowReadyWithNodeAlertExpr(namespace, "handler")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Some virt-handlers are running but not ready.",
+				descriptionAnnotationKey: "virt-handler pod {{ $labels.pod }} on node " +
+					"{{ $labels.node }} has been running but not ready for more than 10 minutes.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",
@@ -57,7 +57,7 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtHandler",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_handler_ready:sum == 0"),
+			Expr:  intstr.FromString(noReadyAlertExpr(namespace, "handler")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-handler was detected for the last 10 min.",

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -30,10 +30,11 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtHandlerDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_handler_pods_running:count == 0"),
+			Expr:  intstr.FromString(daemonSetDownExpr(namespace, "handler")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "No running virt-handler pods were detected for the last 10 min.",
+				summaryAnnotationKey:     "No running virt-handler pods were detected for the last 10 min.",
+				descriptionAnnotationKey: componentDownDescription("virt-handler", " on node {{ $labels.node }}"),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",
@@ -42,13 +43,12 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowReadyVirtHandlerCount",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_handler_ready:sum < cluster:kubevirt_virt_handler_pods_running:count " +
-					"and cluster:kubevirt_virt_handler_ready:sum > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(lowReadyWithNodeAlertExpr(namespace, "handler")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Some virt-handlers are running but not ready.",
+				descriptionAnnotationKey: "virt-handler pod {{ $labels.pod }} on node " +
+					"{{ $labels.node }} has been running but not ready for more than 10 minutes.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",
@@ -57,11 +57,8 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtHandler",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_handler_ready:sum == 0 " +
-					"and cluster:kubevirt_virt_handler_pods_running:count > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(noReadyAlertExpr(namespace, "handler")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-handler was detected for the last 10 min.",
 			},

--- a/pkg/monitoring/rules/alerts/virt-operator.go
+++ b/pkg/monitoring/rules/alerts/virt-operator.go
@@ -30,10 +30,11 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtOperatorDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_pods_running:count == 0"),
+			Expr:  intstr.FromString(componentDownExpr(namespace, "operator")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "No running virt-operator pods were detected for the last 10 min.",
+				summaryAnnotationKey:     "No running virt-operator pods were detected for the last 10 min.",
+				descriptionAnnotationKey: componentDownDescription("virt-operator", ""),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",
@@ -70,13 +71,11 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowReadyVirtOperatorsCount",
-			Expr: intstr.FromString(
-				"cluster:kubevirt_virt_operator_ready:sum < cluster:kubevirt_virt_operator_pods_running:count " +
-					"and cluster:kubevirt_virt_operator_ready:sum > 0",
-			),
-			For: ptr.To(promv1.Duration("10m")),
+			Expr:  intstr.FromString(lowReadyAlertExpr(namespace, "operator")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "Some virt-operators are running but not ready.",
+				summaryAnnotationKey:     "Some virt-operators are running but not ready.",
+				descriptionAnnotationKey: "virt-operator pod {{ $labels.pod }} has been running but not ready for more than 10 minutes.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",
@@ -85,7 +84,7 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtOperator",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_ready:sum == 0"),
+			Expr:  intstr.FromString(noReadyAlertExpr(namespace, "operator")),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-operator was detected for the last 10 min.",

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -138,12 +138,15 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			libmonitoring.VerifyAlertExist(virtClient, virtOperator.downAlert)
 		})
 
-		It("NoReadyVirtOperator should be triggered when virt-operator is down", func() {
-			By("Waiting for the operator to be down")
+		// NoReadyVirtOperator no longer fires when all pods are absent (false-positive fix).
+		// When the operator is scaled to 0, the app-level ready_status metric becomes stale,
+		// so the NoReady expression returns empty. The VirtOperatorDown alert covers this scenario.
+		It("NoReadyVirtOperator should not fire when operator is scaled to zero", func() {
+			By("Waiting for the operator ready metric to be zero")
 			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_ready:sum", 0)
 
-			By("Verifying the alert exists")
-			libmonitoring.VerifyAlertExist(virtClient, virtOperator.noReadyAlert)
+			By("Verifying the NoReady alert does NOT fire (absent metrics)")
+			libmonitoring.WaitUntilAlertDoesNotExist(virtClient, virtOperator.noReadyAlert)
 		})
 
 		It("VirtControllerDown should be triggered when virt-controller is down", func() {
@@ -157,15 +160,17 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			libmonitoring.VerifyAlertExist(virtClient, virtController.downAlert)
 		})
 
-		It("NoReadyVirtController should be triggered when virt-controller is down", func() {
+		// NoReadyVirtController no longer fires when all pods are absent (false-positive fix).
+		// VirtControllerDown covers the "scaled to 0" scenario.
+		It("NoReadyVirtController should not fire when controller is scaled to zero", func() {
 			By("Scaling down the controller")
 			scales.UpdateScale(virtController.deploymentName, int32(0))
 
-			By("Waiting for the controller to be down")
+			By("Waiting for the controller ready metric to be zero")
 			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_controller_ready:sum", 0)
 
-			By("Verifying the alert exists")
-			libmonitoring.VerifyAlertExist(virtClient, virtController.noReadyAlert)
+			By("Verifying the NoReady alert does NOT fire (absent metrics)")
+			libmonitoring.WaitUntilAlertDoesNotExist(virtClient, virtController.noReadyAlert)
 		})
 
 		It("VirtAPIDown should be triggered when virt-api is down", func() {
@@ -179,15 +184,17 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			libmonitoring.VerifyAlertExist(virtClient, virtAPI.downAlert)
 		})
 
-		It("NoReadyVirtAPI should be triggered when virt-api is down", func() {
+		// NoReadyVirtAPI no longer fires when all pods are absent (false-positive fix).
+		// VirtAPIDown covers the "scaled to 0" scenario.
+		It("NoReadyVirtAPI should not fire when api is scaled to zero", func() {
 			By("Scaling down the api")
 			scales.UpdateScale(virtAPI.deploymentName, int32(0))
 
 			By("Waiting for the api ready metric to be zero")
 			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_api_ready:sum", 0)
 
-			By("Verifying the alert exists")
-			libmonitoring.VerifyAlertExist(virtClient, virtAPI.noReadyAlert)
+			By("Verifying the NoReady alert does NOT fire (absent metrics)")
+			libmonitoring.WaitUntilAlertDoesNotExist(virtClient, virtAPI.noReadyAlert)
 		})
 
 		It("VirtHandlerDown should be triggered when virt-handler is down", func() {
@@ -218,7 +225,92 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			libmonitoring.VerifyAlertExist(virtClient, virtHandler.downAlert)
 		})
 
-		It("NoReadyVirtHandler should be triggered when virt-handler is not ready", func() {
+		It("VirtControllerDown should report waiting reason when controller pods have bad image", func() {
+			By("Scaling down the controller so no healthy pods remain during the image patch")
+			scales.UpdateScale(virtController.deploymentName, int32(0))
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_controller_pods_running:count", 0)
+
+			By("Saving the original image for later restoration")
+			deployment, getErr := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), virtController.deploymentName, metav1.GetOptions{},
+			)
+			Expect(getErr).ToNot(HaveOccurred())
+			originalImage := deployment.Spec.Template.Spec.Containers[0].Image
+			containerName := deployment.Spec.Template.Spec.Containers[0].Name
+
+			patchContainerImage := func(image string) {
+				patch := map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []map[string]interface{}{
+									{
+										"name":  containerName,
+										"image": image,
+									},
+								},
+							},
+						},
+					},
+				}
+				patchBytes, patchErr := json.Marshal(patch)
+				Expect(patchErr).ToNot(HaveOccurred())
+				_, patchErr = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(
+					context.Background(), virtController.deploymentName,
+					types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{},
+				)
+				Expect(patchErr).ToNot(HaveOccurred())
+			}
+
+			By("Patching the controller deployment with a non-existent image")
+			patchContainerImage("registry.example.com/nonexistent:v0.0.0")
+
+			defer func() {
+				By("Restoring the controller image")
+				patchContainerImage(originalImage)
+				scales.RestoreScale(virtController.deploymentName)
+				libmonitoring.WaitUntilAlertDoesNotExist(virtClient, virtController.downAlert)
+			}()
+
+			By("Scaling up to 1 replica — the only pod that starts has the bad image")
+			Eventually(func() error {
+				scale, scaleErr := virtClient.AppsV1().
+					Deployments(flags.KubeVirtInstallNamespace).
+					GetScale(context.Background(), virtController.deploymentName, metav1.GetOptions{})
+				if scaleErr != nil {
+					return scaleErr
+				}
+				scale.Spec.Replicas = 1
+				_, scaleErr = virtClient.AppsV1().
+					Deployments(flags.KubeVirtInstallNamespace).
+					UpdateScale(context.Background(), virtController.deploymentName, scale, metav1.UpdateOptions{})
+				return scaleErr
+			}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+			By("Verifying VirtControllerDown fires with a reason label")
+			Eventually(func(g Gomega) {
+				alerts, alertErr := libmonitoring.GetAlerts(virtClient)
+				g.Expect(alertErr).ToNot(HaveOccurred())
+
+				found := false
+				for _, a := range alerts {
+					if string(a.Labels["alertname"]) != virtController.downAlert {
+						continue
+					}
+					reason := string(a.Labels["reason"])
+					if reason == "ImagePullBackOff" || reason == "ErrImagePull" {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "expected VirtControllerDown with reason ImagePullBackOff or ErrImagePull")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		})
+
+		// NoReadyVirtHandler no longer fires when the app metric is absent (false-positive fix).
+		// Replacing the container with a non-KubeVirt binary causes ready_status to go stale,
+		// so the NoReady expression returns empty. VirtHandlerDaemonSetRolloutFailing covers this scenario.
+		It("NoReadyVirtHandler should not fire when handler has no app metrics", func() {
 			daemonSet, getErr := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(
 				context.Background(), virtHandler.deploymentName, metav1.GetOptions{},
 			)
@@ -245,14 +337,17 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			By("Waiting for virt-handler ready metric to be zero")
 			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_handler_ready:sum", 0)
 
-			By("Verifying the alert exists")
-			libmonitoring.VerifyAlertExist(virtClient, virtHandler.noReadyAlert)
+			By("Verifying the NoReady alert does NOT fire (absent app metrics)")
+			libmonitoring.WaitUntilAlertDoesNotExist(virtClient, virtHandler.noReadyAlert)
 		})
 	})
 
-	Context("Low ready alerts", func() {
-		It("LowReadyVirtControllersCount should be triggered when virt controller pods ready are less than running and ready > 0", func() {
-			runLowReadyDecoyDeploymentTest(
+	// LowReady alerts now fire per-pod and require the app-level ready_status metric
+	// to report 0 (not just be absent). Decoy pods that don't export the metric
+	// should NOT trigger the alert (false-positive fix).
+	Context("Low ready alerts - false positive prevention", func() {
+		It("LowReadyVirtControllersCount should not fire for decoy pods without app metrics", func() {
+			runLowReadyDecoyDeploymentNoAlertTest(
 				virtClient, scales,
 				virtController.deploymentName, virtController.lowReadyAlert,
 				"cluster:kubevirt_virt_controller_ready:sum",
@@ -260,8 +355,8 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			)
 		})
 
-		It("LowReadyVirtAPICount should be triggered when virt api pods ready are less than running and ready > 0", func() {
-			runLowReadyDecoyDeploymentTest(
+		It("LowReadyVirtAPICount should not fire for decoy pods without app metrics", func() {
+			runLowReadyDecoyDeploymentNoAlertTest(
 				virtClient, scales,
 				virtAPI.deploymentName, virtAPI.lowReadyAlert,
 				"cluster:kubevirt_virt_api_ready:sum",
@@ -269,12 +364,12 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			)
 		})
 
-		It("LowReadyVirtHandlerCount should be triggered when virt-handler pods ready are less than running and ready > 0", func() {
-			runLowReadyDecoyDaemonSetTest(virtClient, virtHandler.lowReadyAlert)
+		It("LowReadyVirtHandlerCount should not fire for decoy pods without app metrics", func() {
+			runLowReadyDecoyDaemonSetNoAlertTest(virtClient, virtHandler.lowReadyAlert)
 		})
 
-		It("LowReadyVirtOperatorsCount should be triggered when virt-operator pods ready are less than running and ready > 0", func() {
-			runLowReadyDecoyDeploymentTest(
+		It("LowReadyVirtOperatorsCount should not fire for decoy pods without app metrics", func() {
+			runLowReadyDecoyDeploymentNoAlertTest(
 				virtClient, scales,
 				virtOperator.deploymentName, virtOperator.lowReadyAlert,
 				"cluster:kubevirt_virt_operator_ready:sum",
@@ -456,7 +551,9 @@ func increaseRateLimit(virtClient kubecli.KubevirtClient) {
 	config.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
 }
 
-func runLowReadyDecoyDeploymentTest(
+// runLowReadyDecoyDeploymentNoAlertTest verifies that a decoy pod (which does not
+// export the app-level ready_status metric) does NOT trigger the per-pod LowReady alert.
+func runLowReadyDecoyDeploymentNoAlertTest(
 	virtClient kubecli.KubevirtClient,
 	scales *libmonitoring.Scaling,
 	deploymentName, lowReadyAlert, readyMetric, runningMetric string,
@@ -479,24 +576,25 @@ func runLowReadyDecoyDeploymentTest(
 	defer func() {
 		By("Deleting the low-ready decoy pod")
 		_ = virtClient.CoreV1().Pods(ns).Delete(ctx, decoyName, metav1.DeleteOptions{})
-		By("Waiting for the low ready alert to not be firing anymore")
-		libmonitoring.WaitUntilAlertDoesNotExist(virtClient, lowReadyAlert)
 		By("Restoring the deployment replica count")
 		scales.RestoreScale(deploymentName)
 	}()
 
-	By("Creating a decoy pod that counts as running but does not contribute to the KubeVirt ready sum")
+	By("Creating a decoy pod that counts as running but does not export ready_status")
 	_, createErr := virtClient.CoreV1().Pods(ns).Create(ctx, decoyPod, metav1.CreateOptions{})
 	Expect(createErr).ToNot(HaveOccurred())
 
-	By("Waiting for two running pods and one ready pod in metrics (decoy running, single real pod ready)")
+	By("Waiting for two running pods while ready sum stays at one")
 	libmonitoring.WaitForMetricValue(virtClient, runningMetric, lowReadyDeploymentRunningCount)
 	libmonitoring.WaitForMetricValue(virtClient, readyMetric, float64(lowReadySingletonWorkloadCount))
 
-	libmonitoring.VerifyAlertExist(virtClient, lowReadyAlert)
+	By("Verifying the LowReady alert does NOT fire (decoy has no app metrics)")
+	libmonitoring.WaitUntilAlertDoesNotExist(virtClient, lowReadyAlert)
 }
 
-func runLowReadyDecoyDaemonSetTest(virtClient kubecli.KubevirtClient, lowReadyAlert string) {
+// runLowReadyDecoyDaemonSetNoAlertTest verifies that a decoy pod alongside real virt-handler
+// pods does NOT trigger the per-pod LowReady alert when the decoy lacks app metrics.
+func runLowReadyDecoyDaemonSetNoAlertTest(virtClient kubecli.KubevirtClient, lowReadyAlert string) {
 	ns := flags.KubeVirtInstallNamespace
 	ctx := context.Background()
 
@@ -509,8 +607,6 @@ func runLowReadyDecoyDaemonSetTest(virtClient kubecli.KubevirtClient, lowReadyAl
 	defer func() {
 		By("Deleting the virt-handler low-ready decoy pod")
 		_ = virtClient.CoreV1().Pods(ns).Delete(ctx, decoyName, metav1.DeleteOptions{})
-		By("Waiting for the low ready alert to not be firing anymore")
-		libmonitoring.WaitUntilAlertDoesNotExist(virtClient, lowReadyAlert)
 	}()
 
 	By("Creating a virt-handler decoy pod so running count exceeds the KubeVirt ready sum")
@@ -531,7 +627,8 @@ func runLowReadyDecoyDaemonSetTest(virtClient kubecli.KubevirtClient, lowReadyAl
 		g.Expect(ready).To(BeNumerically("<", running))
 	}, 5*time.Minute, 2*time.Second).Should(Succeed())
 
-	libmonitoring.VerifyAlertExist(virtClient, lowReadyAlert)
+	By("Verifying the LowReady alert does NOT fire (decoy has no app metrics)")
+	libmonitoring.WaitUntilAlertDoesNotExist(virtClient, lowReadyAlert)
 }
 
 func lowReadyDecoyPodSpecFromTemplate(spec corev1.PodSpec) corev1.PodSpec {

--- a/tools/util/marshaller.go
+++ b/tools/util/marshaller.go
@@ -21,6 +21,7 @@ package util
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -28,6 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
+
+// goTemplateQuotedValueRe matches YAML single-quoted values that contain Go
+// text/template variables (e.g. '{{.Namespace}}' or '{{.Prefix}}/img:{{.Tag}}').
+// These need their quotes stripped so they remain raw template markers for
+// text/template processing. The pattern requires {{. (dot) immediately after the
+// opening braces, which distinguishes Go templates from Prometheus/Alertmanager
+// templates that use {{ $labels.x }} or {{ if ... }} (space after {{).
+var goTemplateQuotedValueRe = regexp.MustCompile(`'(\{\{\.[^']*\}\})'`)
 
 func MarshallObject(obj interface{}, writer io.Writer) error {
 	jsonBytes, err := json.Marshal(obj)
@@ -120,10 +129,11 @@ func MarshallObject(obj interface{}, writer io.Writer) error {
 		return err
 	}
 
-	// fix templates by removing unneeded single quotes...
+	// fix Go text/template variables by removing YAML single quotes around them.
+	// Only targets {{.FieldName}} patterns, leaving Prometheus/Alertmanager
+	// templates ({{ $labels.x }}, {{ if ... }}) properly quoted.
 	s := string(yamlBytes)
-	s = strings.Replace(s, "'{{", "{{", -1)
-	s = strings.Replace(s, "}}'", "}}", -1)
+	s = goTemplateQuotedValueRe.ReplaceAllString(s, "$1")
 
 	// fix double quoted strings by removing unneeded single quotes...
 	s = strings.Replace(s, " '\"", " \"", -1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Virt*Down alerts (VirtAPIDown, VirtControllerDown, VirtHandlerDown,
VirtOperatorDown) fire with no diagnostic context. On-callers must
manually run kubectl commands to determine the root cause.

#### After this PR:
- Virt*Down alerts surface the pod container waiting reason
  (e.g. CrashLoopBackOff, ErrImagePull) directly in alert labels
  and description when the component is fully unavailable.
- The waiting-reason branch is gated on zero ready peers so a
  single unhealthy pod with healthy peers remains a LowReadyVirt*
  warning, not a critical Virt*Down.
- New PromQL expression helpers in `alert_expressions.go` build
  the self-diagnosing queries.
- Table-driven unit tests validate expression correctness.
- Promtool CI assertions updated, including a mixed
  healthy/unhealthy regression case.
- VirtControllerDown E2E test hardened against race conditions.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.

- Fixes #
- Partially addresses #
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Waiting-reason diagnostics are included only when no ready peer
  remains, so rolling updates and single-replica failures stay on
  LowReadyVirt* (warning) instead of paging as Virt*Down (critical).
- When kube-state-metrics reports no waiting_reason series, a
  fallback Virt*Down branch still fires so total unavailability is
  not silent.
- `topk` selects one waiting reason per pod so ErrImagePull and
  ImagePullBackOff do not duplicate the same alert.

The following alternatives were considered:
- Attaching waiting_reason whenever any replica is unhealthy.
  Rejected because it would promote mixed healthy/unhealthy
  clusters to critical Virt*Down during rollouts.
- Leaving diagnosis to runbooks and kubectl. Rejected because the
  waiting reason is already in metrics and is the fastest root-cause
  signal for image pull and crash-loop failures.

Links to places where the discussion took place:
- https://github.com/kubevirt/kubevirt/pull/17985

### Special notes for your reviewer
- `tools/util/marshaller.go` only unquotes Go `{{.Field}}` markers
  so Prometheus/Alertmanager templates such as
  `{{ if $labels.pod }}` are left intact.
- AfterEach restore waits on scraped `kubevirt_virt_operator_*`
  gauges, not `cluster:*` recording rules that use `or vector(0)`.
- The VirtHandlerDown e2e restores `nodeSelector` so later specs
  are not poisoned.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Virt*Down alerts include container waiting reason when the component is fully unavailable
```

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Alert descriptions now identify affected pods, nodes, and container waiting reasons such as `CrashLoopBackOff` or `ImagePullBackOff`.
  - Component-down alerts provide clearer fallback messages when no running pods or waiting reasons are detected.

- **Bug Fixes**
  - Improved alert behavior when readiness metrics are missing, stale, or absent after scaling down.
  - Prevented duplicate alerts when multiple waiting reasons are reported for a pod.
  - Preserved valid Prometheus and Alertmanager template quoting during YAML generation.

- **Tests**
  - Expanded coverage for alert diagnosis, readiness transitions, recovery, and healthy-state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->