### PR TITLE
[release-1.8] Adding missing alerts for virt-handler and virt-api

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -535,6 +535,8 @@ func (app *virtHandlerApp) Run() {
 		s := <-c
 		log.Log.Infof("Received signal %s, initiating graceful shutdown", s.String())
 
+		metrics.SetVirtHandlerNotReady()
+
 		// This triggers the migration proxy to no longer accept new connections
 		migrationProxy.InitiateGracefulShutdown()
 
@@ -651,6 +653,7 @@ func (app *virtHandlerApp) runServer(errCh chan error, consoleHandler *rest.Cons
 		TLSConfig:   app.serverTLSConfig,
 		IdleTimeout: 60 * time.Second,
 	}
+	metrics.SetVirtHandlerReady()
 	errCh <- server.ListenAndServeTLS("", "")
 }
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -11,8 +11,10 @@
 | kubevirt_rest_client_request_latency_seconds | Metric | Histogram | Request latency in seconds. Broken down by verb and URL. |
 | kubevirt_rest_client_requests_total | Metric | Counter | Number of HTTP requests, partitioned by status code, method, and host. |
 | kubevirt_usbredir_active_connections | Metric | Gauge | Amount of active USB redirection connections, broken down by namespace and vmi name. |
+| kubevirt_virt_api_ready_status | Metric | Gauge | Indication for a virt-api server that is ready to serve requests. |
 | kubevirt_virt_controller_leading_status | Metric | Gauge | Indication for an operating virt-controller. |
 | kubevirt_virt_controller_ready_status | Metric | Gauge | Indication for a virt-controller that is ready to take the lead. |
+| kubevirt_virt_handler_ready_status | Metric | Gauge | Indication for a virt-handler that is ready to serve requests. |
 | kubevirt_virt_operator_leading_status | Metric | Gauge | Indication for an operating virt-operator. |
 | kubevirt_virt_operator_ready_status | Metric | Gauge | Indication for a virt-operator that is ready to take the lead. |
 | kubevirt_vm_create_date_timestamp_seconds | Metric | Gauge | Virtual Machine creation timestamp. |
@@ -107,10 +109,14 @@
 | cluster:kubevirt_nodes_allocatable:count | Recording rule | Gauge | The number of allocatable nodes in the cluster. |
 | cluster:kubevirt_nodes_with_kvm:count | Recording rule | Gauge | The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. |
 | cluster:kubevirt_non_schedulable_nodes:sum | Recording rule | Gauge | The number of non-schedulable nodes in the cluster. |
+| cluster:kubevirt_virt_api_pods_running:count | Recording rule | Gauge | The number of virt-api pods that are running. |
+| cluster:kubevirt_virt_api_ready:sum | Recording rule | Gauge | The number of virt-api pods that are ready. |
 | cluster:kubevirt_virt_api_up:sum | Recording rule | Gauge | The number of virt-api pods that are up. |
 | cluster:kubevirt_virt_controller_pods_running:count | Recording rule | Gauge | The number of virt-controller pods that are running. |
 | cluster:kubevirt_virt_controller_ready:sum | Recording rule | Gauge | The number of virt-controller pods that are ready. |
 | cluster:kubevirt_virt_controller_up:sum | Recording rule | Gauge | The number of virt-controller pods that are up. |
+| cluster:kubevirt_virt_handler_pods_running:count | Recording rule | Gauge | The number of virt-handler pods that are running. |
+| cluster:kubevirt_virt_handler_ready:sum | Recording rule | Gauge | The number of virt-handler pods that are ready. |
 | cluster:kubevirt_virt_handler_up:sum | Recording rule | Gauge | The number of virt-handler pods that are up. |
 | cluster:kubevirt_virt_operator_leading:sum | Recording rule | Gauge | The number of virt-operator pods that are leading. |
 | cluster:kubevirt_virt_operator_pods_running:count | Recording rule | Gauge | The number of virt-operator pods that are running. |

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -10,11 +10,13 @@ tests:
   # Alerts to test whether our operators are up or not
   - interval: 1m
     input_series:
-      - series: 'up{namespace="ci", pod="virt-api-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
         values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
       - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
         values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
-      - series: 'up{namespace="ci", pod="virt-operator-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
+        values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Running"}'
         values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
 
     alert_rule_test:
@@ -28,12 +30,15 @@ tests:
       - eval_time: 8m
         alertname: VirtOperatorDown
         exp_alerts: [ ]
+      - eval_time: 8m
+        alertname: VirtHandlerDown
+        exp_alerts: [ ]
       # it must trigger when there is no data
       - eval_time: 10m
         alertname: VirtAPIDown
         exp_alerts:
           - exp_annotations:
-              summary: "All virt-api servers are down."
+              summary: "No running virt-api pods were detected for the last 10 min."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
@@ -55,8 +60,19 @@ tests:
         alertname: VirtOperatorDown
         exp_alerts:
           - exp_annotations:
-              summary: "All virt-operator servers are down."
+              summary: "No running virt-operator pods were detected for the last 10 min."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+      - eval_time: 10m
+        alertname: VirtHandlerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-handler pods were detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
             exp_labels:
               severity: "critical"
               operator_health_impact: "critical"
@@ -67,7 +83,7 @@ tests:
         alertname: VirtAPIDown
         exp_alerts:
           - exp_annotations:
-              summary: "All virt-api servers are down."
+              summary: "No running virt-api pods were detected for the last 10 min."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
@@ -89,8 +105,19 @@ tests:
         alertname: VirtOperatorDown
         exp_alerts:
           - exp_annotations:
-              summary: "All virt-operator servers are down."
+              summary: "No running virt-operator pods were detected for the last 10 min."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+      - eval_time: 16m
+        alertname: VirtHandlerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-handler pods were detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerDown"
             exp_labels:
               severity: "critical"
               operator_health_impact: "critical"
@@ -105,6 +132,9 @@ tests:
         exp_alerts: [ ]
       - eval_time: 17m
         alertname: VirtOperatorDown
+        exp_alerts: [ ]
+      - eval_time: 17m
+        alertname: VirtHandlerDown
         exp_alerts: [ ]
 
     # Alert to test when there are VMIs running on a node with an unready virt-handler pod
@@ -201,6 +231,10 @@ tests:
         values: '1+0x11'
       - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-2", phase="Running"}'
         values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-controller-1", condition="true"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-controller-2", condition="true"}'
+        values: '0+0x11'
 
     alert_rule_test:
       - eval_time: 10m
@@ -244,10 +278,130 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
+  # Some virt-api pods are not ready
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_api_ready_status{namespace="ci", pod="virt-api-1"}'
+        values: '1+0x11'
+      - series: 'kubevirt_virt_api_ready_status{namespace="ci", pod="virt-api-2"}'
+        values: '0+0x11'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-2", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-api-1", condition="true"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-api-2", condition="true"}'
+        values: '0+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LowReadyVirtAPICount
+        exp_alerts:
+          - exp_annotations:
+              summary: "Some virt-api pods are running but not ready."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtAPICount"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # All virt-api are not ready
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_api_ready_status{namespace="ci", pod="virt-api-1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-api-1", condition="true"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NoReadyVirtAPI
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoReadyVirtAPI
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-api was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtAPI"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+      - eval_time: 10m
+        alertname: LowReadyVirtAPICount
+        exp_alerts: [ ]
+
+  # Some virt-handlers are not ready
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_handler_ready_status{namespace="ci", pod="virt-handler-1"}'
+        values: '1+0x11'
+      - series: 'kubevirt_virt_handler_ready_status{namespace="ci", pod="virt-handler-2"}'
+        values: '0+0x11'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-2", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-handler-1", condition="true"}'
+        values: '1+0x11'
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-handler-2", condition="true"}'
+        values: '0+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LowReadyVirtHandlerCount
+        exp_alerts:
+          - exp_annotations:
+              summary: "Some virt-handlers are running but not ready."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtHandlerCount"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # All virt-handlers are not ready
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_handler_ready_status{namespace="ci", pod="virt-handler-1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-handler-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-handler-1", condition="true"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NoReadyVirtHandler
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoReadyVirtHandler
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-handler was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtHandler"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+      - eval_time: 10m
+        alertname: LowReadyVirtHandlerCount
+        exp_alerts: [ ]
+
   # All virt controllers are not ready
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_controller_ready_status{namespace="ci", pod="virt-controller-1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_status_ready{namespace="ci", pod="virt-controller-1", condition="true"}'
         values: "0 0 0 0 0 0 0 0 0 0 0"
 
     alert_rule_test:
@@ -266,6 +420,9 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+      - eval_time: 10m
+        alertname: LowReadyVirtControllersCount
+        exp_alerts: [ ]
 
   # All virt controllers are not ready (ImagePullBackOff)
   - interval: 1m
@@ -322,6 +479,8 @@ tests:
         values: "0x10"
       - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1"}'
         values: "0x10"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
+        values: "1x10"
 
     alert_rule_test:
       # no alert before 10 minutes
@@ -339,6 +498,9 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+      - eval_time: 10m
+        alertname: LowReadyVirtOperatorsCount
+        exp_alerts: [ ]
 
   # All virt operators are not ready, according to kubevirt_virt_operator_ready_status
   - interval: 1m
@@ -347,6 +509,8 @@ tests:
         values: "0x10"
       - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1"}'
         values: "1x10"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
+        values: "1x10"
 
     alert_rule_test:
       # no alert before 10 minutes
@@ -364,6 +528,9 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+      - eval_time: 10m
+        alertname: LowReadyVirtOperatorsCount
+        exp_alerts: [ ]
 
   # All virt operators are not ready, according to kube_pod_status_ready
   - interval: 1m
@@ -372,6 +539,8 @@ tests:
         values: "1x10"
       - series: 'kube_pod_status_ready{namespace="ci", pod="virt-operator-1", condition="true"}'
         values: "0x10"
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
+        values: "1x10"
 
     alert_rule_test:
       # no alert before 10 minutes
@@ -389,6 +558,9 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+      - eval_time: 10m
+        alertname: LowReadyVirtOperatorsCount
+        exp_alerts: [ ]
 
   # virt operator is ready, according to both metrics
   - interval: 1m

--- a/pkg/monitoring/metrics/virt-api/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-api/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "component_metrics.go",
         "connection_metrics.go",
         "metrics.go",
         "vm_metrics.go",

--- a/pkg/monitoring/metrics/virt-api/component_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/component_metrics.go
@@ -16,27 +16,27 @@
  * Copyright The KubeVirt Authors.
  */
 
-package virt_handler
+package virt_api
 
 import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 
 var (
 	componentMetrics = []operatormetrics.Metric{
-		virtHandlerReady,
+		virtAPIReady,
 	}
 
-	virtHandlerReady = operatormetrics.NewGauge(
+	virtAPIReady = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
-			Name: "kubevirt_virt_handler_ready_status",
-			Help: "Indication for a virt-handler that is ready to serve requests.",
+			Name: "kubevirt_virt_api_ready_status",
+			Help: "Indication for a virt-api server that is ready to serve requests.",
 		},
 	)
 )
 
-func SetVirtHandlerReady() {
-	virtHandlerReady.Set(1)
+func SetVirtAPIReady() {
+	virtAPIReady.Set(1)
 }
 
-func SetVirtHandlerNotReady() {
-	virtHandlerReady.Set(0)
+func SetVirtAPINotReady() {
+	virtAPIReady.Set(0)
 }

--- a/pkg/monitoring/metrics/virt-api/metrics.go
+++ b/pkg/monitoring/metrics/virt-api/metrics.go
@@ -36,6 +36,7 @@ func SetupMetrics() error {
 	}
 
 	return operatormetrics.RegisterMetrics(
+		componentMetrics,
 		connectionMetrics,
 		vmMetrics,
 	)

--- a/pkg/monitoring/metrics/virt-handler/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "component_metrics.go",
         "machine_type.go",
         "metrics.go",
         "version_metrics.go",

--- a/pkg/monitoring/metrics/virt-handler/component_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/component_metrics.go
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package virthandler
+
+import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+
+var (
+	componentMetrics = []operatormetrics.Metric{
+		virtHandlerReady,
+	}
+
+	virtHandlerReady = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_virt_handler_ready_status",
+			Help: "Indication for a virt-handler that is ready to serve requests.",
+		},
+	)
+)
+
+func SetVirtHandlerReady() {
+	virtHandlerReady.Set(1)
+}
+
+func SetVirtHandlerNotReady() {
+	virtHandlerReady.Set(0)
+}

--- a/pkg/monitoring/metrics/virt-handler/metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/metrics.go
@@ -38,7 +38,7 @@ func SetupMetrics(nodeName string, MaxRequestsInFlight int, vmiInformer cache.Sh
 		return err
 	}
 
-	if err := operatormetrics.RegisterMetrics(versionMetrics, machineTypeMetrics); err != nil {
+	if err := operatormetrics.RegisterMetrics(componentMetrics, versionMetrics, machineTypeMetrics); err != nil {
 		return err
 	}
 	SetVersionInfo()

--- a/pkg/monitoring/metrics/virt-operator/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-operator/BUILD.bazel
@@ -3,9 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "component_metrics.go",
         "leader_metrics.go",
         "metrics.go",
-        "operator_metrics.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-operator",
     visibility = ["//visibility:public"],

--- a/pkg/monitoring/metrics/virt-operator/component_metrics.go
+++ b/pkg/monitoring/metrics/virt-operator/component_metrics.go
@@ -21,19 +21,19 @@ package virt_operator
 import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 
 var (
-	operatorMetrics = []operatormetrics.Metric{
-		leaderGauge,
-		readyGauge,
+	componentMetrics = []operatormetrics.Metric{
+		virtOperatorLeading,
+		virtOperatorReady,
 	}
 
-	leaderGauge = operatormetrics.NewGauge(
+	virtOperatorLeading = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_virt_operator_leading_status",
 			Help: "Indication for an operating virt-operator.",
 		},
 	)
 
-	readyGauge = operatormetrics.NewGauge(
+	virtOperatorReady = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_virt_operator_ready_status",
 			Help: "Indication for a virt-operator that is ready to take the lead.",
@@ -41,10 +41,18 @@ var (
 	)
 )
 
-func SetLeader(isLeader bool) {
-	leaderGauge.Set(boolToFloat64(isLeader))
+func SetVirtOperatorLeading() {
+	virtOperatorLeading.Set(1)
 }
 
-func SetReady(isReady bool) {
-	readyGauge.Set(boolToFloat64(isReady))
+func SetVirtOperatorNotLeading() {
+	virtOperatorLeading.Set(0)
+}
+
+func SetVirtOperatorReady() {
+	virtOperatorReady.Set(1)
+}
+
+func SetVirtOperatorNotReady() {
+	virtOperatorReady.Set(0)
 }

--- a/pkg/monitoring/metrics/virt-operator/metrics.go
+++ b/pkg/monitoring/metrics/virt-operator/metrics.go
@@ -36,7 +36,7 @@ func SetupMetrics() error {
 	}
 
 	return operatormetrics.RegisterMetrics(
-		operatorMetrics,
+		componentMetrics,
 	)
 }
 

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -41,6 +41,33 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 			},
 		},
 		{
+			Alert: "LowReadyVirtAPICount",
+			Expr: intstr.FromString(
+				"cluster:kubevirt_virt_api_ready:sum < cluster:kubevirt_virt_api_pods_running:count " +
+					"and cluster:kubevirt_virt_api_ready:sum > 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "Some virt-api pods are running but not ready.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "warning",
+			},
+		},
+		{
+			Alert: "NoReadyVirtAPI",
+			Expr:  intstr.FromString("cluster:kubevirt_virt_api_ready:sum == 0"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "No ready virt-api was detected for the last 10 min.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "critical",
+			},
+		},
+		{
 			Alert: "LowVirtAPICount",
 			Expr: intstr.FromString(fmt.Sprintf(
 				"cluster:kubevirt_virt_api_up:sum / on() kube_deployment_spec_replicas{deployment='virt-api', namespace='%s'} < 0.75", namespace,

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -30,10 +30,10 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtAPIDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_api_up:sum == 0"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_api_pods_running:count == 0"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "All virt-api servers are down.",
+				summaryAnnotationKey: "No running virt-api pods were detected for the last 10 min.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -30,8 +30,11 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "LowReadyVirtControllersCount",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_ready:sum < cluster:kubevirt_virt_controller_pods_running:count"),
-			For:   ptr.To(promv1.Duration("10m")),
+			Expr: intstr.FromString(
+				"cluster:kubevirt_virt_controller_ready:sum < cluster:kubevirt_virt_controller_pods_running:count " +
+					"and cluster:kubevirt_virt_controller_ready:sum > 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Some virt controllers are running but not ready.",
 			},

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -29,6 +29,45 @@ import (
 func virtHandlerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
+			Alert: "VirtHandlerDown",
+			Expr:  intstr.FromString("cluster:kubevirt_virt_handler_pods_running:count == 0"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "No running virt-handler pods were detected for the last 10 min.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "critical",
+			},
+		},
+		{
+			Alert: "LowReadyVirtHandlerCount",
+			Expr: intstr.FromString(
+				"cluster:kubevirt_virt_handler_ready:sum < cluster:kubevirt_virt_handler_pods_running:count " +
+					"and cluster:kubevirt_virt_handler_ready:sum > 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "Some virt-handlers are running but not ready.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "warning",
+			},
+		},
+		{
+			Alert: "NoReadyVirtHandler",
+			Expr:  intstr.FromString("cluster:kubevirt_virt_handler_ready:sum == 0"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "No ready virt-handler was detected for the last 10 min.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "critical",
+			},
+		},
+		{
 			Alert: "VirtHandlerDaemonSetRolloutFailing",
 			Expr: intstr.FromString(
 				fmt.Sprintf("(%s - %s) != 0",

--- a/pkg/monitoring/rules/alerts/virt-operator.go
+++ b/pkg/monitoring/rules/alerts/virt-operator.go
@@ -30,10 +30,10 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
 			Alert: "VirtOperatorDown",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_up:sum == 0"),
+			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_pods_running:count == 0"),
 			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "All virt-operator servers are down.",
+				summaryAnnotationKey: "No running virt-operator pods were detected for the last 10 min.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "critical",
@@ -72,8 +72,11 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowReadyVirtOperatorsCount",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_operator_ready:sum < cluster:kubevirt_virt_operator_pods_running:count"),
-			For:   ptr.To(promv1.Duration("10m")),
+			Expr: intstr.FromString(
+				"cluster:kubevirt_virt_operator_ready:sum < cluster:kubevirt_virt_operator_pods_running:count " +
+					"and cluster:kubevirt_virt_operator_ready:sum > 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Some virt-operators are running but not ready.",
 			},

--- a/pkg/monitoring/rules/recordingrules/virt.go
+++ b/pkg/monitoring/rules/recordingrules/virt.go
@@ -28,95 +28,109 @@ import (
 
 func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 	return []operatorrules.RecordingRule{
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_api_up:sum",
-				Help: "The number of virt-api pods that are up.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-api-.*'}) or vector(0)", namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_controller_pods_running:count",
-				Help: "The number of virt-controller pods that are running.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("count(kube_pod_status_phase{pod=~'virt-controller-.*', namespace='%s', phase='Running'} == 1) or vector(0)", namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_controller_up:sum",
-				Help: "The number of virt-controller pods that are up.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("sum(up{pod=~'virt-controller-.*', namespace='%s'}) or vector(0)", namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_controller_ready:sum",
-				Help: "The number of virt-controller pods that are ready.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("sum(kube_pod_status_ready{pod=~'virt-controller-.*', namespace='%s', condition='true'} * "+
-					" on(pod, namespace) kubevirt_virt_controller_ready_status{namespace='%s'}) or vector(0)", namespace, namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_operator_up:sum",
-				Help: "The number of virt-operator pods that are up.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-operator-.*'}) or vector(0)", namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_operator_pods_running:count",
-				Help: "The number of virt-operator pods that are running.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("count(kube_pod_status_phase{pod=~'virt-operator-.*', namespace='%s', phase='Running'} == 1) or vector(0)", namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_operator_ready:sum",
-				Help: "The number of virt-operator pods that are ready.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("sum(kube_pod_status_ready{pod=~'virt-operator-.*', condition='true', namespace='%s'} * "+
-					"on (pod) kubevirt_virt_operator_ready_status{namespace='%s'}) or vector(0)", namespace, namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_operator_leading:sum",
-				Help: "The number of virt-operator pods that are leading.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr: intstr.FromString(
-				fmt.Sprintf("sum(kubevirt_virt_operator_leading_status{namespace='%s'})", namespace),
-			),
-		},
-		{
-			MetricsOpts: operatormetrics.MetricOpts{
-				Name: "cluster:kubevirt_virt_handler_up:sum",
-				Help: "The number of virt-handler pods that are up.",
-			},
-			MetricType: operatormetrics.GaugeType,
-			Expr:       intstr.FromString(fmt.Sprintf("sum(up{pod=~'virt-handler-.*', namespace='%s'}) or vector(0)", namespace)),
-		},
+		// up
+		newRecordingRule(
+			"cluster:kubevirt_virt_api_up:sum",
+			"The number of virt-api pods that are up.",
+			upExpr(namespace, "api"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_controller_up:sum",
+			"The number of virt-controller pods that are up.",
+			upExpr(namespace, "controller"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_operator_up:sum",
+			"The number of virt-operator pods that are up.",
+			upExpr(namespace, "operator"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_handler_up:sum",
+			"The number of virt-handler pods that are up.",
+			upExpr(namespace, "handler"),
+		),
+
+		// pods running
+		newRecordingRule(
+			"cluster:kubevirt_virt_api_pods_running:count",
+			"The number of virt-api pods that are running.",
+			podsRunningExpr(namespace, "api"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_controller_pods_running:count",
+			"The number of virt-controller pods that are running.",
+			podsRunningExpr(namespace, "controller"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_operator_pods_running:count",
+			"The number of virt-operator pods that are running.",
+			podsRunningExpr(namespace, "operator"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_handler_pods_running:count",
+			"The number of virt-handler pods that are running.",
+			podsRunningExpr(namespace, "handler"),
+		),
+
+		// ready
+		newRecordingRule(
+			"cluster:kubevirt_virt_api_ready:sum",
+			"The number of virt-api pods that are ready.",
+			readyExpr(namespace, "api", "kubevirt_virt_api_ready_status"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_controller_ready:sum",
+			"The number of virt-controller pods that are ready.",
+			readyExpr(namespace, "controller", "kubevirt_virt_controller_ready_status"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_operator_ready:sum",
+			"The number of virt-operator pods that are ready.",
+			readyExpr(namespace, "operator", "kubevirt_virt_operator_ready_status"),
+		),
+		newRecordingRule(
+			"cluster:kubevirt_virt_handler_ready:sum",
+			"The number of virt-handler pods that are ready.",
+			readyExpr(namespace, "handler", "kubevirt_virt_handler_ready_status"),
+		),
+
+		// leading
+		newRecordingRule(
+			"cluster:kubevirt_virt_operator_leading:sum",
+			"The number of virt-operator pods that are leading.",
+			fmt.Sprintf("sum(kubevirt_virt_operator_leading_status{namespace='%s'})", namespace),
+		),
 	}
+}
+
+func newRecordingRule(name, help, expr string) operatorrules.RecordingRule {
+	return operatorrules.RecordingRule{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: name,
+			Help: help,
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString(expr),
+	}
+}
+
+func upExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"sum(up{namespace='%s', pod=~'virt-%s-.*'}) or vector(0)",
+		namespace, component,
+	)
+}
+
+func podsRunningExpr(namespace, component string) string {
+	return fmt.Sprintf(
+		"count(kube_pod_status_phase{pod=~'virt-%s-.*', namespace='%s', phase='Running'} == 1) or vector(0)",
+		component, namespace,
+	)
+}
+
+func readyExpr(namespace, component, readyStatusMetric string) string {
+	return fmt.Sprintf(
+		"sum(kube_pod_status_ready{pod=~'virt-%s-.*', namespace='%s', condition='true'} * on(pod, namespace) %s{namespace='%s'}) or vector(0)",
+		component, namespace, readyStatusMetric, namespace,
+	)
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1125,6 +1125,8 @@ func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory) 
 		errors <- server.ListenAndServeTLS("", "")
 	}()
 
+	metrics.SetVirtAPIReady()
+
 	// start graceful shutdown handler
 	go func() {
 		select {
@@ -1133,6 +1135,8 @@ func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory) 
 		case msg := <-app.reInitChan:
 			log.Log.Infof("Received signal to reInitialize virt-api [%s], initiating graceful shutdown", msg)
 		}
+
+		metrics.SetVirtAPINotReady()
 
 		// pause briefly to ensure the load balancer has had a chance to
 		// remove this endpoint from rotation due to pod.DeletionTimestamp != nil

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -450,14 +450,14 @@ func (app *VirtOperatorApp) Run() {
 					if err := metrics.RegisterLeaderMetrics(); err != nil {
 						golog.Fatalf("failed to register leader metrics: %v", err)
 					}
-					metrics.SetLeader(true)
+					metrics.SetVirtOperatorLeading()
 					log.Log.Infof("Started leading")
 
 					// run app
 					go app.kubeVirtController.Run(controllerThreads, stop)
 				},
 				OnStoppedLeading: func() {
-					metrics.SetLeader(false)
+					metrics.SetVirtOperatorNotLeading()
 					log.Log.V(5).Info("stop monitoring the kubevirt-config configMap")
 					golog.Fatal("leaderelection lost")
 				},
@@ -467,7 +467,7 @@ func (app *VirtOperatorApp) Run() {
 		golog.Fatal(err)
 	}
 
-	metrics.SetReady(true)
+	metrics.SetVirtOperatorReady()
 	log.Log.Infof("Attempting to acquire leader status")
 	leaderElector.Run(app.ctx)
 

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -28,6 +28,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,6 +50,12 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const (
+	randNodeSelectorSuffixLength   = 8
+	lowReadySingletonWorkloadCount = 1
+	lowReadyDeploymentRunningCount = 2
+)
+
 type alerts struct {
 	deploymentName       string
 	downAlert            string
@@ -57,10 +65,12 @@ type alerts struct {
 }
 
 var (
-	virtApi = alerts{
+	virtAPI = alerts{
 		deploymentName:       "virt-api",
 		downAlert:            "VirtAPIDown",
+		noReadyAlert:         "NoReadyVirtAPI",
 		restErrorsBurtsAlert: "VirtApiRESTErrorsBurst",
+		lowReadyAlert:        "LowReadyVirtAPICount",
 	}
 	virtController = alerts{
 		deploymentName:       "virt-controller",
@@ -71,7 +81,10 @@ var (
 	}
 	virtHandler = alerts{
 		deploymentName:       "virt-handler",
+		downAlert:            "VirtHandlerDown",
+		noReadyAlert:         "NoReadyVirtHandler",
 		restErrorsBurtsAlert: "VirtHandlerRESTErrorsBurst",
+		lowReadyAlert:        "LowReadyVirtHandlerCount",
 	}
 	virtOperator = alerts{
 		deploymentName:       "virt-operator",
@@ -92,7 +105,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 		scales = libmonitoring.NewScaling(virtClient, []string{
 			virtOperator.deploymentName,
 			virtController.deploymentName,
-			virtApi.deploymentName,
+			virtAPI.deploymentName,
 		})
 	})
 
@@ -110,7 +123,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 	AfterEach(func() {
 		By("Restoring the controller and api scales")
 		scales.RestoreScale(virtController.deploymentName)
-		scales.RestoreScale(virtApi.deploymentName)
+		scales.RestoreScale(virtAPI.deploymentName)
 
 		By("Restoring the operator")
 		restoreOperator(virtClient, scales)
@@ -118,8 +131,8 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 
 	Context("Up metrics", func() {
 		It("VirtOperatorDown should be triggered when virt-operator is down", func() {
-			By("Waiting for the operator to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_up:sum", 0)
+			By("Waiting for no running virt-operator pods")
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_pods_running:count", 0)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtOperator.downAlert)
@@ -137,8 +150,8 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			By("Scaling down the controller")
 			scales.UpdateScale(virtController.deploymentName, int32(0))
 
-			By("Waiting for the controller to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_controller_up:sum", 0)
+			By("Waiting for no running virt-controller pods")
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_controller_pods_running:count", 0)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtController.downAlert)
@@ -155,70 +168,141 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			libmonitoring.VerifyAlertExist(virtClient, virtController.noReadyAlert)
 		})
 
-		It("VirtApiDown should be triggered when virt-api is down", func() {
+		It("VirtAPIDown should be triggered when virt-api is down", func() {
 			By("Scaling down the api")
-			scales.UpdateScale(virtApi.deploymentName, int32(0))
+			scales.UpdateScale(virtAPI.deploymentName, int32(0))
 
-			By("Waiting for the api to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_api_up:sum", 0)
+			By("Waiting for no running virt-api pods")
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_api_pods_running:count", 0)
 
 			By("Verifying the alert exists")
-			libmonitoring.VerifyAlertExist(virtClient, virtApi.downAlert)
+			libmonitoring.VerifyAlertExist(virtClient, virtAPI.downAlert)
+		})
+
+		It("NoReadyVirtAPI should be triggered when virt-api is down", func() {
+			By("Scaling down the api")
+			scales.UpdateScale(virtAPI.deploymentName, int32(0))
+
+			By("Waiting for the api ready metric to be zero")
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_api_ready:sum", 0)
+
+			By("Verifying the alert exists")
+			libmonitoring.VerifyAlertExist(virtClient, virtAPI.noReadyAlert)
+		})
+
+		It("VirtHandlerDown should be triggered when virt-handler is down", func() {
+			By("Patching virt-handler DaemonSet with a nodeSelector that matches no node (no running virt-handler pods)")
+			daemonSet, getErr := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), virtHandler.deploymentName, metav1.GetOptions{},
+			)
+			Expect(getErr).ToNot(HaveOccurred())
+
+			if daemonSet.Spec.Template.Spec.NodeSelector == nil {
+				daemonSet.Spec.Template.Spec.NodeSelector = map[string]string{}
+			}
+			// VirtHandlerDown uses running pod count; a non-scrapable-but-Running pod would not satisfy the alert.
+			daemonSet.Spec.Template.Spec.NodeSelector["kubevirt.io/e2e-virt-handler-down"] = rand.String(randNodeSelectorSuffixLength)
+
+			patchBytes, patchErr := json.Marshal(daemonSet)
+			Expect(patchErr).ToNot(HaveOccurred())
+
+			_, err = virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Patch(
+				context.Background(), virtHandler.deploymentName, types.MergePatchType, patchBytes, metav1.PatchOptions{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for no running virt-handler pods")
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_handler_pods_running:count", 0)
+
+			By("Verifying the alert exists")
+			libmonitoring.VerifyAlertExist(virtClient, virtHandler.downAlert)
+		})
+
+		It("NoReadyVirtHandler should be triggered when virt-handler is not ready", func() {
+			daemonSet, getErr := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), virtHandler.deploymentName, metav1.GetOptions{},
+			)
+			Expect(getErr).ToNot(HaveOccurred())
+
+			originalDaemonSet := daemonSet.DeepCopy()
+			defer func() {
+				restoreDaemonSetImage(
+					virtClient, virtHandler.deploymentName,
+					originalDaemonSet, virtHandler.noReadyAlert,
+				)
+			}()
+
+			badContainer := daemonSet.Spec.Template.Spec.Containers[0]
+			badContainer.Image = libregistry.GetUtilityImageFromRegistry("vm-killer")
+			badContainer.Command = []string{"tail", "-f", "/dev/null"}
+			badContainer.Args = []string{}
+			badContainer.ReadinessProbe = nil
+			badContainer.LivenessProbe = nil
+
+			err = patchDaemonSetFirstContainer(virtClient, daemonSet.Name, badContainer)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for virt-handler ready metric to be zero")
+			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_handler_ready:sum", 0)
+
+			By("Verifying the alert exists")
+			libmonitoring.VerifyAlertExist(virtClient, virtHandler.noReadyAlert)
 		})
 	})
 
-	Context("Low ready alerts", decorators.RequiresTwoSchedulableNodes, func() {
-		It("LowReadyVirtControllersCount should be triggered when virt-controller pods exist but are not ready", func() {
-			By("Ensuring the controller is scaled up")
-			scales.RestoreScale(virtController.deploymentName)
+	Context("Low ready alerts", func() {
+		It("LowReadyVirtControllersCount should be triggered when virt controller pods ready are less than running and ready > 0", func() {
+			runLowReadyDecoyDeploymentTest(
+				virtClient, scales,
+				virtController.deploymentName, virtController.lowReadyAlert,
+				"cluster:kubevirt_virt_controller_ready:sum",
+				"cluster:kubevirt_virt_controller_pods_running:count",
+			)
+		})
 
-			virtControllerDeployment, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), virtController.deploymentName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+		It("LowReadyVirtAPICount should be triggered when virt api pods ready are less than running and ready > 0", func() {
+			runLowReadyDecoyDeploymentTest(
+				virtClient, scales,
+				virtAPI.deploymentName, virtAPI.lowReadyAlert,
+				"cluster:kubevirt_virt_api_ready:sum",
+				"cluster:kubevirt_virt_api_pods_running:count",
+			)
+		})
 
-			originalVirtControllerDeployment := virtControllerDeployment.DeepCopy()
-			defer func() {
-				By("Restoring the virt-controller deployment to the correct image")
-				currentDep, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), virtController.deploymentName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				currentDep.Spec.Template.Spec.Containers[0] = originalVirtControllerDeployment.Spec.Template.Spec.Containers[0]
-				patch, err := json.Marshal(currentDep)
-				Expect(err).ToNot(HaveOccurred())
-				_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), virtController.deploymentName, types.MergePatchType, patch, metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred())
+		It("LowReadyVirtHandlerCount should be triggered when virt-handler pods ready are less than running and ready > 0", func() {
+			runLowReadyDecoyDaemonSetTest(virtClient, virtHandler.lowReadyAlert)
+		})
 
-				By("Waiting for the low ready alert to not be firing anymore")
-				libmonitoring.WaitUntilAlertDoesNotExist(virtClient, virtController.lowReadyAlert)
-			}()
-
-			container := &virtControllerDeployment.Spec.Template.Spec.Containers[0]
-			container.Image = libregistry.GetUtilityImageFromRegistry("vm-killer") // any random image
-			container.Command = []string{"tail", "-f", "/dev/null"}
-			container.Args = []string{}
-			container.ReadinessProbe = nil
-			container.LivenessProbe = nil
-
-			patch, err := json.Marshal(virtControllerDeployment)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), virtControllerDeployment.Name, types.MergePatchType, patch, metav1.PatchOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			libmonitoring.VerifyAlertExist(virtClient, virtController.lowReadyAlert)
+		It("LowReadyVirtOperatorsCount should be triggered when virt-operator pods ready are less than running and ready > 0", func() {
+			runLowReadyDecoyDeploymentTest(
+				virtClient, scales,
+				virtOperator.deploymentName, virtOperator.lowReadyAlert,
+				"cluster:kubevirt_virt_operator_ready:sum",
+				"cluster:kubevirt_virt_operator_pods_running:count",
+			)
 		})
 	})
 
 	Context("Errors metrics", func() {
+		const (
+			operatorRoleBindingName = "kubevirt-operator-rolebinding"
+			randStrLen              = 6
+		)
+
 		var crb *rbacv1.ClusterRoleBinding
-		const operatorRoleBindingName = "kubevirt-operator-rolebinding"
 		var operatorRoleBinding *rbacv1.RoleBinding
 
 		BeforeEach(func() {
 			By("Backing up the operator cluster role binding")
-			crb, err = virtClient.RbacV1().ClusterRoleBindings().Get(context.Background(), "kubevirt-operator", metav1.GetOptions{})
+			crb, err = virtClient.RbacV1().ClusterRoleBindings().Get(
+				context.Background(), "kubevirt-operator", metav1.GetOptions{},
+			)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Backing up the operator role binding")
-			operatorRoleBinding, err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Get(context.Background(), operatorRoleBindingName, metav1.GetOptions{})
+			operatorRoleBinding, err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Get(
+				context.Background(), operatorRoleBindingName, metav1.GetOptions{},
+			)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -227,23 +311,29 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			crb.Annotations = nil
 			crb.ObjectMeta.ResourceVersion = ""
 			crb.ObjectMeta.UID = ""
-			_, err = virtClient.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
+			_, err = virtClient.RbacV1().ClusterRoleBindings().Create(
+				context.Background(), crb, metav1.CreateOptions{},
+			)
 			Expect(err).To(Or(Not(HaveOccurred()), MatchError(errors.IsAlreadyExists, "IsAlreadyExists")))
 
 			By("Restoring the operator role binding")
 			operatorRoleBinding.Annotations = nil
 			operatorRoleBinding.ObjectMeta.ResourceVersion = ""
 			operatorRoleBinding.ObjectMeta.UID = ""
-			_, err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Create(context.Background(), operatorRoleBinding, metav1.CreateOptions{})
+			_, err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Create(
+				context.Background(), operatorRoleBinding, metav1.CreateOptions{},
+			)
 			Expect(err).To(Or(Not(HaveOccurred()), MatchError(errors.IsAlreadyExists, "IsAlreadyExists")))
 		})
 
 		It("VirtApiRESTErrorsBurst should be triggered when requests to virt-api are failing", func() {
 			By("Creating VNC connections to the virt-api")
 			Eventually(func(g Gomega) {
-				_, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).VNC(rand.String(6), false)
-				g.Expect(err).To(MatchError(ContainSubstring("not found")))
-				g.Expect(libmonitoring.CheckAlertExists(virtClient, virtApi.restErrorsBurtsAlert)).To(BeTrue())
+				_, vncErr := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).VNC(
+					rand.String(randStrLen), false,
+				)
+				g.Expect(vncErr).To(MatchError(ContainSubstring("not found")))
+				g.Expect(libmonitoring.CheckAlertExists(virtClient, virtAPI.restErrorsBurtsAlert)).To(BeTrue())
 			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
 		})
 
@@ -252,11 +342,15 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			scales.RestoreScale(virtOperator.deploymentName)
 
 			By("Deleting the operator cluster role binding")
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), crb.Name, metav1.DeleteOptions{})
+			err = virtClient.RbacV1().ClusterRoleBindings().Delete(
+				context.Background(), crb.Name, metav1.DeleteOptions{},
+			)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Deleting the operator role binding")
-			err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Delete(context.Background(), operatorRoleBindingName, metav1.DeleteOptions{})
+			err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Delete(
+				context.Background(), operatorRoleBindingName, metav1.DeleteOptions{},
+			)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for the alert to exist")
@@ -265,76 +359,13 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
 		})
 
-		PIt("VirtControllerRESTErrorsBurst should be triggered when requests to virt-controller are failing", func() {
-			By("Deleting the controller cluster role binding")
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-controller", metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi := libvmifact.NewGuestless()
-
-			By("Trying to create a guestless vmi until the alert exists")
-			Eventually(func(g Gomega) {
-				_, _ = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
-				_ = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
-
-				g.Expect(libmonitoring.CheckAlertExists(virtClient, virtController.restErrorsBurtsAlert)).To(BeTrue())
-			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
+		PIt("VirtControllerRESTErrorsBurst should be triggered for virt-controller", func() {
+			checkRESTErrorsBurst(virtClient, "kubevirt-controller", virtController.restErrorsBurtsAlert)
 		})
 
 		It("VirtHandlerRESTErrorsBurst should be triggered when requests to virt-handler are failing", func() {
-			By("Deleting the handler cluster role binding")
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-handler", metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi := libvmifact.NewGuestless()
-
-			By("Trying to create a guestless vmi until the alert exists")
-			Eventually(func(g Gomega) {
-				_, _ = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
-				_ = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
-
-				g.Expect(libmonitoring.CheckAlertExists(virtClient, virtHandler.restErrorsBurtsAlert)).To(BeTrue())
-			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
+			checkRESTErrorsBurst(virtClient, "kubevirt-handler", virtHandler.restErrorsBurtsAlert)
 		})
-	})
-})
-
-var _ = Describe("[sig-monitoring] Virt-operator alerts", Serial, Ordered, decorators.SigMonitoring, decorators.RequiresTwoSchedulableNodes, func() {
-	It("LowReadyVirtOperatorsCount should be triggered when virt-operator pods exist but are not ready", func() {
-		virtClient := kubevirt.Client()
-
-		virtOperatorDeployment, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), virtOperator.deploymentName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		originalVirtOperatorDeployment := virtOperatorDeployment.DeepCopy()
-		defer func() {
-			By("Restoring the virt-operator deployment to the correct image")
-			currentDep, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), virtOperator.deploymentName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			currentDep.Spec.Template.Spec.Containers[0] = originalVirtOperatorDeployment.Spec.Template.Spec.Containers[0]
-			patch, err := json.Marshal(currentDep)
-			Expect(err).ToNot(HaveOccurred())
-			_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), virtOperator.deploymentName, types.MergePatchType, patch, metav1.PatchOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Waiting for the low ready alert to not be firing anymore")
-			libmonitoring.WaitUntilAlertDoesNotExist(virtClient, virtOperator.lowReadyAlert)
-		}()
-
-		container := &virtOperatorDeployment.Spec.Template.Spec.Containers[0]
-		container.Image = libregistry.GetUtilityImageFromRegistry("vm-killer") // any random image
-		container.Command = []string{"tail", "-f", "/dev/null"}
-		container.Args = []string{}
-		container.ReadinessProbe = nil
-		container.LivenessProbe = nil
-
-		patch, err := json.Marshal(virtOperatorDeployment)
-		Expect(err).ToNot(HaveOccurred())
-
-		_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), virtOperatorDeployment.Name, types.MergePatchType, patch, metav1.PatchOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		libmonitoring.VerifyAlertExist(virtClient, virtOperator.lowReadyAlert)
 	})
 })
 
@@ -345,10 +376,10 @@ func restoreOperator(virtClient kubecli.KubevirtClient, scales *libmonitoring.Sc
 		replica := i + 1
 
 		By(fmt.Sprintf("Updating the operator scale to %d", replica))
-		scales.UpdateScale(virtOperator.deploymentName, int32(replica))
+		scales.UpdateScale(virtOperator.deploymentName, replica)
 
-		By("Waiting for the operator to be up")
-		libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_up:sum", float64(replica))
+		By("Waiting for running virt-operator pods")
+		libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_pods_running:count", float64(replica))
 
 		By("Waiting for the operator to be ready")
 		libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_ready:sum", float64(replica))
@@ -356,6 +387,28 @@ func restoreOperator(virtClient kubecli.KubevirtClient, scales *libmonitoring.Sc
 
 	By("Waiting for an operator to be leading")
 	libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_operator_leading:sum", 1.0)
+}
+
+func checkRESTErrorsBurst(virtClient kubecli.KubevirtClient, roleBindingName, alertName string) {
+	By("Deleting the cluster role binding")
+	err := virtClient.RbacV1().ClusterRoleBindings().Delete(
+		context.Background(), roleBindingName, metav1.DeleteOptions{},
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	vmi := libvmifact.NewGuestless()
+
+	By("Trying to create a guestless vmi until the alert exists")
+	Eventually(func(g Gomega) {
+		_, _ = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(
+			context.Background(), vmi, metav1.CreateOptions{},
+		)
+		_ = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Delete(
+			context.Background(), vmi.Name, metav1.DeleteOptions{},
+		)
+
+		g.Expect(libmonitoring.CheckAlertExists(virtClient, alertName)).To(BeTrue())
+	}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
 }
 
 func increaseRateLimit(virtClient kubecli.KubevirtClient) {
@@ -373,4 +426,167 @@ func increaseRateLimit(virtClient kubecli.KubevirtClient) {
 	originalKubeVirt.Spec.Configuration.ControllerConfiguration = rateLimitConfig
 	originalKubeVirt.Spec.Configuration.HandlerConfiguration = rateLimitConfig
 	config.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
+}
+
+func runLowReadyDecoyDeploymentTest(
+	virtClient kubecli.KubevirtClient,
+	scales *libmonitoring.Scaling,
+	deploymentName, lowReadyAlert, readyMetric, runningMetric string,
+) {
+	ns := flags.KubeVirtInstallNamespace
+	ctx := context.Background()
+
+	By("Scaling the deployment to one real pod (decoy will be the second running pod)")
+	scales.UpdateScale(deploymentName, int32(lowReadySingletonWorkloadCount))
+
+	libmonitoring.WaitForMetricValue(virtClient, runningMetric, float64(lowReadySingletonWorkloadCount))
+	libmonitoring.WaitForMetricValue(virtClient, readyMetric, float64(lowReadySingletonWorkloadCount))
+
+	deployment, getErr := virtClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
+	Expect(getErr).ToNot(HaveOccurred())
+
+	decoyName := fmt.Sprintf("%s-e2e-lowready-decoy-%s", deploymentName, rand.String(randNodeSelectorSuffixLength))
+	decoyPod := newLowReadyDecoyPod(decoyName, deployment.Spec.Template.Spec)
+
+	defer func() {
+		By("Deleting the low-ready decoy pod")
+		_ = virtClient.CoreV1().Pods(ns).Delete(ctx, decoyName, metav1.DeleteOptions{})
+		By("Waiting for the low ready alert to not be firing anymore")
+		libmonitoring.WaitUntilAlertDoesNotExist(virtClient, lowReadyAlert)
+		By("Restoring the deployment replica count")
+		scales.RestoreScale(deploymentName)
+	}()
+
+	By("Creating a decoy pod that counts as running but does not contribute to the KubeVirt ready sum")
+	_, createErr := virtClient.CoreV1().Pods(ns).Create(ctx, decoyPod, metav1.CreateOptions{})
+	Expect(createErr).ToNot(HaveOccurred())
+
+	By("Waiting for two running pods and one ready pod in metrics (decoy running, single real pod ready)")
+	libmonitoring.WaitForMetricValue(virtClient, runningMetric, lowReadyDeploymentRunningCount)
+	libmonitoring.WaitForMetricValue(virtClient, readyMetric, float64(lowReadySingletonWorkloadCount))
+
+	libmonitoring.VerifyAlertExist(virtClient, lowReadyAlert)
+}
+
+func runLowReadyDecoyDaemonSetTest(virtClient kubecli.KubevirtClient, lowReadyAlert string) {
+	ns := flags.KubeVirtInstallNamespace
+	ctx := context.Background()
+
+	daemonSet, getErr := virtClient.AppsV1().DaemonSets(ns).Get(ctx, virtHandler.deploymentName, metav1.GetOptions{})
+	Expect(getErr).ToNot(HaveOccurred())
+
+	decoyName := fmt.Sprintf("%s-e2e-lowready-decoy-%s", virtHandler.deploymentName, rand.String(randNodeSelectorSuffixLength))
+	decoyPod := newLowReadyDecoyPod(decoyName, daemonSet.Spec.Template.Spec)
+
+	defer func() {
+		By("Deleting the virt-handler low-ready decoy pod")
+		_ = virtClient.CoreV1().Pods(ns).Delete(ctx, decoyName, metav1.DeleteOptions{})
+		By("Waiting for the low ready alert to not be firing anymore")
+		libmonitoring.WaitUntilAlertDoesNotExist(virtClient, lowReadyAlert)
+	}()
+
+	By("Creating a virt-handler decoy pod so running count exceeds the KubeVirt ready sum")
+	_, createErr := virtClient.CoreV1().Pods(ns).Create(ctx, decoyPod, metav1.CreateOptions{})
+	Expect(createErr).ToNot(HaveOccurred())
+
+	const (
+		handlerReadyMetric   = "cluster:kubevirt_virt_handler_ready:sum"
+		handlerRunningMetric = "cluster:kubevirt_virt_handler_pods_running:count"
+	)
+	By("Waiting for running count to exceed ready sum with ready still positive")
+	Eventually(func(g Gomega) {
+		ready, errR := libmonitoring.GetMetricValueWithLabels(virtClient, handlerReadyMetric, nil)
+		running, errRun := libmonitoring.GetMetricValueWithLabels(virtClient, handlerRunningMetric, nil)
+		g.Expect(errR).ToNot(HaveOccurred())
+		g.Expect(errRun).ToNot(HaveOccurred())
+		g.Expect(ready).To(BeNumerically(">", 0))
+		g.Expect(ready).To(BeNumerically("<", running))
+	}, 5*time.Minute, 2*time.Second).Should(Succeed())
+
+	libmonitoring.VerifyAlertExist(virtClient, lowReadyAlert)
+}
+
+func lowReadyDecoyPodSpecFromTemplate(spec corev1.PodSpec) corev1.PodSpec {
+	out := *spec.DeepCopy()
+	Expect(out.Containers).NotTo(BeEmpty())
+	c := &out.Containers[0]
+	c.Image = libregistry.GetUtilityImageFromRegistry("vm-killer")
+	c.Command = []string{"tail", "-f", "/dev/null"}
+	c.Args = nil
+	c.ReadinessProbe = nil
+	c.LivenessProbe = nil
+	c.StartupProbe = nil
+	return out
+}
+
+func newLowReadyDecoyPod(decoyPodName string, templateSpec corev1.PodSpec) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      decoyPodName,
+			Namespace: flags.KubeVirtInstallNamespace,
+			Labels: map[string]string{
+				"kubevirt.io/e2e-lowready-decoy": decoyPodName,
+			},
+		},
+		Spec: lowReadyDecoyPodSpecFromTemplate(templateSpec),
+	}
+}
+
+func restoreImageAndWaitForAlert(
+	virtClient kubecli.KubevirtClient,
+	alertName string,
+	restoreMsg string,
+	doRestore func() error,
+) {
+	By(restoreMsg)
+	Expect(doRestore()).ToNot(HaveOccurred())
+	By("Waiting for the low ready alert to not be firing anymore")
+	libmonitoring.WaitUntilAlertDoesNotExist(virtClient, alertName)
+}
+
+func restoreDaemonSetImage(
+	virtClient kubecli.KubevirtClient,
+	daemonSetName string,
+	originalDaemonSet *appsv1.DaemonSet,
+	alertName string,
+) {
+	restoreImageAndWaitForAlert(virtClient, alertName, "Restoring the virt-handler DaemonSet to the correct image", func() error {
+		return patchDaemonSetFirstContainer(
+			virtClient,
+			daemonSetName,
+			originalDaemonSet.Spec.Template.Spec.Containers[0],
+		)
+	})
+}
+
+func patchDaemonSetFirstContainer(virtClient kubecli.KubevirtClient, daemonSetName string, container corev1.Container) error {
+	ns := flags.KubeVirtInstallNamespace
+	ctx := context.Background()
+
+	ds, err := virtClient.AppsV1().DaemonSets(ns).Get(ctx, daemonSetName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	ds.Spec.Template.Spec.Containers[0] = container
+
+	return mergePatchDaemonSet(ctx, virtClient, ns, ds)
+}
+
+func mergePatchDaemonSet(
+	ctx context.Context,
+	virtClient kubecli.KubevirtClient,
+	ns string,
+	daemonSet *appsv1.DaemonSet,
+) error {
+	patchBytes, err := json.Marshal(daemonSet)
+	if err != nil {
+		return err
+	}
+
+	_, err = virtClient.AppsV1().DaemonSets(ns).Patch(
+		ctx, daemonSet.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
+	)
+
+	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/17015

### What this PR does
#### Before this PR:
- Virt-api: No ready metric and no recording rules based on ready metric.
- Virt-handler: No ready metric and no recording rules based on ready metric, also no VirtHandlerDown.
- Tests: Prom rule tests and component monitoring e2e did not cover the above virt-api and virt-handler behaviors.
- Down alerts: Some of the Down alerts used up rule instead of running rule. 

#### After this PR:
- Virt-api: metric: kubevirt_virt_api_ready_status; recording rules: cluster:kubevirt_virt_api_pods_running:count and cluster:kubevirt_virt_api_ready:sum; alerts LowReadyVirtAPICount and NoReadyVirtAPI.
- Virt-handler: metric:kubevirt_virt_handler_ready_status; recording rules: cluster:kubevirt_virt_handler_pods_running:count and cluster:kubevirt_virt_handler_ready:sum; alerts VirtHandlerDown, LowReadyVirtHandlerCount, and NoReadyVirtHandler.
- Tests: Prom rule unit tests (hack/prom-rule-ci/prom-rules-tests.yaml) and component monitoring e2e (tests/monitoring/component_monitoring.go) added/updated for these recording rules and alerts.
- Docs: Observability metrics documentation updated for the new recording rules
- Down alerts: all down alerts are using running rule instead of up rule
- Ready alerts: low ready alerts now using 
- Refactor operator_metrics and changed the name for component_metrics in order to do alignment
```
cluster:kubevirt_virt_<component>_ready:sum < cluster:kubevirt_virt_<component>_pods_running:count " +
					"and cluster:kubevirt_virt_<component>_ready:sum > 0"
```
- Rename operator_metrics to component_metrics to match virt controller.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding missing metrics, recording rules and alerts for virt components
```

