### PR TITLE
tests: address review feedback for guest OS panic test

### DIFF
--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
+        "//tests/events:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -47,6 +47,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	virtcontroller "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/events"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -562,15 +563,23 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 
 			By("triggering a kernel panic inside the guest")
-			Expect(console.ExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "sudo su -\n"},
-				&expect.BExp{R: "#"},
-				&expect.BSnd{S: "echo c > /proc/sysrq-trigger\n"},
-				&expect.BExp{R: "sysrq triggered crash"},
-			}, 15*time.Second)).To(Succeed())
+			const consoleTimeout = 30 * time.Second
+			expecter, _, err := console.NewExpecter(virtClient, vmi, consoleTimeout)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+
+			_, err = expecter.ExpectBatch([]expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: "echo c | sudo tee /proc/sysrq-trigger\n"},
+			}, consoleTimeout)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for VMI to reach Failed phase")
 			Eventually(matcher.ThisVMI(vmi), 2*time.Minute, 5*time.Second).Should(matcher.BeInPhase(v1.Failed))
+
+			By("verifying the GuestPanicked event was emitted")
+			events.ExpectEvent(vmi, corev1.EventTypeWarning, "GuestPanicked")
 
 			By("verifying the guest OS panic metric was incremented")
 			labels := map[string]string{


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The guest OS panic test (added in https://github.com/kubevirt/kubevirt/pull/17836) used a multi-step approach to trigger a kernel panic: `sudo su -` followed by `echo c > /proc/sysrq-trigger`, which was flaky due to the unreliable `#` root prompt match and the `sysrq triggered crash` output expectation. The test also did not verify the `GuestPanicked` Kubernetes event.

#### After this PR:

- The kernel panic trigger is simplified to a single fire-and-forget one-liner: `echo c | sudo tee /proc/sysrq-trigger`, eliminating flaky prompt and output matching.
- The test now verifies the `GuestPanicked` Kubernetes event via `events.ExpectEvent`, ensuring the full observability path (k8s event + Prometheus metric) is validated.

### References

Addresses review feedback from https://github.com/kubevirt/kubevirt/pull/17836

### Special notes for your reviewer

This is a small follow-up addressing review feedback from jean-edouard on the original PR https://github.com/kubevirt/kubevirt/pull/17836.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~~Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required~~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```