### PR TITLE
CBT: live migration with RWO backend storage

### DIFF
--- a/pkg/virt-launcher/virtwrap/storage/backup.go
+++ b/pkg/virt-launcher/virtwrap/storage/backup.go
@@ -562,6 +562,10 @@ func hasBitmap(bitmapsByFile map[string][]qmpBitmapInfo, filePath, bitmapName st
 	}
 	for _, bm := range bitmaps {
 		if bm.Name == bitmapName {
+			if bm.Inconsistent {
+				log.Log.Warningf("Bitmap %s on %s is inconsistent (possibly from failed migration), treating as absent", bitmapName, filePath)
+				return false
+			}
 			return true
 		}
 	}
@@ -569,7 +573,8 @@ func hasBitmap(bitmapsByFile map[string][]qmpBitmapInfo, filePath, bitmapName st
 }
 
 type qmpBitmapInfo struct {
-	Name string `json:"name"`
+	Name         string `json:"name"`
+	Inconsistent bool   `json:"inconsistent,omitempty"`
 }
 
 type qmpBlockNodeInfo struct {

--- a/pkg/virt-launcher/virtwrap/storage/backup_test.go
+++ b/pkg/virt-launcher/virtwrap/storage/backup_test.go
@@ -966,6 +966,37 @@ var _ = Describe("Backup", func() {
 			Expect(disksWithoutBitmap[0]).To(Equal("vda"))
 		})
 
+		It("should treat inconsistent bitmap as absent", func() {
+			domainXML := `<domain>
+				<devices>
+					<disk type="file" device="disk">
+						<source file="/var/run/kubevirt-private/vmi-disks/disk1/disk.qcow2">
+							<dataStore>
+								<source file="/var/lib/kubevirt/disks/disk1-backing.qcow2"/>
+							</dataStore>
+						</source>
+						<target dev="vda"/>
+					</disk>
+				</devices>
+			</domain>`
+
+			mockDomain.EXPECT().GetXMLDesc(gomock.Any()).Return(domainXML, nil)
+			queryBitmaps = func(dom cli.VirDomain) (map[string][]qmpBitmapInfo, error) {
+				return map[string][]qmpBitmapInfo{
+					"/var/run/kubevirt-private/vmi-disks/disk1/disk.qcow2": {
+						{Name: checkpointName, Inconsistent: true},
+					},
+				}, nil
+			}
+
+			result, disksWithoutBitmap, err := findDisksWithCheckpointBitmap(mockDomain, checkpointName)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Disks).To(BeEmpty())
+			Expect(disksWithoutBitmap).To(HaveLen(1))
+			Expect(disksWithoutBitmap[0]).To(Equal("vda"))
+		})
+
 		It("should find multiple disks with checkpoint bitmap", func() {
 			domainXML := `<domain>
 				<devices>

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -1301,10 +1301,7 @@ var _ = Describe("Backup with migration", func() {
 		},
 		Entry("[sig-compute-migrations] RWX backend storage", decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.RequiresRWXFsVMStateStorageClass, decorators.NoFlakeCheck,
 			corev1.ReadWriteMany),
-		// TODO: Currently there is a bug in libvirt where the bitmap migration fails when using RWO block storage.
-		// Will remove the skip once the bug fix is released. (it passed locally with custom libvirt patch)
-		// Bug: https://issues.redhat.com/browse/RHEL-145770
-		PEntry("[sig-storage] RWO backend storage", decorators.SigStorage, decorators.RequiresTwoSchedulableNodes, decorators.RequiresRWOFsVMStateStorageClass, decorators.RequiresRWXBlock,
+		Entry("[sig-storage] RWO backend storage", decorators.SigStorage, decorators.RequiresTwoSchedulableNodes, decorators.RequiresRWOFsVMStateStorageClass, decorators.RequiresRWXBlock,
 			corev1.ReadWriteOnce),
 	)
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
KubeVirt was using Libvirt 11.9.0-1 which didn't contain https://www.mail-archive.com/devel@lists.libvirt.org/msg14596.html, a necessary patch for supporting CBT live migration with RWO backend storage. 

#### After this PR:
KubeVirt is now using Libvirt 11.10.0-12 which includes patches to always migrate block dirty bitmaps during live migration, even when the qcow2 overlay is non-shared.
This PR adds a guard to reject inconsistent bitmaps during checkpoint redefinition (in case bitmap transfer fails mid-migration) and unskips a test that verifies incremental backup continuity across migration with RWO backend storage..

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- PR is dependent on https://github.com/kubevirt/kubevirt/pull/17422

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Live migration with CBT and RWO backend storage now correctly retains checkpoints post-migration
```

