### PR TITLE
e2e, net, tests: validate guest only iface limit in status

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -21,10 +21,14 @@ package network
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -177,6 +181,119 @@ var _ = Describe(SIG("Infosource", func() {
 			Expect(vmi.Status.Interfaces).To(ConsistOf(expectedInterfaces))
 		})
 	})
+
+	Context("VMI with many interfaces guest only interfaces", func() {
+		const (
+			nadName                 = "test-nad"
+			secondaryNetworkName    = "secondary-net"
+			numGuestBridges         = 3
+			numGuestVethPairs       = 2
+			numGuestDummyInterfaces = 8
+			guestOnlyInterfaceLimit = 10
+		)
+
+		var vmi *v1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			netAttachDef := libnet.NewBridgeNetAttachDef(nadName, "br1")
+			_, err := libnet.CreateNetAttachDef(context.Background(), testsuite.GetTestNamespace(nil), netAttachDef)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		BeforeEach(func() {
+			cloudInitUserData := generateMultipleGuestOnlyInterfaceCloudInit(numGuestBridges, numGuestVethPairs, numGuestDummyInterfaces)
+
+			vmi = libvmifact.NewAlpineWithTestTooling(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("default")),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, nadName)),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(cloudInitUserData)),
+			)
+
+			var err error
+			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			libwait.WaitForSuccessfulVMIStart(vmi)
+
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(
+				matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+		})
+
+		It("should correctly report interface status with limit", func() {
+			const linkStateUp = "up"
+
+			expectedInterfaces := []v1.VirtualMachineInstanceNetworkInterface{
+				{
+					InfoSource: netvmispec.NewInfoSource(
+						netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent),
+					InterfaceName:    "eth0",
+					Name:             "default",
+					PodInterfaceName: namescheme.PrimaryPodInterfaceName,
+					QueueCount:       network.DefaultInterfaceQueueCount,
+					LinkState:        linkStateUp,
+				},
+				{
+					InfoSource: netvmispec.NewInfoSource(
+						netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus),
+					InterfaceName:    "eth1",
+					Name:             secondaryNetworkName,
+					PodInterfaceName: namescheme.GenerateHashedInterfaceName(secondaryNetworkName),
+					QueueCount:       network.DefaultInterfaceQueueCount,
+					LinkState:        linkStateUp,
+				},
+			}
+
+			for i := 0; i < numGuestBridges; i++ {
+				expectedInterfaces = append(expectedInterfaces, v1.VirtualMachineInstanceNetworkInterface{
+					InfoSource:    netvmispec.InfoSourceGuestAgent,
+					InterfaceName: fmt.Sprintf("br%d", i),
+					QueueCount:    network.UnknownInterfaceQueueCount,
+				})
+			}
+
+			for i := 0; i < numGuestVethPairs; i++ {
+				expectedInterfaces = append(expectedInterfaces, v1.VirtualMachineInstanceNetworkInterface{
+					InfoSource:    netvmispec.InfoSourceGuestAgent,
+					InterfaceName: fmt.Sprintf("veth%db", i),
+					QueueCount:    network.UnknownInterfaceQueueCount,
+				})
+				expectedInterfaces = append(expectedInterfaces, v1.VirtualMachineInstanceNetworkInterface{
+					InfoSource:    netvmispec.InfoSourceGuestAgent,
+					InterfaceName: fmt.Sprintf("veth%da", i),
+					QueueCount:    network.UnknownInterfaceQueueCount,
+				})
+			}
+
+			remainingGuestInterfaces := guestOnlyInterfaceLimit - numGuestBridges - (numGuestVethPairs * 2)
+			for i := 0; i < remainingGuestInterfaces; i++ {
+				expectedInterfaces = append(expectedInterfaces, v1.VirtualMachineInstanceNetworkInterface{
+					InfoSource:    netvmispec.InfoSourceGuestAgent,
+					InterfaceName: fmt.Sprintf("dummy%d", i),
+					QueueCount:    network.UnknownInterfaceQueueCount,
+				})
+			}
+
+			var matchers []gomegatypes.GomegaMatcher
+			for _, expected := range expectedInterfaces {
+				matchers = append(matchers, gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"InfoSource":       Equal(expected.InfoSource),
+					"InterfaceName":    Equal(expected.InterfaceName),
+					"Name":             Equal(expected.Name),
+					"PodInterfaceName": Equal(expected.PodInterfaceName),
+					"QueueCount":       Equal(expected.QueueCount),
+					"LinkState":        Equal(expected.LinkState),
+				}))
+			}
+
+			Eventually(func() []v1.VirtualMachineInstanceNetworkInterface {
+				var err error
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return vmi.Status.Interfaces
+			}, 120*time.Second, 5*time.Second).Should(HaveExactElements(matchers))
+		})
+	})
 }))
 
 func dummyInterfaceExists(vmi *v1.VirtualMachineInstance) bool {
@@ -196,4 +313,33 @@ func manipulateGuestLinksScript(eth0NewMac, dummyInterfaceMac string) string {
 		"ip link set eth2 netns testns\n"
 
 	return "#!/bin/bash\n" + changeEth0Mac + createDummyInterface + moveEth2ToOtherNS
+}
+
+func generateMultipleGuestOnlyInterfaceCloudInit(numBridges, numVethPairs, numDummyInterfaces int) string {
+	var b strings.Builder
+
+	b.WriteString("#cloud-config\n")
+	b.WriteString("runcmd:\n")
+
+	for i := 0; i < numBridges; i++ {
+		name := fmt.Sprintf("br%d", i)
+		fmt.Fprintf(&b, "  - [ip, link, add, %s, type, bridge]\n", name)
+		fmt.Fprintf(&b, "  - [ip, link, set, %s, up]\n", name)
+	}
+
+	for i := 0; i < numVethPairs; i++ {
+		vethA := fmt.Sprintf("veth%da", i)
+		vethB := fmt.Sprintf("veth%db", i)
+		fmt.Fprintf(&b, "  - [ip, link, add, %s, type, veth, peer, name, %s]\n", vethA, vethB)
+		fmt.Fprintf(&b, "  - [ip, link, set, %s, up]\n", vethA)
+		fmt.Fprintf(&b, "  - [ip, link, set, %s, up]\n", vethB)
+	}
+
+	for i := 0; i < numDummyInterfaces; i++ {
+		name := fmt.Sprintf("dummy%d", i)
+		fmt.Fprintf(&b, "  - [ip, link, add, %s, type, dummy]\n", name)
+		fmt.Fprintf(&b, "  - [ip, link, set, %s, up]\n", name)
+	}
+
+	return b.String()
 }


### PR DESCRIPTION
PR https://github.com/kubevirt/kubevirt/pull/16391 limited guest agent interface reporting to 10 to prevent
etcd exhaustion. The limit was verified in unit tests against a guest agent mock. However, live guest agents may behave differently and report interfaces in unexpected order.

This test creates 15 guest interfaces (above the limit) and validates that VMI status reporting remains consistent: exactly 10 interfaces reported with correct InfoSource and deterministic ordering.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

