### PR TITLE
monitoring: add namespace label to component alerts and validate in E2E

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -45,6 +45,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: VirtControllerDown
         exp_alerts:
@@ -56,6 +57,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: VirtOperatorDown
         exp_alerts:
@@ -67,6 +69,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: VirtHandlerDown
         exp_alerts:
@@ -78,6 +81,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       # it must trigger when operators are not healthy
       - eval_time: 16m
         alertname: VirtAPIDown
@@ -90,6 +94,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 16m
         alertname: VirtControllerDown
         exp_alerts:
@@ -101,6 +106,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 16m
         alertname: VirtOperatorDown
         exp_alerts:
@@ -112,6 +118,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 16m
         alertname: VirtHandlerDown
         exp_alerts:
@@ -123,6 +130,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       # it must not trigger when operators are healthy
       - eval_time: 17m
         alertname: VirtAPIDown
@@ -248,6 +256,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # Some virt operators are not ready
   - interval: 1m
@@ -277,6 +286,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # Some virt-api pods are not ready
   - interval: 1m
@@ -306,6 +316,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # All virt-api are not ready
   - interval: 1m
@@ -332,6 +343,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: LowReadyVirtAPICount
         exp_alerts: [ ]
@@ -364,6 +376,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # All virt-handlers are not ready
   - interval: 1m
@@ -390,6 +403,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: LowReadyVirtHandlerCount
         exp_alerts: [ ]
@@ -420,6 +434,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: LowReadyVirtControllersCount
         exp_alerts: [ ]
@@ -446,6 +461,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # No virt-controller is leading
   - interval: 1m
@@ -470,6 +486,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # A virt-controller is leading
   - interval: 1m
@@ -505,6 +522,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # No virt-operator is leading
   - interval: 1m
@@ -529,6 +547,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # A virt-operator is leading
   - interval: 1m
@@ -564,6 +583,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # All virt operators are not ready (ImagePullBackOff)
   - interval: 1m
@@ -589,6 +609,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # All virt operators are not ready
   - interval: 1m
@@ -616,6 +637,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: LowReadyVirtOperatorsCount
         exp_alerts: [ ]
@@ -646,6 +668,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: LowReadyVirtOperatorsCount
         exp_alerts: [ ]
@@ -676,6 +699,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 10m
         alertname: LowReadyVirtOperatorsCount
         exp_alerts: [ ]
@@ -735,6 +759,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 20m
         alertname: VirtOperatorRESTErrorsBurst
         exp_alerts:
@@ -746,6 +771,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 20m
         alertname: VirtHandlerRESTErrorsBurst
         exp_alerts:
@@ -757,6 +783,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
       - eval_time: 20m
         alertname: VirtApiRESTErrorsBurst
         exp_alerts:
@@ -768,6 +795,7 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
 
   # Some nodes without KVM resources
@@ -791,6 +819,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # All nodes without KVM resources
   - interval: 1m
@@ -813,6 +842,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # Two nodes with KVM resources
   - interval: 1m
@@ -1073,6 +1103,7 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
 
@@ -1091,6 +1122,7 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
 
@@ -1116,6 +1148,7 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
 
@@ -1134,6 +1167,7 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
 
@@ -1160,6 +1194,7 @@ tests:
             exp_labels:
               severity: "warning"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
 
@@ -1187,6 +1222,7 @@ tests:
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
               resource: "virtualmachines"
               group: "kubevirt.io"
               version: "v1alpha3"
@@ -1202,6 +1238,7 @@ tests:
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
               resource: "virtualmachines"
               group: "kubevirt.io"
               version: "v1alpha3"
@@ -1852,6 +1889,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # LowVirtAPICount - should not fire when 75% or more of desired virt-api pods are running
   - interval: 1m
@@ -1895,6 +1933,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # LowVirtControllersCount - should not fire when 75% or more of desired virt-controller pods are up
   - interval: 1m
@@ -1938,6 +1977,7 @@ tests:
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # LowVirtOperatorCount - should not fire when 75% or more of desired virt-operator pods are running
   - interval: 1m

--- a/pkg/monitoring/rules/BUILD.bazel
+++ b/pkg/monitoring/rules/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/testutil:go_default_library",
     ],
 )

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -39,6 +39,7 @@ const (
 	descriptionAnnotationKey     = "description"
 	partOfAlertLabelKey          = "kubernetes_operator_part_of"
 	componentAlertLabelKey       = "kubernetes_operator_component"
+	namespaceAlertLabelKey       = "namespace"
 	kubevirtLabelValue           = "kubevirt"
 
 	eightyPercent = 80
@@ -46,17 +47,20 @@ const (
 )
 
 func Register(registry *operatorrules.Registry, namespace string) error {
-	alerts := [][]promv1.Rule{
+	componentAlerts := [][]promv1.Rule{
 		systemAlerts(namespace),
 		virtAPIAlerts(namespace),
 		virtControllerAlerts(namespace),
 		virtHandlerAlerts(namespace),
 		virtOperatorAlerts(namespace),
-		vmsAlerts,
 	}
 
+	allAlerts := make([][]promv1.Rule, 0, len(componentAlerts)+1)
+	allAlerts = append(allAlerts, componentAlerts...)
+	allAlerts = append(allAlerts, vmsAlerts)
+
 	runbookURLTemplate := getRunbookURLTemplate()
-	for _, alertGroup := range alerts {
+	for _, alertGroup := range allAlerts {
 		for _, alert := range alertGroup {
 			alert.Labels[partOfAlertLabelKey] = kubevirtLabelValue
 			alert.Labels[componentAlertLabelKey] = kubevirtLabelValue
@@ -65,7 +69,15 @@ func Register(registry *operatorrules.Registry, namespace string) error {
 		}
 	}
 
-	return registry.RegisterAlerts(alerts...)
+	// Component and system alerts operate in the KubeVirt install namespace.
+	// VM workload alerts derive namespace from their PromQL expression instead.
+	for _, alertGroup := range componentAlerts {
+		for _, alert := range alertGroup {
+			alert.Labels[namespaceAlertLabelKey] = namespace
+		}
+	}
+
+	return registry.RegisterAlerts(allAlerts...)
 }
 
 func getRunbookURLTemplate() string {

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -38,7 +38,7 @@ const excludedFilesystemTypesRegex = "CDFS|iso9660|udf|squashfs|cramfs|tmpfs|dev
 var vmsAlerts = []promv1.Rule{
 	{
 		Alert: "VirtLauncherPodsStuckFailed",
-		Expr:  intstr.FromString("sum(kube_pod_status_phase{phase='Failed', pod=~'virt-launcher-.*'}) >= 200"),
+		Expr:  intstr.FromString("sum by (namespace) (kube_pod_status_phase{phase='Failed', pod=~'virt-launcher-.*'}) >= 200"),
 		For:   ptr.To(promv1.Duration("10m")),
 		Annotations: map[string]string{
 			summaryAnnotationKey: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes.",
@@ -51,9 +51,9 @@ var vmsAlerts = []promv1.Rule{
 	{
 		Alert: "OrphanedVirtualMachineInstances",
 		Expr: intstr.FromString(
-			"(((max by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} " +
-				"* on(pod) group_left(node) max by(pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) " +
-				"or (count by (node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0",
+			"(((max by (namespace, node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} " +
+				"* on(pod, namespace) group_left(node) max by(namespace,pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) " +
+				"or (count by (namespace, node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0",
 		),
 		For: ptr.To(promv1.Duration("10m")),
 		Annotations: map[string]string{
@@ -98,7 +98,7 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "OutdatedVirtualMachineInstanceWorkloads",
-		Expr:  intstr.FromString("kubevirt_vmi_number_of_outdated != 0"),
+		Expr:  intstr.FromString("kubevirt_vmi_number_of_outdated{namespace!=''} != 0"),
 		For:   ptr.To(promv1.Duration("24h")),
 		Annotations: map[string]string{
 			summaryAnnotationKey: "Some running VMIs are still active in outdated pods after KubeVirt control plane update has completed.",
@@ -110,7 +110,7 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "GuestVCPUQueueHighWarning",
-		Expr:  intstr.FromString("vmi:kubevirt_vmi_guest_queue_length:sum > 10"),
+		Expr:  intstr.FromString("vmi:kubevirt_vmi_guest_queue_length:sum{namespace!=''} > 10"),
 		Annotations: map[string]string{
 			descriptionAnnotationKey: "VirtualMachineInstance {{ $labels.name }} CPU queue length > 10",
 			summaryAnnotationKey:     "Guest vCPU Queue within collection cycle > 10",
@@ -122,7 +122,7 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "GuestVCPUQueueHighCritical",
-		Expr:  intstr.FromString("vmi:kubevirt_vmi_guest_queue_length:sum > 20"),
+		Expr:  intstr.FromString("vmi:kubevirt_vmi_guest_queue_length:sum{namespace!=''} > 20"),
 		Annotations: map[string]string{
 			descriptionAnnotationKey: "VirtualMachineInstance {{ $labels.name }} CPU queue length > 20",
 			summaryAnnotationKey:     "Guest vCPU Queue within collection cycle > 20",
@@ -176,8 +176,9 @@ var vmsAlerts = []promv1.Rule{
 		Expr: intstr.FromString("((" +
 			"(vmi:kubevirt_vmi_memory_headroom_ratio:sum < 0.05) and (vmi:kubevirt_vmi_pgmajfaults:rate5m > 5 " +
 			"or (vmi:kubevirt_vmi_swap_traffic_bytes:rate5m > 1048576)) and (vmi:kubevirt_vmi_memory_available_bytes:sum > 0)) " +
-			"* on(name, namespace) group_left(vm)" +
-			"label_replace(label_replace(kubevirt_vmi_info{phase='running'}, 'vm', '$1', 'name', '(.+)'), 'name', '$1', 'vmi_pod', '(.+)'" +
+			"* on(name, namespace) group_left(vm) " +
+			"topk by(name, namespace) (1, " +
+			"label_replace(label_replace(kubevirt_vmi_info{phase='running'}, 'vm', '$1', 'name', '(.+)'), 'name', '$1', 'vmi_pod', '(.+)')" +
 			"))",
 		),
 		For: ptr.To(promv1.Duration("5m")),
@@ -194,8 +195,8 @@ var vmsAlerts = []promv1.Rule{
 	{
 		Alert: "GuestFilesystemAlmostOutOfSpace",
 		Expr: intstr.FromString(fmt.Sprintf(
-			"(kubevirt_vmi_filesystem_used_bytes{file_system_type!~'%s',mount_point!='System Reserved'} / "+
-				"kubevirt_vmi_filesystem_capacity_bytes{file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 85 < 95",
+			"(kubevirt_vmi_filesystem_used_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'} / "+
+				"kubevirt_vmi_filesystem_capacity_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 85 < 95",
 			excludedFilesystemTypesRegex, excludedFilesystemTypesRegex,
 		)),
 		For: ptr.To(promv1.Duration("10m")),
@@ -212,8 +213,8 @@ var vmsAlerts = []promv1.Rule{
 	{
 		Alert: "GuestFilesystemAlmostOutOfSpace",
 		Expr: intstr.FromString(fmt.Sprintf(
-			"(kubevirt_vmi_filesystem_used_bytes{file_system_type!~'%s',mount_point!='System Reserved'} / "+
-				"kubevirt_vmi_filesystem_capacity_bytes{file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 95",
+			"(kubevirt_vmi_filesystem_used_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'} / "+
+				"kubevirt_vmi_filesystem_capacity_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 95",
 			excludedFilesystemTypesRegex, excludedFilesystemTypesRegex,
 		)),
 		Annotations: map[string]string{
@@ -233,7 +234,8 @@ var vmsAlerts = []promv1.Rule{
 				"(vmi:kubevirt_vmi_memory_headroom_ratio:sum < 0.03) and (vmi:kubevirt_vmi_swap_traffic_bytes:rate30m < 2048) " +
 				"and (vmi:kubevirt_vmi_pgmajfaults:rate30m < 1) and (vmi:kubevirt_vmi_memory_available_bytes:sum > 0)) " +
 				"* on(name, namespace) group_left(vm) " +
-				"label_replace(label_replace(kubevirt_vmi_info{phase='running'}, 'vm', '$1', 'name', '(.+)'), 'name', '$1', 'vmi_pod', '(.+)')" +
+				"topk by(name, namespace) (1, " +
+				"label_replace(label_replace(kubevirt_vmi_info{phase='running'}, 'vm', '$1', 'name', '(.+)'), 'name', '$1', 'vmi_pod', '(.+)'))" +
 				")",
 		),
 		For: ptr.To(promv1.Duration("30m")),

--- a/pkg/monitoring/rules/rules_test.go
+++ b/pkg/monitoring/rules/rules_test.go
@@ -19,19 +19,44 @@
 package rules_test
 
 import (
+	"regexp"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/rhobs/operator-observability-toolkit/pkg/testutil"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/rules"
 )
 
+// namespaceRe matches "namespace" used as a PromQL label name — in label
+// matchers, by/on/group_left/group_right clauses — but not as a substring
+// of a metric or recording-rule name.
+var namespaceRe = regexp.MustCompile(`\bnamespace\b`)
+
+// validateAlertNamespaceLabel checks that every alert has a namespace
+// label, either as a static label or derived from its PromQL expression.
+func validateAlertNamespaceLabel(alert *promv1.Rule) []testutil.Problem {
+	if _, hasNamespace := alert.Labels["namespace"]; hasNamespace {
+		return nil
+	}
+	if namespaceRe.MatchString(alert.Expr.String()) {
+		return nil
+	}
+	return []testutil.Problem{{
+		ResourceName: alert.Alert,
+		Description: "alert must have a namespace label " +
+			"(add a static namespace label or ensure " +
+			"the PromQL expression produces one)",
+	}}
+}
+
 var _ = Describe("Rules Validation", func() {
 	var linter *testutil.Linter
 
 	BeforeEach(func() {
-		Expect(rules.SetupRules("")).To(Succeed())
+		Expect(rules.SetupRules("test-ns")).To(Succeed())
 		linter = testutil.New()
 	})
 
@@ -40,7 +65,8 @@ var _ = Describe("Rules Validation", func() {
 			testutil.ValidateAlertNameLength,
 			testutil.ValidateAlertRunbookURLAnnotation,
 			testutil.ValidateAlertHealthImpactLabel,
-			testutil.ValidateAlertPartOfAndComponentLabels)
+			testutil.ValidateAlertPartOfAndComponentLabels,
+			validateAlertNamespaceLabel)
 
 		problems := linter.LintAlerts(rules.ListAlerts())
 		Expect(problems).To(BeEmpty())


### PR DESCRIPTION
### What this PR does
#### Before this PR:
KubeVirt component and system alerts lack a `namespace` label.
OpenShift monitoring requires namespace on all alerts for routing,
silencing, and multi-tenant isolation. No test validates this.

#### After this PR:
- All component/system alerts receive a static `namespace` label
  via `Register()`.
- VM workload alerts that derive namespace from PromQL now
  explicitly reference `namespace` in their expressions.
- Unit-test validator in `rules_test.go` checks every alert for
  a namespace label (static or expression-derived).
- E2E check in `monitoring.go` validates namespace presence on
  deployed PrometheusRule objects.
- Promtool expected labels updated accordingly.

### Why we need it and why it was done in this way
OpenShift monitoring guidelines mandate a `namespace` label on
every alert for proper routing, silencing, and multi-tenant
isolation. Component alerts get a static label because they all
fire in the install namespace. VM workload alerts are excluded
from the static label because they derive namespace from their
PromQL expressions (a static label would overwrite the workload
namespace).

The following alternatives were considered:
- Adding a static namespace to all alerts: rejected because it
  overwrites PromQL-derived namespaces on VM workload alerts.
- Hardcoded exemption list for VM alerts: rejected as fragile;
  replaced with a dynamic heuristic check.

jira-ticket: https://redhat.atlassian.net/browse/CNV-88371

### Special notes for your reviewer
This is the base PR for the stacked PR #17985 (self-diagnosing
Virt*Down alerts).

### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit test validator and E2E check added
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note
```release-note
Add namespace label to all KubeVirt alerts for proper OpenShift
monitoring routing, silencing, and multi-tenant isolation.
```

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>
Co-authored-by: Cursor <cursoragent@cursor.com>