### PR TITLE
virt-operator: fix DeploymentInProgress after toggling optional feature gates

### DIFF
--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -1094,15 +1094,18 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 	// the entire sync can't always occur within a single control loop execution.
 	// when synced==true that means SyncAll() has completed and has nothing left to wait on.
 	if synced {
-		// record the version that has been completely installed
-		config.SetObservedDeploymentConfig(kv)
-
 		// update conditions
 		util.UpdateConditionsCreated(kv)
 		logger.Info("All KubeVirt resources created")
 
 		// check if components are ready
 		if c.isReady(kv) {
+			// record the version that has been completely installed only once all
+			// components are ready. This ensures isUpdating() returns true while
+			// optional feature deployments (e.g. virt-template) are still starting,
+			// keeping Available=True during the transition instead of flipping to
+			// Available=False (DeploymentInProgress).
+			config.SetObservedDeploymentConfig(kv)
 			logger.Info("All KubeVirt components ready")
 			kv.Status.Phase = v1.KubeVirtPhaseDeployed
 			util.UpdateConditionsAvailable(kv)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2163,6 +2163,95 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 		})
 
+		It("should advance ObservedDeploymentID only once all pods are ready when toggling an optional feature gate", func() {
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			// Start with KubeVirt deployed without any optional feature gates.
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Finalizers: []string{util.KubeVirtFinalizer},
+					Generation: int64(1),
+				},
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						// Disable to avoid instancetype create/update noise across both Execute cycles.
+						CommonInstancetypesDeployment: &v1.CommonInstancetypesDeployment{
+							Enabled: pointer.P(false),
+						},
+					},
+				},
+				Status: v1.KubeVirtStatus{
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.P(int64(1)),
+				},
+			}
+			oldConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
+			oldConfig.SetTargetDeploymentConfig(kv)
+			oldConfig.SetObservedDeploymentConfig(kv)
+			util.UpdateConditionsCreated(kv)
+			util.UpdateConditionsAvailable(kv)
+
+			// Toggle the Template feature gate — changes TargetDeploymentID but not version/registry.
+			enableTemplateFeatureGate(kv)
+			initialObservedID := kv.Status.ObservedDeploymentID
+
+			newConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
+
+			// kvNoFG: a minimal KV without the Template FG, used to restrict
+			// makeDeploymentsReady and addPodsWithOptionalPodDisruptionBudgets to
+			// non-virt-template components only (simulating pods still starting).
+			kvNoFG := &v1.KubeVirt{}
+
+			kubecontroller.SetLatestApiVersionAnnotation(kv)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(newConfig)
+			kvTestData.addAll(newConfig, kv)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kvNoFG)
+			kvTestData.makeDeploymentsReady(kvNoFG)
+			kvTestData.makeHandlerReady()
+
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates(kv)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+
+			kvTestData.controller.Execute()
+			kv = kvTestData.getLatestKubeVirt(kv)
+
+			// ObservedDeploymentID must not advance: SetObservedDeploymentConfig must only
+			// be called once isReady() returns true (virt-template pods are still starting).
+			Expect(kv.Status.ObservedDeploymentID).To(Equal(initialObservedID))
+			// isUpdating() stayed true throughout, so Available remains True.
+			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
+
+			// Second cycle: mark all pods ready (including virt-template) and verify
+			// that ObservedDeploymentID is now advanced to the new config's ID.
+			// Drain pending queue items left over from the first cycle so the
+			// KubeVirt key can lead the queue for the second Execute().
+			for kvTestData.mockQueue.Len() > 0 {
+				key, quit := kvTestData.mockQueue.Get()
+				if quit {
+					break
+				}
+				kvTestData.mockQueue.Done(key)
+			}
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kv)
+			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.shouldExpectPatchesAndUpdates(kv)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+
+			kvTestData.controller.Execute()
+			kv = kvTestData.getLatestKubeVirt(kv)
+			Expect(kv.Status.ObservedDeploymentID).NotTo(Equal(initialObservedID))
+			Expect(kv.Status.ObservedDeploymentID).To(Equal(kv.Status.TargetDeploymentID))
+		})
+
 		It("should update KubeVirt object if generation IDs do not match", func() {
 			kvTestData := KubeVirtTestData{}
 			kvTestData.BeforeTest()


### PR DESCRIPTION
### What this PR does
When an optional feature gate (e.g. VirtTemplateDeployment) is enabled without a version/registry change, the infrastructureRolledOver check hits the fallback branch:

  (targetVersion == observedVersion) && (targetImageRegistry == observedImageRegistry)

This causes Sync() to return true (AllResourcesCreated) before the new feature's pods are ready. Previously, SetObservedDeploymentConfig was called immediately on synced=true, updating ObservedDeploymentID to the new value. On the next reconcile, isUpdating() returned false (Target == Observed), so UpdateConditionsDeploying was called, setting Available=False. The system was stuck in this "DeploymentInProgress" loop indefinitely because isReady() kept returning false while the new pods were starting.

Fix: move SetObservedDeploymentConfig inside the isReady() block. Now ObservedDeploymentID is only updated once ALL pods (including the newly enabled optional feature) are actually ready. During the transition:
  - isUpdating() returns true → UpdateConditionsUpdating → Available=True
  - When pods become ready → SetObservedDeploymentConfig called
  - isUpdating() becomes false → UpdateConditionsAvailable sets the final Available=True, Progressing=False state

- Fixes CNV-88900

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
virt-operator: fix DeploymentInProgress after toggling optional feature gates
```

