### PR TITLE
VEP-199: add GraceIOVirtualization admission foundation (PR4)

### DIFF
--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["hw_utils.go"],
+    srcs = [
+        "grace.go",
+        "hw_utils.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/util/hardware",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,6 +17,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "grace_test.go",
         "hw_utils_suite_test.go",
         "hw_utils_test.go",
     ],

--- a/pkg/util/hardware/grace.go
+++ b/pkg/util/hardware/grace.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package hardware
+
+const (
+	nvidiaPCIVendorID          = "10DE"
+	nvidiaGraceGPUDeviceID2342 = "2342"
+	nvidiaGraceGPUDeviceID2348 = "2348"
+	nvidiaGraceGPUDeviceID2941 = "2941"
+)
+
+var nvidiaGraceGPUDeviceIDs = map[string]struct{}{
+	nvidiaGraceGPUDeviceID2342: {},
+	nvidiaGraceGPUDeviceID2348: {},
+	nvidiaGraceGPUDeviceID2941: {},
+}
+
+func IsNVIDIAGraceGPU(vendorID, deviceID string) bool {
+	if NormalizePCIID(vendorID) != nvidiaPCIVendorID {
+		return false
+	}
+	_, ok := nvidiaGraceGPUDeviceIDs[NormalizePCIID(deviceID)]
+	return ok
+}
+
+func IsNVIDIAPCIVendor(vendorID string) bool {
+	return NormalizePCIID(vendorID) == nvidiaPCIVendorID
+}

--- a/pkg/util/hardware/grace_test.go
+++ b/pkg/util/hardware/grace_test.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package hardware
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NVIDIA Grace PCI IDs", func() {
+	DescribeTable("detects supported Grace GPU PCI IDs", func(vendorID, deviceID string, expected bool) {
+		Expect(IsNVIDIAGraceGPU(vendorID, deviceID)).To(Equal(expected))
+	},
+		Entry("Grace GPU", "10DE", "2342", true),
+		Entry("Grace GPU with sysfs prefixes", "0x10de", "0x2348", true),
+		Entry("Grace GPU with mixed case", "10de", "2941", true),
+		Entry("Grace GPU with surrounding spaces", " 10de ", " 2342 ", true),
+		Entry("empty vendor", "", "2342", false),
+		Entry("empty device", "10DE", "", false),
+		Entry("short vendor ID", "10D", "2342", false),
+		Entry("long vendor ID", "010DE", "2342", false),
+		Entry("short device ID", "10DE", "234", false),
+		Entry("long device ID", "10DE", "02342", false),
+		Entry("non-Grace NVIDIA GPU", "10DE", "2330", false),
+		Entry("non-NVIDIA device", "1AF4", "2342", false),
+	)
+
+	DescribeTable("detects NVIDIA PCI vendor IDs", func(vendorID string, expected bool) {
+		Expect(IsNVIDIAPCIVendor(vendorID)).To(Equal(expected))
+	},
+		Entry("uppercase vendor ID", "10DE", true),
+		Entry("lowercase vendor ID", "10de", true),
+		Entry("sysfs-prefixed vendor ID", "0x10DE", true),
+		Entry("surrounding spaces", " 10de ", true),
+		Entry("non-NVIDIA vendor ID", "1AF4", false),
+		Entry("empty vendor ID", "", false),
+		Entry("short vendor ID", "10D", false),
+		Entry("long vendor ID", "010DE", false),
+	)
+})

--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -116,6 +116,12 @@ func ParsePciAddress(pciAddress string) ([]string, error) {
 	return res[1:], nil
 }
 
+// NormalizePCIID normalizes PCI vendor and device IDs for comparison.
+func NormalizePCIID(id string) string {
+	id = strings.ToUpper(strings.TrimSpace(id))
+	return strings.TrimPrefix(id, "0X")
+}
+
 var (
 	PciBasePath  = "/sys/bus/pci/devices"
 	NodeBasePath = "/sys/bus/node/devices"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "grace_io_virtualization.go",
         "migration-create-admitter.go",
         "migration-update-admitter.go",
         "migrationpolicy-admitter.go",
@@ -82,6 +83,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "admitters_suite_test.go",
+        "grace_io_virtualization_test.go",
         "migration-create-admitter_test.go",
         "migration-update-admitter_test.go",
         "migrationpolicy-admitter_test.go",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/grace_io_virtualization.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/grace_io_virtualization.go
@@ -1,0 +1,237 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package admitters
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+)
+
+const graceVirtMachineType = "virt"
+
+type gracePCIDeviceRequest struct {
+	path         *k8sfield.Path
+	resourceName string
+}
+
+type pciVendorSelector struct {
+	vendorID string
+	deviceID string
+}
+
+func validateGraceIOVirtualization(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+	graceRequests, ambiguousNVIDIARequests := gracePCIDeviceRequests(field, spec, config.GetPermittedHostDevices())
+	if len(graceRequests) == 0 && len(ambiguousNVIDIARequests) == 0 {
+		return nil
+	}
+
+	var causes []metav1.StatusCause
+	if config.GraceIOVirtualizationEnabled() {
+		for _, request := range ambiguousNVIDIARequests {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("GraceIOVirtualization requires an exact pciVendorSelector for NVIDIA PCI host device resource %q", request.resourceName),
+				Field:   request.path.String(),
+			})
+		}
+	}
+
+	if len(graceRequests) == 0 {
+		return causes
+	}
+
+	if !config.GraceIOVirtualizationEnabled() {
+		for _, request := range graceRequests {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("%s feature gate must be enabled for NVIDIA Grace GPU passthrough resource %q", featuregate.GraceIOVirtualization, request.resourceName),
+				Field:   request.path.String(),
+			})
+		}
+		return causes
+	}
+
+	if effectiveGraceArchitecture(spec, config) != "arm64" {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "GraceIOVirtualization requires arm64 architecture",
+			Field:   field.Child("architecture").String(),
+		})
+	}
+
+	if effectiveGraceMachineType(spec, config) != graceVirtMachineType {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("GraceIOVirtualization requires %q machine type", graceVirtMachineType),
+			Field:   field.Child("domain", "machine", "type").String(),
+		})
+	}
+
+	if spec.Domain.CPU == nil || !spec.Domain.CPU.DedicatedCPUPlacement {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueRequired,
+			Message: "GraceIOVirtualization requires dedicated CPU placement",
+			Field:   field.Child("domain", "cpu", "dedicatedCpuPlacement").String(),
+		})
+	}
+
+	if !config.PCINUMAAwareTopologyEnabled() {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s feature gate must be enabled when GraceIOVirtualization is used",
+				featuregate.PCINUMAAwareTopologyEnabled),
+			Field: field.Child("domain", "devices").String(),
+		})
+	}
+
+	if !config.IOMMUFDEnabled() {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s feature gate must be enabled when GraceIOVirtualization is used",
+				featuregate.IOMMUFDGate),
+			Field: field.Child("domain", "devices").String(),
+		})
+	}
+
+	return causes
+}
+
+func gracePCIDeviceRequests(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, permittedHostDevices *v1.PermittedHostDevices) ([]gracePCIDeviceRequest, []gracePCIDeviceRequest) {
+	resourceSelectors := permittedPCIResourceSelectors(permittedHostDevices)
+	if len(resourceSelectors) == 0 {
+		return nil, nil
+	}
+
+	var graceRequests []gracePCIDeviceRequest
+	var ambiguousNVIDIARequests []gracePCIDeviceRequest
+	for _, request := range requestedPCIDeviceResources(field, spec) {
+		selector, exists := resourceSelectors[request.resourceName]
+		if !exists {
+			continue
+		}
+
+		parsedSelector, ok := parsePCIVendorSelector(selector)
+		if !ok {
+			continue
+		}
+
+		if hwutil.IsNVIDIAGraceGPU(parsedSelector.vendorID, parsedSelector.deviceID) {
+			graceRequests = append(graceRequests, request)
+			continue
+		}
+		if hwutil.IsNVIDIAPCIVendor(parsedSelector.vendorID) && parsedSelector.deviceID == "*" {
+			ambiguousNVIDIARequests = append(ambiguousNVIDIARequests, request)
+		}
+	}
+
+	return graceRequests, ambiguousNVIDIARequests
+}
+
+func permittedPCIResourceSelectors(permittedHostDevices *v1.PermittedHostDevices) map[string]string {
+	if permittedHostDevices == nil || len(permittedHostDevices.PciHostDevices) == 0 {
+		return nil
+	}
+
+	selectors := map[string]string{}
+	for _, pciHostDevice := range permittedHostDevices.PciHostDevices {
+		if pciHostDevice.ResourceName == "" || pciHostDevice.PCIVendorSelector == "" {
+			continue
+		}
+		selectors[pciHostDevice.ResourceName] = pciHostDevice.PCIVendorSelector
+	}
+	return selectors
+}
+
+func requestedPCIDeviceResources(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []gracePCIDeviceRequest {
+	var requests []gracePCIDeviceRequest
+	for index, gpu := range spec.Domain.Devices.GPUs {
+		if gpu.DeviceName == "" {
+			continue
+		}
+		requests = append(requests, gracePCIDeviceRequest{
+			path:         field.Child("domain", "devices", "gpus").Index(index).Child("deviceName"),
+			resourceName: gpu.DeviceName,
+		})
+	}
+	for index, hostDevice := range spec.Domain.Devices.HostDevices {
+		if hostDevice.DeviceName == "" {
+			continue
+		}
+		requests = append(requests, gracePCIDeviceRequest{
+			path:         field.Child("domain", "devices", "hostDevices").Index(index).Child("deviceName"),
+			resourceName: hostDevice.DeviceName,
+		})
+	}
+	return requests
+}
+
+func parsePCIVendorSelector(selector string) (pciVendorSelector, bool) {
+	parts := strings.Split(selector, ":")
+	if len(parts) != 2 {
+		return pciVendorSelector{}, false
+	}
+
+	parsedSelector := pciVendorSelector{
+		vendorID: hwutil.NormalizePCIID(parts[0]),
+		deviceID: hwutil.NormalizePCIID(parts[1]),
+	}
+	if !isHexPCIID(parsedSelector.vendorID) {
+		return pciVendorSelector{}, false
+	}
+	if parsedSelector.deviceID != "*" && !isHexPCIID(parsedSelector.deviceID) {
+		return pciVendorSelector{}, false
+	}
+	return parsedSelector, true
+}
+
+func isHexPCIID(id string) bool {
+	if len(id) != 4 {
+		return false
+	}
+	for _, char := range id {
+		if !strings.ContainsRune("0123456789ABCDEF", char) {
+			return false
+		}
+	}
+	return true
+}
+
+func effectiveGraceArchitecture(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) string {
+	if spec.Architecture != "" {
+		return spec.Architecture
+	}
+	return config.GetDefaultArchitecture()
+}
+
+func effectiveGraceMachineType(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) string {
+	if spec.Domain.Machine != nil && spec.Domain.Machine.Type != "" {
+		return spec.Domain.Machine.Type
+	}
+	return config.GetMachineType(effectiveGraceArchitecture(spec, config))
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/grace_io_virtualization_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/grace_io_virtualization_test.go
@@ -1,0 +1,216 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package admitters
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/api"
+
+	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+)
+
+var _ = Describe("GraceIOVirtualization admission", func() {
+	const graceResourceName = "nvidia.com/grace-gpu"
+
+	newGraceConfig := func(pciVendorSelector string, featureGates ...string) *virtconfig.ClusterConfig {
+		kv := &v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubevirt",
+				Namespace: "kubevirt",
+			},
+			Spec: v1.KubeVirtSpec{
+				Configuration: v1.KubeVirtConfiguration{
+					DeveloperConfiguration: &v1.DeveloperConfiguration{FeatureGates: featureGates},
+					PermittedHostDevices: &v1.PermittedHostDevices{
+						PciHostDevices: []v1.PciHostDevice{
+							{
+								PCIVendorSelector: pciVendorSelector,
+								ResourceName:      graceResourceName,
+							},
+						},
+					},
+				},
+			},
+			Status: v1.KubeVirtStatus{
+				Phase:               v1.KubeVirtPhaseDeploying,
+				DefaultArchitecture: "arm64",
+			},
+		}
+		config, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
+		return config
+	}
+
+	newGraceSpec := func() *v1.VirtualMachineInstanceSpec {
+		return &v1.VirtualMachineInstanceSpec{
+			Architecture: "arm64",
+			Domain: v1.DomainSpec{
+				Machine: &v1.Machine{Type: "virt"},
+				CPU:     &v1.CPU{DedicatedCPUPlacement: true},
+				Devices: v1.Devices{
+					GPUs: []v1.GPU{
+						{
+							Name:       "gpu1",
+							DeviceName: graceResourceName,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	graceCauses := func(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+		return validateGraceIOVirtualization(k8sfield.NewPath("spec"), spec, config)
+	}
+
+	It("accepts a Grace GPU request that satisfies the static baseline", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+
+		Expect(graceCauses(newGraceSpec(), config)).To(BeEmpty())
+	})
+
+	It("accepts a Grace host device request that satisfies the static baseline", func() {
+		config := newGraceConfig("10DE:2941", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+		spec := newGraceSpec()
+		spec.Domain.Devices.GPUs = nil
+		spec.Domain.Devices.HostDevices = []v1.HostDevice{{Name: "hostdev1", DeviceName: graceResourceName}}
+
+		Expect(graceCauses(spec, config)).To(BeEmpty())
+	})
+
+	It("requires the GraceIOVirtualization feature gate for Grace GPU resources", func() {
+		config := newGraceConfig("10DE:2342", featuregate.PCINUMAAwareTopologyEnabled)
+
+		causes := graceCauses(newGraceSpec(), config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus[0].deviceName"))
+		Expect(causes[0].Message).To(ContainSubstring(featuregate.GraceIOVirtualization))
+	})
+
+	It("requires the PCI NUMA-aware topology feature gate", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.IOMMUFDGate)
+
+		causes := graceCauses(newGraceSpec(), config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("spec.domain.devices"))
+		Expect(causes[0].Message).To(ContainSubstring(featuregate.PCINUMAAwareTopologyEnabled))
+	})
+
+	It("requires arm64 architecture", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+		spec := newGraceSpec()
+		spec.Architecture = "amd64"
+
+		causes := graceCauses(spec, config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("spec.architecture"))
+		Expect(causes[0].Message).To(ContainSubstring("arm64"))
+	})
+
+	It("uses the effective default architecture and machine type", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+		spec := newGraceSpec()
+		spec.Architecture = ""
+		spec.Domain.Machine = nil
+
+		Expect(graceCauses(spec, config)).To(BeEmpty())
+	})
+
+	It("requires virt machine type", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+		spec := newGraceSpec()
+		spec.Domain.Machine.Type = "q35"
+
+		causes := graceCauses(spec, config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("spec.domain.machine.type"))
+		Expect(causes[0].Message).To(ContainSubstring("virt"))
+	})
+
+	It("requires dedicated CPU placement", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+		spec := newGraceSpec()
+		spec.Domain.CPU.DedicatedCPUPlacement = false
+
+		causes := graceCauses(spec, config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("spec.domain.cpu.dedicatedCpuPlacement"))
+	})
+
+	It("requires the IOMMUFD feature gate", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled)
+
+		causes := graceCauses(newGraceSpec(), config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("spec.domain.devices"))
+		Expect(causes[0].Message).To(ContainSubstring(featuregate.IOMMUFDGate))
+	})
+
+	It("does not classify DRA claim requests as Grace PCI host devices", func() {
+		config := newGraceConfig("10DE:2342", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+		spec := newGraceSpec()
+		spec.Domain.Devices.GPUs = []v1.GPU{
+			{
+				Name:         "gpu1",
+				ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "gpu"},
+			},
+		}
+
+		Expect(graceCauses(spec, config)).To(BeEmpty())
+	})
+
+	It("rejects ambiguous NVIDIA wildcard PCI selectors when GraceIOVirtualization is enabled", func() {
+		config := newGraceConfig("10DE:*", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+
+		causes := graceCauses(newGraceSpec(), config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("spec.domain.devices.gpus[0].deviceName"))
+		Expect(causes[0].Message).To(ContainSubstring("exact pciVendorSelector"))
+	})
+
+	It("does not classify non-Grace NVIDIA PCI selectors", func() {
+		config := newGraceConfig("10DE:2330", featuregate.GraceIOVirtualization, featuregate.PCINUMAAwareTopologyEnabled, featuregate.IOMMUFDGate)
+
+		Expect(graceCauses(newGraceSpec(), config)).To(BeEmpty())
+	})
+
+	It("runs as part of the VMI spec validator", func() {
+		config := newGraceConfig("10DE:2342")
+		vmi := api.NewMinimalVMI("testvm")
+		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{{Name: "gpu1", DeviceName: graceResourceName}}
+
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &vmi.Spec, config)
+		var graceCause *metav1.StatusCause
+		for index := range causes {
+			if causes[index].Field == "spec.domain.devices.gpus[0].deviceName" {
+				graceCause = &causes[index]
+				break
+			}
+		}
+		Expect(graceCause).ToNot(BeNil())
+		Expect(graceCause.Message).To(ContainSubstring(featuregate.GraceIOVirtualization))
+	})
+})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -228,6 +228,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateLiveMigration(field, spec, config)...)
 	causes = append(causes, validateMDEVRamFB(field, spec)...)
 	causes = append(causes, validateHostDevicesWithPassthroughEnabled(field, spec, config)...)
+	causes = append(causes, validateGraceIOVirtualization(field, spec, config)...)
 	causes = append(causes, validateSoundDevices(field, spec)...)
 	causes = append(causes, validateLaunchSecurity(field, spec, config)...)
 	causes = append(causes, validateVSOCK(field, spec, config)...)


### PR DESCRIPTION
### What this PR does

This PR adds the admission-time foundation for `GraceIOVirtualization` from kubevirt/enhancements#199.

It implements the Layer4 of [NVIDIA Grace Virtualization Upstreaming Plan](https://docs.google.com/document/d/1pJBirt79ZJLb8qXNje1sKj_U8IdYjinkKInQLbV0Zjw/edit?tab=t.0#heading=h.czlquu3cqsra)

It detects VMI GPU/hostDevice requests that reference permitted PCI host-device resources backed by known NVIDIA Grace GPU PCI IDs, then validates the static baseline required before later runtime/domain conversion work consumes Grace GPU passthrough.

Specifically, this PR:

- classifies requested PCI resources through `permittedHostDevices.pciHostDevices[].pciVendorSelector`
- uses exact NVIDIA Grace GPU PCI IDs instead of resource-name heuristics
- rejects ambiguous NVIDIA wildcard selectors, such as `10DE:*`, when `GraceIOVirtualization` is enabled
- requires Grace GPU passthrough VMIs to use:
  - `arm64`
  - `virt` machine type
  - dedicated CPU placement
  - `GraceIOVirtualization`
  - `PCINUMAAwareTopology`
  - `IOMMUFD`

This PR does not require all `permittedHostDevices` entries to be Grace hardware. It only validates VMI requests that reference a permitted PCI resource whose selector matches a known Grace GPU PCI ID.

### Example

Permitted Grace GPU resource:

```yaml
spec:
  configuration:
    developerConfiguration:
      featureGates:
      - GraceIOVirtualization
      - PCINUMAAwareTopology
      - IOMMUFD
    permittedHostDevices:
      pciHostDevices:
      - resourceName: nvidia.com/grace-gpu
        pciVendorSelector: "10DE:2342" # also valid: 10DE:2348, 10DE:2941
```

**1. Valid VMI shape**:

```yaml
spec:
  architecture: arm64
  domain:
    machine:
      type: virt
    cpu:
      dedicatedCpuPlacement: true
    devices:
      gpus:
      - name: grace-gpu0
        deviceName: nvidia.com/grace-gpu
```

Also valid using hostDevices instead of gpus:
```yaml
spec:
  architecture: arm64
  domain:
    machine:
      type: virt
    cpu:
      dedicatedCpuPlacement: true
    devices:
      hostDevices:
      - name: grace-gpu0
        deviceName: nvidia.com/grace-gpu
```

**2. Invalid VMI examples**:

Invalid: wrong architecture and machine type:
```yaml
spec:
  architecture: amd64
  domain:
    machine:
      type: q35
    cpu:
      dedicatedCpuPlacement: true
    devices:
      gpus:
      - name: grace-gpu0
        deviceName: nvidia.com/grace-gpu
```

Invalid VMI: missing dedicated CPU placement:
```yaml
spec:
  architecture: arm64
  domain:
    machine:
      type: virt
    devices:
      gpus:
      - name: grace-gpu0
        deviceName: nvidia.com/grace-gpu
``` 

**3. Rejected when GraceIOVirtualization is enabled because the NVIDIA selector is ambiguous**:

```yaml
permittedHostDevices:
  pciHostDevices:
  - resourceName: nvidia.com/nvidia-gpu
    pciVendorSelector: "10DE:*"
```

### Dependency notes

The Layer2 https://github.com/kubevirt/kubevirt/pull/17956 and Layer3 https://github.com/kubevirt/kubevirt/pull/17891 dependencies have merged into main. This branch has been rebased on current main and carries only the Layer4 admission change.

### Out of scope

This PR does not add runtime BDF/sysfs verification, SMMUv3 domain conversion, ACPI Generic Initiator NUMA generation, NUMA distance synthesis, pcihole64 sizing, EGM, vCMDQ, physical PCIe switch mirroring, or per-GPU PXB topology policy.



### Testing

```bash
go test ./pkg/util/hardware ./pkg/virt-api/webhooks/validating-webhook/admitters
bazel test //pkg/util/hardware:go_default_test //pkg/virt-api/webhooks/validating-webhook/admitters:go_default_test
```

### Release Note

```release-note
VMIs requesting NVIDIA Grace GPU PCI passthrough resources are now validated by admission. Such VMIs require the GraceIOVirtualization, PCINUMAAwareTopology, and IOMMUFD feature gates, arm64 architecture, the virt machine type, and dedicated CPU placement; ambiguous NVIDIA wildcard PCI selectors are rejected when GraceIOVirtualization is enabled.
```