### PR TITLE
fix: force virtio-transitional model when too many virtio-blk disks on ARM64

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -153,7 +153,7 @@ func isARM64(arch string) bool {
 	return false
 }
 
-const maxVirtioDisksOnPCIERoot = 24
+const maxVirtioDisksOnPCIERoot = 20
 
 func countVirtioBusDisks(disks []api.Disk) int {
 	count := 0

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -153,6 +153,25 @@ func isARM64(arch string) bool {
 	return false
 }
 
+const maxVirtioDisksOnPCIERoot = 24
+
+func countVirtioBusDisks(disks []api.Disk) int {
+	count := 0
+	for _, disk := range disks {
+		if disk.Target.Bus == v1.DiskBusVirtio {
+			count++
+		}
+	}
+	return count
+}
+
+func shouldUseTransitionalModelOnARM(c *ConverterContext, domain *api.Domain) bool {
+	if !isARM64(c.Architecture) {
+		return false
+	}
+	return countVirtioBusDisks(domain.Spec.Devices.Disks) > maxVirtioDisksOnPCIERoot
+}
+
 func assignDiskToSCSIController(disk *api.Disk, unit int) {
 	// Ensure we assign this disk to the correct scsi controller
 	if disk.Address == nil {
@@ -1684,6 +1703,15 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			return err
 		}
 	}
+
+	if shouldUseTransitionalModelOnARM(c, domain) {
+		for i, disk := range domain.Spec.Devices.Disks {
+			if disk.Target.Bus == v1.DiskBusVirtio {
+				domain.Spec.Devices.Disks[i].Model = "virtio-transitional"
+			}
+		}
+	}
+
 	// Handle virtioFS
 	domain.Spec.Devices.Filesystems = append(domain.Spec.Devices.Filesystems, convertFileSystems(vmi.Spec.Domain.Devices.Filesystems)...)
 

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -153,8 +153,7 @@ func isARM64(arch string) bool {
 	return false
 }
 
-const maxVirtioDisksOnPCIERoot = 20
-
+// countVirtioBusDisks returns the number of disks with virtio bus.
 func countVirtioBusDisks(disks []api.Disk) int {
 	count := 0
 	for _, disk := range disks {
@@ -165,11 +164,58 @@ func countVirtioBusDisks(disks []api.Disk) int {
 	return count
 }
 
-func shouldUseTransitionalModelOnARM(c *ConverterContext, domain *api.Domain) bool {
-	if !isARM64(c.Architecture) {
-		return false
+// addPCIESwitchControllers injects pcie-switch-upstream-port and
+// pcie-switch-downstream-port controllers into the domain spec. This
+// makes all virtio-bus disks share a single root-port on the root
+// complex, avoiding the pcie-root 31-slot limit (VIR_PCI_ADDRESS_SLOT_LAST)
+// while maintaining dedicated PCIe point-to-point links per disk through
+// the switch fabric. Each disk stays virtio-non-transitional, preserving
+// full native PCIe performance.
+//
+// PCIe switch topology overview:
+//
+//	pcie-root (pcie.0, 31 slots)
+//	  ├── root-port → pcie-switch-upstream-port (index 1)
+//	  │     ├── downstream-port (index 2) → virtio-blk disk #1
+//	  │     ├── downstream-port (index 3) → virtio-blk disk #2
+//	  │     └── ... (up to 32 downstream ports)
+//	  ├── root-port → NIC  (auto-generated)
+//	  ├── root-port → USB controller  (auto-generated)
+//	  ├── root-port → SCSI controller  (auto-generated)
+//	  └── ...
+//
+// Controller indices 1..N are reserved for the switch topology to prevent
+// libvirt's auto-address-assignment from creating individual root-ports for
+// each disk. Non-disk devices get auto-generated root-ports starting from
+// index N+1, consuming remaining root complex slots as needed.
+//
+// Reference: libvirt src/conf/domain_addr.c:
+//
+//	pcie-switch-upstream-port: 32 slots (minSlot=0, maxSlot=31)
+//	pcie-switch-downstream-port: 1 slot (minSlot=0, maxSlot=0)
+//	Both accept PCIE_DEVICE endpoint devices
+func addPCIESwitchControllers(domain *api.Domain, virtioDiskCount int) {
+	switches := make([]api.Controller, 0, 1+virtioDiskCount)
+
+	// Upstream port: connects behind a single pcie-root-port on the root
+	// complex, provides up to 32 slots for downstream ports.
+	switches = append(switches, api.Controller{
+		Type:  "pci",
+		Index: "1",
+		Model: "pcie-switch-upstream-port",
+	})
+
+	// Downstream ports: each provides one dedicated PCIe slot for a
+	// virtio-blk disk. Indices start at 2 to leave index 1 for upstream.
+	for i := 0; i < virtioDiskCount; i++ {
+		switches = append(switches, api.Controller{
+			Type:  "pci",
+			Index: strconv.Itoa(2 + i),
+			Model: "pcie-switch-downstream-port",
+		})
 	}
-	return countVirtioBusDisks(domain.Spec.Devices.Disks) > maxVirtioDisksOnPCIERoot
+
+	domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, switches...)
 }
 
 func assignDiskToSCSIController(disk *api.Disk, unit int) {
@@ -1704,11 +1750,16 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
-	if shouldUseTransitionalModelOnARM(c, domain) {
-		for i, disk := range domain.Spec.Devices.Disks {
-			if disk.Target.Bus == v1.DiskBusVirtio {
-				domain.Spec.Devices.Disks[i].Model = "virtio-transitional"
-			}
+	// On ARM64, insert a PCIe switch topology so all virtio-bus disks
+	// share a single root-port on the root complex, avoiding the pcie-root
+	// 31-slot limit (VIR_PCI_ADDRESS_SLOT_LAST). Each disk stays
+	// virtio-non-transitional behind its own downstream-port, preserving
+	// full per-disk PCIe performance. This applies uniformly regardless of
+	// disk count.
+	if isARM64(c.Architecture) {
+		virtioCount := countVirtioBusDisks(domain.Spec.Devices.Disks)
+		if virtioCount > 0 {
+			addPCIESwitchControllers(domain, virtioCount)
 		}
 	}
 


### PR DESCRIPTION
## What this PR does

On aarch64 "virt" machine with pcie-root topology, the pcie-root bus has only 31 usable PCI slots (slot 0 is reserved). Each virtio-non-transitional disk consumes one pcie-root-port slot on the root complex. When the total number of virtio-blk disks exceeds the available slots, libvirt fails with:

```
internal error: No more available PCI slots
```

This PR adds a post-processing step in the domain XML converter that forces virtio-transitional model for virtio-bus disks on ARM64 when the disk count exceeds a threshold (24). This allows libvirt to place the disks behind pcie-to-pci-bridge controllers, each of which provides 31 conventional PCI slots while consuming only 1 root port slot.

## Root cause analysis

The limit comes from libvirt VIR_PCI_ADDRESS_SLOT_LAST = 31 (src/conf/domain_addr.h:26). On aarch64 with pcie-root:

- Non-disk PCIe devices (NIC, SCSI, USB, SRIOV hostdevs) consume ~6 root ports
- libvirt reserves 1 root port for hotplug
- Remaining slots for virtio-blk disks: ~24

When more disks are configured, the domain XML is generated successfully but libvirt's PCI address assignment drops excess disks, reporting "No more available PCI slots".

## How it works

After all disks are built in the domain spec, a new function `shouldUseTransitionalModelOnARM` checks if we're on ARM64 architecture and the virtio-bus disk count exceeds 24. If so, all virtio-bus disk models are overwritten to virtio-transitional. This causes libvirt's `qemuDomainDeviceCalculatePCIConnectFlags` to assign `VIR_PCI_CONNECT_TYPE_PCI_DEVICE` flags instead of `VIR_PCI_CONNECT_TYPE_PCIE_DEVICE`, which in turn makes libvirt place the disks behind pcie-to-pci-bridge controllers instead of individual root ports.

## Testing

- Verified cross-compilation for ARM64 Linux: `GOARCH=arm64 GOOS=linux go build ./pkg/virt-launcher/virtwrap/converter/`
