### PR TITLE
tests/network: use nicer affinity in ping tests

### DIFF
--- a/pkg/libvmi/selector.go
+++ b/pkg/libvmi/selector.go
@@ -80,6 +80,22 @@ func WithNodeAffinityForLabel(nodeLabelKey, nodeLabelValue string) Option {
 	}
 }
 
+func WithRequiredPodAffinity(term k8sv1.PodAffinityTerm) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Affinity == nil {
+			vmi.Spec.Affinity = &k8sv1.Affinity{}
+		}
+
+		if vmi.Spec.Affinity.PodAffinity == nil {
+			vmi.Spec.Affinity.PodAffinity = &k8sv1.PodAffinity{}
+		}
+
+		vmi.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			vmi.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, term,
+		)
+	}
+}
+
 func WithPreferredPodAffinity(term k8sv1.WeightedPodAffinityTerm) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Spec.Affinity == nil {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -148,17 +148,6 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 		}, 6*time.Minute, 1*time.Second).Should(BeEmpty())
 	})
 
-	createVMIOnNode := func(interfaces []v1.Interface, networks []v1.Network) *v1.VirtualMachineInstance {
-		// Arbitrarily select one compute node in the cluster, on which it is possible to create a VMI
-		// (i.e. a schedulable node).
-		vmi := libvmifact.NewAlpine(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-		vmi.Spec.Domain.Devices.Interfaces = interfaces
-		vmi.Spec.Networks = networks
-		vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		return vmi
-	}
-
 	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.", func() {
 		const ptpGateway = ptpSubnetIP1
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
@@ -448,16 +437,14 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
 			It("[test_id:1756]should report all interfaces in Status", decorators.WgS390x, func() {
-				interfaces := []v1.Interface{
-					*v1.DefaultMasqueradeNetworkInterface(),
-					linuxBridgeInterface,
-				}
-				networks := []v1.Network{
-					*v1.DefaultPodNetwork(),
-					linuxBridgeNetwork,
-				}
-
-				vmiOne := createVMIOnNode(interfaces, networks)
+				vmiOne := libvmifact.NewAlpine(
+					libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
+					libvmi.WithInterface(linuxBridgeInterface),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithNetwork(&linuxBridgeNetwork),
+				)
+				vmiOne, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiOne)).Create(context.Background(), vmiOne, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 
@@ -470,8 +457,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					interfacesByName[ifc.Name] = ifc
 				}
 
-				for _, network := range networks {
-					ifc, isPresent := interfacesByName[network.Name]
+				for _, name := range []string{masqueradeIfaceName, linuxBridgeIfaceName} {
+					ifc, isPresent := interfacesByName[name]
 					Expect(isPresent).To(BeTrue())
 					Expect(ifc.MAC).To(Not(BeZero()))
 				}

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -33,7 +33,6 @@ import (
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -86,6 +85,19 @@ const (
 	bridge10MacSpoofCheck = false
 )
 
+func withCoLocationAffinity(group string) libvmi.Option {
+	const coLocationLabel = "kubevirt.io/test-co-location"
+	return func(vmi *v1.VirtualMachineInstance) {
+		libvmi.WithLabel(coLocationLabel, group)(vmi)
+		libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{coLocationLabel: group},
+			},
+			TopologyKey: k8sv1.LabelHostname,
+		})(vmi)
+	}
+}
+
 var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -128,9 +140,9 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 		// Multus tests need to ensure that old VMIs are gone
 		Eventually(func() []v1.VirtualMachineInstance {
-			list1, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).List(context.Background(), v13.ListOptions{})
+			list1, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			list2, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestAlternative).List(context.Background(), v13.ListOptions{})
+			list2, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestAlternative).List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return append(list1.Items, list2.Items...)
 		}, 6*time.Minute, 1*time.Second).Should(BeEmpty())
@@ -274,9 +286,12 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				return "", fmt.Errorf("couldn't find iface %s on vmi %s", networkName, vmiName)
 			}
 
-			DescribeTable("should be able to ping between two vms", func(interfaces []v1.Interface, networks []v1.Network, ifaceName string) {
-				vmiOne := createVMIOnNode(interfaces, networks)
-				vmiTwo := createVMIOnNode(interfaces, networks)
+			DescribeTable("should be able to ping between two vms", func(vmiOpts []libvmi.Option, ifaceName string) {
+				ns := testsuite.GetTestNamespace(nil)
+				vmiOne, err := virtClient.VirtualMachineInstance(ns).Create(context.Background(), libvmifact.NewAlpine(vmiOpts...), metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vmiTwo, err := virtClient.VirtualMachineInstance(ns).Create(context.Background(), libvmifact.NewAlpine(vmiOpts...), metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToAlpine)
@@ -297,13 +312,21 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				Expect(libnet.PingFromVMConsole(vmiOne, ipAddr)).To(Succeed())
 			},
 				Entry("[test_id:1577]with secondary network only",
-					[]v1.Interface{linuxBridgeInterface},
-					[]v1.Network{linuxBridgeNetwork},
+					[]libvmi.Option{
+						libvmi.WithInterface(linuxBridgeInterface),
+						libvmi.WithNetwork(&linuxBridgeNetwork),
+						withCoLocationAffinity("linux-bridge-ping"),
+					},
 					"eth0",
 				),
 				Entry("[test_id:1578]with default network and secondary network", decorators.WgS390x,
-					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterface},
-					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeNetwork},
+					[]libvmi.Option{
+						libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
+						libvmi.WithInterface(linuxBridgeInterface),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithNetwork(&linuxBridgeNetwork),
+						withCoLocationAffinity("linux-bridge-ping"),
+					},
 					"eth1",
 				),
 			)
@@ -313,14 +336,20 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				Expect(createBridgeNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), linuxBridgeVlan100WithIPAMNetwork, bridge10Name, 0, ipam, bridge10MacSpoofCheck)).To(Succeed())
 
 				const ifaceName = "eth1"
-				vmiOne := createVMIOnNode(
-					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterfaceWithIPAM},
-					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeWithIPAMNetwork},
-				)
-				vmiTwo := createVMIOnNode(
-					[]v1.Interface{*v1.DefaultMasqueradeNetworkInterface(), linuxBridgeInterfaceWithIPAM},
-					[]v1.Network{*v1.DefaultPodNetwork(), linuxBridgeWithIPAMNetwork},
-				)
+				newVMI := func() *v1.VirtualMachineInstance {
+					return libvmifact.NewAlpine(
+						libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
+						libvmi.WithInterface(linuxBridgeInterfaceWithIPAM),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithNetwork(&linuxBridgeWithIPAMNetwork),
+						withCoLocationAffinity("linux-bridge-ipam"),
+					)
+				}
+				ns := testsuite.GetTestNamespace(nil)
+				vmiOne, err := virtClient.VirtualMachineInstance(ns).Create(context.Background(), newVMI(), metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vmiTwo, err := virtClient.VirtualMachineInstance(ns).Create(context.Background(), newVMI(), metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				libwait.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 				libwait.WaitUntilVMIReady(vmiTwo, console.LoginToAlpine)


### PR DESCRIPTION
### What this PR does

#### Before this PR:

The linux-bridge ping tests in `vmi_multus.go` used a local `createVMIOnNode` helper that pinned both VMIs to `nodes.Items[0]` via
hard-coded node affinity. This approach is fragile: it selects a node by list index rather than by intent, and it bypassed the
`libvmi` option pattern by mutating `Spec.Domain.Devices.Interfaces` and `Spec.Networks` directly.

#### After this PR:

The two VMIs that must ping each other are co-located using **pod affinity**: each VMI carries a shared label and a
`RequiredDuringSchedulingIgnoredDuringExecution` affinity term that matches it. Kubernetes scheduling ensures both land on the same
node without hard-coding any node name. A new `libvmi.WithRequiredPodAffinity` option (symmetric to the existing
`WithPreferredPodAffinity`) makes this reusable across the codebase.

### Why we need it and why it was done in this way

Linux-bridge connectivity requires both VMIs to land on the same node — the bridge is node-local. The old implementation satisfied
this by pinning to `nodes.Items[0]`, which works but communicates the wrong intent: the constraint is *co-location*, not *a specific 
node*. Using pod affinity expresses the actual scheduling invariant and lets the scheduler pick any suitable node, improving
resilience in heterogeneous clusters.

The `withCoLocationAffinity(context)` helper applies both a label and the affinity term in one call, so the label used for matching is
guaranteed to be consistent. The `context` string namespaces distinct co-location groups within the same test run (e.g.
`"linux-bridge-ping"` vs `"linux-bridge-ipam"`).

`WithRequiredPodAffinity` was added to `pkg/libvmi/selector.go` alongside `WithPreferredPodAffinity` to keep the affinity API
symmetric and discoverable.

### Special notes for your reviewer

The duplicate import alias `v13 "k8s.io/apimachinery/pkg/apis/meta/v1"` (a leftover alias for `metav1`) is removed as a minor cleanup
made necessary by the refactor.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was
considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it 
simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout 
Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit 
tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes
require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not
required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution 
Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
NONE
```
