### PR TITLE
[release-1.5] Fix symlink traversal in VMExport dir handler

### DIFF
--- a/pkg/storage/export/virt-exportserver/BUILD.bazel
+++ b/pkg/storage/export/virt-exportserver/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/storage/export/virt-exportserver",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/safepath:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/storage/export/export:go_default_library",
         "//pkg/storage/utils:go_default_library",

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
 	storageutils "kubevirt.io/kubevirt/pkg/storage/utils"
@@ -705,8 +706,37 @@ func resourceToBytesYaml(resources []runtime.Object) ([]byte, error) {
 	return data, nil
 }
 
+// symlinkSafeDir is an http.FileSystem that prevents symlink traversal outside root.
+// Unlike http.Dir, it resolves symlinks via safepath and rejects any that escape the
+// root boundary, preventing attackers from reading files outside the exported PVC.
+type symlinkSafeDir struct {
+	root string
+}
+
+func (d symlinkSafeDir) Open(name string) (http.File, error) {
+	cleanName := path.Clean("/" + name)
+	if cleanName == "/" {
+		cleanName = "."
+	} else {
+		cleanName = cleanName[1:]
+	}
+
+	resolved, err := safepath.JoinAndResolveWithRelativeRoot(d.root, cleanName)
+	if err != nil {
+		return nil, err
+	}
+
+	fd, err := safepath.OpenAtNoFollow(resolved)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	return os.Open(fd.SafePath())
+}
+
 func dirHandler(uri, mountPoint string) http.Handler {
-	return http.StripPrefix(uri, http.FileServer(http.Dir(mountPoint)))
+	return http.StripPrefix(uri, http.FileServer(symlinkSafeDir{root: mountPoint}))
 }
 
 func fileHandler(file string) http.Handler {

--- a/pkg/storage/export/virt-exportserver/exportserver_test.go
+++ b/pkg/storage/export/virt-exportserver/exportserver_test.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -768,6 +770,83 @@ var _ = Describe("exportserver", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(HaveLen(1))
 			verifySecret(string(list.Items[0].Raw))
+		})
+	})
+
+	Context("dirHandler symlink safety", func() {
+		It("should serve files within the mount root", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(root, "hello.txt"), []byte("hello"), 0644)).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/hello.txt", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(Equal("hello"))
+		})
+
+		It("should block symlinks pointing outside the mount root", func() {
+			root := GinkgoT().TempDir()
+			outside := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(outside, "secret"), []byte("ESCAPED"), 0600)).To(Succeed())
+			Expect(os.Symlink(filepath.Join(outside, "secret"), filepath.Join(root, "escape-link"))).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/escape-link", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("should allow symlinks that stay within the mount root", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.MkdirAll(filepath.Join(root, "subdir"), 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(root, "subdir", "data.txt"), []byte("internal"), 0644)).To(Succeed())
+			Expect(os.Symlink("subdir/data.txt", filepath.Join(root, "internal-link"))).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/internal-link", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(Equal("internal"))
+		})
+
+		It("should block path traversal via dot-dot segments", func() {
+			root := GinkgoT().TempDir()
+			outside := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(outside, "secret"), []byte("ESCAPED"), 0600)).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/../../"+filepath.Base(outside)+"/secret", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+			Expect(rec.Body.String()).ToNot(ContainSubstring("ESCAPED"))
+		})
+
+		It("should block symlink to absolute path outside root", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.Symlink("/etc/hostname", filepath.Join(root, "host-link"))).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/host-link", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("should serve the root directory listing", func() {
+			root := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(root, "file.txt"), []byte("content"), 0644)).To(Succeed())
+
+			req := httptest.NewRequest(http.MethodGet, "/volumes/pvc/dir/", nil)
+			rec := httptest.NewRecorder()
+			dirHandler("/volumes/pvc/dir/", root).ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(rec.Body.String()).To(ContainSubstring("file.txt"))
 		})
 	})
 })


### PR DESCRIPTION
Cherry-pick of #17959 to release-1.5.

### What this PR does

The VMExport dirHandler uses `http.FileServer(http.Dir(mountPoint))` to serve filesystem PVC contents. `http.Dir` follows symlinks without restriction, so an attacker who can control files inside an exported filesystem PVC can place a symlink pointing outside the PVC mount root and retrieve files from the exporter pod filesystem through the VMExport directory endpoint.

Replace `http.Dir` with a `symlinkSafeDir` implementation that resolves symlinks safely using KubeVirt's existing safepath package:
1. `safepath.JoinAndResolveWithRelativeRoot` resolves symlinks chroot-style — symlinks within the PVC root are followed normally, but any symlink that would escape the root boundary is rejected.
2. `safepath.OpenAtNoFollow` opens the resolved path component-by-component via `openat(O_NOFOLLOW)`, preventing TOCTOU attacks where a symlink is injected after resolution.

```release-note
Fix symlink traversal in VMExport dir handler
```