### PR TITLE
feat: Support PCI hole64 aperture size override by annotation

### DIFF
--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -2,12 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["hw_utils.go"],
+    srcs = [
+        "hw_utils.go",
+        "pcihole64.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/util/hardware",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )
 

--- a/pkg/util/hardware/pcihole64.go
+++ b/pkg/util/hardware/pcihole64.go
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package hardware
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const pciHole64KiB = int64(1024)
+
+func PCIHole64SizeToKiB(size resource.Quantity) (uint, error) {
+	bytes := size.Value()
+	if bytes <= 0 {
+		return 0, fmt.Errorf("pcihole64 size must be greater than zero")
+	}
+
+	kib := (uint64(bytes) + uint64(pciHole64KiB) - 1) / uint64(pciHole64KiB)
+	if kib > uint64(^uint(0)) {
+		return 0, fmt.Errorf("pcihole64 size %s is too large", size.String())
+	}
+
+	return uint(kib), nil
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -125,6 +125,7 @@ func (admitter *VMICreateAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 
 	_, isKubeVirtServiceAccount := admitter.KubeVirtServiceAccounts[ar.Request.UserInfo.Username]
 	causes = append(causes, ValidateVirtualMachineInstanceMetadata(k8sfield.NewPath("metadata"), &vmi.ObjectMeta, admitter.ClusterConfig, isKubeVirtServiceAccount)...)
+	causes = append(causes, validatePCIHole64SizeAnnotation(k8sfield.NewPath("metadata"), vmi.Annotations)...)
 	causes = append(causes, webhooks.ValidateVirtualMachineInstanceHyperv(k8sfield.NewPath("spec").Child("domain").Child("features").Child("hyperv"), &vmi.Spec)...)
 	causes = append(causes, ValidateVirtualMachineInstancePerArch(k8sfield.NewPath("spec"), &vmi.Spec)...)
 	if len(causes) > 0 {
@@ -240,6 +241,42 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateReservedOverheadMemlock(field, spec, config)...)
 
 	return causes
+}
+
+func validatePCIHole64SizeAnnotation(field *k8sfield.Path, annotations map[string]string) []metav1.StatusCause {
+	value, ok := annotations[v1.PCIHole64SizeAnnotation]
+	if !ok {
+		return nil
+	}
+
+	annotationField := field.Child("annotations").Key(v1.PCIHole64SizeAnnotation).String()
+	size, err := resource.ParseQuantity(value)
+	if err != nil {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s must be a valid memory quantity: %v", annotationField, err),
+			Field:   annotationField,
+		}}
+	}
+
+	if _, err := hwutil.PCIHole64SizeToKiB(size); err != nil {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s must be a positive memory quantity representable in KiB: %v", annotationField, err),
+			Field:   annotationField,
+		}}
+	}
+
+	if value, ok := annotations[v1.DisablePCIHole64]; ok && strings.EqualFold(value, "true") {
+		return []metav1.StatusCause{{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s cannot be set when annotation %s is true",
+				annotationField, v1.DisablePCIHole64),
+			Field: annotationField,
+		}}
+	}
+
+	return nil
 }
 
 func validateFilesystemsWithVirtIOFSEnabled(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) (causes []metav1.StatusCause) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -123,6 +123,41 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		Expect(resp.Result.Details.Causes).To(Equal(expectedStatusCauses))
 	})
 
+	It("should accept positive PCIHole64 size annotation", func() {
+		vmi := newBaseVmi(libvmi.WithAnnotation(v1.PCIHole64SizeAnnotation, "64Gi"))
+
+		ar, err := newAdmissionReviewForVMICreation(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
+		Expect(resp.Allowed).To(BeTrue(), fmt.Sprint(resp.Result))
+	})
+
+	It("should reject non-positive PCIHole64 size annotation", func() {
+		vmi := newBaseVmi(libvmi.WithAnnotation(v1.PCIHole64SizeAnnotation, "0"))
+
+		ar, err := newAdmissionReviewForVMICreation(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(resp.Result.Message).To(ContainSubstring(v1.PCIHole64SizeAnnotation))
+	})
+
+	It("should reject PCIHole64 size annotation when PCIHole64 is disabled by annotation", func() {
+		vmi := newBaseVmi(
+			libvmi.WithAnnotation(v1.PCIHole64SizeAnnotation, "64Gi"),
+			libvmi.WithAnnotation(v1.DisablePCIHole64, "true"),
+		)
+
+		ar, err := newAdmissionReviewForVMICreation(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(resp.Result.Message).To(ContainSubstring("cannot be set"))
+	})
+
 	It("should reject invalid VirtualMachineInstance spec on create", func() {
 		vmi := newBaseVmi()
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -219,6 +219,7 @@ func ValidateVirtualMachineSpec(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 
 	causes = append(causes, ValidateVirtualMachineInstanceMetadata(field.Child("template", "metadata"), &spec.Template.ObjectMeta, config, isKubeVirtServiceAccount)...)
 	causes = append(causes, ValidateVirtualMachineInstanceSpec(field.Child("template", "spec"), &spec.Template.Spec, config)...)
+	causes = append(causes, validatePCIHole64SizeAnnotation(field.Child("template", "metadata"), spec.Template.ObjectMeta.Annotations)...)
 
 	causes = append(causes, storageadmitters.ValidateDataVolumeTemplate(field, spec)...)
 	causes = append(causes, validateRunStrategy(field, spec, config)...)

--- a/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
@@ -93,6 +93,10 @@ func (converterAMD64) SupportPCIHole64Disabling() bool {
 	return true
 }
 
+func (converterAMD64) SupportPCIHole64Sizing() bool {
+	return true
+}
+
 func (converterAMD64) SupportPCIePlacement() bool {
 	return true
 }

--- a/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
@@ -70,6 +70,10 @@ func (converterARM64) SupportPCIHole64Disabling() bool {
 	return false
 }
 
+func (converterARM64) SupportPCIHole64Sizing() bool {
+	return true
+}
+
 func (converterARM64) SupportPCIePlacement() bool {
 	return true
 }

--- a/pkg/virt-launcher/virtwrap/converter/arch/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/converter.go
@@ -40,6 +40,7 @@ type Converter interface {
 	RequiresMPXCPUValidation() bool
 	ShouldVerboseLogsBeEnabled() bool
 	SupportPCIHole64Disabling() bool
+	SupportPCIHole64Sizing() bool
 	SupportPCIePlacement() bool
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
@@ -73,6 +73,10 @@ func (converterS390X) SupportPCIHole64Disabling() bool {
 	return false
 }
 
+func (converterS390X) SupportPCIHole64Sizing() bool {
+	return false
+}
+
 func (converterS390X) SupportPCIePlacement() bool {
 	// s390x does not support PCIe topology features used in other architectures.
 	// Specifically:

--- a/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/pointer:go_default_library",
         "//pkg/tpm:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/hardware:go_default_library",
         "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/iothreads:go_default_library",
@@ -45,6 +46,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/launchsecurity:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -20,12 +20,16 @@
 package compute
 
 import (
+	"fmt"
 	"slices"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/iothreads"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
@@ -41,6 +45,7 @@ type ControllersDomainConfigurator struct {
 	autoThreads               uint
 	controllerDriver          *api.ControllerDriver
 	supportPCIHole64Disabling bool
+	supportPCIHole64Sizing    bool
 	virtioSerialModel         string
 }
 
@@ -64,8 +69,21 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newSCSIController(c.scsiModel, scsiControllerDriver))
 	}
 
-	if c.supportPCIHole64Disabling && shouldDisablePCIHole64(vmi) {
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newPCIControllerWithHole64Disabled())
+	pciHole64SizeKiB, err := pciHole64SizeAnnotationKiB(vmi)
+	if err != nil {
+		return err
+	}
+
+	if pciHole64SizeKiB != nil {
+		if shouldDisablePCIHole64(vmi) {
+			return fmt.Errorf("%s cannot be set when annotation %s is true", v1.PCIHole64SizeAnnotation, v1.DisablePCIHole64)
+		}
+		if !c.supportPCIHole64Sizing {
+			return fmt.Errorf("pcihole64 sizing is not supported by this architecture")
+		}
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newPCIControllerWithHole64KiB(*pciHole64SizeKiB))
+	} else if c.supportPCIHole64Disabling && shouldDisablePCIHole64(vmi) {
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newPCIControllerWithHole64KiB(0))
 	}
 
 	if requiresVirtioSerialController(vmi) {
@@ -105,6 +123,12 @@ func ControllersWithSupportPCIHole64Disabling(support bool) controllersOption {
 	}
 }
 
+func ControllersWithSupportPCIHole64Sizing(support bool) controllersOption {
+	return func(c *ControllersDomainConfigurator) {
+		c.supportPCIHole64Sizing = support
+	}
+}
+
 func ControllersWithVirtioSerialModel(model string) controllersOption {
 	return func(c *ControllersDomainConfigurator) {
 		c.virtioSerialModel = model
@@ -134,13 +158,13 @@ func newSCSIController(controllerModel string, controllerDriver *api.ControllerD
 	}
 }
 
-func newPCIControllerWithHole64Disabled() api.Controller {
+func newPCIControllerWithHole64KiB(sizeKiB uint) api.Controller {
 	return api.Controller{
 		Type:  "pci",
 		Index: "0",
 		Model: "pcie-root",
 		PCIHole64: &api.PCIHole64{
-			Value: 0,
+			Value: sizeKiB,
 			Unit:  "KiB",
 		},
 	}
@@ -153,6 +177,25 @@ func newVirtioSerialController(model string, controllerDriver *api.ControllerDri
 		Model:  model,
 		Driver: controllerDriver,
 	}
+}
+
+func pciHole64SizeAnnotationKiB(vmi *v1.VirtualMachineInstance) (*uint, error) {
+	value, ok := vmi.Annotations[v1.PCIHole64SizeAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	size, err := resource.ParseQuantity(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s annotation: %w", v1.PCIHole64SizeAnnotation, err)
+	}
+
+	sizeKiB, err := hardware.PCIHole64SizeToKiB(size)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s annotation: %w", v1.PCIHole64SizeAnnotation, err)
+	}
+
+	return pointer.P(sizeKiB), nil
 }
 
 func shouldDisablePCIHole64(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 	const (
 		usbNeeded                   = true
 		pciHole64DisablingSupported = true
+		pciHole64SizingSupported    = true
 	)
 
 	DescribeTable("should configure USB and SCSI controllers", func(vmi *v1.VirtualMachineInstance, isUSBNeeded bool, autoThreads int, expectedControllers []api.Controller) {
@@ -175,7 +176,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			}),
 	)
 
-	DescribeTable("should configure PCI controller based on arch support and annotation", func(vmi *v1.VirtualMachineInstance, supportPCIHole64Disabling bool, expectedControllers []api.Controller) {
+	DescribeTable("should configure PCI controller based on arch support and annotation", func(vmi *v1.VirtualMachineInstance, supportPCIHole64Disabling, supportPCIHole64Sizing bool, expectedControllers []api.Controller) {
 		var domain api.Domain
 
 		configurator := compute.NewControllersDomainConfigurator(
@@ -184,6 +185,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			compute.ControllersWithSCSIIOThreads(0),
 			compute.ControllersWithControllerDriver(nil),
 			compute.ControllersWithSupportPCIHole64Disabling(supportPCIHole64Disabling),
+			compute.ControllersWithSupportPCIHole64Sizing(supportPCIHole64Sizing),
 			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
 		)
 		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
@@ -193,6 +195,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		Entry("when arch does not support PCIHole64 disabling, annotation not set",
 			libvmi.New(),
 			!pciHole64DisablingSupported,
+			!pciHole64SizingSupported,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
@@ -201,6 +204,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		Entry("when arch does not support PCIHole64 disabling, annotation set",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
 			!pciHole64DisablingSupported,
+			!pciHole64SizingSupported,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
@@ -209,6 +213,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		Entry("when arch supports PCIHole64 disabling, annotation not set",
 			libvmi.New(),
 			pciHole64DisablingSupported,
+			pciHole64SizingSupported,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
@@ -217,6 +222,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		Entry("when arch supports PCIHole64 disabling, annotation set to false",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "false")),
 			pciHole64DisablingSupported,
+			pciHole64SizingSupported,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
@@ -225,13 +231,59 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		Entry("when arch supports PCIHole64 disabling and annotation is true",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
 			pciHole64DisablingSupported,
+			pciHole64SizingSupported,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
 				{Type: "scsi", Index: "0", Model: "test-model"},
 				{Type: "pci", Index: "0", Model: "pcie-root", PCIHole64: &api.PCIHole64{Value: 0, Unit: "KiB"}},
 				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
+		Entry("when arch supports PCIHole64 sizing and size is set",
+			libvmi.New(withPCIHole64Size("64Gi")),
+			pciHole64DisablingSupported,
+			pciHole64SizingSupported,
+			[]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: "pci", Index: "0", Model: "pcie-root", PCIHole64: &api.PCIHole64{Value: 67108864, Unit: "KiB"}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+			}),
 	)
+
+	It("should reject PCIHole64 sizing when unsupported by the architecture", func() {
+		var domain api.Domain
+
+		configurator := compute.NewControllersDomainConfigurator(
+			compute.ControllersWithUSBNeeded(!usbNeeded),
+			compute.ControllersWithSCSIModel("test-model"),
+			compute.ControllersWithControllerDriver(nil),
+			compute.ControllersWithSupportPCIHole64Sizing(!pciHole64SizingSupported),
+			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
+		)
+
+		Expect(configurator.Configure(libvmi.New(withPCIHole64Size("64Gi")), &domain)).To(MatchError(ContainSubstring("pcihole64 sizing is not supported")))
+	})
+
+	It("should reject PCIHole64 sizing when incompatible annotations are set", func() {
+		var domain api.Domain
+
+		configurator := compute.NewControllersDomainConfigurator(
+			compute.ControllersWithUSBNeeded(!usbNeeded),
+			compute.ControllersWithSCSIModel("test-model"),
+			compute.ControllersWithControllerDriver(nil),
+			compute.ControllersWithSupportPCIHole64Disabling(pciHole64DisablingSupported),
+			compute.ControllersWithSupportPCIHole64Sizing(pciHole64SizingSupported),
+			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
+		)
+		vmi := libvmi.New(
+			withPCIHole64Size("64Gi"),
+			libvmi.WithAnnotation(v1.DisablePCIHole64, "true"),
+		)
+
+		err := configurator.Configure(vmi, &domain)
+		Expect(err).To(MatchError(ContainSubstring(v1.PCIHole64SizeAnnotation)))
+		Expect(err).To(MatchError(ContainSubstring(v1.DisablePCIHole64)))
+	})
 
 	DescribeTable("should configure virtio-serial controller based on serial console setting", func(vmiOpts []libvmi.Option, expectedControllers []api.Controller) {
 		var domain api.Domain
@@ -284,4 +336,8 @@ func withHotplugDisabled() libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Devices.DisableHotplug = true
 	}
+}
+
+func withPCIHole64Size(size string) libvmi.Option {
+	return libvmi.WithAnnotation(v1.PCIHole64SizeAnnotation, size)
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1037,6 +1037,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			compute.ControllersWithSCSIIOThreads(uint(autoThreads)),
 			compute.ControllersWithControllerDriver(controllerDriver),
 			compute.ControllersWithSupportPCIHole64Disabling(c.Architecture.SupportPCIHole64Disabling()),
+			compute.ControllersWithSupportPCIHole64Sizing(c.Architecture.SupportPCIHole64Sizing()),
 			compute.ControllersWithVirtioSerialModel(virtioModel),
 		),
 		compute.NewQemuCmdDomainConfigurator(c.Architecture.ShouldVerboseLogsBeEnabled()),

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1450,6 +1450,40 @@ var _ = Describe("Converter", func() {
 			Entry("not be set on s390x when annotation was set not to true", s390x, "something", false),
 		)
 
+		DescribeTable("PCIHole64 size on pcie-root Controller should", func(arch string) {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			if vmi.Annotations == nil {
+				vmi.Annotations = make(map[string]string)
+			}
+			vmi.Annotations[v1.PCIHole64SizeAnnotation] = "64Gi"
+			c.Architecture = archconverter.NewConverter(arch)
+			domain := vmiToDomain(vmi, c)
+
+			Expect(domain.Spec.Devices.Controllers).To(ContainElement(api.Controller{
+				Type:  "pci",
+				Index: "0",
+				Model: "pcie-root",
+				PCIHole64: &api.PCIHole64{
+					Value: 67108864,
+					Unit:  "KiB",
+				},
+			}))
+		},
+			Entry("be set on amd64", amd64),
+			Entry("be set on arm64", arm64),
+		)
+
+		It("should reject PCIHole64 sizing on unsupported architecture", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			if vmi.Annotations == nil {
+				vmi.Annotations = make(map[string]string)
+			}
+			vmi.Annotations[v1.PCIHole64SizeAnnotation] = "64Gi"
+			c.Architecture = archconverter.NewConverter(s390x)
+
+			Expect(Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, &api.Domain{}, c)).To(MatchError(ContainSubstring("pcihole64 sizing is not supported")))
+		})
+
 		It("should fail when input device is set to ps2 bus", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Inputs[0].Bus = "ps2"

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1415,6 +1415,10 @@ const (
 	// This annotation might be deprecated in the future if we decided to add a struct for it.
 	DisablePCIHole64 string = "kubevirt.io/disablePCIHole64"
 
+	// PCIHole64SizeAnnotation configures the 64-bit PCI MMIO aperture size for the root PCIe controller.
+	// This annotation is alpha and may be replaced by a typed API field in the future.
+	PCIHole64SizeAnnotation string = "alpha.kubevirt.io/pciHole64Size"
+
 	// EvictionSourceAnnotation indicates the origin of an api initiated eviction in the VirtualMachineInstance.
 	// This annotation might be empty if the source is not a recognized actor (an admin for example).
 	// This could be useful to distinguish evictions originated from the descheduler.


### PR DESCRIPTION
### What this PR does
This PR adds an alpha annotation for configuring the 64-bit PCI MMIO aperture size on the PCIe root controller:
```yaml
alpha.kubevirt.io/pciHole64Size: "4Ti"
```
This gives users an explicit escape hatch for PCI passthrough devices with large BAR requirements, without adding a new field to the VMI API.

### Why we need it
Some assigned PCI devices require a larger 64-bit MMIO aperture than the platform default. KubeVirt already has libvirt XML support for pcihole64, and already supports disabling it through kubevirt.io/disablePCIHole64.

This PR adds the corresponding alpha override path for users that need to increase the aperture size.

### User-facing changes
A VMI or VM template can set:
```yaml
metadata:
  annotations:
    alpha.kubevirt.io/pciHole64Size: "4Ti"
```
The value uses Kubernetes quantity syntax. Valid examples include:
```yaml
alpha.kubevirt.io/pciHole64Size: "4Ti"
alpha.kubevirt.io/pciHole64Size: "4294967296KiB"
```
Invalid or non-positive values are rejected during admission.
The annotation cannot be combined with:
```yaml
kubevirt.io/disablePCIHole64: "true"
```
because one asks KubeVirt to size the aperture while the other disables it.

### Implementation details
This PR:
- adds the alpha.kubevirt.io/pciHole64Size annotation constant;
- validates the annotation for VMI creation and VM template admission;
- parses the value as a Kubernetes resource.Quantity;
- converts the value to KiB for the libvirt pcihole64 XML value;
- rejects invalid, zero, negative, or overflowing values;
- wires architecture support for explicit pcihole64 sizing;
- emits pcihole64 on the PCIe root controller when requested.
Existing kubevirt.io/disablePCIHole64 behavior is unchanged when the new annotation is absent.

### Relationship with VEP-199 / PR #18011

This PR is generic large-BAR PCI aperture plumbing. It is not Grace-specific and does not depend on VEP-199.

The draft VEP-199 Grace conversion PR, #18011, also sets pcihole64 automatically for Grace GPUs based on detected BAR requirements. These two changes touch related behavior but serve different purposes:
- this PR provides an explicit user override;
- #18011 provides automatic sizing for Grace virtualization.

The expected combined behavior is:
- if no annotation is set, Grace conversion may auto-size pcihole64;
- if alpha.kubevirt.io/pciHole64Size is set, Grace conversion should treat it as an explicit user value;
- if the explicit value is large enough, Grace conversion should preserve it;
- if the explicit value is too small for the assigned Grace devices, Grace conversion should fail with a clear error;
- `kubevirt.io/disablePCIHole64=true` should remain incompatible with Grace auto-sizing.

Depending on merge order, either this PR or #18011 will need a small rebase adjustment in the Grace applyGracePCIHole64 path so that Grace does not silently overwrite an explicit non-zero user-provided aperture.

### Release note

```release-note
Add alpha annotation alpha.kubevirt.io/pciHole64Size for configuring the 64-bit PCI MMIO aperture size.
```