### PR TITLE
Automate rpm version bump

### DIFF
--- a/hack/bump-rpm-versions.sh
+++ b/hack/bump-rpm-versions.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RPM_DEPS="${SCRIPT_DIR}/rpm-deps.sh"
+REPO_URL="http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os"
+
+dry_run=false
+check_only=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) dry_run=true ;;
+        --check) check_only=true ;;
+        -h|--help) echo "Usage: $0 [--dry-run|--check]"; exit 0 ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+[[ -f "$RPM_DEPS" ]] || { echo "Cannot find $RPM_DEPS" >&2; exit 1; }
+
+primary_href=$(curl -sL "${REPO_URL}/repodata/repomd.xml" |
+    grep -oP 'href="\Krepodata/[^"]*primary\.xml\.gz') || true
+[[ -n "$primary_href" ]] || { echo "repomd.xml: cannot find primary.xml.gz" >&2; exit 1; }
+
+metadata=$(mktemp)
+trap 'rm -f "$metadata"' EXIT
+curl -sL "${REPO_URL}/${primary_href}" | gunzip >"$metadata"
+
+query_latest() {
+    grep -A2 ">$1<" "$metadata" |
+        grep '<version' |
+        sed -E 's/.*epoch="([^"]+)" ver="([^"]+)" rel="([^"]+)".*/\1:\2-\3/' |
+        sort -V | tail -1 || true
+}
+
+read_pinned() {
+    sed -n "s/^[[:space:]]*${1}=\${${1}:-\(.*\)}/\1/p" "$RPM_DEPS" |
+        grep '\.el9' | head -1 || true
+}
+
+declare -A pkg_map=(
+    [LIBVIRT_VERSION]="libvirt-daemon-driver-qemu"
+    [QEMU_VERSION]="qemu-kvm-core"
+    [SEABIOS_VERSION]="seabios-bin"
+    [EDK2_VERSION]="edk2-ovmf"
+    [PASST_VERSION]="passt"
+    [VIRTIOFSD_VERSION]="virtiofsd"
+    [SWTPM_VERSION]="swtpm-tools"
+    [LIBNBD_VERSION]="libnbd"
+)
+
+changes=0
+
+for varname in "${!pkg_map[@]}"; do
+    pkg="${pkg_map[$varname]}"
+    current=$(read_pinned "$varname")
+    latest=$(query_latest "$pkg")
+
+    if [[ -z "$latest" ]]; then
+        echo "SKIP $varname ($pkg not in repo)"
+        continue
+    fi
+    if [[ -z "$current" ]]; then
+        echo "SKIP $varname (not pinned in rpm-deps.sh)"
+        continue
+    fi
+    [[ "$current" != "$latest" ]] || continue
+
+    echo "$varname: $current -> $latest"
+    changes=$((changes + 1))
+
+    if $dry_run || $check_only; then
+        continue
+    fi
+    sed -i "s|${varname}=\${${varname}:-${current}}|${varname}=\${${varname}:-${latest}}|" "$RPM_DEPS"
+done
+
+if [[ $changes -eq 0 ]]; then
+    echo "All versions up to date."
+    exit 0
+fi
+
+$check_only && { echo "$changes outdated"; exit 1; }
+$dry_run && { echo "$changes would be updated"; exit 0; }
+echo "Updated $changes version(s) in $RPM_DEPS"

--- a/pkg/hypervisor/kvm/hypervisorbackend_test.go
+++ b/pkg/hypervisor/kvm/hypervisorbackend_test.go
@@ -308,7 +308,7 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 	})
 
 	When("reservedOverhead value is provided", func() {
-		DescribeTable("should be considered as a resource overhead", func(overhead *resource.Quantity) {
+		DescribeTable("should include addedOverhead in the overhead", func(overhead *resource.Quantity) {
 			cpuArch := "amd64"
 			vmi.Spec.Domain.Memory = &v1.Memory{}
 			vmi.Spec.Domain.Memory.ReservedOverhead = &v1.ReservedOverhead{
@@ -327,6 +327,50 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			Entry("with some value", resource.NewScaledQuantity(100, resource.Giga)),
 			Entry("with zero value", &resource.Quantity{}),
 		)
+	})
+
+	When("reservedOverhead with addedOverhead is set", func() {
+		It("should include addedOverhead regardless of memLock setting", func() {
+			cpuArch := "amd64"
+			addedOverhead := resource.MustParse("1Gi")
+			vmi.Spec.Domain.Memory = &v1.Memory{}
+			vmi.Spec.Domain.Memory.ReservedOverhead = &v1.ReservedOverhead{
+				AddedOverhead: &addedOverhead,
+				MemLock:       pointer.P(v1.MemLockRequirement(v1.MemLockNotRequired)),
+			}
+
+			overhead := kvm.NewKvmHypervisorBackend().GetMemoryOverhead(vmi, cpuArch, nil)
+
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(addedOverhead)
+
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+
+		It("should include addedOverhead with memLock Required", func() {
+			cpuArch := "amd64"
+			addedOverhead := resource.MustParse("1Gi")
+			vmi.Spec.Domain.Memory = &v1.Memory{}
+			vmi.Spec.Domain.Memory.ReservedOverhead = &v1.ReservedOverhead{
+				AddedOverhead: &addedOverhead,
+				MemLock:       pointer.P(v1.MemLockRequirement(v1.MemLockRequired)),
+			}
+
+			overhead := kvm.NewKvmHypervisorBackend().GetMemoryOverhead(vmi, cpuArch, nil)
+
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(addedOverhead)
+
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
 	})
 
 	Context("Template with guest-to-request memory headroom", func() {

--- a/pkg/hypervisor/kvm/runtime.go
+++ b/pkg/hypervisor/kvm/runtime.go
@@ -94,6 +94,13 @@ func (k *KvmVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config 
 
 	memlockSize := k.CalculateMemlockSize(vmi, config)
 
+	// addedOverhead is included in GetMemoryOverhead for pod memory sizing,
+	// but should be excluded from the memlock rlimit when memLock is "NotRequired".
+	// See https://github.com/kubevirt/enhancements/issues/144
+	if util.RequiresMemoryOverheadReservation(vmi) && !util.RequiresLockingMemory(vmi) {
+		memlockSize.Sub(*vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead)
+	}
+
 	if err := common.SetProcessMemoryLockRLimit(targetProcessID, memlockSize.Value()); err != nil {
 		return fmt.Errorf("failed to set process %d memlock rlimit to %d: %v", targetProcessID, memlockSize.Value(), err)
 	}

--- a/pkg/hypervisor/mshv/runtime.go
+++ b/pkg/hypervisor/mshv/runtime.go
@@ -97,6 +97,14 @@ func (m *MshvVirtRuntime) AdjustResources(vmi *v1.VirtualMachineInstance, config
 		// and we are sure that all VMIs include the MemoryOverhead status field
 		memlockSize = m.GetMemoryOverhead(vmi, runtime.GOARCH, config.AdditionalGuestMemoryOverheadRatio)
 	}
+
+	// addedOverhead is included in GetMemoryOverhead for pod memory sizing,
+	// but should be excluded from the memlock rlimit when memLock is "NotRequired".
+	// See https://github.com/kubevirt/enhancements/issues/144
+	if util.RequiresMemoryOverheadReservation(vmi) && !util.RequiresLockingMemory(vmi) {
+		memlockSize.Sub(*vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead)
+	}
+
 	// Add memory assigned to the VM
 	vmiBaseMemory := getVMIBaseMemory(vmi)
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
There is no automated way to detect and update stale RPM versions in `hack/rpm-deps.sh`. When CentOS Stream 9 removes old package versions from their mirrors, `make rpm-deps` breaks and someone has to manually look up and update each version.

#### After this PR:

Adds `hack/bump-rpm-versions.sh` that queries CentOS Stream 9 repo metadata and bumps all pinned RPM versions in `hack/rpm-deps.sh` to the latest available. Supports `--dry-run` and `--check` modes for CI gating.


### Why we need it and why it was done in this way
CentOS Stream is a rolling release — old package versions get removed from mirrors regularly. When that happens, our pinned versions in hack/rpm-deps.sh become unavailable and `make rpm-deps` breaks. This script prevents that by keeping versions current.

The following tradeoffs were made:
- Uses curl to parse repo metadata directly, so it works in any CI container with no extra dependencies.
- Only handles CS9 versions since CS10 entries in rpm-deps.sh are currently empty.

### Special notes for your reviewer
This script is meant to be called by the existing `bump-kubevirt-rpms-weekly` Prow job. It can also be run manually when `make rpm-deps` breaks due to missing packages.


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

