### PR TITLE
WIP: Migrate unsafe file path operations to safepath in virt-launcher

### DIFF
--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/cmd-server:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/util"
 )
 
@@ -260,7 +261,16 @@ func pidExists(pid int) (exists bool, isZombie bool, err error) {
 }
 
 func FindPid(domainName string, pidDir string) (int, error) {
-	content, err := os.ReadFile(filepath.Join(pidDir, domainName+".pid"))
+	pidFile, err := safepath.JoinAndResolveWithRelativeRoot(pidDir, domainName+".pid")
+	if err != nil {
+		return 0, err
+	}
+
+	var content []byte
+	err = pidFile.ExecuteNoFollow(func(safePath string) (err error) {
+		content, err = os.ReadFile(safePath)
+		return err
+	})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config:go_default_library",
+        "//pkg/safepath:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
         "//pkg/virt-launcher/virtwrap/agent:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
@@ -28,6 +29,7 @@ go_test(
     race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/safepath:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/config"
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -533,8 +534,14 @@ func (l *AccessCredentialManager) HandleQemuAgentAccessCredentials(vmi *v1.Virtu
 	}
 
 	for _, dir := range secretDirs {
-		err = l.watcher.Add(dir)
+		dirSafePath, err := safepath.NewPathNoFollow(dir)
 		if err != nil {
+			_ = l.watcher.Close()
+			return err
+		}
+		if err := dirSafePath.ExecuteNoFollow(func(resolvedPath string) error {
+			return l.watcher.Add(resolvedPath)
+		}); err != nil {
 			// Ignoring error returned by watcher.Close(),
 			// because another error will be returned.
 			_ = l.watcher.Close()
@@ -586,7 +593,11 @@ func (a *accessCredentialsInfo) addAccessCredential(accessCred *v1.AccessCredent
 		return nil
 	}
 
-	secretDir := getSecretDir(secretName)
+	secretDir, err := safepath.JoinAndResolveWithRelativeRoot(getSecretBaseDir(), secretName+"-access-cred")
+	if err != nil {
+		return fmt.Errorf("failed to resolve secret directory for %q: %w", secretName, err)
+	}
+
 	if isSSHPublicKey(accessCred) {
 		for _, user := range accessCred.SSHPublicKey.PropagationMethod.QemuGuestAgent.Users {
 			a.userSSHMap[user] = append(a.userSSHMap[user], secretName)
@@ -610,8 +621,12 @@ func (a *accessCredentialsInfo) addAccessCredential(accessCred *v1.AccessCredent
 	return nil
 }
 
-func readKeysFromDirectory(dir string) ([]string, error) {
-	files, err := os.ReadDir(dir)
+func readKeysFromDirectory(dir *safepath.Path) ([]string, error) {
+	var files []os.DirEntry
+	err := dir.ExecuteNoFollow(func(safePath string) (err error) {
+		files, err = os.ReadDir(safePath)
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error occurred while reading the list of secrets files from the base directory %s: %w", dir, err)
 	}
@@ -622,9 +637,18 @@ func readKeysFromDirectory(dir string) ([]string, error) {
 			continue
 		}
 
-		pubKeyBytes, err := os.ReadFile(filepath.Join(dir, file.Name()))
+		filePath, err := dir.AppendAndResolveWithRelativeRoot(file.Name())
 		if err != nil {
-			return nil, fmt.Errorf("error occurred while reading the access credential secret file [%s]: %w", filepath.Join(dir, file.Name()), err)
+			return nil, fmt.Errorf("error occurred while reading the access credential secret file [%s/%s]: %w", dir, file.Name(), err)
+		}
+
+		var pubKeyBytes []byte
+		err = filePath.ExecuteNoFollow(func(safePath string) (err error) {
+			pubKeyBytes, err = os.ReadFile(safePath)
+			return err
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while reading the access credential secret file [%s/%s]: %w", dir, file.Name(), err)
 		}
 
 		for _, pubKey := range strings.Split(string(pubKeyBytes), "\n") {
@@ -638,8 +662,12 @@ func readKeysFromDirectory(dir string) ([]string, error) {
 	return authorizedKeys, nil
 }
 
-func readAndAddPasswordsFromDirectory(dir string, passMap map[string]string) error {
-	files, err := os.ReadDir(dir)
+func readAndAddPasswordsFromDirectory(dir *safepath.Path, passMap map[string]string) error {
+	var files []os.DirEntry
+	err := dir.ExecuteNoFollow(func(safePath string) (err error) {
+		files, err = os.ReadDir(safePath)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("error occurred while reading the list of secrets files from the base directory %s: %w", dir, err)
 	}
@@ -651,9 +679,18 @@ func readAndAddPasswordsFromDirectory(dir string, passMap map[string]string) err
 			continue
 		}
 
-		passwordBytes, err := os.ReadFile(filepath.Join(dir, file.Name()))
+		filePath, err := dir.AppendAndResolveWithRelativeRoot(file.Name())
 		if err != nil {
-			return fmt.Errorf("error occurred while reading the access credential secret file [%s]: %w", filepath.Join(dir, file.Name()), err)
+			return fmt.Errorf("error occurred while reading the access credential secret file [%s/%s]: %w", dir, file.Name(), err)
+		}
+
+		var passwordBytes []byte
+		err = filePath.ExecuteNoFollow(func(safePath string) (err error) {
+			passwordBytes, err = os.ReadFile(safePath)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("error occurred while reading the access credential secret file [%s/%s]: %w", dir, file.Name(), err)
 		}
 
 		password := strings.TrimSpace(string(passwordBytes))

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -43,6 +43,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
@@ -279,6 +280,47 @@ var _ = Describe("AccessCredentials", func() {
 
 		// Wait until ssh keys reload is detected
 		Eventually(keysLoaded, 5*time.Second, 50*time.Millisecond).Should(BeClosed())
+	})
+
+	Context("path traversal defense", func() {
+		It("should not access paths outside base directory when secretName contains path traversal", func() {
+			// Create a sibling directory that would be reached via traversal without safepath.
+			siblingDir := filepath.Join(filepath.Dir(tmpDir), "sensitive-secret-access-cred")
+			Expect(os.MkdirAll(siblingDir, 0o755)).To(Succeed())
+			defer os.RemoveAll(siblingDir)
+			Expect(os.WriteFile(filepath.Join(siblingDir, "password"), []byte("secret"), 0o600)).To(Succeed())
+
+			vmi := &v1.VirtualMachineInstance{}
+			vmi.Spec.AccessCredentials = []v1.AccessCredential{{
+				UserPassword: &v1.UserPasswordAccessCredential{
+					Source: v1.UserPasswordAccessCredentialSource{
+						Secret: &v1.AccessCredentialSecretSource{SecretName: "../sensitive-secret"},
+					},
+					PropagationMethod: v1.UserPasswordAccessCredentialPropagationMethod{
+						QemuGuestAgent: &v1.QemuGuestAgentUserPasswordAccessCredentialPropagation{},
+					},
+				},
+			}}
+
+			info := newAccessCredentialsInfo()
+			err := info.addAccessCredential(&vmi.Spec.AccessCredentials[0])
+			Expect(err).To(HaveOccurred(), "secretName path traversal must be rejected")
+		})
+
+		It("should not follow symlinks when reading SSH public keys from secret directory", func() {
+			secretDir := filepath.Join(tmpDir, "some-secret-access-cred")
+			Expect(os.Mkdir(secretDir, 0o755)).To(Succeed())
+
+			sensitiveFile := filepath.Join(tmpDir, "sensitive-data")
+			Expect(os.WriteFile(sensitiveFile, []byte("sensitive-content"), 0o600)).To(Succeed())
+			Expect(os.Symlink(sensitiveFile, filepath.Join(secretDir, "malicious-key"))).To(Succeed())
+
+			dir, err := safepath.JoinAndResolveWithRelativeRoot(secretDir)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = readKeysFromDirectory(dir)
+			Expect(err).To(HaveOccurred(), "symlink traversal outside secret directory must be rejected")
+		})
+
 	})
 
 	It("should trigger updating a credential when secret propagation change occurs.", func() {

--- a/pkg/virt-launcher/virtwrap/storage/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/storage/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/os/disk:go_default_library",
+        "//pkg/safepath:go_default_library",
         "//pkg/storage/cbt:go_default_library",
         "//pkg/storage/volumepath:go_default_library",
         "//pkg/tpm:go_default_library",

--- a/pkg/virt-launcher/virtwrap/storage/backup.go
+++ b/pkg/virt-launcher/virtwrap/storage/backup.go
@@ -35,7 +35,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
-	kutil "kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
@@ -140,19 +140,30 @@ func (m *StorageManager) backup(vmi *v1.VirtualMachineInstance, backupOptions *b
 
 	var backupPath string
 	if backupOptions.TargetPath != nil {
+		targetSafePath, err := safepath.NewPathNoFollow(*backupOptions.TargetPath)
+		if err != nil {
+			return fmt.Errorf("error validating backup target path: %w", err)
+		}
 		backupPath = getBackupPath(backupOptions, vmi.Name)
-		if err := kutil.MkdirAllWithNosec(backupPath); err != nil {
-			logger.Reason(err).Error("error creating dir for backup")
+		if err := targetSafePath.ExecuteNoFollow(func(safePath string) error {
+			return os.MkdirAll(filepath.Join(safePath, vmi.Name, filepath.Base(backupPath)), 0750)
+		}); err != nil {
 			return fmt.Errorf("error creating dir for backup: %w", err)
 		}
-		defer func(path string) {
+		backupSafePath, err := safepath.JoinAndResolveWithRelativeRoot(*backupOptions.TargetPath, vmi.Name, filepath.Base(backupPath))
+		if err != nil {
+			return fmt.Errorf("error resolving backup path: %w", err)
+		}
+		defer func() {
 			if failed != nil {
 				logger.Reason(failed).Error("failed to run backup, cleaning up backup directory")
-				if err := os.RemoveAll(path); err != nil {
+				if err := backupSafePath.ExecuteNoFollow(func(safePath string) error {
+					return os.RemoveAll(safePath)
+				}); err != nil {
 					logger.Reason(err).Error("failed to clean up backup directory")
 				}
 			}
-		}(backupPath)
+		}()
 	}
 	domainBackup, domainCheckpoint, backupVolumesInfo := generateDomainBackup(domainDisks, backupOptions, backupPath)
 	backupXML, err := xml.Marshal(domainBackup)

--- a/pkg/virt-launcher/virtwrap/storage/memoryDump.go
+++ b/pkg/virt-launcher/virtwrap/storage/memoryDump.go
@@ -31,6 +31,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/safepath"
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -121,15 +122,27 @@ func (m *StorageManager) setMemoryDumpResult(failed bool, reason string) {
 }
 
 func removePreviousMemoryDump(dir string) {
-	files, err := os.ReadDir(dir)
+	dirPath, err := safepath.NewPathNoFollow(dir)
 	if err != nil {
+		log.Log.Reason(err).Errorf("failed to remove older memory dumps")
+		return
+	}
+	var files []os.DirEntry
+	if err := dirPath.ExecuteNoFollow(func(safePath string) (err error) {
+		files, err = os.ReadDir(safePath)
+		return err
+	}); err != nil {
 		log.Log.Reason(err).Errorf("failed to remove older memory dumps")
 		return
 	}
 	for _, file := range files {
 		if strings.Contains(file.Name(), "memory.dump") {
-			err = os.Remove(filepath.Join(dir, file.Name()))
+			filePath, err := dirPath.AppendAndResolveWithRelativeRoot(file.Name())
 			if err != nil {
+				log.Log.Reason(err).Errorf("failed to remove older memory dumps")
+				continue
+			}
+			if err := safepath.UnlinkAtNoFollow(filePath); err != nil {
 				log.Log.Reason(err).Errorf("failed to remove older memory dumps")
 			}
 		}

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/hooks:go_default_library",
+        "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",

--- a/pkg/virt-launcher/virtwrap/util/panic_info.go
+++ b/pkg/virt-launcher/virtwrap/util/panic_info.go
@@ -29,6 +29,7 @@ import (
 
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -133,8 +134,15 @@ func ParseGuestPanicLogLine(line string) *api.GuestPanicInfo {
 // ReadPanicInfoFromLog reads the QEMU log file and extracts panic info.
 // It scans from the end of the file for efficiency since panics are typically logged last.
 func ReadPanicInfoFromLog(logPath string) (*api.GuestPanicInfo, error) {
-	file, err := os.Open(logPath)
+	logSafePath, err := safepath.NewPathNoFollow(logPath)
 	if err != nil {
+		return nil, fmt.Errorf("failed to open log file: %w", err)
+	}
+	var file *os.File
+	if err := logSafePath.ExecuteNoFollow(func(safePath string) (err error) {
+		file, err = os.Open(safePath)
+		return
+	}); err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
 	defer file.Close()


### PR DESCRIPTION
### What this PR does

Migrates file path operations in virt-launcher that use VMI-derived input from raw filepath.Join/fmt.Sprintf to pkg/safepath, preventing path traversal via symlinks or ../ sequences in user-controlled fields like secretName or vmi.Name.

#### Before this PR:

File operations on paths built from VMI spec fields (e.g. secret names, VMI names) had no traversal protection.

#### After this PR:

Paths derived from VMI input go through safepath.JoinAndResolveWithRelativeRoot or NewPathNoFollow, which validate each component against the relative root before any file operation.

### References

Fixes #16772 

### Why we need it and why it was done in this way

**Migrated:**
paths that virt-launcher opens directly and contain at least one VMI-derived component — FindPid, addAccessCredential, readKeysFromDirectory, readAndAddPasswordsFromDirectory, HandleQemuAgentAccessCredentials (watcher), backup dir creation/cleanup, removePreviousMemoryDump, QEMU log open, ReadPanicInfoFromLog.

**Not migrated, intentionally:**

Paths passed as strings to libvirt XML (e.g. disk paths built from volumeName) — virt-launcher doesn't open these, libvirt does, so safepath's fd-based guarantees don't apply

https://github.com/kubevirt/kubevirt/blob/2b2bb6a54d6df16b6458f6e7f3ee9d0a20258c93/pkg/virt-launcher/virtwrap/converter/converter.go#L221
I initially considered migrating check() to safepath since BackendPath() is shared across multiple callers, but the existing #nosec comments explain why it's safe: the function only opens the file to probe O_DIRECT support and never reads content. 
Additionally, BackendPath() for the same disk is already validated through safepath in getOptimalBlockIOForDevice, so migrating check() would add complexity without meaningful security benefit.


### Special notes for your reviewer

Although I've searched through the codebase using grep on filepath.Join, fmt.Sprintf, and related patterns, and cross-checked with my best effort, I may have missed some vulnerable points. 
If you spot anything I overlooked, please let me know — I'll fix and amend.

### Checklist


- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
NONE
```

