### PR TITLE
virtiofsd: Workaround K8s 1.36+ service account protected symlink error

### DIFF
--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -79,6 +79,23 @@ func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv
 	// This migration mode doesn't require any privileges.
 	args = append(args, "--migration-mode=find-paths")
 
+	if volume.ServiceAccount != nil {
+		// In K8s 1.36+, the Service Account symlink token file owner matches
+		// the pod's `RunAsUser` UID
+		// (see https://github.com/kubernetes/kubernetes/pull/137332).
+		//
+		// Because `/var/run/secrets/kubernetes.io/serviceaccount/` has the
+		// sticky bit (`+t`) set, the guest kernel's protected symlinks feature
+		// blocks the `root` user from following this symlink since the symlink
+		// owner no longer matches the directory owner.
+		// (see: https://github.com/kubevirt/kubevirt/issues/17792)
+		//
+		// Workaround: Force the symlink's owner to show up as UID 0.
+		// This is safe because the `serviceaccount` mount point is read-only.
+		mapUidToGuestRoot := fmt.Sprintf("--translate-uid=host:%d:0:1", util.NonRootUID)
+		args = append(args, mapUidToGuestRoot)
+	}
+
 	volumeMounts := []k8sv1.VolumeMount{
 		// This is required to pass socket to compute
 		{

--- a/pkg/virt-controller/services/virtiofs_test.go
+++ b/pkg/virt-controller/services/virtiofs_test.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -9,6 +11,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
@@ -127,5 +130,29 @@ var _ = Describe("virtiofs container", func() {
 		// Only the PVC volume should have a container, not the ContainerPath volume
 		Expect(containers).To(HaveLen(1))
 		Expect(containers[0].Name).To(Equal("virtiofs-pvc-volume"))
+	})
+
+	It("should translate UIDs for ServiceAccounts", func() {
+		vmi := api.NewMinimalVMI("testvm")
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "sa-volume",
+			VolumeSource: v1.VolumeSource{
+				ServiceAccount: &v1.ServiceAccountVolumeSource{
+					ServiceAccountName: "default",
+				},
+			},
+		})
+
+		vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
+			Name:     "sa-volume",
+			Virtiofs: &v1.FilesystemVirtiofs{},
+		})
+
+		container := generateVirtioFSContainers(vmi, "virtiofs-container", config)
+		Expect(container).To(HaveLen(1))
+
+		mapUidToGuestRoot := fmt.Sprintf("--translate-uid=host:%d:0:1", util.NonRootUID)
+		Expect(container[0].Args).Should(ContainElement(mapUidToGuestRoot))
 	})
 })

--- a/tests/virtiofs/config.go
+++ b/tests/virtiofs/config.go
@@ -170,7 +170,7 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 
 		serviceAccountPath := config.ServiceAccountSourceDir
 
-		It("[QUARANTINE]Should be the namespace and token the same for a pod and vmi with virtiofs", decorators.Quarantine, func() {
+		It("Should be the namespace and token the same for a pod and vmi with virtiofs", func() {
 			serviceAccountVolumeName := "default-disk"
 
 			By("Running VMI")


### PR DESCRIPTION
In Kubernetes 1.36+, the owner of the Service Account token symlink was changed from root to the pod's non-root `RunAsUser` UID (https://github.com/kubernetes/kubernetes/pull/137332).

Because the `/var/run/secrets/kubernetes.io/serviceaccount/` directory has the sticky bit (+t) set, the guest kernel's protected symlinks feature (`fs.protected_symlinks`) blocks the guest 'root' user from following the symlink due to the owner mismatch, resulting in an EACCES (Permission Denied) error before the request ever reaches virtiofsd.

Fix this by transforming the symlink's owner to UID 0 (root). This satisfies the guest kernel's validation check (directory owner matches symlink owner).

This workaround is safe because the service account mount point is explicitly read-only, making it impossible for an attacker to exploit this mapping via a TOCTOU symlink swap.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
Fixes #17792 

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

