### PR TITLE
virt-operator: Fix nil pointer and logic errors

### DIFF
--- a/pkg/virt-operator/strategy.go
+++ b/pkg/virt-operator/strategy.go
@@ -53,7 +53,11 @@ func (c *KubeVirtController) deleteAllInstallStrategy() error {
 
 func (c *KubeVirtController) deleteAllOldInstallStrategies(kvVersion string) error {
 	for _, obj := range c.stores.InstallStrategyConfigMapCache.List() {
-		configMap := obj.(*k8sv1.ConfigMap)
+		configMap, ok := obj.(*k8sv1.ConfigMap)
+		if !ok {
+			log.Log.Errorf("Unexpected object type %T in install strategy config map cache, skipping", obj)
+			continue
+		}
 		version, ok := configMap.ObjectMeta.Annotations[v1.InstallStrategyVersionAnnotation]
 		if ok && configMap.DeletionTimestamp == nil && version != kvVersion {
 			err := c.k8sClient.CoreV1().ConfigMaps(configMap.Namespace).Delete(context.Background(), configMap.Name, metav1.DeleteOptions{})

--- a/pkg/virt-operator/strategy.go
+++ b/pkg/virt-operator/strategy.go
@@ -53,7 +53,11 @@ func (c *KubeVirtController) deleteAllInstallStrategy() error {
 
 func (c *KubeVirtController) deleteAllOldInstallStrategies(kvVersion string) error {
 	for _, obj := range c.stores.InstallStrategyConfigMapCache.List() {
-		configMap := obj.(*k8sv1.ConfigMap)
+		configMap, ok := obj.(*k8sv1.ConfigMap)
+		if !ok {
+			log.Log.Errorf("Unexpected object type %T in install strategy config map cache, skipping", obj)
+			continue
+		}
 		version, ok := configMap.ObjectMeta.Annotations[v1.InstallStrategyVersionAnnotation]
 		if ok && configMap.DeletionTimestamp == nil && version != kvVersion {
 			err := c.clientset.CoreV1().ConfigMaps(configMap.Namespace).Delete(context.Background(), configMap.Name, metav1.DeleteOptions{})

--- a/pkg/virt-operator/strategy.go
+++ b/pkg/virt-operator/strategy.go
@@ -55,7 +55,6 @@ func (c *KubeVirtController) deleteAllOldInstallStrategies(kvVersion string) err
 	for _, obj := range c.stores.InstallStrategyConfigMapCache.List() {
 		configMap, ok := obj.(*k8sv1.ConfigMap)
 		if !ok {
-			log.Log.Errorf("Unexpected object type %T in install strategy config map cache, skipping", obj)
 			continue
 		}
 		version, ok := configMap.ObjectMeta.Annotations[v1.InstallStrategyVersionAnnotation]

--- a/pkg/virt-operator/strategy_test.go
+++ b/pkg/virt-operator/strategy_test.go
@@ -1,0 +1,216 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virt_operator
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/virt-operator/util"
+)
+
+var _ = Describe("Strategy", func() {
+
+	Context("deleteAllOldInstallStrategies", func() {
+
+		var (
+			ctrl       *gomock.Controller
+			clientset  *kubecli.MockKubevirtClient
+			kubeClient *fake.Clientset
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			kubeClient = fake.NewSimpleClientset()
+			clientset = kubecli.NewMockKubevirtClient(ctrl)
+			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should not panic when cache contains non-ConfigMap objects", func() {
+			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+			store.Add("not-a-configmap")
+			store.Add(42)
+
+			controller := &KubeVirtController{
+				stores: util.Stores{
+					InstallStrategyConfigMapCache: store,
+				},
+				clientset: clientset,
+			}
+
+			err := controller.deleteAllOldInstallStrategies("v1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should delete configmaps with outdated versions", func() {
+			oldConfigMap := &k8sv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "old-strategy",
+					Namespace: "kubevirt",
+					Annotations: map[string]string{
+						v1.InstallStrategyVersionAnnotation: "v0.9.0",
+					},
+				},
+			}
+
+			kubeClient = fake.NewSimpleClientset(oldConfigMap)
+			clientset = kubecli.NewMockKubevirtClient(ctrl)
+			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
+
+			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+			Expect(store.Add(oldConfigMap)).To(Succeed())
+
+			controller := &KubeVirtController{
+				stores: util.Stores{
+					InstallStrategyConfigMapCache: store,
+				},
+				clientset: clientset,
+			}
+
+			err := controller.deleteAllOldInstallStrategies("v1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = kubeClient.CoreV1().ConfigMaps("kubevirt").Get(context.Background(), "old-strategy", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not delete configmaps with matching versions", func() {
+			currentConfigMap := &k8sv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "current-strategy",
+					Namespace: "kubevirt",
+					Annotations: map[string]string{
+						v1.InstallStrategyVersionAnnotation: "v1.0.0",
+					},
+				},
+			}
+
+			kubeClient = fake.NewSimpleClientset(currentConfigMap)
+			clientset = kubecli.NewMockKubevirtClient(ctrl)
+			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
+
+			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+			Expect(store.Add(currentConfigMap)).To(Succeed())
+
+			controller := &KubeVirtController{
+				stores: util.Stores{
+					InstallStrategyConfigMapCache: store,
+				},
+				clientset: clientset,
+			}
+
+			err := controller.deleteAllOldInstallStrategies("v1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = kubeClient.CoreV1().ConfigMaps("kubevirt").Get(context.Background(), "current-strategy", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should skip configmaps without version annotation", func() {
+			noAnnotationConfigMap := &k8sv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-annotation",
+					Namespace: "kubevirt",
+				},
+			}
+
+			kubeClient = fake.NewSimpleClientset(noAnnotationConfigMap)
+			clientset = kubecli.NewMockKubevirtClient(ctrl)
+			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
+
+			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+			Expect(store.Add(noAnnotationConfigMap)).To(Succeed())
+
+			controller := &KubeVirtController{
+				stores: util.Stores{
+					InstallStrategyConfigMapCache: store,
+				},
+				clientset: clientset,
+			}
+
+			err := controller.deleteAllOldInstallStrategies("v1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = kubeClient.CoreV1().ConfigMaps("kubevirt").Get(context.Background(), "no-annotation", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should handle mixed cache contents without panic", func() {
+			oldConfigMap := &k8sv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "old-strategy",
+					Namespace: "kubevirt",
+					Annotations: map[string]string{
+						v1.InstallStrategyVersionAnnotation: "v0.9.0",
+					},
+				},
+			}
+			currentConfigMap := &k8sv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "current-strategy",
+					Namespace: "kubevirt",
+					Annotations: map[string]string{
+						v1.InstallStrategyVersionAnnotation: "v1.0.0",
+					},
+				},
+			}
+
+			kubeClient = fake.NewSimpleClientset(oldConfigMap, currentConfigMap)
+			clientset = kubecli.NewMockKubevirtClient(ctrl)
+			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
+
+			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+			store.Add("unexpected-string")
+			store.Add(oldConfigMap)
+			store.Add(currentConfigMap)
+			store.Add(42)
+
+			controller := &KubeVirtController{
+				stores: util.Stores{
+					InstallStrategyConfigMapCache: store,
+				},
+				clientset: clientset,
+			}
+
+			err := controller.deleteAllOldInstallStrategies("v1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = kubeClient.CoreV1().ConfigMaps("kubevirt").Get(context.Background(), "old-strategy", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+
+			_, err = kubeClient.CoreV1().ConfigMaps("kubevirt").Get(context.Background(), "current-strategy", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/virt-operator/strategy_test.go
+++ b/pkg/virt-operator/strategy_test.go
@@ -24,14 +24,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
@@ -41,32 +39,29 @@ var _ = Describe("Strategy", func() {
 	Context("deleteAllOldInstallStrategies", func() {
 
 		var (
-			ctrl       *gomock.Controller
-			clientset  *kubecli.MockKubevirtClient
 			kubeClient *fake.Clientset
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
 			kubeClient = fake.NewSimpleClientset()
-			clientset = kubecli.NewMockKubevirtClient(ctrl)
-			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
 		})
 
 		It("should not panic when cache contains non-ConfigMap objects", func() {
 			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-			store.Add("not-a-configmap")
-			store.Add(42)
+			Expect(store.Add(cache.DeletedFinalStateUnknown{
+				Key: "not-a-configmap",
+				Obj: &k8sv1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "not-a-configmap"}},
+			})).To(Succeed())
+			Expect(store.Add(cache.DeletedFinalStateUnknown{
+				Key: "another-not-a-configmap",
+				Obj: &k8sv1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "another-not-a-configmap"}},
+			})).To(Succeed())
 
 			controller := &KubeVirtController{
 				stores: util.Stores{
 					InstallStrategyConfigMapCache: store,
 				},
-				clientset: clientset,
+				k8sClient: kubeClient,
 			}
 
 			err := controller.deleteAllOldInstallStrategies("v1.0.0")
@@ -85,8 +80,6 @@ var _ = Describe("Strategy", func() {
 			}
 
 			kubeClient = fake.NewSimpleClientset(oldConfigMap)
-			clientset = kubecli.NewMockKubevirtClient(ctrl)
-			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 			Expect(store.Add(oldConfigMap)).To(Succeed())
@@ -95,7 +88,7 @@ var _ = Describe("Strategy", func() {
 				stores: util.Stores{
 					InstallStrategyConfigMapCache: store,
 				},
-				clientset: clientset,
+				k8sClient: kubeClient,
 			}
 
 			err := controller.deleteAllOldInstallStrategies("v1.0.0")
@@ -117,8 +110,6 @@ var _ = Describe("Strategy", func() {
 			}
 
 			kubeClient = fake.NewSimpleClientset(currentConfigMap)
-			clientset = kubecli.NewMockKubevirtClient(ctrl)
-			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 			Expect(store.Add(currentConfigMap)).To(Succeed())
@@ -127,7 +118,7 @@ var _ = Describe("Strategy", func() {
 				stores: util.Stores{
 					InstallStrategyConfigMapCache: store,
 				},
-				clientset: clientset,
+				k8sClient: kubeClient,
 			}
 
 			err := controller.deleteAllOldInstallStrategies("v1.0.0")
@@ -146,8 +137,6 @@ var _ = Describe("Strategy", func() {
 			}
 
 			kubeClient = fake.NewSimpleClientset(noAnnotationConfigMap)
-			clientset = kubecli.NewMockKubevirtClient(ctrl)
-			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 			Expect(store.Add(noAnnotationConfigMap)).To(Succeed())
@@ -156,7 +145,7 @@ var _ = Describe("Strategy", func() {
 				stores: util.Stores{
 					InstallStrategyConfigMapCache: store,
 				},
-				clientset: clientset,
+				k8sClient: kubeClient,
 			}
 
 			err := controller.deleteAllOldInstallStrategies("v1.0.0")
@@ -187,20 +176,24 @@ var _ = Describe("Strategy", func() {
 			}
 
 			kubeClient = fake.NewSimpleClientset(oldConfigMap, currentConfigMap)
-			clientset = kubecli.NewMockKubevirtClient(ctrl)
-			clientset.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 			store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-			store.Add("unexpected-string")
-			store.Add(oldConfigMap)
-			store.Add(currentConfigMap)
-			store.Add(42)
+			Expect(store.Add(cache.DeletedFinalStateUnknown{
+				Key: "unexpected-string",
+				Obj: &k8sv1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "unexpected-string"}},
+			})).To(Succeed())
+			Expect(store.Add(oldConfigMap)).To(Succeed())
+			Expect(store.Add(currentConfigMap)).To(Succeed())
+			Expect(store.Add(cache.DeletedFinalStateUnknown{
+				Key: "another-unexpected-object",
+				Obj: &k8sv1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "another-unexpected-object"}},
+			})).To(Succeed())
 
 			controller := &KubeVirtController{
 				stores: util.Stores{
 					InstallStrategyConfigMapCache: store,
 				},
-				clientset: clientset,
+				k8sClient: kubeClient,
 			}
 
 			err := controller.deleteAllOldInstallStrategies("v1.0.0")


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`deleteAllOldInstallStrategies` assumed every object in the install-strategy cache was a `*v1.ConfigMap`. An unexpected cache object could panic during cleanup.

#### After this PR:

Unexpected cache objects are skipped safely. Tests cover normal ConfigMap cleanup and realistic `cache.DeletedFinalStateUnknown` tombstones.

### References

- Partially addresses #18018

### Why we need it and why it was done in this way

The informer cache can contain tombstones during resync. Checking the type assertion prevents virt-operator from panicking while preserving cleanup of valid ConfigMaps.

The following tradeoffs were made:

- Tombstones are skipped without logging because they are normal cache behavior and the sibling install-strategy cleanup follows the same pattern.

The following alternatives were considered:

- Logging unexpected cache objects at error level was rejected because tombstones are expected during resync.

### Special notes for your reviewer

The Route TLS and RBAC backup issues originally investigated under #18018 are out of scope. The RBAC issue is tracked separately in #18057 because enabling the incomplete backup path changes upgrade behavior.

### Checklist

- [ ] Design: VEP not required
- [x] PR: The PR description is expressive enough
- [x] Code: The change is simple and understandable
- [x] Refactor: No unrelated refactoring
- [x] Upgrade: Upgrade cleanup behavior was considered
- [x] Testing: Unit tests added
- [ ] Documentation: User-guide update not required
- [ ] Community: Announcement not required
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note

```release-note
Fix a potential panic in virt-operator when the install strategy config map cache contains an unexpected object type
```