### PR TITLE
Allow network conformance tests to use a binding plugin

### DIFF
--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -46,6 +46,10 @@ if [[ ! -z "$KUBEVIRT_PROVIDER" ]]; then
     sonobuoy_args+=" --plugin-env kubevirt-conformance.KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER}"
 fi
 
+if [[ ! -z "$PRIMARY_NETWORK_BINDING_PLUGIN" ]]; then
+    sonobuoy_args+=" --plugin-env kubevirt-conformance.PRIMARY_NETWORK_BINDING_PLUGIN=${PRIMARY_NETWORK_BINDING_PLUGIN}"
+fi
+
 echo 'Executing conformance tests and wait for them to finish'
 echo "Using $sonobuoy_args as arguments to sonobuoy"
 sonobuoy run ${sonobuoy_args} --plugin-env kubevirt-conformance.E2E_LABEL="${label_filter}"

--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -52,6 +52,9 @@ func execute() error {
 	if value, exists := os.LookupEnv("CONTAINER_TAG"); exists {
 		args = append(args, "--container-tag", value)
 	}
+	if value, exists := os.LookupEnv("PRIMARY_NETWORK_BINDING_PLUGIN"); exists {
+		args = append(args, "--primary-network-binding-plugin", value)
+	}
 
 	args = append(args, "--config", "/conformance-config.json")
 

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -60,6 +60,7 @@ var (
 	InPlaceHotplugNICs                   = Label("in-place-hotplug-NICs")
 	MigrationBasedHotplugNICs            = Label("migration-based-hotplug-NICs")
 	NetCustomBindingPlugins              = Label("netCustomBindingPlugins")
+	IPv6                                 = Label("IPv6")
 	RequiresTwoSchedulableNodes          = Label("requires-two-schedulable-nodes")
 	RequiresThreeSchedulableNodes        = Label("requires-three-schedulable-nodes")
 	RequiresDedicatedWorkerNodes         = Label("requires-dedicated-worker-nodes")

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -60,6 +60,8 @@ var (
 	InPlaceHotplugNICs                   = Label("in-place-hotplug-NICs")
 	MigrationBasedHotplugNICs            = Label("migration-based-hotplug-NICs")
 	NetCustomBindingPlugins              = Label("netCustomBindingPlugins")
+	InterfacePorts                       = Label("interface-ports")
+	NetworkCIDR                          = Label("network-cidr")
 	IPv6                                 = Label("IPv6")
 	RequiresTwoSchedulableNodes          = Label("requires-two-schedulable-nodes")
 	RequiresThreeSchedulableNodes        = Label("requires-three-schedulable-nodes")

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -60,6 +60,7 @@ var DNSServiceNamespace = ""
 var MigrationNetworkNIC = "eth1"
 var MigrationNetworkName string
 var EmulatedSRIOV bool
+var PrimaryNetworkBindingPlugin string
 
 func init() {
 	kubecli.Init()
@@ -95,6 +96,7 @@ func init() {
 	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
 	flag.StringVar(&MigrationNetworkName, "migration-network-name", "", "name of the NetworkAttachmentDefinition CR to be used for dedicated migration network tests")
 	flag.BoolVar(&EmulatedSRIOV, "emulated-sriov", false, "Run SR-IOV tests in emulated mode")
+	flag.StringVar(&PrimaryNetworkBindingPlugin, "primary-network-binding-plugin", "", "Name of a pre-registered network binding plugin to use instead of masquerade in conformance tests")
 }
 
 func NormalizeFlags() {

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//tests/console:go_default_library",
+        "//tests/flags:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libnet/cloudinit:go_default_library",

--- a/tests/libnet/vmibuilder.go
+++ b/tests/libnet/vmibuilder.go
@@ -25,8 +25,20 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
+	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 )
+
+func ConformancePodNetworkInterface(ports ...v1.Port) v1.Interface {
+	if flags.PrimaryNetworkBindingPlugin == "" {
+		return libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)
+	}
+	return libvmi.InterfaceWithBindingPlugin(
+		v1.DefaultPodNetwork().Name,
+		v1.PluginBinding{Name: flags.PrimaryNetworkBindingPlugin},
+		ports...,
+	)
+}
 
 func WithMasqueradeNetworking(ports ...v1.Port) libvmi.Option {
 	networkData := cloudinit.CreateDefaultCloudInitNetworkData()

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -24,10 +24,12 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	libvmi "kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -394,11 +396,14 @@ func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
 }
 
 func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {
+	networkData := cloudinit.CreateDefaultCloudInitNetworkData()
 	clientVMI := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithCloudInitNoCloud(
 			libvmifact.WithDummyCloudForFastBoot(),
+			libvmici.WithNoCloudNetworkData(networkData),
 		),
-		libnet.WithMasqueradeNetworking(),
+		libvmi.WithInterface(libnet.ConformancePodNetworkInterface()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 	clientVMI, err := virtClient.VirtualMachineInstance(namespace).Create(context.Background(), clientVMI, metav1.CreateOptions{})
 	if err != nil {
@@ -410,22 +415,17 @@ func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.V
 }
 
 func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, serverVMILabels map[string]string) (*v1.VirtualMachineInstance, error) {
+	networkData := cloudinit.CreateDefaultCloudInitNetworkData()
 	serverVMI := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithCloudInitNoCloud(
 			libvmifact.WithDummyCloudForFastBoot(),
+			libvmici.WithNoCloudNetworkData(networkData),
 		),
-		libnet.WithMasqueradeNetworking(
-			v1.Port{
-				Name:     "http80",
-				Port:     80,
-				Protocol: "TCP",
-			},
-			v1.Port{
-				Name:     "http81",
-				Port:     81,
-				Protocol: "TCP",
-			},
-		),
+		libvmi.WithInterface(libnet.ConformancePodNetworkInterface(
+			v1.Port{Name: "http80", Port: 80, Protocol: "TCP"},
+			v1.Port{Name: "http81", Port: 81, Protocol: "TCP"},
+		)),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 	serverVMI.Labels = serverVMILabels
 	serverVMI, err := virtClient.VirtualMachineInstance(namespace).Create(context.Background(), serverVMI, metav1.CreateOptions{})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -131,7 +131,7 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 					vmi = setupVMI(
 						virtClient,
 						libvmifact.NewAlpine(
-							libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
+							libvmi.WithInterface(libnet.ConformancePodNetworkInterface()),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						),
 					)

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -36,11 +36,13 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libnet/dns"
 	"kubevirt.io/kubevirt/tests/libnet/job"
 	netservice "kubevirt.io/kubevirt/tests/libnet/service"
@@ -136,7 +138,7 @@ var _ = Describe(SIG("Services", func() {
 		})
 	})
 
-	Context("Masquerade interface binding", func() {
+	Context("interface binding to pod network", func() {
 		var inboundVMI *v1.VirtualMachineInstance
 
 		const (
@@ -146,8 +148,11 @@ var _ = Describe(SIG("Services", func() {
 		)
 
 		BeforeEach(func() {
+			networkData := cloudinit.CreateDefaultCloudInitNetworkData()
 			inboundVMI = libvmifact.NewFedora(
-				libnet.WithMasqueradeNetworking(),
+				libvmi.WithInterface(libnet.ConformancePodNetworkInterface()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
 				libvmi.WithSubdomain("vmi"),
 				libvmi.WithHostname("inbound"),

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -500,7 +500,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
 			})
 
-			DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {
+			DescribeTable("IPv6", decorators.IPv6, func(ports []v1.Port, tcpPort int, networkCIDR string) {
 				libnet.SkipWhenClusterNotSupportIpv6()
 
 				clientVMI, err := newFedoraMasqueradeIPv6VMI([]v1.Port{}, networkCIDR)
@@ -531,7 +531,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Entry("with custom CIDR [IPv6]", []v1.Port{}, 8080, "fd10:10:10::2/120"),
 			)
 
-			It("should be able to reach the outside world", Label("RequiresOutsideConnectivity", "IPv6"), func() {
+			It("should be able to reach the outside world", decorators.IPv6, Label("RequiresOutsideConnectivity"), func() {
 				libnet.SkipWhenClusterNotSupportIpv6()
 				// Cluster nodes subnet (docker network gateway)
 				// Docker network subnet cidr definition:
@@ -609,7 +609,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Entry("with explicit ports used by live migration", portsUsedByLiveMigration()),
 			)
 
-			It("should preserve connectivity - IPv6", decorators.Conformance, func() {
+			It("should preserve connectivity - IPv6", decorators.Conformance, decorators.IPv6, func() {
 				libnet.SkipWhenClusterNotSupportIpv6()
 
 				var err error

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -414,7 +414,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			}
 		}
 
-		Context("[test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", decorators.Conformance, func() {
+		Context("[test_id:1780]should allow regular network connection", decorators.Conformance, func() {
 			// This CIDR tests backwards compatibility of the "vmNetworkCIDR" field.
 			// The leading zero is intentional.
 			// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
@@ -442,18 +442,20 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				return nil
 			}
 
-			DescribeTable("ipv4", func(ports []v1.Port, tcpPort int, networkCIDR string) {
+			DescribeTable("ipv4", func(clientVMI, serverVMI *v1.VirtualMachineInstance, tcpPort int, networkCIDR string) {
 				libnet.SkipWhenClusterNotSupportIpv4()
 
-				clientVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(
-					context.Background(), masqueradeVMI([]v1.Port{}, networkCIDR), metav1.CreateOptions{},
+				var err error
+				clientVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(
+					context.Background(), clientVMI, metav1.CreateOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
 				clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToAlpine)
 
-				serverVMI := masqueradeVMI(ports, networkCIDR)
 				serverVMI.Labels = map[string]string{"expose": "server"}
-				serverVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), serverVMI, metav1.CreateOptions{})
+				serverVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(
+					context.Background(), serverVMI, metav1.CreateOptions{},
+				)
 				Expect(err).ToNot(HaveOccurred())
 				serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToAlpine)
 				Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
@@ -462,20 +464,26 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				By("starting a tcp server")
 				vmnetserver.StartTCPServer(serverVMI, tcpPort, console.LoginToAlpine)
 
-				if networkCIDR == "" {
+				if networkCIDR == "" && flags.PrimaryNetworkBindingPlugin == "" {
 					networkCIDR = api.DefaultVMCIDR
 				}
 
-				By("Checking ping (IPv4) to gateway")
-				ipAddr := gatewayIPFromCIDR(networkCIDR)
-				Expect(libnet.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
+				if networkCIDR != "" {
+					By("Checking ping (IPv4) to gateway")
+					ipAddr := gatewayIPFromCIDR(networkCIDR)
+					Expect(libnet.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
+				}
 
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv4Protocol)).To(Succeed())
 			},
-				Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
-				Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtDirectMigrationPort, ""),
-				Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, ""),
-				Entry("with custom CIDR [IPv4] containing leading zeros", []v1.Port{}, 8080, cidrWithLeadingZeros),
+				Entry("basic connectivity [IPv4]",
+					conformanceVMI(), conformanceVMI(), 8080, ""),
+				Entry("with a specific port number [IPv4]", decorators.InterfacePorts,
+					masqueradeVMI([]v1.Port{}, ""), masqueradeVMI([]v1.Port{{Name: "http", Port: 8080}}, ""), 8080, api.DefaultVMCIDR),
+				Entry("with a specific port used by live migration", decorators.InterfacePorts,
+					masqueradeVMI([]v1.Port{}, ""), masqueradeVMI(portsUsedByLiveMigration(), ""), LibvirtDirectMigrationPort, api.DefaultVMCIDR),
+				Entry("with custom CIDR [IPv4] containing leading zeros", decorators.NetworkCIDR,
+					masqueradeVMI([]v1.Port{}, cidrWithLeadingZeros), masqueradeVMI([]v1.Port{}, cidrWithLeadingZeros), 8080, cidrWithLeadingZeros),
 			)
 
 			It("should be able to reach the outside world [IPv4]", Label("RequiresOutsideConnectivity"), func() {
@@ -490,7 +498,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				}
 
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(
-					context.Background(), masqueradeVMI([]v1.Port{}, ""), metav1.CreateOptions{},
+					context.Background(), conformanceVMI(), metav1.CreateOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
@@ -559,7 +567,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				return libnet.PingFromVMConsole(vmi, ipAddr, "-c 1", "-w 2")
 			}
 
-			DescribeTable("preserves connectivity - IPv4", decorators.Conformance, func(ports []v1.Port) {
+			DescribeTable("preserves connectivity - IPv4", decorators.Conformance, func(testVMI *v1.VirtualMachineInstance) {
 				libnet.SkipWhenClusterNotSupportIpv4()
 
 				var err error
@@ -570,9 +578,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Create VMI")
-				vmi = masqueradeVMI(ports, "")
-
-				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), testVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
@@ -605,8 +611,9 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 					return ping(podIP)
 				}, 30*time.Second, 1*time.Second).Should(Succeed(), "expected pod to be reachable after DHCP renew")
 			},
-				Entry("without a specific port number", []v1.Port{}),
-				Entry("with explicit ports used by live migration", portsUsedByLiveMigration()),
+				Entry("without explicit ports specification", conformanceVMI()),
+				Entry("with explicit ports used by live migration", decorators.InterfacePorts,
+					masqueradeVMI(portsUsedByLiveMigration(), "")),
 			)
 
 			It("should preserve connectivity - IPv6", decorators.Conformance, decorators.IPv6, func() {
@@ -767,6 +774,13 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 		})
 	})
 }))
+
+func conformanceVMI() *v1.VirtualMachineInstance {
+	return libvmifact.NewAlpineWithTestTooling(
+		libvmi.WithInterface(libnet.ConformancePodNetworkInterface()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+	)
+}
 
 func newFedoraMasqueradeIPv6VMI(ports []v1.Port, ipv6NetworkCIDR string) (*v1.VirtualMachineInstance, error) {
 	networkData, err := cloudinit.NewNetworkData(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
CNI vendors and network binding plugin authors need to certify their implementations against the same conformance tests that masquerade passes today. This PR adds a `--primary-network-binding-plugin` flag that switches the primary pod network interface from masquerade to a pre-registered binding plugin in conformance tests. When the flag is not set, all tests behave exactly as before

Masquerade-specific tests (port-based DNAT filtering, custom vmNetworkCIDR, IPv6) hardcode masquerade regardless of the flag and are labeled with `interface-ports`, `network-cidr`, and `IPv6` so vendors can exclude them via label filtering. They pass harmlessly when not filtered out.

CNI and binding plugin authors running conformance via sonobuoy can test with:
  
```bash
sonobuoy run --skip-preflight --plugin kubevirt-conformance.yaml \
  --plugin-env kubevirt-conformance.E2E_LABEL='(conformance && !interface-ports && !network-cidr && !IPv6)' \
  --plugin-env kubevirt-conformance.PRIMARY_NETWORK_BINDING_PLUGIN=<plugin-name>
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network conformance tests can now be run with a custom network binding plugin via the `--primary-network-binding-plugin` test flag.
```

