### PR TITLE
containerpath: add --translate-uid for projected SA token volumes

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator.go
@@ -172,7 +172,8 @@ func (m *VirtLauncherPodMutator) generateContainerPathVirtiofsContainers(
 			continue
 		}
 
-		container := m.createVirtiofsContainer(vmi, volume, computeContainer.Image, volumeMount, subPath)
+		translateUID := virtiofs.ProjectedVolumeHasServiceAccountToken(podVolume)
+		container := m.createVirtiofsContainer(vmi, volume, computeContainer.Image, volumeMount, subPath, translateUID)
 		containers = append(containers, container)
 	}
 
@@ -185,6 +186,7 @@ func (m *VirtLauncherPodMutator) createVirtiofsContainer(
 	image string,
 	sourceMount *k8sv1.VolumeMount,
 	subPath string,
+	translateUID bool,
 ) k8sv1.Container {
 	// Use an internal mount path to avoid conflicts with third-party webhooks
 	// that may inject volumes at the same containerPath (e.g., IRSA, Vault).
@@ -200,6 +202,10 @@ func (m *VirtLauncherPodMutator) createVirtiofsContainer(
 		"--cache=auto",
 		"--migration-on-error=guest-error",
 		"--migration-mode=find-paths",
+	}
+
+	if translateUID {
+		args = append(args, fmt.Sprintf("--translate-uid=host:%d:0:1", util.NonRootUID))
 	}
 
 	// Volume mounts for the virtiofs container

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator_test.go
@@ -21,6 +21,7 @@ package mutators_test
 
 import (
 	"encoding/json"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,6 +37,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/mutating-webhook/mutators"
 	"kubevirt.io/kubevirt/pkg/virtiofs"
 )
@@ -126,6 +128,54 @@ var _ = Describe("VirtLauncherPodMutator", func() {
 			Entry("should not inject when readOnly is false", pointer.P(false), false),
 			Entry("should not inject when readOnly is nil", nil, false),
 		)
+
+		It("should include --translate-uid when projected volume has SA token source", func() {
+			vmi := newVMIWithContainerPath()
+			pod := newVirtLauncherPodWithProjectedSAToken(vmi)
+
+			virtClient.EXPECT().VirtualMachineInstance(pod.Namespace).Return(vmiInterface)
+			vmiInterface.EXPECT().Get(gomock.Any(), vmi.Name, gomock.Any()).Return(vmi, nil)
+
+			clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+			mutator := mutators.NewVirtLauncherPodMutator(clusterConfig, virtClient)
+
+			ar := createPodAdmissionReview(pod)
+			response := mutator.Mutate(ar)
+
+			Expect(response.Allowed).To(BeTrue())
+			Expect(response.Patch).ToNot(BeNil())
+			var patches []map[string]any
+			Expect(json.Unmarshal(response.Patch, &patches)).To(Succeed())
+			Expect(patches).To(HaveLen(1))
+			container := patches[0]["value"].(map[string]any)
+			args := container["args"].([]any)
+			expectedArg := fmt.Sprintf("--translate-uid=host:%d:0:1", util.NonRootUID)
+			Expect(args).To(ContainElement(expectedArg))
+		})
+
+		It("should not include --translate-uid when projected volume has no SA token source", func() {
+			vmi := newVMIWithContainerPath()
+			pod := newVirtLauncherPodWithProjectedNoSAToken(vmi)
+
+			virtClient.EXPECT().VirtualMachineInstance(pod.Namespace).Return(vmiInterface)
+			vmiInterface.EXPECT().Get(gomock.Any(), vmi.Name, gomock.Any()).Return(vmi, nil)
+
+			clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+			mutator := mutators.NewVirtLauncherPodMutator(clusterConfig, virtClient)
+
+			ar := createPodAdmissionReview(pod)
+			response := mutator.Mutate(ar)
+
+			Expect(response.Allowed).To(BeTrue())
+			Expect(response.Patch).ToNot(BeNil())
+			var patches []map[string]any
+			Expect(json.Unmarshal(response.Patch, &patches)).To(Succeed())
+			Expect(patches).To(HaveLen(1))
+			container := patches[0]["value"].(map[string]any)
+			args := container["args"].([]any)
+			translateArg := fmt.Sprintf("--translate-uid=host:%d:0:1", util.NonRootUID)
+			Expect(args).ToNot(ContainElement(translateArg))
+		})
 
 		It("should not mutate if virtiofs container already exists", func() {
 			vmi := newVMIWithContainerPath()
@@ -272,6 +322,86 @@ func newVirtLauncherPodWithVolumeMounts(vmi *v1.VirtualMachineInstance) *k8sv1.P
 		},
 		{
 			Name:      "aws-iam-token",
+			MountPath: "/var/run/secrets/token",
+			ReadOnly:  true,
+		},
+	}
+
+	return pod
+}
+
+func newVirtLauncherPodWithProjectedSAToken(vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
+	pod := newVirtLauncherPod(vmi)
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes,
+		k8sv1.Volume{
+			Name: virtiofs.VirtioFSContainers,
+			VolumeSource: k8sv1.VolumeSource{
+				EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+			},
+		},
+		k8sv1.Volume{
+			Name: "aws-iam-token",
+			VolumeSource: k8sv1.VolumeSource{
+				Projected: &k8sv1.ProjectedVolumeSource{
+					Sources: []k8sv1.VolumeProjection{
+						{ServiceAccountToken: &k8sv1.ServiceAccountTokenProjection{
+							Audience:          "sts.amazonaws.com",
+							ExpirationSeconds: pointer.P(int64(3600)),
+							Path:              "token",
+						}},
+					},
+				},
+			},
+		},
+	)
+
+	pod.Spec.Containers[0].VolumeMounts = []k8sv1.VolumeMount{
+		{
+			Name:      virtiofs.VirtioFSContainers,
+			MountPath: virtiofs.VirtioFSContainersMountBaseDir,
+		},
+		{
+			Name:      "aws-iam-token",
+			MountPath: "/var/run/secrets/token",
+			ReadOnly:  true,
+		},
+	}
+
+	return pod
+}
+
+func newVirtLauncherPodWithProjectedNoSAToken(vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
+	pod := newVirtLauncherPod(vmi)
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes,
+		k8sv1.Volume{
+			Name: virtiofs.VirtioFSContainers,
+			VolumeSource: k8sv1.VolumeSource{
+				EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+			},
+		},
+		k8sv1.Volume{
+			Name: "config-projected",
+			VolumeSource: k8sv1.VolumeSource{
+				Projected: &k8sv1.ProjectedVolumeSource{
+					Sources: []k8sv1.VolumeProjection{
+						{ConfigMap: &k8sv1.ConfigMapProjection{
+							LocalObjectReference: k8sv1.LocalObjectReference{Name: "my-config"},
+						}},
+					},
+				},
+			},
+		},
+	)
+
+	pod.Spec.Containers[0].VolumeMounts = []k8sv1.VolumeMount{
+		{
+			Name:      virtiofs.VirtioFSContainers,
+			MountPath: virtiofs.VirtioFSContainersMountBaseDir,
+		},
+		{
+			Name:      "config-projected",
 			MountPath: "/var/run/secrets/token",
 			ReadOnly:  true,
 		},

--- a/pkg/virtiofs/BUILD.bazel
+++ b/pkg/virtiofs/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     embed = [":go_default_library"],
     race = "on",
     deps = [
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virtiofs/containerpath.go
+++ b/pkg/virtiofs/containerpath.go
@@ -117,6 +117,24 @@ func IsSupportedContainerPathVolumeType(volume *k8sv1.Volume) bool {
 		vs.EmptyDir != nil
 }
 
+// ProjectedVolumeHasServiceAccountToken checks if a pod volume is a Projected volume
+// containing at least one ServiceAccountToken source.
+// On k8s 1.36+, projected SA token symlinks are owned by the pod's runAsUser instead
+// of root. Combined with the sticky bit on the mount directory, the guest kernel's
+// protected_symlinks feature blocks root from following these symlinks (EACCES).
+// Callers use this to decide whether virtiofsd needs --translate-uid.
+func ProjectedVolumeHasServiceAccountToken(volume *k8sv1.Volume) bool {
+	if volume == nil || volume.Projected == nil {
+		return false
+	}
+	for _, source := range volume.Projected.Sources {
+		if source.ServiceAccountToken != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // FindPodVolumeByName finds a volume in the pod spec by name.
 func FindPodVolumeByName(pod *k8sv1.Pod, name string) *k8sv1.Volume {
 	for i := range pod.Spec.Volumes {

--- a/pkg/virtiofs/containerpath_test.go
+++ b/pkg/virtiofs/containerpath_test.go
@@ -27,6 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 var _ = Describe("ContainerPath helpers", func() {
@@ -120,6 +122,64 @@ var _ = Describe("ContainerPath helpers", func() {
 					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "claim"},
 				},
 			}, false),
+		)
+	})
+
+	Context("ProjectedVolumeHasServiceAccountToken", func() {
+		DescribeTable("should correctly detect projected SA token sources",
+			func(volume *k8sv1.Volume, expected bool) {
+				Expect(ProjectedVolumeHasServiceAccountToken(volume)).To(Equal(expected))
+			},
+			Entry("nil volume", nil, false),
+			Entry("non-projected volume", &k8sv1.Volume{
+				Name: "cm",
+				VolumeSource: k8sv1.VolumeSource{
+					ConfigMap: &k8sv1.ConfigMapVolumeSource{},
+				},
+			}, false),
+			Entry("projected without sources", &k8sv1.Volume{
+				Name: "projected",
+				VolumeSource: k8sv1.VolumeSource{
+					Projected: &k8sv1.ProjectedVolumeSource{},
+				},
+			}, false),
+			Entry("projected with only configmap source", &k8sv1.Volume{
+				Name: "projected",
+				VolumeSource: k8sv1.VolumeSource{
+					Projected: &k8sv1.ProjectedVolumeSource{
+						Sources: []k8sv1.VolumeProjection{
+							{ConfigMap: &k8sv1.ConfigMapProjection{}},
+						},
+					},
+				},
+			}, false),
+			Entry("projected with SA token source", &k8sv1.Volume{
+				Name: "aws-iam-token",
+				VolumeSource: k8sv1.VolumeSource{
+					Projected: &k8sv1.ProjectedVolumeSource{
+						Sources: []k8sv1.VolumeProjection{
+							{ServiceAccountToken: &k8sv1.ServiceAccountTokenProjection{
+								Audience:          "sts.amazonaws.com",
+								ExpirationSeconds: pointer.P(int64(3600)),
+								Path:              "token",
+							}},
+						},
+					},
+				},
+			}, true),
+			Entry("projected with mixed sources including SA token", &k8sv1.Volume{
+				Name: "mixed-projected",
+				VolumeSource: k8sv1.VolumeSource{
+					Projected: &k8sv1.ProjectedVolumeSource{
+						Sources: []k8sv1.VolumeProjection{
+							{ConfigMap: &k8sv1.ConfigMapProjection{}},
+							{ServiceAccountToken: &k8sv1.ServiceAccountTokenProjection{
+								Path: "token",
+							}},
+						},
+					},
+				},
+			}, true),
 		)
 	})
 

--- a/tests/virtiofs/containerpath.go
+++ b/tests/virtiofs/containerpath.go
@@ -269,6 +269,52 @@ var _ = Describe("[sig-storage] ContainerPath virtiofs volumes", decorators.SigS
 			}, 200)).To(Succeed())
 		})
 	})
+
+	Context("With projected ServiceAccountToken volume via native k8s SA projection", func() {
+		const (
+			containerPathFilesystemName = "sa-projected-fs"
+			saTokenPath                 = "/var/run/secrets/kubernetes.io/serviceaccount"
+		)
+
+		It("Should access projected ServiceAccountToken volume via ContainerPath virtiofs", func() {
+			virtClient := kubevirt.Client()
+
+			By("Creating VMI with ContainerPath pointing to SA token projected volume")
+			vmi := libvmifact.NewAlpine(
+				libvmi.WithFilesystemContainerPath(containerPathFilesystemName, saTokenPath),
+			)
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "sa-enabler",
+				VolumeSource: v1.VolumeSource{
+					ServiceAccount: &v1.ServiceAccountVolumeSource{
+						ServiceAccountName: "default",
+					},
+				},
+			})
+
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for virt-launcher pod and verifying virtiofsd container exists")
+			_ = waitForVirtiofsContainerInPod(vmi, containerPathFilesystemName)
+
+			By("Waiting for VMI to be running")
+			vmi = libwait.WaitForVMIPhase(vmi, []v1.VirtualMachineInstancePhase{v1.Running})
+
+			By("Logging into the VMI")
+			Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+			By("Mounting and reading the projected SA token file via virtiofs")
+			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: fmt.Sprintf("mount -t virtiofs %s /mnt\n", containerPathFilesystemName)},
+				&expect.BExp{R: ""},
+				&expect.BSnd{S: "echo $?\n"},
+				&expect.BExp{R: console.RetValue("0")},
+				&expect.BSnd{S: "cat /mnt/token > /dev/null 2>&1 && echo ok\n"},
+				&expect.BExp{R: "ok"},
+			}, 200)).To(Succeed())
+		})
+	})
 })
 
 // setupWebhook creates and deploys a test webhook with TLS certificates


### PR DESCRIPTION
### What this PR does
#### Before this PR:

On k8s 1.36+, ContainerPath volumes backed by Projected volumes with ServiceAccountToken sources (AWS IRSA, EKS Pod Identity, Azure Workload Identity) fail with `EACCES` when the guest VM tries to read the token file. The kubelet now sets symlink ownership to the pod's `runAsUser` UID instead of root ([kubernetes#137332](https://github.com/kubernetes/kubernetes/pull/137332)), and the guest kernel's `fs.protected_symlinks` blocks root from following symlinks in sticky-bit directories when the symlink owner doesn't match the directory owner.

#### After this PR:

The ContainerPath pod mutating webhook detects Projected volumes containing ServiceAccountToken sources and adds `--translate-uid=host:107:0:1` to virtiofsd args, making the symlinks appear as root-owned inside the guest.

### References

- Partially addresses #17792
- Related: #18017 (same fix for ServiceAccount volumes in virt-controller path)

### Why we need it and why it was done in this way
The following tradeoffs were made:

Same approach as #18017 — UID translation in virtiofsd. This is safe because ContainerPath volumes with SA tokens are read-only, so TOCTOU symlink swap attacks are not possible.

The following alternatives were considered:

Sharing virtiofs container creation code between virt-controller and the ContainerPath webhook was considered but rejected — the two paths have enough structural differences (mount resolution, path selection, auto-mount logic) that a shared function would require awkward parameterization for little gain.

### Special notes for your reviewer

The e2e test commit is authored by @akalenyu (cherry-picked). It uses the native k8s SA token projection path rather than requiring external webhook infrastructure (AWS/Azure), so it runs in standard CI.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```