### PR TITLE
tests/infrastructure: remove e2e test_id:6246 for node-labeller labels

### DIFF
--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -161,29 +161,6 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 			}, 15*time.Second, 1*time.Second).Should(BeTrue())
 		})
 
-		It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", decorators.WgS390x, func() {
-			for _, node := range nodesWithHypervisor {
-				errorMessageTemplate := "node " + node.Name + " does not contain %s label"
-				Expect(node.Labels).To(HaveKey(HavePrefix(v1.CPUModelLabel)), fmt.Sprintf(errorMessageTemplate, "cpu"))
-				Expect(node.Labels).To(HaveKey(HavePrefix(v1.CPUFeatureLabel)), fmt.Sprintf(errorMessageTemplate, "feature"))
-				Expect(node.Labels).To(HaveKey(HavePrefix(v1.HostModelCPULabel)), fmt.Sprintf(errorMessageTemplate, "host cpu model"))
-				Expect(node.Labels).To(HaveKey(HavePrefix(v1.HostModelRequiredFeaturesLabel)),
-					fmt.Sprintf(errorMessageTemplate, "host cpu required features"))
-
-				arch := node.Labels[k8sv1.LabelArchStable]
-
-				if arch == testsuite.ArchAMD64 {
-					Expect(node.Labels).To(HaveKey(HavePrefix(v1.HypervLabel)), fmt.Sprintf(errorMessageTemplate, "hyperV"))
-				}
-
-				if arch == testsuite.ArchAMD64 || arch == testsuite.ArchS390x {
-					Expect(node.Labels).To(HaveKey(HavePrefix(v1.CPUModelVendorLabel)), fmt.Sprintf(errorMessageTemplate, "vendor"))
-				} else {
-					Expect(node.Labels).ToNot(HaveKey(HavePrefix(v1.CPUModelVendorLabel)))
-				}
-			}
-		})
-
 		It("[test_id:6247] should set default obsolete cpu models filter when obsolete-cpus-models is not set in kubevirt config",
 			decorators.WgS390x, func() {
 				kvConfig := libkubevirt.GetCurrentKv(virtClient)


### PR DESCRIPTION
### What this PR does
Removes the e2e test_id:6246 which validates that node-labeller sets cpu model, cpu feature, host model, required features, hyperv, and vendor labels on nodes.

#### Before this PR:
- The e2e test duplicates assertions already covered by unit tests and fails on multi-arch clusters where label sets differ by architecture

#### After this PR:
- The redundant e2e test is removed
- Label correctness is validated by existing unit tests in `pkg/virt-handler/node-labeller/`:
  - `CPUModelLabel` → `node_labeller_test.go` ("should add usable cpu model labels")
  - `CPUFeatureLabel` → `cpu_plugin_test.go` (`getSupportedCpuFeatures`)
  - `HostModelCPULabel` → `node_labeller_test.go` ("should add host cpu model label")
  - `HostModelRequiredFeaturesLabel` → `node_labeller_test.go` ("should add host cpu required features")
  - `HypervLabel` → `cpu_plugin_test.go` (`removeLabellerLabels`)
  - `CPUModelVendorLabel` → `cpu_plugin_test.go` ("Should default to IBM as CPU Vendor on s390x")

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```