### PR TITLE
[release-1.8] Fix gRPC connection leak in GetLauncherClient

### DIFF
--- a/pkg/virt-handler/launcher-clients/BUILD.bazel
+++ b/pkg/virt-handler/launcher-clients/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/virt-handler/notify-server/pipe:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/golang.org/x/sync/singleflight:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/launcher-clients/launcher-clients.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients.go
@@ -25,6 +25,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
@@ -45,6 +47,7 @@ type LauncherClientsManager interface {
 
 type launcherClientsManager struct {
 	virtShareDir         string
+	connGroup            singleflight.Group
 	launcherClients      virtcache.LauncherClientInfoByVMI
 	podIsolationDetector isolation.PodIsolationDetector
 }
@@ -76,46 +79,59 @@ func (l *launcherClientsManager) GetVerifiedLauncherClient(vmi *v1.VirtualMachin
 }
 
 func (l *launcherClientsManager) GetLauncherClient(vmi *v1.VirtualMachineInstance) (cmdclient.LauncherClient, error) {
-	var err error
-
+	// Fast path: return cached connection without any synchronization.
 	clientInfo, exists := l.launcherClients.Load(vmi.UID)
 	if exists && clientInfo.Client != nil {
 		return clientInfo.Client, nil
 	}
 
-	socketFile, err := cmdclient.FindSocket(vmi)
-	if err != nil {
-		return nil, err
-	}
+	// Slow path: use singleflight to ensure only one connection is created per VMI
+	// even when multiple controllers (VM, MigrationSource, MigrationTarget) race
+	// on the same VMI concurrently. Other VMIs are not blocked.
+	result, err, _ := l.connGroup.Do(string(vmi.UID), func() (interface{}, error) {
+		// Re-check: another goroutine may have created the connection while we waited.
+		if clientInfo, exists := l.launcherClients.Load(vmi.UID); exists && clientInfo.Client != nil {
+			return clientInfo.Client, nil
+		}
 
-	err = virtcache.GhostRecordGlobalStore.Add(vmi.Namespace, vmi.Name, socketFile, vmi.UID)
-	if err != nil {
-		return nil, err
-	}
+		socketFile, err := cmdclient.FindSocket(vmi)
+		if err != nil {
+			return nil, err
+		}
 
-	client, err := cmdclient.NewClient(socketFile)
-	if err != nil {
-		return nil, err
-	}
+		err = virtcache.GhostRecordGlobalStore.Add(vmi.Namespace, vmi.Name, socketFile, vmi.UID)
+		if err != nil {
+			return nil, err
+		}
 
-	domainPipeStopChan := make(chan struct{})
-	//we pipe in the domain socket into the VMI's filesystem
-	err = l.startDomainNotifyPipe(domainPipeStopChan, vmi)
-	if err != nil {
-		client.Close()
-		close(domainPipeStopChan)
-		return nil, err
-	}
+		client, err := cmdclient.NewClient(socketFile)
+		if err != nil {
+			return nil, err
+		}
 
-	l.launcherClients.Store(vmi.UID, &virtcache.LauncherClientInfo{
-		Client:              client,
-		SocketFile:          socketFile,
-		DomainPipeStopChan:  domainPipeStopChan,
-		NotInitializedSince: time.Now(),
-		Ready:               true,
+		domainPipeStopChan := make(chan struct{})
+		err = l.startDomainNotifyPipe(domainPipeStopChan, vmi)
+		if err != nil {
+			client.Close()
+			close(domainPipeStopChan)
+			return nil, err
+		}
+
+		l.launcherClients.Store(vmi.UID, &virtcache.LauncherClientInfo{
+			Client:              client,
+			SocketFile:          socketFile,
+			DomainPipeStopChan:  domainPipeStopChan,
+			NotInitializedSince: time.Now(),
+			Ready:               true,
+		})
+
+		return client, nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
-	return client, nil
+	return result.(cmdclient.LauncherClient), nil
 }
 
 func (l *launcherClientsManager) GetLauncherClientInfo(vmi *v1.VirtualMachineInstance) *virtcache.LauncherClientInfo {

--- a/pkg/virt-handler/launcher-clients/launcher-clients.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients.go
@@ -106,6 +106,7 @@ func (l *launcherClientsManager) GetLauncherClient(vmi *v1.VirtualMachineInstanc
 
 		client, err := cmdclient.NewClient(socketFile)
 		if err != nil {
+			virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
 			return nil, err
 		}
 
@@ -114,6 +115,7 @@ func (l *launcherClientsManager) GetLauncherClient(vmi *v1.VirtualMachineInstanc
 		if err != nil {
 			client.Close()
 			close(domainPipeStopChan)
+			virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
 			return nil, err
 		}
 

--- a/vendor/golang.org/x/sync/singleflight/BUILD.bazel
+++ b/vendor/golang.org/x/sync/singleflight/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["singleflight.go"],
+    importmap = "kubevirt.io/kubevirt/vendor/golang.org/x/sync/singleflight",
+    importpath = "golang.org/x/sync/singleflight",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -1,0 +1,214 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight // import "golang.org/x/sync/singleflight"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// errGoexit indicates the runtime.Goexit was called in
+// the user given function.
+var errGoexit = errors.New("runtime.Goexit was called")
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value interface{}
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func (p *panicError) Unwrap() error {
+	err, ok := p.value.(error)
+	if !ok {
+		return nil
+	}
+
+	return err
+}
+
+func newPanicError(v interface{}) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+
+		if e, ok := c.err.(*panicError); ok {
+			panic(e)
+		} else if c.err == errGoexit {
+			runtime.Goexit()
+		}
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+//
+// The returned channel will not be closed.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	normalReturn := false
+	recovered := false
+
+	// use double-defer to distinguish panic from runtime.Goexit,
+	// more details see https://golang.org/cl/134395
+	defer func() {
+		// the given function invoked runtime.Goexit
+		if !normalReturn && !recovered {
+			c.err = errGoexit
+		}
+
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		c.wg.Done()
+		if g.m[key] == c {
+			delete(g.m, key)
+		}
+
+		if e, ok := c.err.(*panicError); ok {
+			// In order to prevent the waiting channels from being blocked forever,
+			// needs to ensure that this panic cannot be recovered.
+			if len(c.chans) > 0 {
+				go panic(e)
+				select {} // Keep this goroutine around so that it will appear in the crash dump.
+			} else {
+				panic(e)
+			}
+		} else if c.err == errGoexit {
+			// Already in the process of goexit, no need to call again
+		} else {
+			// Normal return
+			for _, ch := range c.chans {
+				ch <- Result{c.val, c.err, c.dups > 0}
+			}
+		}
+	}()
+
+	func() {
+		defer func() {
+			if !normalReturn {
+				// Ideally, we would wait to take a stack trace until we've determined
+				// whether this is a panic or a runtime.Goexit.
+				//
+				// Unfortunately, the only way we can distinguish the two is to see
+				// whether the recover stopped the goroutine from terminating, and by
+				// the time we know that, the part of the stack trace relevant to the
+				// panic has been discarded.
+				if r := recover(); r != nil {
+					c.err = newPanicError(r)
+				}
+			}
+		}()
+
+		c.val, c.err = fn()
+		normalReturn = true
+	}()
+
+	if !normalReturn {
+		recovered = true
+	}
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -634,6 +634,7 @@ golang.org/x/oauth2/internal
 # golang.org/x/sync v0.19.0
 ## explicit; go 1.24.0
 golang.org/x/sync/errgroup
+golang.org/x/sync/singleflight
 # golang.org/x/sys v0.39.0
 ## explicit; go 1.24.0
 golang.org/x/sys/cpu


### PR DESCRIPTION
Backport: https://github.com/kubevirt/kubevirt/pull/17798

#### Release note
```release-note
Fixed a gRPC connection leak in virt-handler's GetLauncherClient that caused unbounded memory growth, socket accumulation, and goroutine leaks when multiple controllers raced to create connections for the same VMI.
```

