### PR TITLE
tests: move ObsoleteCPUModels label tests to unit tests

### DIFF
--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -24,6 +24,7 @@ package nodelabeller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -345,6 +346,54 @@ var _ = Describe("Node-labeller ", func() {
 
 		recorder := nlController.recorder.(*record.FakeRecorder)
 		Expect(recorder.Events).To(Receive(ContainSubstring("in ObsoleteCPUModels")))
+	})
+
+	It("should remove cpu model label when model is added to ObsoleteCPUModels", func() {
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(HaveKey(v1.CPUModelLabel + "Penryn"))
+		fakeNodeStore.Update(node)
+
+		nlController.clusterConfig.GetConfig().ObsoleteCPUModels["Penryn"] = true
+		nlController.queue.Add(nodeName)
+
+		res = nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node = retrieveNode(kubeClient)
+		Expect(node.Labels).ToNot(HaveKey(v1.CPUModelLabel + "Penryn"))
+	})
+
+	It("should remove all cpu model and migration labels when all models are obsolete", func() {
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node := retrieveNode(kubeClient)
+		Expect(node.Labels).To(HaveKey(HavePrefix(v1.CPUModelLabel)))
+		Expect(node.Labels).To(HaveKey(HavePrefix(v1.SupportedHostModelMigrationCPU)))
+		fakeNodeStore.Update(node)
+
+		obsolete := nlController.clusterConfig.GetConfig().ObsoleteCPUModels
+		for key := range node.Labels {
+			if strings.HasPrefix(key, v1.CPUModelLabel) {
+				obsolete[strings.TrimPrefix(key, v1.CPUModelLabel)] = true
+			}
+			if strings.HasPrefix(key, v1.SupportedHostModelMigrationCPU) {
+				obsolete[strings.TrimPrefix(key, v1.SupportedHostModelMigrationCPU)] = true
+			}
+		}
+		nlController.queue.Add(nodeName)
+
+		res = nlController.execute()
+		Expect(res).To(BeTrue())
+
+		node = retrieveNode(kubeClient)
+		for key := range node.Labels {
+			Expect(key).ToNot(HavePrefix(v1.CPUModelLabel))
+			Expect(key).ToNot(HavePrefix(v1.SupportedHostModelMigrationCPU))
+		}
 	})
 
 	It("should keep existing label that is not owned by node labeller", func() {

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -98,19 +98,6 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 		}
 	})
 
-	expectNodeLabels := func(nodeName string, labelValidation func(map[string]string) (valid bool, errorMsg string)) {
-		var errorMsg string
-
-		EventuallyWithOffset(1, func() (isValid bool) {
-			node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			isValid, errorMsg = labelValidation(node.Labels)
-
-			return isValid
-		}, 30*time.Second, 2*time.Second).Should(BeTrue(), errorMsg)
-	}
-
 	Context("basic labeling", func() {
 		type patch struct {
 			Op    string            `json:"op"`
@@ -228,30 +215,6 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 			config.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
 		})
 
-		It("[test_id:6249] should update node with new cpu model label set", func() {
-			obsoleteModel := ""
-			node := nodesWithHypervisor[0]
-
-			kvConfig := originalKubeVirt.Spec.Configuration.DeepCopy()
-			kvConfig.ObsoleteCPUModels = make(map[string]bool)
-
-			for key := range node.Labels {
-				if strings.Contains(key, v1.CPUModelLabel) {
-					obsoleteModel = strings.TrimPrefix(key, v1.CPUModelLabel)
-					kvConfig.ObsoleteCPUModels[obsoleteModel] = true
-					break
-				}
-			}
-
-			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
-
-			labelKeyExpectedToBeMissing := v1.CPUModelLabel + obsoleteModel
-			expectNodeLabels(node.Name, func(m map[string]string) (valid bool, errorMsg string) {
-				_, exists := m[labelKeyExpectedToBeMissing]
-				return !exists, fmt.Sprintf("node %s is expected to not have label key %s", node.Name, labelKeyExpectedToBeMissing)
-			})
-		})
-
 		It("[test_id:6250] should update node with new cpu model vendor label", decorators.WgS390x, func() {
 			nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -264,42 +227,6 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 			}
 
 			Fail("No node contains label " + v1.CPUModelVendorLabel)
-		})
-
-		It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", func() {
-			node := nodesWithHypervisor[0]
-
-			obsoleteModels := map[string]bool{}
-			for k, v := range nodelabellerutil.DefaultObsoleteCPUModels {
-				obsoleteModels[k] = v
-			}
-
-			for key := range node.Labels {
-				if strings.Contains(key, v1.CPUModelLabel) {
-					obsoleteModels[strings.TrimPrefix(key, v1.CPUModelLabel)] = true
-				}
-				if strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
-					obsoleteModels[strings.TrimPrefix(key, v1.SupportedHostModelMigrationCPU)] = true
-				}
-			}
-
-			kvConfig := originalKubeVirt.Spec.Configuration.DeepCopy()
-			kvConfig.ObsoleteCPUModels = obsoleteModels
-			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
-
-			expectNodeLabels(node.Name, func(m map[string]string) (valid bool, errorMsg string) {
-				found := false
-				label := ""
-				for key := range m {
-					if strings.Contains(key, v1.CPUModelLabel) || strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
-						found = true
-						label = key
-						break
-					}
-				}
-
-				return !found, fmt.Sprintf("node %s should not contain any cpu model label, but contains %s", node.Name, label)
-			})
 		})
 	})
 


### PR DESCRIPTION
### What this PR does
Moves test_id:6249 and test_id:6252 from e2e tests to unit tests in `pkg/virt-handler/node-labeller/node_labeller_test.go`.

These tests verify that node-labeller removes CPU model labels when models are added to `ObsoleteCPUModels`. This is pure controller reconciliation logic that does not require a running cluster.

#### Before this PR:
- Two e2e tests in the "advanced labeling" context update the KubeVirt config and wait for node-labeller to reconcile labels on a real cluster node

#### After this PR:
- Equivalent unit tests call `execute()` directly with mutated `ObsoleteCPUModels` config and assert label removal, running in under 1 second with no cluster dependency

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```