### PR TITLE
tests: remove redundant unsupported machine type e2e test

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -418,41 +418,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 			})
 
-			Context("for Machine Type", func() {
-
-				DescribeTable("should prevent scheduling of a pod for a VMI with an unsupported machine type", func(unsupportedMachineType string) {
-					virtClient := kubevirt.Client()
-					vmi := libvmifact.NewGuestless()
-					vmi.Namespace = testsuite.GetTestNamespace(vmi)
-					vmi.Spec.Domain.Machine = &v1.Machine{Type: unsupportedMachineType}
-
-					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.BeInPhase(v1.Scheduling))
-
-					virtLauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(virtLauncherPod.Spec.NodeSelector).To(HaveKey(ContainSubstring(v1.SupportedMachineTypeLabel + unsupportedMachineType)))
-
-					var scheduledCond *v1.VirtualMachineInstanceCondition
-					Eventually(func() *v1.VirtualMachineInstanceCondition {
-						curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-						scheduledCond = controller.NewVirtualMachineInstanceConditionManager().
-							GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-						return scheduledCond
-					}, 10*time.Second, 1*time.Second).ShouldNot(BeNil(), "The PodScheduled condition should eventually appear")
-
-					Expect(scheduledCond.Status).To(BeEquivalentTo(k8sv1.ConditionFalse))
-					Expect(scheduledCond.Reason).To(BeEquivalentTo(k8sv1.PodReasonUnschedulable))
-					Expect(scheduledCond.Message).To(ContainSubstring("node(s) didn't match Pod's node affinity/selector"))
-				},
-					Entry("amd64", "pc-q35-test-1.2.3", decorators.RequiresAMD64),
-					Entry("arm64", "virt-test-1.2.3", decorators.RequiresARM64),
-					Entry("s390x", "s390-ccw-virtio-test-1.2.3", decorators.RequiresS390X, decorators.WgS390x),
-				)
-			})
 		})
 
 		Context("when guest crashes", Serial, decorators.VMIlifecycle, func() {


### PR DESCRIPTION
### What this PR does
Removes the "should prevent scheduling of a pod for a VMI with an unsupported machine type" DescribeTable from `tests/vmi_lifecycle_test.go` (3 entries: amd64, arm64, s390x).

In this test, a VMI is created with an architecture-specific machine type (e.g. `virt-test-1.2.3` for arm64) but without setting `VMI.Spec.Architecture`. The mutating webhook resolves architecture to the cluster default (amd64). For the arm64 and s390x entries, the webhook then checks the machine type against the amd64 emulated machines list (`q35*`, `pc-q35*`) and rejects VMI creation because `virt-test-1.2.3` is not in that list.

Even if the architecture were set correctly, the core KubeVirt logic being tested — adding `SupportedMachineTypeLabel` to the pod's nodeSelector — is already covered by the unit test in `pkg/virt-controller/services/template_test.go:1223` ("should add node selector for machine type"). The remainder of the e2e test only verifies that the k8s scheduler rejects a pod whose nodeSelector doesn't match any node, which is standard scheduler behavior.

#### Before this PR:
- Three e2e test entries create VMIs with architecture-specific machine types without setting architecture
- The arm64 and s390x entries fail on multi-arch clusters because the webhook resolves to amd64 and rejects the machine type

#### After this PR:
- The redundant e2e test is removed
- Machine-type nodeSelector logic remains covered by unit tests

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```