### PR TITLE
WIP: Parallel for emulated SR-IOV (legacy)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -370,7 +370,7 @@ oci_pull(
 # like stress and qemu guest agent pre-configured
 oci_pull(
     name = "fedora_with_test_tooling",
-    digest = "sha256:a53fd982787799c2d8cfaa37a2b6fbac4f416437768a25d2eb246dff46bb9d79",
+    digest = "sha256:73ad845b934476c560ffb484b036e6de318e91f7a059178661c5460b35457062",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -376,13 +376,13 @@ oci_pull(
 
 oci_pull(
     name = "alpine_with_test_tooling",
-    digest = "sha256:8c8e8bb6cd81c75e492c678abb3e5f186d52eba2174ebabc328316250acfea58",
+    digest = "sha256:699cf2a04a18b792d87664eb404a82b64d8d411ebf47f6b3112d727cb4286c30",
     image = "quay.io/kubevirtci/alpine-with-test-tooling-container-disk",
 )
 
 oci_pull(
     name = "alpine_with_test_tooling_arm64",
-    digest = "sha256:5b443506b62f29f5ef5ac1bbf709338212b0b289ee2579e4feead42205685f43",
+    digest = "sha256:7b415db6db13a387893164f379a3524f90f0cca5e5180785b46c97f42a91b3aa",
     image = "quay.io/kubevirtci/alpine-with-test-tooling-container-disk",
 )
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1992,8 +1992,14 @@ func (c *VirtualMachineController) handleVMIState(vmi *v1.VirtualMachineInstance
 
 // handleRunningVMI contains the logic specifically for running VMs (hotplugging in running state, metrics, network updates)
 func (c *VirtualMachineController) handleRunningVMI(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager, errorTolerantFeaturesError *[]error) error {
-	if err := c.hotplugSriovInterfaces(vmi); err != nil {
+	sriovPending, err := c.hotplugSriovInterfaces(vmi)
+	if err != nil {
 		c.logger.Object(vmi).Error(err.Error())
+	}
+	if sriovPending {
+		// SR-IOV hotplug retries are rate-limited by sriovHotplugExecutorPool.
+		// Requeue ensures we keep reconciling until domain+multus statuses converge.
+		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second)
 	}
 
 	if err := c.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
@@ -2136,7 +2142,7 @@ func (c *VirtualMachineController) getPreallocatedVolumes(vmi *v1.VirtualMachine
 	return preallocatedVolumes
 }
 
-func (c *VirtualMachineController) hotplugSriovInterfaces(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) hotplugSriovInterfaces(vmi *v1.VirtualMachineInstance) (bool, error) {
 	sriovSpecInterfaces := netvmispec.FilterSRIOVInterfaces(vmi.Spec.Domain.Devices.Interfaces)
 
 	sriovSpecIfacesNames := netvmispec.IndexInterfaceSpecByName(sriovSpecInterfaces)
@@ -2153,11 +2159,11 @@ func (c *VirtualMachineController) hotplugSriovInterfaces(vmi *v1.VirtualMachine
 
 	if len(desiredSriovMultusPluggedIfaces) == len(attachedSriovStatusIfaces) {
 		c.sriovHotplugExecutorPool.Delete(vmi.UID)
-		return nil
+		return false, nil
 	}
 
 	rateLimitedExecutor := c.sriovHotplugExecutorPool.LoadOrStore(vmi.UID)
-	return rateLimitedExecutor.Exec(func() error {
+	return true, rateLimitedExecutor.Exec(func() error {
 		return c.hotplugSriovInterfacesCommand(vmi)
 	})
 }

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -85,7 +85,6 @@ func NewAlpine(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 }
 
 func NewAlpineWithTestTooling(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
-	alpineMemory := cirrosMemory
 	alpineOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
 		libvmi.WithMemoryRequest(alpineMemory()),
@@ -139,6 +138,13 @@ func cirrosMemory() string {
 		return "256Mi"
 	}
 	return "128Mi"
+}
+
+func alpineMemory() string {
+	if isARM64() || isS390X() {
+		return "256Mi"
+	}
+	return "512Mi"
 }
 
 func NewWindows(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -85,6 +85,7 @@ func NewAlpine(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 }
 
 func NewAlpineWithTestTooling(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
+	alpineMemory := cirrosMemory
 	alpineOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
 		libvmi.WithMemoryRequest(alpineMemory()),
@@ -138,13 +139,6 @@ func cirrosMemory() string {
 		return "256Mi"
 	}
 	return "128Mi"
-}
-
-func alpineMemory() string {
-	if isARM64() || isS390X() {
-		return "256Mi"
-	}
-	return "512Mi"
 }
 
 func NewWindows(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -87,7 +87,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 		BeforeEach(func() {
 			By("Creating a VM")
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
@@ -98,7 +98,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 			Eventually(matcher.ThisVM(hotPluggedVM)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			hotPluggedVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), hotPluggedVM.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(console.LoginToAlpine(hotPluggedVMI)).To(Succeed())
+			Expect(console.LoginToFedora(hotPluggedVMI)).To(Succeed())
 
 			By("Creating a NAD")
 			Expect(createSRIOVNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), nadName, sriovResourceName)).To(Succeed())

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -50,13 +50,6 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 	sriovResourceName := readSRIOVResourceName()
 
 	BeforeEach(func() {
-		// Check if the hardware supports SRIOV
-		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
-			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
-
-	})
-
-	BeforeEach(func() {
 		virtClient := kubevirt.Client()
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{
 			WorkloadUpdateMethods: []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate},

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -47,6 +47,7 @@ import (
 )
 
 var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
+	const hotplugSRIOVTestMAC = "0e:ad:00:00:be:20"
 	sriovResourceName := readSRIOVResourceName()
 
 	BeforeEach(func() {
@@ -97,7 +98,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 			Expect(createSRIOVNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), nadName, sriovResourceName)).To(Succeed())
 
 			By("Hotplugging an interface to the VM")
-			Expect(addSRIOVInterface(hotPluggedVM, ifaceName, nadName)).To(Succeed())
+			Expect(addSRIOVInterface(hotPluggedVM, ifaceName, nadName, hotplugSRIOVTestMAC)).To(Succeed())
 		})
 
 		It("can hotplug a network interface", func() {
@@ -174,13 +175,9 @@ func newSRIOVNetworkInterface(name, netAttachDefName string) (v1.Network, v1.Int
 	return network, iface
 }
 
-func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName string) error {
+func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName, mac string) error {
 	newNetwork, newIface := newSRIOVNetworkInterface(name, netAttachDefName)
-	mac, err := libnet.GenerateRandomMac()
-	if err != nil {
-		return err
-	}
-	return libnet.PatchVMWithNewInterface(vm, newNetwork, libvmi.InterfaceWithMac(newIface, mac.String()))
+	return libnet.PatchVMWithNewInterface(vm, newNetwork, libvmi.InterfaceWithMac(newIface, mac))
 }
 
 func verifySriovDynamicInterfaceChange(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -87,7 +87,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 		BeforeEach(func() {
 			By("Creating a VM")
-			vmi := libvmifact.NewFedora(
+			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
@@ -98,7 +98,7 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 			Eventually(matcher.ThisVM(hotPluggedVM)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			hotPluggedVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), hotPluggedVM.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(console.LoginToFedora(hotPluggedVMI)).To(Succeed())
+			Expect(console.LoginToAlpine(hotPluggedVMI)).To(Succeed())
 
 			By("Creating a NAD")
 			Expect(createSRIOVNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), nadName, sriovResourceName)).To(Succeed())

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -114,7 +114,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 
 		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
-			vmi := libvmifact.NewFedora(
+			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithCPUCount(4, 0, 0),
 				libvmi.WithDedicatedCPUPlacement(),
@@ -424,7 +424,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 
 		It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
-			vmi := libvmifact.NewFedora(
+			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -693,7 +693,7 @@ func newSRIOVVmi(networks []string, opts ...libvmi.Option) *v1.VirtualMachineIns
 		)
 	}
 	opts = append(options, opts...)
-	return libvmifact.NewFedora(opts...)
+	return libvmifact.NewAlpineWithTestTooling(opts...)
 }
 
 func checkInterfacesInGuest(vmi *v1.VirtualMachineInstance, interfaces []string) {
@@ -778,7 +778,7 @@ func waitVMI(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 
 	Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-	libwait.WaitUntilVMIReady(vmi, console.LoginToFedora, libwait.WithWarningsIgnoreList(warningsIgnoreList))
+	libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine, libwait.WithWarningsIgnoreList(warningsIgnoreList))
 
 	return kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -81,11 +81,13 @@ const (
 )
 
 const (
-	sriovnet1           = "sriov"
-	sriovnet2           = "sriov2"
-	sriovnet3           = "sriov3"
-	sriovnet4           = "sriov4"
-	sriovnetLinkEnabled = "sriov-linked"
+	sriovnet1             = "sriov"
+	sriovnet2             = "sriov2"
+	sriovnet3             = "sriov3"
+	sriovnet4             = "sriov4"
+	sriovnetLinkEnabled   = "sriov-linked"
+	sriovPeerLabel        = "sriov-peer"
+	sriovMultiVFTestLabel = "sriov-multi-vf-test"
 )
 
 var pciAddressRegex = regexp.MustCompile(hardware.PCI_ADDRESS_PATTERN)
@@ -461,7 +463,11 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		It("should correctly plug all the interfaces based on the specified MAC and (guest) PCI addresses", func() {
 			macAddressTemplate := "de:ad:00:be:ef:%02d"
 			pciAddressTemplate := "0000:2%d:00.0"
-			vmi := newSRIOVVmi(sriovNetworks, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
+			vmi := newSRIOVVmi(sriovNetworks,
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
+				libvmi.WithLabel(sriovMultiVFTestLabel, ""),
+				withRequiredPodAntiAffinity(sriovPeerLabel),
+			)
 			for i := range sriovNetworks {
 				secondaryInterfaceIdx := i + 1
 				vmi.Spec.Domain.Devices.Interfaces[secondaryInterfaceIdx].MacAddress = fmt.Sprintf(macAddressTemplate, secondaryInterfaceIdx)
@@ -483,8 +489,6 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 	})
 
 	Context("VMI connected to link-enabled SRIOV network", func() {
-		const sriovPeerLabel = "sriov-peer"
-
 		BeforeEach(func() {
 			netAttachDef := libnet.NewSriovNetAttachDef(sriovnetLinkEnabled, defaultVLAN, withLinkState())
 			netAttachDef.Annotations = map[string]string{libnet.ResourceNameAnnotation: sriovResourceName}
@@ -503,18 +507,12 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			// create two vms on the same sriov network
 			vmi1, err := createSRIOVVmi(sriovnetLinkEnabled, cidrA,
 				libvmi.WithLabel(sriovPeerLabel, ""),
+				withRequiredPodAntiAffinity(sriovMultiVFTestLabel),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi1)
 			vmi2, err := createSRIOVVmi(sriovnetLinkEnabled, cidrB,
-				libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{Key: sriovPeerLabel, Operator: metav1.LabelSelectorOpExists},
-						},
-					},
-					TopologyKey: k8sv1.LabelHostname,
-				}),
+				libvmi.WithRequiredPodAffinity(podAffinityTermForLabel(sriovPeerLabel)),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi2)
@@ -553,18 +551,12 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			It("should be able to ping between two VMIs with the same VLAN over SRIOV network", func() {
 				vlanedVMI1, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1,
 					libvmi.WithLabel(sriovPeerLabel, ""),
+					withRequiredPodAntiAffinity(sriovMultiVFTestLabel),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI1)
 				vlanedVMI2, err := createSRIOVVmi(sriovnetVlanned, "192.168.0.2/24",
-					libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{Key: sriovPeerLabel, Operator: metav1.LabelSelectorOpExists},
-							},
-						},
-						TopologyKey: k8sv1.LabelHostname,
-					}),
+					libvmi.WithRequiredPodAffinity(podAffinityTermForLabel(sriovPeerLabel)),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI2)
@@ -583,18 +575,12 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			It("should NOT be able to ping between Vlaned VMI and a non Vlaned VMI", func() {
 				vlanedVMI, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1,
 					libvmi.WithLabel(sriovPeerLabel, ""),
+					withRequiredPodAntiAffinity(sriovMultiVFTestLabel),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI)
 				nonVlanedVMI, err := createSRIOVVmi(sriovnetLinkEnabled, "192.168.0.3/24",
-					libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{Key: sriovPeerLabel, Operator: metav1.LabelSelectorOpExists},
-							},
-						},
-						TopologyKey: k8sv1.LabelHostname,
-					}),
+					libvmi.WithRequiredPodAffinity(podAffinityTermForLabel(sriovPeerLabel)),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, nonVlanedVMI)
@@ -655,6 +641,32 @@ func getInterfaceNetworkNameByMAC(vmi *v1.VirtualMachineInstance, macAddress str
 func defaultCloudInitNetworkData() string {
 	networkData := netcloudinit.CreateDefaultCloudInitNetworkData()
 	return networkData
+}
+
+func podAffinityTermForLabel(labelKey string) k8sv1.PodAffinityTerm {
+	return k8sv1.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: labelKey, Operator: metav1.LabelSelectorOpExists},
+			},
+		},
+		TopologyKey: k8sv1.LabelHostname,
+	}
+}
+
+func withRequiredPodAntiAffinity(labelKey string) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Affinity == nil {
+			vmi.Spec.Affinity = &k8sv1.Affinity{}
+		}
+		if vmi.Spec.Affinity.PodAntiAffinity == nil {
+			vmi.Spec.Affinity.PodAntiAffinity = &k8sv1.PodAntiAffinity{}
+		}
+		vmi.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			vmi.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			podAffinityTermForLabel(labelKey),
+		)
+	}
 }
 
 func findIfaceByMAC(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, mac string, timeout time.Duration) (string, error) {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -91,7 +91,7 @@ const (
 
 var pciAddressRegex = regexp.MustCompile(hardware.PCI_ADDRESS_PATTERN)
 
-var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
+var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 	var virtClient kubecli.KubevirtClient
 
 	sriovResourceName := readSRIOVResourceName()
@@ -113,7 +113,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			Expect(err).NotTo(HaveOccurred(), shouldCreateNetwork)
 		})
 
-		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
+		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", Serial, decorators.RequiresNodeWithCPUManager, func() {
 			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithCPUCount(4, 0, 0),
@@ -234,11 +234,13 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			checkInterfacesInGuest(vmi, []string{"eth0", "eth1"})
 		})
 		It("[test_id:3985]should create a virtual machine with sriov interface with custom MAC address", func() {
-			const mac = "de:ad:00:00:be:ef"
+			macAddr, err := libnet.GenerateRandomMac()
+			Expect(err).NotTo(HaveOccurred())
+			mac := macAddr.String()
 			vmi := newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
 			vmi.Spec.Domain.Devices.Interfaces[1].MacAddress = mac
 
-			vmi, err := createVMIAndWait(vmi)
+			vmi, err = createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
 
@@ -264,16 +266,20 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 					"Migration tests require at least 2 nodes with SR-IOV resources")
 			})
 
-			var vmi *v1.VirtualMachineInstance
-
-			const mac = "de:ad:00:00:be:ef"
+			var (
+				vmi *v1.VirtualMachineInstance
+				mac string
+			)
 
 			BeforeEach(func() {
 				// The SR-IOV VF MAC should be preserved on migration, therefore explicitly specify it.
+				macAddr, err := libnet.GenerateRandomMac()
+				Expect(err).NotTo(HaveOccurred())
+				mac = macAddr.String()
+
 				vmi = newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
 				vmi.Spec.Domain.Devices.Interfaces[1].MacAddress = mac
 
-				var err error
 				vmi, err = createVMIAndWait(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vmi)
@@ -349,8 +355,10 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 					initialGuestMemory      = "1Gi"
 					updatedGuestMemory      = "3Gi"
 					sriovNetworkLogicalName = "sriov-network"
-					mac                     = "de:ad:00:00:be:af"
 				)
+				macAddr, err := libnet.GenerateRandomMac()
+				Expect(err).NotTo(HaveOccurred())
+				mac := macAddr.String()
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithGuestMemory(initialGuestMemory),
 					libvmi.WithInterface(libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(sriovNetworkLogicalName), mac)),
@@ -360,7 +368,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 
 				vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 
-				vm, err := kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
+				vm, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -90,6 +90,28 @@ const (
 	sriovMultiVFTestLabel = "sriov-multi-vf-test"
 )
 
+const (
+	sriovCloudInitMetadataTestMAC = "0e:ad:00:00:be:01"
+	sriovSingleNetworkTestMAC     = "0e:ad:00:00:be:02"
+	sriovRootBusTestMAC           = "0e:ad:00:00:be:03"
+	sriovDedicatedCPUTestMAC      = "0e:ad:00:00:be:04"
+	sriovCustomMacTestMAC         = "0e:ad:00:00:be:05"
+	sriovMigrationTestMAC         = "0e:ad:00:00:be:06"
+	sriovMemoryHotplugTestMAC     = "0e:ad:00:00:be:07"
+	sriovTwoNetworkTestMAC1       = "0e:ad:00:00:be:08"
+	sriovTwoNetworkTestMAC2       = "0e:ad:00:00:be:09"
+	sriovMultiNetworkTestMAC1     = "0e:ad:00:00:be:10"
+	sriovMultiNetworkTestMAC2     = "0e:ad:00:00:be:11"
+	sriovMultiNetworkTestMAC3     = "0e:ad:00:00:be:12"
+	sriovMultiNetworkTestMAC4     = "0e:ad:00:00:be:13"
+	sriovLinkEnabledTestMAC1      = "0e:ad:00:00:be:14"
+	sriovLinkEnabledTestMAC2      = "0e:ad:00:00:be:15"
+	sriovVlanPingTestMAC1         = "0e:ad:00:00:be:16"
+	sriovVlanPingTestMAC2         = "0e:ad:00:00:be:17"
+	sriovNonVlanPingTestMAC1      = "0e:ad:00:00:be:18"
+	sriovNonVlanPingTestMAC2      = "0e:ad:00:00:be:19"
+)
+
 var pciAddressRegex = regexp.MustCompile(hardware.PCI_ADDRESS_PATTERN)
 
 var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
@@ -118,7 +140,10 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 				libvmi.WithDedicatedCPUPlacement(),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(libvmi.InterfaceWithTag(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet1), "specialNet")),
+				libvmi.WithInterface(libvmi.InterfaceWithTag(
+					libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet1), sriovCloudInitMetadataTestMAC),
+					"specialNet",
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(sriovnet1, sriovnet1)),
 			)
 			vmi, err := createVMIAndWait(vmi)
@@ -179,7 +204,8 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		})
 
 		It("[test_id:1754]should create a virtual machine with sriov interface", func() {
-			vmi := newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
+			vmi := newSRIOVVmi([]string{sriovnet1}, []string{sriovSingleNetworkTestMAC},
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
 			vmi, err := createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
@@ -195,7 +221,7 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		})
 
 		It("[test_id:1754]should create a virtual machine with sriov interface with all pci devices on the root bus", func() {
-			vmi := newSRIOVVmi([]string{sriovnet1},
+			vmi := newSRIOVVmi([]string{sriovnet1}, []string{sriovRootBusTestMAC},
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithAnnotation(v1.PlacePCIDevicesOnRootComplex, "true"),
 			)
@@ -217,7 +243,7 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
 			// In addition to verifying that we can start a VMI with CPU pinning
 			// this also tests if we've correctly calculated the overhead for VFIO devices.
-			vmi := newSRIOVVmi([]string{sriovnet1},
+			vmi := newSRIOVVmi([]string{sriovnet1}, []string{sriovDedicatedCPUTestMAC},
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithCPUCount(2, 0, 0),
 				libvmi.WithDedicatedCPUPlacement(),
@@ -232,12 +258,11 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			checkInterfacesInGuest(vmi, []string{"eth0", "eth1"})
 		})
 		It("[test_id:3985]should create a virtual machine with sriov interface with custom MAC address", func() {
-			macAddr, err := libnet.GenerateRandomMac()
-			Expect(err).NotTo(HaveOccurred())
-			mac := macAddr.String()
-			vmi := newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
-			vmi.Spec.Domain.Devices.Interfaces[1].MacAddress = mac
+			mac := sriovCustomMacTestMAC
+			vmi := newSRIOVVmi([]string{sriovnet1}, []string{mac},
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
 
+			var err error
 			vmi, err = createVMIAndWait(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi)
@@ -266,13 +291,12 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 
 			BeforeEach(func() {
 				// The SR-IOV VF MAC should be preserved on migration, therefore explicitly specify it.
-				macAddr, err := libnet.GenerateRandomMac()
-				Expect(err).NotTo(HaveOccurred())
-				mac = macAddr.String()
+				mac = sriovMigrationTestMAC
 
-				vmi = newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
-				vmi.Spec.Domain.Devices.Interfaces[1].MacAddress = mac
+				vmi = newSRIOVVmi([]string{sriovnet1}, []string{mac},
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())))
 
+				var err error
 				vmi, err = createVMIAndWait(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vmi)
@@ -349,9 +373,7 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 					updatedGuestMemory      = "3Gi"
 					sriovNetworkLogicalName = "sriov-network"
 				)
-				macAddr, err := libnet.GenerateRandomMac()
-				Expect(err).NotTo(HaveOccurred())
-				mac := macAddr.String()
+				mac := sriovMemoryHotplugTestMAC
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithGuestMemory(initialGuestMemory),
 					libvmi.WithInterface(libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(sriovNetworkLogicalName), mac)),
@@ -361,6 +383,7 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 
 				vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 
+				var err error
 				vm, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -429,9 +452,15 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(libvmi.InterfaceWithPciAddress(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet1), "0000:06:00.0")),
+				libvmi.WithInterface(libvmi.InterfaceWithPciAddress(
+					libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet1), sriovTwoNetworkTestMAC1),
+					"0000:06:00.0",
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(sriovnet1, sriovnet1)),
-				libvmi.WithInterface(libvmi.InterfaceWithPciAddress(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet2), "0000:07:00.0")),
+				libvmi.WithInterface(libvmi.InterfaceWithPciAddress(
+					libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet2), sriovTwoNetworkTestMAC2),
+					"0000:07:00.0",
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(sriovnet2, sriovnet2)),
 			)
 
@@ -451,6 +480,12 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 
 	Context("Connected to multiple SRIOV networks", func() {
 		sriovNetworks := []string{sriovnet1, sriovnet2, sriovnet3, sriovnet4}
+		sriovMultiNetworkMACs := []string{
+			sriovMultiNetworkTestMAC1,
+			sriovMultiNetworkTestMAC2,
+			sriovMultiNetworkTestMAC3,
+			sriovMultiNetworkTestMAC4,
+		}
 		BeforeEach(func() {
 			for _, sriovNetwork := range sriovNetworks {
 				netAttachDef := libnet.NewSriovNetAttachDef(sriovNetwork, defaultVLAN)
@@ -461,16 +496,14 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		})
 
 		It("should correctly plug all the interfaces based on the specified MAC and (guest) PCI addresses", func() {
-			macAddressTemplate := "de:ad:00:be:ef:%02d"
 			pciAddressTemplate := "0000:2%d:00.0"
-			vmi := newSRIOVVmi(sriovNetworks,
+			vmi := newSRIOVVmi(sriovNetworks, sriovMultiNetworkMACs,
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithLabel(sriovMultiVFTestLabel, ""),
 				withRequiredPodAntiAffinity(sriovPeerLabel),
 			)
 			for i := range sriovNetworks {
 				secondaryInterfaceIdx := i + 1
-				vmi.Spec.Domain.Devices.Interfaces[secondaryInterfaceIdx].MacAddress = fmt.Sprintf(macAddressTemplate, secondaryInterfaceIdx)
 				vmi.Spec.Domain.Devices.Interfaces[secondaryInterfaceIdx].PciAddress = fmt.Sprintf(pciAddressTemplate, secondaryInterfaceIdx)
 			}
 
@@ -505,13 +538,15 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// create two vms on the same sriov network
-			vmi1, err := createSRIOVVmi(sriovnetLinkEnabled, cidrA,
+			vmi1, err := createSRIOVVmi(sriovnetLinkEnabled, cidrA, sriovLinkEnabledTestMAC1,
+				withManualSRIOVGuestIP(sriovnetLinkEnabled, cidrA, sriovLinkEnabledTestMAC1),
 				libvmi.WithLabel(sriovPeerLabel, ""),
 				withRequiredPodAntiAffinity(sriovMultiVFTestLabel),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi1)
-			vmi2, err := createSRIOVVmi(sriovnetLinkEnabled, cidrB,
+			vmi2, err := createSRIOVVmi(sriovnetLinkEnabled, cidrB, sriovLinkEnabledTestMAC2,
+				withManualSRIOVGuestIP(sriovnetLinkEnabled, cidrB, sriovLinkEnabledTestMAC2),
 				libvmi.WithRequiredPodAffinity(podAffinityTermForLabel(sriovPeerLabel)),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -549,13 +584,15 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			})
 
 			It("should be able to ping between two VMIs with the same VLAN over SRIOV network", func() {
-				vlanedVMI1, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1,
+				vlanedVMI1, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1, sriovVlanPingTestMAC1,
+					withManualSRIOVGuestIP(sriovnetVlanned, cidrVlaned1, sriovVlanPingTestMAC1),
 					libvmi.WithLabel(sriovPeerLabel, ""),
 					withRequiredPodAntiAffinity(sriovMultiVFTestLabel),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI1)
-				vlanedVMI2, err := createSRIOVVmi(sriovnetVlanned, "192.168.0.2/24",
+				vlanedVMI2, err := createSRIOVVmi(sriovnetVlanned, "192.168.0.2/24", sriovVlanPingTestMAC2,
+					withManualSRIOVGuestIP(sriovnetVlanned, "192.168.0.2/24", sriovVlanPingTestMAC2),
 					libvmi.WithRequiredPodAffinity(podAffinityTermForLabel(sriovPeerLabel)),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -573,13 +610,15 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			})
 
 			It("should NOT be able to ping between Vlaned VMI and a non Vlaned VMI", func() {
-				vlanedVMI, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1,
+				vlanedVMI, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1, sriovNonVlanPingTestMAC1,
+					withManualSRIOVGuestIP(sriovnetVlanned, cidrVlaned1, sriovNonVlanPingTestMAC1),
 					libvmi.WithLabel(sriovPeerLabel, ""),
 					withRequiredPodAntiAffinity(sriovMultiVFTestLabel),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI)
-				nonVlanedVMI, err := createSRIOVVmi(sriovnetLinkEnabled, "192.168.0.3/24",
+				nonVlanedVMI, err := createSRIOVVmi(sriovnetLinkEnabled, "192.168.0.3/24", sriovNonVlanPingTestMAC2,
+					withManualSRIOVGuestIP(sriovnetLinkEnabled, "192.168.0.3/24", sriovNonVlanPingTestMAC2),
 					libvmi.WithRequiredPodAffinity(podAffinityTermForLabel(sriovPeerLabel)),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -643,6 +682,30 @@ func defaultCloudInitNetworkData() string {
 	return networkData
 }
 
+func withManualSRIOVGuestIP(networkName, cidr, mac string) libvmi.Option {
+	userData := fmt.Sprintf(`#!/bin/bash
+set -euo pipefail
+
+iface=""
+for _ in $(seq 1 30); do
+    iface="$(ip -o link | grep -i "%s" | awk -F': ' '{print $2; exit}' | cut -d@ -f1 || true)"
+    if [ -n "$iface" ]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ -z "$iface" ]; then
+    iface="%s"
+fi
+
+ip link set "$iface" up
+ip addr replace "%s" dev "$iface"
+`, strings.ToLower(mac), networkName, cidr)
+
+	return libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData))
+}
+
 func podAffinityTermForLabel(labelKey string) k8sv1.PodAffinityTerm {
 	return k8sv1.PodAffinityTerm{
 		LabelSelector: &metav1.LabelSelector{
@@ -692,15 +755,19 @@ func findIfaceByMAC(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineIns
 	return ifaceName, nil
 }
 
-func newSRIOVVmi(networks []string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
+func newSRIOVVmi(networks, macs []string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
+	if len(networks) != len(macs) {
+		panic(fmt.Sprintf("expected one unmanaged MAC per SR-IOV network, got %d networks and %d MACs", len(networks), len(macs)))
+	}
+
 	options := []libvmi.Option{
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	}
 
-	for _, name := range networks {
+	for idx, name := range networks {
 		options = append(options,
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(name)),
+			libvmi.WithInterface(libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(name), macs[idx])),
 			libvmi.WithNetwork(libvmi.MultusNetwork(name, name)),
 		)
 	}
@@ -847,29 +914,22 @@ func checkDefaultInterfaceInPod(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func createSRIOVVmi(networkName, cidr string, opts ...libvmi.Option) (*v1.VirtualMachineInstance, error) {
-	// Explicitly choose different random mac addresses instead of relying on kubemacpool to do it:
+func createSRIOVVmi(networkName, cidr, mac string, opts ...libvmi.Option) (*v1.VirtualMachineInstance, error) {
+	// Explicitly choose unmanaged MAC addresses instead of relying on kubemacpool to do it:
 	// 1) we don't at the moment deploy kubemacpool in kind providers
 	// 2) even if we would do, it's probably a good idea to have the suite not depend on this fact
 	//
 	// This step is needed to guarantee that no VFs on the PF carry a duplicate MAC address that may affect
 	// ability of VMIs to send and receive ICMP packets on their ports.
-	mac, err := libnet.GenerateRandomMac()
-	if err != nil {
-		return nil, err
-	}
-
 	// manually configure IP/link on sriov interfaces because there is
 	// no DHCP server to serve the address to the guest
-	networkData := netcloudinit.CreateNetworkDataWithStaticIPsByMac(networkName, mac.String(), cidr)
-	vmi := newSRIOVVmi([]string{networkName}, append(opts,
+	networkData := netcloudinit.CreateNetworkDataWithStaticIPsByMac(networkName, mac, cidr)
+	vmi := newSRIOVVmi([]string{networkName}, []string{mac}, append(opts,
 		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 	)...)
-	const secondaryInterfaceIndex = 1
-	vmi.Spec.Domain.Devices.Interfaces[secondaryInterfaceIndex].MacAddress = mac.String()
 
 	virtCli := kubevirt.Client()
-	vmi, err = virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+	vmi, err := virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	return vmi, nil
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -114,7 +114,7 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		})
 
 		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", Serial, decorators.RequiresNodeWithCPUManager, func() {
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithCPUCount(4, 0, 0),
 				libvmi.WithDedicatedCPUPlacement(),
@@ -432,7 +432,7 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		})
 
 		It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
-			vmi := libvmifact.NewAlpineWithTestTooling(
+			vmi := libvmifact.NewFedora(
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -701,7 +701,7 @@ func newSRIOVVmi(networks []string, opts ...libvmi.Option) *v1.VirtualMachineIns
 		)
 	}
 	opts = append(options, opts...)
-	return libvmifact.NewAlpineWithTestTooling(opts...)
+	return libvmifact.NewFedora(opts...)
 }
 
 func checkInterfacesInGuest(vmi *v1.VirtualMachineInstance, interfaces []string) {
@@ -786,7 +786,7 @@ func waitVMI(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 
 	Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-	libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine, libwait.WithWarningsIgnoreList(warningsIgnoreList))
+	libwait.WaitUntilVMIReady(vmi, console.LoginToFedora, libwait.WithWarningsIgnoreList(warningsIgnoreList))
 
 	return kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -69,7 +69,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	netcloudinit "kubevirt.io/kubevirt/tests/libnet/cloudinit"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -98,9 +97,6 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
-			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
 
 		checks.FailTestIfNoFeatureGate(featuregate.ExternalNetResourceInjection)
 	})
@@ -261,11 +257,6 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 		})
 
 		Context("migration", decorators.RequiresTwoSchedulableNodes, func() {
-			BeforeEach(func() {
-				Expect(validateSRIOVSetup(sriovResourceName, 2)).To(Succeed(),
-					"Migration tests require at least 2 nodes with SR-IOV resources")
-			})
-
 			var (
 				vmi *v1.VirtualMachineInstance
 				mac string
@@ -492,13 +483,7 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 	})
 
 	Context("VMI connected to link-enabled SRIOV network", func() {
-		var sriovNode string
-
-		BeforeEach(func() {
-			var err error
-			sriovNode, err = sriovNodeName(sriovResourceName)
-			Expect(err).ToNot(HaveOccurred())
-		})
+		const sriovPeerLabel = "sriov-peer"
 
 		BeforeEach(func() {
 			netAttachDef := libnet.NewSriovNetAttachDef(sriovnetLinkEnabled, defaultVLAN, withLinkState())
@@ -516,10 +501,21 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// create two vms on the same sriov network
-			vmi1, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, cidrA)
+			vmi1, err := createSRIOVVmi(sriovnetLinkEnabled, cidrA,
+				libvmi.WithLabel(sriovPeerLabel, ""),
+			)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi1)
-			vmi2, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, cidrB)
+			vmi2, err := createSRIOVVmi(sriovnetLinkEnabled, cidrB,
+				libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{Key: sriovPeerLabel, Operator: metav1.LabelSelectorOpExists},
+						},
+					},
+					TopologyKey: k8sv1.LabelHostname,
+				}),
+			)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi2)
 
@@ -555,10 +551,21 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			})
 
 			It("should be able to ping between two VMIs with the same VLAN over SRIOV network", func() {
-				vlanedVMI1, err := createSRIOVVmiOnNode(sriovNode, sriovnetVlanned, cidrVlaned1)
+				vlanedVMI1, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1,
+					libvmi.WithLabel(sriovPeerLabel, ""),
+				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI1)
-				vlanedVMI2, err := createSRIOVVmiOnNode(sriovNode, sriovnetVlanned, "192.168.0.2/24")
+				vlanedVMI2, err := createSRIOVVmi(sriovnetVlanned, "192.168.0.2/24",
+					libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: sriovPeerLabel, Operator: metav1.LabelSelectorOpExists},
+							},
+						},
+						TopologyKey: k8sv1.LabelHostname,
+					}),
+				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI2)
 
@@ -574,10 +581,21 @@ var _ = Describe(SIG("SRIOV", decorators.SRIOV, func() {
 			})
 
 			It("should NOT be able to ping between Vlaned VMI and a non Vlaned VMI", func() {
-				vlanedVMI, err := createSRIOVVmiOnNode(sriovNode, sriovnetVlanned, cidrVlaned1)
+				vlanedVMI, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1,
+					libvmi.WithLabel(sriovPeerLabel, ""),
+				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI)
-				nonVlanedVMI, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, "192.168.0.3/24")
+				nonVlanedVMI, err := createSRIOVVmi(sriovnetLinkEnabled, "192.168.0.3/24",
+					libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: sriovPeerLabel, Operator: metav1.LabelSelectorOpExists},
+							},
+						},
+						TopologyKey: k8sv1.LabelHostname,
+					}),
+				)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, nonVlanedVMI)
 
@@ -632,32 +650,6 @@ func getInterfaceNetworkNameByMAC(vmi *v1.VirtualMachineInstance, macAddress str
 	}
 
 	return ""
-}
-
-func validateSRIOVSetup(sriovResourceName string, minRequiredNodes int) error {
-	sriovNodes := getNodesWithAllocatedResource(sriovResourceName)
-	if len(sriovNodes) < minRequiredNodes {
-		return fmt.Errorf("not enough compute nodes with SR-IOV support detected")
-	}
-	return nil
-}
-
-func getNodesWithAllocatedResource(resourceName string) []k8sv1.Node {
-	nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-	filteredNodes := []k8sv1.Node{}
-	for _, node := range nodes.Items {
-		resourceList := node.Status.Allocatable
-		for k, v := range resourceList {
-			if string(k) == resourceName {
-				if v.Value() > 0 {
-					filteredNodes = append(filteredNodes, node)
-					break
-				}
-			}
-		}
-	}
-
-	return filteredNodes
 }
 
 func defaultCloudInitNetworkData() string {
@@ -843,8 +835,7 @@ func checkDefaultInterfaceInPod(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-// createSRIOVVmiOnNode creates a VMI on the specified node, connected to the specified SR-IOV network.
-func createSRIOVVmiOnNode(nodeName, networkName, cidr string) (*v1.VirtualMachineInstance, error) {
+func createSRIOVVmi(networkName, cidr string, opts ...libvmi.Option) (*v1.VirtualMachineInstance, error) {
 	// Explicitly choose different random mac addresses instead of relying on kubemacpool to do it:
 	// 1) we don't at the moment deploy kubemacpool in kind providers
 	// 2) even if we would do, it's probably a good idea to have the suite not depend on this fact
@@ -859,8 +850,9 @@ func createSRIOVVmiOnNode(nodeName, networkName, cidr string) (*v1.VirtualMachin
 	// manually configure IP/link on sriov interfaces because there is
 	// no DHCP server to serve the address to the guest
 	networkData := netcloudinit.CreateNetworkDataWithStaticIPsByMac(networkName, mac.String(), cidr)
-	vmi := newSRIOVVmi([]string{networkName}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)))
-	libvmi.WithNodeAffinityFor(nodeName)(vmi)
+	vmi := newSRIOVVmi([]string{networkName}, append(opts,
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+	)...)
 	const secondaryInterfaceIndex = 1
 	vmi.Spec.Domain.Devices.Interfaces[secondaryInterfaceIndex].MacAddress = mac.String()
 
@@ -868,14 +860,6 @@ func createSRIOVVmiOnNode(nodeName, networkName, cidr string) (*v1.VirtualMachin
 	vmi, err = virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	return vmi, nil
-}
-
-func sriovNodeName(sriovResourceName string) (string, error) {
-	sriovNodes := getNodesWithAllocatedResource(sriovResourceName)
-	if len(sriovNodes) == 0 {
-		return "", fmt.Errorf("failed to detect nodes with allocatable resources (%s)", sriovResourceName)
-	}
-	return sriovNodes[0].Name, nil
 }
 
 func mountGuestDevice(vmi *v1.VirtualMachineInstance, devName string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
If we take it, need the mem inc all over, and polish the enq fix / inc timeout for 
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/5090/rehearsal-pull-kubevirt-e2e-k8s-1.36-emulated-igb/2062463151089127424
note - happens not just on this PR

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

