### PR TITLE
tests: remove taint/toleration and affinity scheduling e2e tests

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -766,67 +766,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 		})
 
-		Context("with affinity", decorators.WgS390x, func() {
-			var node *k8sv1.Node
-
-			BeforeEach(func() {
-				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-				node = nodes.Items[0].DeepCopy()
-			})
-
-			It("[test_id:1637]the vmi with node affinity and no conflicts should be scheduled", decorators.Conformance, func() {
-				vmi := libvmifact.NewGuestless(libvmi.WithNodeAffinityFor(node.Name))
-
-				vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).To(Not(HaveOccurred()))
-				vmi = libwait.WaitForVMIPhase(vmi, []v1.VirtualMachineInstancePhase{v1.Scheduled, v1.Running}, libwait.WithTimeout(startupTimeout))
-
-				By("Asserting that VMI is scheduled on the pre-picked node")
-				Expect(vmi.Status.NodeName).To(Equal(node.Name), "Updated VMI name run on the same node")
-
-			})
-
-			It("[test_id:1638]the vmi with node affinity and anti-pod affinity should not be scheduled", decorators.Conformance, func() {
-				vmi := libvmifact.NewGuestless(libvmi.WithNodeAffinityFor(node.Name))
-				vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).To(Not(HaveOccurred()))
-				vmi = libwait.WaitForVMIPhase(vmi, []v1.VirtualMachineInstancePhase{v1.Scheduled, v1.Running}, libwait.WithTimeout(startupTimeout))
-
-				secondVMI := libvmifact.NewGuestless(libvmi.WithNodeAffinityFor(node.Name))
-
-				secondVMI.Spec.Affinity.PodAntiAffinity = &k8sv1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									{Key: v1.CreatedByLabel, Operator: metav1.LabelSelectorOpIn, Values: []string{string(vmi.GetUID())}},
-								},
-							},
-							TopologyKey: k8sv1.LabelHostname,
-						},
-					},
-				}
-
-				secondVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(secondVMI)).Create(context.Background(), secondVMI, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should create VMIB")
-
-				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() string {
-					curVmiB, err := kubevirt.Client().VirtualMachineInstance(secondVMI.Namespace).Get(context.Background(), secondVMI.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMIB")
-					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
-						GetCondition(curVmiB, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-					if scheduledCond != nil {
-						return scheduledCond.Reason
-					}
-					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
-
-			})
-
-		})
-
 		Context("with default cpu model", Serial, decorators.WgS390x, decorators.CPUModel, func() {
 			var originalConfig v1.KubeVirtConfiguration
 			var supportedCpuModels []string

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -766,52 +766,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 		})
 
-		Context("with node tainted", Serial, decorators.WgS390x, func() {
-			var nodes *k8sv1.NodeList
-			BeforeEach(func() {
-				Eventually(func() []k8sv1.Node {
-					nodes = libnode.GetAllSchedulableNodes(kubevirt.Client())
-					return nodes.Items
-				}, 60*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "There should be some compute node")
-
-				// Taint first node with "NoSchedule"
-				data := []byte(`{"spec":{"taints":[{"effect":"NoSchedule","key":"test","timeAdded":null,"value":"123"}]}}`)
-				_, err := kubevirt.Client().CoreV1().Nodes().Patch(context.Background(), nodes.Items[0].Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should patch node")
-
-			})
-
-			AfterEach(func() {
-				// Untaint first node
-				data := []byte(`{"spec":{"taints":[]}}`)
-				_, err := kubevirt.Client().CoreV1().Nodes().Patch(context.Background(), nodes.Items[0].Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should patch node")
-			})
-
-			It("[test_id:1635]the vmi with tolerations should be scheduled", func() {
-				vmi := libvmifact.NewGuestless(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmi.Spec.Tolerations = []k8sv1.Toleration{{Key: "test", Value: "123"}}
-				libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
-			})
-
-			It("[test_id:1636]the vmi without tolerations should not be scheduled", func() {
-				vmi := libvmifact.NewGuestless(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() string {
-					curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
-						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-					if scheduledCond != nil {
-						return scheduledCond.Reason
-					}
-					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unschedulable")
-			})
-		})
-
 		Context("with affinity", decorators.WgS390x, func() {
 			var node *k8sv1.Node
 


### PR DESCRIPTION
### What this PR does
Removes test_id:1635, 1636, 1637, and 1638 from `tests/vmi_lifecycle_test.go`.

These tests verify standard Kubernetes scheduling behavior that KubeVirt does not implement — it passes the fields directly to the launcher pod spec:

- **test_id:1635/1636** (taint/toleration): Creates a VMI with/without a toleration, pins it to a tainted node via `WithNodeAffinityFor`, and checks if the k8s scheduler accepts/rejects it. KubeVirt passes `vmi.Spec.Tolerations` straight through to the pod spec — no custom logic involved.
- **test_id:1637/1638** (node affinity / pod anti-affinity): Creates a VMI with `WithNodeAffinityFor(node.Name)` and checks scheduling. Then creates a second VMI with pod anti-affinity against the first and checks it becomes Unschedulable. Again, KubeVirt passes `vmi.Spec.Affinity` directly to the pod — this only tests the k8s scheduler.

All four tests use `nodes.Items[0]` to pick a target node. On multi-arch clusters where `nodes.Items[0]` is ARM64, the VMI defaults to amd64 architecture (set by the mutating webhook based on the control plane). The pod gets `kubernetes.io/arch=amd64` in its nodeSelector, which conflicts with the ARM64 node affinity — making the VMI Unschedulable before the test logic even runs.

Rather than fixing the arch mismatch, these tests are removed because they only validate the Kubernetes scheduler, not KubeVirt logic.

#### Unit tests that cover the same VMI-to-pod translation

The following unit tests in `pkg/virt-controller/services/template_test.go` verify that `RenderLaunchManifest()` correctly translates VMI spec fields onto the virt-launcher pod:

- Line 2006: "should add tolerations to pod"
- Line 1863: "should add node affinity to pod"
- Line 1886: "should add pod affinity to pod"
- Line 1906: "should add pod anti-affinity to pod"
- Line 2136: "should not add empty affinity to pod"
- Line 1155: "should add node selectors to template" (DescribeTable, multiple arches)
- Line 1305: "should add node selectors from kubevirt-config configMap"

#### Before this PR:
- Four e2e tests verify k8s scheduling primitives (taints, tolerations, node affinity, pod anti-affinity) through VMIs
- They fail on multi-arch clusters due to the `nodes.Items[0]` + default-amd64 architecture conflict

#### After this PR:
- The redundant tests are removed
- KubeVirt's own scheduling logic (architecture nodeSelectors, machine-type nodeSelectors, etc.) remains fully tested via the unit tests above

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```