### PR TITLE
fedora: bump fedora-with-test-tooling to F44

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -372,7 +372,7 @@ oci_pull(
 # like stress and qemu guest agent pre-configured
 oci_pull(
     name = "fedora_with_test_tooling",
-    digest = "sha256:1da18664c0bc5921b0ecfcb4c881031dd638d33fcf43c1e6cd206c50bde3c8f6",
+    digest = "sha256:a53fd982787799c2d8cfaa37a2b6fbac4f416437768a25d2eb246dff46bb9d79",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
 
@@ -396,13 +396,13 @@ oci_pull(
 
 oci_pull(
     name = "fedora_with_test_tooling_aarch64",
-    digest = "sha256:05fb8855266b60845fc7831a05b2466853116eedc6bd4edd02426271bbda8bfe",
+    digest = "sha256:0b29f1b32b2f8d75e35de165a121a9cb211741978972f27ed47e4879c1122b18",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
 
 oci_pull(
     name = "fedora_with_test_tooling_s390x",
-    digest = "sha256:336806201d9ff4f9b9686e7481106a8156a14eaa0127ad34d4853b558f148d60",
+    digest = "sha256:ae6d6510dfb1e1cbcf09ad85c2c0b3e58494fe10bdaa720362934422037d42a2",
     image = "quay.io/kubevirtci/fedora-with-test-tooling",
 )
 

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -35,6 +35,7 @@ const (
 	windowsDiskName = "windows-disk"
 	WindowsFirmware = "5d307ca9-b3ef-428c-8861-06e72d69f223"
 	WindowsPVCName  = "disk-windows"
+	FedoraMemory    = "544Mi"
 )
 
 // NewFedora instantiates a new Fedora based VMI configuration,
@@ -42,7 +43,7 @@ const (
 // This image has tooling for the guest agent, stress, SR-IOV and more.
 func NewFedora(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	fedoraOptions := []libvmi.Option{
-		libvmi.WithMemoryRequest("512Mi"),
+		libvmi.WithMemoryRequest(FedoraMemory),
 		libvmi.WithRng(),
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)),
 	}

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -107,7 +107,6 @@ var _ = Describe(SIG("Live Migrate A Paused VMI", decorators.RequiresTwoSchedula
 						By("creating a large Virtual Machine Instance")
 						vmi := libvmifact.NewFedora(
 							libnet.WithMasqueradeNetworking(),
-							libvmi.WithMemoryRequest("512Mi"),
 							libvmi.WithRng())
 
 						// update the migration policy to ensure slow pre-copy migration progress instead of an immediate cancellation.

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,8 +128,6 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 
 		DescribeTable("[test_id:4747] using", func(settingsType applySettingsType) {
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")
-			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Namespace = testsuite.NamespacePrivileged
 
 			switch settingsType {
@@ -175,7 +172,6 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 				By("Creating a Fedora VMI with a GuestAgentPing liveness probe")
 				vmi := libvmifact.NewFedora(
 					libnet.WithMasqueradeNetworking(),
-					libvmi.WithMemoryRequest("512Mi"),
 					libvmi.WithRng(),
 					libvmi.WithNamespace(testsuite.NamespacePrivileged),
 					libvmi.WithGuestAgentPingLivenessProbe(120, 5, 2),

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -1203,7 +1203,7 @@ var _ = Describe("Backup with migration", func() {
 			)
 
 			vm = libvmi.NewVirtualMachine(
-				libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace, libvmi.WithMemoryRequest("512Mi")),
+				libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace, libvmi.WithMemoryRequest(libvmifact.FedoraMemory)),
 				libvmi.WithDataVolumeTemplate(dv),
 				libvmi.WithLabels(cbt.CBTLabel),
 				libvmi.WithRunStrategy(v1.RunStrategyAlways),

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1038,7 +1038,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 
 			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, testsuite.GetTestNamespace(nil),
 				libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()),
-				libvmi.WithMemoryRequest("512Mi"),
+				libvmi.WithMemoryRequest(libvmifact.FedoraMemory),
 			)
 
 			dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
@@ -1251,7 +1251,7 @@ func renderVMWithRegistryImportDataVolume(containerDisk cd.ContainerDisk, storag
 	)
 	var vmiOpts []libvmi.Option
 	if containerDisk == cd.ContainerDiskFedoraTestTooling {
-		vmiOpts = append(vmiOpts, libvmi.WithMemoryRequest("512Mi"))
+		vmiOpts = append(vmiOpts, libvmi.WithMemoryRequest(libvmifact.FedoraMemory))
 	}
 	return libvmi.NewVirtualMachine(
 		libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace, vmiOpts...),

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1383,7 +1383,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			)
 
 			DescribeTable("Should restore a vm with backend storage", func(onlineSnapshot bool) {
-				vm = createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithMemoryRequest("512Mi"))
+				vm = createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithMemoryRequest(libvmifact.FedoraMemory))
 				vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
 				vm, vmi = createAndStartVM(vm)
 				Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
@@ -1575,7 +1575,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			)
 
 			DescribeTable("should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", decorators.StorageCritical, func(restoreToNewVM bool) {
-				vm, vmi = createAndStartVM(createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithMemoryRequest("512Mi")))
+				vm, vmi = createAndStartVM(createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithMemoryRequest(libvmifact.FedoraMemory)))
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
@@ -1588,7 +1588,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 			)
 
 			It("should restore vm spec at startup without new changes", func() {
-				vm, vmi = createAndStartVM(createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithMemoryRequest("512Mi")))
+				vm, vmi = createAndStartVM(createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithMemoryRequest(libvmifact.FedoraMemory)))
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Depends on https://github.com/kubevirt/kubevirtci/pull/1725 - merged
See it for more info.

Motivation: fix random modprobe errors, by using latest GA fedora, and newer kernel that ships with it.
(if it wouldn't fix it, we can try to update kernel according needs, as the cloud image doesn't ship the newest kernel).

Update the pinned fedora-with-test-tooling digests in WORKSPACE so tests 
resolve the intended per-architecture images consistently.

Increase guest memory by 32Mi,
as the new fedora requires around ~6Mi more than what it needs now.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
wrt 2nd commit:
when also tried to update kernel on F43, saw that virt-launcher consumes 12Mi more,
so extended by 32Mi so we will cover that case in case kernel update will be required,
and in order to not be too marginal.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

