### PR TITLE
tests: stop pinning VMI to nodes.Items[0] in lifecycle logging tests

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1224,31 +1224,25 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					namespace = testsuite.NamespaceTestAlternative
 				}
 
-				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-				node := nodes.Items[0].Name
-
 				By("Creating a VirtualMachineInstance with different namespace")
 				vmi := libvmi.New(
 					libvmi.WithMemoryRequest("1Mi"),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				)
-				virtHandlerPod, err := libnode.GetVirtHandlerPod(kubevirt.Client(), node)
+
+				var err error
+				vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+				vmi = libwait.WaitForSuccessfulVMIStart(vmi)
+
+				virtHandlerPod, err := libnode.GetVirtHandlerPod(kubevirt.Client(), vmi.Status.NodeName)
 				Expect(err).ToNot(HaveOccurred(), "Should get virthandler client for node")
 
 				handlerName := virtHandlerPod.GetObjectMeta().GetName()
 				handlerNamespace := virtHandlerPod.GetObjectMeta().GetNamespace()
 				seconds := int64(120)
 				logsQuery := kubevirt.Client().CoreV1().Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds, Container: "virt-handler"})
-
-				// Make sure we schedule the VirtualMachineInstance to master
-				vmi.Spec.NodeSelector = map[string]string{k8sv1.LabelHostname: node}
-
-				// Start the VirtualMachineInstance and wait for the confirmation of the start
-				vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				libwait.WaitForSuccessfulVMIStart(vmi)
 
 				// Check if the start event was logged
 				By("Checking that virt-handler logs VirtualMachineInstance creation")


### PR DESCRIPTION
### What this PR does
Fixes test_id:1641 and test_id:1642 ("should log libvirt start and stop lifecycle events of the domain") failing on multi-arch clusters.

In `tests/vmi_lifecycle_test.go`, these tests pick `nodes.Items[0]`, get the virt-handler pod on that node, then pin the VMI to the same node via `NodeSelector` so they can correlate virt-handler logs with the VMI's domain lifecycle events.

On a multi-arch cluster where `nodes.Items[0]` is ARM64, the VMI defaults to amd64 architecture (set by the mutating webhook based on the control plane). The pod gets `kubernetes.io/arch=amd64` in its nodeSelector, which conflicts with the ARM64 node's `NodeSelector` entry — the VMI becomes Unschedulable.

The node pinning was never part of what these tests validate — it was only test infrastructure to correlate VMI with virt-handler logs. The fix flips the dependency: the VMI schedules freely, then `vmi.Status.NodeName` is used to find the virt-handler pod on whichever node the VMI landed on.

#### Before this PR:
- Test picks `nodes.Items[0]` and gets virt-handler pod for that node
- VMI is pinned to the same node via `NodeSelector`
- On multi-arch clusters, the arch nodeSelector conflicts with the ARM64 node → Unschedulable

#### After this PR:
- VMI is created and schedules on any compatible node
- After VMI starts, `vmi.Status.NodeName` identifies the node
- Virt-handler pod is fetched from that node for log verification
- No architecture assumptions needed

### References
Part of: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```