### PR TITLE
Fix hotplug volume detach deadlock in virt-handler

### DIFF
--- a/pkg/virt-handler/hotplug-disk/BUILD.bazel
+++ b/pkg/virt-handler/hotplug-disk/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -45,6 +45,7 @@ import (
 
 	devices "github.com/opencontainers/cgroups/devices/config"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -347,9 +348,22 @@ func (m *volumeMounter) mountFromPod(vmi *v1.VirtualMachineInstance, sourceUID t
 		return err
 	}
 
+	specVolumes := sets.New[string]()
+	for i := range vmi.Spec.Volumes {
+		specVolumes.Insert(vmi.Spec.Volumes[i].Name)
+	}
+	for i := range vmi.Spec.UtilityVolumes {
+		specVolumes.Insert(vmi.Spec.UtilityVolumes[i].Name)
+	}
+
 	for _, volumeStatus := range vmi.Status.VolumeStatus {
 		if volumeStatus.HotplugVolume == nil {
 			// Skip non hotplug volumes
+			continue
+		}
+
+		if !specVolumes.Has(volumeStatus.Name) {
+			log.Log.Object(vmi).V(3).Infof("Skipping mount for volume %s: no longer in VMI spec", volumeStatus.Name)
 			continue
 		}
 

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -381,6 +381,89 @@ var _ = Describe("HotplugVolume", func() {
 			Expect(record.MountTargetEntries).To(BeEmpty())
 		})
 
+		It("should skip mounting hotplug volumes no longer in VMI spec", func() {
+			vmi := api.NewMinimalVMI("fake-vmi")
+			vmi.UID = "1234"
+			// Volume is in status but NOT in spec (simulates RemoveVolume)
+			vmi.Spec.Volumes = []v1.Volume{}
+			vmi.Status.VolumeStatus = []v1.VolumeStatus{
+				{
+					Name:  "removed-vol",
+					Phase: v1.VolumeReady,
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "test-pod",
+						AttachPodUID:  "test-uid",
+					},
+				},
+			}
+
+			err = m.mountFromPod(vmi, "", cgroupManagerMock)
+			Expect(err).ToNot(HaveOccurred())
+
+			record, err := m.getMountTargetRecord(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(record.MountTargetEntries).To(BeEmpty())
+		})
+
+		It("should mount volumes still in spec while skipping removed ones", func() {
+			blockSourcePodUID := types.UID("fghij")
+			_, err := newFile(tempDir, string(blockSourcePodUID), "volumes", "kept-vol", "file")
+			Expect(err).ToNot(HaveOccurred())
+
+			blockMode := k8sv1.PersistentVolumeBlock
+			vmi.Spec.Volumes = []v1.Volume{
+				{Name: "kept-vol", VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "kept-pvc"},
+						Hotpluggable:                      true,
+					},
+				}},
+			}
+			vmi.Status.VolumeStatus = []v1.VolumeStatus{
+				{
+					Name:  "removed-vol",
+					Phase: v1.VolumeReady,
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "old-pod",
+						AttachPodUID:  "old-uid",
+					},
+				},
+				{
+					Name:  "kept-vol",
+					Phase: v1.HotplugVolumeAttachedToNode,
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "test-pod",
+						AttachPodUID:  blockSourcePodUID,
+					},
+					PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+						VolumeMode: &blockMode,
+					},
+				},
+			}
+
+			statDevice = func(fileName *safepath.Path) (os.FileInfo, error) {
+				return fakeStat(true, 0666, 123456), nil
+			}
+			isBlockDevice = func(fileName *safepath.Path) (bool, error) {
+				return true, nil
+			}
+			mknodCommand = func(basePath *safepath.Path, deviceName string, dev uint64, blockDevicePermissions os.FileMode) error {
+				return os.WriteFile(filepath.Join(unsafepath.UnsafeAbsolute(basePath.Raw()), deviceName), []byte("test"), 0644)
+			}
+			setExpectedCgroupRuns(1)
+			expectCgroupRule(devices.BlockDevice, 482, 64, true)
+			ownershipManager.EXPECT().SetFileOwnership(gomock.Any())
+
+			err = m.mountFromPod(vmi, "", cgroupManagerMock)
+			Expect(err).ToNot(HaveOccurred())
+
+			record, err = m.getMountTargetRecord(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			// Only the kept-vol should have been mounted
+			Expect(record.MountTargetEntries).To(HaveLen(1))
+			Expect(record.MountTargetEntries[0].TargetFile).To(ContainSubstring("kept-vol"))
+		})
+
 		It("findVirtlauncherUID should find the right UID", func() {
 			res := m.findVirtlauncherUID(vmi)
 			Expect(res).To(BeEquivalentTo("abcd"))
@@ -461,6 +544,11 @@ var _ = Describe("HotplugVolume", func() {
 						AttachPodUID:  sourcePodUIDC,
 					},
 				},
+			}
+			vmi.Spec.Volumes = []v1.Volume{
+				{Name: "volume-a"},
+				{Name: "volume-b"},
+				{Name: "volume-c"},
 			}
 
 			for _, volume := range []struct {
@@ -1014,6 +1102,35 @@ var _ = Describe("HotplugVolume", func() {
 				},
 			})
 			vmi.Status.VolumeStatus = volumeStatuses
+
+			// Volumes must be in spec for Mount to process them
+			vmi.Spec.Volumes = []v1.Volume{
+				{
+					Name: "permanent",
+				},
+				{
+					Name: "filesystemvolume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "filesystemvolume",
+							},
+							Hotpluggable: true,
+						},
+					},
+				},
+				{
+					Name: "blockvolume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "blockvolume",
+							},
+							Hotpluggable: true,
+						},
+					},
+				},
+			}
 			deviceBasePath = func(podUID types.UID, kubeletPodDir string) (*safepath.Path, error) {
 				return newDir(tempDir, string(podUID), "volumeDevices")
 			}
@@ -1174,6 +1291,35 @@ var _ = Describe("HotplugVolume", func() {
 				},
 			})
 			vmi.Status.VolumeStatus = volumeStatuses
+
+			// Volumes must be in spec for Mount to process them
+			vmi.Spec.Volumes = []v1.Volume{
+				{
+					Name: "permanent",
+				},
+				{
+					Name: "filesystemvolume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "filesystemvolume",
+							},
+							Hotpluggable: true,
+						},
+					},
+				},
+				{
+					Name: "blockvolume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "blockvolume",
+							},
+							Hotpluggable: true,
+						},
+					},
+				},
+			}
 			deviceBasePath = func(podUID types.UID, kubeletPodDir string) (*safepath.Path, error) {
 				return newDir(tempDir, string(podUID), "volumeDevices")
 			}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1663,6 +1663,38 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Entry("When current phase is bound for hotplug volume", v1.HotplugVolumeAttachedToNode),
 			)
 
+			DescribeTable("should not change phase when volume is mounted but not in spec", func(currentPhase v1.VolumePhase) {
+				vmi := api2.NewMinimalVMI("testvmi")
+				vmi.UID = vmiTestUUID
+				vmi.Status.Phase = v1.Running
+				// Volume is NOT in spec (simulates RemoveVolume having been called)
+				vmi.Spec.Volumes = []v1.Volume{}
+				vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
+					Name:    "test",
+					Phase:   currentPhase,
+					Reason:  "reason",
+					Message: "message",
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "testpod",
+						AttachPodUID:  "1234",
+					},
+				})
+				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain.Status.Status = api.Running
+				addVMI(vmi, domain)
+				// IsMounted returns true — block device still exists on host
+				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				Expect(hasHotplug).To(BeTrue())
+				// Phase should NOT change — we wait for Unmount() to clean up the
+				// block device before advancing to avoid breaking the safety invariant
+				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(currentPhase))
+			},
+				Entry("When current phase is VolumeReady", v1.VolumeReady),
+				Entry("When current phase is HotplugVolumeMounted", v1.HotplugVolumeMounted),
+				Entry("When current phase is HotplugVolumeAttachedToNode", v1.HotplugVolumeAttachedToNode),
+			)
+
 			DescribeTable("should generate an unmount event for cdrom when appropriate", func(source string) {
 				vmi := api2.NewMinimalVMI("testvmi")
 				vmi.UID = vmiTestUUID


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When a hotplug volume is removed from VMI spec (via RemoveVolume API), a deadlock can occur because `mountFromPod()` in the reconcile loop continues to mount volumes that are in VMI status but no longer in spec. This recreates the block device on every cycle, preventing `Unmount()` from cleaning it up and `IsMounted()` from returning false, which means the volume phase never advances past VolumeReady/MountedToPod.

The root cause is that `mountFromPod()` iterates `vmi.Status.VolumeStatus` without checking whether the volume is still in `vmi.Spec.Volumes`. This creates a mutual dependency: virt-controller waits for the phase to advance before deleting the attachment pod, but virt-handler keeps re-mounting the volume, preventing the phase from advancing.

#### After this PR:

Fix: Skip volumes in `mountFromPod()` that are no longer in VMI spec. This allows `Unmount()` to clean up stale mounts, `IsMounted()` to return false, and the existing 'mounted=false AND NOT in spec' code path in `updateHotplugVolumeStatus()` to advance the phase to UnMountedFromPod.

Also add a log message in `updateHotplugVolumeStatus()` for the 'mounted=true AND NOT in spec' transient state, improving observability during the detach process.

### Release note
```release-note
BugFix: hotplug volume detach deadlock for already removed volumes.
```