### PR TITLE
Fix cleanupAttachmentPods fallback keeping useless old pods

### DIFF
--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -4386,6 +4386,135 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 			}, true),
 		)
+
+		DescribeTable("should handle old running pod kept as fallback based on volume status", func(volName string, volPhase virtv1.VolumePhase, inSpec bool, expectDelete bool) {
+			vmi := watchtesting.NewRunningVirtualMachine("testvmi", &k8sv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+				},
+			})
+			vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				{
+					Name:  volName,
+					Phase: volPhase,
+					HotplugVolume: &virtv1.HotplugVolumeStatus{
+						AttachPodName: "old-pod",
+						AttachPodUID:  "old-uid",
+					},
+				},
+			}
+			if inSpec {
+				vmi.Spec.Volumes = []virtv1.Volume{
+					{
+						Name: volName,
+						VolumeSource: virtv1.VolumeSource{
+							PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: volName + "-pvc",
+								},
+								Hotpluggable: true,
+							},
+						},
+					},
+				}
+			} else {
+				vmi.Spec.Volumes = []virtv1.Volume{}
+			}
+
+			readyVolumes := []*virtv1.Volume{{}}
+			oldPod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "old-pod",
+					Namespace: vmi.Namespace,
+				},
+				Spec: k8sv1.PodSpec{
+					Volumes: []k8sv1.Volume{
+						{Name: volName},
+					},
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodRunning,
+				},
+			}
+			addPod(oldPod)
+
+			err := controller.cleanupAttachmentPods(nil, []*k8sv1.Pod{oldPod}, vmi, len(readyVolumes))
+			Expect(err).ToNot(HaveOccurred())
+			if expectDelete {
+				testutils.ExpectEvent(recorder, kvcontroller.SuccessfulDeletePodReason)
+				expectPodDoesNotExist(oldPod.Namespace, oldPod.Name)
+			} else {
+				expectPodExists(oldPod.Namespace, oldPod.Name)
+			}
+		},
+			Entry("should delete when all volumes are Detaching",
+				"detaching-vol", virtv1.HotplugVolumeDetaching, false, true),
+			Entry("should keep when volume is still in spec",
+				"active-vol", virtv1.VolumeReady, true, false),
+			Entry("should keep when removed volume is in deletion-blocking phase",
+				"blocking-vol", virtv1.VolumeReady, false, false),
+		)
+
+		It("should keep old running pod as fallback when it has both a Detaching and an in-spec volume", func() {
+			vmi := watchtesting.NewRunningVirtualMachine("testvmi", &k8sv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+				},
+			})
+			vmi.Spec.Volumes = []virtv1.Volume{
+				{
+					Name: "active-vol",
+					VolumeSource: virtv1.VolumeSource{
+						PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "active-pvc",
+							},
+							Hotpluggable: true,
+						},
+					},
+				},
+			}
+			vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				{
+					Name:  "detaching-vol",
+					Phase: virtv1.HotplugVolumeDetaching,
+					HotplugVolume: &virtv1.HotplugVolumeStatus{
+						AttachPodName: "old-pod",
+						AttachPodUID:  "old-uid",
+					},
+				},
+				{
+					Name:  "active-vol",
+					Phase: virtv1.VolumeReady,
+					HotplugVolume: &virtv1.HotplugVolumeStatus{
+						AttachPodName: "old-pod",
+						AttachPodUID:  "old-uid",
+					},
+				},
+			}
+
+			readyVolumes := []*virtv1.Volume{{}}
+			oldPod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "old-pod",
+					Namespace: vmi.Namespace,
+				},
+				Spec: k8sv1.PodSpec{
+					Volumes: []k8sv1.Volume{
+						{Name: "detaching-vol"},
+						{Name: "active-vol"},
+					},
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodRunning,
+				},
+			}
+			addPod(oldPod)
+
+			err := controller.cleanupAttachmentPods(nil, []*k8sv1.Pod{oldPod}, vmi, len(readyVolumes))
+			Expect(err).ToNot(HaveOccurred())
+			expectPodExists(oldPod.Namespace, oldPod.Name)
+		})
 	})
 
 	Context("topology hints", func() {

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -84,8 +84,10 @@ func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8s
 		}
 	}
 
+	specHotplugVolumes := make(map[string]struct{})
 	for _, vmiVolume := range vmi.Spec.Volumes {
 		if storagetypes.IsHotplugVolume(&vmiVolume) {
+			specHotplugVolumes[vmiVolume.Name] = struct{}{}
 			delete(statusMap, vmiVolume.Name)
 		}
 	}
@@ -95,7 +97,8 @@ func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8s
 		if !foundRunning &&
 			attachmentPod.Status.Phase == k8sv1.PodRunning && attachmentPod.DeletionTimestamp == nil &&
 			numReadyVolumes > 0 &&
-			currentPodIsNotRunning {
+			currentPodIsNotRunning &&
+			podContainsVolumesToPreserve(attachmentPod, statusMap, specHotplugVolumes) {
 			foundRunning = true
 			continue
 		}
@@ -130,6 +133,24 @@ func volumeReadyForPodDelete(phase v1.VolumePhase) bool {
 		return false
 	}
 	return true
+}
+
+// podContainsVolumesToPreserve returns true if the pod contains at least one
+// hotplug volume that justifies keeping the pod alive as a fallback:
+// - A volume still in the VMI spec (the VMI needs it until the new pod is Running)
+// - A volume being detached but whose phase still blocks pod deletion
+// An old pod whose hotplug volumes are all in Detaching/UnMounted phase provides
+// no fallback value and should not block PVC cleanup on other VMIs.
+func podContainsVolumesToPreserve(pod *k8sv1.Pod, statusMap map[string]v1.VolumeStatus, specHotplugVolumes map[string]struct{}) bool {
+	for _, podVol := range pod.Spec.Volumes {
+		if _, inSpec := specHotplugVolumes[podVol.Name]; inSpec {
+			return true
+		}
+		if vs, ok := statusMap[podVol.Name]; ok && !volumeReadyForPodDelete(vs.Phase) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Controller) isUtilityVolumeWithBlockPVC(vmi *v1.VirtualMachineInstance, volume *v1.Volume) (bool, error) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The fallback logic in `cleanupAttachmentPods()` keeps the first old Running attachment pod alive when the new pod is not yet Running, to preserve volume accessibility. However, it does not check whether the old pod actually contains any volumes worth preserving. An old pod whose hotplug volumes are all in Detaching phase (removed from VMI spec, fully unmounted by virt-handler) is kept alive pointlessly.

This becomes a permanent deadlock when two or more VMIs are simultaneously exchanging RWO PVCs: VMI A's old pod holds PVCs that VMI B's new pod needs, and VMI B's old pod holds PVCs that VMI A's new pod needs. Neither old pod is deleted (fallback logic), so neither new pod can start (RWO conflict).

#### After this PR:

Fix: Add `podContainsVolumesToPreserve()` check to the fallback condition. An old pod is only kept as fallback if it contains at least one hotplug volume that is either still in the VMI spec (VMI needs it) or in a status phase that blocks pod deletion (Ready/MountedToPod). Old pods with only Detaching/UnMounted volumes fall through to the normal deletion path.

**Release note**:
```release-note
BugFix: hotplug volume detach deadlock when VMIs exchange RWO PVCs between attachment pods.
```