### PR TITLE
WorkloadEncryptionSEV Alpha -> Beta graduation

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -95,6 +95,11 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	disableFeatureGates := func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
+	disableSEVFeatureGate := func() {
+		kvConfig := kv.DeepCopy()
+		kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.WorkloadEncryptionSEV}
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
+	}
 
 	updateDefaultArchitecture := func(defaultArchitecture string) {
 		kvConfig := kv.DeepCopy()
@@ -2696,7 +2701,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject when the feature gate is disabled", func() {
-			disableFeatureGates()
+			disableSEVFeatureGate()
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.WorkloadEncryptionSEV)))
@@ -2779,7 +2784,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			It("should reject when the feature gate is disabled", func() {
-				disableFeatureGates()
+				disableSEVFeatureGate()
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.WorkloadEncryptionSEV)))

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -42,9 +42,13 @@ const (
 
 	DownwardMetricsFeatureGate = "DownwardMetrics"
 	Root                       = "Root"
-	WorkloadEncryptionSEV      = "WorkloadEncryptionSEV"
-	WorkloadEncryptionTDX      = "WorkloadEncryptionTDX"
-	VSOCKGate                  = "VSOCK"
+
+	// Owner: sig-compute / @alancaldelas
+	// Alpha: v0.49.0
+	// Beta: v1.9.0
+	WorkloadEncryptionSEV = "WorkloadEncryptionSEV"
+	WorkloadEncryptionTDX = "WorkloadEncryptionTDX"
+	VSOCKGate             = "VSOCK"
 	// KubevirtSeccompProfile indicate that Kubevirt will install its custom profile and
 	// user can tell Kubevirt to use it
 	KubevirtSeccompProfile = "KubevirtSeccompProfile"
@@ -243,7 +247,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HostDiskGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DownwardMetricsFeatureGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: Root, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionSEV, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionSEV, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionTDX, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VSOCKGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: KubevirtSeccompProfile, State: Beta})

--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -202,7 +202,15 @@ var _ = Describe("Device Controller", func() {
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
 			}, 5*time.Second).Should(BeNumerically(">=", 1))
-			Expect(deviceController.Initialized()).To(BeTrue())
+			// The always-on SEV plugin can't bind its socket in the sandbox, so
+			// scope the check to the plugin under test, not controller-wide Initialized().
+			Eventually(func(g Gomega) {
+				deviceController.startedPluginsMutex.Lock()
+				defer deviceController.startedPluginsMutex.Unlock()
+				dev, exists := deviceController.startedPlugins[deviceName2]
+				g.Expect(exists).To(BeTrue())
+				g.Expect(dev.devicePlugin.GetInitialized()).To(BeTrue())
+			}, 5*time.Second).Should(Succeed())
 		})
 
 		It("should restart the device plugin with delays if it returns errors", func() {

--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -231,9 +231,9 @@ var _ = Describe("Mediated Device", func() {
 			enabledDevicePlugins, disabledDevicePlugins := deviceController.splitPermittedDevices(
 				deviceController.updatePermittedHostDevicePlugins(),
 			)
-			Expect(enabledDevicePlugins).To(HaveLen(1), "a device plugin wasn't created for the fake device")
-			Expect(disabledDevicePlugins).To(BeEmpty())
-			Ω(enabledDevicePlugins).Should(HaveKey(fakeMdevResourceName))
+			// SEV plugin is on-by-default at Beta, so assert on our fake device, not the whole set.
+			Expect(enabledDevicePlugins).To(HaveKey(fakeMdevResourceName), "a device plugin wasn't created for the fake device")
+			Expect(disabledDevicePlugins).ToNot(HaveKey(fakeMdevResourceName), "the fake device plugin should not be disabled")
 			// Manually adding the enabled plugin, since the device controller is not actually running
 			deviceController.startedPlugins[fakeMdevResourceName] = controlledDevice{
 				devicePlugin: enabledDevicePlugins[fakeMdevResourceName],
@@ -250,9 +250,8 @@ var _ = Describe("Mediated Device", func() {
 			enabledDevicePlugins, disabledDevicePlugins = deviceController.splitPermittedDevices(
 				deviceController.updatePermittedHostDevicePlugins(),
 			)
-			Expect(enabledDevicePlugins).To(BeEmpty())
-			Expect(disabledDevicePlugins).To(HaveLen(1), "the fake device plugin did not get disabled")
-			Ω(disabledDevicePlugins).Should(HaveKey(fakeMdevResourceName))
+			Expect(enabledDevicePlugins).ToNot(HaveKey(fakeMdevResourceName), "the fake device plugin should no longer be enabled")
+			Expect(disabledDevicePlugins).To(HaveKey(fakeMdevResourceName), "the fake device plugin did not get disabled")
 		})
 	})
 })

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -172,9 +172,9 @@ pciHostDevices:
 		enabledDevicePlugins, disabledDevicePlugins := deviceController.splitPermittedDevices(
 			deviceController.updatePermittedHostDevicePlugins(),
 		)
-		Expect(enabledDevicePlugins).To(HaveLen(1), "a device plugin wasn't created for the fake device")
-		Expect(disabledDevicePlugins).To(BeEmpty(), "no disabled device plugins are expected")
-		Ω(enabledDevicePlugins).Should(HaveKey(fakeName))
+		// SEV plugin is on-by-default at Beta, so assert on our fake device, not the whole set.
+		Expect(enabledDevicePlugins).To(HaveKey(fakeName), "a device plugin wasn't created for the fake device")
+		Expect(disabledDevicePlugins).ToNot(HaveKey(fakeName), "the fake device plugin should not be disabled")
 		// Manually adding the enabled plugin, since the device controller is not actually running
 		deviceController.startedPlugins[fakeName] = controlledDevice{devicePlugin: enabledDevicePlugins[fakeName]}
 
@@ -189,9 +189,8 @@ pciHostDevices:
 		enabledDevicePlugins, disabledDevicePlugins = deviceController.splitPermittedDevices(
 			deviceController.updatePermittedHostDevicePlugins(),
 		)
-		Expect(enabledDevicePlugins).To(BeEmpty(), "no enabled device plugins should be found")
-		Expect(disabledDevicePlugins).To(HaveLen(1), "the fake device plugin did not get disabled")
-		Ω(disabledDevicePlugins).Should(HaveKey(fakeName))
+		Expect(enabledDevicePlugins).ToNot(HaveKey(fakeName), "the fake device plugin should no longer be enabled")
+		Expect(disabledDevicePlugins).To(HaveKey(fakeName), "the fake device plugin did not get disabled")
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Moves the WorkloadEncryptionSEV feature gate from Alpha to Beta, per graduation criteria in VEP 80.
#### Before this PR:
WorkloadEncryptionSEV was Alpha.
#### After this PR:
WorkloadEncryptionSEV is Beta. 
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->
VEP 80: https://github.com/kubevirt/enhancements/pull/296

### Why we need it and why it was done in this way
SEV-SNP support was released in v1.7.0 and since then, we have EPYC CI lanes for Prow and e2e testing for SEV-SNP, which satisfies the requirement in VEP 80
The following tradeoffs were made:
N/A
The following alternatives were considered:
N/A
Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [X] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
WorkloadEncryptionSEV graduated from Alpha -> Beta
```

