### PR TITLE
network: scope pod network state by virt-launcher pod UID

### DIFF
--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -22,6 +22,7 @@ package network
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	"kubevirt.io/client-go/log"
@@ -80,17 +81,39 @@ func NewNetConfWithCustomFactoryAndConfigState(nsFactory nsFactory, cacheCreator
 	}
 }
 
+// networkConfigStateKey returns a key for tracking network preparation state.
+// The key includes the active virt-launcher pod UID so a new pod always starts
+// with a fresh network setup, even when the VMI UID is unchanged.
+func networkConfigStateKey(vmi *v1.VirtualMachineInstance) string {
+	vmiUID := string(vmi.UID)
+	for podUID, nodeName := range vmi.Status.ActivePods {
+		if nodeName == vmi.Status.NodeName {
+			return vmiUID + "/" + string(podUID)
+		}
+	}
+	return vmiUID
+}
+
+func deleteNetworkConfigStatesForVMI(state map[string]*netpod.State, vmiUID string) {
+	for key := range state {
+		if key == vmiUID || strings.HasPrefix(key, vmiUID+"/") {
+			delete(state, key)
+		}
+	}
+}
+
 // Setup applies (privilege) network related changes for an existing virt-launcher pod.
 func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, launcherPid int) error {
+	stateKey := networkConfigStateKey(vmi)
 	c.configStateMutex.RLock()
-	state, ok := c.state[string(vmi.UID)]
+	state, ok := c.state[stateKey]
 	c.configStateMutex.RUnlock()
 	if !ok {
 		configStateCache := NewConfigStateCache(string(vmi.UID), c.cacheCreator)
 		ns := c.nsFactory(launcherPid)
 		state = netpod.NewState(&configStateCache, ns)
 		c.configStateMutex.Lock()
-		c.state[string(vmi.UID)] = state
+		c.state[stateKey] = state
 		c.configStateMutex.Unlock()
 	}
 
@@ -122,7 +145,7 @@ func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, l
 
 func (c *NetConf) Teardown(vmi *v1.VirtualMachineInstance) error {
 	c.configStateMutex.Lock()
-	delete(c.state, string(vmi.UID))
+	deleteNetworkConfigStatesForVMI(c.state, string(vmi.UID))
 	c.configStateMutex.Unlock()
 	podCache := cache.NewPodInterfaceCache(c.cacheCreator, string(vmi.UID))
 	if err := podCache.Remove(); err != nil {

--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -21,6 +21,7 @@ package network
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -86,12 +87,31 @@ func NewNetConfWithCustomFactoryAndConfigState(nsFactory nsFactory, cacheCreator
 // with a fresh network setup, even when the VMI UID is unchanged.
 func networkConfigStateKey(vmi *v1.VirtualMachineInstance) string {
 	vmiUID := string(vmi.UID)
-	for podUID, nodeName := range vmi.Status.ActivePods {
-		if nodeName == vmi.Status.NodeName {
-			return vmiUID + "/" + string(podUID)
+	nodeName := vmi.Status.NodeName
+	if nodeName == "" || len(vmi.Status.ActivePods) == 0 {
+		return vmiUID
+	}
+
+	var matchingPodUIDs []string
+	for podUID, podNodeName := range vmi.Status.ActivePods {
+		if podNodeName == nodeName {
+			matchingPodUIDs = append(matchingPodUIDs, string(podUID))
 		}
 	}
-	return vmiUID
+
+	switch len(matchingPodUIDs) {
+	case 0:
+		return vmiUID
+	case 1:
+		return vmiUID + "/" + matchingPodUIDs[0]
+	default:
+		sort.Strings(matchingPodUIDs)
+		log.Log.Object(vmi).Warningf(
+			"multiple active pods (%v) found on node %s; using %s for network state key",
+			matchingPodUIDs, nodeName, matchingPodUIDs[0],
+		)
+		return vmiUID + "/" + matchingPodUIDs[0]
+	}
 }
 
 func deleteNetworkConfigStatesForVMI(state map[string]*netpod.State, vmiUID string) {

--- a/pkg/network/setup/netconf_state_key_test.go
+++ b/pkg/network/setup/netconf_state_key_test.go
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/setup/netpod"
+)
+
+var _ = Describe("networkConfigStateKey", func() {
+	const (
+		vmiUID   = "vmi-uid"
+		nodeName = "node1"
+	)
+
+	It("includes the active pod UID when one pod matches the node", func() {
+		vmi := &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID(vmiUID)},
+			Status: v1.VirtualMachineInstanceStatus{
+				NodeName: nodeName,
+				ActivePods: map[types.UID]string{
+					types.UID("pod-uid"): nodeName,
+				},
+			},
+		}
+
+		Expect(networkConfigStateKey(vmi)).To(Equal(vmiUID + "/pod-uid"))
+	})
+
+	It("falls back to the VMI UID when no active pod matches the node", func() {
+		vmi := &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID(vmiUID)},
+			Status: v1.VirtualMachineInstanceStatus{
+				NodeName: nodeName,
+				ActivePods: map[types.UID]string{
+					types.UID("pod-uid"): "other-node",
+				},
+			},
+		}
+
+		Expect(networkConfigStateKey(vmi)).To(Equal(vmiUID))
+	})
+
+	It("uses the lexicographically smallest pod UID when multiple pods match the node", func() {
+		vmi := &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID(vmiUID)},
+			Status: v1.VirtualMachineInstanceStatus{
+				NodeName: nodeName,
+				ActivePods: map[types.UID]string{
+					types.UID("pod-z"): nodeName,
+					types.UID("pod-a"): nodeName,
+				},
+			},
+		}
+
+		Expect(networkConfigStateKey(vmi)).To(Equal(vmiUID + "/pod-a"))
+	})
+})
+
+var _ = Describe("deleteNetworkConfigStatesForVMI", func() {
+	It("removes all state entries for the VMI", func() {
+		stateMap := map[string]*netpod.State{
+			"vmi-uid":           nil,
+			"vmi-uid/old-pod":   nil,
+			"vmi-uid/new-pod":   nil,
+			"other-vmi/pod-uid": nil,
+		}
+
+		deleteNetworkConfigStatesForVMI(stateMap, "vmi-uid")
+
+		Expect(stateMap).To(Equal(map[string]*netpod.State{
+			"other-vmi/pod-uid": nil,
+		}))
+	})
+})

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -120,6 +121,36 @@ var _ = Describe("netconf", func() {
 	It("fails the teardown run", func() {
 		netConf := netsetup.NewNetConfWithCustomFactoryAndConfigState(nil, failingCacheCreator{}, stateMap, cConfigStub{})
 		Expect(netConf.Teardown(vmi)).NotTo(Succeed())
+	})
+
+	It("uses a fresh network state when the virt-launcher pod is replaced", func() {
+		const (
+			oldPodUID = "old-pod-uid"
+			newPodUID = "new-pod-uid"
+			nodeName  = "node1"
+		)
+
+		oldStateCache := newConfigStateCacheStub()
+		stateMap[fmt.Sprintf("%s/%s", vmi.UID, oldPodUID)] = netpod.NewState(oldStateCache, ns)
+		Expect(oldStateCache.Write(testNetworkName, cache.PodIfaceNetworkPreparationFinished)).To(Succeed())
+
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name:                   testNetworkName,
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+		}}
+		vmi.Spec.Networks = []v1.Network{{
+			Name:          testNetworkName,
+			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+		}}
+		vmi.Status.NodeName = nodeName
+		vmi.Status.ActivePods = map[types.UID]string{
+			types.UID(newPodUID): nodeName,
+		}
+
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid)).To(Succeed())
+		Expect(oldStateCache.stateCache).To(Equal(map[string]cache.PodIfaceState{
+			testNetworkName: cache.PodIfaceNetworkPreparationFinished,
+		}))
 	})
 })
 

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -130,8 +130,12 @@ var _ = Describe("netconf", func() {
 			nodeName  = "node1"
 		)
 
+		oldStateKey := fmt.Sprintf("%s/%s", vmi.UID, oldPodUID)
+		newStateKey := fmt.Sprintf("%s/%s", vmi.UID, newPodUID)
+
 		oldStateCache := newConfigStateCacheStub()
-		stateMap[fmt.Sprintf("%s/%s", vmi.UID, oldPodUID)] = netpod.NewState(oldStateCache, ns)
+		oldState := netpod.NewState(oldStateCache, ns)
+		stateMap[oldStateKey] = oldState
 		Expect(oldStateCache.Write(testNetworkName, cache.PodIfaceNetworkPreparationFinished)).To(Succeed())
 
 		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
@@ -151,6 +155,78 @@ var _ = Describe("netconf", func() {
 		Expect(oldStateCache.stateCache).To(Equal(map[string]cache.PodIfaceState{
 			testNetworkName: cache.PodIfaceNetworkPreparationFinished,
 		}))
+
+		newState, ok := stateMap[newStateKey]
+		Expect(ok).To(BeTrue())
+		Expect(newState).NotTo(BeNil())
+		Expect(newState).NotTo(BeIdenticalTo(oldState))
+	})
+
+	It("falls back to the VMI UID key when ActivePods has no entry matching NodeName", func() {
+		const nodeName = "node-a"
+
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name:                   testNetworkName,
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+		}}
+		vmi.Spec.Networks = []v1.Network{{
+			Name:          testNetworkName,
+			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+		}}
+		vmi.Status.NodeName = nodeName
+		vmi.Status.ActivePods = map[types.UID]string{
+			types.UID("pod-on-other-node"): "node-b",
+		}
+
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid)).To(Succeed())
+		Expect(stateMap).To(HaveKey(string(vmi.UID)))
+		Expect(stateMap).NotTo(HaveKey(fmt.Sprintf("%s/%s", vmi.UID, "pod-on-other-node")))
+	})
+
+	It("uses only the pod UID matching NodeName when multiple ActivePods entries exist", func() {
+		const (
+			nodeName      = "node-a"
+			matchingPod   = "pod-on-node-a"
+			nonMatchingPod = "pod-on-node-b"
+		)
+
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name:                   testNetworkName,
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+		}}
+		vmi.Spec.Networks = []v1.Network{{
+			Name:          testNetworkName,
+			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+		}}
+		vmi.Status.NodeName = nodeName
+		vmi.Status.ActivePods = map[types.UID]string{
+			types.UID(matchingPod):    nodeName,
+			types.UID(nonMatchingPod): "node-b",
+		}
+
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid)).To(Succeed())
+		Expect(stateMap).To(HaveKey(fmt.Sprintf("%s/%s", vmi.UID, matchingPod)))
+		Expect(stateMap).NotTo(HaveKey(fmt.Sprintf("%s/%s", vmi.UID, nonMatchingPod)))
+	})
+
+	It("removes all pod-specific state entries on teardown", func() {
+		const vmiUID = "vmi-cleanup"
+
+		vmi.ObjectMeta.UID = types.UID(vmiUID)
+		stateMap[vmiUID] = netpod.NewState(newConfigStateCacheStub(), ns)
+		stateMap[fmt.Sprintf("%s/old-pod", vmiUID)] = netpod.NewState(newConfigStateCacheStub(), ns)
+		stateMap[fmt.Sprintf("%s/new-pod", vmiUID)] = netpod.NewState(newConfigStateCacheStub(), ns)
+
+		otherVmiUID := "other-vmi"
+		stateMap[otherVmiUID] = netpod.NewState(newConfigStateCacheStub(), ns)
+		stateMap[fmt.Sprintf("%s/pod", otherVmiUID)] = netpod.NewState(newConfigStateCacheStub(), ns)
+
+		Expect(netConf.Teardown(vmi)).To(Succeed())
+		Expect(stateMap).To(HaveKey(otherVmiUID))
+		Expect(stateMap).To(HaveKey(fmt.Sprintf("%s/pod", otherVmiUID)))
+		Expect(stateMap).NotTo(HaveKey(vmiUID))
+		Expect(stateMap).NotTo(HaveKey(fmt.Sprintf("%s/old-pod", vmiUID)))
+		Expect(stateMap).NotTo(HaveKey(fmt.Sprintf("%s/new-pod", vmiUID)))
 	})
 })
 

--- a/tests/network/guest_shutdown_masquerade.go
+++ b/tests/network/guest_shutdown_masquerade.go
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package network
+
+import (
+	"context"
+	"time"
+
+	expect "github.com/google/goexpect"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe(SIG("Guest shutdown with masquerade binding", decorators.Networking, func() {
+	const tcpPort = 8080
+
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		virtClient = kubevirt.Client()
+	})
+
+	It("should preserve declared-port connectivity after in-guest shutdown with runStrategy Always", decorators.WgS390x, func() {
+		libnet.SkipWhenClusterNotSupportIpv4()
+
+		const declaredPortName = "http"
+		serverVM := libvmi.NewVirtualMachine(
+			libvmifact.NewAlpine(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(v1.Port{Name: declaredPortName, Port: tcpPort})),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			),
+			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+		)
+		serverVM, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(serverVM)).Create(context.Background(), serverVM, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(matcher.ThisVM(serverVM)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+
+		serverVMI, err := virtClient.VirtualMachineInstance(serverVM.Namespace).Get(context.Background(), serverVM.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		clientVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(
+			context.Background(),
+			libvmifact.NewCirros(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			),
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		clientVMI = libwait.WaitUntilVMIReady(clientVMI, console.LoginToCirros)
+
+		verifyMasqueradePortConnectivity := func(server *v1.VirtualMachineInstance) {
+			Expect(console.LoginToAlpine(server)).To(Succeed())
+			vmnetserver.StartTCPServer(server, tcpPort, console.LoginToAlpine)
+
+			serverIP := libnet.GetVmiPrimaryIPByFamily(server, k8sv1.IPv4Protocol)
+			Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
+			Expect(console.SafeExpectBatch(clientVMI, createExpectConnectToServer(serverIP, tcpPort, true), 30)).To(Succeed())
+		}
+
+		By("Verifying declared-port connectivity before guest shutdown")
+		verifyMasqueradePortConnectivity(serverVMI)
+
+		By("Shutting down the guest from inside the VM")
+		guestPowerOff(serverVMI)
+
+		By("Waiting for the controller to replace the shut-down VMI with a new instance")
+		Eventually(matcher.ThisVMI(serverVMI), 240*time.Second, time.Second).Should(matcher.BeRestarted(serverVMI.UID))
+
+		restartedVMI, err := virtClient.VirtualMachineInstance(serverVM.Namespace).Get(context.Background(), serverVM.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying declared-port connectivity after guest shutdown and restart")
+		verifyMasqueradePortConnectivity(restartedVMI)
+	})
+}))
+
+func guestPowerOff(vmi *v1.VirtualMachineInstance) {
+	expecter, _, err := console.NewExpecter(kubevirt.Client(), vmi, 60*time.Second)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = expecter.ExpectBatch([]expect.Batcher{
+		&expect.BSnd{S: "poweroff\n"},
+	}, 20*time.Second)
+	Expect(err).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
## Summary

- Key virt-handler in-memory network preparation state by `VMI UID + active virt-launcher pod UID` instead of VMI UID alone
- When `runStrategy: Always` replaces the virt-launcher pod after an in-guest shutdown, the new pod now runs full masquerade/NAT setup instead of reusing a stale `Finished` state from the previous pod
- Add unit tests covering pod replacement, ActivePods selection, and teardown cleanup
- Add e2e test verifying declared-port connectivity via masquerade after in-guest shutdown with `runStrategy: Always`

Fixes #17888

```release-note
Fixed VM network connectivity after virt-launcher pod replacement by scoping virt-handler network preparation state to the active launcher pod UID.
```

## Use case / failure workflow

1. Create a VM with `runStrategy: Always`, pod network, `masquerade` binding, and a declared port (e.g. SSH on 22/TCP).
2. Confirm the VM is reachable over the declared port (e.g. SSH to the pod IP).
3. Shut down the guest from inside the VM (e.g. `poweroff`).
4. KubeVirt replaces the virt-launcher pod; the VMI returns to `Running` with `Ready=True`.
5. **Bug:** ICMP to the pod IP works, but TCP to declared ports fails (e.g. `ssh: connect to host <ip> port 22: No route to host`) because virt-handler reused a stale `Finished` network-preparation state from the previous pod and skipped masquerade/NAT setup. The VMI may also stop reporting `status.interfaces[].ipAddress` even though the pod has an IP.

This reproduces with standard pod-network masquerade (no Cilium public IP required).

## Root cause

`NetConf.Setup` cached network preparation state in an in-memory map keyed only by VMI UID. After a guest-initiated shutdown with `runStrategy: Always`, KubeVirt creates a new virt-launcher pod for the same VMI. virt-handler reused the previous pod's `Finished` state and skipped network setup (including masquerade NAT rules), leaving the VM unreachable on TCP despite ICMP working.

## Backward compatibility / upgrade path

| Scenario | Expected behavior after upgrade |
|----------|----------------------------------|
| **Running VM, same virt-launcher pod** | First sync after virt-handler restart uses key `vmiUID/podUID`. On-disk cache still reports `Finished` → setup correctly skips (network already configured in the pod). |
| **Pod replaced while VMI UID unchanged** (launcher crash/restart) | New key → fresh in-memory state → full network setup runs. This is the primary bug fix. |
| **Guest shutdown + `runStrategy: Always`** | Controller recreates the VMI (new UID) and virt-launcher pod; stale in-memory state from the old pod UID is no longer reused. |
| **Stale in-memory entries** | Old `vmiUID`-only keys may linger until `Teardown`; `deleteNetworkConfigStatesForVMI` removes all keys matching `vmiUID` and `vmiUID/*`. |
| **On-disk cache (`network-info-cache/{vmiUID}`)** | Format unchanged; remains VMI-scoped. A new pod UID forces a new in-memory state entry so setup is not skipped due to virt-handler memory reuse alone. No disk migration required. |

## Test plan

- [x] Unit tests in `pkg/network/setup/netconf_test.go` and `netconf_state_key_test.go`
- [x] E2e: `tests/network/guest_shutdown_masquerade.go` — masquerade declared-port connectivity survives in-guest shutdown with `runStrategy: Always`
- [ ] CI: `/test all` (requires maintainer trigger)