### PR TITLE
hypervisor/common: stub setsched for unsupported architectures

### DIFF
--- a/pkg/hypervisor/common/BUILD.bazel
+++ b/pkg/hypervisor/common/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "process.go",
         "qemu.go",
         "setsched.go",
+        "setsched_common.go",
         "vcpu.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/hypervisor/common",

--- a/pkg/hypervisor/common/BUILD.bazel
+++ b/pkg/hypervisor/common/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "qemu.go",
         "setsched.go",
         "setsched_common.go",
+        "setsched_unsupported.go",
         "vcpu.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/hypervisor/common",

--- a/pkg/hypervisor/common/setsched_common.go
+++ b/pkg/hypervisor/common/setsched_common.go
@@ -1,5 +1,3 @@
-//go:build (linux && amd64) || (linux && arm64) || (linux && s390x)
-
 /*
  * This file is part of the KubeVirt project
  *
@@ -21,16 +19,24 @@
 
 package common
 
-import (
-	"unsafe"
-
-	"golang.org/x/sys/unix"
-)
-
-func SchedSetScheduler(pid int, policy policy, param SchedParam) error {
-	_, _, e1 := unix.Syscall(unix.SYS_SCHED_SETSCHEDULER, uintptr(pid), uintptr(policy), uintptr(unsafe.Pointer(&param)))
-	if e1 != 0 {
-		return e1
-	}
-	return nil
+// SchedParam represents the Linux sched_param struct:
+//
+//	struct sched_param {
+//	   int sched_priority;
+//	};
+//
+// Ref: https://github.com/torvalds/linux/blob/c2bf05db6c78f53ca5cd4b48f3b9b71f78d215f1/include/uapi/linux/sched/types.h#L7-L9
+type SchedParam struct {
+	Priority int
 }
+
+type policy uint32
+
+const (
+	// SchedFIFO represents the Linux SCHED_FIFO scheduling policy ID:
+	//
+	// #define SCHED_FIFO		1
+	//
+	// Ref: https://github.com/torvalds/linux/blob/c2bf05db6c78f53ca5cd4b48f3b9b71f78d215f1/include/uapi/linux/sched.h#L115
+	SchedFIFO policy = 1
+)

--- a/pkg/hypervisor/common/setsched_unsupported.go
+++ b/pkg/hypervisor/common/setsched_unsupported.go
@@ -1,0 +1,31 @@
+//go:build !((linux && amd64) || (linux && arm64) || (linux && s390x))
+
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package common
+
+import "errors"
+
+// ErrUnsupportedRTScheduling indicates real-time scheduling is unavailable on the current platform.
+var ErrUnsupportedRTScheduling = errors.New("real-time scheduling not supported on this platform")
+
+func SchedSetScheduler(pid int, policy policy, param SchedParam) error {
+	return ErrUnsupportedRTScheduling
+}


### PR DESCRIPTION
`setsched.go` is gated to `linux/{amd64,arm64,s390x}`. On every other GOOS/GOARCH the package leaves `SchedParam`, `SchedFIFO`, and `SchedSetScheduler` undefined, which breaks any transitive consumer, including some `pkg/virtctl` tests.

- Extracted the shared types `SchedParam`, `policy`, `SchedFIFO` into a build-tag-neutral `setsched_common.go` so they are defined in exactly one place.
- Added a sibling `setsched_unsupported.go` with the inverse build tag that provides only the `SchedSetScheduler` stub, returning the sentinel `ErrUnsupportedRTScheduling` so a call cannot silently no-op on a platform without the syscall.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Cross-building `pkg/hypervisor/...` for any GOOS/GOARCH outside `linux/{amd64,arm64,s390x}` fails:
```
  pkg/hypervisor/kvm/realtime.go: undefined: common.SchedParam
  pkg/hypervisor/kvm/realtime.go: undefined: common.SchedSetScheduler
  pkg/hypervisor/kvm/realtime.go: undefined: common.SchedFIFO
  pkg/hypervisor/mshv/realtime.go: undefined: common.SchedParam
  ...
```
Anything transitively importing `pkg/hypervisor` fails the same way, which is how the reporter hit it when packaging `virtctl` for Alpine across `armhf`, `armv7`, `loongarch64`, `ppc64le`, `riscv64`, and `x86`.

#### After this PR:
`pkg/hypervisor/...` builds on every GOOS/GOARCH. Shared types `SchedParam`, `policy`, `SchedFIFO` live in build-tag-neutral `setsched_common.go`, so the real implementation in `setsched.go` and the stub in `setsched_unsupported.go` cannot drift. The stub returns the sentinel `ErrUnsupportedRTScheduling` for `errors.Is` checks.

### References
- Fixes #17855
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- The stub keeps the public surface defined on architectures where the underlying syscall is not available, in exchange for an explicit runtime error if anyone ever calls into it on those targets. Downstream packagers (Alpine and similar distros that ship `virtctl` across many arches) get a buildable package without KubeVirt needing to claim runtime support on those arches.
  
The following alternatives were considered:
- Add matching `//go:build` constraints to each file in `pkg/hypervisor/kvm` and `pkg/hypervisor/mshv` that uses these symbols. Propagates the constraint up to every caller and leaves `pkg/hypervisor/launcherhypervisorresources.go` needing its own constraints. Larger blast radius for the same outcome.
- Move the symbols into `pkg/hypervisor/kvm` and `pkg/hypervisor/mshv` directly. Duplicates the same three definitions
in two places.
- The chosen approach localises the constraint to `pkg/hypervisor/common`, mirroring the existing `setsched.go` gate.

Links to places where the discussion took place: n/a

### Special notes for your reviewer
Verified locally with `go build ./pkg/hypervisor/...` across the matrix:
- Previously failing, now OK: `linux/riscv64`, `linux/ppc64le`, `linux/386`, `linux/arm`, `linux/loong64`
- No regression on supported targets: `linux/amd64`, `linux/arm64`, `linux/s390x`

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a build failure in `pkg/hypervisor` on GOOS/GOARCH combinations outside linux/{amd64,arm64,s390x}, which previously prevented downstream packagers from cross-building virtctl on architectures such as riscv64, ppc64le, and 386. On those architectures, `common.SchedSetScheduler` now returns the new sentinel error `common.ErrUnsupportedRTScheduling`.
```