### PR TITLE
Deprecate NewCirros in favor of NewAlpine/NewAlpineWithTestTooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ fmt: format
 
 lint:
 	hack/dockerized "hack/lint-test-cleanup-label.sh"
+	hack/dockerized "hack/lint-newcirros-deprecation.sh"
 	hack/dockerized "hack/golangci-lint.sh"
 	hack/dockerized "monitoringlinter ./pkg/..."
 	hack/dockerized "hack/license-header-check.sh"

--- a/hack/lint-newcirros-deprecation.sh
+++ b/hack/lint-newcirros-deprecation.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+# Ensures no new CirrOS usages are introduced outside the known baseline.
+# As you migrate a file, remove it from the BASELINE list below.
+
+set -eo pipefail
+
+NEWCIRROS_BASELINE="
+pkg/virt-controller/watch/vsock/vsock_test.go
+tests/container_disk_test.go
+tests/hotplug/pci-ports.go
+tests/hotplug/pci_topology.go
+tests/network/bindingplugin_slirp.go
+tests/network/services.go
+tests/network/vmi_istio.go
+tests/network/vmi_lifecycle.go
+tests/network/vmi_networking.go
+tests/performance/density-kwok.go
+tests/performance/density.go
+tests/stability_test.go
+tests/vmi_cloudinit_hook_sidecar_test.go
+tests/vmi_cloudinit_test.go
+tests/vmi_configuration_test.go
+tests/vmi_lifecycle_test.go
+tests/vmi_sound_test.go
+"
+
+CONTAINERDISK_BASELINE="
+tests/container_disk_test.go
+tests/objectgraph_test.go
+tests/vmi_configuration_test.go
+tests/vmi_lifecycle_test.go
+"
+
+EXCLUDE_FILES="
+tests/containerdisk/containerdisk.go
+tests/libvmifact/factory.go
+"
+
+exit_code=0
+
+check_pattern() {
+    local pattern="$1"
+    local baseline="$2"
+    local msg="$3"
+
+    raw_files="$(grep -Erl "$pattern" --include='*.go' . || true)"
+
+    if [ -z "$raw_files" ]; then
+        return
+    fi
+
+    actual_files="$(printf '%s\n' "$raw_files" |
+        sed 's|^\./||' |
+        sort)"
+
+    while IFS= read -r f; do
+        if echo "$EXCLUDE_FILES" | grep -Fqx -- "$f"; then
+            continue
+        fi
+        if ! echo "$baseline" | grep -Fqx -- "$f"; then
+            echo "ERROR: $f $msg"
+            echo "       Use NewAlpine or NewAlpineWithTestTooling instead."
+            echo "       See https://github.com/kubevirt/kubevirt/issues/15043"
+            echo ""
+            exit_code=1
+        fi
+    done <<EOF
+$actual_files
+EOF
+}
+
+check_pattern 'libvmifact\.NewCirros\(' "$NEWCIRROS_BASELINE" \
+    "uses NewCirros which is deprecated."
+
+check_pattern 'ContainerDiskCirros(CustomLocation)?' "$CONTAINERDISK_BASELINE" \
+    "uses ContainerDiskCirros directly which is deprecated."
+
+if [ "$exit_code" -ne 0 ]; then
+    exit 1
+fi
+
+echo "No new CirrOS usages found outside the baseline."

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -28,16 +28,18 @@ import (
 type ContainerDisk string
 
 const (
+	// Deprecated: Use ContainerDiskAlpine or ContainerDiskAlpineTestTooling instead. See https://github.com/kubevirt/kubevirt/issues/15043
 	ContainerDiskCirrosCustomLocation ContainerDisk = "cirros-custom"
-	ContainerDiskCirros               ContainerDisk = "cirros"
-	ContainerDiskAlpine               ContainerDisk = "alpine"
-	ContainerDiskAlpineTestTooling    ContainerDisk = "alpine-with-test-tooling"
-	ContainerDiskFedoraTestTooling    ContainerDisk = "fedora-with-test-tooling"
-	ContainerDiskVirtio               ContainerDisk = "virtio-container-disk"
-	ContainerDiskEmpty                ContainerDisk = "empty"
-	ContainerDiskFedoraRealtime       ContainerDisk = "fedora-realtime"
-	KernelBoot                        ContainerDisk = "alpine-ext-kernel-boot-demo"
-	KernelBootS390xGuestless          ContainerDisk = "s390x-guestless-kernel"
+	// Deprecated: Use ContainerDiskAlpine or ContainerDiskAlpineTestTooling instead. See https://github.com/kubevirt/kubevirt/issues/15043
+	ContainerDiskCirros            ContainerDisk = "cirros"
+	ContainerDiskAlpine            ContainerDisk = "alpine"
+	ContainerDiskAlpineTestTooling ContainerDisk = "alpine-with-test-tooling"
+	ContainerDiskFedoraTestTooling ContainerDisk = "fedora-with-test-tooling"
+	ContainerDiskVirtio            ContainerDisk = "virtio-container-disk"
+	ContainerDiskEmpty             ContainerDisk = "empty"
+	ContainerDiskFedoraRealtime    ContainerDisk = "fedora-realtime"
+	KernelBoot                     ContainerDisk = "alpine-ext-kernel-boot-demo"
+	KernelBootS390xGuestless       ContainerDisk = "s390x-guestless-kernel"
 )
 
 const (

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -50,7 +50,11 @@ func NewFedora(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	return libvmi.New(opts...)
 }
 
-// NewCirros instantiates a new CirrOS based VMI configuration
+// NewCirros instantiates a new CirrOS based VMI configuration.
+//
+// Deprecated: Use NewAlpine or NewAlpineWithTestTooling instead.
+// CirrOS is not available on s390x and is being removed from the test suite.
+// See https://github.com/kubevirt/kubevirt/issues/15043
 func NewCirros(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskCirros)),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
NewCirros` can be used freely in new tests without any warning or CI enforcement.

#### After this PR:
- `NewCirros` is marked as `// Deprecated:` (Go-standard, surfaced by staticcheck SA1019 and IDEs).
- A `forbidigo` lint rule blocks any **new** usage of `NewCirros` in CI.
- Existing callsites are temporarily excluded via a baseline list that will shrink as migration PRs land.

### References

- Partially addresses #https://github.com/kubevirt/kubevirt/issues/15043


### Why we need it and why it was done in this way
CirrOS is not available on s390x, preventing E2E tests from running consistently across architectures. Alpine/AlpineTesttolling works with the same 128Mi memory footprint, making it a drop-in replacement for most tests.
The following tradeoffs were made:
- A temporary baseline exclusion list is used so that existing tests are not broken by this PR. Each subsequent migration PR will remove entries from the list.

### Special notes for your reviewer
The `forbidigo` rule uses `analyze-types: true` to match on the fully-qualified `kubevirt.io/kubevirt/tests/libvmifact.NewCirros`, so it won't produce false positives on unrelated functions named `NewCirros`.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
  None.

```

